### PR TITLE
B-11c30d: AiO binder split gate

### DIFF
--- a/docs/architecture/comfy-host-provider-bridge.md
+++ b/docs/architecture/comfy-host-provider-bridge.md
@@ -1474,6 +1474,73 @@ Implementation result:
   four root-only, and two explicit callbacks; and
 - `nodes.py` is 1,662 lines, down 15 lines from the S167-01a base.
 
+### B-11c30d — AiO binder split gate
+
+- **State:** IN PROGRESS
+- **Owner:** #184
+- **Behavior boundary:** #168 and #169
+- **Type:** Contract/gate
+- **Production changes:** none
+- **Base:** `dev@1debd5c3ea75f1d14e66a3cfbba0e93e003f69cb`
+
+Pre-edit inventory:
+
+- twelve AiO binders remain: eight provider-then-root and four root-only;
+- each binder mutates one `_RUNTIME_RESOLVER` slot, for twelve bind-time
+  global slots over one unique name;
+- 260 root resolver slots cover 187 unique names;
+- thirteen provider slots cover `_comfy_max_resolution`,
+  `_encode_with_comfy_clip`, `_find_comfy_node_class`,
+  `_require_any_custom_node_class`, and `_require_custom_node_class`;
+- eight direct root dependency slots all name
+  `_resolve_comfy_host_helper`;
+- repository tests replace 199 binder slots over 133 unique names in fourteen
+  files. This is migration-cost evidence, not public compatibility;
+- `easyuse_anima.aio.first_pass_cache` owns the actual cache dictionary, order
+  list, and entry limit. Their object identity, ordering, eviction, cloning,
+  and key semantics belong to the #169 behavior boundary; and
+- `easyuse_anima.aio.legacy_generation` is the 59-root-slot orchestration
+  consumer, while `easyuse_anima.nodes.aio_nodes` is the separate 30-slot
+  public node adapter.
+
+The production-free split is:
+
+| Move | Owned binders | Root slots / unique | Provider slots | Direct slots | Replacement slots / unique |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| B-11c30d1 cache state | 1 | 7 / 7 | 0 | 0 | 7 / 7 |
+| B-11c30d2 normalization/planning | 3 | 72 / 66 | 1 | 1 | 37 / 31 |
+| B-11c30d3 I/O boundary | 3 | 49 / 46 | 4 | 3 | 47 / 44 |
+| B-11c30d4 execution services | 3 | 43 / 37 | 6 | 3 | 30 / 25 |
+| B-11c30d5 legacy orchestration | 1 | 59 / 59 | 2 | 1 | 48 / 48 |
+| B-11c30d6 node adapter | 1 | 30 / 30 | 0 | 0 | 30 / 30 |
+
+Group ownership is exact:
+
+- d1: `_bind_aio_first_pass_cache_runtime`;
+- d2: `_bind_aio_generation_normalization_runtime`,
+  `_bind_aio_usdu_planning_runtime`, and `_bind_aio_postprocess_runtime`;
+- d3: `_bind_aio_resource_runtime`, `_bind_aio_preview_runtime`, and
+  `_bind_aio_output_runtime`;
+- d4: `_bind_aio_model_preparation_runtime`, `_bind_aio_sampling_runtime`, and
+  `_bind_aio_conditioning_runtime`;
+- d5: `_bind_aio_legacy_generation_runtime`; and
+- d6: `_bind_aio_node_runtime`.
+
+This gate may change only
+`tests/test_python_compatibility_surface.py`,
+`tests/fixtures/python_compatibility_surface.v1.json`,
+`docs/architecture/comfy-host-provider-bridge.md`,
+`docs/architecture/python-backend-execution-roadmap.md`, and
+`docs/architecture/python-compatibility-shims.md`. Production files, runtime
+binders, root imports/calls, schemas, settings, workflows, stage order, seed
+resolution, cache behavior, model preparation, sampling, preview, save,
+conditioning, provider lookup, and error text remain unchanged.
+
+Each Move is a separate rollback unit. d5 cannot begin until its canonical
+service dependencies are direct, and d6 remains last because the public node
+adapter consumes the legacy orchestrator and service owners. No Move may begin
+#169 stage/cache Behavior or combine the Wildcard/NAIA family.
+
 ### B-11d — Final root shim
 
 - **State:** BLOCKED by the remaining AiO and Wildcard/NAIA binder families

--- a/docs/architecture/comfy-host-provider-bridge.md
+++ b/docs/architecture/comfy-host-provider-bridge.md
@@ -1476,7 +1476,7 @@ Implementation result:
 
 ### B-11c30d — AiO binder split gate
 
-- **State:** IN PROGRESS
+- **State:** COMPLETE in PR #346
 - **Owner:** #184
 - **Behavior boundary:** #168 and #169
 - **Type:** Contract/gate
@@ -1541,6 +1541,33 @@ service dependencies are direct, and d6 remains last because the public node
 adapter consumes the legacy orchestrator and service owners. No Move may begin
 #169 stage/cache Behavior or combine the Wildcard/NAIA family.
 
+The machine-readable gate records the exact, non-overlapping subgroup
+membership and the per-group mode, root/provider/direct dependency, replacement
+slot, and replacement-file counts. Later Moves consume that frozen subgroup
+instead of reconstructing the full twelve-binder inventory.
+
+Two import cycles require separate behavior-preserving prerequisite Moves:
+
+1. **B-11c30d0a output settings owner:** move only
+   `_normalize_aio_hash_bundles` and
+   `_normalize_aio_civitai_hash_fetchers` from
+   `easyuse_anima.aio.output` to the new pure
+   `easyuse_anima.aio.output_settings` owner. This breaks the
+   generation-normalization → output → sampling → generation-normalization
+   cycle and unblocks d2 through d4.
+2. **B-11c30d0b input context owner:** move only
+   `_easy_use_anima_input_signature` and
+   `_require_easy_use_anima_input` from
+   `easyuse_anima.nodes.aio_nodes` to the new pure
+   `easyuse_anima.aio.input_context` owner. This breaks the
+   legacy-generation ↔ node-adapter cycle and unblocks d5 and d6.
+
+Neither prerequisite is implemented in this Contract/gate. d1 has no blocking
+cycle and is the first READY production Move. d0a may follow as a separate
+Move before d2; d0b remains a separate Move before d5. The two prerequisite
+Moves preserve existing root aliases and do not change normalization, input,
+stage, seed, cache, provider, error, or workflow behavior.
+
 ### B-11d — Final root shim
 
 - **State:** BLOCKED by the remaining AiO and Wildcard/NAIA binder families
@@ -1586,6 +1613,12 @@ COMPLETE: B-11c30c1 Prompt/Regional service binder Move / PR #340
 COMPLETE: B-11c30c2 Prompt/Regional node-adapter split gate / PR #341
 COMPLETE: B-11c30c2a Prompt Data / Classic Prompt adapter Move / PR #342
 COMPLETE: B-11c30c2b Advanced / Regional adapter Move / PR #345
+COMPLETE: B-11c30d AiO binder split gate / PR #346
+READY:    B-11c30d1 AiO cache-state binder Move
+PLANNED:  B-11c30d0a output-settings owner Move before d2-d4
+PLANNED:  B-11c30d2-d4 normalization, I/O, and execution-service Moves
+PLANNED:  B-11c30d0b input-context owner Move before d5-d6
+PLANNED:  B-11c30d5-d6 orchestration and node-adapter Moves
 BLOCKED:  B-11d final root shim
 
 LATER:    #167 seed reservation

--- a/docs/architecture/python-backend-execution-roadmap.md
+++ b/docs/architecture/python-backend-execution-roadmap.md
@@ -31,7 +31,7 @@ merged PR, the owning issue's evidence record, and every stated exit gate.
 | Phase | Integrated snapshot / open implementation state | Remaining exit work |
 | --- | --- | --- |
 | A - baseline | Complete; #191 is closed | Keep fixtures and analyzers current during later moves |
-| B - `nodes.py` extraction | Integrated through S167-01a / PR #344; B-11c30c2b completes in PR #345 | Complete the remaining AiO and Wildcard/NAIA binder families, then perform the final root shim as a separate Move |
+| B - `nodes.py` extraction | Integrated through B-11c30c2b / PR #345; B-11c30d completes the AiO split gate in PR #346 | Execute the frozen AiO Moves, then Wildcard/NAIA and the final root shim as separate rollback units |
 | C - feature contracts/behavior | Partially complete through S167-01a / PR #344 | Continue #167 and #169 in separate Contract/Move/Behavior PRs |
 | D - root consolidation | Not started | Execute #186 feature by feature after the corresponding behavior contracts are stable |
 | E - runtime ownership | Partial: E-02a and E-07a/E-07b integrated | Continue #187 only where canonical feature owners and explicit contracts exist |
@@ -115,7 +115,14 @@ merged PR, the owning issue's evidence record, and every stated exit gate.
   and exact owner-Move boundary. S167-01a / PR #344 supplies that canonical
   compatibility owner. B-11c30c2b / PR #345 retires the final two Prompt
   node-adapter binders, leaving 14 binders across the AiO and Wildcard/NAIA
-  families.
+  families. B-11c30d / PR #346 is a production-free gate that freezes the
+  twelve AiO binders into six exact, non-overlapping Move groups and records
+  their per-group resolver and repository-replacement cost. It also records two
+  separate prerequisite owner Moves: d0a breaks the output/settings/sampling
+  import cycle before d2 through d4, and d0b breaks the
+  legacy-orchestration/node-adapter cycle before d5 and d6. d1 cache state is
+  the first READY Move and remains mechanically separate from #169 cache
+  Behavior.
 
 ### Current quality baseline
 
@@ -338,9 +345,11 @@ Copy this block into the owning issue or PR before implementation.
 
 ## 6. Current executable queue
 
-The ordering below is the default critical path at the snapshot. B-07f,
-C168-03, and G-02b may proceed in parallel because they should own disjoint
-surfaces. AiO mechanical extraction must not start until #168 exits.
+The ordering below records the integrated path and the current next boundary.
+B-11c30d freezes the remaining AiO migration cost once; later Moves consume
+their subgroup gate instead of repeating the full inventory. The two cycle
+breakers remain standalone owner Moves, and #169 Behavior does not enter the
+mechanical retirement series.
 
 | Order | Task | State | Type | Owner | Prerequisites |
 | ---: | --- | --- | --- | --- | --- |
@@ -357,7 +366,7 @@ surfaces. AiO mechanical extraction must not start until #168 exits.
 | 11 | B-09b2 AiO generator adapter move | COMPLETE on `dev` | Move | #184 | PR #270 / `57d40b4` |
 | 12 | B-10a machine-readable compatibility audit | COMPLETE on `dev` | Contract/gate | #184/#188 | PR #271 / `3c7b857` |
 | 13 | B-10b private alias reduction | COMPLETE on `dev` through PR #291 / `c6b4680` | Contract/cleanup, split PRs | #184/#188 | Audited alias surface integrated |
-| 14 | B-11 registration/bootstrap/root shim | IN PROGRESS through B-11c30c2b PR #345; remaining AiO and Wildcard/NAIA binder Moves precede B-11d | Move/Contract, split PRs | #184 | S167-01 contract |
+| 14 | B-11 registration/bootstrap/root shim | IN PROGRESS through B-11c30d PR #346; d1 is READY, d0a precedes d2-d4, and d0b precedes d5-d6 | Move/Contract, split PRs | #184 | Frozen AiO split gate; S167-01 contract |
 | 15 | S167 backend seed reservation series | S167-01 Contract COMPLETE in PR #343 and S167-01a consumer Move COMPLETE in PR #344; Behavior and Adapter remain | Contract then Move then Behavior | #167 | Canonical AiO/node seams |
 | 16 | A169 stage pipeline series | BLOCKED by #168 and B exit | Contract then Behavior | #169 | Typed config and mechanical AiO move |
 | 17 | A169 first-pass cache policy | BLOCKED by stage/cache ownership seam | Behavior | #169 | Mechanical cache move and benchmark harness |

--- a/docs/architecture/python-compatibility-shims.md
+++ b/docs/architecture/python-compatibility-shims.md
@@ -9,9 +9,10 @@
 - Machine-readable audit:
   [`python_compatibility_surface.v1.json`](../../tests/fixtures/python_compatibility_surface.v1.json)
 - Current state: B-11a through B-11c30c2b / PR #345 are integrated in the
-  reviewed sequence. S167-01a / PR #344 supplies the canonical reserved-seed
-  compatibility consumer while retaining its root aliases. Fourteen AiO and
-  Wildcard/NAIA binders remain before the final root shim.
+  reviewed sequence, and B-11c30d / PR #346 freezes the remaining AiO split
+  without production changes. S167-01a / PR #344 supplies the canonical
+  reserved-seed compatibility consumer while retaining its root aliases.
+  Fourteen AiO and Wildcard/NAIA binders remain before the final root shim.
 
 This is an actionable registry, not a removal schedule. `N` means the first
 published Registry release containing both a canonical target and its root
@@ -76,8 +77,8 @@ inferring public support from spelling or test imports:
 - `nodes.py` preamble implementation imports: 5 (`json`, `logging`, `random`,
   `ceil`, and `sqrt`), excluded from compatibility classification
   by an exact AST allowlist and drift gate;
-- `nodes.py` bindings with an `easyuse_anima` canonical target: 281 in
-  B-11c30c2a (258 at the integrated B-10b20 baseline), with exact
+- `nodes.py` bindings with an `easyuse_anima` canonical target: 282 in
+  B-11c30c2b (258 at the integrated B-10b20 baseline), with exact
   relative-package/flat-fallback parity;
 - bindings still owned by `anima_prompt`, `settings`, `prompt_translation`, or
   `wildcard_engine`: 27, with the same fallback parity;
@@ -85,10 +86,10 @@ inferring public support from spelling or test imports:
 - unmapped root classes: `EasyUseAnimaSAM3Context` and
   `EasyUseAnimaSAM3Detailer`; the canonical legacy Extend class remains in its
   owner module without a root alias or backend mapping;
-- root-owned residual implementation: 1 function, 0 classes, and 26 assigned
-  globals in B-11c29b3 (41/2/33 at the integrated B-10b20 baseline).
-- import-time runtime binders: 16 exact top-level `_bind_*_runtime` calls;
-- root names reached by those canonical runtime resolvers: 232, including
+- root-owned residual implementation: 0 functions, 0 classes, and 24 assigned
+  globals in B-11c30c2b (41/2/33 at the integrated B-10b20 baseline).
+- import-time runtime binders: 14 exact top-level `_bind_*_runtime` calls;
+- root names reached by those canonical runtime resolvers: 187, including
   literal lookups and binder-owned helper-name/default collections;
 - retired private bindings: `_comfy_checkpoint_names`,
   `_EasyUseAnimaAlignedDetailerHook`, and
@@ -840,6 +841,28 @@ convenience-node compatibility; it remains unmapped and is not public support.
 - Schema, mapped-class/input-type identity, outputs, provider timing, seed
   payload/pop order, Wildcard arithmetic, workflows, and optional-dependency
   timing remain unchanged.
+
+### B-11c30d AiO binder split gate
+
+- Production files and all fourteen remaining binders are unchanged.
+- The twelve AiO binders are classified exactly once into six non-overlapping
+  rollback units: d1 cache state; d2 normalization/planning; d3 I/O boundary;
+  d4 execution services; d5 legacy orchestration; and d6 node adapter.
+- The machine-readable audit freezes each subgroup's binder names, binding
+  modes, bound globals, root/provider/direct dependency slots, replacement
+  slots, and replacement files. Later retirement tests select their frozen
+  subgroup rather than rebuilding the full AiO inventory.
+- d1 is READY. Its cache dictionary/list identity, order, limit, key, clone,
+  hit, and eviction behavior remain under #169 and are not changed by the
+  binder Move.
+- d0a is a separate pure-owner Move for the two output-settings normalizers.
+  It breaks the output/sampling/generation-normalization import cycle before
+  d2 through d4.
+- d0b is a separate pure-owner Move for the two input-context helpers. It
+  breaks the legacy-generation/node-adapter import cycle before d5 and d6.
+- Neither prerequisite Move is implemented by this gate. No schema, setting,
+  workflow, stage, seed, cache, model, sampling, preview, save, conditioning,
+  provider, optional-dependency, or error behavior changes.
 
 ### `nodes.py` public node-class surface
 

--- a/tests/fixtures/python_compatibility_surface.v1.json
+++ b/tests/fixtures/python_compatibility_surface.v1.json
@@ -72,7 +72,8 @@
       "B-11c30c1",
       "B-11c30c2",
       "B-11c30c2a",
-      "B-11c30c2b"
+      "B-11c30c2b",
+      "B-11c30d"
     ]
   },
   "enums": {
@@ -823,6 +824,260 @@
       "wildcard_naia": [
         "_bind_wildcard_node_runtime",
         "_bind_naia_node_runtime"
+      ]
+    },
+    "aio_split_gate": {
+      "subgroup_order": [
+        "B-11c30d1_cache_state",
+        "B-11c30d2_normalization_planning",
+        "B-11c30d3_io_boundary",
+        "B-11c30d4_execution_services",
+        "B-11c30d5_legacy_orchestration",
+        "B-11c30d6_node_adapter"
+      ],
+      "subgroups": {
+        "B-11c30d1_cache_state": {
+          "binders": [
+            "_bind_aio_first_pass_cache_runtime"
+          ],
+          "mode_counts": {
+            "comfy_provider_then_root": 0,
+            "root_globals": 1
+          },
+          "bound_global_slots": 1,
+          "unique_bound_globals": [
+            "_RUNTIME_RESOLVER"
+          ],
+          "root_resolver_slots": 7,
+          "unique_root_resolver_names": 7,
+          "provider_resolver_slots": 0,
+          "unique_provider_resolver_names": 0,
+          "direct_root_dependency_slots": 0,
+          "unique_direct_root_dependencies": 0,
+          "repository_replacement_slots": 7,
+          "unique_repository_replacement_names": 7,
+          "repository_replacement_files": [
+            "tests/test_aio_first_pass_cache.py",
+            "tests/test_aio_legacy_generation.py",
+            "tests/test_aio_nodes.py",
+            "tests/test_aio_preview.py"
+          ]
+        },
+        "B-11c30d2_normalization_planning": {
+          "binders": [
+            "_bind_aio_generation_normalization_runtime",
+            "_bind_aio_usdu_planning_runtime",
+            "_bind_aio_postprocess_runtime"
+          ],
+          "mode_counts": {
+            "comfy_provider_then_root": 1,
+            "root_globals": 2
+          },
+          "bound_global_slots": 3,
+          "unique_bound_globals": [
+            "_RUNTIME_RESOLVER"
+          ],
+          "root_resolver_slots": 72,
+          "unique_root_resolver_names": 66,
+          "provider_resolver_slots": 1,
+          "unique_provider_resolver_names": 1,
+          "direct_root_dependency_slots": 1,
+          "unique_direct_root_dependencies": 1,
+          "repository_replacement_slots": 37,
+          "unique_repository_replacement_names": 31,
+          "repository_replacement_files": [
+            "tests/test_aio_first_pass_cache.py",
+            "tests/test_aio_generation_migrations.py",
+            "tests/test_aio_generation_settings.py",
+            "tests/test_aio_legacy_generation.py",
+            "tests/test_aio_nodes.py",
+            "tests/test_aio_output.py",
+            "tests/test_aio_preview.py",
+            "tests/test_aio_resources.py",
+            "tests/test_aio_schema_contract.py",
+            "tests/test_node_contracts.py"
+          ]
+        },
+        "B-11c30d3_io_boundary": {
+          "binders": [
+            "_bind_aio_resource_runtime",
+            "_bind_aio_preview_runtime",
+            "_bind_aio_output_runtime"
+          ],
+          "mode_counts": {
+            "comfy_provider_then_root": 3,
+            "root_globals": 0
+          },
+          "bound_global_slots": 3,
+          "unique_bound_globals": [
+            "_RUNTIME_RESOLVER"
+          ],
+          "root_resolver_slots": 49,
+          "unique_root_resolver_names": 46,
+          "provider_resolver_slots": 4,
+          "unique_provider_resolver_names": 2,
+          "direct_root_dependency_slots": 3,
+          "unique_direct_root_dependencies": 1,
+          "repository_replacement_slots": 47,
+          "unique_repository_replacement_names": 44,
+          "repository_replacement_files": [
+            "tests/test_aio_first_pass_cache.py",
+            "tests/test_aio_generation_settings.py",
+            "tests/test_aio_legacy_generation.py",
+            "tests/test_aio_nodes.py",
+            "tests/test_aio_output.py",
+            "tests/test_aio_preview.py",
+            "tests/test_aio_resources.py",
+            "tests/test_aio_sampling.py",
+            "tests/test_aio_schema_contract.py",
+            "tests/test_comfy_adapters.py",
+            "tests/test_node_contracts.py"
+          ]
+        },
+        "B-11c30d4_execution_services": {
+          "binders": [
+            "_bind_aio_model_preparation_runtime",
+            "_bind_aio_sampling_runtime",
+            "_bind_aio_conditioning_runtime"
+          ],
+          "mode_counts": {
+            "comfy_provider_then_root": 3,
+            "root_globals": 0
+          },
+          "bound_global_slots": 3,
+          "unique_bound_globals": [
+            "_RUNTIME_RESOLVER"
+          ],
+          "root_resolver_slots": 43,
+          "unique_root_resolver_names": 37,
+          "provider_resolver_slots": 6,
+          "unique_provider_resolver_names": 4,
+          "direct_root_dependency_slots": 3,
+          "unique_direct_root_dependencies": 1,
+          "repository_replacement_slots": 30,
+          "unique_repository_replacement_names": 25,
+          "repository_replacement_files": [
+            "tests/test_aio_conditioning.py",
+            "tests/test_aio_legacy_generation.py",
+            "tests/test_aio_model_preparation.py",
+            "tests/test_aio_nodes.py",
+            "tests/test_aio_output.py",
+            "tests/test_aio_resources.py",
+            "tests/test_aio_sampling.py",
+            "tests/test_node_contracts.py"
+          ]
+        },
+        "B-11c30d5_legacy_orchestration": {
+          "binders": [
+            "_bind_aio_legacy_generation_runtime"
+          ],
+          "mode_counts": {
+            "comfy_provider_then_root": 1,
+            "root_globals": 0
+          },
+          "bound_global_slots": 1,
+          "unique_bound_globals": [
+            "_RUNTIME_RESOLVER"
+          ],
+          "root_resolver_slots": 59,
+          "unique_root_resolver_names": 59,
+          "provider_resolver_slots": 2,
+          "unique_provider_resolver_names": 2,
+          "direct_root_dependency_slots": 1,
+          "unique_direct_root_dependencies": 1,
+          "repository_replacement_slots": 48,
+          "unique_repository_replacement_names": 48,
+          "repository_replacement_files": [
+            "tests/test_aio_first_pass_cache.py",
+            "tests/test_aio_legacy_generation.py",
+            "tests/test_aio_nodes.py",
+            "tests/test_aio_output.py",
+            "tests/test_aio_preview.py",
+            "tests/test_aio_resources.py",
+            "tests/test_aio_sampling.py",
+            "tests/test_node_contracts.py"
+          ]
+        },
+        "B-11c30d6_node_adapter": {
+          "binders": [
+            "_bind_aio_node_runtime"
+          ],
+          "mode_counts": {
+            "comfy_provider_then_root": 0,
+            "root_globals": 1
+          },
+          "bound_global_slots": 1,
+          "unique_bound_globals": [
+            "_RUNTIME_RESOLVER"
+          ],
+          "root_resolver_slots": 30,
+          "unique_root_resolver_names": 30,
+          "provider_resolver_slots": 0,
+          "unique_provider_resolver_names": 0,
+          "direct_root_dependency_slots": 0,
+          "unique_direct_root_dependencies": 0,
+          "repository_replacement_slots": 30,
+          "unique_repository_replacement_names": 30,
+          "repository_replacement_files": [
+            "tests/test_aio_first_pass_cache.py",
+            "tests/test_aio_legacy_generation.py",
+            "tests/test_aio_nodes.py",
+            "tests/test_aio_output.py",
+            "tests/test_aio_preview.py",
+            "tests/test_aio_resources.py",
+            "tests/test_aio_sampling.py",
+            "tests/test_node_contracts.py"
+          ]
+        }
+      },
+      "prerequisite_moves": [
+        {
+          "id": "B-11c30d0a_output_settings_owner",
+          "source": "easyuse_anima.aio.output",
+          "target": "easyuse_anima.aio.output_settings",
+          "symbols": [
+            "_normalize_aio_hash_bundles",
+            "_normalize_aio_civitai_hash_fetchers"
+          ],
+          "blocking_edges": [
+            {
+              "consumer": "easyuse_anima.aio.generation_normalization",
+              "symbol": "_normalize_aio_hash_bundles"
+            },
+            {
+              "consumer": "easyuse_anima.aio.generation_normalization",
+              "symbol": "_normalize_aio_civitai_hash_fetchers"
+            }
+          ],
+          "unblocks": [
+            "B-11c30d2_normalization_planning",
+            "B-11c30d3_io_boundary",
+            "B-11c30d4_execution_services"
+          ]
+        },
+        {
+          "id": "B-11c30d0b_input_context_owner",
+          "source": "easyuse_anima.nodes.aio_nodes",
+          "target": "easyuse_anima.aio.input_context",
+          "symbols": [
+            "_easy_use_anima_input_signature",
+            "_require_easy_use_anima_input"
+          ],
+          "blocking_edges": [
+            {
+              "consumer": "easyuse_anima.aio.legacy_generation",
+              "symbol": "_require_easy_use_anima_input"
+            },
+            {
+              "consumer": "easyuse_anima.nodes.aio_nodes",
+              "symbol": "_run_aio_legacy_generation"
+            }
+          ],
+          "unblocks": [
+            "B-11c30d5_legacy_orchestration",
+            "B-11c30d6_node_adapter"
+          ]
+        }
       ]
     },
     "root_resolver_names": [

--- a/tests/test_python_compatibility_surface.py
+++ b/tests/test_python_compatibility_surface.py
@@ -117,6 +117,81 @@ RUNTIME_BINDER_FAMILIES = {
         "_bind_naia_node_runtime",
     ),
 }
+AIO_RUNTIME_BINDER_SUBGROUPS = {
+    "B-11c30d1_cache_state": (
+        "_bind_aio_first_pass_cache_runtime",
+    ),
+    "B-11c30d2_normalization_planning": (
+        "_bind_aio_generation_normalization_runtime",
+        "_bind_aio_usdu_planning_runtime",
+        "_bind_aio_postprocess_runtime",
+    ),
+    "B-11c30d3_io_boundary": (
+        "_bind_aio_resource_runtime",
+        "_bind_aio_preview_runtime",
+        "_bind_aio_output_runtime",
+    ),
+    "B-11c30d4_execution_services": (
+        "_bind_aio_model_preparation_runtime",
+        "_bind_aio_sampling_runtime",
+        "_bind_aio_conditioning_runtime",
+    ),
+    "B-11c30d5_legacy_orchestration": (
+        "_bind_aio_legacy_generation_runtime",
+    ),
+    "B-11c30d6_node_adapter": (
+        "_bind_aio_node_runtime",
+    ),
+}
+AIO_RUNTIME_PREREQUISITE_MOVES = (
+    {
+        "id": "B-11c30d0a_output_settings_owner",
+        "source": "easyuse_anima.aio.output",
+        "target": "easyuse_anima.aio.output_settings",
+        "symbols": (
+            "_normalize_aio_hash_bundles",
+            "_normalize_aio_civitai_hash_fetchers",
+        ),
+        "blocking_edges": (
+            {
+                "consumer": "easyuse_anima.aio.generation_normalization",
+                "symbol": "_normalize_aio_hash_bundles",
+            },
+            {
+                "consumer": "easyuse_anima.aio.generation_normalization",
+                "symbol": "_normalize_aio_civitai_hash_fetchers",
+            },
+        ),
+        "unblocks": (
+            "B-11c30d2_normalization_planning",
+            "B-11c30d3_io_boundary",
+            "B-11c30d4_execution_services",
+        ),
+    },
+    {
+        "id": "B-11c30d0b_input_context_owner",
+        "source": "easyuse_anima.nodes.aio_nodes",
+        "target": "easyuse_anima.aio.input_context",
+        "symbols": (
+            "_easy_use_anima_input_signature",
+            "_require_easy_use_anima_input",
+        ),
+        "blocking_edges": (
+            {
+                "consumer": "easyuse_anima.aio.legacy_generation",
+                "symbol": "_require_easy_use_anima_input",
+            },
+            {
+                "consumer": "easyuse_anima.nodes.aio_nodes",
+                "symbol": "_run_aio_legacy_generation",
+            },
+        ),
+        "unblocks": (
+            "B-11c30d5_legacy_orchestration",
+            "B-11c30d6_node_adapter",
+        ),
+    },
+)
 RETIRED_ARTIST_MIX_MODE_BINDINGS = (
     "ARTIST_MIX_CONTROL_KEY",
     "ARTIST_MIX_EXACT_KEY",
@@ -1637,6 +1712,101 @@ def _repository_root_replacements(
     }
 
 
+def _aio_runtime_split_gate(
+    entries: list[dict[str, Any]],
+    root_replacements: dict[str, list[str]],
+) -> dict[str, Any]:
+    entry_by_binder = {
+        entry["binder"]: entry
+        for entry in entries
+        if entry["family"] == "aio"
+    }
+    classified_binders = [
+        binder
+        for binders in AIO_RUNTIME_BINDER_SUBGROUPS.values()
+        for binder in binders
+    ]
+    if len(classified_binders) != len(set(classified_binders)):
+        raise AssertionError("AiO runtime binder subgroup classification overlaps")
+    if set(classified_binders) != set(RUNTIME_BINDER_FAMILIES["aio"]):
+        raise AssertionError("AiO runtime binder subgroup classification is incomplete")
+
+    subgroups = {}
+    for subgroup, binders in AIO_RUNTIME_BINDER_SUBGROUPS.items():
+        selected = [entry_by_binder[binder] for binder in binders]
+        root_names = [
+            name
+            for entry in selected
+            for name in entry["root_resolver_names"]
+        ]
+        provider_names = [
+            name
+            for entry in selected
+            for name in entry["provider_resolver_names"]
+        ]
+        direct_names = [
+            name
+            for entry in selected
+            for name in entry["direct_root_dependencies"]
+        ]
+        replacement_names = [
+            name
+            for entry in selected
+            for name in entry["repository_replacement_names"]
+        ]
+        unique_replacement_names = sorted(set(replacement_names))
+        replacement_files = sorted({
+            path
+            for name in unique_replacement_names
+            for path in root_replacements[name]
+        })
+        subgroups[subgroup] = {
+            "binders": list(binders),
+            "mode_counts": {
+                mode: sum(entry["mode"] == mode for entry in selected)
+                for mode in (
+                    "comfy_provider_then_root",
+                    "root_globals",
+                )
+            },
+            "bound_global_slots": sum(
+                len(entry["bound_globals"]) for entry in selected
+            ),
+            "unique_bound_globals": sorted({
+                name
+                for entry in selected
+                for name in entry["bound_globals"]
+            }),
+            "root_resolver_slots": len(root_names),
+            "unique_root_resolver_names": len(set(root_names)),
+            "provider_resolver_slots": len(provider_names),
+            "unique_provider_resolver_names": len(set(provider_names)),
+            "direct_root_dependency_slots": len(direct_names),
+            "unique_direct_root_dependencies": len(set(direct_names)),
+            "repository_replacement_slots": len(replacement_names),
+            "unique_repository_replacement_names": len(
+                unique_replacement_names
+            ),
+            "repository_replacement_files": replacement_files,
+        }
+
+    prerequisite_moves = []
+    for move in AIO_RUNTIME_PREREQUISITE_MOVES:
+        prerequisite_moves.append({
+            **move,
+            "symbols": list(move["symbols"]),
+            "blocking_edges": [
+                dict(edge) for edge in move["blocking_edges"]
+            ],
+            "unblocks": list(move["unblocks"]),
+        })
+    return {
+        "subgroup_order": list(AIO_RUNTIME_BINDER_SUBGROUPS),
+        "subgroups": subgroups,
+        "prerequisite_moves": prerequisite_moves,
+    }
+
+
 def _runtime_binder_audit(
     tree: ast.Module,
     canonical_bindings: dict[str, str],
@@ -1762,6 +1932,10 @@ def _runtime_binder_audit(
             family: list(family_binders)
             for family, family_binders in RUNTIME_BINDER_FAMILIES.items()
         },
+        "aio_split_gate": _aio_runtime_split_gate(
+            entries,
+            root_replacements,
+        ),
         "root_resolver_names": sorted(all_root_names),
         "provider_resolver_names": sorted(all_provider_names),
         "repository_root_replacements": root_replacements,
@@ -2133,6 +2307,7 @@ def _build_document() -> dict[str, Any]:
                 "B-11c30c2",
                 "B-11c30c2a",
                 "B-11c30c2b",
+                "B-11c30d",
             ],
         },
         "enums": {
@@ -2473,6 +2648,130 @@ class PythonCompatibilitySurfaceTests(unittest.TestCase):
                     entry["root_observation"],
                     "call_time_resolver",
                 )
+
+    def test_aio_binder_split_gate_is_complete_and_records_cycle_breakers(self):
+        gate = self.document["runtime_binder_audit"]["aio_split_gate"]
+        self.assertEqual(
+            gate["subgroup_order"],
+            list(AIO_RUNTIME_BINDER_SUBGROUPS),
+        )
+        self.assertEqual(
+            {
+                binder
+                for subgroup in gate["subgroups"].values()
+                for binder in subgroup["binders"]
+            },
+            set(RUNTIME_BINDER_FAMILIES["aio"]),
+        )
+        summaries = {
+            subgroup: {
+                key: value
+                for key, value in details.items()
+                if key
+                in {
+                    "root_resolver_slots",
+                    "unique_root_resolver_names",
+                    "provider_resolver_slots",
+                    "direct_root_dependency_slots",
+                    "repository_replacement_slots",
+                    "unique_repository_replacement_names",
+                }
+            }
+            for subgroup, details in gate["subgroups"].items()
+        }
+        self.assertEqual(
+            summaries,
+            {
+                "B-11c30d1_cache_state": {
+                    "root_resolver_slots": 7,
+                    "unique_root_resolver_names": 7,
+                    "provider_resolver_slots": 0,
+                    "direct_root_dependency_slots": 0,
+                    "repository_replacement_slots": 7,
+                    "unique_repository_replacement_names": 7,
+                },
+                "B-11c30d2_normalization_planning": {
+                    "root_resolver_slots": 72,
+                    "unique_root_resolver_names": 66,
+                    "provider_resolver_slots": 1,
+                    "direct_root_dependency_slots": 1,
+                    "repository_replacement_slots": 37,
+                    "unique_repository_replacement_names": 31,
+                },
+                "B-11c30d3_io_boundary": {
+                    "root_resolver_slots": 49,
+                    "unique_root_resolver_names": 46,
+                    "provider_resolver_slots": 4,
+                    "direct_root_dependency_slots": 3,
+                    "repository_replacement_slots": 47,
+                    "unique_repository_replacement_names": 44,
+                },
+                "B-11c30d4_execution_services": {
+                    "root_resolver_slots": 43,
+                    "unique_root_resolver_names": 37,
+                    "provider_resolver_slots": 6,
+                    "direct_root_dependency_slots": 3,
+                    "repository_replacement_slots": 30,
+                    "unique_repository_replacement_names": 25,
+                },
+                "B-11c30d5_legacy_orchestration": {
+                    "root_resolver_slots": 59,
+                    "unique_root_resolver_names": 59,
+                    "provider_resolver_slots": 2,
+                    "direct_root_dependency_slots": 1,
+                    "repository_replacement_slots": 48,
+                    "unique_repository_replacement_names": 48,
+                },
+                "B-11c30d6_node_adapter": {
+                    "root_resolver_slots": 30,
+                    "unique_root_resolver_names": 30,
+                    "provider_resolver_slots": 0,
+                    "direct_root_dependency_slots": 0,
+                    "repository_replacement_slots": 30,
+                    "unique_repository_replacement_names": 30,
+                },
+            },
+        )
+        self.assertEqual(
+            [move["id"] for move in gate["prerequisite_moves"]],
+            [
+                "B-11c30d0a_output_settings_owner",
+                "B-11c30d0b_input_context_owner",
+            ],
+        )
+        prerequisite_by_id = {
+            move["id"]: move for move in gate["prerequisite_moves"]
+        }
+        self.assertEqual(
+            prerequisite_by_id[
+                "B-11c30d0a_output_settings_owner"
+            ]["blocking_edges"],
+            [
+                {
+                    "consumer": "easyuse_anima.aio.generation_normalization",
+                    "symbol": "_normalize_aio_hash_bundles",
+                },
+                {
+                    "consumer": "easyuse_anima.aio.generation_normalization",
+                    "symbol": "_normalize_aio_civitai_hash_fetchers",
+                },
+            ],
+        )
+        self.assertEqual(
+            prerequisite_by_id[
+                "B-11c30d0b_input_context_owner"
+            ]["blocking_edges"],
+            [
+                {
+                    "consumer": "easyuse_anima.aio.legacy_generation",
+                    "symbol": "_require_easy_use_anima_input",
+                },
+                {
+                    "consumer": "easyuse_anima.nodes.aio_nodes",
+                    "symbol": "_run_aio_legacy_generation",
+                },
+            ],
+        )
 
     def test_prompt_service_and_node_adapter_binders_are_retired(self):
         audit = self.document["runtime_binder_audit"]


### PR DESCRIPTION
## 목적

B-11c30d는 남은 AiO runtime binder 12개를 한 PR에 옮기지 않도록 production-free rollback-unit split을 고정하는 Contract/gate입니다.

기준선: `dev@1debd5c3ea75f1d14e66a3cfbba0e93e003f69cb`

## 작업 전 inventory

- binder: 12개 (provider-then-root 8, root-only 4)
- bind-time global: 12 slots, 모두 `_RUNTIME_RESOLVER`
- root resolver: 260 slots / 187 unique
- provider: 13 slots / 5 unique
- direct root dependency: 8 slots, 모두 `_resolve_comfy_host_helper`
- repository replacement evidence: 199 slots / 133 unique / 14 test files
- 실제 mutable cache state는 `easyuse_anima.aio.first_pass_cache`의 dict/order/limit가 소유하며 #169 Behavior 경계를 유지합니다.
- `legacy_generation`은 59-slot orchestration consumer, `aio_nodes`는 별도 30-slot public node adapter입니다.

## 구현 결과

- compatibility fixture에 12개 binder의 정확하고 중복 없는 6개 subgroup을 기록했습니다.
- 각 subgroup의 binding mode, bound global, root/provider/direct dependency, repository replacement slot/file 비용을 고정했습니다.
- 후속 Move는 전체 inventory를 반복하지 않고 자기 subgroup gate를 사용합니다.
- d1 cache-state Move는 즉시 READY입니다.
- 실제 import cycle 두 개는 별도 prerequisite Move로 분리했습니다.
  - d0a: output의 두 hash-setting normalizer를 순수 `aio.output_settings` owner로 이동한 뒤 d2-d4 진행
  - d0b: node adapter의 두 input-context helper를 순수 `aio.input_context` owner로 이동한 뒤 d5-d6 진행
- 이 PR은 d0a/d0b 또는 어떤 production Move도 구현하지 않습니다.

## split 결정

| Move | Binder | Root slots / unique | Provider | Direct | Replacement slots / unique |
| --- | ---: | ---: | ---: | ---: | ---: |
| d1 cache state | 1 | 7 / 7 | 0 | 0 | 7 / 7 |
| d2 normalization/planning | 3 | 72 / 66 | 1 | 1 | 37 / 31 |
| d3 I/O boundary | 3 | 49 / 46 | 4 | 3 | 47 / 44 |
| d4 execution services | 3 | 43 / 37 | 6 | 3 | 30 / 25 |
| d5 legacy orchestration | 1 | 59 / 59 | 2 | 1 | 48 / 48 |
| d6 node adapter | 1 | 30 / 30 | 0 | 0 | 30 / 30 |

각 Move와 두 prerequisite owner Move는 별도 rollback unit입니다. Move, Contract, Behavior를 한 PR에서 섞지 않습니다.

## 변경 파일

- `tests/test_python_compatibility_surface.py`
- `tests/fixtures/python_compatibility_surface.v1.json`
- `docs/architecture/comfy-host-provider-bridge.md`
- `docs/architecture/python-backend-execution-roadmap.md`
- `docs/architecture/python-compatibility-shims.md`

## 금지 경계 확인

- production code 변경 없음
- binder 정의, root import/call, resolver/global-state 변경 없음
- schema/settings/workflow/stage order/seed/cache/model/sampling/preview/save/conditioning 동작 변경 없음
- provider lookup 또는 error text 변경 없음
- #169 Behavior 시작 안 함
- Wildcard/NAIA family 결합 안 함

## 검증

- focused compatibility surface: 15 tests, 통과 (2.048초)
- `tools/check_project.ps1 -Profile full` via repository runner: 통과
  - Python unittest: 982 tests, 통과 (30.048초)
  - frontend: 114 JavaScript files, 통과
  - Pyright baseline: 72 files / 기존 14 errors / 신규 0
  - import boundary: 6 groups / 0 violations
  - Ruff: 기존 report-only 79 findings, 차단 없음
  - `git diff --check`: 통과
- ComfyUI 표면: 정적/계약/패키지 전체 검증
- Live ComfyUI/browser smoke: production-free Contract이므로 미실행

## 남은 위험 및 후속

- d1은 cache 동작을 바꾸지 않는 binder Move로만 진행해야 합니다. cache 정책/성능 변경은 #169 Behavior입니다.
- d2-d4 전에 d0a, d5-d6 전에 d0b가 필요합니다.
- root compatibility alias와 optional dependency의 call-time 관찰 순서는 각 Move에서 보존해야 합니다.