### PR TITLE
B-11c30c2b: Advanced·Regional adapter binder retirement

### DIFF
--- a/docs/architecture/comfy-host-provider-bridge.md
+++ b/docs/architecture/comfy-host-provider-bridge.md
@@ -1409,7 +1409,7 @@ Implementation result:
 
 ### B-11c30c2b — Advanced / Regional adapter Move
 
-- **State:** IN PROGRESS
+- **State:** COMPLETE in PR #345
 - **Owner:** #184, prerequisite #167 S167-01a
 - **Type:** Move
 - **Base:** `dev@b69d33857ef85fb81388f02e9ff1cff195a092d1`
@@ -1455,10 +1455,28 @@ wildcard seed arithmetic, warnings/errors, and saved workflows. It must not
 add a callback/binder, import root `nodes.py` from the canonical package, copy
 seed or Wildcard behavior, or begin S167-02 reservation behavior.
 
+Implementation result:
+
+- root no longer imports or invokes the two binders, and both canonical binder
+  definitions plus their bind-time mutation state are absent;
+- Advanced imports its canonical common, Prompt, seed, NAIA, workflow, and
+  input-type owners directly. Its legacy settings fallback remains explicit,
+  and the existing Prompt service's call-time Wildcard module resolver
+  preserves the no-eager-NumPy boundary;
+- Regional imports canonical Prompt/seed/workflow owners directly and resolves
+  CLIP encoding through the existing E-07 provider at call time;
+- tests that previously patched root only to drive Advanced or Regional now
+  patch the canonical adapter owner;
+- mapped classes and input types remain direct canonical identities, and seed
+  reservation payload parsing remains owned by S167-01a;
+- the Comfy host ledger remains 22 slots across 15 modules;
+- the remaining audit is 14 binders in two families: eight provider-then-root,
+  four root-only, and two explicit callbacks; and
+- `nodes.py` is 1,662 lines, down 15 lines from the S167-01a base.
+
 ### B-11d — Final root shim
 
-- **State:** BLOCKED by the remaining B-11c30 family Moves and the separate
-  seed/Wildcard decision for the final non-provider function
+- **State:** BLOCKED by the remaining AiO and Wildcard/NAIA binder families
 - **Owner:** #184
 - **Type:** Move
 
@@ -1474,10 +1492,9 @@ Final conditions remain:
 - actual package/Registry archive closure passes; and
 - representative live ComfyUI execution is recorded.
 
-The provider bridge itself does not authorize moving
-`_consume_reserved_wildcard_next_seed`. S167-01a / PR #344 is the separate
-#167 behavior-preserving owner Move; it does not also authorize c2b binder
-retirement.
+S167-01a / PR #344 supplies the behavior-preserving reserved-seed owner, and
+B-11c30c2b / PR #345 consumes it directly from both canonical adapters. The
+root aliases remain compatibility surface; S167-02 Behavior is still separate.
 
 ## 6. Updated critical path
 
@@ -1501,7 +1518,7 @@ COMPLETE: B-11c30c Prompt/Regional split gate / PR #339
 COMPLETE: B-11c30c1 Prompt/Regional service binder Move / PR #340
 COMPLETE: B-11c30c2 Prompt/Regional node-adapter split gate / PR #341
 COMPLETE: B-11c30c2a Prompt Data / Classic Prompt adapter Move / PR #342
-BLOCKED:  B-11c30c2b Advanced / Regional adapter Move (#167/D-12)
+COMPLETE: B-11c30c2b Advanced / Regional adapter Move / PR #345
 BLOCKED:  B-11d final root shim
 
 LATER:    #167 seed reservation

--- a/docs/architecture/comfy-host-provider-bridge.md
+++ b/docs/architecture/comfy-host-provider-bridge.md
@@ -1407,6 +1407,54 @@ Implementation result:
   provider-then-root, five root-only, and two explicit callbacks; and
 - `nodes.py` is 1,750 lines, down 13 lines from the B-11c30c2 base.
 
+### B-11c30c2b — Advanced / Regional adapter Move
+
+- **State:** IN PROGRESS
+- **Owner:** #184, prerequisite #167 S167-01a
+- **Type:** Move
+- **Base:** `dev@b69d33857ef85fb81388f02e9ff1cff195a092d1`
+
+Pre-edit inventory:
+
+- `_bind_prompt_advanced_node_runtime` and `_bind_regional_node_runtime` are the
+  only owned binders;
+- 72 bind-time global slots cover 55 unique names;
+- 69 root resolver slots cover 53 unique names;
+- Regional owns the only provider slot, `_encode_with_comfy_clip`;
+- three direct root dependency slots cover `_FlexibleOptionalInputType` and
+  `_resolve_comfy_host_helper`;
+- repository tests replace 21 family slots over 13 unique names; this remains
+  migration-cost evidence, not public compatibility; and
+- both real build paths call
+  `easyuse_anima.seed.compatibility._consume_reserved_wildcard_next_seed`,
+  whose behavior-preserving canonical owner was completed by S167-01a / PR
+  #344.
+
+Allowed production files are `nodes.py`,
+`easyuse_anima/nodes/prompt_advanced_nodes.py`, and
+`easyuse_anima/nodes/regional_nodes.py`. Gate, focused-test, and deterministic
+fixture updates may touch only:
+
+- `tests/test_node_contracts.py`;
+- `tests/test_prompt_corrector.py`;
+- `tests/test_prompt_studio_regional.py`;
+- `tests/test_naia_settings.py`;
+- `tests/test_nodes_module_analyzer.py`;
+- `tests/test_python_compatibility_surface.py`;
+- `tests/fixtures/comfy_host_compatibility.v1.json`;
+- `tests/fixtures/python_backend_baseline.json`;
+- `tests/fixtures/python_compatibility_surface.v1.json`;
+- `docs/architecture/comfy-host-provider-bridge.md`;
+- `docs/architecture/python-backend-execution-roadmap.md`; and
+- `docs/architecture/python-compatibility-shims.md`.
+
+This Move must preserve schemas, mapped-class and input-type identity, prompt
+and Regional conditioning outputs, call-time Comfy provider lookup order,
+NAIA and optional-dependency timing, seed reservation payloads and pop order,
+wildcard seed arithmetic, warnings/errors, and saved workflows. It must not
+add a callback/binder, import root `nodes.py` from the canonical package, copy
+seed or Wildcard behavior, or begin S167-02 reservation behavior.
+
 ### B-11d — Final root shim
 
 - **State:** BLOCKED by the remaining B-11c30 family Moves and the separate

--- a/docs/architecture/python-backend-execution-roadmap.md
+++ b/docs/architecture/python-backend-execution-roadmap.md
@@ -3,9 +3,9 @@
 ## Document status
 
 - Status: operational execution runbook
-- Snapshot date: 2026-07-23
+- Snapshot date: 2026-07-24
 - Snapshot branch: `dev`
-- Integrated `dev` snapshot commit: `53d92aa944663a18ee593c027b90fa0b8e9444be`
+- Integrated `dev` snapshot commit: `b69d33857ef85fb81388f02e9ff1cff195a092d1`
 - Scope: Python backend only
 - Target architecture: [`python-backend.md`](python-backend.md)
 - Architecture decisions: [ADR-001](adr-001-modular-monolith.md) and
@@ -31,7 +31,7 @@ merged PR, the owning issue's evidence record, and every stated exit gate.
 | Phase | Integrated snapshot / open implementation state | Remaining exit work |
 | --- | --- | --- |
 | A - baseline | Complete; #191 is closed | Keep fixtures and analyzers current during later moves |
-| B - `nodes.py` extraction | Integrated through B-11c30c2a / PR #342 / `ddcc251` | Complete S167-01a, retire the Advanced/Regional adapter binders separately, complete the remaining binder families, then perform the final root shim as a separate Move |
+| B - `nodes.py` extraction | Integrated through S167-01a / PR #344; B-11c30c2b completes in PR #345 | Complete the remaining AiO and Wildcard/NAIA binder families, then perform the final root shim as a separate Move |
 | C - feature contracts/behavior | Partially complete through S167-01a / PR #344 | Continue #167 and #169 in separate Contract/Move/Behavior PRs |
 | D - root consolidation | Not started | Execute #186 feature by feature after the corresponding behavior contracts are stable |
 | E - runtime ownership | Partial: E-02a and E-07a/E-07b integrated | Continue #187 only where canonical feature owners and explicit contracts exist |
@@ -42,10 +42,9 @@ merged PR, the owning issue's evidence record, and every stated exit gate.
 ### Measured Phase B progress
 
 - The Phase A baseline recorded root `nodes.py` at 12,663 lines.
-- Against the integrated `dev` snapshot above, root `nodes.py` measures 1,850
-  lines after B-11c29b3.
-- The mechanical extraction has removed 10,813
-  lines, approximately 85.4% of the Phase A baseline, while preserving the root
+- In B-11c30c2b / PR #345, root `nodes.py` measures 1,662 lines.
+- The mechanical extraction has removed 11,001
+  lines, approximately 86.9% of the Phase A baseline, while preserving the root
   compatibility surface.
 - B-01 through B-09b2 are integrated. The latest completed implementation slice
   is the AiO generator adapter Move in PR #270.
@@ -114,7 +113,9 @@ merged PR, the owning issue's evidence record, and every stated exit gate.
   dependency has a canonical behavior-preserving owner. B-11c30c2a completes
   the unblocked adapter Move in PR #342. S167-01 / PR #343 freezes the contract
   and exact owner-Move boundary. S167-01a / PR #344 supplies that canonical
-  compatibility owner; c2b is the next separate adapter Move.
+  compatibility owner. B-11c30c2b / PR #345 retires the final two Prompt
+  node-adapter binders, leaving 14 binders across the AiO and Wildcard/NAIA
+  families.
 
 ### Current quality baseline
 
@@ -356,7 +357,7 @@ surfaces. AiO mechanical extraction must not start until #168 exits.
 | 11 | B-09b2 AiO generator adapter move | COMPLETE on `dev` | Move | #184 | PR #270 / `57d40b4` |
 | 12 | B-10a machine-readable compatibility audit | COMPLETE on `dev` | Contract/gate | #184/#188 | PR #271 / `3c7b857` |
 | 13 | B-10b private alias reduction | COMPLETE on `dev` through PR #291 / `c6b4680` | Contract/cleanup, split PRs | #184/#188 | Audited alias surface integrated |
-| 14 | B-11 registration/bootstrap/root shim | IN PROGRESS through B-11c30c2a PR #342; S167-01a / PR #344 unblocks the separate c2b adapter Move | Move/Contract, split PRs | #184 | S167-01 contract |
+| 14 | B-11 registration/bootstrap/root shim | IN PROGRESS through B-11c30c2b PR #345; remaining AiO and Wildcard/NAIA binder Moves precede B-11d | Move/Contract, split PRs | #184 | S167-01 contract |
 | 15 | S167 backend seed reservation series | S167-01 Contract COMPLETE in PR #343 and S167-01a consumer Move COMPLETE in PR #344; Behavior and Adapter remain | Contract then Move then Behavior | #167 | Canonical AiO/node seams |
 | 16 | A169 stage pipeline series | BLOCKED by #168 and B exit | Contract then Behavior | #169 | Typed config and mechanical AiO move |
 | 17 | A169 first-pass cache policy | BLOCKED by stage/cache ownership seam | Behavior | #169 | Mechanical cache move and benchmark harness |
@@ -1037,6 +1038,12 @@ unchanged. The separate legacy Wildcard unsupported alias remains for D-12.
     Classic Prompt uses its canonical prompt, settings, and legacy
     knowledge-base owners directly. Advanced/Regional binders and
     seed-reservation behavior remain outside this Move.
+  - B-11c30c2b retires only `_bind_prompt_advanced_node_runtime` and
+    `_bind_regional_node_runtime` in PR #345. Both adapters import canonical
+    common, Prompt, workflow, and S167-01a seed owners directly. Regional keeps
+    CLIP encoding behind the existing E-07 provider, while Advanced reuses the
+    Prompt service's call-time Wildcard module resolver to preserve
+    optional-dependency timing. Fourteen AiO and Wildcard/NAIA binders remain.
   - The final B-11c cutover removes remaining root execution ownership and
     leaves the explicit supported `nodes.py` compatibility shim.
 - Add `easyuse_anima/registration.py` as pure mapping composition. It performs no
@@ -1088,7 +1095,8 @@ rollback units before S167-02. PR #343 completes the contract without changing
 any existing runtime, payload bytes, or reservation behavior. S167-01a uses the
 same document for its exact Move inventory and allowed-file gate. PR #344
 completes that Move while preserving the root aliases and both node-adapter
-binders for B-11c30c2b.
+binders for B-11c30c2b. PR #345 then retires those two binders without changing
+the seed contract or beginning S167-02 Behavior.
 
 Do not mix this sequence into B-09 or #169 stages.
 

--- a/docs/architecture/python-compatibility-shims.md
+++ b/docs/architecture/python-compatibility-shims.md
@@ -8,10 +8,10 @@
 - Policy: [ADR-002](adr-002-compatibility-shims.md)
 - Machine-readable audit:
   [`python_compatibility_surface.v1.json`](../../tests/fixtures/python_compatibility_surface.v1.json)
-- Current state: B-11a through B-11c30c2a are integrated. S167-01a / PR #344
-  supplies the canonical reserved-seed compatibility consumer while retaining
-  its root aliases; B-11c30c2b remains the separate Advanced/Regional binder
-  retirement before the final root shim.
+- Current state: B-11a through B-11c30c2b / PR #345 are integrated in the
+  reviewed sequence. S167-01a / PR #344 supplies the canonical reserved-seed
+  compatibility consumer while retaining its root aliases. Fourteen AiO and
+  Wildcard/NAIA binders remain before the final root shim.
 
 This is an actionable registry, not a removal schedule. `N` means the first
 published Registry release containing both a canonical target and its root
@@ -808,8 +808,8 @@ convenience-node compatibility; it remains unmapped and is not public support.
 - Canonical owner:
   `easyuse_anima.seed.compatibility._consume_reserved_wildcard_next_seed`.
 - Root `nodes.py` retains direct aliases for the consumer, hidden input name,
-  and public-safe queue seed bound. Existing Advanced/Regional binders therefore
-  observe the same root object until B-11c30c2b.
+  and public-safe queue seed bound. B-11c30c2b adapters import the canonical
+  consumer directly while those root aliases remain compatibility surface.
 - The canonical owner imports `_single_value` directly and resolves the
   pre-D-12 `wildcard_engine` only at call time. It does not import root
   `nodes.py`, add a callback contract, eagerly import NumPy, or copy Wildcard
@@ -819,6 +819,27 @@ convenience-node compatibility; it remains unmapped and is not public support.
   globals are 24, and runtime binders remain 16.
 - Version-1 payload bytes, pop order, accepted mode/control/seed values, return
   values, workflows, and browser reservation behavior remain unchanged.
+
+### B-11c30c2b Advanced / Regional adapter binder retirement
+
+- Root no longer imports or invokes `_bind_prompt_advanced_node_runtime` or
+  `_bind_regional_node_runtime`; both canonical binder definitions and their
+  bind-time mutation state are absent.
+- Advanced imports canonical common, Prompt, seed, workflow, NAIA, and
+  input-type owners directly. It reuses the Prompt service's call-time
+  Wildcard module resolver and keeps the existing flat settings fallback.
+- Regional imports canonical Prompt/seed/workflow owners directly and resolves
+  `_encode_with_comfy_clip` through the existing E-07 provider at call time.
+  The Comfy host ledger remains 22 slots across 15 modules.
+- Tests that previously patched root only to drive either adapter now patch the
+  canonical adapter owner.
+- Canonical root bindings are 282, root residual functions remain zero, root
+  residual globals remain 24, and the runtime audit is 14 binders in two
+  families: eight provider-then-root, four root-only, and two explicit
+  callbacks.
+- Schema, mapped-class/input-type identity, outputs, provider timing, seed
+  payload/pop order, Wildcard arithmetic, workflows, and optional-dependency
+  timing remain unchanged.
 
 ### `nodes.py` public node-class surface
 

--- a/easyuse_anima/nodes/prompt_advanced_nodes.py
+++ b/easyuse_anima/nodes/prompt_advanced_nodes.py
@@ -5,17 +5,40 @@ from __future__ import annotations
 import json
 from typing import Any
 
+from ..common.serialization import _stable_change_key
+from ..common.values import _as_bool, _as_int, _single_value
+from ..naia.client import _parse_random_response, _post_random
 from ..naia.resolution import (
     CUSTOM_ADVANCED_RESOLUTION_BUCKET,
     DEFAULT_ADVANCED_RESOLUTION_BUCKET,
     DEFAULT_ADVANCED_RESOLUTION_SIZE,
     NAIA_ADVANCED_RESOLUTION_BUCKET,
+    _advanced_resolution_from_selection,
+    _resolution_label,
+    _resolve_naia_resolution,
 )
 from ..prompt.advanced import (
     ADVANCED_FIELDS_WORKFLOW_PROPERTY,
     EXTEND_PROMPT_SLOT_SPECS,
     PROMPT_STUDIO_ADVANCED_RETURN_NAMES,
     PROMPT_STUDIO_ADVANCED_RETURN_TYPES,
+    _advanced_enabled_naia_panes,
+    _advanced_field_input_values,
+    _advanced_fields_json,
+    _advanced_has_enabled_naia,
+    _advanced_uses_naia_resolution,
+    _apply_advanced_field_inputs,
+    _build_advanced_prompt_data,
+    _build_advanced_prompts,
+    _clone_advanced_fields,
+    _expand_advanced_wildcard_fields,
+    _normalize_advanced_fields,
+    _normalize_prompt_studio_wildcard_seed_control,
+    _set_naia_field_text,
+    _translate_prompt_fields,
+    _wildcard_engine_module,
+    normalize_prompt_studio_wildcard_mode,
+    normalize_seed,
 )
 from ..prompt.artist_mix import (
     ARTIST_MIX_DEFAULT_CLUSTER_COUNT,
@@ -28,9 +51,31 @@ from ..prompt.artist_mix import (
     ARTIST_MIX_DEFAULT_STYLE_GAIN,
     ARTIST_MIX_MODE_OFF,
     ARTIST_MIX_STUDIO_MODES,
+    _artist_mix_mode_tooltip,
+    _bounded_artist_mix_float,
+    _bounded_artist_mix_int,
+    _normalize_artist_mix_mode,
 )
-from ..prompt.data import PROMPT_DATA_TYPE
+from ..prompt.correction import (
+    _prompt_translation_change_key,
+    _translate_prompt_text,
+)
+from ..prompt.data import PROMPT_DATA_TYPE, _prompt_data_parameter_snapshot
+from ..seed.compatibility import _consume_reserved_wildcard_next_seed
+from ..workflow import _get_workflow_node
 from .input_types import _FlexibleOptionalInputType
+from .naia_nodes import EasyUseAnimaNAIARandomPrompt
+
+try:
+    from ...settings import (
+        resolve_metadata_filter_words,
+        resolve_naia_settings,
+    )
+except ImportError:
+    from settings import (
+        resolve_metadata_filter_words,
+        resolve_naia_settings,
+    )
 
 WILDCARD_MODE_SEQUENTIAL = "sequential"
 PROMPT_STUDIO_WILDCARD_MODE_LABELS = ("일반", "순차")
@@ -56,109 +101,12 @@ WILDCARD_SEED_RANGE_NOTE = (
 )
 
 
-def _unbound_runtime(*_args, **_kwargs) -> Any:
-    raise RuntimeError("Advanced Prompt Studio node runtime dependencies are not bound.")
+def next_seed(*args, **kwargs):
+    return _wildcard_engine_module().next_seed(*args, **kwargs)
 
 
-_RUNTIME_RESOLVER: Any = None
-_advanced_enabled_naia_panes = _unbound_runtime
-_advanced_field_input_values = _unbound_runtime
-_advanced_fields_json = _unbound_runtime
-_advanced_has_enabled_naia = _unbound_runtime
-_advanced_resolution_from_selection = _unbound_runtime
-_advanced_uses_naia_resolution = _unbound_runtime
-_apply_advanced_field_inputs = _unbound_runtime
-_as_bool = _unbound_runtime
-_as_int = _unbound_runtime
-_bounded_artist_mix_float = _unbound_runtime
-_bounded_artist_mix_int = _unbound_runtime
-_build_advanced_prompt_data = _unbound_runtime
-_build_advanced_prompts = _unbound_runtime
-_clone_advanced_fields = _unbound_runtime
-_consume_reserved_wildcard_next_seed = _unbound_runtime
-_expand_advanced_wildcard_fields = _unbound_runtime
-_get_workflow_node = _unbound_runtime
-_normalize_advanced_fields = _unbound_runtime
-_normalize_artist_mix_mode = _unbound_runtime
-_normalize_prompt_studio_wildcard_seed_control = _unbound_runtime
-_parse_random_response = _unbound_runtime
-_post_random = _unbound_runtime
-_prompt_data_parameter_snapshot = _unbound_runtime
-_prompt_translation_change_key = _unbound_runtime
-_resolution_label = _unbound_runtime
-_resolve_naia_resolution = _unbound_runtime
-_set_naia_field_text = _unbound_runtime
-_single_value = _unbound_runtime
-_stable_change_key = _unbound_runtime
-_translate_prompt_fields = _unbound_runtime
-_translate_prompt_text = _unbound_runtime
-_artist_mix_mode_tooltip = _unbound_runtime
-next_seed = _unbound_runtime
-normalize_prompt_studio_wildcard_mode = _unbound_runtime
-normalize_seed = _unbound_runtime
-resolve_metadata_filter_words = _unbound_runtime
-resolve_naia_settings = _unbound_runtime
-wildcard_sources_signature = _unbound_runtime
-
-
-def _runtime_object(name: str) -> Any:
-    if _RUNTIME_RESOLVER is None:
-        raise RuntimeError("Advanced Prompt Studio node runtime dependencies are not bound.")
-    return _RUNTIME_RESOLVER(name)
-
-
-def _bind_prompt_advanced_node_runtime(*, resolve_helper, flexible_optional_input_type) -> None:
-    global _FlexibleOptionalInputType, _RUNTIME_RESOLVER
-
-    def runtime_helper(name):
-        def call(*args, **kwargs):
-            return resolve_helper(name)(*args, **kwargs)
-
-        return call
-
-    _FlexibleOptionalInputType = flexible_optional_input_type
-    _RUNTIME_RESOLVER = resolve_helper
-    for name in (
-        "_advanced_enabled_naia_panes",
-        "_advanced_field_input_values",
-        "_advanced_fields_json",
-        "_advanced_has_enabled_naia",
-        "_advanced_resolution_from_selection",
-        "_advanced_uses_naia_resolution",
-        "_apply_advanced_field_inputs",
-        "_as_bool",
-        "_as_int",
-        "_bounded_artist_mix_float",
-        "_bounded_artist_mix_int",
-        "_build_advanced_prompt_data",
-        "_build_advanced_prompts",
-        "_clone_advanced_fields",
-        "_consume_reserved_wildcard_next_seed",
-        "_expand_advanced_wildcard_fields",
-        "_get_workflow_node",
-        "_normalize_advanced_fields",
-        "_normalize_artist_mix_mode",
-        "_normalize_prompt_studio_wildcard_seed_control",
-        "_parse_random_response",
-        "_post_random",
-        "_prompt_data_parameter_snapshot",
-        "_prompt_translation_change_key",
-        "_resolution_label",
-        "_resolve_naia_resolution",
-        "_set_naia_field_text",
-        "_single_value",
-        "_stable_change_key",
-        "_translate_prompt_fields",
-        "_translate_prompt_text",
-        "_artist_mix_mode_tooltip",
-        "next_seed",
-        "normalize_prompt_studio_wildcard_mode",
-        "normalize_seed",
-        "resolve_metadata_filter_words",
-        "resolve_naia_settings",
-        "wildcard_sources_signature",
-    ):
-        globals()[name] = runtime_helper(name)
+def wildcard_sources_signature(*args, **kwargs):
+    return _wildcard_engine_module().wildcard_sources_signature(*args, **kwargs)
 
 
 class EasyUseAnimaPromptStudioAdvanced:
@@ -456,7 +404,7 @@ class EasyUseAnimaPromptStudioAdvanced:
 
         if live_use_naia:
             naia_settings = resolve_naia_settings()
-            body = _runtime_object("EasyUseAnimaNAIARandomPrompt")._make_request_body(
+            body = EasyUseAnimaNAIARandomPrompt._make_request_body(
                 _as_bool(naia_settings["use_naia_settings"], True),
                 naia_settings["pre_prompt"],
                 naia_settings["post_prompt"],
@@ -1101,7 +1049,7 @@ class EasyUseAnimaPromptStudioExtend:
 
         if live_fill_naia:
             naia_settings = resolve_naia_settings()
-            body = _runtime_object("EasyUseAnimaNAIARandomPrompt")._make_request_body(
+            body = EasyUseAnimaNAIARandomPrompt._make_request_body(
                 _as_bool(naia_settings["use_naia_settings"], True),
                 naia_settings["pre_prompt"],
                 naia_settings["post_prompt"],

--- a/easyuse_anima/nodes/regional_nodes.py
+++ b/easyuse_anima/nodes/regional_nodes.py
@@ -485,7 +485,10 @@ class EasyUseAnimaRegionalConditioning:
 
         if _as_bool(payload.get("regional_enabled"), False):
             use_mask_bounds = str(set_cond_area or "mask bounds") != "default"
-            mask_prompts = payload.get("mask_prompts") if isinstance(payload.get("mask_prompts"), list) else []
+            mask_prompts_value = payload.get("mask_prompts")
+            mask_prompts = (
+                mask_prompts_value if isinstance(mask_prompts_value, list) else []
+            )
             for entry in mask_prompts:
                 if not isinstance(entry, dict):
                     continue

--- a/easyuse_anima/nodes/regional_nodes.py
+++ b/easyuse_anima/nodes/regional_nodes.py
@@ -4,16 +4,50 @@ from __future__ import annotations
 
 from typing import Any
 
+from ..common.serialization import _stable_change_key
+from ..common.values import _as_bool, _as_float, _single_value
+from ..infrastructure.comfy.wiring import resolve_comfy_host_helper
 from ..naia.resolution import (
     DEFAULT_ADVANCED_RESOLUTION_BUCKET,
     DEFAULT_ADVANCED_RESOLUTION_SIZE,
+    _advanced_resolution_from_selection,
 )
+from ..prompt.advanced import (
+    _advanced_field_input_values,
+    _expand_advanced_wildcard_fields,
+    _normalize_prompt_studio_wildcard_seed_control,
+    _translate_prompt_fields,
+    _wildcard_engine_module,
+    normalize_prompt_studio_wildcard_mode,
+    normalize_seed,
+)
+from ..prompt.correction import _prompt_translation_change_key
 from ..prompt.regional import (
     REGIONAL_CONFIG_WORKFLOW_PROPERTY,
     REGIONAL_FIELDS_WORKFLOW_PROPERTY,
     REGIONAL_PROMPT_DATA_TYPE,
+    _apply_regional_field_inputs,
+    _build_regional_outputs,
+    _clone_regional_fields,
+    _conditioning_set_values,
+    _normalize_mask_ids,
+    _normalize_regional_config,
+    _normalize_regional_fields,
+    _parse_json_object,
+    _regional_config_json,
+    _regional_fields_json,
+    _regional_mask_bounds_area,
+    _regional_payload_canvas,
+    _regional_union_mask_for_ids,
 )
+from ..seed.compatibility import _consume_reserved_wildcard_next_seed
+from ..workflow import _get_workflow_node
 from .input_types import _FlexibleOptionalInputType
+
+try:
+    from ...settings import resolve_metadata_filter_words
+except ImportError:
+    from settings import resolve_metadata_filter_words
 
 
 WILDCARD_MODE_SEQUENTIAL = "sequential"
@@ -40,101 +74,24 @@ WILDCARD_SEED_RANGE_NOTE = (
 )
 
 
-def _unbound_runtime(*_args, **_kwargs):
-    raise RuntimeError("Regional node runtime dependencies are not bound.")
+def next_seed(*args, **kwargs):
+    return _wildcard_engine_module().next_seed(*args, **kwargs)
 
 
-_regional_fields_json = _unbound_runtime
-_regional_config_json = _unbound_runtime
-_advanced_resolution_from_selection = _unbound_runtime
-_normalize_regional_fields = _unbound_runtime
-_normalize_regional_config = _unbound_runtime
-_apply_regional_field_inputs = _unbound_runtime
-normalize_prompt_studio_wildcard_mode = _unbound_runtime
-_normalize_prompt_studio_wildcard_seed_control = _unbound_runtime
-_stable_change_key = _unbound_runtime
-resolve_metadata_filter_words = _unbound_runtime
-_prompt_translation_change_key = _unbound_runtime
-wildcard_sources_signature = _unbound_runtime
-normalize_seed = _unbound_runtime
-_single_value = _unbound_runtime
-_get_workflow_node = _unbound_runtime
-_advanced_field_input_values = _unbound_runtime
-_clone_regional_fields = _unbound_runtime
-_consume_reserved_wildcard_next_seed = _unbound_runtime
-_expand_advanced_wildcard_fields = _unbound_runtime
-_translate_prompt_fields = _unbound_runtime
-next_seed = _unbound_runtime
-_build_regional_outputs = _unbound_runtime
-_parse_json_object = _unbound_runtime
-_regional_payload_canvas = _unbound_runtime
-_encode_with_comfy_clip = _unbound_runtime
-_as_bool = _unbound_runtime
-_normalize_mask_ids = _unbound_runtime
-_regional_union_mask_for_ids = _unbound_runtime
-_as_float = _unbound_runtime
-_regional_mask_bounds_area = _unbound_runtime
-_conditioning_set_values = _unbound_runtime
+def wildcard_sources_signature(*args, **kwargs):
+    return _wildcard_engine_module().wildcard_sources_signature(*args, **kwargs)
 
 
-def _bind_regional_node_runtime(*, resolve_helper, flexible_optional_input_type) -> None:
-    global _FlexibleOptionalInputType
-    global _regional_fields_json, _regional_config_json, _advanced_resolution_from_selection
-    global _normalize_regional_fields, _normalize_regional_config
-    global _apply_regional_field_inputs, normalize_prompt_studio_wildcard_mode
-    global _normalize_prompt_studio_wildcard_seed_control
-    global _stable_change_key, resolve_metadata_filter_words
-    global _prompt_translation_change_key, wildcard_sources_signature, normalize_seed
-    global _single_value, _get_workflow_node, _advanced_field_input_values
-    global _clone_regional_fields
-    global _consume_reserved_wildcard_next_seed, _expand_advanced_wildcard_fields
-    global _translate_prompt_fields, next_seed
-    global _build_regional_outputs, _parse_json_object, _regional_payload_canvas
-    global _encode_with_comfy_clip, _as_bool, _normalize_mask_ids
-    global _regional_union_mask_for_ids, _as_float, _regional_mask_bounds_area
-    global _conditioning_set_values
+def _missing_host_helper(name: str):
+    raise RuntimeError(f"Regional Comfy host helper is unavailable: {name}")
 
-    def runtime_helper(name):
-        def call(*args, **kwargs):
-            return resolve_helper(name)(*args, **kwargs)
 
-        return call
-
-    _FlexibleOptionalInputType = flexible_optional_input_type
-    for name in (
-        "_regional_fields_json",
-        "_regional_config_json",
-        "_advanced_resolution_from_selection",
-        "_normalize_regional_fields",
-        "_normalize_regional_config",
-        "_apply_regional_field_inputs",
-        "normalize_prompt_studio_wildcard_mode",
-        "_normalize_prompt_studio_wildcard_seed_control",
-        "_stable_change_key",
-        "resolve_metadata_filter_words",
-        "_prompt_translation_change_key",
-        "wildcard_sources_signature",
-        "normalize_seed",
-        "_single_value",
-        "_get_workflow_node",
-        "_advanced_field_input_values",
-        "_clone_regional_fields",
-        "_consume_reserved_wildcard_next_seed",
-        "_expand_advanced_wildcard_fields",
-        "_translate_prompt_fields",
-        "next_seed",
-        "_build_regional_outputs",
-        "_parse_json_object",
-        "_regional_payload_canvas",
+def _encode_with_comfy_clip(*args, **kwargs):
+    helper = resolve_comfy_host_helper(
         "_encode_with_comfy_clip",
-        "_as_bool",
-        "_normalize_mask_ids",
-        "_regional_union_mask_for_ids",
-        "_as_float",
-        "_regional_mask_bounds_area",
-        "_conditioning_set_values",
-    ):
-        globals()[name] = runtime_helper(name)
+        _missing_host_helper,
+    )
+    return helper(*args, **kwargs)
 
 
 class EasyUseAnimaPromptStudioRegional:

--- a/nodes.py
+++ b/nodes.py
@@ -362,7 +362,6 @@ try:
         EasyUseAnimaPromptStudioAdvanced as EasyUseAnimaPromptStudioAdvanced,
         EasyUseAnimaPromptStudioAdvancedV2 as EasyUseAnimaPromptStudioAdvancedV2,
         # B-10b11 retires the unmapped legacy Extend root alias.
-        _bind_prompt_advanced_node_runtime as _bind_prompt_advanced_node_runtime,
     )
     from .easyuse_anima.nodes.aio_nodes import (
         EasyUseAnimaAIOGenerator as EasyUseAnimaAIOGenerator,
@@ -443,7 +442,6 @@ try:
     from .easyuse_anima.nodes.regional_nodes import (
         EasyUseAnimaPromptStudioRegional as EasyUseAnimaPromptStudioRegional,
         EasyUseAnimaRegionalConditioning as EasyUseAnimaRegionalConditioning,
-        _bind_regional_node_runtime as _bind_regional_node_runtime,
     )
     from .easyuse_anima.naia.client import (
         # B-10b13 retires 13 unsupported NAIA client root aliases.
@@ -908,7 +906,6 @@ except ImportError:  # allows simple local import tests outside ComfyUI's packag
         EasyUseAnimaPromptStudioAdvanced as EasyUseAnimaPromptStudioAdvanced,
         EasyUseAnimaPromptStudioAdvancedV2 as EasyUseAnimaPromptStudioAdvancedV2,
         # B-10b11 retires the unmapped legacy Extend root alias.
-        _bind_prompt_advanced_node_runtime as _bind_prompt_advanced_node_runtime,
     )
     from easyuse_anima.nodes.aio_nodes import (
         EasyUseAnimaAIOGenerator as EasyUseAnimaAIOGenerator,
@@ -989,7 +986,6 @@ except ImportError:  # allows simple local import tests outside ComfyUI's packag
     from easyuse_anima.nodes.regional_nodes import (
         EasyUseAnimaPromptStudioRegional as EasyUseAnimaPromptStudioRegional,
         EasyUseAnimaRegionalConditioning as EasyUseAnimaRegionalConditioning,
-        _bind_regional_node_runtime as _bind_regional_node_runtime,
     )
     from easyuse_anima.naia.client import (
         # B-10b13 retires 13 unsupported NAIA client root aliases.
@@ -1647,17 +1643,6 @@ _bind_aio_conditioning_runtime(
         name,
         lambda fallback_name: globals()[fallback_name],
     ),
-)
-_bind_regional_node_runtime(
-    resolve_helper=lambda name: _resolve_comfy_host_helper(
-        name,
-        lambda fallback_name: globals()[fallback_name],
-    ),
-    flexible_optional_input_type=_FlexibleOptionalInputType,
-)
-_bind_prompt_advanced_node_runtime(
-    resolve_helper=lambda name: globals()[name],
-    flexible_optional_input_type=_FlexibleOptionalInputType,
 )
 _bind_aio_node_runtime(
     resolve_helper=lambda name: globals()[name],

--- a/tests/fixtures/comfy_host_compatibility.v1.json
+++ b/tests/fixtures/comfy_host_compatibility.v1.json
@@ -118,7 +118,7 @@
         },
         {
           "module": "easyuse_anima.nodes.regional_nodes",
-          "binder": "_bind_regional_node_runtime",
+          "binder": null,
           "root_observation": "call_time"
         },
         {

--- a/tests/fixtures/python_backend_baseline.json
+++ b/tests/fixtures/python_backend_baseline.json
@@ -41207,9 +41207,9 @@
       },
       {
         "is_package": false,
-        "loc": 516,
+        "loc": 519,
         "module": "easyuse_anima.nodes.regional_nodes",
-        "normalized_git_blob_sha1": "72313693ca62f81c38890da7b33df9827a52d5e1",
+        "normalized_git_blob_sha1": "4f712383ac34109210abddde52674f5f4152b1e3",
         "path": "easyuse_anima/nodes/regional_nodes.py",
         "top_level": {
           "class_count": 2,

--- a/tests/fixtures/python_backend_baseline.json
+++ b/tests/fixtures/python_backend_baseline.json
@@ -9987,6 +9987,114 @@
       },
       {
         "alias": null,
+        "bound_name": "_stable_change_key",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": "..common.serialization:_stable_change_key",
+        "kind": "static_from",
+        "line": 8,
+        "name": "_stable_change_key",
+        "optional": false,
+        "requested": "..common.serialization",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/nodes/prompt_advanced_nodes.py",
+        "target": "easyuse_anima/common/serialization.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_as_bool",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": "..common.values:_as_bool",
+        "kind": "static_from",
+        "line": 9,
+        "name": "_as_bool",
+        "optional": false,
+        "requested": "..common.values",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/nodes/prompt_advanced_nodes.py",
+        "target": "easyuse_anima/common/values.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_as_int",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": "..common.values:_as_int",
+        "kind": "static_from",
+        "line": 9,
+        "name": "_as_int",
+        "optional": false,
+        "requested": "..common.values",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/nodes/prompt_advanced_nodes.py",
+        "target": "easyuse_anima/common/values.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_single_value",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": "..common.values:_single_value",
+        "kind": "static_from",
+        "line": 9,
+        "name": "_single_value",
+        "optional": false,
+        "requested": "..common.values",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/nodes/prompt_advanced_nodes.py",
+        "target": "easyuse_anima/common/values.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_parse_random_response",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": "..naia.client:_parse_random_response",
+        "kind": "static_from",
+        "line": 10,
+        "name": "_parse_random_response",
+        "optional": false,
+        "requested": "..naia.client",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/nodes/prompt_advanced_nodes.py",
+        "target": "easyuse_anima/naia/client.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_post_random",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": "..naia.client:_post_random",
+        "kind": "static_from",
+        "line": 10,
+        "name": "_post_random",
+        "optional": false,
+        "requested": "..naia.client",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/nodes/prompt_advanced_nodes.py",
+        "target": "easyuse_anima/naia/client.py"
+      },
+      {
+        "alias": null,
         "bound_name": "CUSTOM_ADVANCED_RESOLUTION_BUCKET",
         "branch_context": [],
         "classification": "internal",
@@ -9994,7 +10102,7 @@
         "conditional": false,
         "imported": "..naia.resolution:CUSTOM_ADVANCED_RESOLUTION_BUCKET",
         "kind": "static_from",
-        "line": 8,
+        "line": 11,
         "name": "CUSTOM_ADVANCED_RESOLUTION_BUCKET",
         "optional": false,
         "requested": "..naia.resolution",
@@ -10012,7 +10120,7 @@
         "conditional": false,
         "imported": "..naia.resolution:DEFAULT_ADVANCED_RESOLUTION_BUCKET",
         "kind": "static_from",
-        "line": 8,
+        "line": 11,
         "name": "DEFAULT_ADVANCED_RESOLUTION_BUCKET",
         "optional": false,
         "requested": "..naia.resolution",
@@ -10030,7 +10138,7 @@
         "conditional": false,
         "imported": "..naia.resolution:DEFAULT_ADVANCED_RESOLUTION_SIZE",
         "kind": "static_from",
-        "line": 8,
+        "line": 11,
         "name": "DEFAULT_ADVANCED_RESOLUTION_SIZE",
         "optional": false,
         "requested": "..naia.resolution",
@@ -10048,8 +10156,62 @@
         "conditional": false,
         "imported": "..naia.resolution:NAIA_ADVANCED_RESOLUTION_BUCKET",
         "kind": "static_from",
-        "line": 8,
+        "line": 11,
         "name": "NAIA_ADVANCED_RESOLUTION_BUCKET",
+        "optional": false,
+        "requested": "..naia.resolution",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/nodes/prompt_advanced_nodes.py",
+        "target": "easyuse_anima/naia/resolution.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_advanced_resolution_from_selection",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": "..naia.resolution:_advanced_resolution_from_selection",
+        "kind": "static_from",
+        "line": 11,
+        "name": "_advanced_resolution_from_selection",
+        "optional": false,
+        "requested": "..naia.resolution",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/nodes/prompt_advanced_nodes.py",
+        "target": "easyuse_anima/naia/resolution.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_resolution_label",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": "..naia.resolution:_resolution_label",
+        "kind": "static_from",
+        "line": 11,
+        "name": "_resolution_label",
+        "optional": false,
+        "requested": "..naia.resolution",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/nodes/prompt_advanced_nodes.py",
+        "target": "easyuse_anima/naia/resolution.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_resolve_naia_resolution",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": "..naia.resolution:_resolve_naia_resolution",
+        "kind": "static_from",
+        "line": 11,
+        "name": "_resolve_naia_resolution",
         "optional": false,
         "requested": "..naia.resolution",
         "role": "ordinary",
@@ -10066,7 +10228,7 @@
         "conditional": false,
         "imported": "..prompt.advanced:ADVANCED_FIELDS_WORKFLOW_PROPERTY",
         "kind": "static_from",
-        "line": 14,
+        "line": 20,
         "name": "ADVANCED_FIELDS_WORKFLOW_PROPERTY",
         "optional": false,
         "requested": "..prompt.advanced",
@@ -10084,7 +10246,7 @@
         "conditional": false,
         "imported": "..prompt.advanced:EXTEND_PROMPT_SLOT_SPECS",
         "kind": "static_from",
-        "line": 14,
+        "line": 20,
         "name": "EXTEND_PROMPT_SLOT_SPECS",
         "optional": false,
         "requested": "..prompt.advanced",
@@ -10102,7 +10264,7 @@
         "conditional": false,
         "imported": "..prompt.advanced:PROMPT_STUDIO_ADVANCED_RETURN_NAMES",
         "kind": "static_from",
-        "line": 14,
+        "line": 20,
         "name": "PROMPT_STUDIO_ADVANCED_RETURN_NAMES",
         "optional": false,
         "requested": "..prompt.advanced",
@@ -10120,8 +10282,314 @@
         "conditional": false,
         "imported": "..prompt.advanced:PROMPT_STUDIO_ADVANCED_RETURN_TYPES",
         "kind": "static_from",
-        "line": 14,
+        "line": 20,
         "name": "PROMPT_STUDIO_ADVANCED_RETURN_TYPES",
+        "optional": false,
+        "requested": "..prompt.advanced",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/nodes/prompt_advanced_nodes.py",
+        "target": "easyuse_anima/prompt/advanced.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_advanced_enabled_naia_panes",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": "..prompt.advanced:_advanced_enabled_naia_panes",
+        "kind": "static_from",
+        "line": 20,
+        "name": "_advanced_enabled_naia_panes",
+        "optional": false,
+        "requested": "..prompt.advanced",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/nodes/prompt_advanced_nodes.py",
+        "target": "easyuse_anima/prompt/advanced.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_advanced_field_input_values",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": "..prompt.advanced:_advanced_field_input_values",
+        "kind": "static_from",
+        "line": 20,
+        "name": "_advanced_field_input_values",
+        "optional": false,
+        "requested": "..prompt.advanced",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/nodes/prompt_advanced_nodes.py",
+        "target": "easyuse_anima/prompt/advanced.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_advanced_fields_json",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": "..prompt.advanced:_advanced_fields_json",
+        "kind": "static_from",
+        "line": 20,
+        "name": "_advanced_fields_json",
+        "optional": false,
+        "requested": "..prompt.advanced",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/nodes/prompt_advanced_nodes.py",
+        "target": "easyuse_anima/prompt/advanced.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_advanced_has_enabled_naia",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": "..prompt.advanced:_advanced_has_enabled_naia",
+        "kind": "static_from",
+        "line": 20,
+        "name": "_advanced_has_enabled_naia",
+        "optional": false,
+        "requested": "..prompt.advanced",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/nodes/prompt_advanced_nodes.py",
+        "target": "easyuse_anima/prompt/advanced.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_advanced_uses_naia_resolution",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": "..prompt.advanced:_advanced_uses_naia_resolution",
+        "kind": "static_from",
+        "line": 20,
+        "name": "_advanced_uses_naia_resolution",
+        "optional": false,
+        "requested": "..prompt.advanced",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/nodes/prompt_advanced_nodes.py",
+        "target": "easyuse_anima/prompt/advanced.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_apply_advanced_field_inputs",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": "..prompt.advanced:_apply_advanced_field_inputs",
+        "kind": "static_from",
+        "line": 20,
+        "name": "_apply_advanced_field_inputs",
+        "optional": false,
+        "requested": "..prompt.advanced",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/nodes/prompt_advanced_nodes.py",
+        "target": "easyuse_anima/prompt/advanced.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_build_advanced_prompt_data",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": "..prompt.advanced:_build_advanced_prompt_data",
+        "kind": "static_from",
+        "line": 20,
+        "name": "_build_advanced_prompt_data",
+        "optional": false,
+        "requested": "..prompt.advanced",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/nodes/prompt_advanced_nodes.py",
+        "target": "easyuse_anima/prompt/advanced.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_build_advanced_prompts",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": "..prompt.advanced:_build_advanced_prompts",
+        "kind": "static_from",
+        "line": 20,
+        "name": "_build_advanced_prompts",
+        "optional": false,
+        "requested": "..prompt.advanced",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/nodes/prompt_advanced_nodes.py",
+        "target": "easyuse_anima/prompt/advanced.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_clone_advanced_fields",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": "..prompt.advanced:_clone_advanced_fields",
+        "kind": "static_from",
+        "line": 20,
+        "name": "_clone_advanced_fields",
+        "optional": false,
+        "requested": "..prompt.advanced",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/nodes/prompt_advanced_nodes.py",
+        "target": "easyuse_anima/prompt/advanced.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_expand_advanced_wildcard_fields",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": "..prompt.advanced:_expand_advanced_wildcard_fields",
+        "kind": "static_from",
+        "line": 20,
+        "name": "_expand_advanced_wildcard_fields",
+        "optional": false,
+        "requested": "..prompt.advanced",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/nodes/prompt_advanced_nodes.py",
+        "target": "easyuse_anima/prompt/advanced.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_normalize_advanced_fields",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": "..prompt.advanced:_normalize_advanced_fields",
+        "kind": "static_from",
+        "line": 20,
+        "name": "_normalize_advanced_fields",
+        "optional": false,
+        "requested": "..prompt.advanced",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/nodes/prompt_advanced_nodes.py",
+        "target": "easyuse_anima/prompt/advanced.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_normalize_prompt_studio_wildcard_seed_control",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": "..prompt.advanced:_normalize_prompt_studio_wildcard_seed_control",
+        "kind": "static_from",
+        "line": 20,
+        "name": "_normalize_prompt_studio_wildcard_seed_control",
+        "optional": false,
+        "requested": "..prompt.advanced",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/nodes/prompt_advanced_nodes.py",
+        "target": "easyuse_anima/prompt/advanced.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_set_naia_field_text",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": "..prompt.advanced:_set_naia_field_text",
+        "kind": "static_from",
+        "line": 20,
+        "name": "_set_naia_field_text",
+        "optional": false,
+        "requested": "..prompt.advanced",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/nodes/prompt_advanced_nodes.py",
+        "target": "easyuse_anima/prompt/advanced.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_translate_prompt_fields",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": "..prompt.advanced:_translate_prompt_fields",
+        "kind": "static_from",
+        "line": 20,
+        "name": "_translate_prompt_fields",
+        "optional": false,
+        "requested": "..prompt.advanced",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/nodes/prompt_advanced_nodes.py",
+        "target": "easyuse_anima/prompt/advanced.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_wildcard_engine_module",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": "..prompt.advanced:_wildcard_engine_module",
+        "kind": "static_from",
+        "line": 20,
+        "name": "_wildcard_engine_module",
+        "optional": false,
+        "requested": "..prompt.advanced",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/nodes/prompt_advanced_nodes.py",
+        "target": "easyuse_anima/prompt/advanced.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "normalize_prompt_studio_wildcard_mode",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": "..prompt.advanced:normalize_prompt_studio_wildcard_mode",
+        "kind": "static_from",
+        "line": 20,
+        "name": "normalize_prompt_studio_wildcard_mode",
+        "optional": false,
+        "requested": "..prompt.advanced",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/nodes/prompt_advanced_nodes.py",
+        "target": "easyuse_anima/prompt/advanced.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "normalize_seed",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": "..prompt.advanced:normalize_seed",
+        "kind": "static_from",
+        "line": 20,
+        "name": "normalize_seed",
         "optional": false,
         "requested": "..prompt.advanced",
         "role": "ordinary",
@@ -10138,7 +10606,7 @@
         "conditional": false,
         "imported": "..prompt.artist_mix:ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
         "kind": "static_from",
-        "line": 20,
+        "line": 43,
         "name": "ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
         "optional": false,
         "requested": "..prompt.artist_mix",
@@ -10156,7 +10624,7 @@
         "conditional": false,
         "imported": "..prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
         "kind": "static_from",
-        "line": 20,
+        "line": 43,
         "name": "ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
         "optional": false,
         "requested": "..prompt.artist_mix",
@@ -10174,7 +10642,7 @@
         "conditional": false,
         "imported": "..prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
         "kind": "static_from",
-        "line": 20,
+        "line": 43,
         "name": "ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
         "optional": false,
         "requested": "..prompt.artist_mix",
@@ -10192,7 +10660,7 @@
         "conditional": false,
         "imported": "..prompt.artist_mix:ARTIST_MIX_DEFAULT_EXACT_TOP_K",
         "kind": "static_from",
-        "line": 20,
+        "line": 43,
         "name": "ARTIST_MIX_DEFAULT_EXACT_TOP_K",
         "optional": false,
         "requested": "..prompt.artist_mix",
@@ -10210,7 +10678,7 @@
         "conditional": false,
         "imported": "..prompt.artist_mix:ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
         "kind": "static_from",
-        "line": 20,
+        "line": 43,
         "name": "ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
         "optional": false,
         "requested": "..prompt.artist_mix",
@@ -10228,7 +10696,7 @@
         "conditional": false,
         "imported": "..prompt.artist_mix:ARTIST_MIX_DEFAULT_START_PERCENT",
         "kind": "static_from",
-        "line": 20,
+        "line": 43,
         "name": "ARTIST_MIX_DEFAULT_START_PERCENT",
         "optional": false,
         "requested": "..prompt.artist_mix",
@@ -10246,7 +10714,7 @@
         "conditional": false,
         "imported": "..prompt.artist_mix:ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
         "kind": "static_from",
-        "line": 20,
+        "line": 43,
         "name": "ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
         "optional": false,
         "requested": "..prompt.artist_mix",
@@ -10264,7 +10732,7 @@
         "conditional": false,
         "imported": "..prompt.artist_mix:ARTIST_MIX_DEFAULT_STYLE_GAIN",
         "kind": "static_from",
-        "line": 20,
+        "line": 43,
         "name": "ARTIST_MIX_DEFAULT_STYLE_GAIN",
         "optional": false,
         "requested": "..prompt.artist_mix",
@@ -10282,7 +10750,7 @@
         "conditional": false,
         "imported": "..prompt.artist_mix:ARTIST_MIX_MODE_OFF",
         "kind": "static_from",
-        "line": 20,
+        "line": 43,
         "name": "ARTIST_MIX_MODE_OFF",
         "optional": false,
         "requested": "..prompt.artist_mix",
@@ -10300,7 +10768,7 @@
         "conditional": false,
         "imported": "..prompt.artist_mix:ARTIST_MIX_STUDIO_MODES",
         "kind": "static_from",
-        "line": 20,
+        "line": 43,
         "name": "ARTIST_MIX_STUDIO_MODES",
         "optional": false,
         "requested": "..prompt.artist_mix",
@@ -10311,6 +10779,114 @@
       },
       {
         "alias": null,
+        "bound_name": "_artist_mix_mode_tooltip",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": "..prompt.artist_mix:_artist_mix_mode_tooltip",
+        "kind": "static_from",
+        "line": 43,
+        "name": "_artist_mix_mode_tooltip",
+        "optional": false,
+        "requested": "..prompt.artist_mix",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/nodes/prompt_advanced_nodes.py",
+        "target": "easyuse_anima/prompt/artist_mix.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_bounded_artist_mix_float",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": "..prompt.artist_mix:_bounded_artist_mix_float",
+        "kind": "static_from",
+        "line": 43,
+        "name": "_bounded_artist_mix_float",
+        "optional": false,
+        "requested": "..prompt.artist_mix",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/nodes/prompt_advanced_nodes.py",
+        "target": "easyuse_anima/prompt/artist_mix.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_bounded_artist_mix_int",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": "..prompt.artist_mix:_bounded_artist_mix_int",
+        "kind": "static_from",
+        "line": 43,
+        "name": "_bounded_artist_mix_int",
+        "optional": false,
+        "requested": "..prompt.artist_mix",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/nodes/prompt_advanced_nodes.py",
+        "target": "easyuse_anima/prompt/artist_mix.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_normalize_artist_mix_mode",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": "..prompt.artist_mix:_normalize_artist_mix_mode",
+        "kind": "static_from",
+        "line": 43,
+        "name": "_normalize_artist_mix_mode",
+        "optional": false,
+        "requested": "..prompt.artist_mix",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/nodes/prompt_advanced_nodes.py",
+        "target": "easyuse_anima/prompt/artist_mix.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_prompt_translation_change_key",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": "..prompt.correction:_prompt_translation_change_key",
+        "kind": "static_from",
+        "line": 59,
+        "name": "_prompt_translation_change_key",
+        "optional": false,
+        "requested": "..prompt.correction",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/nodes/prompt_advanced_nodes.py",
+        "target": "easyuse_anima/prompt/correction.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_translate_prompt_text",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": "..prompt.correction:_translate_prompt_text",
+        "kind": "static_from",
+        "line": 59,
+        "name": "_translate_prompt_text",
+        "optional": false,
+        "requested": "..prompt.correction",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/nodes/prompt_advanced_nodes.py",
+        "target": "easyuse_anima/prompt/correction.py"
+      },
+      {
+        "alias": null,
         "bound_name": "PROMPT_DATA_TYPE",
         "branch_context": [],
         "classification": "internal",
@@ -10318,7 +10894,7 @@
         "conditional": false,
         "imported": "..prompt.data:PROMPT_DATA_TYPE",
         "kind": "static_from",
-        "line": 32,
+        "line": 63,
         "name": "PROMPT_DATA_TYPE",
         "optional": false,
         "requested": "..prompt.data",
@@ -10329,6 +10905,60 @@
       },
       {
         "alias": null,
+        "bound_name": "_prompt_data_parameter_snapshot",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": "..prompt.data:_prompt_data_parameter_snapshot",
+        "kind": "static_from",
+        "line": 63,
+        "name": "_prompt_data_parameter_snapshot",
+        "optional": false,
+        "requested": "..prompt.data",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/nodes/prompt_advanced_nodes.py",
+        "target": "easyuse_anima/prompt/data.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_consume_reserved_wildcard_next_seed",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": "..seed.compatibility:_consume_reserved_wildcard_next_seed",
+        "kind": "static_from",
+        "line": 64,
+        "name": "_consume_reserved_wildcard_next_seed",
+        "optional": false,
+        "requested": "..seed.compatibility",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/nodes/prompt_advanced_nodes.py",
+        "target": "easyuse_anima/seed/compatibility.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_get_workflow_node",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": "..workflow:_get_workflow_node",
+        "kind": "static_from",
+        "line": 65,
+        "name": "_get_workflow_node",
+        "optional": false,
+        "requested": "..workflow",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/nodes/prompt_advanced_nodes.py",
+        "target": "easyuse_anima/workflow.py"
+      },
+      {
+        "alias": null,
         "bound_name": "_FlexibleOptionalInputType",
         "branch_context": [],
         "classification": "internal",
@@ -10336,7 +10966,7 @@
         "conditional": false,
         "imported": ".input_types:_FlexibleOptionalInputType",
         "kind": "static_from",
-        "line": 33,
+        "line": 66,
         "name": "_FlexibleOptionalInputType",
         "optional": false,
         "requested": ".input_types",
@@ -10344,6 +10974,154 @@
         "scope": "<module>",
         "source": "easyuse_anima/nodes/prompt_advanced_nodes.py",
         "target": "easyuse_anima/nodes/input_types.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "EasyUseAnimaNAIARandomPrompt",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".naia_nodes:EasyUseAnimaNAIARandomPrompt",
+        "kind": "static_from",
+        "line": 67,
+        "name": "EasyUseAnimaNAIARandomPrompt",
+        "optional": false,
+        "requested": ".naia_nodes",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/nodes/prompt_advanced_nodes.py",
+        "target": "easyuse_anima/nodes/naia_nodes.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "resolve_metadata_filter_words",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 69
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "resolve_metadata_filter_words",
+          "target": "settings.py",
+          "try_line": 69
+        },
+        "conditional": true,
+        "imported": "...settings:resolve_metadata_filter_words",
+        "kind": "static_from",
+        "line": 70,
+        "name": "resolve_metadata_filter_words",
+        "optional": false,
+        "requested": "...settings",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "easyuse_anima/nodes/prompt_advanced_nodes.py",
+        "target": "settings.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "resolve_naia_settings",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 69
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "resolve_naia_settings",
+          "target": "settings.py",
+          "try_line": 69
+        },
+        "conditional": true,
+        "imported": "...settings:resolve_naia_settings",
+        "kind": "static_from",
+        "line": 70,
+        "name": "resolve_naia_settings",
+        "optional": false,
+        "requested": "...settings",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "easyuse_anima/nodes/prompt_advanced_nodes.py",
+        "target": "settings.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "resolve_metadata_filter_words",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 74,
+            "kind": "try",
+            "line": 69
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "resolve_metadata_filter_words",
+          "target": "settings.py",
+          "try_line": 69
+        },
+        "conditional": true,
+        "imported": "settings:resolve_metadata_filter_words",
+        "kind": "static_from",
+        "line": 75,
+        "name": "resolve_metadata_filter_words",
+        "optional": false,
+        "requested": "settings",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "easyuse_anima/nodes/prompt_advanced_nodes.py",
+        "target": "settings.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "resolve_naia_settings",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 74,
+            "kind": "try",
+            "line": 69
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "resolve_naia_settings",
+          "target": "settings.py",
+          "try_line": 69
+        },
+        "conditional": true,
+        "imported": "settings:resolve_naia_settings",
+        "kind": "static_from",
+        "line": 75,
+        "name": "resolve_naia_settings",
+        "optional": false,
+        "requested": "settings",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "easyuse_anima/nodes/prompt_advanced_nodes.py",
+        "target": "settings.py"
       },
       {
         "alias": null,
@@ -11581,6 +12359,96 @@
       },
       {
         "alias": null,
+        "bound_name": "_stable_change_key",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": "..common.serialization:_stable_change_key",
+        "kind": "static_from",
+        "line": 7,
+        "name": "_stable_change_key",
+        "optional": false,
+        "requested": "..common.serialization",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/nodes/regional_nodes.py",
+        "target": "easyuse_anima/common/serialization.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_as_bool",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": "..common.values:_as_bool",
+        "kind": "static_from",
+        "line": 8,
+        "name": "_as_bool",
+        "optional": false,
+        "requested": "..common.values",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/nodes/regional_nodes.py",
+        "target": "easyuse_anima/common/values.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_as_float",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": "..common.values:_as_float",
+        "kind": "static_from",
+        "line": 8,
+        "name": "_as_float",
+        "optional": false,
+        "requested": "..common.values",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/nodes/regional_nodes.py",
+        "target": "easyuse_anima/common/values.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_single_value",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": "..common.values:_single_value",
+        "kind": "static_from",
+        "line": 8,
+        "name": "_single_value",
+        "optional": false,
+        "requested": "..common.values",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/nodes/regional_nodes.py",
+        "target": "easyuse_anima/common/values.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "resolve_comfy_host_helper",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": "..infrastructure.comfy.wiring:resolve_comfy_host_helper",
+        "kind": "static_from",
+        "line": 9,
+        "name": "resolve_comfy_host_helper",
+        "optional": false,
+        "requested": "..infrastructure.comfy.wiring",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/nodes/regional_nodes.py",
+        "target": "easyuse_anima/infrastructure/comfy/wiring.py"
+      },
+      {
+        "alias": null,
         "bound_name": "DEFAULT_ADVANCED_RESOLUTION_BUCKET",
         "branch_context": [],
         "classification": "internal",
@@ -11588,7 +12456,7 @@
         "conditional": false,
         "imported": "..naia.resolution:DEFAULT_ADVANCED_RESOLUTION_BUCKET",
         "kind": "static_from",
-        "line": 7,
+        "line": 10,
         "name": "DEFAULT_ADVANCED_RESOLUTION_BUCKET",
         "optional": false,
         "requested": "..naia.resolution",
@@ -11606,7 +12474,7 @@
         "conditional": false,
         "imported": "..naia.resolution:DEFAULT_ADVANCED_RESOLUTION_SIZE",
         "kind": "static_from",
-        "line": 7,
+        "line": 10,
         "name": "DEFAULT_ADVANCED_RESOLUTION_SIZE",
         "optional": false,
         "requested": "..naia.resolution",
@@ -11617,6 +12485,168 @@
       },
       {
         "alias": null,
+        "bound_name": "_advanced_resolution_from_selection",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": "..naia.resolution:_advanced_resolution_from_selection",
+        "kind": "static_from",
+        "line": 10,
+        "name": "_advanced_resolution_from_selection",
+        "optional": false,
+        "requested": "..naia.resolution",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/nodes/regional_nodes.py",
+        "target": "easyuse_anima/naia/resolution.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_advanced_field_input_values",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": "..prompt.advanced:_advanced_field_input_values",
+        "kind": "static_from",
+        "line": 15,
+        "name": "_advanced_field_input_values",
+        "optional": false,
+        "requested": "..prompt.advanced",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/nodes/regional_nodes.py",
+        "target": "easyuse_anima/prompt/advanced.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_expand_advanced_wildcard_fields",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": "..prompt.advanced:_expand_advanced_wildcard_fields",
+        "kind": "static_from",
+        "line": 15,
+        "name": "_expand_advanced_wildcard_fields",
+        "optional": false,
+        "requested": "..prompt.advanced",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/nodes/regional_nodes.py",
+        "target": "easyuse_anima/prompt/advanced.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_normalize_prompt_studio_wildcard_seed_control",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": "..prompt.advanced:_normalize_prompt_studio_wildcard_seed_control",
+        "kind": "static_from",
+        "line": 15,
+        "name": "_normalize_prompt_studio_wildcard_seed_control",
+        "optional": false,
+        "requested": "..prompt.advanced",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/nodes/regional_nodes.py",
+        "target": "easyuse_anima/prompt/advanced.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_translate_prompt_fields",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": "..prompt.advanced:_translate_prompt_fields",
+        "kind": "static_from",
+        "line": 15,
+        "name": "_translate_prompt_fields",
+        "optional": false,
+        "requested": "..prompt.advanced",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/nodes/regional_nodes.py",
+        "target": "easyuse_anima/prompt/advanced.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_wildcard_engine_module",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": "..prompt.advanced:_wildcard_engine_module",
+        "kind": "static_from",
+        "line": 15,
+        "name": "_wildcard_engine_module",
+        "optional": false,
+        "requested": "..prompt.advanced",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/nodes/regional_nodes.py",
+        "target": "easyuse_anima/prompt/advanced.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "normalize_prompt_studio_wildcard_mode",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": "..prompt.advanced:normalize_prompt_studio_wildcard_mode",
+        "kind": "static_from",
+        "line": 15,
+        "name": "normalize_prompt_studio_wildcard_mode",
+        "optional": false,
+        "requested": "..prompt.advanced",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/nodes/regional_nodes.py",
+        "target": "easyuse_anima/prompt/advanced.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "normalize_seed",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": "..prompt.advanced:normalize_seed",
+        "kind": "static_from",
+        "line": 15,
+        "name": "normalize_seed",
+        "optional": false,
+        "requested": "..prompt.advanced",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/nodes/regional_nodes.py",
+        "target": "easyuse_anima/prompt/advanced.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_prompt_translation_change_key",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": "..prompt.correction:_prompt_translation_change_key",
+        "kind": "static_from",
+        "line": 24,
+        "name": "_prompt_translation_change_key",
+        "optional": false,
+        "requested": "..prompt.correction",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/nodes/regional_nodes.py",
+        "target": "easyuse_anima/prompt/correction.py"
+      },
+      {
+        "alias": null,
         "bound_name": "REGIONAL_CONFIG_WORKFLOW_PROPERTY",
         "branch_context": [],
         "classification": "internal",
@@ -11624,7 +12654,7 @@
         "conditional": false,
         "imported": "..prompt.regional:REGIONAL_CONFIG_WORKFLOW_PROPERTY",
         "kind": "static_from",
-        "line": 11,
+        "line": 25,
         "name": "REGIONAL_CONFIG_WORKFLOW_PROPERTY",
         "optional": false,
         "requested": "..prompt.regional",
@@ -11642,7 +12672,7 @@
         "conditional": false,
         "imported": "..prompt.regional:REGIONAL_FIELDS_WORKFLOW_PROPERTY",
         "kind": "static_from",
-        "line": 11,
+        "line": 25,
         "name": "REGIONAL_FIELDS_WORKFLOW_PROPERTY",
         "optional": false,
         "requested": "..prompt.regional",
@@ -11660,7 +12690,7 @@
         "conditional": false,
         "imported": "..prompt.regional:REGIONAL_PROMPT_DATA_TYPE",
         "kind": "static_from",
-        "line": 11,
+        "line": 25,
         "name": "REGIONAL_PROMPT_DATA_TYPE",
         "optional": false,
         "requested": "..prompt.regional",
@@ -11671,6 +12701,276 @@
       },
       {
         "alias": null,
+        "bound_name": "_apply_regional_field_inputs",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": "..prompt.regional:_apply_regional_field_inputs",
+        "kind": "static_from",
+        "line": 25,
+        "name": "_apply_regional_field_inputs",
+        "optional": false,
+        "requested": "..prompt.regional",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/nodes/regional_nodes.py",
+        "target": "easyuse_anima/prompt/regional.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_build_regional_outputs",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": "..prompt.regional:_build_regional_outputs",
+        "kind": "static_from",
+        "line": 25,
+        "name": "_build_regional_outputs",
+        "optional": false,
+        "requested": "..prompt.regional",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/nodes/regional_nodes.py",
+        "target": "easyuse_anima/prompt/regional.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_clone_regional_fields",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": "..prompt.regional:_clone_regional_fields",
+        "kind": "static_from",
+        "line": 25,
+        "name": "_clone_regional_fields",
+        "optional": false,
+        "requested": "..prompt.regional",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/nodes/regional_nodes.py",
+        "target": "easyuse_anima/prompt/regional.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_conditioning_set_values",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": "..prompt.regional:_conditioning_set_values",
+        "kind": "static_from",
+        "line": 25,
+        "name": "_conditioning_set_values",
+        "optional": false,
+        "requested": "..prompt.regional",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/nodes/regional_nodes.py",
+        "target": "easyuse_anima/prompt/regional.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_normalize_mask_ids",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": "..prompt.regional:_normalize_mask_ids",
+        "kind": "static_from",
+        "line": 25,
+        "name": "_normalize_mask_ids",
+        "optional": false,
+        "requested": "..prompt.regional",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/nodes/regional_nodes.py",
+        "target": "easyuse_anima/prompt/regional.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_normalize_regional_config",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": "..prompt.regional:_normalize_regional_config",
+        "kind": "static_from",
+        "line": 25,
+        "name": "_normalize_regional_config",
+        "optional": false,
+        "requested": "..prompt.regional",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/nodes/regional_nodes.py",
+        "target": "easyuse_anima/prompt/regional.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_normalize_regional_fields",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": "..prompt.regional:_normalize_regional_fields",
+        "kind": "static_from",
+        "line": 25,
+        "name": "_normalize_regional_fields",
+        "optional": false,
+        "requested": "..prompt.regional",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/nodes/regional_nodes.py",
+        "target": "easyuse_anima/prompt/regional.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_parse_json_object",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": "..prompt.regional:_parse_json_object",
+        "kind": "static_from",
+        "line": 25,
+        "name": "_parse_json_object",
+        "optional": false,
+        "requested": "..prompt.regional",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/nodes/regional_nodes.py",
+        "target": "easyuse_anima/prompt/regional.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_regional_config_json",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": "..prompt.regional:_regional_config_json",
+        "kind": "static_from",
+        "line": 25,
+        "name": "_regional_config_json",
+        "optional": false,
+        "requested": "..prompt.regional",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/nodes/regional_nodes.py",
+        "target": "easyuse_anima/prompt/regional.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_regional_fields_json",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": "..prompt.regional:_regional_fields_json",
+        "kind": "static_from",
+        "line": 25,
+        "name": "_regional_fields_json",
+        "optional": false,
+        "requested": "..prompt.regional",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/nodes/regional_nodes.py",
+        "target": "easyuse_anima/prompt/regional.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_regional_mask_bounds_area",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": "..prompt.regional:_regional_mask_bounds_area",
+        "kind": "static_from",
+        "line": 25,
+        "name": "_regional_mask_bounds_area",
+        "optional": false,
+        "requested": "..prompt.regional",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/nodes/regional_nodes.py",
+        "target": "easyuse_anima/prompt/regional.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_regional_payload_canvas",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": "..prompt.regional:_regional_payload_canvas",
+        "kind": "static_from",
+        "line": 25,
+        "name": "_regional_payload_canvas",
+        "optional": false,
+        "requested": "..prompt.regional",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/nodes/regional_nodes.py",
+        "target": "easyuse_anima/prompt/regional.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_regional_union_mask_for_ids",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": "..prompt.regional:_regional_union_mask_for_ids",
+        "kind": "static_from",
+        "line": 25,
+        "name": "_regional_union_mask_for_ids",
+        "optional": false,
+        "requested": "..prompt.regional",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/nodes/regional_nodes.py",
+        "target": "easyuse_anima/prompt/regional.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_consume_reserved_wildcard_next_seed",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": "..seed.compatibility:_consume_reserved_wildcard_next_seed",
+        "kind": "static_from",
+        "line": 43,
+        "name": "_consume_reserved_wildcard_next_seed",
+        "optional": false,
+        "requested": "..seed.compatibility",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/nodes/regional_nodes.py",
+        "target": "easyuse_anima/seed/compatibility.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_get_workflow_node",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": "..workflow:_get_workflow_node",
+        "kind": "static_from",
+        "line": 44,
+        "name": "_get_workflow_node",
+        "optional": false,
+        "requested": "..workflow",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/nodes/regional_nodes.py",
+        "target": "easyuse_anima/workflow.py"
+      },
+      {
+        "alias": null,
         "bound_name": "_FlexibleOptionalInputType",
         "branch_context": [],
         "classification": "internal",
@@ -11678,7 +12978,7 @@
         "conditional": false,
         "imported": ".input_types:_FlexibleOptionalInputType",
         "kind": "static_from",
-        "line": 16,
+        "line": 45,
         "name": "_FlexibleOptionalInputType",
         "optional": false,
         "requested": ".input_types",
@@ -11686,6 +12986,71 @@
         "scope": "<module>",
         "source": "easyuse_anima/nodes/regional_nodes.py",
         "target": "easyuse_anima/nodes/input_types.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "resolve_metadata_filter_words",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 47
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "resolve_metadata_filter_words",
+          "target": "settings.py",
+          "try_line": 47
+        },
+        "conditional": true,
+        "imported": "...settings:resolve_metadata_filter_words",
+        "kind": "static_from",
+        "line": 48,
+        "name": "resolve_metadata_filter_words",
+        "optional": false,
+        "requested": "...settings",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "easyuse_anima/nodes/regional_nodes.py",
+        "target": "settings.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "resolve_metadata_filter_words",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 49,
+            "kind": "try",
+            "line": 47
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "resolve_metadata_filter_words",
+          "target": "settings.py",
+          "try_line": 47
+        },
+        "conditional": true,
+        "imported": "settings:resolve_metadata_filter_words",
+        "kind": "static_from",
+        "line": 50,
+        "name": "resolve_metadata_filter_words",
+        "optional": false,
+        "requested": "settings",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "easyuse_anima/nodes/regional_nodes.py",
+        "target": "settings.py"
       },
       {
         "alias": null,
@@ -22604,37 +23969,6 @@
         "target": "easyuse_anima/nodes/prompt_advanced_nodes.py"
       },
       {
-        "alias": "_bind_prompt_advanced_node_runtime",
-        "bound_name": "_bind_prompt_advanced_node_runtime",
-        "branch_context": [
-          {
-            "branch": "body",
-            "handles_import_failure": true,
-            "has_import_fallback_handler": true,
-            "kind": "try",
-            "line": 9
-          }
-        ],
-        "classification": "internal",
-        "column": 4,
-        "compatibility_pair": {
-          "bound_name": "_bind_prompt_advanced_node_runtime",
-          "target": "easyuse_anima/nodes/prompt_advanced_nodes.py",
-          "try_line": 9
-        },
-        "conditional": true,
-        "imported": ".easyuse_anima.nodes.prompt_advanced_nodes:_bind_prompt_advanced_node_runtime",
-        "kind": "static_from",
-        "line": 361,
-        "name": "_bind_prompt_advanced_node_runtime",
-        "optional": false,
-        "requested": ".easyuse_anima.nodes.prompt_advanced_nodes",
-        "role": "compatibility_primary",
-        "scope": "<module>",
-        "source": "nodes.py",
-        "target": "easyuse_anima/nodes/prompt_advanced_nodes.py"
-      },
-      {
         "alias": "EasyUseAnimaAIOGenerator",
         "bound_name": "EasyUseAnimaAIOGenerator",
         "branch_context": [
@@ -22656,7 +23990,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.aio_nodes:EasyUseAnimaAIOGenerator",
         "kind": "static_from",
-        "line": 367,
+        "line": 366,
         "name": "EasyUseAnimaAIOGenerator",
         "optional": false,
         "requested": ".easyuse_anima.nodes.aio_nodes",
@@ -22687,7 +24021,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.aio_nodes:EasyUseAnimaInput",
         "kind": "static_from",
-        "line": 367,
+        "line": 366,
         "name": "EasyUseAnimaInput",
         "optional": false,
         "requested": ".easyuse_anima.nodes.aio_nodes",
@@ -22718,7 +24052,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.aio_nodes:_aio_generation_settings_json",
         "kind": "static_from",
-        "line": 367,
+        "line": 366,
         "name": "_aio_generation_settings_json",
         "optional": false,
         "requested": ".easyuse_anima.nodes.aio_nodes",
@@ -22749,7 +24083,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.aio_nodes:_aio_input_settings_json",
         "kind": "static_from",
-        "line": 367,
+        "line": 366,
         "name": "_aio_input_settings_json",
         "optional": false,
         "requested": ".easyuse_anima.nodes.aio_nodes",
@@ -22780,7 +24114,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.aio_nodes:_bind_aio_node_runtime",
         "kind": "static_from",
-        "line": 367,
+        "line": 366,
         "name": "_bind_aio_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.aio_nodes",
@@ -22811,7 +24145,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.aio_nodes:_easy_use_anima_input_signature",
         "kind": "static_from",
-        "line": 367,
+        "line": 366,
         "name": "_easy_use_anima_input_signature",
         "optional": false,
         "requested": ".easyuse_anima.nodes.aio_nodes",
@@ -22842,7 +24176,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.aio_nodes:_require_easy_use_anima_input",
         "kind": "static_from",
-        "line": 367,
+        "line": 366,
         "name": "_require_easy_use_anima_input",
         "optional": false,
         "requested": ".easyuse_anima.nodes.aio_nodes",
@@ -22873,7 +24207,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.geometry:_align_down",
         "kind": "static_from",
-        "line": 376,
+        "line": 375,
         "name": "_align_down",
         "optional": false,
         "requested": ".easyuse_anima.image.geometry",
@@ -22904,7 +24238,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.geometry:_align_nearest",
         "kind": "static_from",
-        "line": 376,
+        "line": 375,
         "name": "_align_nearest",
         "optional": false,
         "requested": ".easyuse_anima.image.geometry",
@@ -22935,7 +24269,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.geometry:_image_tensor_size",
         "kind": "static_from",
-        "line": 376,
+        "line": 375,
         "name": "_image_tensor_size",
         "optional": false,
         "requested": ".easyuse_anima.image.geometry",
@@ -22966,7 +24300,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.sam3:_context_value",
         "kind": "static_from",
-        "line": 387,
+        "line": 386,
         "name": "_context_value",
         "optional": false,
         "requested": ".easyuse_anima.image.sam3",
@@ -22997,7 +24331,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.sam3:_sam3_context",
         "kind": "static_from",
-        "line": 387,
+        "line": 386,
         "name": "_sam3_context",
         "optional": false,
         "requested": ".easyuse_anima.image.sam3",
@@ -23028,7 +24362,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.sam3:_segs_has_items",
         "kind": "static_from",
-        "line": 387,
+        "line": 386,
         "name": "_segs_has_items",
         "optional": false,
         "requested": ".easyuse_anima.image.sam3",
@@ -23059,7 +24393,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.scaling:IMAGE_SCALE_MULTIPLES",
         "kind": "static_from",
-        "line": 399,
+        "line": 398,
         "name": "IMAGE_SCALE_MULTIPLES",
         "optional": false,
         "requested": ".easyuse_anima.image.scaling",
@@ -23090,7 +24424,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.scaling:IMAGE_UPSCALE_METHODS",
         "kind": "static_from",
-        "line": 399,
+        "line": 398,
         "name": "IMAGE_UPSCALE_METHODS",
         "optional": false,
         "requested": ".easyuse_anima.image.scaling",
@@ -23121,7 +24455,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_comfy_sampler_names",
         "kind": "static_from",
-        "line": 407,
+        "line": 406,
         "name": "_comfy_sampler_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -23152,7 +24486,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_comfy_scheduler_names",
         "kind": "static_from",
-        "line": 407,
+        "line": 406,
         "name": "_comfy_scheduler_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -23183,7 +24517,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_impact_scheduler_names",
         "kind": "static_from",
-        "line": 407,
+        "line": 406,
         "name": "_impact_scheduler_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -23214,7 +24548,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.invocation:_call_with_supported_kwargs",
         "kind": "static_from",
-        "line": 413,
+        "line": 412,
         "name": "_call_with_supported_kwargs",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.invocation",
@@ -23245,7 +24579,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.invocation:_common_upscale_image",
         "kind": "static_from",
-        "line": 413,
+        "line": 412,
         "name": "_common_upscale_image",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.invocation",
@@ -23276,7 +24610,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.invocation:_node_output_tuple",
         "kind": "static_from",
-        "line": 413,
+        "line": 412,
         "name": "_node_output_tuple",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.invocation",
@@ -23307,7 +24641,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.wiring:resolve_comfy_host_helper",
         "kind": "static_from",
-        "line": 418,
+        "line": 417,
         "name": "resolve_comfy_host_helper",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.wiring",
@@ -23338,7 +24672,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_comfy_clip_loader_types",
         "kind": "static_from",
-        "line": 421,
+        "line": 420,
         "name": "_comfy_clip_loader_types",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -23369,7 +24703,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_comfy_diffusion_model_names",
         "kind": "static_from",
-        "line": 421,
+        "line": 420,
         "name": "_comfy_diffusion_model_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -23400,7 +24734,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_comfy_text_encoder_names",
         "kind": "static_from",
-        "line": 421,
+        "line": 420,
         "name": "_comfy_text_encoder_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -23431,7 +24765,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_comfy_vae_names",
         "kind": "static_from",
-        "line": 421,
+        "line": 420,
         "name": "_comfy_vae_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -23462,7 +24796,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_folder_path_names",
         "kind": "static_from",
-        "line": 421,
+        "line": 420,
         "name": "_folder_path_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -23493,7 +24827,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.image_nodes:EasyUseAnimaDetailerAlignHook",
         "kind": "static_from",
-        "line": 429,
+        "line": 428,
         "name": "EasyUseAnimaDetailerAlignHook",
         "optional": false,
         "requested": ".easyuse_anima.nodes.image_nodes",
@@ -23524,7 +24858,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.image_nodes:EasyUseAnimaImageScaleByMultiple",
         "kind": "static_from",
-        "line": 429,
+        "line": 428,
         "name": "EasyUseAnimaImageScaleByMultiple",
         "optional": false,
         "requested": ".easyuse_anima.nodes.image_nodes",
@@ -23555,7 +24889,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Context",
         "kind": "static_from",
-        "line": 433,
+        "line": 432,
         "name": "EasyUseAnimaSAM3Context",
         "optional": false,
         "requested": ".easyuse_anima.nodes.sam3_nodes",
@@ -23586,7 +24920,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Detailer",
         "kind": "static_from",
-        "line": 433,
+        "line": 432,
         "name": "EasyUseAnimaSAM3Detailer",
         "optional": false,
         "requested": ".easyuse_anima.nodes.sam3_nodes",
@@ -23617,7 +24951,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptBuilder",
         "kind": "static_from",
-        "line": 437,
+        "line": 436,
         "name": "EasyUseAnimaPromptBuilder",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_nodes",
@@ -23648,7 +24982,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrector",
         "kind": "static_from",
-        "line": 437,
+        "line": 436,
         "name": "EasyUseAnimaPromptCorrector",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_nodes",
@@ -23679,7 +25013,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrectorSimple",
         "kind": "static_from",
-        "line": 437,
+        "line": 436,
         "name": "EasyUseAnimaPromptCorrectorSimple",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_nodes",
@@ -23710,7 +25044,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptStudio",
         "kind": "static_from",
-        "line": 437,
+        "line": 436,
         "name": "EasyUseAnimaPromptStudio",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_nodes",
@@ -23741,7 +25075,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.regional_nodes:EasyUseAnimaPromptStudioRegional",
         "kind": "static_from",
-        "line": 443,
+        "line": 442,
         "name": "EasyUseAnimaPromptStudioRegional",
         "optional": false,
         "requested": ".easyuse_anima.nodes.regional_nodes",
@@ -23772,39 +25106,8 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.regional_nodes:EasyUseAnimaRegionalConditioning",
         "kind": "static_from",
-        "line": 443,
+        "line": 442,
         "name": "EasyUseAnimaRegionalConditioning",
-        "optional": false,
-        "requested": ".easyuse_anima.nodes.regional_nodes",
-        "role": "compatibility_primary",
-        "scope": "<module>",
-        "source": "nodes.py",
-        "target": "easyuse_anima/nodes/regional_nodes.py"
-      },
-      {
-        "alias": "_bind_regional_node_runtime",
-        "bound_name": "_bind_regional_node_runtime",
-        "branch_context": [
-          {
-            "branch": "body",
-            "handles_import_failure": true,
-            "has_import_fallback_handler": true,
-            "kind": "try",
-            "line": 9
-          }
-        ],
-        "classification": "internal",
-        "column": 4,
-        "compatibility_pair": {
-          "bound_name": "_bind_regional_node_runtime",
-          "target": "easyuse_anima/nodes/regional_nodes.py",
-          "try_line": 9
-        },
-        "conditional": true,
-        "imported": ".easyuse_anima.nodes.regional_nodes:_bind_regional_node_runtime",
-        "kind": "static_from",
-        "line": 443,
-        "name": "_bind_regional_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.regional_nodes",
         "role": "compatibility_primary",
@@ -23834,7 +25137,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.client:LATENT_ALIGN",
         "kind": "static_from",
-        "line": 448,
+        "line": 446,
         "name": "LATENT_ALIGN",
         "optional": false,
         "requested": ".easyuse_anima.naia.client",
@@ -23865,7 +25168,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.client:_parse_random_response",
         "kind": "static_from",
-        "line": 448,
+        "line": 446,
         "name": "_parse_random_response",
         "optional": false,
         "requested": ".easyuse_anima.naia.client",
@@ -23896,7 +25199,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.client:_post_random",
         "kind": "static_from",
-        "line": 448,
+        "line": 446,
         "name": "_post_random",
         "optional": false,
         "requested": ".easyuse_anima.naia.client",
@@ -23927,7 +25230,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_advanced_resolution_from_selection",
         "kind": "static_from",
-        "line": 466,
+        "line": 464,
         "name": "_advanced_resolution_from_selection",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -23958,7 +25261,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_normalize_resolution_bucket",
         "kind": "static_from",
-        "line": 466,
+        "line": 464,
         "name": "_normalize_resolution_bucket",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -23989,7 +25292,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_ratio_label",
         "kind": "static_from",
-        "line": 466,
+        "line": 464,
         "name": "_ratio_label",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -24020,7 +25323,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_resolution_label",
         "kind": "static_from",
-        "line": 466,
+        "line": 464,
         "name": "_resolution_label",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -24051,7 +25354,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_resolve_naia_resolution",
         "kind": "static_from",
-        "line": 466,
+        "line": 464,
         "name": "_resolve_naia_resolution",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -24082,7 +25385,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.naia_nodes:EasyUseAnimaNAIARandomPrompt",
         "kind": "static_from",
-        "line": 489,
+        "line": 487,
         "name": "EasyUseAnimaNAIARandomPrompt",
         "optional": false,
         "requested": ".easyuse_anima.nodes.naia_nodes",
@@ -24113,7 +25416,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.naia_nodes:_bind_naia_node_runtime",
         "kind": "static_from",
-        "line": 489,
+        "line": 487,
         "name": "_bind_naia_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.naia_nodes",
@@ -24144,7 +25447,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.wildcard_nodes:EasyUseAnimaWildcard",
         "kind": "static_from",
-        "line": 493,
+        "line": 491,
         "name": "EasyUseAnimaWildcard",
         "optional": false,
         "requested": ".easyuse_anima.nodes.wildcard_nodes",
@@ -24175,7 +25478,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.wildcard_nodes:_bind_wildcard_node_runtime",
         "kind": "static_from",
-        "line": 493,
+        "line": 491,
         "name": "_bind_wildcard_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.wildcard_nodes",
@@ -24206,7 +25509,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_apply_lora_syntax_format",
         "kind": "static_from",
-        "line": 498,
+        "line": 496,
         "name": "_apply_lora_syntax_format",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -24237,7 +25540,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_dedupe_text_values",
         "kind": "static_from",
-        "line": 498,
+        "line": 496,
         "name": "_dedupe_text_values",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -24268,7 +25571,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_fallback_lora_path",
         "kind": "static_from",
-        "line": 498,
+        "line": 496,
         "name": "_fallback_lora_path",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -24299,7 +25602,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_get_lora_info",
         "kind": "static_from",
-        "line": 498,
+        "line": 496,
         "name": "_get_lora_info",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -24330,7 +25633,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_get_lora_manager_trigger_words",
         "kind": "static_from",
-        "line": 498,
+        "line": 496,
         "name": "_get_lora_manager_trigger_words",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -24361,7 +25664,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_load_lora_manager_metadata",
         "kind": "static_from",
-        "line": 498,
+        "line": 496,
         "name": "_load_lora_manager_metadata",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -24392,7 +25695,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_lora_combo_values",
         "kind": "static_from",
-        "line": 498,
+        "line": 496,
         "name": "_lora_combo_values",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -24423,7 +25726,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_lora_manager_trigger_words_from_metadata",
         "kind": "static_from",
-        "line": 498,
+        "line": 496,
         "name": "_lora_manager_trigger_words_from_metadata",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -24454,7 +25757,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_lora_model_exists",
         "kind": "static_from",
-        "line": 498,
+        "line": 496,
         "name": "_lora_model_exists",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -24485,7 +25788,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_lora_stack_name",
         "kind": "static_from",
-        "line": 498,
+        "line": 496,
         "name": "_lora_stack_name",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -24516,7 +25819,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_metadata_json_paths_for_lora",
         "kind": "static_from",
-        "line": 498,
+        "line": 496,
         "name": "_metadata_json_paths_for_lora",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -24547,7 +25850,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_missing_lora_display_name",
         "kind": "static_from",
-        "line": 498,
+        "line": 496,
         "name": "_missing_lora_display_name",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -24578,7 +25881,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_raise_missing_loras",
         "kind": "static_from",
-        "line": 498,
+        "line": 496,
         "name": "_raise_missing_loras",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -24609,7 +25912,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_trigger_words_from_value",
         "kind": "static_from",
-        "line": 498,
+        "line": 496,
         "name": "_trigger_words_from_value",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -24640,7 +25943,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_correct_style_prompt",
         "kind": "static_from",
-        "line": 514,
+        "line": 512,
         "name": "_correct_style_prompt",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -24671,7 +25974,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_format_strength",
         "kind": "static_from",
-        "line": 514,
+        "line": 512,
         "name": "_format_strength",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -24702,7 +26005,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_get_loras_list",
         "kind": "static_from",
-        "line": 514,
+        "line": 512,
         "name": "_get_loras_list",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -24733,7 +26036,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_load_profile_data",
         "kind": "static_from",
-        "line": 514,
+        "line": 512,
         "name": "_load_profile_data",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -24764,7 +26067,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_profile_key",
         "kind": "static_from",
-        "line": 514,
+        "line": 512,
         "name": "_profile_key",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -24795,7 +26098,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_select_profile_values",
         "kind": "static_from",
-        "line": 514,
+        "line": 512,
         "name": "_select_profile_values",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -24826,7 +26129,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_wrap_profile_index",
         "kind": "static_from",
-        "line": 514,
+        "line": 512,
         "name": "_wrap_profile_index",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -24857,7 +26160,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.lora_nodes:EasyUseAnimaLoraPreset",
         "kind": "static_from",
-        "line": 523,
+        "line": 521,
         "name": "EasyUseAnimaLoraPreset",
         "optional": false,
         "requested": ".easyuse_anima.nodes.lora_nodes",
@@ -24888,7 +26191,7 @@
         "conditional": true,
         "imported": ".anima_prompt:correct_prompt",
         "kind": "static_from",
-        "line": 526,
+        "line": 524,
         "name": "correct_prompt",
         "optional": false,
         "requested": ".anima_prompt",
@@ -24919,7 +26222,7 @@
         "conditional": true,
         "imported": ".anima_prompt:load_knowledge_base",
         "kind": "static_from",
-        "line": 526,
+        "line": 524,
         "name": "load_knowledge_base",
         "optional": false,
         "requested": ".anima_prompt",
@@ -24950,7 +26253,7 @@
         "conditional": true,
         "imported": ".anima_prompt.parser:parse_prompt",
         "kind": "static_from",
-        "line": 527,
+        "line": 525,
         "name": "parse_prompt",
         "optional": false,
         "requested": ".anima_prompt.parser",
@@ -24981,7 +26284,7 @@
         "conditional": true,
         "imported": ".settings:resolve_metadata_filter_words",
         "kind": "static_from",
-        "line": 528,
+        "line": 526,
         "name": "resolve_metadata_filter_words",
         "optional": false,
         "requested": ".settings",
@@ -25012,7 +26315,7 @@
         "conditional": true,
         "imported": ".settings:resolve_naia_settings",
         "kind": "static_from",
-        "line": 528,
+        "line": 526,
         "name": "resolve_naia_settings",
         "optional": false,
         "requested": ".settings",
@@ -25043,7 +26346,7 @@
         "conditional": true,
         "imported": ".settings:resolve_prompt_translation_settings",
         "kind": "static_from",
-        "line": 528,
+        "line": 526,
         "name": "resolve_prompt_translation_settings",
         "optional": false,
         "requested": ".settings",
@@ -25074,7 +26377,7 @@
         "conditional": true,
         "imported": ".prompt_translation:has_prompt_translation_markers",
         "kind": "static_from",
-        "line": 533,
+        "line": 531,
         "name": "has_prompt_translation_markers",
         "optional": false,
         "requested": ".prompt_translation",
@@ -25105,7 +26408,7 @@
         "conditional": true,
         "imported": ".prompt_translation:translate_prompt_markers",
         "kind": "static_from",
-        "line": 533,
+        "line": 531,
         "name": "translate_prompt_markers",
         "optional": false,
         "requested": ".prompt_translation",
@@ -25136,7 +26439,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:MAX_SEED",
         "kind": "static_from",
-        "line": 534,
+        "line": 532,
         "name": "MAX_SEED",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -25167,7 +26470,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "kind": "static_from",
-        "line": 534,
+        "line": 532,
         "name": "PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -25198,7 +26501,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:PUBLIC_MAX_SEED",
         "kind": "static_from",
-        "line": 534,
+        "line": 532,
         "name": "PUBLIC_MAX_SEED",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -25229,7 +26532,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_DECREMENT",
         "kind": "static_from",
-        "line": 534,
+        "line": 532,
         "name": "SEED_CONTROL_DECREMENT",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -25260,7 +26563,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_FIXED",
         "kind": "static_from",
-        "line": 534,
+        "line": 532,
         "name": "SEED_CONTROL_FIXED",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -25291,7 +26594,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_INCREMENT",
         "kind": "static_from",
-        "line": 534,
+        "line": 532,
         "name": "SEED_CONTROL_INCREMENT",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -25322,7 +26625,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_MODES",
         "kind": "static_from",
-        "line": 534,
+        "line": 532,
         "name": "SEED_CONTROL_MODES",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -25353,7 +26656,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_RANDOMIZE",
         "kind": "static_from",
-        "line": 534,
+        "line": 532,
         "name": "SEED_CONTROL_RANDOMIZE",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -25384,7 +26687,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:WILDCARD_MODE_FIXED",
         "kind": "static_from",
-        "line": 534,
+        "line": 532,
         "name": "WILDCARD_MODE_FIXED",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -25415,7 +26718,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:WILDCARD_MODE_POPULATE",
         "kind": "static_from",
-        "line": 534,
+        "line": 532,
         "name": "WILDCARD_MODE_POPULATE",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -25446,7 +26749,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:WILDCARD_MODE_SEQUENTIAL",
         "kind": "static_from",
-        "line": 534,
+        "line": 532,
         "name": "WILDCARD_MODE_SEQUENTIAL",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -25477,7 +26780,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:expand_wildcard_texts",
         "kind": "static_from",
-        "line": 534,
+        "line": 532,
         "name": "expand_wildcard_texts",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -25508,7 +26811,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:expand_wildcards",
         "kind": "static_from",
-        "line": 534,
+        "line": 532,
         "name": "expand_wildcards",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -25539,7 +26842,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:has_wildcard_syntax",
         "kind": "static_from",
-        "line": 534,
+        "line": 532,
         "name": "has_wildcard_syntax",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -25570,7 +26873,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:next_seed",
         "kind": "static_from",
-        "line": 534,
+        "line": 532,
         "name": "next_seed",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -25601,7 +26904,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:normalize_prompt_studio_wildcard_mode",
         "kind": "static_from",
-        "line": 534,
+        "line": 532,
         "name": "normalize_prompt_studio_wildcard_mode",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -25632,7 +26935,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:normalize_seed",
         "kind": "static_from",
-        "line": 534,
+        "line": 532,
         "name": "normalize_seed",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -25663,7 +26966,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:normalize_wildcard_mode",
         "kind": "static_from",
-        "line": 534,
+        "line": 532,
         "name": "normalize_wildcard_mode",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -25694,7 +26997,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:wildcard_sources_signature",
         "kind": "static_from",
-        "line": 534,
+        "line": 532,
         "name": "wildcard_sources_signature",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -25713,7 +27016,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -25728,7 +27031,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:AIO_FIRST_PASS_CACHE_MAX_ENTRIES",
         "kind": "static_from",
-        "line": 556,
+        "line": 554,
         "name": "AIO_FIRST_PASS_CACHE_MAX_ENTRIES",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -25747,7 +27050,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -25762,7 +27065,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_AIO_FIRST_PASS_CACHE",
         "kind": "static_from",
-        "line": 556,
+        "line": 554,
         "name": "_AIO_FIRST_PASS_CACHE",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -25781,7 +27084,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -25796,7 +27099,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_AIO_FIRST_PASS_CACHE_ORDER",
         "kind": "static_from",
-        "line": 556,
+        "line": 554,
         "name": "_AIO_FIRST_PASS_CACHE_ORDER",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -25815,7 +27118,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -25830,7 +27133,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_aio_first_pass_cache_key",
         "kind": "static_from",
-        "line": 556,
+        "line": 554,
         "name": "_aio_first_pass_cache_key",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -25849,7 +27152,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -25864,7 +27167,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_bind_aio_first_pass_cache_runtime",
         "kind": "static_from",
-        "line": 556,
+        "line": 554,
         "name": "_bind_aio_first_pass_cache_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -25883,7 +27186,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -25898,7 +27201,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_clone_aio_cache_value",
         "kind": "static_from",
-        "line": 556,
+        "line": 554,
         "name": "_clone_aio_cache_value",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -25917,7 +27220,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -25932,7 +27235,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_get_aio_first_pass_cache",
         "kind": "static_from",
-        "line": 556,
+        "line": 554,
         "name": "_get_aio_first_pass_cache",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -25951,7 +27254,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -25966,7 +27269,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_put_aio_first_pass_cache",
         "kind": "static_from",
-        "line": 556,
+        "line": 554,
         "name": "_put_aio_first_pass_cache",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -25985,7 +27288,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -26000,7 +27303,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_bind_aio_legacy_generation_runtime",
         "kind": "static_from",
-        "line": 567,
+        "line": 565,
         "name": "_bind_aio_legacy_generation_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.legacy_generation",
@@ -26019,7 +27322,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -26034,7 +27337,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_detailer_stage",
         "kind": "static_from",
-        "line": 567,
+        "line": 565,
         "name": "_run_aio_detailer_stage",
         "optional": false,
         "requested": "easyuse_anima.aio.legacy_generation",
@@ -26053,7 +27356,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -26068,7 +27371,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_detailer_target",
         "kind": "static_from",
-        "line": 567,
+        "line": 565,
         "name": "_run_aio_detailer_target",
         "optional": false,
         "requested": "easyuse_anima.aio.legacy_generation",
@@ -26087,7 +27390,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -26102,7 +27405,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_highres_stage",
         "kind": "static_from",
-        "line": 567,
+        "line": 565,
         "name": "_run_aio_highres_stage",
         "optional": false,
         "requested": "easyuse_anima.aio.legacy_generation",
@@ -26121,7 +27424,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -26136,7 +27439,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_legacy_generation",
         "kind": "static_from",
-        "line": 567,
+        "line": 565,
         "name": "_run_aio_legacy_generation",
         "optional": false,
         "requested": "easyuse_anima.aio.legacy_generation",
@@ -26155,7 +27458,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -26170,7 +27473,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_resshift_upscale_stage",
         "kind": "static_from",
-        "line": 567,
+        "line": 565,
         "name": "_run_aio_resshift_upscale_stage",
         "optional": false,
         "requested": "easyuse_anima.aio.legacy_generation",
@@ -26189,7 +27492,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -26204,7 +27507,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_upscale_stage",
         "kind": "static_from",
-        "line": 567,
+        "line": 565,
         "name": "_run_aio_upscale_stage",
         "optional": false,
         "requested": "easyuse_anima.aio.legacy_generation",
@@ -26223,7 +27526,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -26238,7 +27541,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_usdu_upscale_stage",
         "kind": "static_from",
-        "line": 567,
+        "line": 565,
         "name": "_run_aio_usdu_upscale_stage",
         "optional": false,
         "requested": "easyuse_anima.aio.legacy_generation",
@@ -26257,7 +27560,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -26272,7 +27575,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEEDS",
         "kind": "static_from",
-        "line": 577,
+        "line": 575,
         "name": "AIO_SPECIAL_SEEDS",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -26291,7 +27594,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -26306,7 +27609,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEED_DECREMENT",
         "kind": "static_from",
-        "line": 577,
+        "line": 575,
         "name": "AIO_SPECIAL_SEED_DECREMENT",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -26325,7 +27628,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -26340,7 +27643,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEED_INCREMENT",
         "kind": "static_from",
-        "line": 577,
+        "line": 575,
         "name": "AIO_SPECIAL_SEED_INCREMENT",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -26359,7 +27662,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -26374,7 +27677,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEED_RANDOM",
         "kind": "static_from",
-        "line": 577,
+        "line": 575,
         "name": "AIO_SPECIAL_SEED_RANDOM",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -26393,7 +27696,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -26408,7 +27711,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_AIO_DETAILER_CUSTOM_RE",
         "kind": "static_from",
-        "line": 577,
+        "line": 575,
         "name": "_AIO_DETAILER_CUSTOM_RE",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -26427,7 +27730,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -26442,7 +27745,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_AIO_DETAILER_RESERVED_KEYS",
         "kind": "static_from",
-        "line": 577,
+        "line": 575,
         "name": "_AIO_DETAILER_RESERVED_KEYS",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -26461,7 +27764,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -26476,7 +27779,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_aio_detailer_has_enabled_targets",
         "kind": "static_from",
-        "line": 577,
+        "line": 575,
         "name": "_aio_detailer_has_enabled_targets",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -26495,7 +27798,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -26510,7 +27813,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_aio_detailer_target_defaults",
         "kind": "static_from",
-        "line": 577,
+        "line": 575,
         "name": "_aio_detailer_target_defaults",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -26529,7 +27832,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -26544,7 +27847,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_aio_detailer_target_order",
         "kind": "static_from",
-        "line": 577,
+        "line": 575,
         "name": "_aio_detailer_target_order",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -26563,7 +27866,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -26578,7 +27881,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_bind_aio_generation_normalization_runtime",
         "kind": "static_from",
-        "line": 577,
+        "line": 575,
         "name": "_bind_aio_generation_normalization_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -26597,7 +27900,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -26612,7 +27915,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_is_aio_detailer_target_name",
         "kind": "static_from",
-        "line": 577,
+        "line": 575,
         "name": "_is_aio_detailer_target_name",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -26631,7 +27934,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -26646,7 +27949,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_merge_versioned_settings",
         "kind": "static_from",
-        "line": 577,
+        "line": 575,
         "name": "_merge_versioned_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -26665,7 +27968,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -26680,7 +27983,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_dit_corrections_settings",
         "kind": "static_from",
-        "line": 577,
+        "line": 575,
         "name": "_normalize_aio_dit_corrections_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -26699,7 +28002,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -26714,7 +28017,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_generation_settings",
         "kind": "static_from",
-        "line": 577,
+        "line": 575,
         "name": "_normalize_aio_generation_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -26733,7 +28036,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -26748,7 +28051,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_seed",
         "kind": "static_from",
-        "line": 577,
+        "line": 575,
         "name": "_normalize_aio_seed",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -26767,7 +28070,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -26782,7 +28085,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_spectrum_settings",
         "kind": "static_from",
-        "line": 577,
+        "line": 575,
         "name": "_normalize_aio_spectrum_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -26801,7 +28104,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -26816,7 +28119,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_settings:round_trip_aio_generation_settings",
         "kind": "static_from",
-        "line": 595,
+        "line": 593,
         "name": "round_trip_aio_generation_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_settings",
@@ -26835,7 +28138,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -26850,7 +28153,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.usdu:_aio_usdu_auto_tile_dimension",
         "kind": "static_from",
-        "line": 598,
+        "line": 596,
         "name": "_aio_usdu_auto_tile_dimension",
         "optional": false,
         "requested": "easyuse_anima.aio.usdu",
@@ -26869,7 +28172,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -26884,7 +28187,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.usdu:_aio_usdu_tile_plan",
         "kind": "static_from",
-        "line": 598,
+        "line": 596,
         "name": "_aio_usdu_tile_plan",
         "optional": false,
         "requested": "easyuse_anima.aio.usdu",
@@ -26903,7 +28206,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -26918,7 +28221,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.usdu:_bind_aio_usdu_planning_runtime",
         "kind": "static_from",
-        "line": 598,
+        "line": 596,
         "name": "_bind_aio_usdu_planning_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.usdu",
@@ -26937,7 +28240,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -26952,7 +28255,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_aio_final_fit_size",
         "kind": "static_from",
-        "line": 603,
+        "line": 601,
         "name": "_aio_final_fit_size",
         "optional": false,
         "requested": "easyuse_anima.aio.postprocess",
@@ -26971,7 +28274,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -26986,7 +28289,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_apply_aio_final_fit",
         "kind": "static_from",
-        "line": 603,
+        "line": 601,
         "name": "_apply_aio_final_fit",
         "optional": false,
         "requested": "easyuse_anima.aio.postprocess",
@@ -27005,7 +28308,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -27020,7 +28323,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_bind_aio_postprocess_runtime",
         "kind": "static_from",
-        "line": 603,
+        "line": 601,
         "name": "_bind_aio_postprocess_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.postprocess",
@@ -27039,7 +28342,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -27054,7 +28357,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_resize_image_to_size_if_needed",
         "kind": "static_from",
-        "line": 603,
+        "line": 601,
         "name": "_resize_image_to_size_if_needed",
         "optional": false,
         "requested": "easyuse_anima.aio.postprocess",
@@ -27073,7 +28376,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -27088,7 +28391,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_run_aio_postprocess_stage",
         "kind": "static_from",
-        "line": 603,
+        "line": 601,
         "name": "_run_aio_postprocess_stage",
         "optional": false,
         "requested": "easyuse_anima.aio.postprocess",
@@ -27107,7 +28410,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -27122,7 +28425,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_prompt_data_fields_for_usdu",
         "kind": "static_from",
-        "line": 610,
+        "line": 608,
         "name": "_aio_prompt_data_fields_for_usdu",
         "optional": false,
         "requested": "easyuse_anima.aio.conditioning",
@@ -27141,7 +28444,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -27156,7 +28459,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_usdu_conditioning",
         "kind": "static_from",
-        "line": 610,
+        "line": 608,
         "name": "_aio_usdu_conditioning",
         "optional": false,
         "requested": "easyuse_anima.aio.conditioning",
@@ -27175,7 +28478,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -27190,7 +28493,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_usdu_prompt_without_general",
         "kind": "static_from",
-        "line": 610,
+        "line": 608,
         "name": "_aio_usdu_prompt_without_general",
         "optional": false,
         "requested": "easyuse_anima.aio.conditioning",
@@ -27209,7 +28512,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -27224,7 +28527,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_bind_aio_conditioning_runtime",
         "kind": "static_from",
-        "line": 610,
+        "line": 608,
         "name": "_bind_aio_conditioning_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.conditioning",
@@ -27243,7 +28546,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -27258,7 +28561,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_aio_lora_stack_signature",
         "kind": "static_from",
-        "line": 616,
+        "line": 614,
         "name": "_aio_lora_stack_signature",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -27277,7 +28580,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -27292,7 +28595,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_anima_dave_patch",
         "kind": "static_from",
-        "line": 616,
+        "line": 614,
         "name": "_apply_aio_anima_dave_patch",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -27311,7 +28614,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -27326,7 +28629,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_kj_model_patches",
         "kind": "static_from",
-        "line": 616,
+        "line": 614,
         "name": "_apply_aio_kj_model_patches",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -27345,7 +28648,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -27360,7 +28663,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_lora_stack",
         "kind": "static_from",
-        "line": 616,
+        "line": 614,
         "name": "_apply_aio_lora_stack",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -27379,7 +28682,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -27394,7 +28697,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_model_patches",
         "kind": "static_from",
-        "line": 616,
+        "line": 614,
         "name": "_apply_aio_model_patches",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -27413,7 +28716,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -27428,7 +28731,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_safe_pag_patch",
         "kind": "static_from",
-        "line": 616,
+        "line": 614,
         "name": "_apply_aio_safe_pag_patch",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -27447,7 +28750,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -27462,7 +28765,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_correction_patch_for_comfy_sampler",
         "kind": "static_from",
-        "line": 616,
+        "line": 614,
         "name": "_apply_aio_spectrum_correction_patch_for_comfy_sampler",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -27481,7 +28784,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -27496,7 +28799,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_forecast_patch_for_comfy_sampler",
         "kind": "static_from",
-        "line": 616,
+        "line": 614,
         "name": "_apply_aio_spectrum_forecast_patch_for_comfy_sampler",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -27515,7 +28818,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -27530,7 +28833,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_model_patches_for_comfy_sampler",
         "kind": "static_from",
-        "line": 616,
+        "line": 614,
         "name": "_apply_aio_spectrum_model_patches_for_comfy_sampler",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -27549,7 +28852,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -27564,7 +28867,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_bind_aio_model_preparation_runtime",
         "kind": "static_from",
-        "line": 616,
+        "line": 614,
         "name": "_bind_aio_model_preparation_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -27583,7 +28886,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -27598,7 +28901,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_cleanup_aio_ephemeral_model",
         "kind": "static_from",
-        "line": 616,
+        "line": 614,
         "name": "_cleanup_aio_ephemeral_model",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -27617,7 +28920,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -27632,7 +28935,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_normalize_aio_lora_stack",
         "kind": "static_from",
-        "line": 616,
+        "line": 614,
         "name": "_normalize_aio_lora_stack",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -27651,7 +28954,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -27666,7 +28969,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_patch_model_sampling_aura_flow",
         "kind": "static_from",
-        "line": 616,
+        "line": 614,
         "name": "_patch_model_sampling_aura_flow",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -27685,7 +28988,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -27700,7 +29003,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_aio_highres_effective_backend",
         "kind": "static_from",
-        "line": 631,
+        "line": 629,
         "name": "_aio_highres_effective_backend",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -27719,7 +29022,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -27734,7 +29037,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_aio_stage_sampler_settings",
         "kind": "static_from",
-        "line": 631,
+        "line": 629,
         "name": "_aio_stage_sampler_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -27753,7 +29056,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -27768,7 +29071,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_bind_aio_sampling_runtime",
         "kind": "static_from",
-        "line": 631,
+        "line": 629,
         "name": "_bind_aio_sampling_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -27787,7 +29090,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -27802,7 +29105,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_decode_latent_with_comfy",
         "kind": "static_from",
-        "line": 631,
+        "line": 629,
         "name": "_decode_latent_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -27821,7 +29124,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -27836,7 +29139,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_encode_image_with_comfy_vae",
         "kind": "static_from",
-        "line": 631,
+        "line": 629,
         "name": "_encode_image_with_comfy_vae",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -27855,7 +29158,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -27870,7 +29173,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_generate_empty_latent_with_comfy",
         "kind": "static_from",
-        "line": 631,
+        "line": 629,
         "name": "_generate_empty_latent_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -27889,7 +29192,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -27904,7 +29207,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_new_aio_random_seed",
         "kind": "static_from",
-        "line": 631,
+        "line": 629,
         "name": "_new_aio_random_seed",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -27923,7 +29226,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -27938,7 +29241,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_resolve_aio_runtime_seed",
         "kind": "static_from",
-        "line": 631,
+        "line": 629,
         "name": "_resolve_aio_runtime_seed",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -27957,7 +29260,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -27972,7 +29275,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_aio_backend",
         "kind": "static_from",
-        "line": 631,
+        "line": 629,
         "name": "_sample_latent_with_aio_backend",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -27991,7 +29294,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -28006,7 +29309,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_comfy",
         "kind": "static_from",
-        "line": 631,
+        "line": 629,
         "name": "_sample_latent_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -28025,7 +29328,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -28040,7 +29343,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_spectrum_mod_guidance_advanced",
         "kind": "static_from",
-        "line": 631,
+        "line": 629,
         "name": "_sample_latent_with_spectrum_mod_guidance_advanced",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -28059,7 +29362,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -28074,7 +29377,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_spectrum_spd",
         "kind": "static_from",
-        "line": 631,
+        "line": 629,
         "name": "_sample_latent_with_spectrum_spd",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -28093,7 +29396,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -28108,7 +29411,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_CACHE_FORMAT",
         "kind": "static_from",
-        "line": 645,
+        "line": 643,
         "name": "AIO_PREVIEW_CACHE_FORMAT",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -28127,7 +29430,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -28142,7 +29445,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_CACHE_QUALITY",
         "kind": "static_from",
-        "line": 645,
+        "line": 643,
         "name": "AIO_PREVIEW_CACHE_QUALITY",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -28161,7 +29464,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -28176,7 +29479,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_EVENT",
         "kind": "static_from",
-        "line": 645,
+        "line": 643,
         "name": "AIO_PREVIEW_EVENT",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -28195,7 +29498,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -28210,7 +29513,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_STAGE_LABELS",
         "kind": "static_from",
-        "line": 645,
+        "line": 643,
         "name": "AIO_PREVIEW_STAGE_LABELS",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -28229,7 +29532,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -28244,7 +29547,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_aio_preview_base_directory",
         "kind": "static_from",
-        "line": 645,
+        "line": 643,
         "name": "_aio_preview_base_directory",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -28263,7 +29566,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -28278,7 +29581,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_aio_preview_file_size_bytes",
         "kind": "static_from",
-        "line": 645,
+        "line": 643,
         "name": "_aio_preview_file_size_bytes",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -28297,7 +29600,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -28312,7 +29615,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_bind_aio_preview_runtime",
         "kind": "static_from",
-        "line": 645,
+        "line": 643,
         "name": "_bind_aio_preview_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -28331,7 +29634,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -28346,7 +29649,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_save_aio_temp_preview_image",
         "kind": "static_from",
-        "line": 645,
+        "line": 643,
         "name": "_save_aio_temp_preview_image",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -28365,7 +29668,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -28380,7 +29683,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_send_aio_preview_event",
         "kind": "static_from",
-        "line": 645,
+        "line": 643,
         "name": "_send_aio_preview_event",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -28399,7 +29702,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -28414,7 +29717,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_tag_aio_preview_images",
         "kind": "static_from",
-        "line": 645,
+        "line": 643,
         "name": "_tag_aio_preview_images",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -28433,7 +29736,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -28448,7 +29751,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_image_saver_additional_hashes",
         "kind": "static_from",
-        "line": 657,
+        "line": 655,
         "name": "_aio_image_saver_additional_hashes",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -28467,7 +29770,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -28482,7 +29785,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_image_saver_civitai_hash_fetcher_entries",
         "kind": "static_from",
-        "line": 657,
+        "line": 655,
         "name": "_aio_image_saver_civitai_hash_fetcher_entries",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -28501,7 +29804,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -28516,7 +29819,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_lora_metadata_name",
         "kind": "static_from",
-        "line": 657,
+        "line": 655,
         "name": "_aio_lora_metadata_name",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -28535,7 +29838,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -28550,7 +29853,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_prompt_with_lora_metadata",
         "kind": "static_from",
-        "line": 657,
+        "line": 655,
         "name": "_aio_prompt_with_lora_metadata",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -28569,7 +29872,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -28584,7 +29887,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_save_filename_prefix",
         "kind": "static_from",
-        "line": 657,
+        "line": 655,
         "name": "_aio_save_filename_prefix",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -28603,7 +29906,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -28618,7 +29921,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_bind_aio_output_runtime",
         "kind": "static_from",
-        "line": 657,
+        "line": 655,
         "name": "_bind_aio_output_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -28637,7 +29940,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -28652,7 +29955,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_normalize_aio_civitai_hash_fetchers",
         "kind": "static_from",
-        "line": 657,
+        "line": 655,
         "name": "_normalize_aio_civitai_hash_fetchers",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -28671,7 +29974,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -28686,7 +29989,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_normalize_aio_hash_bundles",
         "kind": "static_from",
-        "line": 657,
+        "line": 655,
         "name": "_normalize_aio_hash_bundles",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -28705,7 +30008,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -28720,7 +30023,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_save_image_with_comfy",
         "kind": "static_from",
-        "line": 657,
+        "line": 655,
         "name": "_save_image_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -28739,7 +30042,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -28754,7 +30057,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_save_image_with_image_saver",
         "kind": "static_from",
-        "line": 657,
+        "line": 655,
         "name": "_save_image_with_image_saver",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -28773,7 +30076,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -28788,7 +30091,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_bind_aio_resource_runtime",
         "kind": "static_from",
-        "line": 669,
+        "line": 667,
         "name": "_bind_aio_resource_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -28807,7 +30110,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -28822,7 +30125,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_clip_loader_types",
         "kind": "static_from",
-        "line": 669,
+        "line": 667,
         "name": "_comfy_clip_loader_types",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -28841,7 +30144,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -28856,7 +30159,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_diffusion_model_names",
         "kind": "static_from",
-        "line": 669,
+        "line": 667,
         "name": "_comfy_diffusion_model_names",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -28875,7 +30178,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -28890,7 +30193,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_text_encoder_names",
         "kind": "static_from",
-        "line": 669,
+        "line": 667,
         "name": "_comfy_text_encoder_names",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -28909,7 +30212,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -28924,7 +30227,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_vae_names",
         "kind": "static_from",
-        "line": 669,
+        "line": 667,
         "name": "_comfy_vae_names",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -28943,7 +30246,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -28958,7 +30261,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_aio_resources_from_input_context",
         "kind": "static_from",
-        "line": 669,
+        "line": 667,
         "name": "_load_aio_resources_from_input_context",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -28977,7 +30280,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -28992,7 +30295,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_aio_sam3_context",
         "kind": "static_from",
-        "line": 669,
+        "line": 667,
         "name": "_load_aio_sam3_context",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -29011,7 +30314,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -29026,7 +30329,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_checkpoint_with_comfy",
         "kind": "static_from",
-        "line": 669,
+        "line": 667,
         "name": "_load_checkpoint_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -29045,7 +30348,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -29060,7 +30363,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_clip_with_comfy",
         "kind": "static_from",
-        "line": 669,
+        "line": 667,
         "name": "_load_clip_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -29079,7 +30382,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -29094,7 +30397,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_diffusion_model_with_comfy",
         "kind": "static_from",
-        "line": 669,
+        "line": 667,
         "name": "_load_diffusion_model_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -29113,7 +30416,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -29128,7 +30431,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_upscale_model_with_comfy",
         "kind": "static_from",
-        "line": 669,
+        "line": 667,
         "name": "_load_upscale_model_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -29147,7 +30450,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -29162,7 +30465,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_vae_with_comfy",
         "kind": "static_from",
-        "line": 669,
+        "line": 667,
         "name": "_load_vae_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -29181,7 +30484,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -29196,7 +30499,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_normalize_aio_input_settings",
         "kind": "static_from",
-        "line": 669,
+        "line": 667,
         "name": "_normalize_aio_input_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -29215,7 +30518,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -29230,7 +30533,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_checkpoint_default",
         "kind": "static_from",
-        "line": 669,
+        "line": 667,
         "name": "_preferred_checkpoint_default",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -29249,7 +30552,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -29264,7 +30567,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_clip_type_default",
         "kind": "static_from",
-        "line": 669,
+        "line": 667,
         "name": "_preferred_clip_type_default",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -29283,7 +30586,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -29298,7 +30601,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_name_default",
         "kind": "static_from",
-        "line": 669,
+        "line": 667,
         "name": "_preferred_name_default",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -29317,7 +30620,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -29332,7 +30635,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_json_clone",
         "kind": "static_from",
-        "line": 687,
+        "line": 685,
         "name": "_json_clone",
         "optional": false,
         "requested": "easyuse_anima.common.serialization",
@@ -29351,7 +30654,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -29366,7 +30669,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_json_object",
         "kind": "static_from",
-        "line": 687,
+        "line": 685,
         "name": "_json_object",
         "optional": false,
         "requested": "easyuse_anima.common.serialization",
@@ -29385,7 +30688,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -29400,7 +30703,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_stable_change_key",
         "kind": "static_from",
-        "line": 687,
+        "line": 685,
         "name": "_stable_change_key",
         "optional": false,
         "requested": "easyuse_anima.common.serialization",
@@ -29419,7 +30722,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -29434,7 +30737,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_bool",
         "kind": "static_from",
-        "line": 692,
+        "line": 690,
         "name": "_as_bool",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -29453,7 +30756,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -29468,7 +30771,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_float",
         "kind": "static_from",
-        "line": 692,
+        "line": 690,
         "name": "_as_float",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -29487,7 +30790,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -29502,7 +30805,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_int",
         "kind": "static_from",
-        "line": 692,
+        "line": 690,
         "name": "_as_int",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -29521,7 +30824,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -29536,7 +30839,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_choice",
         "kind": "static_from",
-        "line": 692,
+        "line": 690,
         "name": "_choice",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -29555,7 +30858,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -29570,7 +30873,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_single_value",
         "kind": "static_from",
-        "line": 692,
+        "line": 690,
         "name": "_single_value",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -29589,7 +30892,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -29604,7 +30907,7 @@
         "conditional": true,
         "imported": "easyuse_anima.seed.compatibility:WILDCARD_QUEUE_MAX_SAFE_SEED",
         "kind": "static_from",
-        "line": 699,
+        "line": 697,
         "name": "WILDCARD_QUEUE_MAX_SAFE_SEED",
         "optional": false,
         "requested": "easyuse_anima.seed.compatibility",
@@ -29623,7 +30926,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -29638,7 +30941,7 @@
         "conditional": true,
         "imported": "easyuse_anima.seed.compatibility:WILDCARD_RESERVED_NEXT_SEED_INPUT",
         "kind": "static_from",
-        "line": 699,
+        "line": 697,
         "name": "WILDCARD_RESERVED_NEXT_SEED_INPUT",
         "optional": false,
         "requested": "easyuse_anima.seed.compatibility",
@@ -29657,7 +30960,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -29672,7 +30975,7 @@
         "conditional": true,
         "imported": "easyuse_anima.seed.compatibility:_consume_reserved_wildcard_next_seed",
         "kind": "static_from",
-        "line": 699,
+        "line": 697,
         "name": "_consume_reserved_wildcard_next_seed",
         "optional": false,
         "requested": "easyuse_anima.seed.compatibility",
@@ -29691,7 +30994,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -29706,7 +31009,7 @@
         "conditional": true,
         "imported": "easyuse_anima.workflow:_get_workflow_node",
         "kind": "static_from",
-        "line": 704,
+        "line": 702,
         "name": "_get_workflow_node",
         "optional": false,
         "requested": "easyuse_anima.workflow",
@@ -29725,7 +31028,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -29740,7 +31043,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_prompt_translation_change_key",
         "kind": "static_from",
-        "line": 705,
+        "line": 703,
         "name": "_prompt_translation_change_key",
         "optional": false,
         "requested": "easyuse_anima.prompt.correction",
@@ -29759,7 +31062,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -29774,7 +31077,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_split_tag_text",
         "kind": "static_from",
-        "line": 705,
+        "line": 703,
         "name": "_split_tag_text",
         "optional": false,
         "requested": "easyuse_anima.prompt.correction",
@@ -29793,7 +31096,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -29808,7 +31111,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_translate_prompt_text",
         "kind": "static_from",
-        "line": 705,
+        "line": 703,
         "name": "_translate_prompt_text",
         "optional": false,
         "requested": "easyuse_anima.prompt.correction",
@@ -29827,7 +31130,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -29842,7 +31145,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_HASH_COMMENT_RE",
         "kind": "static_from",
-        "line": 710,
+        "line": 708,
         "name": "_HASH_COMMENT_RE",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -29861,7 +31164,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -29876,7 +31179,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_INLINE_SPACE_RE",
         "kind": "static_from",
-        "line": 710,
+        "line": 708,
         "name": "_INLINE_SPACE_RE",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -29895,7 +31198,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -29910,7 +31213,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_WEIGHTED_TOKEN_RE",
         "kind": "static_from",
-        "line": 710,
+        "line": 708,
         "name": "_WEIGHTED_TOKEN_RE",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -29929,7 +31232,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -29944,7 +31247,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_correct_builder_prompt",
         "kind": "static_from",
-        "line": 710,
+        "line": 708,
         "name": "_correct_builder_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -29963,7 +31266,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -29978,7 +31281,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_filter_metadata_prompt",
         "kind": "static_from",
-        "line": 710,
+        "line": 708,
         "name": "_filter_metadata_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -29997,7 +31300,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -30012,7 +31315,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_join_prompt_tokens",
         "kind": "static_from",
-        "line": 710,
+        "line": 708,
         "name": "_join_prompt_tokens",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -30031,7 +31334,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -30046,7 +31349,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_metadata_filter_key",
         "kind": "static_from",
-        "line": 710,
+        "line": 708,
         "name": "_metadata_filter_key",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -30065,7 +31368,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -30080,7 +31383,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_metadata_filter_keys",
         "kind": "static_from",
-        "line": 710,
+        "line": 708,
         "name": "_metadata_filter_keys",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -30099,7 +31402,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -30114,7 +31417,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_prompt_tokens",
         "kind": "static_from",
-        "line": 710,
+        "line": 708,
         "name": "_prompt_tokens",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -30133,7 +31436,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -30148,7 +31451,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:PROMPT_DATA_TYPE",
         "kind": "static_from",
-        "line": 723,
+        "line": 721,
         "name": "PROMPT_DATA_TYPE",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -30167,7 +31470,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -30182,7 +31485,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_advanced_outputs_from_prompt_data",
         "kind": "static_from",
-        "line": 723,
+        "line": 721,
         "name": "_advanced_outputs_from_prompt_data",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -30201,7 +31504,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -30216,7 +31519,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_apply_prompt_data_overrides",
         "kind": "static_from",
-        "line": 723,
+        "line": 721,
         "name": "_apply_prompt_data_overrides",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -30235,7 +31538,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -30250,7 +31553,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_copy_prompt_data_for_update",
         "kind": "static_from",
-        "line": 723,
+        "line": 721,
         "name": "_copy_prompt_data_for_update",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -30269,7 +31572,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -30284,7 +31587,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_normalize_prompt_data",
         "kind": "static_from",
-        "line": 723,
+        "line": 721,
         "name": "_normalize_prompt_data",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -30303,7 +31606,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -30318,7 +31621,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_prompt_data_json_safe",
         "kind": "static_from",
-        "line": 723,
+        "line": 721,
         "name": "_prompt_data_json_safe",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -30337,7 +31640,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -30352,7 +31655,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_prompt_data_parameter_snapshot",
         "kind": "static_from",
-        "line": 723,
+        "line": 721,
         "name": "_prompt_data_parameter_snapshot",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -30371,7 +31674,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -30386,7 +31689,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_artist_field_prompt",
         "kind": "static_from",
-        "line": 741,
+        "line": 739,
         "name": "_advanced_artist_field_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -30405,7 +31708,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -30420,7 +31723,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_default_fields",
         "kind": "static_from",
-        "line": 741,
+        "line": 739,
         "name": "_advanced_default_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -30439,7 +31742,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -30454,7 +31757,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_enabled_naia_panes",
         "kind": "static_from",
-        "line": 741,
+        "line": 739,
         "name": "_advanced_enabled_naia_panes",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -30473,7 +31776,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -30488,7 +31791,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_enabled_pane_fields",
         "kind": "static_from",
-        "line": 741,
+        "line": 739,
         "name": "_advanced_enabled_pane_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -30507,7 +31810,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -30522,7 +31825,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_field_input_values",
         "kind": "static_from",
-        "line": 741,
+        "line": 739,
         "name": "_advanced_field_input_values",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -30541,7 +31844,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -30556,7 +31859,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_field_socket_name",
         "kind": "static_from",
-        "line": 741,
+        "line": 739,
         "name": "_advanced_field_socket_name",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -30575,7 +31878,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -30590,7 +31893,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_fields_json",
         "kind": "static_from",
-        "line": 741,
+        "line": 739,
         "name": "_advanced_fields_json",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -30609,7 +31912,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -30624,7 +31927,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_has_enabled_naia",
         "kind": "static_from",
-        "line": 741,
+        "line": 739,
         "name": "_advanced_has_enabled_naia",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -30643,7 +31946,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -30658,7 +31961,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_prompt_with_artist_override",
         "kind": "static_from",
-        "line": 741,
+        "line": 739,
         "name": "_advanced_prompt_with_artist_override",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -30677,7 +31980,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -30692,7 +31995,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_uses_naia_resolution",
         "kind": "static_from",
-        "line": 741,
+        "line": 739,
         "name": "_advanced_uses_naia_resolution",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -30711,7 +32014,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -30726,7 +32029,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_apply_advanced_field_inputs",
         "kind": "static_from",
-        "line": 741,
+        "line": 739,
         "name": "_apply_advanced_field_inputs",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -30745,7 +32048,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -30760,7 +32063,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_as_advanced_height",
         "kind": "static_from",
-        "line": 741,
+        "line": 739,
         "name": "_as_advanced_height",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -30779,7 +32082,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -30794,7 +32097,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_build_advanced_prompt_data",
         "kind": "static_from",
-        "line": 741,
+        "line": 739,
         "name": "_build_advanced_prompt_data",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -30813,7 +32116,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -30828,7 +32131,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_build_advanced_prompts",
         "kind": "static_from",
-        "line": 741,
+        "line": 739,
         "name": "_build_advanced_prompts",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -30847,7 +32150,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -30862,7 +32165,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_clone_advanced_fields",
         "kind": "static_from",
-        "line": 741,
+        "line": 739,
         "name": "_clone_advanced_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -30881,7 +32184,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -30896,7 +32199,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_correct_advanced_field_sequence",
         "kind": "static_from",
-        "line": 741,
+        "line": 739,
         "name": "_correct_advanced_field_sequence",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -30915,7 +32218,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -30930,7 +32233,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_expand_advanced_wildcard_fields",
         "kind": "static_from",
-        "line": 741,
+        "line": 739,
         "name": "_expand_advanced_wildcard_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -30949,7 +32252,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -30964,7 +32267,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_normalize_advanced_fields",
         "kind": "static_from",
-        "line": 741,
+        "line": 739,
         "name": "_normalize_advanced_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -30983,7 +32286,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -30998,7 +32301,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_normalize_prompt_studio_wildcard_seed_control",
         "kind": "static_from",
-        "line": 741,
+        "line": 739,
         "name": "_normalize_prompt_studio_wildcard_seed_control",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -31017,7 +32320,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -31032,7 +32335,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_set_naia_field_text",
         "kind": "static_from",
-        "line": 741,
+        "line": 739,
         "name": "_set_naia_field_text",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -31051,7 +32354,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -31066,7 +32369,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_translate_prompt_fields",
         "kind": "static_from",
-        "line": 741,
+        "line": 739,
         "name": "_translate_prompt_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -31085,7 +32388,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -31100,7 +32403,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_apply_regional_field_inputs",
         "kind": "static_from",
-        "line": 776,
+        "line": 774,
         "name": "_apply_regional_field_inputs",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -31119,7 +32422,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -31134,7 +32437,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_build_regional_outputs",
         "kind": "static_from",
-        "line": 776,
+        "line": 774,
         "name": "_build_regional_outputs",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -31153,7 +32456,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -31168,7 +32471,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_clone_regional_fields",
         "kind": "static_from",
-        "line": 776,
+        "line": 774,
         "name": "_clone_regional_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -31187,7 +32490,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -31202,7 +32505,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_conditioning_set_values",
         "kind": "static_from",
-        "line": 776,
+        "line": 774,
         "name": "_conditioning_set_values",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -31221,7 +32524,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -31236,7 +32539,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_mask_ids",
         "kind": "static_from",
-        "line": 776,
+        "line": 774,
         "name": "_normalize_mask_ids",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -31255,7 +32558,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -31270,7 +32573,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_regional_config",
         "kind": "static_from",
-        "line": 776,
+        "line": 774,
         "name": "_normalize_regional_config",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -31289,7 +32592,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -31304,7 +32607,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_regional_fields",
         "kind": "static_from",
-        "line": 776,
+        "line": 774,
         "name": "_normalize_regional_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -31323,7 +32626,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -31338,7 +32641,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_parse_json_object",
         "kind": "static_from",
-        "line": 776,
+        "line": 774,
         "name": "_parse_json_object",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -31357,7 +32660,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -31372,7 +32675,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_config_json",
         "kind": "static_from",
-        "line": 776,
+        "line": 774,
         "name": "_regional_config_json",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -31391,7 +32694,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -31406,7 +32709,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_fields_json",
         "kind": "static_from",
-        "line": 776,
+        "line": 774,
         "name": "_regional_fields_json",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -31425,7 +32728,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -31440,7 +32743,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_mask_bounds_area",
         "kind": "static_from",
-        "line": 776,
+        "line": 774,
         "name": "_regional_mask_bounds_area",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -31459,7 +32762,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -31474,7 +32777,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_payload_canvas",
         "kind": "static_from",
-        "line": 776,
+        "line": 774,
         "name": "_regional_payload_canvas",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -31493,7 +32796,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -31508,7 +32811,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_union_mask_for_ids",
         "kind": "static_from",
-        "line": 776,
+        "line": 774,
         "name": "_regional_union_mask_for_ids",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -31527,7 +32830,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -31542,7 +32845,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
         "kind": "static_from",
-        "line": 803,
+        "line": 801,
         "name": "ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -31561,7 +32864,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -31576,7 +32879,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODES",
         "kind": "static_from",
-        "line": 803,
+        "line": 801,
         "name": "ANIMA_MOD_GUIDANCE_MODES",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -31595,7 +32898,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -31610,7 +32913,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 803,
+        "line": 801,
         "name": "ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -31629,7 +32932,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -31644,7 +32947,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_PROFILE_OFF",
         "kind": "static_from",
-        "line": 803,
+        "line": 801,
         "name": "ANIMA_MOD_GUIDANCE_PROFILE_OFF",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -31663,7 +32966,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -31678,7 +32981,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_apply_spectrum_anima_mod_guidance",
         "kind": "static_from",
-        "line": 803,
+        "line": 801,
         "name": "_apply_spectrum_anima_mod_guidance",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -31697,7 +33000,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -31712,7 +33015,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_find_spectrum_anima_mod_guidance_class",
         "kind": "static_from",
-        "line": 803,
+        "line": 801,
         "name": "_find_spectrum_anima_mod_guidance_class",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -31731,7 +33034,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -31746,7 +33049,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_normalize_anima_mod_guidance_profile",
         "kind": "static_from",
-        "line": 803,
+        "line": 801,
         "name": "_normalize_anima_mod_guidance_profile",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -31765,7 +33068,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -31780,7 +33083,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_resolve_anima_mod_guidance_enabled",
         "kind": "static_from",
-        "line": 803,
+        "line": 801,
         "name": "_resolve_anima_mod_guidance_enabled",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -31799,7 +33102,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -31814,7 +33117,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
         "kind": "static_from",
-        "line": 818,
+        "line": 816,
         "name": "ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31833,7 +33136,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -31848,7 +33151,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
         "kind": "static_from",
-        "line": 818,
+        "line": 816,
         "name": "ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31867,7 +33170,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -31882,7 +33185,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
         "kind": "static_from",
-        "line": 818,
+        "line": 816,
         "name": "ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31901,7 +33204,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -31916,7 +33219,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_EXACT_TOP_K",
         "kind": "static_from",
-        "line": 818,
+        "line": 816,
         "name": "ARTIST_MIX_DEFAULT_EXACT_TOP_K",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31935,7 +33238,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -31950,7 +33253,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
         "kind": "static_from",
-        "line": 818,
+        "line": 816,
         "name": "ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31969,7 +33272,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -31984,7 +33287,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_START_PERCENT",
         "kind": "static_from",
-        "line": 818,
+        "line": 816,
         "name": "ARTIST_MIX_DEFAULT_START_PERCENT",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -32003,7 +33306,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -32018,7 +33321,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
         "kind": "static_from",
-        "line": 818,
+        "line": 816,
         "name": "ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -32037,7 +33340,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -32052,7 +33355,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STYLE_GAIN",
         "kind": "static_from",
-        "line": 818,
+        "line": 816,
         "name": "ARTIST_MIX_DEFAULT_STYLE_GAIN",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -32071,7 +33374,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -32086,7 +33389,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_INPUT_MODES",
         "kind": "static_from",
-        "line": 818,
+        "line": 816,
         "name": "ARTIST_MIX_INPUT_MODES",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -32105,7 +33408,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -32120,7 +33423,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 818,
+        "line": 816,
         "name": "ARTIST_MIX_MODE_FROM_PROMPT_DATA",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -32139,7 +33442,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -32154,7 +33457,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_mix_inline_prompt",
         "kind": "static_from",
-        "line": 818,
+        "line": 816,
         "name": "_artist_mix_inline_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -32173,7 +33476,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -32188,7 +33491,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_mix_mode_tooltip",
         "kind": "static_from",
-        "line": 818,
+        "line": 816,
         "name": "_artist_mix_mode_tooltip",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -32207,7 +33510,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -32222,7 +33525,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_prompt_with_position",
         "kind": "static_from",
-        "line": 818,
+        "line": 816,
         "name": "_artist_prompt_with_position",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -32241,7 +33544,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -32256,7 +33559,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_tags_from_prompt",
         "kind": "static_from",
-        "line": 818,
+        "line": 816,
         "name": "_artist_tags_from_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -32275,7 +33578,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -32290,7 +33593,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_blend_conditionings",
         "kind": "static_from",
-        "line": 818,
+        "line": 816,
         "name": "_blend_conditionings",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -32309,7 +33612,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -32324,7 +33627,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bounded_artist_mix_float",
         "kind": "static_from",
-        "line": 818,
+        "line": 816,
         "name": "_bounded_artist_mix_float",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -32343,7 +33646,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -32358,7 +33661,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bounded_artist_mix_int",
         "kind": "static_from",
-        "line": 818,
+        "line": 816,
         "name": "_bounded_artist_mix_int",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -32377,7 +33680,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -32392,7 +33695,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_clustered",
         "kind": "static_from",
-        "line": 818,
+        "line": 816,
         "name": "_encode_artist_clustered",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -32411,7 +33714,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -32426,7 +33729,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_delta_rms",
         "kind": "static_from",
-        "line": 818,
+        "line": 816,
         "name": "_encode_artist_delta_rms",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -32445,7 +33748,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -32460,7 +33763,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_prompt_data_positive_conditioning",
         "kind": "static_from",
-        "line": 818,
+        "line": 816,
         "name": "_encode_prompt_data_positive_conditioning",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -32479,7 +33782,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -32494,7 +33797,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_join_artist_mix_source_prompts",
         "kind": "static_from",
-        "line": 818,
+        "line": 816,
         "name": "_join_artist_mix_source_prompts",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -32513,7 +33816,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -32528,7 +33831,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_normalize_artist_mix_mode",
         "kind": "static_from",
-        "line": 818,
+        "line": 816,
         "name": "_normalize_artist_mix_mode",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -32547,7 +33850,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -32562,7 +33865,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_normalize_artist_tag_position",
         "kind": "static_from",
-        "line": 818,
+        "line": 816,
         "name": "_normalize_artist_tag_position",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -32581,7 +33884,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -32596,7 +33899,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_parse_artist_mix_items",
         "kind": "static_from",
-        "line": 818,
+        "line": 816,
         "name": "_parse_artist_mix_items",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -32615,7 +33918,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -32630,7 +33933,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaArtistMixConditioning",
         "kind": "static_from",
-        "line": 897,
+        "line": 895,
         "name": "EasyUseAnimaArtistMixConditioning",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_data_nodes",
@@ -32649,7 +33952,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -32664,7 +33967,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataConditioning",
         "kind": "static_from",
-        "line": 897,
+        "line": 895,
         "name": "EasyUseAnimaPromptDataConditioning",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_data_nodes",
@@ -32683,7 +33986,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -32698,7 +34001,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataUnpack",
         "kind": "static_from",
-        "line": 897,
+        "line": 895,
         "name": "EasyUseAnimaPromptDataUnpack",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_data_nodes",
@@ -32717,7 +34020,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -32732,7 +34035,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_ANY_TYPE",
         "kind": "static_from",
-        "line": 902,
+        "line": 900,
         "name": "_ANY_TYPE",
         "optional": false,
         "requested": "easyuse_anima.nodes.input_types",
@@ -32751,7 +34054,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -32766,7 +34069,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_AnyType",
         "kind": "static_from",
-        "line": 902,
+        "line": 900,
         "name": "_AnyType",
         "optional": false,
         "requested": "easyuse_anima.nodes.input_types",
@@ -32785,7 +34088,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -32800,7 +34103,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_FlexibleOptionalInputType",
         "kind": "static_from",
-        "line": 902,
+        "line": 900,
         "name": "_FlexibleOptionalInputType",
         "optional": false,
         "requested": "easyuse_anima.nodes.input_types",
@@ -32819,7 +34122,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -32834,7 +34137,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvanced",
         "kind": "static_from",
-        "line": 907,
+        "line": 905,
         "name": "EasyUseAnimaPromptStudioAdvanced",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_advanced_nodes",
@@ -32853,7 +34156,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -32868,42 +34171,8 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvancedV2",
         "kind": "static_from",
-        "line": 907,
+        "line": 905,
         "name": "EasyUseAnimaPromptStudioAdvancedV2",
-        "optional": false,
-        "requested": "easyuse_anima.nodes.prompt_advanced_nodes",
-        "role": "compatibility_fallback",
-        "scope": "<module>",
-        "source": "nodes.py",
-        "target": "easyuse_anima/nodes/prompt_advanced_nodes.py"
-      },
-      {
-        "alias": "_bind_prompt_advanced_node_runtime",
-        "bound_name": "_bind_prompt_advanced_node_runtime",
-        "branch_context": [
-          {
-            "branch": "except",
-            "catches_import_error": true,
-            "exceptions": [
-              "ImportError"
-            ],
-            "handler_line": 555,
-            "kind": "try",
-            "line": 9
-          }
-        ],
-        "classification": "compatibility_fallback",
-        "column": 4,
-        "compatibility_pair": {
-          "bound_name": "_bind_prompt_advanced_node_runtime",
-          "target": "easyuse_anima/nodes/prompt_advanced_nodes.py",
-          "try_line": 9
-        },
-        "conditional": true,
-        "imported": "easyuse_anima.nodes.prompt_advanced_nodes:_bind_prompt_advanced_node_runtime",
-        "kind": "static_from",
-        "line": 907,
-        "name": "_bind_prompt_advanced_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_advanced_nodes",
         "role": "compatibility_fallback",
@@ -32921,7 +34190,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -32936,7 +34205,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:EasyUseAnimaAIOGenerator",
         "kind": "static_from",
-        "line": 913,
+        "line": 910,
         "name": "EasyUseAnimaAIOGenerator",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -32955,7 +34224,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -32970,7 +34239,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:EasyUseAnimaInput",
         "kind": "static_from",
-        "line": 913,
+        "line": 910,
         "name": "EasyUseAnimaInput",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -32989,7 +34258,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -33004,7 +34273,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_aio_generation_settings_json",
         "kind": "static_from",
-        "line": 913,
+        "line": 910,
         "name": "_aio_generation_settings_json",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -33023,7 +34292,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -33038,7 +34307,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_aio_input_settings_json",
         "kind": "static_from",
-        "line": 913,
+        "line": 910,
         "name": "_aio_input_settings_json",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -33057,7 +34326,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -33072,7 +34341,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_bind_aio_node_runtime",
         "kind": "static_from",
-        "line": 913,
+        "line": 910,
         "name": "_bind_aio_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -33091,7 +34360,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -33106,7 +34375,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_easy_use_anima_input_signature",
         "kind": "static_from",
-        "line": 913,
+        "line": 910,
         "name": "_easy_use_anima_input_signature",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -33125,7 +34394,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -33140,7 +34409,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_require_easy_use_anima_input",
         "kind": "static_from",
-        "line": 913,
+        "line": 910,
         "name": "_require_easy_use_anima_input",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -33159,7 +34428,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -33174,7 +34443,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_align_down",
         "kind": "static_from",
-        "line": 922,
+        "line": 919,
         "name": "_align_down",
         "optional": false,
         "requested": "easyuse_anima.image.geometry",
@@ -33193,7 +34462,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -33208,7 +34477,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_align_nearest",
         "kind": "static_from",
-        "line": 922,
+        "line": 919,
         "name": "_align_nearest",
         "optional": false,
         "requested": "easyuse_anima.image.geometry",
@@ -33227,7 +34496,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -33242,7 +34511,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_image_tensor_size",
         "kind": "static_from",
-        "line": 922,
+        "line": 919,
         "name": "_image_tensor_size",
         "optional": false,
         "requested": "easyuse_anima.image.geometry",
@@ -33261,7 +34530,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -33276,7 +34545,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_context_value",
         "kind": "static_from",
-        "line": 933,
+        "line": 930,
         "name": "_context_value",
         "optional": false,
         "requested": "easyuse_anima.image.sam3",
@@ -33295,7 +34564,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -33310,7 +34579,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_sam3_context",
         "kind": "static_from",
-        "line": 933,
+        "line": 930,
         "name": "_sam3_context",
         "optional": false,
         "requested": "easyuse_anima.image.sam3",
@@ -33329,7 +34598,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -33344,7 +34613,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_segs_has_items",
         "kind": "static_from",
-        "line": 933,
+        "line": 930,
         "name": "_segs_has_items",
         "optional": false,
         "requested": "easyuse_anima.image.sam3",
@@ -33363,7 +34632,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -33378,7 +34647,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:IMAGE_SCALE_MULTIPLES",
         "kind": "static_from",
-        "line": 945,
+        "line": 942,
         "name": "IMAGE_SCALE_MULTIPLES",
         "optional": false,
         "requested": "easyuse_anima.image.scaling",
@@ -33397,7 +34666,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -33412,7 +34681,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:IMAGE_UPSCALE_METHODS",
         "kind": "static_from",
-        "line": 945,
+        "line": 942,
         "name": "IMAGE_UPSCALE_METHODS",
         "optional": false,
         "requested": "easyuse_anima.image.scaling",
@@ -33431,7 +34700,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -33446,7 +34715,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_sampler_names",
         "kind": "static_from",
-        "line": 953,
+        "line": 950,
         "name": "_comfy_sampler_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -33465,7 +34734,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -33480,7 +34749,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_scheduler_names",
         "kind": "static_from",
-        "line": 953,
+        "line": 950,
         "name": "_comfy_scheduler_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -33499,7 +34768,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -33514,7 +34783,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_impact_scheduler_names",
         "kind": "static_from",
-        "line": 953,
+        "line": 950,
         "name": "_impact_scheduler_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -33533,7 +34802,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -33548,7 +34817,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_call_with_supported_kwargs",
         "kind": "static_from",
-        "line": 959,
+        "line": 956,
         "name": "_call_with_supported_kwargs",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.invocation",
@@ -33567,7 +34836,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -33582,7 +34851,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_common_upscale_image",
         "kind": "static_from",
-        "line": 959,
+        "line": 956,
         "name": "_common_upscale_image",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.invocation",
@@ -33601,7 +34870,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -33616,7 +34885,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_node_output_tuple",
         "kind": "static_from",
-        "line": 959,
+        "line": 956,
         "name": "_node_output_tuple",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.invocation",
@@ -33635,7 +34904,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -33650,7 +34919,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.wiring:resolve_comfy_host_helper",
         "kind": "static_from",
-        "line": 964,
+        "line": 961,
         "name": "resolve_comfy_host_helper",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.wiring",
@@ -33669,7 +34938,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -33684,7 +34953,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_clip_loader_types",
         "kind": "static_from",
-        "line": 967,
+        "line": 964,
         "name": "_comfy_clip_loader_types",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -33703,7 +34972,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -33718,7 +34987,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_diffusion_model_names",
         "kind": "static_from",
-        "line": 967,
+        "line": 964,
         "name": "_comfy_diffusion_model_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -33737,7 +35006,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -33752,7 +35021,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_text_encoder_names",
         "kind": "static_from",
-        "line": 967,
+        "line": 964,
         "name": "_comfy_text_encoder_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -33771,7 +35040,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -33786,7 +35055,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_vae_names",
         "kind": "static_from",
-        "line": 967,
+        "line": 964,
         "name": "_comfy_vae_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -33805,7 +35074,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -33820,7 +35089,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_folder_path_names",
         "kind": "static_from",
-        "line": 967,
+        "line": 964,
         "name": "_folder_path_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -33839,7 +35108,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -33854,7 +35123,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.image_nodes:EasyUseAnimaDetailerAlignHook",
         "kind": "static_from",
-        "line": 975,
+        "line": 972,
         "name": "EasyUseAnimaDetailerAlignHook",
         "optional": false,
         "requested": "easyuse_anima.nodes.image_nodes",
@@ -33873,7 +35142,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -33888,7 +35157,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.image_nodes:EasyUseAnimaImageScaleByMultiple",
         "kind": "static_from",
-        "line": 975,
+        "line": 972,
         "name": "EasyUseAnimaImageScaleByMultiple",
         "optional": false,
         "requested": "easyuse_anima.nodes.image_nodes",
@@ -33907,7 +35176,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -33922,7 +35191,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Context",
         "kind": "static_from",
-        "line": 979,
+        "line": 976,
         "name": "EasyUseAnimaSAM3Context",
         "optional": false,
         "requested": "easyuse_anima.nodes.sam3_nodes",
@@ -33941,7 +35210,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -33956,7 +35225,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Detailer",
         "kind": "static_from",
-        "line": 979,
+        "line": 976,
         "name": "EasyUseAnimaSAM3Detailer",
         "optional": false,
         "requested": "easyuse_anima.nodes.sam3_nodes",
@@ -33975,7 +35244,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -33990,7 +35259,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptBuilder",
         "kind": "static_from",
-        "line": 983,
+        "line": 980,
         "name": "EasyUseAnimaPromptBuilder",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -34009,7 +35278,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -34024,7 +35293,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrector",
         "kind": "static_from",
-        "line": 983,
+        "line": 980,
         "name": "EasyUseAnimaPromptCorrector",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -34043,7 +35312,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -34058,7 +35327,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrectorSimple",
         "kind": "static_from",
-        "line": 983,
+        "line": 980,
         "name": "EasyUseAnimaPromptCorrectorSimple",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -34077,7 +35346,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -34092,7 +35361,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptStudio",
         "kind": "static_from",
-        "line": 983,
+        "line": 980,
         "name": "EasyUseAnimaPromptStudio",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -34111,7 +35380,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -34126,7 +35395,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:EasyUseAnimaPromptStudioRegional",
         "kind": "static_from",
-        "line": 989,
+        "line": 986,
         "name": "EasyUseAnimaPromptStudioRegional",
         "optional": false,
         "requested": "easyuse_anima.nodes.regional_nodes",
@@ -34145,7 +35414,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -34160,42 +35429,8 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:EasyUseAnimaRegionalConditioning",
         "kind": "static_from",
-        "line": 989,
+        "line": 986,
         "name": "EasyUseAnimaRegionalConditioning",
-        "optional": false,
-        "requested": "easyuse_anima.nodes.regional_nodes",
-        "role": "compatibility_fallback",
-        "scope": "<module>",
-        "source": "nodes.py",
-        "target": "easyuse_anima/nodes/regional_nodes.py"
-      },
-      {
-        "alias": "_bind_regional_node_runtime",
-        "bound_name": "_bind_regional_node_runtime",
-        "branch_context": [
-          {
-            "branch": "except",
-            "catches_import_error": true,
-            "exceptions": [
-              "ImportError"
-            ],
-            "handler_line": 555,
-            "kind": "try",
-            "line": 9
-          }
-        ],
-        "classification": "compatibility_fallback",
-        "column": 4,
-        "compatibility_pair": {
-          "bound_name": "_bind_regional_node_runtime",
-          "target": "easyuse_anima/nodes/regional_nodes.py",
-          "try_line": 9
-        },
-        "conditional": true,
-        "imported": "easyuse_anima.nodes.regional_nodes:_bind_regional_node_runtime",
-        "kind": "static_from",
-        "line": 989,
-        "name": "_bind_regional_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.regional_nodes",
         "role": "compatibility_fallback",
@@ -34213,7 +35448,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -34228,7 +35463,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:LATENT_ALIGN",
         "kind": "static_from",
-        "line": 994,
+        "line": 990,
         "name": "LATENT_ALIGN",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -34247,7 +35482,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -34262,7 +35497,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_parse_random_response",
         "kind": "static_from",
-        "line": 994,
+        "line": 990,
         "name": "_parse_random_response",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -34281,7 +35516,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -34296,7 +35531,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_post_random",
         "kind": "static_from",
-        "line": 994,
+        "line": 990,
         "name": "_post_random",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -34315,7 +35550,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -34330,7 +35565,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_advanced_resolution_from_selection",
         "kind": "static_from",
-        "line": 1012,
+        "line": 1008,
         "name": "_advanced_resolution_from_selection",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -34349,7 +35584,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -34364,7 +35599,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_normalize_resolution_bucket",
         "kind": "static_from",
-        "line": 1012,
+        "line": 1008,
         "name": "_normalize_resolution_bucket",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -34383,7 +35618,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -34398,7 +35633,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_ratio_label",
         "kind": "static_from",
-        "line": 1012,
+        "line": 1008,
         "name": "_ratio_label",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -34417,7 +35652,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -34432,7 +35667,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolution_label",
         "kind": "static_from",
-        "line": 1012,
+        "line": 1008,
         "name": "_resolution_label",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -34451,7 +35686,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -34466,7 +35701,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolve_naia_resolution",
         "kind": "static_from",
-        "line": 1012,
+        "line": 1008,
         "name": "_resolve_naia_resolution",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -34485,7 +35720,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -34500,7 +35735,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.naia_nodes:EasyUseAnimaNAIARandomPrompt",
         "kind": "static_from",
-        "line": 1035,
+        "line": 1031,
         "name": "EasyUseAnimaNAIARandomPrompt",
         "optional": false,
         "requested": "easyuse_anima.nodes.naia_nodes",
@@ -34519,7 +35754,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -34534,7 +35769,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.naia_nodes:_bind_naia_node_runtime",
         "kind": "static_from",
-        "line": 1035,
+        "line": 1031,
         "name": "_bind_naia_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.naia_nodes",
@@ -34553,7 +35788,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -34568,7 +35803,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.wildcard_nodes:EasyUseAnimaWildcard",
         "kind": "static_from",
-        "line": 1039,
+        "line": 1035,
         "name": "EasyUseAnimaWildcard",
         "optional": false,
         "requested": "easyuse_anima.nodes.wildcard_nodes",
@@ -34587,7 +35822,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -34602,7 +35837,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.wildcard_nodes:_bind_wildcard_node_runtime",
         "kind": "static_from",
-        "line": 1039,
+        "line": 1035,
         "name": "_bind_wildcard_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.wildcard_nodes",
@@ -34621,7 +35856,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -34636,7 +35871,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_apply_lora_syntax_format",
         "kind": "static_from",
-        "line": 1044,
+        "line": 1040,
         "name": "_apply_lora_syntax_format",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -34655,7 +35890,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -34670,7 +35905,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_dedupe_text_values",
         "kind": "static_from",
-        "line": 1044,
+        "line": 1040,
         "name": "_dedupe_text_values",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -34689,7 +35924,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -34704,7 +35939,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_fallback_lora_path",
         "kind": "static_from",
-        "line": 1044,
+        "line": 1040,
         "name": "_fallback_lora_path",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -34723,7 +35958,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -34738,7 +35973,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_get_lora_info",
         "kind": "static_from",
-        "line": 1044,
+        "line": 1040,
         "name": "_get_lora_info",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -34757,7 +35992,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -34772,7 +36007,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_get_lora_manager_trigger_words",
         "kind": "static_from",
-        "line": 1044,
+        "line": 1040,
         "name": "_get_lora_manager_trigger_words",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -34791,7 +36026,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -34806,7 +36041,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_load_lora_manager_metadata",
         "kind": "static_from",
-        "line": 1044,
+        "line": 1040,
         "name": "_load_lora_manager_metadata",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -34825,7 +36060,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -34840,7 +36075,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_combo_values",
         "kind": "static_from",
-        "line": 1044,
+        "line": 1040,
         "name": "_lora_combo_values",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -34859,7 +36094,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -34874,7 +36109,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_manager_trigger_words_from_metadata",
         "kind": "static_from",
-        "line": 1044,
+        "line": 1040,
         "name": "_lora_manager_trigger_words_from_metadata",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -34893,7 +36128,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -34908,7 +36143,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_model_exists",
         "kind": "static_from",
-        "line": 1044,
+        "line": 1040,
         "name": "_lora_model_exists",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -34927,7 +36162,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -34942,7 +36177,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_stack_name",
         "kind": "static_from",
-        "line": 1044,
+        "line": 1040,
         "name": "_lora_stack_name",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -34961,7 +36196,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -34976,7 +36211,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_metadata_json_paths_for_lora",
         "kind": "static_from",
-        "line": 1044,
+        "line": 1040,
         "name": "_metadata_json_paths_for_lora",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -34995,7 +36230,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -35010,7 +36245,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_missing_lora_display_name",
         "kind": "static_from",
-        "line": 1044,
+        "line": 1040,
         "name": "_missing_lora_display_name",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -35029,7 +36264,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -35044,7 +36279,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_raise_missing_loras",
         "kind": "static_from",
-        "line": 1044,
+        "line": 1040,
         "name": "_raise_missing_loras",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -35063,7 +36298,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -35078,7 +36313,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_trigger_words_from_value",
         "kind": "static_from",
-        "line": 1044,
+        "line": 1040,
         "name": "_trigger_words_from_value",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -35097,7 +36332,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -35112,7 +36347,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_correct_style_prompt",
         "kind": "static_from",
-        "line": 1060,
+        "line": 1056,
         "name": "_correct_style_prompt",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -35131,7 +36366,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -35146,7 +36381,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_format_strength",
         "kind": "static_from",
-        "line": 1060,
+        "line": 1056,
         "name": "_format_strength",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -35165,7 +36400,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -35180,7 +36415,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_get_loras_list",
         "kind": "static_from",
-        "line": 1060,
+        "line": 1056,
         "name": "_get_loras_list",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -35199,7 +36434,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -35214,7 +36449,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_load_profile_data",
         "kind": "static_from",
-        "line": 1060,
+        "line": 1056,
         "name": "_load_profile_data",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -35233,7 +36468,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -35248,7 +36483,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_profile_key",
         "kind": "static_from",
-        "line": 1060,
+        "line": 1056,
         "name": "_profile_key",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -35267,7 +36502,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -35282,7 +36517,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_select_profile_values",
         "kind": "static_from",
-        "line": 1060,
+        "line": 1056,
         "name": "_select_profile_values",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -35301,7 +36536,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -35316,7 +36551,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_wrap_profile_index",
         "kind": "static_from",
-        "line": 1060,
+        "line": 1056,
         "name": "_wrap_profile_index",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -35335,7 +36570,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -35350,7 +36585,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.lora_nodes:EasyUseAnimaLoraPreset",
         "kind": "static_from",
-        "line": 1069,
+        "line": 1065,
         "name": "EasyUseAnimaLoraPreset",
         "optional": false,
         "requested": "easyuse_anima.nodes.lora_nodes",
@@ -35369,7 +36604,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -35384,7 +36619,7 @@
         "conditional": true,
         "imported": "anima_prompt:correct_prompt",
         "kind": "static_from",
-        "line": 1072,
+        "line": 1068,
         "name": "correct_prompt",
         "optional": false,
         "requested": "anima_prompt",
@@ -35403,7 +36638,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -35418,7 +36653,7 @@
         "conditional": true,
         "imported": "anima_prompt:load_knowledge_base",
         "kind": "static_from",
-        "line": 1072,
+        "line": 1068,
         "name": "load_knowledge_base",
         "optional": false,
         "requested": "anima_prompt",
@@ -35437,7 +36672,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -35452,7 +36687,7 @@
         "conditional": true,
         "imported": "anima_prompt.parser:parse_prompt",
         "kind": "static_from",
-        "line": 1073,
+        "line": 1069,
         "name": "parse_prompt",
         "optional": false,
         "requested": "anima_prompt.parser",
@@ -35471,7 +36706,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -35486,7 +36721,7 @@
         "conditional": true,
         "imported": "settings:resolve_metadata_filter_words",
         "kind": "static_from",
-        "line": 1074,
+        "line": 1070,
         "name": "resolve_metadata_filter_words",
         "optional": false,
         "requested": "settings",
@@ -35505,7 +36740,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -35520,7 +36755,7 @@
         "conditional": true,
         "imported": "settings:resolve_naia_settings",
         "kind": "static_from",
-        "line": 1074,
+        "line": 1070,
         "name": "resolve_naia_settings",
         "optional": false,
         "requested": "settings",
@@ -35539,7 +36774,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -35554,7 +36789,7 @@
         "conditional": true,
         "imported": "settings:resolve_prompt_translation_settings",
         "kind": "static_from",
-        "line": 1074,
+        "line": 1070,
         "name": "resolve_prompt_translation_settings",
         "optional": false,
         "requested": "settings",
@@ -35573,7 +36808,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -35588,7 +36823,7 @@
         "conditional": true,
         "imported": "prompt_translation:has_prompt_translation_markers",
         "kind": "static_from",
-        "line": 1079,
+        "line": 1075,
         "name": "has_prompt_translation_markers",
         "optional": false,
         "requested": "prompt_translation",
@@ -35607,7 +36842,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -35622,7 +36857,7 @@
         "conditional": true,
         "imported": "prompt_translation:translate_prompt_markers",
         "kind": "static_from",
-        "line": 1079,
+        "line": 1075,
         "name": "translate_prompt_markers",
         "optional": false,
         "requested": "prompt_translation",
@@ -35641,7 +36876,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -35656,7 +36891,7 @@
         "conditional": true,
         "imported": "wildcard_engine:MAX_SEED",
         "kind": "static_from",
-        "line": 1080,
+        "line": 1076,
         "name": "MAX_SEED",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35675,7 +36910,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -35690,7 +36925,7 @@
         "conditional": true,
         "imported": "wildcard_engine:PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "kind": "static_from",
-        "line": 1080,
+        "line": 1076,
         "name": "PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35709,7 +36944,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -35724,7 +36959,7 @@
         "conditional": true,
         "imported": "wildcard_engine:PUBLIC_MAX_SEED",
         "kind": "static_from",
-        "line": 1080,
+        "line": 1076,
         "name": "PUBLIC_MAX_SEED",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35743,7 +36978,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -35758,7 +36993,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_DECREMENT",
         "kind": "static_from",
-        "line": 1080,
+        "line": 1076,
         "name": "SEED_CONTROL_DECREMENT",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35777,7 +37012,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -35792,7 +37027,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_FIXED",
         "kind": "static_from",
-        "line": 1080,
+        "line": 1076,
         "name": "SEED_CONTROL_FIXED",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35811,7 +37046,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -35826,7 +37061,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_INCREMENT",
         "kind": "static_from",
-        "line": 1080,
+        "line": 1076,
         "name": "SEED_CONTROL_INCREMENT",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35845,7 +37080,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -35860,7 +37095,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_MODES",
         "kind": "static_from",
-        "line": 1080,
+        "line": 1076,
         "name": "SEED_CONTROL_MODES",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35879,7 +37114,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -35894,7 +37129,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_RANDOMIZE",
         "kind": "static_from",
-        "line": 1080,
+        "line": 1076,
         "name": "SEED_CONTROL_RANDOMIZE",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35913,7 +37148,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -35928,7 +37163,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_FIXED",
         "kind": "static_from",
-        "line": 1080,
+        "line": 1076,
         "name": "WILDCARD_MODE_FIXED",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35947,7 +37182,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -35962,7 +37197,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_POPULATE",
         "kind": "static_from",
-        "line": 1080,
+        "line": 1076,
         "name": "WILDCARD_MODE_POPULATE",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35981,7 +37216,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -35996,7 +37231,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_SEQUENTIAL",
         "kind": "static_from",
-        "line": 1080,
+        "line": 1076,
         "name": "WILDCARD_MODE_SEQUENTIAL",
         "optional": false,
         "requested": "wildcard_engine",
@@ -36015,7 +37250,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -36030,7 +37265,7 @@
         "conditional": true,
         "imported": "wildcard_engine:expand_wildcard_texts",
         "kind": "static_from",
-        "line": 1080,
+        "line": 1076,
         "name": "expand_wildcard_texts",
         "optional": false,
         "requested": "wildcard_engine",
@@ -36049,7 +37284,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -36064,7 +37299,7 @@
         "conditional": true,
         "imported": "wildcard_engine:expand_wildcards",
         "kind": "static_from",
-        "line": 1080,
+        "line": 1076,
         "name": "expand_wildcards",
         "optional": false,
         "requested": "wildcard_engine",
@@ -36083,7 +37318,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -36098,7 +37333,7 @@
         "conditional": true,
         "imported": "wildcard_engine:has_wildcard_syntax",
         "kind": "static_from",
-        "line": 1080,
+        "line": 1076,
         "name": "has_wildcard_syntax",
         "optional": false,
         "requested": "wildcard_engine",
@@ -36117,7 +37352,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -36132,7 +37367,7 @@
         "conditional": true,
         "imported": "wildcard_engine:next_seed",
         "kind": "static_from",
-        "line": 1080,
+        "line": 1076,
         "name": "next_seed",
         "optional": false,
         "requested": "wildcard_engine",
@@ -36151,7 +37386,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -36166,7 +37401,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_prompt_studio_wildcard_mode",
         "kind": "static_from",
-        "line": 1080,
+        "line": 1076,
         "name": "normalize_prompt_studio_wildcard_mode",
         "optional": false,
         "requested": "wildcard_engine",
@@ -36185,7 +37420,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -36200,7 +37435,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_seed",
         "kind": "static_from",
-        "line": 1080,
+        "line": 1076,
         "name": "normalize_seed",
         "optional": false,
         "requested": "wildcard_engine",
@@ -36219,7 +37454,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -36234,7 +37469,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_wildcard_mode",
         "kind": "static_from",
-        "line": 1080,
+        "line": 1076,
         "name": "normalize_wildcard_mode",
         "optional": false,
         "requested": "wildcard_engine",
@@ -36253,7 +37488,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -36268,7 +37503,7 @@
         "conditional": true,
         "imported": "wildcard_engine:wildcard_sources_signature",
         "kind": "static_from",
-        "line": 1080,
+        "line": 1076,
         "name": "wildcard_sources_signature",
         "optional": false,
         "requested": "wildcard_engine",
@@ -38076,11 +39311,27 @@
       },
       {
         "from": "easyuse_anima/nodes/prompt_advanced_nodes.py",
+        "to": "easyuse_anima/common/serialization.py"
+      },
+      {
+        "from": "easyuse_anima/nodes/prompt_advanced_nodes.py",
+        "to": "easyuse_anima/common/values.py"
+      },
+      {
+        "from": "easyuse_anima/nodes/prompt_advanced_nodes.py",
+        "to": "easyuse_anima/naia/client.py"
+      },
+      {
+        "from": "easyuse_anima/nodes/prompt_advanced_nodes.py",
         "to": "easyuse_anima/naia/resolution.py"
       },
       {
         "from": "easyuse_anima/nodes/prompt_advanced_nodes.py",
         "to": "easyuse_anima/nodes/input_types.py"
+      },
+      {
+        "from": "easyuse_anima/nodes/prompt_advanced_nodes.py",
+        "to": "easyuse_anima/nodes/naia_nodes.py"
       },
       {
         "from": "easyuse_anima/nodes/prompt_advanced_nodes.py",
@@ -38092,7 +39343,23 @@
       },
       {
         "from": "easyuse_anima/nodes/prompt_advanced_nodes.py",
+        "to": "easyuse_anima/prompt/correction.py"
+      },
+      {
+        "from": "easyuse_anima/nodes/prompt_advanced_nodes.py",
         "to": "easyuse_anima/prompt/data.py"
+      },
+      {
+        "from": "easyuse_anima/nodes/prompt_advanced_nodes.py",
+        "to": "easyuse_anima/seed/compatibility.py"
+      },
+      {
+        "from": "easyuse_anima/nodes/prompt_advanced_nodes.py",
+        "to": "easyuse_anima/workflow.py"
+      },
+      {
+        "from": "easyuse_anima/nodes/prompt_advanced_nodes.py",
+        "to": "settings.py"
       },
       {
         "from": "easyuse_anima/nodes/prompt_data_nodes.py",
@@ -38152,6 +39419,18 @@
       },
       {
         "from": "easyuse_anima/nodes/regional_nodes.py",
+        "to": "easyuse_anima/common/serialization.py"
+      },
+      {
+        "from": "easyuse_anima/nodes/regional_nodes.py",
+        "to": "easyuse_anima/common/values.py"
+      },
+      {
+        "from": "easyuse_anima/nodes/regional_nodes.py",
+        "to": "easyuse_anima/infrastructure/comfy/wiring.py"
+      },
+      {
+        "from": "easyuse_anima/nodes/regional_nodes.py",
         "to": "easyuse_anima/naia/resolution.py"
       },
       {
@@ -38160,7 +39439,27 @@
       },
       {
         "from": "easyuse_anima/nodes/regional_nodes.py",
+        "to": "easyuse_anima/prompt/advanced.py"
+      },
+      {
+        "from": "easyuse_anima/nodes/regional_nodes.py",
+        "to": "easyuse_anima/prompt/correction.py"
+      },
+      {
+        "from": "easyuse_anima/nodes/regional_nodes.py",
         "to": "easyuse_anima/prompt/regional.py"
+      },
+      {
+        "from": "easyuse_anima/nodes/regional_nodes.py",
+        "to": "easyuse_anima/seed/compatibility.py"
+      },
+      {
+        "from": "easyuse_anima/nodes/regional_nodes.py",
+        "to": "easyuse_anima/workflow.py"
+      },
+      {
+        "from": "easyuse_anima/nodes/regional_nodes.py",
+        "to": "settings.py"
       },
       {
         "from": "easyuse_anima/nodes/sam3_nodes.py",
@@ -39872,14 +41171,14 @@
       },
       {
         "is_package": false,
-        "loc": 1147,
+        "loc": 1095,
         "module": "easyuse_anima.nodes.prompt_advanced_nodes",
-        "normalized_git_blob_sha1": "b6211be12fb6e0c5153be777717df204a562e1d9",
+        "normalized_git_blob_sha1": "ad1456c2c4ce10a94e8f0df7ec6a34950c314e1e",
         "path": "easyuse_anima/nodes/prompt_advanced_nodes.py",
         "top_level": {
           "class_count": 3,
-          "function_count": 3,
-          "global_count": 50
+          "function_count": 2,
+          "global_count": 11
         }
       },
       {
@@ -39908,14 +41207,14 @@
       },
       {
         "is_package": false,
-        "loc": 559,
+        "loc": 516,
         "module": "easyuse_anima.nodes.regional_nodes",
-        "normalized_git_blob_sha1": "3bcc21c4f3b5e554286f476b9c8eb9f6e9b0df85",
+        "normalized_git_blob_sha1": "72313693ca62f81c38890da7b33df9827a52d5e1",
         "path": "easyuse_anima/nodes/regional_nodes.py",
         "top_level": {
           "class_count": 2,
-          "function_count": 2,
-          "global_count": 42
+          "function_count": 4,
+          "global_count": 11
         }
       },
       {
@@ -40148,9 +41447,9 @@
       },
       {
         "is_package": false,
-        "loc": 1677,
+        "loc": 1662,
         "module": "nodes",
-        "normalized_git_blob_sha1": "df1be7c4ab0172ed7042863a71bea17731c307d5",
+        "normalized_git_blob_sha1": "4821f36548243853249a7a24458a37469985c676",
         "path": "nodes.py",
         "top_level": {
           "class_count": 0,
@@ -41054,6 +42353,52 @@
             "exceptions": [
               "ImportError"
             ],
+            "handler_line": 74,
+            "kind": "try",
+            "line": 69
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "settings:resolve_metadata_filter_words",
+        "kind": "static_from",
+        "line": 75,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "easyuse_anima/nodes/prompt_advanced_nodes.py",
+        "target": "settings.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 74,
+            "kind": "try",
+            "line": 69
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "settings:resolve_naia_settings",
+        "kind": "static_from",
+        "line": 75,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "easyuse_anima/nodes/prompt_advanced_nodes.py",
+        "target": "settings.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
             "handler_line": 25,
             "kind": "try",
             "line": 22
@@ -41113,6 +42458,29 @@
         "optional": false,
         "role": "compatibility_fallback",
         "source": "easyuse_anima/nodes/prompt_nodes.py",
+        "target": "settings.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 49,
+            "kind": "try",
+            "line": 47
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "settings:resolve_metadata_filter_words",
+        "kind": "static_from",
+        "line": 50,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "easyuse_anima/nodes/regional_nodes.py",
         "target": "settings.py"
       },
       {
@@ -41629,7 +42997,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -41638,7 +43006,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:AIO_FIRST_PASS_CACHE_MAX_ENTRIES",
         "kind": "static_from",
-        "line": 556,
+        "line": 554,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41652,7 +43020,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -41661,7 +43029,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_AIO_FIRST_PASS_CACHE",
         "kind": "static_from",
-        "line": 556,
+        "line": 554,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41675,7 +43043,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -41684,7 +43052,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_AIO_FIRST_PASS_CACHE_ORDER",
         "kind": "static_from",
-        "line": 556,
+        "line": 554,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41698,7 +43066,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -41707,7 +43075,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_aio_first_pass_cache_key",
         "kind": "static_from",
-        "line": 556,
+        "line": 554,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41721,7 +43089,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -41730,7 +43098,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_bind_aio_first_pass_cache_runtime",
         "kind": "static_from",
-        "line": 556,
+        "line": 554,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41744,7 +43112,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -41753,7 +43121,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_clone_aio_cache_value",
         "kind": "static_from",
-        "line": 556,
+        "line": 554,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41767,7 +43135,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -41776,7 +43144,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_get_aio_first_pass_cache",
         "kind": "static_from",
-        "line": 556,
+        "line": 554,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41790,7 +43158,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -41799,7 +43167,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_put_aio_first_pass_cache",
         "kind": "static_from",
-        "line": 556,
+        "line": 554,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41813,7 +43181,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -41822,7 +43190,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_bind_aio_legacy_generation_runtime",
         "kind": "static_from",
-        "line": 567,
+        "line": 565,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41836,7 +43204,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -41845,7 +43213,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_detailer_stage",
         "kind": "static_from",
-        "line": 567,
+        "line": 565,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41859,7 +43227,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -41868,7 +43236,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_detailer_target",
         "kind": "static_from",
-        "line": 567,
+        "line": 565,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41882,7 +43250,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -41891,7 +43259,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_highres_stage",
         "kind": "static_from",
-        "line": 567,
+        "line": 565,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41905,7 +43273,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -41914,7 +43282,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_legacy_generation",
         "kind": "static_from",
-        "line": 567,
+        "line": 565,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41928,7 +43296,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -41937,7 +43305,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_resshift_upscale_stage",
         "kind": "static_from",
-        "line": 567,
+        "line": 565,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41951,7 +43319,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -41960,7 +43328,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_upscale_stage",
         "kind": "static_from",
-        "line": 567,
+        "line": 565,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41974,7 +43342,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -41983,7 +43351,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_usdu_upscale_stage",
         "kind": "static_from",
-        "line": 567,
+        "line": 565,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41997,7 +43365,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -42006,7 +43374,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEEDS",
         "kind": "static_from",
-        "line": 577,
+        "line": 575,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42020,7 +43388,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -42029,7 +43397,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEED_DECREMENT",
         "kind": "static_from",
-        "line": 577,
+        "line": 575,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42043,7 +43411,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -42052,7 +43420,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEED_INCREMENT",
         "kind": "static_from",
-        "line": 577,
+        "line": 575,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42066,7 +43434,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -42075,7 +43443,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEED_RANDOM",
         "kind": "static_from",
-        "line": 577,
+        "line": 575,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42089,7 +43457,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -42098,7 +43466,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_AIO_DETAILER_CUSTOM_RE",
         "kind": "static_from",
-        "line": 577,
+        "line": 575,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42112,7 +43480,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -42121,7 +43489,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_AIO_DETAILER_RESERVED_KEYS",
         "kind": "static_from",
-        "line": 577,
+        "line": 575,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42135,7 +43503,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -42144,7 +43512,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_aio_detailer_has_enabled_targets",
         "kind": "static_from",
-        "line": 577,
+        "line": 575,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42158,7 +43526,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -42167,7 +43535,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_aio_detailer_target_defaults",
         "kind": "static_from",
-        "line": 577,
+        "line": 575,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42181,7 +43549,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -42190,7 +43558,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_aio_detailer_target_order",
         "kind": "static_from",
-        "line": 577,
+        "line": 575,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42204,7 +43572,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -42213,7 +43581,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_bind_aio_generation_normalization_runtime",
         "kind": "static_from",
-        "line": 577,
+        "line": 575,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42227,7 +43595,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -42236,7 +43604,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_is_aio_detailer_target_name",
         "kind": "static_from",
-        "line": 577,
+        "line": 575,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42250,7 +43618,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -42259,7 +43627,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_merge_versioned_settings",
         "kind": "static_from",
-        "line": 577,
+        "line": 575,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42273,7 +43641,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -42282,7 +43650,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_dit_corrections_settings",
         "kind": "static_from",
-        "line": 577,
+        "line": 575,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42296,7 +43664,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -42305,7 +43673,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_generation_settings",
         "kind": "static_from",
-        "line": 577,
+        "line": 575,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42319,7 +43687,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -42328,7 +43696,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_seed",
         "kind": "static_from",
-        "line": 577,
+        "line": 575,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42342,7 +43710,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -42351,7 +43719,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_spectrum_settings",
         "kind": "static_from",
-        "line": 577,
+        "line": 575,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42365,7 +43733,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -42374,7 +43742,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_settings:round_trip_aio_generation_settings",
         "kind": "static_from",
-        "line": 595,
+        "line": 593,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42388,7 +43756,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -42397,7 +43765,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.usdu:_aio_usdu_auto_tile_dimension",
         "kind": "static_from",
-        "line": 598,
+        "line": 596,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42411,7 +43779,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -42420,7 +43788,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.usdu:_aio_usdu_tile_plan",
         "kind": "static_from",
-        "line": 598,
+        "line": 596,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42434,7 +43802,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -42443,7 +43811,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.usdu:_bind_aio_usdu_planning_runtime",
         "kind": "static_from",
-        "line": 598,
+        "line": 596,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42457,7 +43825,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -42466,7 +43834,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_aio_final_fit_size",
         "kind": "static_from",
-        "line": 603,
+        "line": 601,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42480,7 +43848,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -42489,7 +43857,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_apply_aio_final_fit",
         "kind": "static_from",
-        "line": 603,
+        "line": 601,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42503,7 +43871,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -42512,7 +43880,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_bind_aio_postprocess_runtime",
         "kind": "static_from",
-        "line": 603,
+        "line": 601,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42526,7 +43894,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -42535,7 +43903,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_resize_image_to_size_if_needed",
         "kind": "static_from",
-        "line": 603,
+        "line": 601,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42549,7 +43917,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -42558,7 +43926,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_run_aio_postprocess_stage",
         "kind": "static_from",
-        "line": 603,
+        "line": 601,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42572,7 +43940,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -42581,7 +43949,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_prompt_data_fields_for_usdu",
         "kind": "static_from",
-        "line": 610,
+        "line": 608,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42595,7 +43963,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -42604,7 +43972,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_usdu_conditioning",
         "kind": "static_from",
-        "line": 610,
+        "line": 608,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42618,7 +43986,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -42627,7 +43995,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_usdu_prompt_without_general",
         "kind": "static_from",
-        "line": 610,
+        "line": 608,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42641,7 +44009,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -42650,7 +44018,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_bind_aio_conditioning_runtime",
         "kind": "static_from",
-        "line": 610,
+        "line": 608,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42664,7 +44032,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -42673,7 +44041,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_aio_lora_stack_signature",
         "kind": "static_from",
-        "line": 616,
+        "line": 614,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42687,7 +44055,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -42696,7 +44064,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_anima_dave_patch",
         "kind": "static_from",
-        "line": 616,
+        "line": 614,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42710,7 +44078,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -42719,7 +44087,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_kj_model_patches",
         "kind": "static_from",
-        "line": 616,
+        "line": 614,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42733,7 +44101,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -42742,7 +44110,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_lora_stack",
         "kind": "static_from",
-        "line": 616,
+        "line": 614,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42756,7 +44124,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -42765,7 +44133,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_model_patches",
         "kind": "static_from",
-        "line": 616,
+        "line": 614,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42779,7 +44147,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -42788,7 +44156,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_safe_pag_patch",
         "kind": "static_from",
-        "line": 616,
+        "line": 614,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42802,7 +44170,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -42811,7 +44179,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_correction_patch_for_comfy_sampler",
         "kind": "static_from",
-        "line": 616,
+        "line": 614,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42825,7 +44193,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -42834,7 +44202,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_forecast_patch_for_comfy_sampler",
         "kind": "static_from",
-        "line": 616,
+        "line": 614,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42848,7 +44216,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -42857,7 +44225,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_model_patches_for_comfy_sampler",
         "kind": "static_from",
-        "line": 616,
+        "line": 614,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42871,7 +44239,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -42880,7 +44248,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_bind_aio_model_preparation_runtime",
         "kind": "static_from",
-        "line": 616,
+        "line": 614,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42894,7 +44262,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -42903,7 +44271,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_cleanup_aio_ephemeral_model",
         "kind": "static_from",
-        "line": 616,
+        "line": 614,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42917,7 +44285,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -42926,7 +44294,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_normalize_aio_lora_stack",
         "kind": "static_from",
-        "line": 616,
+        "line": 614,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42940,7 +44308,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -42949,7 +44317,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_patch_model_sampling_aura_flow",
         "kind": "static_from",
-        "line": 616,
+        "line": 614,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42963,7 +44331,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -42972,7 +44340,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_aio_highres_effective_backend",
         "kind": "static_from",
-        "line": 631,
+        "line": 629,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42986,7 +44354,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -42995,7 +44363,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_aio_stage_sampler_settings",
         "kind": "static_from",
-        "line": 631,
+        "line": 629,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43009,7 +44377,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -43018,7 +44386,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_bind_aio_sampling_runtime",
         "kind": "static_from",
-        "line": 631,
+        "line": 629,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43032,7 +44400,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -43041,7 +44409,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_decode_latent_with_comfy",
         "kind": "static_from",
-        "line": 631,
+        "line": 629,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43055,7 +44423,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -43064,7 +44432,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_encode_image_with_comfy_vae",
         "kind": "static_from",
-        "line": 631,
+        "line": 629,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43078,7 +44446,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -43087,7 +44455,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_generate_empty_latent_with_comfy",
         "kind": "static_from",
-        "line": 631,
+        "line": 629,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43101,7 +44469,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -43110,7 +44478,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_new_aio_random_seed",
         "kind": "static_from",
-        "line": 631,
+        "line": 629,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43124,7 +44492,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -43133,7 +44501,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_resolve_aio_runtime_seed",
         "kind": "static_from",
-        "line": 631,
+        "line": 629,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43147,7 +44515,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -43156,7 +44524,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_aio_backend",
         "kind": "static_from",
-        "line": 631,
+        "line": 629,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43170,7 +44538,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -43179,7 +44547,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_comfy",
         "kind": "static_from",
-        "line": 631,
+        "line": 629,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43193,7 +44561,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -43202,7 +44570,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_spectrum_mod_guidance_advanced",
         "kind": "static_from",
-        "line": 631,
+        "line": 629,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43216,7 +44584,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -43225,7 +44593,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_spectrum_spd",
         "kind": "static_from",
-        "line": 631,
+        "line": 629,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43239,7 +44607,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -43248,7 +44616,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_CACHE_FORMAT",
         "kind": "static_from",
-        "line": 645,
+        "line": 643,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43262,7 +44630,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -43271,7 +44639,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_CACHE_QUALITY",
         "kind": "static_from",
-        "line": 645,
+        "line": 643,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43285,7 +44653,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -43294,7 +44662,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_EVENT",
         "kind": "static_from",
-        "line": 645,
+        "line": 643,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43308,7 +44676,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -43317,7 +44685,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_STAGE_LABELS",
         "kind": "static_from",
-        "line": 645,
+        "line": 643,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43331,7 +44699,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -43340,7 +44708,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_aio_preview_base_directory",
         "kind": "static_from",
-        "line": 645,
+        "line": 643,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43354,7 +44722,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -43363,7 +44731,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_aio_preview_file_size_bytes",
         "kind": "static_from",
-        "line": 645,
+        "line": 643,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43377,7 +44745,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -43386,7 +44754,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_bind_aio_preview_runtime",
         "kind": "static_from",
-        "line": 645,
+        "line": 643,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43400,7 +44768,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -43409,7 +44777,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_save_aio_temp_preview_image",
         "kind": "static_from",
-        "line": 645,
+        "line": 643,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43423,7 +44791,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -43432,7 +44800,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_send_aio_preview_event",
         "kind": "static_from",
-        "line": 645,
+        "line": 643,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43446,7 +44814,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -43455,7 +44823,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_tag_aio_preview_images",
         "kind": "static_from",
-        "line": 645,
+        "line": 643,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43469,7 +44837,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -43478,7 +44846,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_image_saver_additional_hashes",
         "kind": "static_from",
-        "line": 657,
+        "line": 655,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43492,7 +44860,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -43501,7 +44869,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_image_saver_civitai_hash_fetcher_entries",
         "kind": "static_from",
-        "line": 657,
+        "line": 655,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43515,7 +44883,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -43524,7 +44892,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_lora_metadata_name",
         "kind": "static_from",
-        "line": 657,
+        "line": 655,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43538,7 +44906,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -43547,7 +44915,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_prompt_with_lora_metadata",
         "kind": "static_from",
-        "line": 657,
+        "line": 655,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43561,7 +44929,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -43570,7 +44938,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_save_filename_prefix",
         "kind": "static_from",
-        "line": 657,
+        "line": 655,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43584,7 +44952,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -43593,7 +44961,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_bind_aio_output_runtime",
         "kind": "static_from",
-        "line": 657,
+        "line": 655,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43607,7 +44975,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -43616,7 +44984,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_normalize_aio_civitai_hash_fetchers",
         "kind": "static_from",
-        "line": 657,
+        "line": 655,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43630,7 +44998,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -43639,7 +45007,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_normalize_aio_hash_bundles",
         "kind": "static_from",
-        "line": 657,
+        "line": 655,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43653,7 +45021,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -43662,7 +45030,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_save_image_with_comfy",
         "kind": "static_from",
-        "line": 657,
+        "line": 655,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43676,7 +45044,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -43685,7 +45053,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_save_image_with_image_saver",
         "kind": "static_from",
-        "line": 657,
+        "line": 655,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43699,7 +45067,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -43708,7 +45076,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_bind_aio_resource_runtime",
         "kind": "static_from",
-        "line": 669,
+        "line": 667,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43722,7 +45090,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -43731,7 +45099,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_clip_loader_types",
         "kind": "static_from",
-        "line": 669,
+        "line": 667,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43745,7 +45113,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -43754,7 +45122,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_diffusion_model_names",
         "kind": "static_from",
-        "line": 669,
+        "line": 667,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43768,7 +45136,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -43777,7 +45145,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_text_encoder_names",
         "kind": "static_from",
-        "line": 669,
+        "line": 667,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43791,7 +45159,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -43800,7 +45168,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_vae_names",
         "kind": "static_from",
-        "line": 669,
+        "line": 667,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43814,7 +45182,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -43823,7 +45191,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_aio_resources_from_input_context",
         "kind": "static_from",
-        "line": 669,
+        "line": 667,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43837,7 +45205,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -43846,7 +45214,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_aio_sam3_context",
         "kind": "static_from",
-        "line": 669,
+        "line": 667,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43860,7 +45228,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -43869,7 +45237,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_checkpoint_with_comfy",
         "kind": "static_from",
-        "line": 669,
+        "line": 667,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43883,7 +45251,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -43892,7 +45260,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_clip_with_comfy",
         "kind": "static_from",
-        "line": 669,
+        "line": 667,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43906,7 +45274,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -43915,7 +45283,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_diffusion_model_with_comfy",
         "kind": "static_from",
-        "line": 669,
+        "line": 667,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43929,7 +45297,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -43938,7 +45306,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_upscale_model_with_comfy",
         "kind": "static_from",
-        "line": 669,
+        "line": 667,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43952,7 +45320,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -43961,7 +45329,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_vae_with_comfy",
         "kind": "static_from",
-        "line": 669,
+        "line": 667,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43975,7 +45343,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -43984,7 +45352,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_normalize_aio_input_settings",
         "kind": "static_from",
-        "line": 669,
+        "line": 667,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43998,7 +45366,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -44007,7 +45375,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_checkpoint_default",
         "kind": "static_from",
-        "line": 669,
+        "line": 667,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44021,7 +45389,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -44030,7 +45398,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_clip_type_default",
         "kind": "static_from",
-        "line": 669,
+        "line": 667,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44044,7 +45412,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -44053,7 +45421,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_name_default",
         "kind": "static_from",
-        "line": 669,
+        "line": 667,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44067,7 +45435,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -44076,7 +45444,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_json_clone",
         "kind": "static_from",
-        "line": 687,
+        "line": 685,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44090,7 +45458,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -44099,7 +45467,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_json_object",
         "kind": "static_from",
-        "line": 687,
+        "line": 685,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44113,7 +45481,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -44122,7 +45490,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_stable_change_key",
         "kind": "static_from",
-        "line": 687,
+        "line": 685,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44136,7 +45504,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -44145,7 +45513,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_bool",
         "kind": "static_from",
-        "line": 692,
+        "line": 690,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44159,7 +45527,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -44168,7 +45536,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_float",
         "kind": "static_from",
-        "line": 692,
+        "line": 690,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44182,7 +45550,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -44191,7 +45559,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_int",
         "kind": "static_from",
-        "line": 692,
+        "line": 690,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44205,7 +45573,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -44214,7 +45582,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_choice",
         "kind": "static_from",
-        "line": 692,
+        "line": 690,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44228,7 +45596,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -44237,7 +45605,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_single_value",
         "kind": "static_from",
-        "line": 692,
+        "line": 690,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44251,7 +45619,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -44260,7 +45628,7 @@
         "conditional": true,
         "imported": "easyuse_anima.seed.compatibility:WILDCARD_QUEUE_MAX_SAFE_SEED",
         "kind": "static_from",
-        "line": 699,
+        "line": 697,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44274,7 +45642,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -44283,7 +45651,7 @@
         "conditional": true,
         "imported": "easyuse_anima.seed.compatibility:WILDCARD_RESERVED_NEXT_SEED_INPUT",
         "kind": "static_from",
-        "line": 699,
+        "line": 697,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44297,7 +45665,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -44306,7 +45674,7 @@
         "conditional": true,
         "imported": "easyuse_anima.seed.compatibility:_consume_reserved_wildcard_next_seed",
         "kind": "static_from",
-        "line": 699,
+        "line": 697,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44320,7 +45688,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -44329,7 +45697,7 @@
         "conditional": true,
         "imported": "easyuse_anima.workflow:_get_workflow_node",
         "kind": "static_from",
-        "line": 704,
+        "line": 702,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44343,7 +45711,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -44352,7 +45720,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_prompt_translation_change_key",
         "kind": "static_from",
-        "line": 705,
+        "line": 703,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44366,7 +45734,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -44375,7 +45743,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_split_tag_text",
         "kind": "static_from",
-        "line": 705,
+        "line": 703,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44389,7 +45757,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -44398,7 +45766,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_translate_prompt_text",
         "kind": "static_from",
-        "line": 705,
+        "line": 703,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44412,7 +45780,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -44421,7 +45789,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_HASH_COMMENT_RE",
         "kind": "static_from",
-        "line": 710,
+        "line": 708,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44435,7 +45803,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -44444,7 +45812,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_INLINE_SPACE_RE",
         "kind": "static_from",
-        "line": 710,
+        "line": 708,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44458,7 +45826,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -44467,7 +45835,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_WEIGHTED_TOKEN_RE",
         "kind": "static_from",
-        "line": 710,
+        "line": 708,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44481,7 +45849,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -44490,7 +45858,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_correct_builder_prompt",
         "kind": "static_from",
-        "line": 710,
+        "line": 708,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44504,7 +45872,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -44513,7 +45881,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_filter_metadata_prompt",
         "kind": "static_from",
-        "line": 710,
+        "line": 708,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44527,7 +45895,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -44536,7 +45904,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_join_prompt_tokens",
         "kind": "static_from",
-        "line": 710,
+        "line": 708,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44550,7 +45918,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -44559,7 +45927,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_metadata_filter_key",
         "kind": "static_from",
-        "line": 710,
+        "line": 708,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44573,7 +45941,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -44582,7 +45950,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_metadata_filter_keys",
         "kind": "static_from",
-        "line": 710,
+        "line": 708,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44596,7 +45964,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -44605,7 +45973,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_prompt_tokens",
         "kind": "static_from",
-        "line": 710,
+        "line": 708,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44619,7 +45987,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -44628,7 +45996,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:PROMPT_DATA_TYPE",
         "kind": "static_from",
-        "line": 723,
+        "line": 721,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44642,7 +46010,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -44651,7 +46019,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_advanced_outputs_from_prompt_data",
         "kind": "static_from",
-        "line": 723,
+        "line": 721,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44665,7 +46033,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -44674,7 +46042,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_apply_prompt_data_overrides",
         "kind": "static_from",
-        "line": 723,
+        "line": 721,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44688,7 +46056,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -44697,7 +46065,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_copy_prompt_data_for_update",
         "kind": "static_from",
-        "line": 723,
+        "line": 721,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44711,7 +46079,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -44720,7 +46088,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_normalize_prompt_data",
         "kind": "static_from",
-        "line": 723,
+        "line": 721,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44734,7 +46102,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -44743,7 +46111,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_prompt_data_json_safe",
         "kind": "static_from",
-        "line": 723,
+        "line": 721,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44757,7 +46125,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -44766,7 +46134,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_prompt_data_parameter_snapshot",
         "kind": "static_from",
-        "line": 723,
+        "line": 721,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44780,7 +46148,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -44789,7 +46157,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_artist_field_prompt",
         "kind": "static_from",
-        "line": 741,
+        "line": 739,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44803,7 +46171,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -44812,7 +46180,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_default_fields",
         "kind": "static_from",
-        "line": 741,
+        "line": 739,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44826,7 +46194,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -44835,7 +46203,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_enabled_naia_panes",
         "kind": "static_from",
-        "line": 741,
+        "line": 739,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44849,7 +46217,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -44858,7 +46226,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_enabled_pane_fields",
         "kind": "static_from",
-        "line": 741,
+        "line": 739,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44872,7 +46240,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -44881,7 +46249,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_field_input_values",
         "kind": "static_from",
-        "line": 741,
+        "line": 739,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44895,7 +46263,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -44904,7 +46272,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_field_socket_name",
         "kind": "static_from",
-        "line": 741,
+        "line": 739,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44918,7 +46286,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -44927,7 +46295,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_fields_json",
         "kind": "static_from",
-        "line": 741,
+        "line": 739,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44941,7 +46309,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -44950,7 +46318,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_has_enabled_naia",
         "kind": "static_from",
-        "line": 741,
+        "line": 739,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44964,7 +46332,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -44973,7 +46341,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_prompt_with_artist_override",
         "kind": "static_from",
-        "line": 741,
+        "line": 739,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44987,7 +46355,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -44996,7 +46364,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_uses_naia_resolution",
         "kind": "static_from",
-        "line": 741,
+        "line": 739,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45010,7 +46378,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -45019,7 +46387,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_apply_advanced_field_inputs",
         "kind": "static_from",
-        "line": 741,
+        "line": 739,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45033,7 +46401,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -45042,7 +46410,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_as_advanced_height",
         "kind": "static_from",
-        "line": 741,
+        "line": 739,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45056,7 +46424,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -45065,7 +46433,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_build_advanced_prompt_data",
         "kind": "static_from",
-        "line": 741,
+        "line": 739,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45079,7 +46447,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -45088,7 +46456,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_build_advanced_prompts",
         "kind": "static_from",
-        "line": 741,
+        "line": 739,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45102,7 +46470,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -45111,7 +46479,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_clone_advanced_fields",
         "kind": "static_from",
-        "line": 741,
+        "line": 739,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45125,7 +46493,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -45134,7 +46502,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_correct_advanced_field_sequence",
         "kind": "static_from",
-        "line": 741,
+        "line": 739,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45148,7 +46516,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -45157,7 +46525,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_expand_advanced_wildcard_fields",
         "kind": "static_from",
-        "line": 741,
+        "line": 739,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45171,7 +46539,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -45180,7 +46548,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_normalize_advanced_fields",
         "kind": "static_from",
-        "line": 741,
+        "line": 739,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45194,7 +46562,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -45203,7 +46571,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_normalize_prompt_studio_wildcard_seed_control",
         "kind": "static_from",
-        "line": 741,
+        "line": 739,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45217,7 +46585,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -45226,7 +46594,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_set_naia_field_text",
         "kind": "static_from",
-        "line": 741,
+        "line": 739,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45240,7 +46608,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -45249,7 +46617,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_translate_prompt_fields",
         "kind": "static_from",
-        "line": 741,
+        "line": 739,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45263,7 +46631,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -45272,7 +46640,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_apply_regional_field_inputs",
         "kind": "static_from",
-        "line": 776,
+        "line": 774,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45286,7 +46654,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -45295,7 +46663,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_build_regional_outputs",
         "kind": "static_from",
-        "line": 776,
+        "line": 774,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45309,7 +46677,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -45318,7 +46686,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_clone_regional_fields",
         "kind": "static_from",
-        "line": 776,
+        "line": 774,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45332,7 +46700,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -45341,7 +46709,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_conditioning_set_values",
         "kind": "static_from",
-        "line": 776,
+        "line": 774,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45355,7 +46723,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -45364,7 +46732,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_mask_ids",
         "kind": "static_from",
-        "line": 776,
+        "line": 774,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45378,7 +46746,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -45387,7 +46755,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_regional_config",
         "kind": "static_from",
-        "line": 776,
+        "line": 774,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45401,7 +46769,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -45410,7 +46778,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_regional_fields",
         "kind": "static_from",
-        "line": 776,
+        "line": 774,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45424,7 +46792,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -45433,7 +46801,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_parse_json_object",
         "kind": "static_from",
-        "line": 776,
+        "line": 774,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45447,7 +46815,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -45456,7 +46824,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_config_json",
         "kind": "static_from",
-        "line": 776,
+        "line": 774,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45470,7 +46838,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -45479,7 +46847,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_fields_json",
         "kind": "static_from",
-        "line": 776,
+        "line": 774,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45493,7 +46861,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -45502,7 +46870,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_mask_bounds_area",
         "kind": "static_from",
-        "line": 776,
+        "line": 774,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45516,7 +46884,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -45525,7 +46893,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_payload_canvas",
         "kind": "static_from",
-        "line": 776,
+        "line": 774,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45539,7 +46907,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -45548,7 +46916,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_union_mask_for_ids",
         "kind": "static_from",
-        "line": 776,
+        "line": 774,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45562,7 +46930,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -45571,7 +46939,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
         "kind": "static_from",
-        "line": 803,
+        "line": 801,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45585,7 +46953,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -45594,7 +46962,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODES",
         "kind": "static_from",
-        "line": 803,
+        "line": 801,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45608,7 +46976,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -45617,7 +46985,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 803,
+        "line": 801,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45631,7 +46999,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -45640,7 +47008,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_PROFILE_OFF",
         "kind": "static_from",
-        "line": 803,
+        "line": 801,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45654,7 +47022,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -45663,7 +47031,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_apply_spectrum_anima_mod_guidance",
         "kind": "static_from",
-        "line": 803,
+        "line": 801,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45677,7 +47045,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -45686,7 +47054,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_find_spectrum_anima_mod_guidance_class",
         "kind": "static_from",
-        "line": 803,
+        "line": 801,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45700,7 +47068,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -45709,7 +47077,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_normalize_anima_mod_guidance_profile",
         "kind": "static_from",
-        "line": 803,
+        "line": 801,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45723,7 +47091,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -45732,7 +47100,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_resolve_anima_mod_guidance_enabled",
         "kind": "static_from",
-        "line": 803,
+        "line": 801,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45746,7 +47114,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -45755,7 +47123,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
         "kind": "static_from",
-        "line": 818,
+        "line": 816,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45769,7 +47137,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -45778,7 +47146,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
         "kind": "static_from",
-        "line": 818,
+        "line": 816,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45792,7 +47160,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -45801,7 +47169,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
         "kind": "static_from",
-        "line": 818,
+        "line": 816,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45815,7 +47183,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -45824,7 +47192,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_EXACT_TOP_K",
         "kind": "static_from",
-        "line": 818,
+        "line": 816,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45838,7 +47206,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -45847,7 +47215,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
         "kind": "static_from",
-        "line": 818,
+        "line": 816,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45861,7 +47229,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -45870,7 +47238,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_START_PERCENT",
         "kind": "static_from",
-        "line": 818,
+        "line": 816,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45884,7 +47252,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -45893,7 +47261,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
         "kind": "static_from",
-        "line": 818,
+        "line": 816,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45907,7 +47275,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -45916,7 +47284,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STYLE_GAIN",
         "kind": "static_from",
-        "line": 818,
+        "line": 816,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45930,7 +47298,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -45939,7 +47307,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_INPUT_MODES",
         "kind": "static_from",
-        "line": 818,
+        "line": 816,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45953,7 +47321,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -45962,7 +47330,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 818,
+        "line": 816,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45976,7 +47344,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -45985,7 +47353,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_mix_inline_prompt",
         "kind": "static_from",
-        "line": 818,
+        "line": 816,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45999,7 +47367,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -46008,7 +47376,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_mix_mode_tooltip",
         "kind": "static_from",
-        "line": 818,
+        "line": 816,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46022,7 +47390,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -46031,7 +47399,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_prompt_with_position",
         "kind": "static_from",
-        "line": 818,
+        "line": 816,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46045,7 +47413,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -46054,7 +47422,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_tags_from_prompt",
         "kind": "static_from",
-        "line": 818,
+        "line": 816,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46068,7 +47436,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -46077,7 +47445,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_blend_conditionings",
         "kind": "static_from",
-        "line": 818,
+        "line": 816,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46091,7 +47459,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -46100,7 +47468,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bounded_artist_mix_float",
         "kind": "static_from",
-        "line": 818,
+        "line": 816,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46114,7 +47482,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -46123,7 +47491,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bounded_artist_mix_int",
         "kind": "static_from",
-        "line": 818,
+        "line": 816,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46137,7 +47505,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -46146,7 +47514,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_clustered",
         "kind": "static_from",
-        "line": 818,
+        "line": 816,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46160,7 +47528,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -46169,7 +47537,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_delta_rms",
         "kind": "static_from",
-        "line": 818,
+        "line": 816,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46183,7 +47551,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -46192,7 +47560,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_prompt_data_positive_conditioning",
         "kind": "static_from",
-        "line": 818,
+        "line": 816,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46206,7 +47574,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -46215,7 +47583,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_join_artist_mix_source_prompts",
         "kind": "static_from",
-        "line": 818,
+        "line": 816,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46229,7 +47597,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -46238,7 +47606,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_normalize_artist_mix_mode",
         "kind": "static_from",
-        "line": 818,
+        "line": 816,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46252,7 +47620,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -46261,7 +47629,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_normalize_artist_tag_position",
         "kind": "static_from",
-        "line": 818,
+        "line": 816,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46275,7 +47643,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -46284,7 +47652,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_parse_artist_mix_items",
         "kind": "static_from",
-        "line": 818,
+        "line": 816,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46298,7 +47666,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -46307,7 +47675,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaArtistMixConditioning",
         "kind": "static_from",
-        "line": 897,
+        "line": 895,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46321,7 +47689,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -46330,7 +47698,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataConditioning",
         "kind": "static_from",
-        "line": 897,
+        "line": 895,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46344,7 +47712,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -46353,7 +47721,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataUnpack",
         "kind": "static_from",
-        "line": 897,
+        "line": 895,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46367,7 +47735,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -46376,7 +47744,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_ANY_TYPE",
         "kind": "static_from",
-        "line": 902,
+        "line": 900,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46390,7 +47758,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -46399,7 +47767,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_AnyType",
         "kind": "static_from",
-        "line": 902,
+        "line": 900,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46413,7 +47781,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -46422,7 +47790,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_FlexibleOptionalInputType",
         "kind": "static_from",
-        "line": 902,
+        "line": 900,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46436,7 +47804,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -46445,7 +47813,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvanced",
         "kind": "static_from",
-        "line": 907,
+        "line": 905,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46459,7 +47827,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -46468,7 +47836,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvancedV2",
         "kind": "static_from",
-        "line": 907,
+        "line": 905,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46482,30 +47850,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
-            "kind": "try",
-            "line": 9
-          }
-        ],
-        "classification": "compatibility_fallback",
-        "conditional": true,
-        "imported": "easyuse_anima.nodes.prompt_advanced_nodes:_bind_prompt_advanced_node_runtime",
-        "kind": "static_from",
-        "line": 907,
-        "optional": false,
-        "role": "compatibility_fallback",
-        "source": "nodes.py",
-        "target": "easyuse_anima/nodes/prompt_advanced_nodes.py"
-      },
-      {
-        "branch_context": [
-          {
-            "branch": "except",
-            "catches_import_error": true,
-            "exceptions": [
-              "ImportError"
-            ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -46514,7 +47859,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:EasyUseAnimaAIOGenerator",
         "kind": "static_from",
-        "line": 913,
+        "line": 910,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46528,7 +47873,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -46537,7 +47882,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:EasyUseAnimaInput",
         "kind": "static_from",
-        "line": 913,
+        "line": 910,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46551,7 +47896,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -46560,7 +47905,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_aio_generation_settings_json",
         "kind": "static_from",
-        "line": 913,
+        "line": 910,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46574,7 +47919,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -46583,7 +47928,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_aio_input_settings_json",
         "kind": "static_from",
-        "line": 913,
+        "line": 910,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46597,7 +47942,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -46606,7 +47951,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_bind_aio_node_runtime",
         "kind": "static_from",
-        "line": 913,
+        "line": 910,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46620,7 +47965,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -46629,7 +47974,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_easy_use_anima_input_signature",
         "kind": "static_from",
-        "line": 913,
+        "line": 910,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46643,7 +47988,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -46652,7 +47997,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_require_easy_use_anima_input",
         "kind": "static_from",
-        "line": 913,
+        "line": 910,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46666,7 +48011,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -46675,7 +48020,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_align_down",
         "kind": "static_from",
-        "line": 922,
+        "line": 919,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46689,7 +48034,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -46698,7 +48043,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_align_nearest",
         "kind": "static_from",
-        "line": 922,
+        "line": 919,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46712,7 +48057,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -46721,7 +48066,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_image_tensor_size",
         "kind": "static_from",
-        "line": 922,
+        "line": 919,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46735,7 +48080,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -46744,7 +48089,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_context_value",
         "kind": "static_from",
-        "line": 933,
+        "line": 930,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46758,7 +48103,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -46767,7 +48112,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_sam3_context",
         "kind": "static_from",
-        "line": 933,
+        "line": 930,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46781,7 +48126,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -46790,7 +48135,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_segs_has_items",
         "kind": "static_from",
-        "line": 933,
+        "line": 930,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46804,7 +48149,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -46813,7 +48158,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:IMAGE_SCALE_MULTIPLES",
         "kind": "static_from",
-        "line": 945,
+        "line": 942,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46827,7 +48172,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -46836,7 +48181,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:IMAGE_UPSCALE_METHODS",
         "kind": "static_from",
-        "line": 945,
+        "line": 942,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46850,7 +48195,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -46859,7 +48204,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_sampler_names",
         "kind": "static_from",
-        "line": 953,
+        "line": 950,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46873,7 +48218,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -46882,7 +48227,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_scheduler_names",
         "kind": "static_from",
-        "line": 953,
+        "line": 950,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46896,7 +48241,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -46905,7 +48250,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_impact_scheduler_names",
         "kind": "static_from",
-        "line": 953,
+        "line": 950,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46919,7 +48264,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -46928,7 +48273,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_call_with_supported_kwargs",
         "kind": "static_from",
-        "line": 959,
+        "line": 956,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46942,7 +48287,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -46951,7 +48296,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_common_upscale_image",
         "kind": "static_from",
-        "line": 959,
+        "line": 956,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46965,7 +48310,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -46974,7 +48319,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_node_output_tuple",
         "kind": "static_from",
-        "line": 959,
+        "line": 956,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46988,7 +48333,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -46997,7 +48342,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.wiring:resolve_comfy_host_helper",
         "kind": "static_from",
-        "line": 964,
+        "line": 961,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47011,7 +48356,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -47020,7 +48365,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_clip_loader_types",
         "kind": "static_from",
-        "line": 967,
+        "line": 964,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47034,7 +48379,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -47043,7 +48388,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_diffusion_model_names",
         "kind": "static_from",
-        "line": 967,
+        "line": 964,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47057,7 +48402,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -47066,7 +48411,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_text_encoder_names",
         "kind": "static_from",
-        "line": 967,
+        "line": 964,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47080,7 +48425,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -47089,7 +48434,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_vae_names",
         "kind": "static_from",
-        "line": 967,
+        "line": 964,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47103,7 +48448,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -47112,7 +48457,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_folder_path_names",
         "kind": "static_from",
-        "line": 967,
+        "line": 964,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47126,7 +48471,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -47135,7 +48480,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.image_nodes:EasyUseAnimaDetailerAlignHook",
         "kind": "static_from",
-        "line": 975,
+        "line": 972,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47149,7 +48494,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -47158,7 +48503,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.image_nodes:EasyUseAnimaImageScaleByMultiple",
         "kind": "static_from",
-        "line": 975,
+        "line": 972,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47172,7 +48517,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -47181,7 +48526,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Context",
         "kind": "static_from",
-        "line": 979,
+        "line": 976,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47195,7 +48540,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -47204,7 +48549,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Detailer",
         "kind": "static_from",
-        "line": 979,
+        "line": 976,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47218,7 +48563,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -47227,7 +48572,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptBuilder",
         "kind": "static_from",
-        "line": 983,
+        "line": 980,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47241,7 +48586,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -47250,7 +48595,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrector",
         "kind": "static_from",
-        "line": 983,
+        "line": 980,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47264,7 +48609,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -47273,7 +48618,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrectorSimple",
         "kind": "static_from",
-        "line": 983,
+        "line": 980,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47287,7 +48632,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -47296,7 +48641,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptStudio",
         "kind": "static_from",
-        "line": 983,
+        "line": 980,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47310,7 +48655,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -47319,7 +48664,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:EasyUseAnimaPromptStudioRegional",
         "kind": "static_from",
-        "line": 989,
+        "line": 986,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47333,7 +48678,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -47342,7 +48687,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:EasyUseAnimaRegionalConditioning",
         "kind": "static_from",
-        "line": 989,
+        "line": 986,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47356,30 +48701,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
-            "kind": "try",
-            "line": 9
-          }
-        ],
-        "classification": "compatibility_fallback",
-        "conditional": true,
-        "imported": "easyuse_anima.nodes.regional_nodes:_bind_regional_node_runtime",
-        "kind": "static_from",
-        "line": 989,
-        "optional": false,
-        "role": "compatibility_fallback",
-        "source": "nodes.py",
-        "target": "easyuse_anima/nodes/regional_nodes.py"
-      },
-      {
-        "branch_context": [
-          {
-            "branch": "except",
-            "catches_import_error": true,
-            "exceptions": [
-              "ImportError"
-            ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -47388,7 +48710,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:LATENT_ALIGN",
         "kind": "static_from",
-        "line": 994,
+        "line": 990,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47402,7 +48724,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -47411,7 +48733,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_parse_random_response",
         "kind": "static_from",
-        "line": 994,
+        "line": 990,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47425,7 +48747,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -47434,7 +48756,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_post_random",
         "kind": "static_from",
-        "line": 994,
+        "line": 990,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47448,7 +48770,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -47457,7 +48779,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_advanced_resolution_from_selection",
         "kind": "static_from",
-        "line": 1012,
+        "line": 1008,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47471,7 +48793,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -47480,7 +48802,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_normalize_resolution_bucket",
         "kind": "static_from",
-        "line": 1012,
+        "line": 1008,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47494,7 +48816,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -47503,7 +48825,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_ratio_label",
         "kind": "static_from",
-        "line": 1012,
+        "line": 1008,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47517,7 +48839,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -47526,7 +48848,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolution_label",
         "kind": "static_from",
-        "line": 1012,
+        "line": 1008,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47540,7 +48862,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -47549,7 +48871,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolve_naia_resolution",
         "kind": "static_from",
-        "line": 1012,
+        "line": 1008,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47563,7 +48885,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -47572,7 +48894,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.naia_nodes:EasyUseAnimaNAIARandomPrompt",
         "kind": "static_from",
-        "line": 1035,
+        "line": 1031,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47586,7 +48908,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -47595,7 +48917,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.naia_nodes:_bind_naia_node_runtime",
         "kind": "static_from",
-        "line": 1035,
+        "line": 1031,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47609,7 +48931,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -47618,7 +48940,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.wildcard_nodes:EasyUseAnimaWildcard",
         "kind": "static_from",
-        "line": 1039,
+        "line": 1035,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47632,7 +48954,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -47641,7 +48963,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.wildcard_nodes:_bind_wildcard_node_runtime",
         "kind": "static_from",
-        "line": 1039,
+        "line": 1035,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47655,7 +48977,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -47664,7 +48986,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_apply_lora_syntax_format",
         "kind": "static_from",
-        "line": 1044,
+        "line": 1040,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47678,7 +49000,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -47687,7 +49009,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_dedupe_text_values",
         "kind": "static_from",
-        "line": 1044,
+        "line": 1040,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47701,7 +49023,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -47710,7 +49032,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_fallback_lora_path",
         "kind": "static_from",
-        "line": 1044,
+        "line": 1040,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47724,7 +49046,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -47733,7 +49055,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_get_lora_info",
         "kind": "static_from",
-        "line": 1044,
+        "line": 1040,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47747,7 +49069,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -47756,7 +49078,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_get_lora_manager_trigger_words",
         "kind": "static_from",
-        "line": 1044,
+        "line": 1040,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47770,7 +49092,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -47779,7 +49101,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_load_lora_manager_metadata",
         "kind": "static_from",
-        "line": 1044,
+        "line": 1040,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47793,7 +49115,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -47802,7 +49124,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_combo_values",
         "kind": "static_from",
-        "line": 1044,
+        "line": 1040,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47816,7 +49138,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -47825,7 +49147,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_manager_trigger_words_from_metadata",
         "kind": "static_from",
-        "line": 1044,
+        "line": 1040,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47839,7 +49161,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -47848,7 +49170,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_model_exists",
         "kind": "static_from",
-        "line": 1044,
+        "line": 1040,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47862,7 +49184,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -47871,7 +49193,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_stack_name",
         "kind": "static_from",
-        "line": 1044,
+        "line": 1040,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47885,7 +49207,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -47894,7 +49216,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_metadata_json_paths_for_lora",
         "kind": "static_from",
-        "line": 1044,
+        "line": 1040,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47908,7 +49230,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -47917,7 +49239,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_missing_lora_display_name",
         "kind": "static_from",
-        "line": 1044,
+        "line": 1040,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47931,7 +49253,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -47940,7 +49262,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_raise_missing_loras",
         "kind": "static_from",
-        "line": 1044,
+        "line": 1040,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47954,7 +49276,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -47963,7 +49285,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_trigger_words_from_value",
         "kind": "static_from",
-        "line": 1044,
+        "line": 1040,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47977,7 +49299,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -47986,7 +49308,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_correct_style_prompt",
         "kind": "static_from",
-        "line": 1060,
+        "line": 1056,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48000,7 +49322,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -48009,7 +49331,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_format_strength",
         "kind": "static_from",
-        "line": 1060,
+        "line": 1056,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48023,7 +49345,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -48032,7 +49354,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_get_loras_list",
         "kind": "static_from",
-        "line": 1060,
+        "line": 1056,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48046,7 +49368,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -48055,7 +49377,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_load_profile_data",
         "kind": "static_from",
-        "line": 1060,
+        "line": 1056,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48069,7 +49391,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -48078,7 +49400,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_profile_key",
         "kind": "static_from",
-        "line": 1060,
+        "line": 1056,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48092,7 +49414,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -48101,7 +49423,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_select_profile_values",
         "kind": "static_from",
-        "line": 1060,
+        "line": 1056,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48115,7 +49437,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -48124,7 +49446,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_wrap_profile_index",
         "kind": "static_from",
-        "line": 1060,
+        "line": 1056,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48138,7 +49460,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -48147,7 +49469,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.lora_nodes:EasyUseAnimaLoraPreset",
         "kind": "static_from",
-        "line": 1069,
+        "line": 1065,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48161,7 +49483,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -48170,7 +49492,7 @@
         "conditional": true,
         "imported": "anima_prompt:correct_prompt",
         "kind": "static_from",
-        "line": 1072,
+        "line": 1068,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48184,7 +49506,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -48193,7 +49515,7 @@
         "conditional": true,
         "imported": "anima_prompt:load_knowledge_base",
         "kind": "static_from",
-        "line": 1072,
+        "line": 1068,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48207,7 +49529,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -48216,7 +49538,7 @@
         "conditional": true,
         "imported": "anima_prompt.parser:parse_prompt",
         "kind": "static_from",
-        "line": 1073,
+        "line": 1069,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48230,7 +49552,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -48239,7 +49561,7 @@
         "conditional": true,
         "imported": "settings:resolve_metadata_filter_words",
         "kind": "static_from",
-        "line": 1074,
+        "line": 1070,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48253,7 +49575,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -48262,7 +49584,7 @@
         "conditional": true,
         "imported": "settings:resolve_naia_settings",
         "kind": "static_from",
-        "line": 1074,
+        "line": 1070,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48276,7 +49598,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -48285,7 +49607,7 @@
         "conditional": true,
         "imported": "settings:resolve_prompt_translation_settings",
         "kind": "static_from",
-        "line": 1074,
+        "line": 1070,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48299,7 +49621,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -48308,7 +49630,7 @@
         "conditional": true,
         "imported": "prompt_translation:has_prompt_translation_markers",
         "kind": "static_from",
-        "line": 1079,
+        "line": 1075,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48322,7 +49644,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -48331,7 +49653,7 @@
         "conditional": true,
         "imported": "prompt_translation:translate_prompt_markers",
         "kind": "static_from",
-        "line": 1079,
+        "line": 1075,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48345,7 +49667,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -48354,7 +49676,7 @@
         "conditional": true,
         "imported": "wildcard_engine:MAX_SEED",
         "kind": "static_from",
-        "line": 1080,
+        "line": 1076,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48368,7 +49690,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -48377,7 +49699,7 @@
         "conditional": true,
         "imported": "wildcard_engine:PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "kind": "static_from",
-        "line": 1080,
+        "line": 1076,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48391,7 +49713,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -48400,7 +49722,7 @@
         "conditional": true,
         "imported": "wildcard_engine:PUBLIC_MAX_SEED",
         "kind": "static_from",
-        "line": 1080,
+        "line": 1076,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48414,7 +49736,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -48423,7 +49745,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_DECREMENT",
         "kind": "static_from",
-        "line": 1080,
+        "line": 1076,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48437,7 +49759,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -48446,7 +49768,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_FIXED",
         "kind": "static_from",
-        "line": 1080,
+        "line": 1076,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48460,7 +49782,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -48469,7 +49791,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_INCREMENT",
         "kind": "static_from",
-        "line": 1080,
+        "line": 1076,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48483,7 +49805,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -48492,7 +49814,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_MODES",
         "kind": "static_from",
-        "line": 1080,
+        "line": 1076,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48506,7 +49828,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -48515,7 +49837,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_RANDOMIZE",
         "kind": "static_from",
-        "line": 1080,
+        "line": 1076,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48529,7 +49851,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -48538,7 +49860,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_FIXED",
         "kind": "static_from",
-        "line": 1080,
+        "line": 1076,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48552,7 +49874,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -48561,7 +49883,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_POPULATE",
         "kind": "static_from",
-        "line": 1080,
+        "line": 1076,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48575,7 +49897,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -48584,7 +49906,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_SEQUENTIAL",
         "kind": "static_from",
-        "line": 1080,
+        "line": 1076,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48598,7 +49920,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -48607,7 +49929,7 @@
         "conditional": true,
         "imported": "wildcard_engine:expand_wildcard_texts",
         "kind": "static_from",
-        "line": 1080,
+        "line": 1076,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48621,7 +49943,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -48630,7 +49952,7 @@
         "conditional": true,
         "imported": "wildcard_engine:expand_wildcards",
         "kind": "static_from",
-        "line": 1080,
+        "line": 1076,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48644,7 +49966,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -48653,7 +49975,7 @@
         "conditional": true,
         "imported": "wildcard_engine:has_wildcard_syntax",
         "kind": "static_from",
-        "line": 1080,
+        "line": 1076,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48667,7 +49989,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -48676,7 +49998,7 @@
         "conditional": true,
         "imported": "wildcard_engine:next_seed",
         "kind": "static_from",
-        "line": 1080,
+        "line": 1076,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48690,7 +50012,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -48699,7 +50021,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_prompt_studio_wildcard_mode",
         "kind": "static_from",
-        "line": 1080,
+        "line": 1076,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48713,7 +50035,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -48722,7 +50044,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_seed",
         "kind": "static_from",
-        "line": 1080,
+        "line": 1076,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48736,7 +50058,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -48745,7 +50067,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_wildcard_mode",
         "kind": "static_from",
-        "line": 1080,
+        "line": 1076,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48759,7 +50081,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 555,
+            "handler_line": 553,
             "kind": "try",
             "line": 9
           }
@@ -48768,7 +50090,7 @@
         "conditional": true,
         "imported": "wildcard_engine:wildcard_sources_signature",
         "kind": "static_from",
-        "line": 1080,
+        "line": 1076,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -55498,7 +56820,7 @@
         "column": 9,
         "context": "assign:logger",
         "kind": "import_time_call",
-        "line": 1102,
+        "line": 1098,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55507,7 +56829,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1594,
+        "line": 1590,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55516,7 +56838,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1597,
+        "line": 1593,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55525,7 +56847,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1603,
+        "line": 1599,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55534,7 +56856,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1609,
+        "line": 1605,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55543,7 +56865,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1612,
+        "line": 1608,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55552,7 +56874,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1615,
+        "line": 1611,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55561,7 +56883,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1621,
+        "line": 1617,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55570,7 +56892,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1627,
+        "line": 1623,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55579,7 +56901,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1633,
+        "line": 1629,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55588,7 +56910,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1639,
+        "line": 1635,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55597,25 +56919,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1645,
-        "module": "nodes.py",
-        "scope": "<module>"
-      },
-      {
-        "callee": "_bind_regional_node_runtime",
-        "column": 0,
-        "context": "expression",
-        "kind": "import_time_call",
-        "line": 1651,
-        "module": "nodes.py",
-        "scope": "<module>"
-      },
-      {
-        "callee": "_bind_prompt_advanced_node_runtime",
-        "column": 0,
-        "context": "expression",
-        "kind": "import_time_call",
-        "line": 1658,
+        "line": 1641,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55624,7 +56928,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1662,
+        "line": 1647,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55633,7 +56937,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1665,
+        "line": 1650,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55642,7 +56946,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1672,
+        "line": 1657,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -56156,13 +57460,13 @@
       },
       {
         "kind": "dict",
-        "line": 1162,
+        "line": 1158,
         "module": "nodes.py",
         "name": "AIO_GENERATION_DEFAULT_SETTINGS"
       },
       {
         "kind": "dict",
-        "line": 1151,
+        "line": 1147,
         "module": "nodes.py",
         "name": "AIO_INPUT_DEFAULT_SETTINGS"
       },

--- a/tests/fixtures/python_compatibility_surface.v1.json
+++ b/tests/fixtures/python_compatibility_surface.v1.json
@@ -71,7 +71,8 @@
       "B-11c30c",
       "B-11c30c1",
       "B-11c30c2",
-      "B-11c30c2a"
+      "B-11c30c2a",
+      "B-11c30c2b"
     ]
   },
   "enums": {
@@ -106,14 +107,14 @@
   "expected_counts": {
     "root_entrypoints": 3,
     "excluded_preamble_implementation_bindings": 5,
-    "nodes_canonical_bindings": 284,
+    "nodes_canonical_bindings": 282,
     "nodes_legacy_bindings": 27,
     "mapped_public_classes": 18,
     "unmapped_classes": 2,
     "root_residual_functions": 0,
     "root_residual_classes": 0,
     "root_residual_globals": 24,
-    "runtime_binders": 16,
+    "runtime_binders": 14,
     "direct_nodes_import_test_files": 21
   },
   "mapped_public_classes": [
@@ -159,8 +160,6 @@
     "_bind_aio_preview_runtime",
     "_bind_aio_output_runtime",
     "_bind_aio_conditioning_runtime",
-    "_bind_regional_node_runtime",
-    "_bind_prompt_advanced_node_runtime",
     "_bind_aio_node_runtime",
     "_bind_wildcard_node_runtime",
     "_bind_naia_node_runtime"
@@ -311,9 +310,6 @@
     "EasyUseAnimaImageScaleByMultiple": [
       "easyuse_anima.aio.legacy_generation"
     ],
-    "EasyUseAnimaNAIARandomPrompt": [
-      "easyuse_anima.nodes.prompt_advanced_nodes"
-    ],
     "EasyUseAnimaSAM3Detailer": [
       "easyuse_anima.aio.legacy_generation"
     ],
@@ -367,31 +363,11 @@
     "_advanced_artist_field_prompt": [
       "easyuse_anima.aio.conditioning"
     ],
-    "_advanced_enabled_naia_panes": [
-      "easyuse_anima.nodes.prompt_advanced_nodes"
-    ],
     "_advanced_enabled_pane_fields": [
       "easyuse_anima.aio.conditioning"
     ],
-    "_advanced_field_input_values": [
-      "easyuse_anima.nodes.prompt_advanced_nodes",
-      "easyuse_anima.nodes.regional_nodes"
-    ],
-    "_advanced_fields_json": [
-      "easyuse_anima.nodes.prompt_advanced_nodes"
-    ],
-    "_advanced_has_enabled_naia": [
-      "easyuse_anima.nodes.prompt_advanced_nodes"
-    ],
     "_advanced_outputs_from_prompt_data": [
       "easyuse_anima.aio.legacy_generation"
-    ],
-    "_advanced_resolution_from_selection": [
-      "easyuse_anima.nodes.prompt_advanced_nodes",
-      "easyuse_anima.nodes.regional_nodes"
-    ],
-    "_advanced_uses_naia_resolution": [
-      "easyuse_anima.nodes.prompt_advanced_nodes"
     ],
     "_aio_detailer_has_enabled_targets": [
       "easyuse_anima.aio.legacy_generation"
@@ -467,9 +443,6 @@
     "_align_nearest": [
       "easyuse_anima.aio.usdu"
     ],
-    "_apply_advanced_field_inputs": [
-      "easyuse_anima.nodes.prompt_advanced_nodes"
-    ],
     "_apply_aio_anima_dave_patch": [
       "easyuse_anima.aio.model_preparation"
     ],
@@ -497,14 +470,8 @@
     "_apply_aio_spectrum_model_patches_for_comfy_sampler": [
       "easyuse_anima.aio.legacy_generation"
     ],
-    "_apply_regional_field_inputs": [
-      "easyuse_anima.nodes.regional_nodes"
-    ],
     "_apply_spectrum_anima_mod_guidance": [
       "easyuse_anima.aio.legacy_generation"
-    ],
-    "_artist_mix_mode_tooltip": [
-      "easyuse_anima.nodes.prompt_advanced_nodes"
     ],
     "_as_bool": [
       "easyuse_anima.aio.conditioning",
@@ -514,9 +481,7 @@
       "easyuse_anima.aio.output",
       "easyuse_anima.aio.postprocess",
       "easyuse_anima.aio.sampling",
-      "easyuse_anima.aio.usdu",
-      "easyuse_anima.nodes.prompt_advanced_nodes",
-      "easyuse_anima.nodes.regional_nodes"
+      "easyuse_anima.aio.usdu"
     ],
     "_as_float": [
       "easyuse_anima.aio.generation_normalization",
@@ -524,8 +489,7 @@
       "easyuse_anima.aio.model_preparation",
       "easyuse_anima.aio.output",
       "easyuse_anima.aio.postprocess",
-      "easyuse_anima.aio.sampling",
-      "easyuse_anima.nodes.regional_nodes"
+      "easyuse_anima.aio.sampling"
     ],
     "_as_int": [
       "easyuse_anima.aio.generation_normalization",
@@ -535,25 +499,13 @@
       "easyuse_anima.aio.postprocess",
       "easyuse_anima.aio.resources",
       "easyuse_anima.aio.sampling",
-      "easyuse_anima.aio.usdu",
-      "easyuse_anima.nodes.prompt_advanced_nodes"
+      "easyuse_anima.aio.usdu"
     ],
     "_bounded_artist_mix_float": [
-      "easyuse_anima.aio.generation_normalization",
-      "easyuse_anima.nodes.prompt_advanced_nodes"
+      "easyuse_anima.aio.generation_normalization"
     ],
     "_bounded_artist_mix_int": [
-      "easyuse_anima.aio.generation_normalization",
-      "easyuse_anima.nodes.prompt_advanced_nodes"
-    ],
-    "_build_advanced_prompt_data": [
-      "easyuse_anima.nodes.prompt_advanced_nodes"
-    ],
-    "_build_advanced_prompts": [
-      "easyuse_anima.nodes.prompt_advanced_nodes"
-    ],
-    "_build_regional_outputs": [
-      "easyuse_anima.nodes.regional_nodes"
+      "easyuse_anima.aio.generation_normalization"
     ],
     "_call_with_supported_kwargs": [
       "easyuse_anima.aio.model_preparation",
@@ -566,14 +518,8 @@
     "_cleanup_aio_ephemeral_model": [
       "easyuse_anima.aio.legacy_generation"
     ],
-    "_clone_advanced_fields": [
-      "easyuse_anima.nodes.prompt_advanced_nodes"
-    ],
     "_clone_aio_cache_value": [
       "easyuse_anima.aio.first_pass_cache"
-    ],
-    "_clone_regional_fields": [
-      "easyuse_anima.nodes.regional_nodes"
     ],
     "_comfy_clip_loader_types": [
       "easyuse_anima.nodes.aio_nodes"
@@ -596,13 +542,6 @@
     "_common_upscale_image": [
       "easyuse_anima.aio.postprocess"
     ],
-    "_conditioning_set_values": [
-      "easyuse_anima.nodes.regional_nodes"
-    ],
-    "_consume_reserved_wildcard_next_seed": [
-      "easyuse_anima.nodes.prompt_advanced_nodes",
-      "easyuse_anima.nodes.regional_nodes"
-    ],
     "_context_value": [
       "easyuse_anima.aio.legacy_generation"
     ],
@@ -624,10 +563,6 @@
     "_encode_prompt_data_positive_conditioning": [
       "easyuse_anima.aio.legacy_generation"
     ],
-    "_expand_advanced_wildcard_fields": [
-      "easyuse_anima.nodes.prompt_advanced_nodes",
-      "easyuse_anima.nodes.regional_nodes"
-    ],
     "_folder_path_names": [
       "easyuse_anima.aio.resources"
     ],
@@ -639,10 +574,6 @@
     ],
     "_get_aio_first_pass_cache": [
       "easyuse_anima.aio.legacy_generation"
-    ],
-    "_get_workflow_node": [
-      "easyuse_anima.nodes.prompt_advanced_nodes",
-      "easyuse_anima.nodes.regional_nodes"
     ],
     "_image_tensor_size": [
       "easyuse_anima.aio.legacy_generation",
@@ -701,8 +632,7 @@
       "easyuse_anima.aio.sampling"
     ],
     "_normalize_advanced_fields": [
-      "easyuse_anima.aio.conditioning",
-      "easyuse_anima.nodes.prompt_advanced_nodes"
+      "easyuse_anima.aio.conditioning"
     ],
     "_normalize_aio_civitai_hash_fetchers": [
       "easyuse_anima.aio.generation_normalization",
@@ -738,38 +668,13 @@
       "easyuse_anima.aio.legacy_generation",
       "easyuse_anima.aio.sampling"
     ],
-    "_normalize_artist_mix_mode": [
-      "easyuse_anima.nodes.prompt_advanced_nodes"
-    ],
-    "_normalize_mask_ids": [
-      "easyuse_anima.nodes.regional_nodes"
-    ],
     "_normalize_prompt_data": [
       "easyuse_anima.aio.conditioning",
       "easyuse_anima.aio.legacy_generation",
       "easyuse_anima.nodes.aio_nodes"
     ],
-    "_normalize_prompt_studio_wildcard_seed_control": [
-      "easyuse_anima.nodes.prompt_advanced_nodes",
-      "easyuse_anima.nodes.regional_nodes"
-    ],
-    "_normalize_regional_config": [
-      "easyuse_anima.nodes.regional_nodes"
-    ],
-    "_normalize_regional_fields": [
-      "easyuse_anima.nodes.regional_nodes"
-    ],
-    "_parse_json_object": [
-      "easyuse_anima.nodes.regional_nodes"
-    ],
-    "_parse_random_response": [
-      "easyuse_anima.nodes.prompt_advanced_nodes"
-    ],
     "_patch_model_sampling_aura_flow": [
       "easyuse_anima.aio.model_preparation"
-    ],
-    "_post_random": [
-      "easyuse_anima.nodes.prompt_advanced_nodes"
     ],
     "_preferred_clip_type_default": [
       "easyuse_anima.nodes.aio_nodes"
@@ -784,30 +689,8 @@
       "easyuse_anima.aio.preview",
       "easyuse_anima.nodes.aio_nodes"
     ],
-    "_prompt_data_parameter_snapshot": [
-      "easyuse_anima.nodes.prompt_advanced_nodes"
-    ],
-    "_prompt_translation_change_key": [
-      "easyuse_anima.nodes.prompt_advanced_nodes",
-      "easyuse_anima.nodes.regional_nodes"
-    ],
     "_put_aio_first_pass_cache": [
       "easyuse_anima.aio.legacy_generation"
-    ],
-    "_regional_config_json": [
-      "easyuse_anima.nodes.regional_nodes"
-    ],
-    "_regional_fields_json": [
-      "easyuse_anima.nodes.regional_nodes"
-    ],
-    "_regional_mask_bounds_area": [
-      "easyuse_anima.nodes.regional_nodes"
-    ],
-    "_regional_payload_canvas": [
-      "easyuse_anima.nodes.regional_nodes"
-    ],
-    "_regional_union_mask_for_ids": [
-      "easyuse_anima.nodes.regional_nodes"
     ],
     "_require_easy_use_anima_input": [
       "easyuse_anima.aio.legacy_generation"
@@ -815,9 +698,6 @@
     "_resize_image_to_size_if_needed": [
       "easyuse_anima.aio.legacy_generation",
       "easyuse_anima.aio.postprocess"
-    ],
-    "_resolution_label": [
-      "easyuse_anima.nodes.prompt_advanced_nodes"
     ],
     "_resolve_aio_runtime_seed": [
       "easyuse_anima.aio.legacy_generation",
@@ -827,9 +707,6 @@
     ],
     "_resolve_anima_mod_guidance_enabled": [
       "easyuse_anima.aio.legacy_generation"
-    ],
-    "_resolve_naia_resolution": [
-      "easyuse_anima.nodes.prompt_advanced_nodes"
     ],
     "_round_trip_aio_generation_settings": [
       "easyuse_anima.aio.generation_normalization"
@@ -888,32 +765,18 @@
     "_send_aio_preview_event": [
       "easyuse_anima.aio.legacy_generation"
     ],
-    "_set_naia_field_text": [
-      "easyuse_anima.nodes.prompt_advanced_nodes"
-    ],
     "_single_value": [
       "easyuse_anima.aio.legacy_generation",
       "easyuse_anima.aio.output",
-      "easyuse_anima.aio.preview",
-      "easyuse_anima.nodes.prompt_advanced_nodes",
-      "easyuse_anima.nodes.regional_nodes"
+      "easyuse_anima.aio.preview"
     ],
     "_stable_change_key": [
       "easyuse_anima.aio.first_pass_cache",
-      "easyuse_anima.nodes.aio_nodes",
-      "easyuse_anima.nodes.prompt_advanced_nodes",
-      "easyuse_anima.nodes.regional_nodes"
+      "easyuse_anima.nodes.aio_nodes"
     ],
     "_tag_aio_preview_images": [
       "easyuse_anima.aio.legacy_generation",
       "easyuse_anima.aio.preview"
-    ],
-    "_translate_prompt_fields": [
-      "easyuse_anima.nodes.prompt_advanced_nodes",
-      "easyuse_anima.nodes.regional_nodes"
-    ],
-    "_translate_prompt_text": [
-      "easyuse_anima.nodes.prompt_advanced_nodes"
     ],
     "logger": [
       "easyuse_anima.aio.legacy_generation",
@@ -921,49 +784,26 @@
       "easyuse_anima.aio.output",
       "easyuse_anima.aio.postprocess",
       "easyuse_anima.aio.preview"
-    ],
-    "next_seed": [
-      "easyuse_anima.nodes.prompt_advanced_nodes",
-      "easyuse_anima.nodes.regional_nodes"
-    ],
-    "normalize_prompt_studio_wildcard_mode": [
-      "easyuse_anima.nodes.prompt_advanced_nodes",
-      "easyuse_anima.nodes.regional_nodes"
-    ],
-    "normalize_seed": [
-      "easyuse_anima.nodes.prompt_advanced_nodes",
-      "easyuse_anima.nodes.regional_nodes"
-    ],
-    "resolve_metadata_filter_words": [
-      "easyuse_anima.nodes.prompt_advanced_nodes",
-      "easyuse_anima.nodes.regional_nodes"
-    ],
-    "resolve_naia_settings": [
-      "easyuse_anima.nodes.prompt_advanced_nodes"
-    ],
-    "wildcard_sources_signature": [
-      "easyuse_anima.nodes.prompt_advanced_nodes",
-      "easyuse_anima.nodes.regional_nodes"
     ]
   },
   "runtime_binder_audit": {
     "summary": {
-      "binder_count": 16,
-      "family_count": 3,
+      "binder_count": 14,
+      "family_count": 2,
       "mode_counts": {
-        "comfy_provider_then_root": 9,
-        "root_globals": 5,
+        "comfy_provider_then_root": 8,
+        "root_globals": 4,
         "explicit_callbacks": 2
       },
-      "unique_resolver_names": 237,
-      "unique_root_resolver_names": 232,
+      "unique_resolver_names": 192,
+      "unique_root_resolver_names": 187,
       "unique_provider_resolver_names": 5,
-      "unique_direct_root_dependencies": 10,
-      "direct_root_dependency_slots": 20,
-      "provider_consumer_slots": 14,
-      "provider_consumer_modules": 9,
-      "repository_replacement_names": 142,
-      "repository_replacement_files": 18
+      "unique_direct_root_dependencies": 9,
+      "direct_root_dependency_slots": 17,
+      "provider_consumer_slots": 13,
+      "provider_consumer_modules": 8,
+      "repository_replacement_names": 138,
+      "repository_replacement_files": 16
     },
     "families": {
       "aio": [
@@ -979,10 +819,6 @@
         "_bind_aio_output_runtime",
         "_bind_aio_conditioning_runtime",
         "_bind_aio_node_runtime"
-      ],
-      "prompt_node_adapters": [
-        "_bind_regional_node_runtime",
-        "_bind_prompt_advanced_node_runtime"
       ],
       "wildcard_naia": [
         "_bind_wildcard_node_runtime",
@@ -1034,7 +870,6 @@
       "EASY_USE_ANIMA_INPUT_SETTINGS_VERSION",
       "EASY_USE_ANIMA_INPUT_TYPE",
       "EasyUseAnimaImageScaleByMultiple",
-      "EasyUseAnimaNAIARandomPrompt",
       "EasyUseAnimaSAM3Detailer",
       "IMAGE_SCALE_MULTIPLES",
       "IMAGE_UPSCALE_METHODS",
@@ -1052,14 +887,8 @@
       "_adapter_comfy_text_encoder_names",
       "_adapter_comfy_vae_names",
       "_advanced_artist_field_prompt",
-      "_advanced_enabled_naia_panes",
       "_advanced_enabled_pane_fields",
-      "_advanced_field_input_values",
-      "_advanced_fields_json",
-      "_advanced_has_enabled_naia",
       "_advanced_outputs_from_prompt_data",
-      "_advanced_resolution_from_selection",
-      "_advanced_uses_naia_resolution",
       "_aio_detailer_has_enabled_targets",
       "_aio_detailer_target_defaults",
       "_aio_detailer_target_order",
@@ -1084,7 +913,6 @@
       "_aio_usdu_tile_plan",
       "_align_down",
       "_align_nearest",
-      "_apply_advanced_field_inputs",
       "_apply_aio_anima_dave_patch",
       "_apply_aio_final_fit",
       "_apply_aio_kj_model_patches",
@@ -1094,23 +922,16 @@
       "_apply_aio_spectrum_correction_patch_for_comfy_sampler",
       "_apply_aio_spectrum_forecast_patch_for_comfy_sampler",
       "_apply_aio_spectrum_model_patches_for_comfy_sampler",
-      "_apply_regional_field_inputs",
       "_apply_spectrum_anima_mod_guidance",
-      "_artist_mix_mode_tooltip",
       "_as_bool",
       "_as_float",
       "_as_int",
       "_bounded_artist_mix_float",
       "_bounded_artist_mix_int",
-      "_build_advanced_prompt_data",
-      "_build_advanced_prompts",
-      "_build_regional_outputs",
       "_call_with_supported_kwargs",
       "_choice",
       "_cleanup_aio_ephemeral_model",
-      "_clone_advanced_fields",
       "_clone_aio_cache_value",
-      "_clone_regional_fields",
       "_comfy_clip_loader_types",
       "_comfy_diffusion_model_names",
       "_comfy_sampler_names",
@@ -1118,8 +939,6 @@
       "_comfy_text_encoder_names",
       "_comfy_vae_names",
       "_common_upscale_image",
-      "_conditioning_set_values",
-      "_consume_reserved_wildcard_next_seed",
       "_context_value",
       "_copy_prompt_data_for_update",
       "_correct_advanced_field_sequence",
@@ -1127,12 +946,10 @@
       "_easy_use_anima_input_signature",
       "_encode_image_with_comfy_vae",
       "_encode_prompt_data_positive_conditioning",
-      "_expand_advanced_wildcard_fields",
       "_folder_path_names",
       "_format_strength",
       "_generate_empty_latent_with_comfy",
       "_get_aio_first_pass_cache",
-      "_get_workflow_node",
       "_image_tensor_size",
       "_impact_scheduler_names",
       "_is_aio_detailer_target_name",
@@ -1159,33 +976,16 @@
       "_normalize_aio_seed",
       "_normalize_aio_spectrum_settings",
       "_normalize_anima_mod_guidance_profile",
-      "_normalize_artist_mix_mode",
-      "_normalize_mask_ids",
       "_normalize_prompt_data",
-      "_normalize_prompt_studio_wildcard_seed_control",
-      "_normalize_regional_config",
-      "_normalize_regional_fields",
-      "_parse_json_object",
-      "_parse_random_response",
       "_patch_model_sampling_aura_flow",
-      "_post_random",
       "_preferred_clip_type_default",
       "_preferred_name_default",
       "_prompt_data_json_safe",
-      "_prompt_data_parameter_snapshot",
-      "_prompt_translation_change_key",
       "_put_aio_first_pass_cache",
-      "_regional_config_json",
-      "_regional_fields_json",
-      "_regional_mask_bounds_area",
-      "_regional_payload_canvas",
-      "_regional_union_mask_for_ids",
       "_require_easy_use_anima_input",
       "_resize_image_to_size_if_needed",
-      "_resolution_label",
       "_resolve_aio_runtime_seed",
       "_resolve_anima_mod_guidance_enabled",
-      "_resolve_naia_resolution",
       "_round_trip_aio_generation_settings",
       "_run_aio_detailer_stage",
       "_run_aio_detailer_target",
@@ -1205,23 +1005,14 @@
       "_save_image_with_image_saver",
       "_segs_has_items",
       "_send_aio_preview_event",
-      "_set_naia_field_text",
       "_single_value",
       "_stable_change_key",
       "_tag_aio_preview_images",
-      "_translate_prompt_fields",
-      "_translate_prompt_text",
       "ceil",
       "json",
       "logger",
-      "next_seed",
-      "normalize_prompt_studio_wildcard_mode",
-      "normalize_seed",
       "random",
-      "resolve_metadata_filter_words",
-      "resolve_naia_settings",
-      "sqrt",
-      "wildcard_sources_signature"
+      "sqrt"
     ],
     "provider_resolver_names": [
       "_comfy_max_resolution",
@@ -1286,9 +1077,6 @@
       ],
       "EASY_USE_ANIMA_INPUT_TYPE": [
         "tests/test_aio_nodes.py"
-      ],
-      "EasyUseAnimaNAIARandomPrompt": [
-        "tests/test_node_contracts.py"
       ],
       "LATENT_ALIGN": [
         "tests/test_node_contracts.py"
@@ -1593,9 +1381,7 @@
         "tests/test_aio_nodes.py"
       ],
       "_post_random": [
-        "tests/test_naia_settings.py",
-        "tests/test_node_contracts.py",
-        "tests/test_prompt_corrector.py"
+        "tests/test_naia_settings.py"
       ],
       "_preferred_clip_type_default": [
         "tests/test_aio_nodes.py"
@@ -1608,9 +1394,6 @@
         "tests/test_aio_legacy_generation.py",
         "tests/test_aio_nodes.py",
         "tests/test_aio_preview.py"
-      ],
-      "_prompt_translation_change_key": [
-        "tests/test_node_contracts.py"
       ],
       "_put_aio_first_pass_cache": [
         "tests/test_aio_legacy_generation.py"
@@ -1690,8 +1473,7 @@
       ],
       "_stable_change_key": [
         "tests/test_aio_first_pass_cache.py",
-        "tests/test_aio_nodes.py",
-        "tests/test_node_contracts.py"
+        "tests/test_aio_nodes.py"
       ],
       "_tag_aio_preview_images": [
         "tests/test_aio_legacy_generation.py",
@@ -1709,20 +1491,13 @@
       "logger": [
         "tests/test_node_contracts.py"
       ],
-      "next_seed": [
-        "tests/test_prompt_studio_regional.py"
-      ],
       "random": [
         "tests/test_aio_legacy_generation.py",
         "tests/test_node_contracts.py"
       ],
-      "resolve_metadata_filter_words": [
-        "tests/test_node_contracts.py"
-      ],
       "resolve_naia_settings": [
         "tests/test_naia_settings.py",
-        "tests/test_node_contracts.py",
-        "tests/test_prompt_corrector.py"
+        "tests/test_node_contracts.py"
       ],
       "sqrt": [
         "tests/test_node_contracts.py"
@@ -2640,287 +2415,6 @@
           "_aio_usdu_prompt_without_general",
           "_as_bool",
           "_normalize_prompt_data"
-        ]
-      },
-      {
-        "binder": "_bind_regional_node_runtime",
-        "module": "easyuse_anima.nodes.regional_nodes",
-        "family": "prompt_node_adapters",
-        "mode": "comfy_provider_then_root",
-        "root_observation": "call_time_resolver",
-        "root_keywords": [
-          "flexible_optional_input_type",
-          "resolve_helper"
-        ],
-        "bound_globals": [
-          "_FlexibleOptionalInputType",
-          "_advanced_field_input_values",
-          "_advanced_resolution_from_selection",
-          "_apply_regional_field_inputs",
-          "_as_bool",
-          "_as_float",
-          "_build_regional_outputs",
-          "_clone_regional_fields",
-          "_conditioning_set_values",
-          "_consume_reserved_wildcard_next_seed",
-          "_encode_with_comfy_clip",
-          "_expand_advanced_wildcard_fields",
-          "_get_workflow_node",
-          "_normalize_mask_ids",
-          "_normalize_prompt_studio_wildcard_seed_control",
-          "_normalize_regional_config",
-          "_normalize_regional_fields",
-          "_parse_json_object",
-          "_prompt_translation_change_key",
-          "_regional_config_json",
-          "_regional_fields_json",
-          "_regional_mask_bounds_area",
-          "_regional_payload_canvas",
-          "_regional_union_mask_for_ids",
-          "_single_value",
-          "_stable_change_key",
-          "_translate_prompt_fields",
-          "next_seed",
-          "normalize_prompt_studio_wildcard_mode",
-          "normalize_seed",
-          "resolve_metadata_filter_words",
-          "wildcard_sources_signature"
-        ],
-        "direct_root_dependencies": [
-          "_FlexibleOptionalInputType",
-          "_resolve_comfy_host_helper"
-        ],
-        "resolver_names": [
-          "_advanced_field_input_values",
-          "_advanced_resolution_from_selection",
-          "_apply_regional_field_inputs",
-          "_as_bool",
-          "_as_float",
-          "_build_regional_outputs",
-          "_clone_regional_fields",
-          "_conditioning_set_values",
-          "_consume_reserved_wildcard_next_seed",
-          "_encode_with_comfy_clip",
-          "_expand_advanced_wildcard_fields",
-          "_get_workflow_node",
-          "_normalize_mask_ids",
-          "_normalize_prompt_studio_wildcard_seed_control",
-          "_normalize_regional_config",
-          "_normalize_regional_fields",
-          "_parse_json_object",
-          "_prompt_translation_change_key",
-          "_regional_config_json",
-          "_regional_fields_json",
-          "_regional_mask_bounds_area",
-          "_regional_payload_canvas",
-          "_regional_union_mask_for_ids",
-          "_single_value",
-          "_stable_change_key",
-          "_translate_prompt_fields",
-          "next_seed",
-          "normalize_prompt_studio_wildcard_mode",
-          "normalize_seed",
-          "resolve_metadata_filter_words",
-          "wildcard_sources_signature"
-        ],
-        "root_resolver_names": [
-          "_advanced_field_input_values",
-          "_advanced_resolution_from_selection",
-          "_apply_regional_field_inputs",
-          "_as_bool",
-          "_as_float",
-          "_build_regional_outputs",
-          "_clone_regional_fields",
-          "_conditioning_set_values",
-          "_consume_reserved_wildcard_next_seed",
-          "_expand_advanced_wildcard_fields",
-          "_get_workflow_node",
-          "_normalize_mask_ids",
-          "_normalize_prompt_studio_wildcard_seed_control",
-          "_normalize_regional_config",
-          "_normalize_regional_fields",
-          "_parse_json_object",
-          "_prompt_translation_change_key",
-          "_regional_config_json",
-          "_regional_fields_json",
-          "_regional_mask_bounds_area",
-          "_regional_payload_canvas",
-          "_regional_union_mask_for_ids",
-          "_single_value",
-          "_stable_change_key",
-          "_translate_prompt_fields",
-          "next_seed",
-          "normalize_prompt_studio_wildcard_mode",
-          "normalize_seed",
-          "resolve_metadata_filter_words",
-          "wildcard_sources_signature"
-        ],
-        "provider_resolver_names": [
-          "_encode_with_comfy_clip"
-        ],
-        "repository_replacement_names": [
-          "_as_bool",
-          "_as_float",
-          "_get_workflow_node",
-          "_prompt_translation_change_key",
-          "_single_value",
-          "_stable_change_key",
-          "next_seed",
-          "resolve_metadata_filter_words",
-          "wildcard_sources_signature"
-        ]
-      },
-      {
-        "binder": "_bind_prompt_advanced_node_runtime",
-        "module": "easyuse_anima.nodes.prompt_advanced_nodes",
-        "family": "prompt_node_adapters",
-        "mode": "root_globals",
-        "root_observation": "call_time_resolver",
-        "root_keywords": [
-          "flexible_optional_input_type",
-          "resolve_helper"
-        ],
-        "bound_globals": [
-          "_FlexibleOptionalInputType",
-          "_RUNTIME_RESOLVER",
-          "_advanced_enabled_naia_panes",
-          "_advanced_field_input_values",
-          "_advanced_fields_json",
-          "_advanced_has_enabled_naia",
-          "_advanced_resolution_from_selection",
-          "_advanced_uses_naia_resolution",
-          "_apply_advanced_field_inputs",
-          "_artist_mix_mode_tooltip",
-          "_as_bool",
-          "_as_int",
-          "_bounded_artist_mix_float",
-          "_bounded_artist_mix_int",
-          "_build_advanced_prompt_data",
-          "_build_advanced_prompts",
-          "_clone_advanced_fields",
-          "_consume_reserved_wildcard_next_seed",
-          "_expand_advanced_wildcard_fields",
-          "_get_workflow_node",
-          "_normalize_advanced_fields",
-          "_normalize_artist_mix_mode",
-          "_normalize_prompt_studio_wildcard_seed_control",
-          "_parse_random_response",
-          "_post_random",
-          "_prompt_data_parameter_snapshot",
-          "_prompt_translation_change_key",
-          "_resolution_label",
-          "_resolve_naia_resolution",
-          "_set_naia_field_text",
-          "_single_value",
-          "_stable_change_key",
-          "_translate_prompt_fields",
-          "_translate_prompt_text",
-          "next_seed",
-          "normalize_prompt_studio_wildcard_mode",
-          "normalize_seed",
-          "resolve_metadata_filter_words",
-          "resolve_naia_settings",
-          "wildcard_sources_signature"
-        ],
-        "direct_root_dependencies": [
-          "_FlexibleOptionalInputType"
-        ],
-        "resolver_names": [
-          "EasyUseAnimaNAIARandomPrompt",
-          "_advanced_enabled_naia_panes",
-          "_advanced_field_input_values",
-          "_advanced_fields_json",
-          "_advanced_has_enabled_naia",
-          "_advanced_resolution_from_selection",
-          "_advanced_uses_naia_resolution",
-          "_apply_advanced_field_inputs",
-          "_artist_mix_mode_tooltip",
-          "_as_bool",
-          "_as_int",
-          "_bounded_artist_mix_float",
-          "_bounded_artist_mix_int",
-          "_build_advanced_prompt_data",
-          "_build_advanced_prompts",
-          "_clone_advanced_fields",
-          "_consume_reserved_wildcard_next_seed",
-          "_expand_advanced_wildcard_fields",
-          "_get_workflow_node",
-          "_normalize_advanced_fields",
-          "_normalize_artist_mix_mode",
-          "_normalize_prompt_studio_wildcard_seed_control",
-          "_parse_random_response",
-          "_post_random",
-          "_prompt_data_parameter_snapshot",
-          "_prompt_translation_change_key",
-          "_resolution_label",
-          "_resolve_naia_resolution",
-          "_set_naia_field_text",
-          "_single_value",
-          "_stable_change_key",
-          "_translate_prompt_fields",
-          "_translate_prompt_text",
-          "next_seed",
-          "normalize_prompt_studio_wildcard_mode",
-          "normalize_seed",
-          "resolve_metadata_filter_words",
-          "resolve_naia_settings",
-          "wildcard_sources_signature"
-        ],
-        "root_resolver_names": [
-          "EasyUseAnimaNAIARandomPrompt",
-          "_advanced_enabled_naia_panes",
-          "_advanced_field_input_values",
-          "_advanced_fields_json",
-          "_advanced_has_enabled_naia",
-          "_advanced_resolution_from_selection",
-          "_advanced_uses_naia_resolution",
-          "_apply_advanced_field_inputs",
-          "_artist_mix_mode_tooltip",
-          "_as_bool",
-          "_as_int",
-          "_bounded_artist_mix_float",
-          "_bounded_artist_mix_int",
-          "_build_advanced_prompt_data",
-          "_build_advanced_prompts",
-          "_clone_advanced_fields",
-          "_consume_reserved_wildcard_next_seed",
-          "_expand_advanced_wildcard_fields",
-          "_get_workflow_node",
-          "_normalize_advanced_fields",
-          "_normalize_artist_mix_mode",
-          "_normalize_prompt_studio_wildcard_seed_control",
-          "_parse_random_response",
-          "_post_random",
-          "_prompt_data_parameter_snapshot",
-          "_prompt_translation_change_key",
-          "_resolution_label",
-          "_resolve_naia_resolution",
-          "_set_naia_field_text",
-          "_single_value",
-          "_stable_change_key",
-          "_translate_prompt_fields",
-          "_translate_prompt_text",
-          "next_seed",
-          "normalize_prompt_studio_wildcard_mode",
-          "normalize_seed",
-          "resolve_metadata_filter_words",
-          "resolve_naia_settings",
-          "wildcard_sources_signature"
-        ],
-        "provider_resolver_names": [],
-        "repository_replacement_names": [
-          "EasyUseAnimaNAIARandomPrompt",
-          "_as_bool",
-          "_as_int",
-          "_get_workflow_node",
-          "_post_random",
-          "_prompt_translation_change_key",
-          "_single_value",
-          "_stable_change_key",
-          "next_seed",
-          "resolve_metadata_filter_words",
-          "resolve_naia_settings",
-          "wildcard_sources_signature"
         ]
       },
       {
@@ -4421,17 +3915,13 @@
         "canonical runtime resolver: easyuse_anima.aio.first_pass_cache",
         "canonical runtime resolver: easyuse_anima.aio.generation_normalization",
         "canonical runtime resolver: easyuse_anima.aio.sampling",
-        "canonical runtime resolver: easyuse_anima.nodes.aio_nodes",
-        "canonical runtime resolver: easyuse_anima.nodes.prompt_advanced_nodes",
-        "canonical runtime resolver: easyuse_anima.nodes.regional_nodes"
+        "canonical runtime resolver: easyuse_anima.nodes.aio_nodes"
       ],
       "evidence": [
         "AST:easyuse_anima.aio.first_pass_cache string runtime lookup",
         "AST:easyuse_anima.aio.generation_normalization string runtime lookup",
         "AST:easyuse_anima.aio.sampling string runtime lookup",
-        "AST:easyuse_anima.nodes.aio_nodes string runtime lookup",
-        "AST:easyuse_anima.nodes.prompt_advanced_nodes string runtime lookup",
-        "AST:easyuse_anima.nodes.regional_nodes string runtime lookup"
+        "AST:easyuse_anima.nodes.aio_nodes string runtime lookup"
       ],
       "removal_gates": [
         "canonical production consumer migration",
@@ -4469,9 +3959,7 @@
         "canonical runtime resolver: easyuse_anima.aio.preview",
         "canonical runtime resolver: easyuse_anima.aio.resources",
         "canonical runtime resolver: easyuse_anima.aio.sampling",
-        "canonical runtime resolver: easyuse_anima.aio.usdu",
-        "canonical runtime resolver: easyuse_anima.nodes.prompt_advanced_nodes",
-        "canonical runtime resolver: easyuse_anima.nodes.regional_nodes"
+        "canonical runtime resolver: easyuse_anima.aio.usdu"
       ],
       "evidence": [
         "AST:easyuse_anima.aio.conditioning string runtime lookup",
@@ -4483,9 +3971,7 @@
         "AST:easyuse_anima.aio.preview string runtime lookup",
         "AST:easyuse_anima.aio.resources string runtime lookup",
         "AST:easyuse_anima.aio.sampling string runtime lookup",
-        "AST:easyuse_anima.aio.usdu string runtime lookup",
-        "AST:easyuse_anima.nodes.prompt_advanced_nodes string runtime lookup",
-        "AST:easyuse_anima.nodes.regional_nodes string runtime lookup"
+        "AST:easyuse_anima.aio.usdu string runtime lookup"
       ],
       "removal_gates": [
         "canonical production consumer migration",
@@ -4869,45 +4355,11 @@
       "first_release": null,
       "known_consumers": [
         "nodes.py residual runtime",
-        "canonical runtime resolver: easyuse_anima.aio.postprocess",
-        "canonical runtime resolver: easyuse_anima.nodes.prompt_advanced_nodes"
+        "canonical runtime resolver: easyuse_anima.aio.postprocess"
       ],
       "evidence": [
         "AST:nodes.py direct runtime load",
-        "AST:easyuse_anima.aio.postprocess string runtime lookup",
-        "AST:easyuse_anima.nodes.prompt_advanced_nodes string runtime lookup"
-      ],
-      "removal_gates": [
-        "canonical production consumer migration",
-        "focused monkeypatch and identity contract review",
-        "separate B-10b or B-11 rollback unit"
-      ],
-      "lifecycle_state": "transitional"
-    },
-    {
-      "id": "nodes_canonical_bindings:easyuse_anima.naia.resolution:transitional_private_seam",
-      "surface": "nodes_canonical_bindings",
-      "symbols": {
-        "_advanced_resolution_from_selection": "_advanced_resolution_from_selection",
-        "_resolution_label": "_resolution_label",
-        "_resolve_naia_resolution": "_resolve_naia_resolution"
-      },
-      "classification": "transitional_private_seam",
-      "current_target": "nodes.py",
-      "canonical_target": "easyuse_anima.naia.resolution",
-      "target_state": "canonical",
-      "identity_requirement": "required",
-      "binding_shape": "direct_import",
-      "import_target": "easyuse_anima.naia.resolution",
-      "owner": "#184/#188",
-      "first_release": null,
-      "known_consumers": [
-        "canonical runtime resolver: easyuse_anima.nodes.prompt_advanced_nodes",
-        "canonical runtime resolver: easyuse_anima.nodes.regional_nodes"
-      ],
-      "evidence": [
-        "AST:easyuse_anima.nodes.prompt_advanced_nodes string runtime lookup",
-        "AST:easyuse_anima.nodes.regional_nodes string runtime lookup"
+        "AST:easyuse_anima.aio.postprocess string runtime lookup"
       ],
       "removal_gates": [
         "canonical production consumer migration",
@@ -4920,8 +4372,11 @@
       "id": "nodes_canonical_bindings:easyuse_anima.naia.resolution:unsupported_test_only",
       "surface": "nodes_canonical_bindings",
       "symbols": {
+        "_advanced_resolution_from_selection": "_advanced_resolution_from_selection",
         "_normalize_resolution_bucket": "_normalize_resolution_bucket",
-        "_ratio_label": "_ratio_label"
+        "_ratio_label": "_ratio_label",
+        "_resolution_label": "_resolution_label",
+        "_resolve_naia_resolution": "_resolve_naia_resolution"
       },
       "classification": "unsupported_test_only",
       "current_target": "nodes.py",
@@ -5045,39 +4500,12 @@
       "lifecycle_state": "supported"
     },
     {
-      "id": "nodes_canonical_bindings:easyuse_anima.nodes.input_types:transitional_private_seam",
-      "surface": "nodes_canonical_bindings",
-      "symbols": {
-        "_FlexibleOptionalInputType": "_FlexibleOptionalInputType"
-      },
-      "classification": "transitional_private_seam",
-      "current_target": "nodes.py",
-      "canonical_target": "easyuse_anima.nodes.input_types",
-      "target_state": "canonical",
-      "identity_requirement": "required",
-      "binding_shape": "direct_import",
-      "import_target": "easyuse_anima.nodes.input_types",
-      "owner": "#184/#188",
-      "first_release": null,
-      "known_consumers": [
-        "nodes.py residual runtime"
-      ],
-      "evidence": [
-        "AST:nodes.py direct runtime load"
-      ],
-      "removal_gates": [
-        "canonical production consumer migration",
-        "focused monkeypatch and identity contract review",
-        "separate B-10b or B-11 rollback unit"
-      ],
-      "lifecycle_state": "transitional"
-    },
-    {
       "id": "nodes_canonical_bindings:easyuse_anima.nodes.input_types:unsupported_test_only",
       "surface": "nodes_canonical_bindings",
       "symbols": {
         "_ANY_TYPE": "_ANY_TYPE",
-        "_AnyType": "_AnyType"
+        "_AnyType": "_AnyType",
+        "_FlexibleOptionalInputType": "_FlexibleOptionalInputType"
       },
       "classification": "unsupported_test_only",
       "current_target": "nodes.py",
@@ -5222,34 +4650,6 @@
       "lifecycle_state": "supported"
     },
     {
-      "id": "nodes_canonical_bindings:easyuse_anima.nodes.prompt_advanced_nodes:transitional_private_seam",
-      "surface": "nodes_canonical_bindings",
-      "symbols": {
-        "_bind_prompt_advanced_node_runtime": "_bind_prompt_advanced_node_runtime"
-      },
-      "classification": "transitional_private_seam",
-      "current_target": "nodes.py",
-      "canonical_target": "easyuse_anima.nodes.prompt_advanced_nodes",
-      "target_state": "canonical",
-      "identity_requirement": "required",
-      "binding_shape": "direct_import",
-      "import_target": "easyuse_anima.nodes.prompt_advanced_nodes",
-      "owner": "#184/#188",
-      "first_release": null,
-      "known_consumers": [
-        "nodes.py residual runtime"
-      ],
-      "evidence": [
-        "AST:nodes.py direct runtime load"
-      ],
-      "removal_gates": [
-        "canonical production consumer migration",
-        "focused monkeypatch and identity contract review",
-        "separate B-10b or B-11 rollback unit"
-      ],
-      "lifecycle_state": "transitional"
-    },
-    {
       "id": "nodes_canonical_bindings:easyuse_anima.nodes.prompt_data_nodes:supported_public_reexport",
       "surface": "nodes_canonical_bindings",
       "symbols": {
@@ -5346,34 +4746,6 @@
       "lifecycle_state": "supported"
     },
     {
-      "id": "nodes_canonical_bindings:easyuse_anima.nodes.regional_nodes:transitional_private_seam",
-      "surface": "nodes_canonical_bindings",
-      "symbols": {
-        "_bind_regional_node_runtime": "_bind_regional_node_runtime"
-      },
-      "classification": "transitional_private_seam",
-      "current_target": "nodes.py",
-      "canonical_target": "easyuse_anima.nodes.regional_nodes",
-      "target_state": "canonical",
-      "identity_requirement": "required",
-      "binding_shape": "direct_import",
-      "import_target": "easyuse_anima.nodes.regional_nodes",
-      "owner": "#184/#188",
-      "first_release": null,
-      "known_consumers": [
-        "nodes.py residual runtime"
-      ],
-      "evidence": [
-        "AST:nodes.py direct runtime load"
-      ],
-      "removal_gates": [
-        "canonical production consumer migration",
-        "focused monkeypatch and identity contract review",
-        "separate B-10b or B-11 rollback unit"
-      ],
-      "lifecycle_state": "transitional"
-    },
-    {
       "id": "nodes_canonical_bindings:easyuse_anima.nodes.sam3_nodes:transitional_private_seam",
       "surface": "nodes_canonical_bindings",
       "symbols": {
@@ -5467,22 +4839,9 @@
       "surface": "nodes_canonical_bindings",
       "symbols": {
         "_advanced_artist_field_prompt": "_advanced_artist_field_prompt",
-        "_advanced_enabled_naia_panes": "_advanced_enabled_naia_panes",
         "_advanced_enabled_pane_fields": "_advanced_enabled_pane_fields",
-        "_advanced_field_input_values": "_advanced_field_input_values",
-        "_advanced_fields_json": "_advanced_fields_json",
-        "_advanced_has_enabled_naia": "_advanced_has_enabled_naia",
-        "_advanced_uses_naia_resolution": "_advanced_uses_naia_resolution",
-        "_apply_advanced_field_inputs": "_apply_advanced_field_inputs",
-        "_build_advanced_prompt_data": "_build_advanced_prompt_data",
-        "_build_advanced_prompts": "_build_advanced_prompts",
-        "_clone_advanced_fields": "_clone_advanced_fields",
         "_correct_advanced_field_sequence": "_correct_advanced_field_sequence",
-        "_expand_advanced_wildcard_fields": "_expand_advanced_wildcard_fields",
-        "_normalize_advanced_fields": "_normalize_advanced_fields",
-        "_normalize_prompt_studio_wildcard_seed_control": "_normalize_prompt_studio_wildcard_seed_control",
-        "_set_naia_field_text": "_set_naia_field_text",
-        "_translate_prompt_fields": "_translate_prompt_fields"
+        "_normalize_advanced_fields": "_normalize_advanced_fields"
       },
       "classification": "transitional_private_seam",
       "current_target": "nodes.py",
@@ -5494,14 +4853,10 @@
       "owner": "#184/#188",
       "first_release": null,
       "known_consumers": [
-        "canonical runtime resolver: easyuse_anima.aio.conditioning",
-        "canonical runtime resolver: easyuse_anima.nodes.prompt_advanced_nodes",
-        "canonical runtime resolver: easyuse_anima.nodes.regional_nodes"
+        "canonical runtime resolver: easyuse_anima.aio.conditioning"
       ],
       "evidence": [
-        "AST:easyuse_anima.aio.conditioning string runtime lookup",
-        "AST:easyuse_anima.nodes.prompt_advanced_nodes string runtime lookup",
-        "AST:easyuse_anima.nodes.regional_nodes string runtime lookup"
+        "AST:easyuse_anima.aio.conditioning string runtime lookup"
       ],
       "removal_gates": [
         "canonical production consumer migration",
@@ -5515,9 +4870,22 @@
       "surface": "nodes_canonical_bindings",
       "symbols": {
         "_advanced_default_fields": "_advanced_default_fields",
+        "_advanced_enabled_naia_panes": "_advanced_enabled_naia_panes",
+        "_advanced_field_input_values": "_advanced_field_input_values",
         "_advanced_field_socket_name": "_advanced_field_socket_name",
+        "_advanced_fields_json": "_advanced_fields_json",
+        "_advanced_has_enabled_naia": "_advanced_has_enabled_naia",
         "_advanced_prompt_with_artist_override": "_advanced_prompt_with_artist_override",
-        "_as_advanced_height": "_as_advanced_height"
+        "_advanced_uses_naia_resolution": "_advanced_uses_naia_resolution",
+        "_apply_advanced_field_inputs": "_apply_advanced_field_inputs",
+        "_as_advanced_height": "_as_advanced_height",
+        "_build_advanced_prompt_data": "_build_advanced_prompt_data",
+        "_build_advanced_prompts": "_build_advanced_prompts",
+        "_clone_advanced_fields": "_clone_advanced_fields",
+        "_expand_advanced_wildcard_fields": "_expand_advanced_wildcard_fields",
+        "_normalize_prompt_studio_wildcard_seed_control": "_normalize_prompt_studio_wildcard_seed_control",
+        "_set_naia_field_text": "_set_naia_field_text",
+        "_translate_prompt_fields": "_translate_prompt_fields"
       },
       "classification": "unsupported_test_only",
       "current_target": "nodes.py",
@@ -5556,11 +4924,9 @@
         "ARTIST_MIX_DEFAULT_STYLE_GAIN": "ARTIST_MIX_DEFAULT_STYLE_GAIN",
         "ARTIST_MIX_INPUT_MODES": "ARTIST_MIX_INPUT_MODES",
         "ARTIST_MIX_MODE_FROM_PROMPT_DATA": "ARTIST_MIX_MODE_FROM_PROMPT_DATA",
-        "_artist_mix_mode_tooltip": "_artist_mix_mode_tooltip",
         "_bounded_artist_mix_float": "_bounded_artist_mix_float",
         "_bounded_artist_mix_int": "_bounded_artist_mix_int",
-        "_encode_prompt_data_positive_conditioning": "_encode_prompt_data_positive_conditioning",
-        "_normalize_artist_mix_mode": "_normalize_artist_mix_mode"
+        "_encode_prompt_data_positive_conditioning": "_encode_prompt_data_positive_conditioning"
       },
       "classification": "transitional_private_seam",
       "current_target": "nodes.py",
@@ -5574,14 +4940,12 @@
       "known_consumers": [
         "nodes.py residual runtime",
         "canonical runtime resolver: easyuse_anima.aio.generation_normalization",
-        "canonical runtime resolver: easyuse_anima.aio.legacy_generation",
-        "canonical runtime resolver: easyuse_anima.nodes.prompt_advanced_nodes"
+        "canonical runtime resolver: easyuse_anima.aio.legacy_generation"
       ],
       "evidence": [
         "AST:nodes.py direct runtime load",
         "AST:easyuse_anima.aio.generation_normalization string runtime lookup",
-        "AST:easyuse_anima.aio.legacy_generation string runtime lookup",
-        "AST:easyuse_anima.nodes.prompt_advanced_nodes string runtime lookup"
+        "AST:easyuse_anima.aio.legacy_generation string runtime lookup"
       ],
       "removal_gates": [
         "canonical production consumer migration",
@@ -5595,12 +4959,14 @@
       "surface": "nodes_canonical_bindings",
       "symbols": {
         "_artist_mix_inline_prompt": "_artist_mix_inline_prompt",
+        "_artist_mix_mode_tooltip": "_artist_mix_mode_tooltip",
         "_artist_prompt_with_position": "_artist_prompt_with_position",
         "_artist_tags_from_prompt": "_artist_tags_from_prompt",
         "_blend_conditionings": "_blend_conditionings",
         "_encode_artist_clustered": "_encode_artist_clustered",
         "_encode_artist_delta_rms": "_encode_artist_delta_rms",
         "_join_artist_mix_source_prompts": "_join_artist_mix_source_prompts",
+        "_normalize_artist_mix_mode": "_normalize_artist_mix_mode",
         "_normalize_artist_tag_position": "_normalize_artist_tag_position",
         "_parse_artist_mix_items": "_parse_artist_mix_items"
       },
@@ -5697,41 +5063,12 @@
       "lifecycle_state": "unsupported"
     },
     {
-      "id": "nodes_canonical_bindings:easyuse_anima.prompt.correction:transitional_private_seam",
-      "surface": "nodes_canonical_bindings",
-      "symbols": {
-        "_prompt_translation_change_key": "_prompt_translation_change_key",
-        "_translate_prompt_text": "_translate_prompt_text"
-      },
-      "classification": "transitional_private_seam",
-      "current_target": "nodes.py",
-      "canonical_target": "easyuse_anima.prompt.correction",
-      "target_state": "canonical",
-      "identity_requirement": "required",
-      "binding_shape": "direct_import",
-      "import_target": "easyuse_anima.prompt.correction",
-      "owner": "#184/#188",
-      "first_release": null,
-      "known_consumers": [
-        "canonical runtime resolver: easyuse_anima.nodes.prompt_advanced_nodes",
-        "canonical runtime resolver: easyuse_anima.nodes.regional_nodes"
-      ],
-      "evidence": [
-        "AST:easyuse_anima.nodes.prompt_advanced_nodes string runtime lookup",
-        "AST:easyuse_anima.nodes.regional_nodes string runtime lookup"
-      ],
-      "removal_gates": [
-        "canonical production consumer migration",
-        "focused monkeypatch and identity contract review",
-        "separate B-10b or B-11 rollback unit"
-      ],
-      "lifecycle_state": "transitional"
-    },
-    {
       "id": "nodes_canonical_bindings:easyuse_anima.prompt.correction:unsupported_test_only",
       "surface": "nodes_canonical_bindings",
       "symbols": {
-        "_split_tag_text": "_split_tag_text"
+        "_prompt_translation_change_key": "_prompt_translation_change_key",
+        "_split_tag_text": "_split_tag_text",
+        "_translate_prompt_text": "_translate_prompt_text"
       },
       "classification": "unsupported_test_only",
       "current_target": "nodes.py",
@@ -5764,8 +5101,7 @@
         "_advanced_outputs_from_prompt_data": "_advanced_outputs_from_prompt_data",
         "_copy_prompt_data_for_update": "_copy_prompt_data_for_update",
         "_normalize_prompt_data": "_normalize_prompt_data",
-        "_prompt_data_json_safe": "_prompt_data_json_safe",
-        "_prompt_data_parameter_snapshot": "_prompt_data_parameter_snapshot"
+        "_prompt_data_json_safe": "_prompt_data_json_safe"
       },
       "classification": "transitional_private_seam",
       "current_target": "nodes.py",
@@ -5782,8 +5118,7 @@
         "canonical runtime resolver: easyuse_anima.aio.generation_normalization",
         "canonical runtime resolver: easyuse_anima.aio.legacy_generation",
         "canonical runtime resolver: easyuse_anima.aio.preview",
-        "canonical runtime resolver: easyuse_anima.nodes.aio_nodes",
-        "canonical runtime resolver: easyuse_anima.nodes.prompt_advanced_nodes"
+        "canonical runtime resolver: easyuse_anima.nodes.aio_nodes"
       ],
       "evidence": [
         "AST:easyuse_anima.aio.conditioning string runtime lookup",
@@ -5791,8 +5126,7 @@
         "AST:easyuse_anima.aio.generation_normalization string runtime lookup",
         "AST:easyuse_anima.aio.legacy_generation string runtime lookup",
         "AST:easyuse_anima.aio.preview string runtime lookup",
-        "AST:easyuse_anima.nodes.aio_nodes string runtime lookup",
-        "AST:easyuse_anima.nodes.prompt_advanced_nodes string runtime lookup"
+        "AST:easyuse_anima.nodes.aio_nodes string runtime lookup"
       ],
       "removal_gates": [
         "canonical production consumer migration",
@@ -5805,7 +5139,8 @@
       "id": "nodes_canonical_bindings:easyuse_anima.prompt.data:unsupported_test_only",
       "surface": "nodes_canonical_bindings",
       "symbols": {
-        "_apply_prompt_data_overrides": "_apply_prompt_data_overrides"
+        "_apply_prompt_data_overrides": "_apply_prompt_data_overrides",
+        "_prompt_data_parameter_snapshot": "_prompt_data_parameter_snapshot"
       },
       "classification": "unsupported_test_only",
       "current_target": "nodes.py",
@@ -5868,7 +5203,7 @@
       "lifecycle_state": "unsupported"
     },
     {
-      "id": "nodes_canonical_bindings:easyuse_anima.prompt.regional:transitional_private_seam",
+      "id": "nodes_canonical_bindings:easyuse_anima.prompt.regional:unsupported_test_only",
       "surface": "nodes_canonical_bindings",
       "symbols": {
         "_apply_regional_field_inputs": "_apply_regional_field_inputs",
@@ -5885,64 +5220,36 @@
         "_regional_payload_canvas": "_regional_payload_canvas",
         "_regional_union_mask_for_ids": "_regional_union_mask_for_ids"
       },
-      "classification": "transitional_private_seam",
+      "classification": "unsupported_test_only",
       "current_target": "nodes.py",
       "canonical_target": "easyuse_anima.prompt.regional",
       "target_state": "canonical",
-      "identity_requirement": "required",
+      "identity_requirement": "not_applicable",
       "binding_shape": "direct_import",
       "import_target": "easyuse_anima.prompt.regional",
       "owner": "#184/#188",
       "first_release": null,
       "known_consumers": [
-        "canonical runtime resolver: easyuse_anima.nodes.regional_nodes"
+        "repository tests may import this root name"
       ],
       "evidence": [
-        "AST:easyuse_anima.nodes.regional_nodes string runtime lookup"
+        "AST:no nodes.py runtime load",
+        "test-only consumption is not public support evidence"
       ],
       "removal_gates": [
-        "canonical production consumer migration",
-        "focused monkeypatch and identity contract review",
-        "separate B-10b or B-11 rollback unit"
+        "test imports migrate to canonical targets",
+        "no production consumer evidence",
+        "separate B-10b removal review"
       ],
-      "lifecycle_state": "transitional"
-    },
-    {
-      "id": "nodes_canonical_bindings:easyuse_anima.seed.compatibility:transitional_private_seam",
-      "surface": "nodes_canonical_bindings",
-      "symbols": {
-        "_consume_reserved_wildcard_next_seed": "_consume_reserved_wildcard_next_seed"
-      },
-      "classification": "transitional_private_seam",
-      "current_target": "nodes.py",
-      "canonical_target": "easyuse_anima.seed.compatibility",
-      "target_state": "canonical",
-      "identity_requirement": "required",
-      "binding_shape": "direct_import",
-      "import_target": "easyuse_anima.seed.compatibility",
-      "owner": "#184/#188",
-      "first_release": null,
-      "known_consumers": [
-        "canonical runtime resolver: easyuse_anima.nodes.prompt_advanced_nodes",
-        "canonical runtime resolver: easyuse_anima.nodes.regional_nodes"
-      ],
-      "evidence": [
-        "AST:easyuse_anima.nodes.prompt_advanced_nodes string runtime lookup",
-        "AST:easyuse_anima.nodes.regional_nodes string runtime lookup"
-      ],
-      "removal_gates": [
-        "canonical production consumer migration",
-        "focused monkeypatch and identity contract review",
-        "separate B-10b or B-11 rollback unit"
-      ],
-      "lifecycle_state": "transitional"
+      "lifecycle_state": "unsupported"
     },
     {
       "id": "nodes_canonical_bindings:easyuse_anima.seed.compatibility:unsupported_test_only",
       "surface": "nodes_canonical_bindings",
       "symbols": {
         "WILDCARD_QUEUE_MAX_SAFE_SEED": "WILDCARD_QUEUE_MAX_SAFE_SEED",
-        "WILDCARD_RESERVED_NEXT_SEED_INPUT": "WILDCARD_RESERVED_NEXT_SEED_INPUT"
+        "WILDCARD_RESERVED_NEXT_SEED_INPUT": "WILDCARD_RESERVED_NEXT_SEED_INPUT",
+        "_consume_reserved_wildcard_next_seed": "_consume_reserved_wildcard_next_seed"
       },
       "classification": "unsupported_test_only",
       "current_target": "nodes.py",
@@ -5983,14 +5290,10 @@
       "owner": "#184/#188",
       "first_release": null,
       "known_consumers": [
-        "nodes.py residual runtime",
-        "canonical runtime resolver: easyuse_anima.nodes.prompt_advanced_nodes",
-        "canonical runtime resolver: easyuse_anima.nodes.regional_nodes"
+        "nodes.py residual runtime"
       ],
       "evidence": [
-        "AST:nodes.py direct runtime load",
-        "AST:easyuse_anima.nodes.prompt_advanced_nodes string runtime lookup",
-        "AST:easyuse_anima.nodes.regional_nodes string runtime lookup"
+        "AST:nodes.py direct runtime load"
       ],
       "removal_gates": [
         "canonical production consumer migration",
@@ -6092,7 +5395,6 @@
       "id": "nodes_legacy_bindings:settings:transitional_private_seam",
       "surface": "nodes_legacy_bindings",
       "symbols": {
-        "resolve_metadata_filter_words": "resolve_metadata_filter_words",
         "resolve_naia_settings": "resolve_naia_settings"
       },
       "classification": "transitional_private_seam",
@@ -6105,14 +5407,10 @@
       "owner": "#163/#186",
       "first_release": null,
       "known_consumers": [
-        "nodes.py residual runtime",
-        "canonical runtime resolver: easyuse_anima.nodes.prompt_advanced_nodes",
-        "canonical runtime resolver: easyuse_anima.nodes.regional_nodes"
+        "nodes.py residual runtime"
       ],
       "evidence": [
-        "AST:nodes.py direct runtime load",
-        "AST:easyuse_anima.nodes.prompt_advanced_nodes string runtime lookup",
-        "AST:easyuse_anima.nodes.regional_nodes string runtime lookup"
+        "AST:nodes.py direct runtime load"
       ],
       "removal_gates": [
         "canonical production consumer migration",
@@ -6125,6 +5423,7 @@
       "id": "nodes_legacy_bindings:settings:unsupported_test_only",
       "surface": "nodes_legacy_bindings",
       "symbols": {
+        "resolve_metadata_filter_words": "resolve_metadata_filter_words",
         "resolve_prompt_translation_settings": "resolve_prompt_translation_settings"
       },
       "classification": "unsupported_test_only",
@@ -6158,8 +5457,6 @@
         "SEED_CONTROL_FIXED": "SEED_CONTROL_FIXED",
         "SEED_CONTROL_MODES": "SEED_CONTROL_MODES",
         "expand_wildcards": "expand_wildcards",
-        "next_seed": "next_seed",
-        "normalize_prompt_studio_wildcard_mode": "normalize_prompt_studio_wildcard_mode",
         "normalize_seed": "normalize_seed",
         "normalize_wildcard_mode": "normalize_wildcard_mode",
         "wildcard_sources_signature": "wildcard_sources_signature"
@@ -6176,16 +5473,12 @@
       "known_consumers": [
         "nodes.py residual runtime",
         "canonical runtime resolver: easyuse_anima.aio.generation_normalization",
-        "canonical runtime resolver: easyuse_anima.aio.sampling",
-        "canonical runtime resolver: easyuse_anima.nodes.prompt_advanced_nodes",
-        "canonical runtime resolver: easyuse_anima.nodes.regional_nodes"
+        "canonical runtime resolver: easyuse_anima.aio.sampling"
       ],
       "evidence": [
         "AST:nodes.py direct runtime load",
         "AST:easyuse_anima.aio.generation_normalization string runtime lookup",
-        "AST:easyuse_anima.aio.sampling string runtime lookup",
-        "AST:easyuse_anima.nodes.prompt_advanced_nodes string runtime lookup",
-        "AST:easyuse_anima.nodes.regional_nodes string runtime lookup"
+        "AST:easyuse_anima.aio.sampling string runtime lookup"
       ],
       "removal_gates": [
         "canonical production consumer migration",
@@ -6207,7 +5500,9 @@
         "WILDCARD_MODE_POPULATE": "WILDCARD_MODE_POPULATE",
         "WILDCARD_MODE_SEQUENTIAL": "WILDCARD_MODE_SEQUENTIAL",
         "expand_wildcard_texts": "expand_wildcard_texts",
-        "has_wildcard_syntax": "has_wildcard_syntax"
+        "has_wildcard_syntax": "has_wildcard_syntax",
+        "next_seed": "next_seed",
+        "normalize_prompt_studio_wildcard_mode": "normalize_prompt_studio_wildcard_mode"
       },
       "classification": "unsupported_test_only",
       "current_target": "nodes.py",

--- a/tests/test_node_contracts.py
+++ b/tests/test_node_contracts.py
@@ -2619,14 +2619,17 @@ class WorkflowLookupMoveContractTests(unittest.TestCase):
             for adapter in (
                 wildcard_nodes,
                 naia_nodes,
-                prompt_advanced_nodes,
-                regional_nodes,
             ):
                 with self.subTest(adapter=adapter.__name__):
                     self.assertIs(
                         adapter._get_workflow_node(None, "3"),
                         patched_result,
                     )
+
+    def test_retired_prompt_adapters_use_the_canonical_workflow_lookup(self):
+        for adapter in (prompt_advanced_nodes, regional_nodes):
+            with self.subTest(adapter=adapter.__name__):
+                self.assertIs(adapter._get_workflow_node, workflow._get_workflow_node)
 
 
 class InputTypeMoveContractTests(unittest.TestCase):

--- a/tests/test_node_contracts.py
+++ b/tests/test_node_contracts.py
@@ -223,6 +223,31 @@ def _deterministic_comfy_inputs():
                 "_prompt_translation_change_key"
             ],
         ),
+        patch.multiple(
+            prompt_advanced_nodes,
+            resolve_metadata_filter_words=replacements[
+                "resolve_metadata_filter_words"
+            ],
+            resolve_naia_settings=replacements["resolve_naia_settings"],
+            _prompt_translation_change_key=replacements[
+                "_prompt_translation_change_key"
+            ],
+            wildcard_sources_signature=replacements[
+                "wildcard_sources_signature"
+            ],
+        ),
+        patch.multiple(
+            regional_nodes,
+            resolve_metadata_filter_words=replacements[
+                "resolve_metadata_filter_words"
+            ],
+            _prompt_translation_change_key=replacements[
+                "_prompt_translation_change_key"
+            ],
+            wildcard_sources_signature=replacements[
+                "wildcard_sources_signature"
+            ],
+        ),
         patch_comfy_helper(
             nodes,
             "_comfy_max_resolution",
@@ -3517,6 +3542,9 @@ class PromptAdvancedMoveContractTests(unittest.TestCase):
 
     def test_root_advanced_objects_are_direct_canonical_aliases(self):
         self.assertFalse(hasattr(prompt_advanced, "_bind_advanced_runtime"))
+        self.assertFalse(
+            hasattr(prompt_advanced_nodes, "_bind_prompt_advanced_node_runtime")
+        )
         for name in (*self.RETIRED_NODE_CLASSES, *self.RETIRED_ADVANCED_ALIASES):
             with self.subTest(retired=name):
                 self.assertFalse(hasattr(nodes, name))
@@ -3567,16 +3595,20 @@ class PromptAdvancedMoveContractTests(unittest.TestCase):
             (prompt_advanced_nodes.EasyUseAnimaPromptStudioAdvanced,),
         )
 
-    def test_root_monkeypatches_drive_the_canonical_advanced_change_key(self):
+    def test_canonical_monkeypatches_drive_the_advanced_change_key(self):
         with (
-            patch.object(nodes, "_stable_change_key", side_effect=lambda value: value) as stable,
             patch.object(
-                nodes,
+                prompt_advanced_nodes,
+                "_stable_change_key",
+                side_effect=lambda value: value,
+            ) as stable,
+            patch.object(
+                prompt_advanced_nodes,
                 "_prompt_translation_change_key",
                 return_value={"bound": "translation"},
             ) as translation_key,
             patch.object(
-                nodes,
+                prompt_advanced_nodes,
                 "resolve_metadata_filter_words",
                 return_value="bound filters",
             ) as resolve_filters,
@@ -3590,7 +3622,7 @@ class PromptAdvancedMoveContractTests(unittest.TestCase):
         translation_key.assert_called_once_with()
         resolve_filters.assert_called_once_with()
 
-    def test_root_naia_class_monkeypatch_drives_advanced_and_extend(self):
+    def test_canonical_naia_monkeypatch_drives_advanced_and_extend(self):
         request_bodies = []
 
         class BoundNAIARandomPrompt:
@@ -3630,9 +3662,21 @@ class PromptAdvancedMoveContractTests(unittest.TestCase):
         ])
 
         with (
-            patch.object(nodes, "EasyUseAnimaNAIARandomPrompt", BoundNAIARandomPrompt),
-            patch.object(nodes, "resolve_naia_settings", return_value=settings),
-            patch.object(nodes, "_post_random", side_effect=post_random),
+            patch.object(
+                prompt_advanced_nodes,
+                "EasyUseAnimaNAIARandomPrompt",
+                BoundNAIARandomPrompt,
+            ),
+            patch.object(
+                prompt_advanced_nodes,
+                "resolve_naia_settings",
+                return_value=settings,
+            ),
+            patch.object(
+                prompt_advanced_nodes,
+                "_post_random",
+                side_effect=post_random,
+            ),
         ):
             advanced = prompt_advanced_nodes.EasyUseAnimaPromptStudioAdvanced().build(
                 True,
@@ -3728,6 +3772,7 @@ class RegionalMoveContractTests(unittest.TestCase):
 
     def test_root_regional_objects_are_direct_canonical_aliases(self):
         self.assertFalse(hasattr(prompt_regional, "_bind_regional_runtime"))
+        self.assertFalse(hasattr(regional_nodes, "_bind_regional_node_runtime"))
         for name in self.RETIRED_REGIONAL_ALIASES:
             with self.subTest(retired=name):
                 self.assertFalse(hasattr(nodes, name))

--- a/tests/test_nodes_module_analyzer.py
+++ b/tests/test_nodes_module_analyzer.py
@@ -73,12 +73,12 @@ def load_dynamic():
     def test_current_nodes_module_shape_matches_recorded_baseline(self):
         report = analyzer.analyze_path(ROOT / "nodes.py")
 
-        self.assertEqual(report["git_blob_sha1"], "df1be7c4ab0172ed7042863a71bea17731c307d5")
-        # S167-01a moves the final root function body to the canonical seed
-        # compatibility owner without changing the public class surface.
+        self.assertEqual(report["git_blob_sha1"], "4821f36548243853249a7a24458a37469985c676")
+        # B-11c30c2b retires the Advanced and Regional adapter binder imports
+        # and calls without changing the public class surface.
         self.assertEqual(report["top_level"]["function_count"], 0)
         self.assertEqual(report["top_level"]["class_count"], 0)
-        self.assertEqual(report["line_count"], 1_677)
+        self.assertEqual(report["line_count"], 1_662)
         class_names = {item["name"] for item in report["top_level"]["classes"]}
         self.assertNotIn("EasyUseAnimaAIOGenerator", class_names)
         self.assertNotIn("EasyUseAnimaInput", class_names)

--- a/tests/test_prompt_corrector.py
+++ b/tests/test_prompt_corrector.py
@@ -2060,9 +2060,12 @@ class PromptBuilderTests(unittest.TestCase):
         }
 
         with (
-            patch("nodes.resolve_naia_settings", return_value=settings),
             patch(
-                "nodes._post_random",
+                "easyuse_anima.nodes.prompt_advanced_nodes.resolve_naia_settings",
+                return_value=settings,
+            ),
+            patch(
+                "easyuse_anima.nodes.prompt_advanced_nodes._post_random",
                 return_value={
                     "ok": True,
                     "prompt": "1girl, silver hair",
@@ -2159,9 +2162,12 @@ class PromptBuilderTests(unittest.TestCase):
         }
 
         with (
-            patch("nodes.resolve_naia_settings", return_value=settings),
             patch(
-                "nodes._post_random",
+                "easyuse_anima.nodes.prompt_advanced_nodes.resolve_naia_settings",
+                return_value=settings,
+            ),
+            patch(
+                "easyuse_anima.nodes.prompt_advanced_nodes._post_random",
                 return_value={
                     "ok": True,
                     "prompt": "current image prompt",
@@ -2252,8 +2258,11 @@ class PromptBuilderTests(unittest.TestCase):
             }
 
         with (
-            patch("nodes.resolve_naia_settings", return_value=settings),
-            patch("nodes._post_random", fake_post),
+            patch(
+                "easyuse_anima.nodes.prompt_advanced_nodes.resolve_naia_settings",
+                return_value=settings,
+            ),
+            patch("easyuse_anima.nodes.prompt_advanced_nodes._post_random", fake_post),
         ):
             result = EasyUseAnimaPromptStudioAdvanced().build(
                 True,
@@ -2332,8 +2341,11 @@ class PromptBuilderTests(unittest.TestCase):
             return responses[len(calls) - 1]
 
         with (
-            patch("nodes.resolve_naia_settings", return_value=settings),
-            patch("nodes._post_random", fake_post),
+            patch(
+                "easyuse_anima.nodes.prompt_advanced_nodes.resolve_naia_settings",
+                return_value=settings,
+            ),
+            patch("easyuse_anima.nodes.prompt_advanced_nodes._post_random", fake_post),
         ):
             first = EasyUseAnimaPromptStudioAdvanced().build(
                 True,
@@ -2407,8 +2419,11 @@ class PromptBuilderTests(unittest.TestCase):
             }
 
         with (
-            patch("nodes.resolve_naia_settings", return_value=settings),
-            patch("nodes._post_random", fake_post),
+            patch(
+                "easyuse_anima.nodes.prompt_advanced_nodes.resolve_naia_settings",
+                return_value=settings,
+            ),
+            patch("easyuse_anima.nodes.prompt_advanced_nodes._post_random", fake_post),
         ):
             result = EasyUseAnimaPromptStudioAdvanced().build(
                 True,
@@ -2480,8 +2495,11 @@ class PromptBuilderTests(unittest.TestCase):
             }
 
         with (
-            patch("nodes.resolve_naia_settings", return_value=settings),
-            patch("nodes._post_random", fake_post),
+            patch(
+                "easyuse_anima.nodes.prompt_advanced_nodes.resolve_naia_settings",
+                return_value=settings,
+            ),
+            patch("easyuse_anima.nodes.prompt_advanced_nodes._post_random", fake_post),
         ):
             result = EasyUseAnimaPromptStudioAdvanced().build(
                 True,
@@ -2532,8 +2550,11 @@ class PromptBuilderTests(unittest.TestCase):
             }
 
         with (
-            patch("nodes.resolve_naia_settings", return_value=settings),
-            patch("nodes._post_random", fake_post),
+            patch(
+                "easyuse_anima.nodes.prompt_advanced_nodes.resolve_naia_settings",
+                return_value=settings,
+            ),
+            patch("easyuse_anima.nodes.prompt_advanced_nodes._post_random", fake_post),
         ):
             result = EasyUseAnimaPromptStudioAdvanced().build(
                 True,
@@ -2796,9 +2817,12 @@ class PromptBuilderTests(unittest.TestCase):
         }
 
         with (
-            patch("nodes.resolve_naia_settings", return_value=settings),
             patch(
-                "nodes._post_random",
+                "easyuse_anima.nodes.prompt_advanced_nodes.resolve_naia_settings",
+                return_value=settings,
+            ),
+            patch(
+                "easyuse_anima.nodes.prompt_advanced_nodes._post_random",
                 return_value={
                     "ok": True,
                     "prompt": "1girl, blue eyes",

--- a/tests/test_prompt_studio_regional.py
+++ b/tests/test_prompt_studio_regional.py
@@ -321,7 +321,7 @@ class PromptStudioRegionalTests(unittest.TestCase):
             }
         }
 
-        with patch("nodes.next_seed") as fallback_next_seed:
+        with patch.object(regional_nodes, "next_seed") as fallback_next_seed:
             result = EasyUseAnimaPromptStudioRegional().build(
                 "",
                 "",
@@ -354,7 +354,11 @@ class PromptStudioRegionalTests(unittest.TestCase):
             "42": {"inputs": {reservation_key: mismatched_reservation}}
         }
 
-        with patch("nodes.next_seed", return_value=3) as fallback_next_seed:
+        with patch.object(
+            regional_nodes,
+            "next_seed",
+            return_value=3,
+        ) as fallback_next_seed:
             result = EasyUseAnimaPromptStudioRegional().build(
                 "",
                 "",

--- a/tests/test_python_compatibility_surface.py
+++ b/tests/test_python_compatibility_surface.py
@@ -94,13 +94,8 @@ PROMPT_SERVICE_RUNTIME_BINDERS = (
 PROMPT_NODE_ADAPTER_RETIRED_RUNTIME_BINDERS = (
     "_bind_prompt_data_node_runtime",
     "_bind_prompt_node_runtime",
-)
-PROMPT_NODE_ADAPTER_SEED_BLOCKED_RUNTIME_BINDERS = (
     "_bind_regional_node_runtime",
     "_bind_prompt_advanced_node_runtime",
-)
-PROMPT_NODE_ADAPTER_RUNTIME_BINDERS = (
-    *PROMPT_NODE_ADAPTER_SEED_BLOCKED_RUNTIME_BINDERS,
 )
 RUNTIME_BINDER_FAMILIES = {
     "aio": (
@@ -117,7 +112,6 @@ RUNTIME_BINDER_FAMILIES = {
         "_bind_aio_conditioning_runtime",
         "_bind_aio_node_runtime",
     ),
-    "prompt_node_adapters": PROMPT_NODE_ADAPTER_RUNTIME_BINDERS,
     "wildcard_naia": (
         "_bind_wildcard_node_runtime",
         "_bind_naia_node_runtime",
@@ -2138,6 +2132,7 @@ def _build_document() -> dict[str, Any]:
                 "B-11c30c1",
                 "B-11c30c2",
                 "B-11c30c2a",
+                "B-11c30c2b",
             ],
         },
         "enums": {
@@ -2150,14 +2145,14 @@ def _build_document() -> dict[str, Any]:
         "expected_counts": {
             "root_entrypoints": 3,
             "excluded_preamble_implementation_bindings": 5,
-            "nodes_canonical_bindings": 284,
+            "nodes_canonical_bindings": 282,
             "nodes_legacy_bindings": 27,
             "mapped_public_classes": 18,
             "unmapped_classes": 2,
             "root_residual_functions": 0,
             "root_residual_classes": 0,
             "root_residual_globals": 24,
-            "runtime_binders": 16,
+            "runtime_binders": 14,
             "direct_nodes_import_test_files": 21,
         },
         "mapped_public_classes": sorted(mapped_classes),
@@ -2389,7 +2384,7 @@ class PythonCompatibilitySurfaceTests(unittest.TestCase):
             len(self.document["direct_nodes_import_test_files"]),
             counts["direct_nodes_import_test_files"],
         )
-        self.assertEqual(len(set(self.document["runtime_binders"])), 16)
+        self.assertEqual(len(set(self.document["runtime_binders"])), 14)
         self.assertEqual(len(set(self.document["direct_nodes_import_test_files"])), 21)
 
     def test_runtime_binder_audit_covers_provider_and_root_names(self):
@@ -2397,22 +2392,22 @@ class PythonCompatibilitySurfaceTests(unittest.TestCase):
         self.assertEqual(
             audit["summary"],
             {
-                "binder_count": 16,
-                "family_count": 3,
+                "binder_count": 14,
+                "family_count": 2,
                 "mode_counts": {
-                    "comfy_provider_then_root": 9,
-                    "root_globals": 5,
+                    "comfy_provider_then_root": 8,
+                    "root_globals": 4,
                     "explicit_callbacks": 2,
                 },
-                "unique_resolver_names": 237,
-                "unique_root_resolver_names": 232,
+                "unique_resolver_names": 192,
+                "unique_root_resolver_names": 187,
                 "unique_provider_resolver_names": 5,
-                "unique_direct_root_dependencies": 10,
-                "direct_root_dependency_slots": 20,
-                "provider_consumer_slots": 14,
-                "provider_consumer_modules": 9,
-                "repository_replacement_names": 142,
-                "repository_replacement_files": 18,
+                "unique_direct_root_dependencies": 9,
+                "direct_root_dependency_slots": 17,
+                "provider_consumer_slots": 13,
+                "provider_consumer_modules": 8,
+                "repository_replacement_names": 138,
+                "repository_replacement_files": 16,
             },
         )
         self.assertEqual(
@@ -2479,24 +2474,16 @@ class PythonCompatibilitySurfaceTests(unittest.TestCase):
                     "call_time_resolver",
                 )
 
-    def test_prompt_service_and_unblocked_node_adapter_binders_are_retired(self):
+    def test_prompt_service_and_node_adapter_binders_are_retired(self):
         audit = self.document["runtime_binder_audit"]
         self.assertNotIn("prompt_regional", audit["families"])
         self.assertNotIn("prompt_services", audit["families"])
-        self.assertEqual(
-            audit["families"]["prompt_node_adapters"],
-            list(PROMPT_NODE_ADAPTER_RUNTIME_BINDERS),
-        )
+        self.assertNotIn("prompt_node_adapters", audit["families"])
         self.assertEqual(
             list(PROMPT_NODE_ADAPTER_RETIRED_RUNTIME_BINDERS),
             [
                 "_bind_prompt_data_node_runtime",
                 "_bind_prompt_node_runtime",
-            ],
-        )
-        self.assertEqual(
-            list(PROMPT_NODE_ADAPTER_SEED_BLOCKED_RUNTIME_BINDERS),
-            [
                 "_bind_regional_node_runtime",
                 "_bind_prompt_advanced_node_runtime",
             ],
@@ -2516,6 +2503,10 @@ class PythonCompatibilitySurfaceTests(unittest.TestCase):
             "_bind_prompt_correction_runtime": "easyuse_anima.prompt.correction",
             "_bind_prompt_data_node_runtime": "easyuse_anima.nodes.prompt_data_nodes",
             "_bind_prompt_node_runtime": "easyuse_anima.nodes.prompt_nodes",
+            "_bind_regional_node_runtime": "easyuse_anima.nodes.regional_nodes",
+            "_bind_prompt_advanced_node_runtime": (
+                "easyuse_anima.nodes.prompt_advanced_nodes"
+            ),
         }
         for binder, module in retired_modules.items():
             functions = {
@@ -2525,36 +2516,6 @@ class PythonCompatibilitySurfaceTests(unittest.TestCase):
             }
             with self.subTest(module=module, binder=binder):
                 self.assertNotIn(binder, functions)
-        entries = {
-            entry["binder"]: (entry["module"], entry["mode"])
-            for entry in audit["entries"]
-            if entry["binder"] in PROMPT_NODE_ADAPTER_RUNTIME_BINDERS
-        }
-        self.assertEqual(
-            entries,
-            {
-                "_bind_regional_node_runtime": (
-                    "easyuse_anima.nodes.regional_nodes",
-                    "comfy_provider_then_root",
-                ),
-                "_bind_prompt_advanced_node_runtime": (
-                    "easyuse_anima.nodes.prompt_advanced_nodes",
-                    "root_globals",
-                ),
-            },
-        )
-        entry_by_binder = {
-            entry["binder"]: entry
-            for entry in audit["entries"]
-            if entry["binder"] in PROMPT_NODE_ADAPTER_RUNTIME_BINDERS
-        }
-        for binder in PROMPT_NODE_ADAPTER_SEED_BLOCKED_RUNTIME_BINDERS:
-            with self.subTest(seed_blocked=binder):
-                self.assertIn(
-                    "_consume_reserved_wildcard_next_seed",
-                    entry_by_binder[binder]["root_resolver_names"],
-                )
-
     def test_string_runtime_resolvers_keep_production_seams_transitional(self):
         representative = {
             "_run_aio_legacy_generation",
@@ -2562,7 +2523,7 @@ class PythonCompatibilitySurfaceTests(unittest.TestCase):
             "_AIO_FIRST_PASS_CACHE_ORDER",
             "_load_aio_resources_from_input_context",
             "_sample_latent_with_aio_backend",
-            "_advanced_fields_json",
+            "_aio_generation_settings_json",
         }
         consumers = self.document["runtime_resolver_consumers"]
         classifications = {


### PR DESCRIPTION
## 목적

B-11c30c2b는 B-11c30c2a와 S167-01a 다음의 별도 rollback unit입니다. Advanced/Regional node adapter의 두 runtime binder를 제거하고 canonical/common/seed/provider owner를 직접 사용하게 하되 동작은 바꾸지 않습니다.

기준선: `dev@b69d33857ef85fb81388f02e9ff1cff195a092d1`
검증 head: `423d6f51e9ff787f386bd429dbd73c64b088f8f7`

## 작업 전 inventory

### symbol / caller / alias

- owned binder는 `_bind_prompt_advanced_node_runtime`, `_bind_regional_node_runtime` 두 개입니다.
- root `nodes.py`는 두 binder를 relative/flat branch에서 import하고 import time에 각각 한 번 호출했습니다.
- 두 canonical adapter의 mapped class는 이미 root direct alias이며 이 identity를 유지합니다.
- Advanced/Regional 실제 build path 모두 S167-01a canonical owner `easyuse_anima.seed.compatibility._consume_reserved_wildcard_next_seed`를 호출합니다.

### resolver / global state

- bind-time global: 72 slots, 55 unique names
- root resolver: 69 slots, 53 unique names
- provider: Regional의 `_encode_with_comfy_clip` 1 slot
- direct root dependency: 3 slots, `_FlexibleOptionalInputType`와 `_resolve_comfy_host_helper`
- repository test replacement: 21 slots, 13 unique names
- binder가 보유한 mutable cache/lock/service state는 없습니다. bind-time module-global mutation과 Advanced의 root class resolver가 제거 대상입니다.

## 구현 결과

- root에서 두 binder import와 import-time 호출을 제거했습니다.
- Advanced adapter는 common, Prompt, seed, NAIA, workflow, input-type canonical owner를 직접 사용합니다.
- Regional adapter는 canonical owner를 직접 사용하고 CLIP encoding은 기존 E-07 Comfy host provider를 call time에 조회합니다.
- 두 adapter의 Wildcard 접근은 기존 Prompt service의 call-time module resolver를 재사용하여 eager NumPy import를 만들지 않습니다.
- root-only monkeypatch 테스트를 canonical adapter owner 기준으로 전환했습니다.
- workflow lookup과 Comfy host ledger를 retired-binder 구조에 맞게 갱신했습니다.
- `nodes.py`는 1,662줄이며 runtime binder audit은 14개, 2개 family로 감소했습니다.

## 변경 파일

Production:

- `nodes.py`
- `easyuse_anima/nodes/prompt_advanced_nodes.py`
- `easyuse_anima/nodes/regional_nodes.py`

Gate/test/fixture/docs:

- `tests/test_node_contracts.py`
- `tests/test_prompt_corrector.py`
- `tests/test_prompt_studio_regional.py`
- `tests/test_nodes_module_analyzer.py`
- `tests/test_python_compatibility_surface.py`
- `tests/fixtures/comfy_host_compatibility.v1.json`
- `tests/fixtures/python_backend_baseline.json`
- `tests/fixtures/python_compatibility_surface.v1.json`
- `docs/architecture/comfy-host-provider-bridge.md`
- `docs/architecture/python-backend-execution-roadmap.md`
- `docs/architecture/python-compatibility-shims.md`

## 유지한 경계

- schema, mapped-class/input-type identity, prompt/conditioning output 변경 없음
- provider lookup order와 optional-dependency timing 변경 없음
- seed reservation payload/pop order와 Wildcard seed arithmetic 변경 없음
- 새 callback/binder, canonical-to-root import, seed/Wildcard behavior 복제 없음
- S167-02 Behavior 미시작

## 검증

- affected focused unittest suites: 통과
- Pyright baseline ratchet: 72 files, 기존 baseline 14 errors, 신규 진단 0
- backend analyzer fixture gate: 통과
- `powershell -NoProfile -ExecutionPolicy Bypass -File D:\ComfyUI\custom_nodes_workplace\tools\check_custom_node.ps1 -Project <absolute-worktree> -Profile full -TimeoutSeconds 300`: 통과
  - Python unittest: 981 passed
  - frontend: 114 JavaScript files passed
  - import boundary: 6 package groups, 0 violations
  - `git diff --check`: 통과
  - Ruff: 기존 G-01 report-only 79건, blocking 아님
- 중간 full이 찾아낸 Pyright 신규 진단 1건과 stale retirement 계약 3건은 각각 focused 검증 후 수정했고, 최종 full이 통과했습니다.
- Live ComfyUI/browser smoke: pure backend Move이므로 미실행

## 위험과 rollback

- 주 위험은 기존 root-only monkeypatch에 의존한 비공개 테스트/도구입니다. 저장소 내 소비자는 canonical seam으로 전환했습니다.
- rollback 단위는 PR #345 전체입니다.

## 다음 경계

이 PR 병합 뒤 남은 AiO와 Wildcard/NAIA binder family를 별도 Move로 진행합니다. B-11d final root shim과 S167-02 Behavior는 섞지 않습니다.