### PR TITLE
B-11c30d1: retire AiO cache-state binder

### DIFF
--- a/docs/architecture/comfy-host-provider-bridge.md
+++ b/docs/architecture/comfy-host-provider-bridge.md
@@ -1568,6 +1568,74 @@ Move before d2; d0b remains a separate Move before d5. The two prerequisite
 Moves preserve existing root aliases and do not change normalization, input,
 stage, seed, cache, provider, error, or workflow behavior.
 
+### B-11c30d1 — AiO cache-state binder Move
+
+- **State:** IN PROGRESS
+- **Owner:** #184
+- **Behavior boundary:** #169
+- **Type:** Move
+- **Base:** `dev@7b25483c23fc3f430bf108fcb3ef23b6a64cd7e3`
+
+Pre-edit inventory:
+
+- root `nodes.py` imports `_bind_aio_first_pass_cache_runtime` in both package
+  and flat-import paths and invokes it once with a root-global resolver;
+- the binder installs one `_RUNTIME_RESOLVER` global. The canonical module
+  resolves seven root names at call time:
+  `AIO_FIRST_PASS_CACHE_MAX_ENTRIES`, `_AIO_FIRST_PASS_CACHE`,
+  `_AIO_FIRST_PASS_CACHE_ORDER`, `_clone_aio_cache_value`,
+  `_stable_change_key`, `_prompt_data_json_safe`, and
+  `_aio_lora_stack_signature`;
+- the entry limit, cache dictionary, order list, and recursive clone function
+  are already owned by `easyuse_anima.aio.first_pass_cache`;
+- the other three dependencies have canonical owners in
+  `easyuse_anima.common.serialization`, `easyuse_anima.prompt.data`, and
+  `easyuse_anima.aio.model_preparation`;
+- the seven names are replaced across four repository test files, but only
+  `tests/test_aio_first_pass_cache.py` uses root replacement to drive the cache
+  owner. Replacements in legacy-generation, node-adapter, and preview tests
+  belong to their still-active binder families and remain unchanged;
+- root retains direct identity aliases for the limit, mutable state, clone,
+  key, get, and put symbols. The previously retired private cache-clear alias
+  remains absent; and
+- mutable object identity, limit 2, key field order and values, recursive clone
+  and CPU-failure handling, falsey miss, LRU refresh, overwrite, and
+  oldest-first eviction are #169 Behavior and are frozen in this Move.
+
+Allowed production files:
+
+```text
+nodes.py
+easyuse_anima/aio/first_pass_cache.py
+```
+
+Allowed supporting files are `tests/test_aio_first_pass_cache.py`, the Python
+compatibility gate and fixture, the nodes/backend analyzer gate and fixture,
+and the three architecture documents.
+
+Exit:
+
+- root no longer imports or invokes the cache binder, and the canonical binder
+  definition plus `_RUNTIME_RESOLVER` state are absent;
+- the cache module uses its own state and recursive helper directly and imports
+  the three canonical cross-module dependencies without importing root
+  `nodes.py`;
+- root cache aliases retain exact canonical object identity;
+- tests that used root replacement to drive the cache owner replace the
+  canonical owner instead;
+- the frozen AiO split gate marks only d1 retired and keeps d2 through d6
+  active; and
+- cache behavior and the #169 boundary remain unchanged.
+
+Forbidden:
+
+- changing cache key schema/version/order, copy/clone policy, hit/miss
+  semantics, eviction order/limit, cache scope, stage metadata, or performance
+  policy;
+- retiring root cache aliases or changing callers in the legacy-generation
+  binder; and
+- combining d0a, d2 through d6, Wildcard/NAIA, Contract, or Behavior work.
+
 ### B-11d — Final root shim
 
 - **State:** BLOCKED by the remaining AiO and Wildcard/NAIA binder families

--- a/docs/architecture/comfy-host-provider-bridge.md
+++ b/docs/architecture/comfy-host-provider-bridge.md
@@ -1570,7 +1570,7 @@ stage, seed, cache, provider, error, or workflow behavior.
 
 ### B-11c30d1 — AiO cache-state binder Move
 
-- **State:** IN PROGRESS
+- **State:** COMPLETE in PR #347
 - **Owner:** #184
 - **Behavior boundary:** #169
 - **Type:** Move
@@ -1636,6 +1636,25 @@ Forbidden:
   binder; and
 - combining d0a, d2 through d6, Wildcard/NAIA, Contract, or Behavior work.
 
+Implementation result:
+
+- root no longer imports or invokes `_bind_aio_first_pass_cache_runtime`, and
+  the canonical binder, `_RUNTIME_RESOLVER`, and `_runtime_helper` are absent;
+- the cache owner directly uses its module-owned limit, dictionary, order list,
+  and recursive clone function;
+- `_stable_change_key`, `_prompt_data_json_safe`, and
+  `_aio_lora_stack_signature` are direct imports from their existing canonical
+  owners, with no root import or new callback seam;
+- cache-specific tests replace the canonical owner while the root aliases
+  retain exact object identity;
+- the split gate now marks only d1 retired and retains d2 through d6 as the
+  complete active AiO set;
+- the remaining audit is 13 binders in two families: eight provider-then-root,
+  three root-only, and two explicit callbacks;
+- `nodes.py` is 1,657 lines, down 5 lines from the B-11c30d base; and
+- focused cache, compatibility, nodes-analyzer, and backend-analyzer validation
+  passes 45 tests.
+
 ### B-11d — Final root shim
 
 - **State:** BLOCKED by the remaining AiO and Wildcard/NAIA binder families
@@ -1682,8 +1701,8 @@ COMPLETE: B-11c30c2 Prompt/Regional node-adapter split gate / PR #341
 COMPLETE: B-11c30c2a Prompt Data / Classic Prompt adapter Move / PR #342
 COMPLETE: B-11c30c2b Advanced / Regional adapter Move / PR #345
 COMPLETE: B-11c30d AiO binder split gate / PR #346
-READY:    B-11c30d1 AiO cache-state binder Move
-PLANNED:  B-11c30d0a output-settings owner Move before d2-d4
+COMPLETE: B-11c30d1 AiO cache-state binder Move / PR #347
+READY:    B-11c30d0a output-settings owner Move before d2-d4
 PLANNED:  B-11c30d2-d4 normalization, I/O, and execution-service Moves
 PLANNED:  B-11c30d0b input-context owner Move before d5-d6
 PLANNED:  B-11c30d5-d6 orchestration and node-adapter Moves

--- a/docs/architecture/python-backend-execution-roadmap.md
+++ b/docs/architecture/python-backend-execution-roadmap.md
@@ -31,7 +31,7 @@ merged PR, the owning issue's evidence record, and every stated exit gate.
 | Phase | Integrated snapshot / open implementation state | Remaining exit work |
 | --- | --- | --- |
 | A - baseline | Complete; #191 is closed | Keep fixtures and analyzers current during later moves |
-| B - `nodes.py` extraction | Integrated through B-11c30c2b / PR #345; B-11c30d completes the AiO split gate in PR #346 | Execute the frozen AiO Moves, then Wildcard/NAIA and the final root shim as separate rollback units |
+| B - `nodes.py` extraction | Integrated through B-11c30d / PR #346; B-11c30d1 completes in PR #347 | Execute d0a then the remaining frozen AiO Moves, followed by Wildcard/NAIA and the final root shim as separate rollback units |
 | C - feature contracts/behavior | Partially complete through S167-01a / PR #344 | Continue #167 and #169 in separate Contract/Move/Behavior PRs |
 | D - root consolidation | Not started | Execute #186 feature by feature after the corresponding behavior contracts are stable |
 | E - runtime ownership | Partial: E-02a and E-07a/E-07b integrated | Continue #187 only where canonical feature owners and explicit contracts exist |
@@ -122,7 +122,12 @@ merged PR, the owning issue's evidence record, and every stated exit gate.
   import cycle before d2 through d4, and d0b breaks the
   legacy-orchestration/node-adapter cycle before d5 and d6. d1 cache state is
   the first READY Move and remains mechanically separate from #169 cache
-  Behavior.
+  Behavior. B-11c30d1 / PR #347 retires only that cache-state binder: the
+  canonical cache module directly owns its existing state and imports the
+  existing serialization, Prompt Data, and LoRA-signature owners. The split
+  gate marks d1 retired while keeping d2 through d6 active. Thirteen binders
+  remain across AiO and Wildcard/NAIA; cache key, clone, hit/miss, LRU, limit,
+  and eviction behavior are unchanged.
 
 ### Current quality baseline
 
@@ -366,7 +371,7 @@ mechanical retirement series.
 | 11 | B-09b2 AiO generator adapter move | COMPLETE on `dev` | Move | #184 | PR #270 / `57d40b4` |
 | 12 | B-10a machine-readable compatibility audit | COMPLETE on `dev` | Contract/gate | #184/#188 | PR #271 / `3c7b857` |
 | 13 | B-10b private alias reduction | COMPLETE on `dev` through PR #291 / `c6b4680` | Contract/cleanup, split PRs | #184/#188 | Audited alias surface integrated |
-| 14 | B-11 registration/bootstrap/root shim | IN PROGRESS through B-11c30d PR #346; d1 is READY, d0a precedes d2-d4, and d0b precedes d5-d6 | Move/Contract, split PRs | #184 | Frozen AiO split gate; S167-01 contract |
+| 14 | B-11 registration/bootstrap/root shim | IN PROGRESS through B-11c30d1 PR #347; d0a is READY before d2-d4, and d0b precedes d5-d6 | Move/Contract, split PRs | #184 | Frozen AiO split gate; S167-01 contract |
 | 15 | S167 backend seed reservation series | S167-01 Contract COMPLETE in PR #343 and S167-01a consumer Move COMPLETE in PR #344; Behavior and Adapter remain | Contract then Move then Behavior | #167 | Canonical AiO/node seams |
 | 16 | A169 stage pipeline series | BLOCKED by #168 and B exit | Contract then Behavior | #169 | Typed config and mechanical AiO move |
 | 17 | A169 first-pass cache policy | BLOCKED by stage/cache ownership seam | Behavior | #169 | Mechanical cache move and benchmark harness |
@@ -1053,6 +1058,16 @@ unchanged. The separate legacy Wildcard unsupported alias remains for D-12.
     CLIP encoding behind the existing E-07 provider, while Advanced reuses the
     Prompt service's call-time Wildcard module resolver to preserve
     optional-dependency timing. Fourteen AiO and Wildcard/NAIA binders remain.
+  - B-11c30d changes no production code. It freezes the twelve AiO binders into
+    six non-overlapping retirement groups, records incremental active/retired
+    state, and identifies d0a and d0b as separate cycle-breaking owner Moves.
+    d1 is independent of those prerequisites and remains separate from #169
+    cache Behavior.
+  - B-11c30d1 retires only `_bind_aio_first_pass_cache_runtime` in PR #347.
+    The cache module directly owns its existing limit/state/clone calls and
+    imports the three existing canonical helpers. Root cache aliases and all
+    cache semantics remain unchanged. Thirteen AiO and Wildcard/NAIA binders
+    remain.
   - The final B-11c cutover removes remaining root execution ownership and
     leaves the explicit supported `nodes.py` compatibility shim.
 - Add `easyuse_anima/registration.py` as pure mapping composition. It performs no

--- a/docs/architecture/python-compatibility-shims.md
+++ b/docs/architecture/python-compatibility-shims.md
@@ -8,11 +8,11 @@
 - Policy: [ADR-002](adr-002-compatibility-shims.md)
 - Machine-readable audit:
   [`python_compatibility_surface.v1.json`](../../tests/fixtures/python_compatibility_surface.v1.json)
-- Current state: B-11a through B-11c30c2b / PR #345 are integrated in the
-  reviewed sequence, and B-11c30d / PR #346 freezes the remaining AiO split
-  without production changes. S167-01a / PR #344 supplies the canonical
-  reserved-seed compatibility consumer while retaining its root aliases.
-  Fourteen AiO and Wildcard/NAIA binders remain before the final root shim.
+- Current state: B-11a through B-11c30d / PR #346 are integrated in the
+  reviewed sequence, and B-11c30d1 / PR #347 retires only the AiO cache-state
+  binder. S167-01a / PR #344 supplies the canonical reserved-seed compatibility
+  consumer while retaining its root aliases. Thirteen AiO and Wildcard/NAIA
+  binders remain before the final root shim.
 
 This is an actionable registry, not a removal schedule. `N` means the first
 published Registry release containing both a canonical target and its root
@@ -77,8 +77,8 @@ inferring public support from spelling or test imports:
 - `nodes.py` preamble implementation imports: 5 (`json`, `logging`, `random`,
   `ceil`, and `sqrt`), excluded from compatibility classification
   by an exact AST allowlist and drift gate;
-- `nodes.py` bindings with an `easyuse_anima` canonical target: 282 in
-  B-11c30c2b (258 at the integrated B-10b20 baseline), with exact
+- `nodes.py` bindings with an `easyuse_anima` canonical target: 281 in
+  B-11c30d1 (258 at the integrated B-10b20 baseline), with exact
   relative-package/flat-fallback parity;
 - bindings still owned by `anima_prompt`, `settings`, `prompt_translation`, or
   `wildcard_engine`: 27, with the same fallback parity;
@@ -88,8 +88,8 @@ inferring public support from spelling or test imports:
   owner module without a root alias or backend mapping;
 - root-owned residual implementation: 0 functions, 0 classes, and 24 assigned
   globals in B-11c30c2b (41/2/33 at the integrated B-10b20 baseline).
-- import-time runtime binders: 14 exact top-level `_bind_*_runtime` calls;
-- root names reached by those canonical runtime resolvers: 187, including
+- import-time runtime binders: 13 exact top-level `_bind_*_runtime` calls;
+- root names reached by those canonical runtime resolvers: 183, including
   literal lookups and binder-owned helper-name/default collections;
 - retired private bindings: `_comfy_checkpoint_names`,
   `_EasyUseAnimaAlignedDetailerHook`, and
@@ -863,6 +863,24 @@ convenience-node compatibility; it remains unmapped and is not public support.
 - Neither prerequisite Move is implemented by this gate. No schema, setting,
   workflow, stage, seed, cache, model, sampling, preview, save, conditioning,
   provider, optional-dependency, or error behavior changes.
+
+### B-11c30d1 AiO cache-state binder retirement
+
+- Root no longer imports or invokes `_bind_aio_first_pass_cache_runtime`; the
+  canonical binder, `_RUNTIME_RESOLVER`, and `_runtime_helper` are removed.
+- `easyuse_anima.aio.first_pass_cache` uses its module-owned limit, dictionary,
+  order list, and recursive clone function directly. It imports the stable-key,
+  Prompt Data JSON-safe, and LoRA-signature helpers from their existing
+  canonical owners without a root dependency.
+- Root limit/state/clone/key/get/put bindings remain direct canonical aliases.
+  The already-retired cache-clear root alias remains absent.
+- Cache-specific tests replace the canonical owner. Root replacements owned by
+  still-active legacy-generation, node-adapter, or preview binders do not move.
+- The incremental split gate marks d1 retired and keeps d2 through d6 as the
+  exact active AiO set. The total audit is 13 binders in two families.
+- Cache object identity, key schema/order, clone behavior, falsey miss, hit
+  refresh, overwrite, limit 2, oldest-first eviction, stage metadata, and #169
+  Behavior remain unchanged.
 
 ### `nodes.py` public node-class surface
 

--- a/easyuse_anima/aio/first_pass_cache.py
+++ b/easyuse_anima/aio/first_pass_cache.py
@@ -2,45 +2,27 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable
-from typing import Any, TypeAlias
+from typing import Any
+
+from ..common.serialization import _stable_change_key
+from ..prompt.data import _prompt_data_json_safe
+from .model_preparation import _aio_lora_stack_signature
 
 AIO_FIRST_PASS_CACHE_MAX_ENTRIES = 2
 _AIO_FIRST_PASS_CACHE: dict[str, dict[str, Any]] = {}
 _AIO_FIRST_PASS_CACHE_ORDER: list[str] = []
 
-_RuntimeResolver: TypeAlias = Callable[[str], Any]
-_RUNTIME_RESOLVER: _RuntimeResolver | None = None
-
-
-def _bind_aio_first_pass_cache_runtime(*, resolve_helper: _RuntimeResolver) -> None:
-    """Bind root compatibility helpers and state without importing the root module."""
-
-    global _RUNTIME_RESOLVER
-    _RUNTIME_RESOLVER = resolve_helper
-
-
-def _runtime_helper(name: str) -> Any:
-    resolver = _RUNTIME_RESOLVER
-    if resolver is None:
-        raise RuntimeError(
-            f"[EasyUseAnima] AiO first-pass cache runtime helper is not bound: {name}"
-        )
-    return resolver(name)
-
 
 def _clone_aio_cache_value(value):
     if isinstance(value, dict):
         return {
-            key: _runtime_helper("_clone_aio_cache_value")(item)
+            key: _clone_aio_cache_value(item)
             for key, item in value.items()
         }
     if isinstance(value, list):
-        return [_runtime_helper("_clone_aio_cache_value")(item) for item in value]
+        return [_clone_aio_cache_value(item) for item in value]
     if isinstance(value, tuple):
-        return tuple(
-            _runtime_helper("_clone_aio_cache_value")(item) for item in value
-        )
+        return tuple(_clone_aio_cache_value(item) for item in value)
     detach = getattr(value, "detach", None)
     clone = getattr(value, "clone", None)
     if callable(detach) and callable(clone):
@@ -57,8 +39,8 @@ def _clone_aio_cache_value(value):
 
 
 def _clear_aio_first_pass_cache() -> None:
-    _runtime_helper("_AIO_FIRST_PASS_CACHE").clear()
-    _runtime_helper("_AIO_FIRST_PASS_CACHE_ORDER").clear()
+    _AIO_FIRST_PASS_CACHE.clear()
+    _AIO_FIRST_PASS_CACHE_ORDER.clear()
 
 
 def _aio_first_pass_cache_key(
@@ -77,29 +59,29 @@ def _aio_first_pass_cache_key(
     width: int,
     height: int,
 ) -> str:
-    return _runtime_helper("_stable_change_key")({
+    return _stable_change_key({
         "schema": "easyuse_anima_aio_first_pass_cache",
         "version": 1,
         "scope": str(cache_scope or ""),
         "mode": settings.get("mode"),
-        "resource_info": _runtime_helper("_prompt_data_json_safe")(
+        "resource_info": _prompt_data_json_safe(
             context.get("resource_info", {})
         ),
-        "input_settings": _runtime_helper("_prompt_data_json_safe")(
+        "input_settings": _prompt_data_json_safe(
             context.get("input_settings", {})
         ),
-        "prompt_data": _runtime_helper("_prompt_data_json_safe")(prompt_data),
-        "lora_stack": _runtime_helper("_aio_lora_stack_signature")(lora_stack),
-        "sampler": _runtime_helper("_prompt_data_json_safe")(
+        "prompt_data": _prompt_data_json_safe(prompt_data),
+        "lora_stack": _aio_lora_stack_signature(lora_stack),
+        "sampler": _prompt_data_json_safe(
             settings.get("sampler", {})
         ),
-        "model_patches": _runtime_helper("_prompt_data_json_safe")(
+        "model_patches": _prompt_data_json_safe(
             settings.get("model_patches", {})
         ),
-        "mod_guidance": _runtime_helper("_prompt_data_json_safe")(
+        "mod_guidance": _prompt_data_json_safe(
             settings.get("mod_guidance", {})
         ),
-        "artist_mix": _runtime_helper("_prompt_data_json_safe")(
+        "artist_mix": _prompt_data_json_safe(
             settings.get("artist_mix", {})
         ),
         "positive_prompt": str(positive_prompt or ""),
@@ -114,32 +96,30 @@ def _aio_first_pass_cache_key(
 
 
 def _get_aio_first_pass_cache(cache_key: str):
-    entry = _runtime_helper("_AIO_FIRST_PASS_CACHE").get(cache_key)
+    entry = _AIO_FIRST_PASS_CACHE.get(cache_key)
     if not entry:
         return None
-    if cache_key in _runtime_helper("_AIO_FIRST_PASS_CACHE_ORDER"):
-        _runtime_helper("_AIO_FIRST_PASS_CACHE_ORDER").remove(cache_key)
-    _runtime_helper("_AIO_FIRST_PASS_CACHE_ORDER").append(cache_key)
+    if cache_key in _AIO_FIRST_PASS_CACHE_ORDER:
+        _AIO_FIRST_PASS_CACHE_ORDER.remove(cache_key)
+    _AIO_FIRST_PASS_CACHE_ORDER.append(cache_key)
     return (
-        _runtime_helper("_clone_aio_cache_value")(entry["latent"]),
-        _runtime_helper("_clone_aio_cache_value")(entry["image"]),
+        _clone_aio_cache_value(entry["latent"]),
+        _clone_aio_cache_value(entry["image"]),
     )
 
 
 def _put_aio_first_pass_cache(cache_key: str, latent, image) -> None:
     entry = {
-        "latent": _runtime_helper("_clone_aio_cache_value")(latent),
-        "image": _runtime_helper("_clone_aio_cache_value")(image),
+        "latent": _clone_aio_cache_value(latent),
+        "image": _clone_aio_cache_value(image),
     }
-    _runtime_helper("_AIO_FIRST_PASS_CACHE")[cache_key] = entry
-    if cache_key in _runtime_helper("_AIO_FIRST_PASS_CACHE_ORDER"):
-        _runtime_helper("_AIO_FIRST_PASS_CACHE_ORDER").remove(cache_key)
-    _runtime_helper("_AIO_FIRST_PASS_CACHE_ORDER").append(cache_key)
-    while len(_runtime_helper("_AIO_FIRST_PASS_CACHE_ORDER")) > _runtime_helper(
-        "AIO_FIRST_PASS_CACHE_MAX_ENTRIES"
-    ):
-        old_key = _runtime_helper("_AIO_FIRST_PASS_CACHE_ORDER").pop(0)
-        _runtime_helper("_AIO_FIRST_PASS_CACHE").pop(old_key, None)
+    _AIO_FIRST_PASS_CACHE[cache_key] = entry
+    if cache_key in _AIO_FIRST_PASS_CACHE_ORDER:
+        _AIO_FIRST_PASS_CACHE_ORDER.remove(cache_key)
+    _AIO_FIRST_PASS_CACHE_ORDER.append(cache_key)
+    while len(_AIO_FIRST_PASS_CACHE_ORDER) > AIO_FIRST_PASS_CACHE_MAX_ENTRIES:
+        old_key = _AIO_FIRST_PASS_CACHE_ORDER.pop(0)
+        _AIO_FIRST_PASS_CACHE.pop(old_key, None)
 
 
 __all__ = ()

--- a/nodes.py
+++ b/nodes.py
@@ -12,7 +12,6 @@ try:
         _AIO_FIRST_PASS_CACHE as _AIO_FIRST_PASS_CACHE,
         _AIO_FIRST_PASS_CACHE_ORDER as _AIO_FIRST_PASS_CACHE_ORDER,
         _aio_first_pass_cache_key as _aio_first_pass_cache_key,
-        _bind_aio_first_pass_cache_runtime as _bind_aio_first_pass_cache_runtime,
         # B-10b7 retires the test-only root cache-clear function alias.
         _clone_aio_cache_value as _clone_aio_cache_value,
         _get_aio_first_pass_cache as _get_aio_first_pass_cache,
@@ -556,7 +555,6 @@ except ImportError:  # allows simple local import tests outside ComfyUI's packag
         _AIO_FIRST_PASS_CACHE as _AIO_FIRST_PASS_CACHE,
         _AIO_FIRST_PASS_CACHE_ORDER as _AIO_FIRST_PASS_CACHE_ORDER,
         _aio_first_pass_cache_key as _aio_first_pass_cache_key,
-        _bind_aio_first_pass_cache_runtime as _bind_aio_first_pass_cache_runtime,
         # B-10b7 retires the test-only root cache-clear function alias.
         _clone_aio_cache_value as _clone_aio_cache_value,
         _get_aio_first_pass_cache as _get_aio_first_pass_cache,
@@ -1587,9 +1585,6 @@ AIO_RESHIFT_DTYPES = ("bf16", "fp32")
 _TRIGGER_WORD_KEYS = ("trainedWords", "trained_words", "trigger_words", "activation_text")
 
 
-_bind_aio_first_pass_cache_runtime(
-    resolve_helper=lambda name: globals()[name],
-)
 _bind_aio_legacy_generation_runtime(
     resolve_helper=lambda name: _resolve_comfy_host_helper(
         name,

--- a/tests/fixtures/python_backend_baseline.json
+++ b/tests/fixtures/python_backend_baseline.json
@@ -4512,23 +4512,6 @@
       },
       {
         "alias": null,
-        "bound_name": "Callable",
-        "branch_context": [],
-        "classification": "external",
-        "column": 0,
-        "conditional": false,
-        "imported": "collections.abc:Callable",
-        "kind": "static_from",
-        "line": 5,
-        "name": "Callable",
-        "optional": false,
-        "requested": "collections.abc",
-        "role": "ordinary",
-        "scope": "<module>",
-        "source": "easyuse_anima/aio/first_pass_cache.py"
-      },
-      {
-        "alias": null,
         "bound_name": "Any",
         "branch_context": [],
         "classification": "external",
@@ -4536,7 +4519,7 @@
         "conditional": false,
         "imported": "typing:Any",
         "kind": "static_from",
-        "line": 6,
+        "line": 5,
         "name": "Any",
         "optional": false,
         "requested": "typing",
@@ -4546,20 +4529,57 @@
       },
       {
         "alias": null,
-        "bound_name": "TypeAlias",
+        "bound_name": "_stable_change_key",
         "branch_context": [],
-        "classification": "external",
+        "classification": "internal",
         "column": 0,
         "conditional": false,
-        "imported": "typing:TypeAlias",
+        "imported": "..common.serialization:_stable_change_key",
         "kind": "static_from",
-        "line": 6,
-        "name": "TypeAlias",
+        "line": 7,
+        "name": "_stable_change_key",
         "optional": false,
-        "requested": "typing",
+        "requested": "..common.serialization",
         "role": "ordinary",
         "scope": "<module>",
-        "source": "easyuse_anima/aio/first_pass_cache.py"
+        "source": "easyuse_anima/aio/first_pass_cache.py",
+        "target": "easyuse_anima/common/serialization.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_prompt_data_json_safe",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": "..prompt.data:_prompt_data_json_safe",
+        "kind": "static_from",
+        "line": 8,
+        "name": "_prompt_data_json_safe",
+        "optional": false,
+        "requested": "..prompt.data",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/aio/first_pass_cache.py",
+        "target": "easyuse_anima/prompt/data.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_aio_lora_stack_signature",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".model_preparation:_aio_lora_stack_signature",
+        "kind": "static_from",
+        "line": 9,
+        "name": "_aio_lora_stack_signature",
+        "optional": false,
+        "requested": ".model_preparation",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/aio/first_pass_cache.py",
+        "target": "easyuse_anima/aio/model_preparation.py"
       },
       {
         "alias": null,
@@ -17552,37 +17572,6 @@
         "target": "easyuse_anima/aio/first_pass_cache.py"
       },
       {
-        "alias": "_bind_aio_first_pass_cache_runtime",
-        "bound_name": "_bind_aio_first_pass_cache_runtime",
-        "branch_context": [
-          {
-            "branch": "body",
-            "handles_import_failure": true,
-            "has_import_fallback_handler": true,
-            "kind": "try",
-            "line": 9
-          }
-        ],
-        "classification": "internal",
-        "column": 4,
-        "compatibility_pair": {
-          "bound_name": "_bind_aio_first_pass_cache_runtime",
-          "target": "easyuse_anima/aio/first_pass_cache.py",
-          "try_line": 9
-        },
-        "conditional": true,
-        "imported": ".easyuse_anima.aio.first_pass_cache:_bind_aio_first_pass_cache_runtime",
-        "kind": "static_from",
-        "line": 10,
-        "name": "_bind_aio_first_pass_cache_runtime",
-        "optional": false,
-        "requested": ".easyuse_anima.aio.first_pass_cache",
-        "role": "compatibility_primary",
-        "scope": "<module>",
-        "source": "nodes.py",
-        "target": "easyuse_anima/aio/first_pass_cache.py"
-      },
-      {
         "alias": "_clone_aio_cache_value",
         "bound_name": "_clone_aio_cache_value",
         "branch_context": [
@@ -17697,7 +17686,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.legacy_generation:_bind_aio_legacy_generation_runtime",
         "kind": "static_from",
-        "line": 21,
+        "line": 20,
         "name": "_bind_aio_legacy_generation_runtime",
         "optional": false,
         "requested": ".easyuse_anima.aio.legacy_generation",
@@ -17728,7 +17717,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.legacy_generation:_run_aio_detailer_stage",
         "kind": "static_from",
-        "line": 21,
+        "line": 20,
         "name": "_run_aio_detailer_stage",
         "optional": false,
         "requested": ".easyuse_anima.aio.legacy_generation",
@@ -17759,7 +17748,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.legacy_generation:_run_aio_detailer_target",
         "kind": "static_from",
-        "line": 21,
+        "line": 20,
         "name": "_run_aio_detailer_target",
         "optional": false,
         "requested": ".easyuse_anima.aio.legacy_generation",
@@ -17790,7 +17779,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.legacy_generation:_run_aio_highres_stage",
         "kind": "static_from",
-        "line": 21,
+        "line": 20,
         "name": "_run_aio_highres_stage",
         "optional": false,
         "requested": ".easyuse_anima.aio.legacy_generation",
@@ -17821,7 +17810,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.legacy_generation:_run_aio_legacy_generation",
         "kind": "static_from",
-        "line": 21,
+        "line": 20,
         "name": "_run_aio_legacy_generation",
         "optional": false,
         "requested": ".easyuse_anima.aio.legacy_generation",
@@ -17852,7 +17841,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.legacy_generation:_run_aio_resshift_upscale_stage",
         "kind": "static_from",
-        "line": 21,
+        "line": 20,
         "name": "_run_aio_resshift_upscale_stage",
         "optional": false,
         "requested": ".easyuse_anima.aio.legacy_generation",
@@ -17883,7 +17872,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.legacy_generation:_run_aio_upscale_stage",
         "kind": "static_from",
-        "line": 21,
+        "line": 20,
         "name": "_run_aio_upscale_stage",
         "optional": false,
         "requested": ".easyuse_anima.aio.legacy_generation",
@@ -17914,7 +17903,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.legacy_generation:_run_aio_usdu_upscale_stage",
         "kind": "static_from",
-        "line": 21,
+        "line": 20,
         "name": "_run_aio_usdu_upscale_stage",
         "optional": false,
         "requested": ".easyuse_anima.aio.legacy_generation",
@@ -17945,7 +17934,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEEDS",
         "kind": "static_from",
-        "line": 31,
+        "line": 30,
         "name": "AIO_SPECIAL_SEEDS",
         "optional": false,
         "requested": ".easyuse_anima.aio.generation_normalization",
@@ -17976,7 +17965,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEED_DECREMENT",
         "kind": "static_from",
-        "line": 31,
+        "line": 30,
         "name": "AIO_SPECIAL_SEED_DECREMENT",
         "optional": false,
         "requested": ".easyuse_anima.aio.generation_normalization",
@@ -18007,7 +17996,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEED_INCREMENT",
         "kind": "static_from",
-        "line": 31,
+        "line": 30,
         "name": "AIO_SPECIAL_SEED_INCREMENT",
         "optional": false,
         "requested": ".easyuse_anima.aio.generation_normalization",
@@ -18038,7 +18027,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEED_RANDOM",
         "kind": "static_from",
-        "line": 31,
+        "line": 30,
         "name": "AIO_SPECIAL_SEED_RANDOM",
         "optional": false,
         "requested": ".easyuse_anima.aio.generation_normalization",
@@ -18069,7 +18058,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.generation_normalization:_AIO_DETAILER_CUSTOM_RE",
         "kind": "static_from",
-        "line": 31,
+        "line": 30,
         "name": "_AIO_DETAILER_CUSTOM_RE",
         "optional": false,
         "requested": ".easyuse_anima.aio.generation_normalization",
@@ -18100,7 +18089,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.generation_normalization:_AIO_DETAILER_RESERVED_KEYS",
         "kind": "static_from",
-        "line": 31,
+        "line": 30,
         "name": "_AIO_DETAILER_RESERVED_KEYS",
         "optional": false,
         "requested": ".easyuse_anima.aio.generation_normalization",
@@ -18131,7 +18120,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.generation_normalization:_aio_detailer_has_enabled_targets",
         "kind": "static_from",
-        "line": 31,
+        "line": 30,
         "name": "_aio_detailer_has_enabled_targets",
         "optional": false,
         "requested": ".easyuse_anima.aio.generation_normalization",
@@ -18162,7 +18151,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.generation_normalization:_aio_detailer_target_defaults",
         "kind": "static_from",
-        "line": 31,
+        "line": 30,
         "name": "_aio_detailer_target_defaults",
         "optional": false,
         "requested": ".easyuse_anima.aio.generation_normalization",
@@ -18193,7 +18182,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.generation_normalization:_aio_detailer_target_order",
         "kind": "static_from",
-        "line": 31,
+        "line": 30,
         "name": "_aio_detailer_target_order",
         "optional": false,
         "requested": ".easyuse_anima.aio.generation_normalization",
@@ -18224,7 +18213,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.generation_normalization:_bind_aio_generation_normalization_runtime",
         "kind": "static_from",
-        "line": 31,
+        "line": 30,
         "name": "_bind_aio_generation_normalization_runtime",
         "optional": false,
         "requested": ".easyuse_anima.aio.generation_normalization",
@@ -18255,7 +18244,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.generation_normalization:_is_aio_detailer_target_name",
         "kind": "static_from",
-        "line": 31,
+        "line": 30,
         "name": "_is_aio_detailer_target_name",
         "optional": false,
         "requested": ".easyuse_anima.aio.generation_normalization",
@@ -18286,7 +18275,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.generation_normalization:_merge_versioned_settings",
         "kind": "static_from",
-        "line": 31,
+        "line": 30,
         "name": "_merge_versioned_settings",
         "optional": false,
         "requested": ".easyuse_anima.aio.generation_normalization",
@@ -18317,7 +18306,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.generation_normalization:_normalize_aio_dit_corrections_settings",
         "kind": "static_from",
-        "line": 31,
+        "line": 30,
         "name": "_normalize_aio_dit_corrections_settings",
         "optional": false,
         "requested": ".easyuse_anima.aio.generation_normalization",
@@ -18348,7 +18337,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.generation_normalization:_normalize_aio_generation_settings",
         "kind": "static_from",
-        "line": 31,
+        "line": 30,
         "name": "_normalize_aio_generation_settings",
         "optional": false,
         "requested": ".easyuse_anima.aio.generation_normalization",
@@ -18379,7 +18368,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.generation_normalization:_normalize_aio_seed",
         "kind": "static_from",
-        "line": 31,
+        "line": 30,
         "name": "_normalize_aio_seed",
         "optional": false,
         "requested": ".easyuse_anima.aio.generation_normalization",
@@ -18410,7 +18399,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.generation_normalization:_normalize_aio_spectrum_settings",
         "kind": "static_from",
-        "line": 31,
+        "line": 30,
         "name": "_normalize_aio_spectrum_settings",
         "optional": false,
         "requested": ".easyuse_anima.aio.generation_normalization",
@@ -18441,7 +18430,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.generation_settings:round_trip_aio_generation_settings",
         "kind": "static_from",
-        "line": 49,
+        "line": 48,
         "name": "round_trip_aio_generation_settings",
         "optional": false,
         "requested": ".easyuse_anima.aio.generation_settings",
@@ -18472,7 +18461,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.usdu:_aio_usdu_auto_tile_dimension",
         "kind": "static_from",
-        "line": 52,
+        "line": 51,
         "name": "_aio_usdu_auto_tile_dimension",
         "optional": false,
         "requested": ".easyuse_anima.aio.usdu",
@@ -18503,7 +18492,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.usdu:_aio_usdu_tile_plan",
         "kind": "static_from",
-        "line": 52,
+        "line": 51,
         "name": "_aio_usdu_tile_plan",
         "optional": false,
         "requested": ".easyuse_anima.aio.usdu",
@@ -18534,7 +18523,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.usdu:_bind_aio_usdu_planning_runtime",
         "kind": "static_from",
-        "line": 52,
+        "line": 51,
         "name": "_bind_aio_usdu_planning_runtime",
         "optional": false,
         "requested": ".easyuse_anima.aio.usdu",
@@ -18565,7 +18554,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.postprocess:_aio_final_fit_size",
         "kind": "static_from",
-        "line": 57,
+        "line": 56,
         "name": "_aio_final_fit_size",
         "optional": false,
         "requested": ".easyuse_anima.aio.postprocess",
@@ -18596,7 +18585,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.postprocess:_apply_aio_final_fit",
         "kind": "static_from",
-        "line": 57,
+        "line": 56,
         "name": "_apply_aio_final_fit",
         "optional": false,
         "requested": ".easyuse_anima.aio.postprocess",
@@ -18627,7 +18616,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.postprocess:_bind_aio_postprocess_runtime",
         "kind": "static_from",
-        "line": 57,
+        "line": 56,
         "name": "_bind_aio_postprocess_runtime",
         "optional": false,
         "requested": ".easyuse_anima.aio.postprocess",
@@ -18658,7 +18647,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.postprocess:_resize_image_to_size_if_needed",
         "kind": "static_from",
-        "line": 57,
+        "line": 56,
         "name": "_resize_image_to_size_if_needed",
         "optional": false,
         "requested": ".easyuse_anima.aio.postprocess",
@@ -18689,7 +18678,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.postprocess:_run_aio_postprocess_stage",
         "kind": "static_from",
-        "line": 57,
+        "line": 56,
         "name": "_run_aio_postprocess_stage",
         "optional": false,
         "requested": ".easyuse_anima.aio.postprocess",
@@ -18720,7 +18709,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.conditioning:_aio_prompt_data_fields_for_usdu",
         "kind": "static_from",
-        "line": 64,
+        "line": 63,
         "name": "_aio_prompt_data_fields_for_usdu",
         "optional": false,
         "requested": ".easyuse_anima.aio.conditioning",
@@ -18751,7 +18740,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.conditioning:_aio_usdu_conditioning",
         "kind": "static_from",
-        "line": 64,
+        "line": 63,
         "name": "_aio_usdu_conditioning",
         "optional": false,
         "requested": ".easyuse_anima.aio.conditioning",
@@ -18782,7 +18771,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.conditioning:_aio_usdu_prompt_without_general",
         "kind": "static_from",
-        "line": 64,
+        "line": 63,
         "name": "_aio_usdu_prompt_without_general",
         "optional": false,
         "requested": ".easyuse_anima.aio.conditioning",
@@ -18813,7 +18802,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.conditioning:_bind_aio_conditioning_runtime",
         "kind": "static_from",
-        "line": 64,
+        "line": 63,
         "name": "_bind_aio_conditioning_runtime",
         "optional": false,
         "requested": ".easyuse_anima.aio.conditioning",
@@ -18844,7 +18833,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_aio_lora_stack_signature",
         "kind": "static_from",
-        "line": 70,
+        "line": 69,
         "name": "_aio_lora_stack_signature",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -18875,7 +18864,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_apply_aio_anima_dave_patch",
         "kind": "static_from",
-        "line": 70,
+        "line": 69,
         "name": "_apply_aio_anima_dave_patch",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -18906,7 +18895,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_apply_aio_kj_model_patches",
         "kind": "static_from",
-        "line": 70,
+        "line": 69,
         "name": "_apply_aio_kj_model_patches",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -18937,7 +18926,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_apply_aio_lora_stack",
         "kind": "static_from",
-        "line": 70,
+        "line": 69,
         "name": "_apply_aio_lora_stack",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -18968,7 +18957,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_apply_aio_model_patches",
         "kind": "static_from",
-        "line": 70,
+        "line": 69,
         "name": "_apply_aio_model_patches",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -18999,7 +18988,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_apply_aio_safe_pag_patch",
         "kind": "static_from",
-        "line": 70,
+        "line": 69,
         "name": "_apply_aio_safe_pag_patch",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -19030,7 +19019,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_apply_aio_spectrum_correction_patch_for_comfy_sampler",
         "kind": "static_from",
-        "line": 70,
+        "line": 69,
         "name": "_apply_aio_spectrum_correction_patch_for_comfy_sampler",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -19061,7 +19050,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_apply_aio_spectrum_forecast_patch_for_comfy_sampler",
         "kind": "static_from",
-        "line": 70,
+        "line": 69,
         "name": "_apply_aio_spectrum_forecast_patch_for_comfy_sampler",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -19092,7 +19081,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_apply_aio_spectrum_model_patches_for_comfy_sampler",
         "kind": "static_from",
-        "line": 70,
+        "line": 69,
         "name": "_apply_aio_spectrum_model_patches_for_comfy_sampler",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -19123,7 +19112,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_bind_aio_model_preparation_runtime",
         "kind": "static_from",
-        "line": 70,
+        "line": 69,
         "name": "_bind_aio_model_preparation_runtime",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -19154,7 +19143,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_cleanup_aio_ephemeral_model",
         "kind": "static_from",
-        "line": 70,
+        "line": 69,
         "name": "_cleanup_aio_ephemeral_model",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -19185,7 +19174,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_normalize_aio_lora_stack",
         "kind": "static_from",
-        "line": 70,
+        "line": 69,
         "name": "_normalize_aio_lora_stack",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -19216,7 +19205,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_patch_model_sampling_aura_flow",
         "kind": "static_from",
-        "line": 70,
+        "line": 69,
         "name": "_patch_model_sampling_aura_flow",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -19247,7 +19236,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_aio_highres_effective_backend",
         "kind": "static_from",
-        "line": 85,
+        "line": 84,
         "name": "_aio_highres_effective_backend",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -19278,7 +19267,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_aio_stage_sampler_settings",
         "kind": "static_from",
-        "line": 85,
+        "line": 84,
         "name": "_aio_stage_sampler_settings",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -19309,7 +19298,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_bind_aio_sampling_runtime",
         "kind": "static_from",
-        "line": 85,
+        "line": 84,
         "name": "_bind_aio_sampling_runtime",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -19340,7 +19329,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_decode_latent_with_comfy",
         "kind": "static_from",
-        "line": 85,
+        "line": 84,
         "name": "_decode_latent_with_comfy",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -19371,7 +19360,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_encode_image_with_comfy_vae",
         "kind": "static_from",
-        "line": 85,
+        "line": 84,
         "name": "_encode_image_with_comfy_vae",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -19402,7 +19391,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_generate_empty_latent_with_comfy",
         "kind": "static_from",
-        "line": 85,
+        "line": 84,
         "name": "_generate_empty_latent_with_comfy",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -19433,7 +19422,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_new_aio_random_seed",
         "kind": "static_from",
-        "line": 85,
+        "line": 84,
         "name": "_new_aio_random_seed",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -19464,7 +19453,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_resolve_aio_runtime_seed",
         "kind": "static_from",
-        "line": 85,
+        "line": 84,
         "name": "_resolve_aio_runtime_seed",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -19495,7 +19484,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_sample_latent_with_aio_backend",
         "kind": "static_from",
-        "line": 85,
+        "line": 84,
         "name": "_sample_latent_with_aio_backend",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -19526,7 +19515,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_sample_latent_with_comfy",
         "kind": "static_from",
-        "line": 85,
+        "line": 84,
         "name": "_sample_latent_with_comfy",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -19557,7 +19546,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_sample_latent_with_spectrum_mod_guidance_advanced",
         "kind": "static_from",
-        "line": 85,
+        "line": 84,
         "name": "_sample_latent_with_spectrum_mod_guidance_advanced",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -19588,7 +19577,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_sample_latent_with_spectrum_spd",
         "kind": "static_from",
-        "line": 85,
+        "line": 84,
         "name": "_sample_latent_with_spectrum_spd",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -19619,7 +19608,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.preview:AIO_PREVIEW_CACHE_FORMAT",
         "kind": "static_from",
-        "line": 99,
+        "line": 98,
         "name": "AIO_PREVIEW_CACHE_FORMAT",
         "optional": false,
         "requested": ".easyuse_anima.aio.preview",
@@ -19650,7 +19639,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.preview:AIO_PREVIEW_CACHE_QUALITY",
         "kind": "static_from",
-        "line": 99,
+        "line": 98,
         "name": "AIO_PREVIEW_CACHE_QUALITY",
         "optional": false,
         "requested": ".easyuse_anima.aio.preview",
@@ -19681,7 +19670,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.preview:AIO_PREVIEW_EVENT",
         "kind": "static_from",
-        "line": 99,
+        "line": 98,
         "name": "AIO_PREVIEW_EVENT",
         "optional": false,
         "requested": ".easyuse_anima.aio.preview",
@@ -19712,7 +19701,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.preview:AIO_PREVIEW_STAGE_LABELS",
         "kind": "static_from",
-        "line": 99,
+        "line": 98,
         "name": "AIO_PREVIEW_STAGE_LABELS",
         "optional": false,
         "requested": ".easyuse_anima.aio.preview",
@@ -19743,7 +19732,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.preview:_aio_preview_base_directory",
         "kind": "static_from",
-        "line": 99,
+        "line": 98,
         "name": "_aio_preview_base_directory",
         "optional": false,
         "requested": ".easyuse_anima.aio.preview",
@@ -19774,7 +19763,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.preview:_aio_preview_file_size_bytes",
         "kind": "static_from",
-        "line": 99,
+        "line": 98,
         "name": "_aio_preview_file_size_bytes",
         "optional": false,
         "requested": ".easyuse_anima.aio.preview",
@@ -19805,7 +19794,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.preview:_bind_aio_preview_runtime",
         "kind": "static_from",
-        "line": 99,
+        "line": 98,
         "name": "_bind_aio_preview_runtime",
         "optional": false,
         "requested": ".easyuse_anima.aio.preview",
@@ -19836,7 +19825,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.preview:_save_aio_temp_preview_image",
         "kind": "static_from",
-        "line": 99,
+        "line": 98,
         "name": "_save_aio_temp_preview_image",
         "optional": false,
         "requested": ".easyuse_anima.aio.preview",
@@ -19867,7 +19856,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.preview:_send_aio_preview_event",
         "kind": "static_from",
-        "line": 99,
+        "line": 98,
         "name": "_send_aio_preview_event",
         "optional": false,
         "requested": ".easyuse_anima.aio.preview",
@@ -19898,7 +19887,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.preview:_tag_aio_preview_images",
         "kind": "static_from",
-        "line": 99,
+        "line": 98,
         "name": "_tag_aio_preview_images",
         "optional": false,
         "requested": ".easyuse_anima.aio.preview",
@@ -19929,7 +19918,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.output:_aio_image_saver_additional_hashes",
         "kind": "static_from",
-        "line": 111,
+        "line": 110,
         "name": "_aio_image_saver_additional_hashes",
         "optional": false,
         "requested": ".easyuse_anima.aio.output",
@@ -19960,7 +19949,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.output:_aio_image_saver_civitai_hash_fetcher_entries",
         "kind": "static_from",
-        "line": 111,
+        "line": 110,
         "name": "_aio_image_saver_civitai_hash_fetcher_entries",
         "optional": false,
         "requested": ".easyuse_anima.aio.output",
@@ -19991,7 +19980,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.output:_aio_lora_metadata_name",
         "kind": "static_from",
-        "line": 111,
+        "line": 110,
         "name": "_aio_lora_metadata_name",
         "optional": false,
         "requested": ".easyuse_anima.aio.output",
@@ -20022,7 +20011,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.output:_aio_prompt_with_lora_metadata",
         "kind": "static_from",
-        "line": 111,
+        "line": 110,
         "name": "_aio_prompt_with_lora_metadata",
         "optional": false,
         "requested": ".easyuse_anima.aio.output",
@@ -20053,7 +20042,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.output:_aio_save_filename_prefix",
         "kind": "static_from",
-        "line": 111,
+        "line": 110,
         "name": "_aio_save_filename_prefix",
         "optional": false,
         "requested": ".easyuse_anima.aio.output",
@@ -20084,7 +20073,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.output:_bind_aio_output_runtime",
         "kind": "static_from",
-        "line": 111,
+        "line": 110,
         "name": "_bind_aio_output_runtime",
         "optional": false,
         "requested": ".easyuse_anima.aio.output",
@@ -20115,7 +20104,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.output:_normalize_aio_civitai_hash_fetchers",
         "kind": "static_from",
-        "line": 111,
+        "line": 110,
         "name": "_normalize_aio_civitai_hash_fetchers",
         "optional": false,
         "requested": ".easyuse_anima.aio.output",
@@ -20146,7 +20135,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.output:_normalize_aio_hash_bundles",
         "kind": "static_from",
-        "line": 111,
+        "line": 110,
         "name": "_normalize_aio_hash_bundles",
         "optional": false,
         "requested": ".easyuse_anima.aio.output",
@@ -20177,7 +20166,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.output:_save_image_with_comfy",
         "kind": "static_from",
-        "line": 111,
+        "line": 110,
         "name": "_save_image_with_comfy",
         "optional": false,
         "requested": ".easyuse_anima.aio.output",
@@ -20208,7 +20197,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.output:_save_image_with_image_saver",
         "kind": "static_from",
-        "line": 111,
+        "line": 110,
         "name": "_save_image_with_image_saver",
         "optional": false,
         "requested": ".easyuse_anima.aio.output",
@@ -20239,7 +20228,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_bind_aio_resource_runtime",
         "kind": "static_from",
-        "line": 123,
+        "line": 122,
         "name": "_bind_aio_resource_runtime",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -20270,7 +20259,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_comfy_clip_loader_types",
         "kind": "static_from",
-        "line": 123,
+        "line": 122,
         "name": "_comfy_clip_loader_types",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -20301,7 +20290,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_comfy_diffusion_model_names",
         "kind": "static_from",
-        "line": 123,
+        "line": 122,
         "name": "_comfy_diffusion_model_names",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -20332,7 +20321,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_comfy_text_encoder_names",
         "kind": "static_from",
-        "line": 123,
+        "line": 122,
         "name": "_comfy_text_encoder_names",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -20363,7 +20352,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_comfy_vae_names",
         "kind": "static_from",
-        "line": 123,
+        "line": 122,
         "name": "_comfy_vae_names",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -20394,7 +20383,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_load_aio_resources_from_input_context",
         "kind": "static_from",
-        "line": 123,
+        "line": 122,
         "name": "_load_aio_resources_from_input_context",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -20425,7 +20414,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_load_aio_sam3_context",
         "kind": "static_from",
-        "line": 123,
+        "line": 122,
         "name": "_load_aio_sam3_context",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -20456,7 +20445,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_load_checkpoint_with_comfy",
         "kind": "static_from",
-        "line": 123,
+        "line": 122,
         "name": "_load_checkpoint_with_comfy",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -20487,7 +20476,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_load_clip_with_comfy",
         "kind": "static_from",
-        "line": 123,
+        "line": 122,
         "name": "_load_clip_with_comfy",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -20518,7 +20507,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_load_diffusion_model_with_comfy",
         "kind": "static_from",
-        "line": 123,
+        "line": 122,
         "name": "_load_diffusion_model_with_comfy",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -20549,7 +20538,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_load_upscale_model_with_comfy",
         "kind": "static_from",
-        "line": 123,
+        "line": 122,
         "name": "_load_upscale_model_with_comfy",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -20580,7 +20569,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_load_vae_with_comfy",
         "kind": "static_from",
-        "line": 123,
+        "line": 122,
         "name": "_load_vae_with_comfy",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -20611,7 +20600,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_normalize_aio_input_settings",
         "kind": "static_from",
-        "line": 123,
+        "line": 122,
         "name": "_normalize_aio_input_settings",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -20642,7 +20631,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_preferred_checkpoint_default",
         "kind": "static_from",
-        "line": 123,
+        "line": 122,
         "name": "_preferred_checkpoint_default",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -20673,7 +20662,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_preferred_clip_type_default",
         "kind": "static_from",
-        "line": 123,
+        "line": 122,
         "name": "_preferred_clip_type_default",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -20704,7 +20693,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_preferred_name_default",
         "kind": "static_from",
-        "line": 123,
+        "line": 122,
         "name": "_preferred_name_default",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -20735,7 +20724,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.common.serialization:_json_clone",
         "kind": "static_from",
-        "line": 141,
+        "line": 140,
         "name": "_json_clone",
         "optional": false,
         "requested": ".easyuse_anima.common.serialization",
@@ -20766,7 +20755,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.common.serialization:_json_object",
         "kind": "static_from",
-        "line": 141,
+        "line": 140,
         "name": "_json_object",
         "optional": false,
         "requested": ".easyuse_anima.common.serialization",
@@ -20797,7 +20786,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.common.serialization:_stable_change_key",
         "kind": "static_from",
-        "line": 141,
+        "line": 140,
         "name": "_stable_change_key",
         "optional": false,
         "requested": ".easyuse_anima.common.serialization",
@@ -20828,7 +20817,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.common.values:_as_bool",
         "kind": "static_from",
-        "line": 146,
+        "line": 145,
         "name": "_as_bool",
         "optional": false,
         "requested": ".easyuse_anima.common.values",
@@ -20859,7 +20848,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.common.values:_as_float",
         "kind": "static_from",
-        "line": 146,
+        "line": 145,
         "name": "_as_float",
         "optional": false,
         "requested": ".easyuse_anima.common.values",
@@ -20890,7 +20879,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.common.values:_as_int",
         "kind": "static_from",
-        "line": 146,
+        "line": 145,
         "name": "_as_int",
         "optional": false,
         "requested": ".easyuse_anima.common.values",
@@ -20921,7 +20910,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.common.values:_choice",
         "kind": "static_from",
-        "line": 146,
+        "line": 145,
         "name": "_choice",
         "optional": false,
         "requested": ".easyuse_anima.common.values",
@@ -20952,7 +20941,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.common.values:_single_value",
         "kind": "static_from",
-        "line": 146,
+        "line": 145,
         "name": "_single_value",
         "optional": false,
         "requested": ".easyuse_anima.common.values",
@@ -20983,7 +20972,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.seed.compatibility:WILDCARD_QUEUE_MAX_SAFE_SEED",
         "kind": "static_from",
-        "line": 153,
+        "line": 152,
         "name": "WILDCARD_QUEUE_MAX_SAFE_SEED",
         "optional": false,
         "requested": ".easyuse_anima.seed.compatibility",
@@ -21014,7 +21003,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.seed.compatibility:WILDCARD_RESERVED_NEXT_SEED_INPUT",
         "kind": "static_from",
-        "line": 153,
+        "line": 152,
         "name": "WILDCARD_RESERVED_NEXT_SEED_INPUT",
         "optional": false,
         "requested": ".easyuse_anima.seed.compatibility",
@@ -21045,7 +21034,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.seed.compatibility:_consume_reserved_wildcard_next_seed",
         "kind": "static_from",
-        "line": 153,
+        "line": 152,
         "name": "_consume_reserved_wildcard_next_seed",
         "optional": false,
         "requested": ".easyuse_anima.seed.compatibility",
@@ -21076,7 +21065,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.workflow:_get_workflow_node",
         "kind": "static_from",
-        "line": 158,
+        "line": 157,
         "name": "_get_workflow_node",
         "optional": false,
         "requested": ".easyuse_anima.workflow",
@@ -21107,7 +21096,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.correction:_prompt_translation_change_key",
         "kind": "static_from",
-        "line": 159,
+        "line": 158,
         "name": "_prompt_translation_change_key",
         "optional": false,
         "requested": ".easyuse_anima.prompt.correction",
@@ -21138,7 +21127,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.correction:_split_tag_text",
         "kind": "static_from",
-        "line": 159,
+        "line": 158,
         "name": "_split_tag_text",
         "optional": false,
         "requested": ".easyuse_anima.prompt.correction",
@@ -21169,7 +21158,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.correction:_translate_prompt_text",
         "kind": "static_from",
-        "line": 159,
+        "line": 158,
         "name": "_translate_prompt_text",
         "optional": false,
         "requested": ".easyuse_anima.prompt.correction",
@@ -21200,7 +21189,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_HASH_COMMENT_RE",
         "kind": "static_from",
-        "line": 164,
+        "line": 163,
         "name": "_HASH_COMMENT_RE",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -21231,7 +21220,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_INLINE_SPACE_RE",
         "kind": "static_from",
-        "line": 164,
+        "line": 163,
         "name": "_INLINE_SPACE_RE",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -21262,7 +21251,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_WEIGHTED_TOKEN_RE",
         "kind": "static_from",
-        "line": 164,
+        "line": 163,
         "name": "_WEIGHTED_TOKEN_RE",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -21293,7 +21282,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_correct_builder_prompt",
         "kind": "static_from",
-        "line": 164,
+        "line": 163,
         "name": "_correct_builder_prompt",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -21324,7 +21313,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_filter_metadata_prompt",
         "kind": "static_from",
-        "line": 164,
+        "line": 163,
         "name": "_filter_metadata_prompt",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -21355,7 +21344,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_join_prompt_tokens",
         "kind": "static_from",
-        "line": 164,
+        "line": 163,
         "name": "_join_prompt_tokens",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -21386,7 +21375,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_metadata_filter_key",
         "kind": "static_from",
-        "line": 164,
+        "line": 163,
         "name": "_metadata_filter_key",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -21417,7 +21406,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_metadata_filter_keys",
         "kind": "static_from",
-        "line": 164,
+        "line": 163,
         "name": "_metadata_filter_keys",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -21448,7 +21437,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_prompt_tokens",
         "kind": "static_from",
-        "line": 164,
+        "line": 163,
         "name": "_prompt_tokens",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -21479,7 +21468,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:PROMPT_DATA_TYPE",
         "kind": "static_from",
-        "line": 177,
+        "line": 176,
         "name": "PROMPT_DATA_TYPE",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -21510,7 +21499,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:_advanced_outputs_from_prompt_data",
         "kind": "static_from",
-        "line": 177,
+        "line": 176,
         "name": "_advanced_outputs_from_prompt_data",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -21541,7 +21530,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:_apply_prompt_data_overrides",
         "kind": "static_from",
-        "line": 177,
+        "line": 176,
         "name": "_apply_prompt_data_overrides",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -21572,7 +21561,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:_copy_prompt_data_for_update",
         "kind": "static_from",
-        "line": 177,
+        "line": 176,
         "name": "_copy_prompt_data_for_update",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -21603,7 +21592,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:_normalize_prompt_data",
         "kind": "static_from",
-        "line": 177,
+        "line": 176,
         "name": "_normalize_prompt_data",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -21634,7 +21623,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:_prompt_data_json_safe",
         "kind": "static_from",
-        "line": 177,
+        "line": 176,
         "name": "_prompt_data_json_safe",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -21665,7 +21654,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:_prompt_data_parameter_snapshot",
         "kind": "static_from",
-        "line": 177,
+        "line": 176,
         "name": "_prompt_data_parameter_snapshot",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -21696,7 +21685,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_artist_field_prompt",
         "kind": "static_from",
-        "line": 195,
+        "line": 194,
         "name": "_advanced_artist_field_prompt",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -21727,7 +21716,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_default_fields",
         "kind": "static_from",
-        "line": 195,
+        "line": 194,
         "name": "_advanced_default_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -21758,7 +21747,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_enabled_naia_panes",
         "kind": "static_from",
-        "line": 195,
+        "line": 194,
         "name": "_advanced_enabled_naia_panes",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -21789,7 +21778,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_enabled_pane_fields",
         "kind": "static_from",
-        "line": 195,
+        "line": 194,
         "name": "_advanced_enabled_pane_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -21820,7 +21809,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_field_input_values",
         "kind": "static_from",
-        "line": 195,
+        "line": 194,
         "name": "_advanced_field_input_values",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -21851,7 +21840,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_field_socket_name",
         "kind": "static_from",
-        "line": 195,
+        "line": 194,
         "name": "_advanced_field_socket_name",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -21882,7 +21871,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_fields_json",
         "kind": "static_from",
-        "line": 195,
+        "line": 194,
         "name": "_advanced_fields_json",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -21913,7 +21902,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_has_enabled_naia",
         "kind": "static_from",
-        "line": 195,
+        "line": 194,
         "name": "_advanced_has_enabled_naia",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -21944,7 +21933,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_prompt_with_artist_override",
         "kind": "static_from",
-        "line": 195,
+        "line": 194,
         "name": "_advanced_prompt_with_artist_override",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -21975,7 +21964,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_uses_naia_resolution",
         "kind": "static_from",
-        "line": 195,
+        "line": 194,
         "name": "_advanced_uses_naia_resolution",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -22006,7 +21995,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_apply_advanced_field_inputs",
         "kind": "static_from",
-        "line": 195,
+        "line": 194,
         "name": "_apply_advanced_field_inputs",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -22037,7 +22026,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_as_advanced_height",
         "kind": "static_from",
-        "line": 195,
+        "line": 194,
         "name": "_as_advanced_height",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -22068,7 +22057,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_build_advanced_prompt_data",
         "kind": "static_from",
-        "line": 195,
+        "line": 194,
         "name": "_build_advanced_prompt_data",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -22099,7 +22088,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_build_advanced_prompts",
         "kind": "static_from",
-        "line": 195,
+        "line": 194,
         "name": "_build_advanced_prompts",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -22130,7 +22119,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_clone_advanced_fields",
         "kind": "static_from",
-        "line": 195,
+        "line": 194,
         "name": "_clone_advanced_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -22161,7 +22150,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_correct_advanced_field_sequence",
         "kind": "static_from",
-        "line": 195,
+        "line": 194,
         "name": "_correct_advanced_field_sequence",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -22192,7 +22181,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_expand_advanced_wildcard_fields",
         "kind": "static_from",
-        "line": 195,
+        "line": 194,
         "name": "_expand_advanced_wildcard_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -22223,7 +22212,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_normalize_advanced_fields",
         "kind": "static_from",
-        "line": 195,
+        "line": 194,
         "name": "_normalize_advanced_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -22254,7 +22243,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_normalize_prompt_studio_wildcard_seed_control",
         "kind": "static_from",
-        "line": 195,
+        "line": 194,
         "name": "_normalize_prompt_studio_wildcard_seed_control",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -22285,7 +22274,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_set_naia_field_text",
         "kind": "static_from",
-        "line": 195,
+        "line": 194,
         "name": "_set_naia_field_text",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -22316,7 +22305,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_translate_prompt_fields",
         "kind": "static_from",
-        "line": 195,
+        "line": 194,
         "name": "_translate_prompt_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -22347,7 +22336,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_apply_regional_field_inputs",
         "kind": "static_from",
-        "line": 230,
+        "line": 229,
         "name": "_apply_regional_field_inputs",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -22378,7 +22367,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_build_regional_outputs",
         "kind": "static_from",
-        "line": 230,
+        "line": 229,
         "name": "_build_regional_outputs",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -22409,7 +22398,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_clone_regional_fields",
         "kind": "static_from",
-        "line": 230,
+        "line": 229,
         "name": "_clone_regional_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -22440,7 +22429,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_conditioning_set_values",
         "kind": "static_from",
-        "line": 230,
+        "line": 229,
         "name": "_conditioning_set_values",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -22471,7 +22460,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_normalize_mask_ids",
         "kind": "static_from",
-        "line": 230,
+        "line": 229,
         "name": "_normalize_mask_ids",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -22502,7 +22491,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_normalize_regional_config",
         "kind": "static_from",
-        "line": 230,
+        "line": 229,
         "name": "_normalize_regional_config",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -22533,7 +22522,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_normalize_regional_fields",
         "kind": "static_from",
-        "line": 230,
+        "line": 229,
         "name": "_normalize_regional_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -22564,7 +22553,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_parse_json_object",
         "kind": "static_from",
-        "line": 230,
+        "line": 229,
         "name": "_parse_json_object",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -22595,7 +22584,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_regional_config_json",
         "kind": "static_from",
-        "line": 230,
+        "line": 229,
         "name": "_regional_config_json",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -22626,7 +22615,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_regional_fields_json",
         "kind": "static_from",
-        "line": 230,
+        "line": 229,
         "name": "_regional_fields_json",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -22657,7 +22646,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_regional_mask_bounds_area",
         "kind": "static_from",
-        "line": 230,
+        "line": 229,
         "name": "_regional_mask_bounds_area",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -22688,7 +22677,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_regional_payload_canvas",
         "kind": "static_from",
-        "line": 230,
+        "line": 229,
         "name": "_regional_payload_canvas",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -22719,7 +22708,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_regional_union_mask_for_ids",
         "kind": "static_from",
-        "line": 230,
+        "line": 229,
         "name": "_regional_union_mask_for_ids",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -22750,7 +22739,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
         "kind": "static_from",
-        "line": 257,
+        "line": 256,
         "name": "ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -22781,7 +22770,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODES",
         "kind": "static_from",
-        "line": 257,
+        "line": 256,
         "name": "ANIMA_MOD_GUIDANCE_MODES",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -22812,7 +22801,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 257,
+        "line": 256,
         "name": "ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -22843,7 +22832,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_PROFILE_OFF",
         "kind": "static_from",
-        "line": 257,
+        "line": 256,
         "name": "ANIMA_MOD_GUIDANCE_PROFILE_OFF",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -22874,7 +22863,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:_apply_spectrum_anima_mod_guidance",
         "kind": "static_from",
-        "line": 257,
+        "line": 256,
         "name": "_apply_spectrum_anima_mod_guidance",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -22905,7 +22894,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:_find_spectrum_anima_mod_guidance_class",
         "kind": "static_from",
-        "line": 257,
+        "line": 256,
         "name": "_find_spectrum_anima_mod_guidance_class",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -22936,7 +22925,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:_normalize_anima_mod_guidance_profile",
         "kind": "static_from",
-        "line": 257,
+        "line": 256,
         "name": "_normalize_anima_mod_guidance_profile",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -22967,7 +22956,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:_resolve_anima_mod_guidance_enabled",
         "kind": "static_from",
-        "line": 257,
+        "line": 256,
         "name": "_resolve_anima_mod_guidance_enabled",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -22998,7 +22987,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
         "kind": "static_from",
-        "line": 272,
+        "line": 271,
         "name": "ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -23029,7 +23018,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
         "kind": "static_from",
-        "line": 272,
+        "line": 271,
         "name": "ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -23060,7 +23049,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
         "kind": "static_from",
-        "line": 272,
+        "line": 271,
         "name": "ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -23091,7 +23080,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_EXACT_TOP_K",
         "kind": "static_from",
-        "line": 272,
+        "line": 271,
         "name": "ARTIST_MIX_DEFAULT_EXACT_TOP_K",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -23122,7 +23111,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
         "kind": "static_from",
-        "line": 272,
+        "line": 271,
         "name": "ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -23153,7 +23142,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_START_PERCENT",
         "kind": "static_from",
-        "line": 272,
+        "line": 271,
         "name": "ARTIST_MIX_DEFAULT_START_PERCENT",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -23184,7 +23173,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
         "kind": "static_from",
-        "line": 272,
+        "line": 271,
         "name": "ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -23215,7 +23204,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STYLE_GAIN",
         "kind": "static_from",
-        "line": 272,
+        "line": 271,
         "name": "ARTIST_MIX_DEFAULT_STYLE_GAIN",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -23246,7 +23235,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_INPUT_MODES",
         "kind": "static_from",
-        "line": 272,
+        "line": 271,
         "name": "ARTIST_MIX_INPUT_MODES",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -23277,7 +23266,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 272,
+        "line": 271,
         "name": "ARTIST_MIX_MODE_FROM_PROMPT_DATA",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -23308,7 +23297,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_artist_mix_inline_prompt",
         "kind": "static_from",
-        "line": 272,
+        "line": 271,
         "name": "_artist_mix_inline_prompt",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -23339,7 +23328,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_artist_mix_mode_tooltip",
         "kind": "static_from",
-        "line": 272,
+        "line": 271,
         "name": "_artist_mix_mode_tooltip",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -23370,7 +23359,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_artist_prompt_with_position",
         "kind": "static_from",
-        "line": 272,
+        "line": 271,
         "name": "_artist_prompt_with_position",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -23401,7 +23390,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_artist_tags_from_prompt",
         "kind": "static_from",
-        "line": 272,
+        "line": 271,
         "name": "_artist_tags_from_prompt",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -23432,7 +23421,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_blend_conditionings",
         "kind": "static_from",
-        "line": 272,
+        "line": 271,
         "name": "_blend_conditionings",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -23463,7 +23452,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_bounded_artist_mix_float",
         "kind": "static_from",
-        "line": 272,
+        "line": 271,
         "name": "_bounded_artist_mix_float",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -23494,7 +23483,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_bounded_artist_mix_int",
         "kind": "static_from",
-        "line": 272,
+        "line": 271,
         "name": "_bounded_artist_mix_int",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -23525,7 +23514,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_encode_artist_clustered",
         "kind": "static_from",
-        "line": 272,
+        "line": 271,
         "name": "_encode_artist_clustered",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -23556,7 +23545,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_encode_artist_delta_rms",
         "kind": "static_from",
-        "line": 272,
+        "line": 271,
         "name": "_encode_artist_delta_rms",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -23587,7 +23576,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_encode_prompt_data_positive_conditioning",
         "kind": "static_from",
-        "line": 272,
+        "line": 271,
         "name": "_encode_prompt_data_positive_conditioning",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -23618,7 +23607,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_join_artist_mix_source_prompts",
         "kind": "static_from",
-        "line": 272,
+        "line": 271,
         "name": "_join_artist_mix_source_prompts",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -23649,7 +23638,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_normalize_artist_mix_mode",
         "kind": "static_from",
-        "line": 272,
+        "line": 271,
         "name": "_normalize_artist_mix_mode",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -23680,7 +23669,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_normalize_artist_tag_position",
         "kind": "static_from",
-        "line": 272,
+        "line": 271,
         "name": "_normalize_artist_tag_position",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -23711,7 +23700,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_parse_artist_mix_items",
         "kind": "static_from",
-        "line": 272,
+        "line": 271,
         "name": "_parse_artist_mix_items",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -23742,7 +23731,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaArtistMixConditioning",
         "kind": "static_from",
-        "line": 351,
+        "line": 350,
         "name": "EasyUseAnimaArtistMixConditioning",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_data_nodes",
@@ -23773,7 +23762,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataConditioning",
         "kind": "static_from",
-        "line": 351,
+        "line": 350,
         "name": "EasyUseAnimaPromptDataConditioning",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_data_nodes",
@@ -23804,7 +23793,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataUnpack",
         "kind": "static_from",
-        "line": 351,
+        "line": 350,
         "name": "EasyUseAnimaPromptDataUnpack",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_data_nodes",
@@ -23835,7 +23824,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.input_types:_ANY_TYPE",
         "kind": "static_from",
-        "line": 356,
+        "line": 355,
         "name": "_ANY_TYPE",
         "optional": false,
         "requested": ".easyuse_anima.nodes.input_types",
@@ -23866,7 +23855,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.input_types:_AnyType",
         "kind": "static_from",
-        "line": 356,
+        "line": 355,
         "name": "_AnyType",
         "optional": false,
         "requested": ".easyuse_anima.nodes.input_types",
@@ -23897,7 +23886,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.input_types:_FlexibleOptionalInputType",
         "kind": "static_from",
-        "line": 356,
+        "line": 355,
         "name": "_FlexibleOptionalInputType",
         "optional": false,
         "requested": ".easyuse_anima.nodes.input_types",
@@ -23928,7 +23917,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvanced",
         "kind": "static_from",
-        "line": 361,
+        "line": 360,
         "name": "EasyUseAnimaPromptStudioAdvanced",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_advanced_nodes",
@@ -23959,7 +23948,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvancedV2",
         "kind": "static_from",
-        "line": 361,
+        "line": 360,
         "name": "EasyUseAnimaPromptStudioAdvancedV2",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_advanced_nodes",
@@ -23990,7 +23979,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.aio_nodes:EasyUseAnimaAIOGenerator",
         "kind": "static_from",
-        "line": 366,
+        "line": 365,
         "name": "EasyUseAnimaAIOGenerator",
         "optional": false,
         "requested": ".easyuse_anima.nodes.aio_nodes",
@@ -24021,7 +24010,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.aio_nodes:EasyUseAnimaInput",
         "kind": "static_from",
-        "line": 366,
+        "line": 365,
         "name": "EasyUseAnimaInput",
         "optional": false,
         "requested": ".easyuse_anima.nodes.aio_nodes",
@@ -24052,7 +24041,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.aio_nodes:_aio_generation_settings_json",
         "kind": "static_from",
-        "line": 366,
+        "line": 365,
         "name": "_aio_generation_settings_json",
         "optional": false,
         "requested": ".easyuse_anima.nodes.aio_nodes",
@@ -24083,7 +24072,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.aio_nodes:_aio_input_settings_json",
         "kind": "static_from",
-        "line": 366,
+        "line": 365,
         "name": "_aio_input_settings_json",
         "optional": false,
         "requested": ".easyuse_anima.nodes.aio_nodes",
@@ -24114,7 +24103,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.aio_nodes:_bind_aio_node_runtime",
         "kind": "static_from",
-        "line": 366,
+        "line": 365,
         "name": "_bind_aio_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.aio_nodes",
@@ -24145,7 +24134,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.aio_nodes:_easy_use_anima_input_signature",
         "kind": "static_from",
-        "line": 366,
+        "line": 365,
         "name": "_easy_use_anima_input_signature",
         "optional": false,
         "requested": ".easyuse_anima.nodes.aio_nodes",
@@ -24176,7 +24165,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.aio_nodes:_require_easy_use_anima_input",
         "kind": "static_from",
-        "line": 366,
+        "line": 365,
         "name": "_require_easy_use_anima_input",
         "optional": false,
         "requested": ".easyuse_anima.nodes.aio_nodes",
@@ -24207,7 +24196,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.geometry:_align_down",
         "kind": "static_from",
-        "line": 375,
+        "line": 374,
         "name": "_align_down",
         "optional": false,
         "requested": ".easyuse_anima.image.geometry",
@@ -24238,7 +24227,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.geometry:_align_nearest",
         "kind": "static_from",
-        "line": 375,
+        "line": 374,
         "name": "_align_nearest",
         "optional": false,
         "requested": ".easyuse_anima.image.geometry",
@@ -24269,7 +24258,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.geometry:_image_tensor_size",
         "kind": "static_from",
-        "line": 375,
+        "line": 374,
         "name": "_image_tensor_size",
         "optional": false,
         "requested": ".easyuse_anima.image.geometry",
@@ -24300,7 +24289,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.sam3:_context_value",
         "kind": "static_from",
-        "line": 386,
+        "line": 385,
         "name": "_context_value",
         "optional": false,
         "requested": ".easyuse_anima.image.sam3",
@@ -24331,7 +24320,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.sam3:_sam3_context",
         "kind": "static_from",
-        "line": 386,
+        "line": 385,
         "name": "_sam3_context",
         "optional": false,
         "requested": ".easyuse_anima.image.sam3",
@@ -24362,7 +24351,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.sam3:_segs_has_items",
         "kind": "static_from",
-        "line": 386,
+        "line": 385,
         "name": "_segs_has_items",
         "optional": false,
         "requested": ".easyuse_anima.image.sam3",
@@ -24393,7 +24382,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.scaling:IMAGE_SCALE_MULTIPLES",
         "kind": "static_from",
-        "line": 398,
+        "line": 397,
         "name": "IMAGE_SCALE_MULTIPLES",
         "optional": false,
         "requested": ".easyuse_anima.image.scaling",
@@ -24424,7 +24413,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.scaling:IMAGE_UPSCALE_METHODS",
         "kind": "static_from",
-        "line": 398,
+        "line": 397,
         "name": "IMAGE_UPSCALE_METHODS",
         "optional": false,
         "requested": ".easyuse_anima.image.scaling",
@@ -24455,7 +24444,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_comfy_sampler_names",
         "kind": "static_from",
-        "line": 406,
+        "line": 405,
         "name": "_comfy_sampler_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -24486,7 +24475,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_comfy_scheduler_names",
         "kind": "static_from",
-        "line": 406,
+        "line": 405,
         "name": "_comfy_scheduler_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -24517,7 +24506,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_impact_scheduler_names",
         "kind": "static_from",
-        "line": 406,
+        "line": 405,
         "name": "_impact_scheduler_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -24548,7 +24537,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.invocation:_call_with_supported_kwargs",
         "kind": "static_from",
-        "line": 412,
+        "line": 411,
         "name": "_call_with_supported_kwargs",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.invocation",
@@ -24579,7 +24568,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.invocation:_common_upscale_image",
         "kind": "static_from",
-        "line": 412,
+        "line": 411,
         "name": "_common_upscale_image",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.invocation",
@@ -24610,7 +24599,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.invocation:_node_output_tuple",
         "kind": "static_from",
-        "line": 412,
+        "line": 411,
         "name": "_node_output_tuple",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.invocation",
@@ -24641,7 +24630,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.wiring:resolve_comfy_host_helper",
         "kind": "static_from",
-        "line": 417,
+        "line": 416,
         "name": "resolve_comfy_host_helper",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.wiring",
@@ -24672,7 +24661,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_comfy_clip_loader_types",
         "kind": "static_from",
-        "line": 420,
+        "line": 419,
         "name": "_comfy_clip_loader_types",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -24703,7 +24692,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_comfy_diffusion_model_names",
         "kind": "static_from",
-        "line": 420,
+        "line": 419,
         "name": "_comfy_diffusion_model_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -24734,7 +24723,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_comfy_text_encoder_names",
         "kind": "static_from",
-        "line": 420,
+        "line": 419,
         "name": "_comfy_text_encoder_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -24765,7 +24754,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_comfy_vae_names",
         "kind": "static_from",
-        "line": 420,
+        "line": 419,
         "name": "_comfy_vae_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -24796,7 +24785,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_folder_path_names",
         "kind": "static_from",
-        "line": 420,
+        "line": 419,
         "name": "_folder_path_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -24827,7 +24816,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.image_nodes:EasyUseAnimaDetailerAlignHook",
         "kind": "static_from",
-        "line": 428,
+        "line": 427,
         "name": "EasyUseAnimaDetailerAlignHook",
         "optional": false,
         "requested": ".easyuse_anima.nodes.image_nodes",
@@ -24858,7 +24847,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.image_nodes:EasyUseAnimaImageScaleByMultiple",
         "kind": "static_from",
-        "line": 428,
+        "line": 427,
         "name": "EasyUseAnimaImageScaleByMultiple",
         "optional": false,
         "requested": ".easyuse_anima.nodes.image_nodes",
@@ -24889,7 +24878,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Context",
         "kind": "static_from",
-        "line": 432,
+        "line": 431,
         "name": "EasyUseAnimaSAM3Context",
         "optional": false,
         "requested": ".easyuse_anima.nodes.sam3_nodes",
@@ -24920,7 +24909,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Detailer",
         "kind": "static_from",
-        "line": 432,
+        "line": 431,
         "name": "EasyUseAnimaSAM3Detailer",
         "optional": false,
         "requested": ".easyuse_anima.nodes.sam3_nodes",
@@ -24951,7 +24940,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptBuilder",
         "kind": "static_from",
-        "line": 436,
+        "line": 435,
         "name": "EasyUseAnimaPromptBuilder",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_nodes",
@@ -24982,7 +24971,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrector",
         "kind": "static_from",
-        "line": 436,
+        "line": 435,
         "name": "EasyUseAnimaPromptCorrector",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_nodes",
@@ -25013,7 +25002,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrectorSimple",
         "kind": "static_from",
-        "line": 436,
+        "line": 435,
         "name": "EasyUseAnimaPromptCorrectorSimple",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_nodes",
@@ -25044,7 +25033,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptStudio",
         "kind": "static_from",
-        "line": 436,
+        "line": 435,
         "name": "EasyUseAnimaPromptStudio",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_nodes",
@@ -25075,7 +25064,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.regional_nodes:EasyUseAnimaPromptStudioRegional",
         "kind": "static_from",
-        "line": 442,
+        "line": 441,
         "name": "EasyUseAnimaPromptStudioRegional",
         "optional": false,
         "requested": ".easyuse_anima.nodes.regional_nodes",
@@ -25106,7 +25095,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.regional_nodes:EasyUseAnimaRegionalConditioning",
         "kind": "static_from",
-        "line": 442,
+        "line": 441,
         "name": "EasyUseAnimaRegionalConditioning",
         "optional": false,
         "requested": ".easyuse_anima.nodes.regional_nodes",
@@ -25137,7 +25126,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.client:LATENT_ALIGN",
         "kind": "static_from",
-        "line": 446,
+        "line": 445,
         "name": "LATENT_ALIGN",
         "optional": false,
         "requested": ".easyuse_anima.naia.client",
@@ -25168,7 +25157,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.client:_parse_random_response",
         "kind": "static_from",
-        "line": 446,
+        "line": 445,
         "name": "_parse_random_response",
         "optional": false,
         "requested": ".easyuse_anima.naia.client",
@@ -25199,7 +25188,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.client:_post_random",
         "kind": "static_from",
-        "line": 446,
+        "line": 445,
         "name": "_post_random",
         "optional": false,
         "requested": ".easyuse_anima.naia.client",
@@ -25230,7 +25219,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_advanced_resolution_from_selection",
         "kind": "static_from",
-        "line": 464,
+        "line": 463,
         "name": "_advanced_resolution_from_selection",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -25261,7 +25250,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_normalize_resolution_bucket",
         "kind": "static_from",
-        "line": 464,
+        "line": 463,
         "name": "_normalize_resolution_bucket",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -25292,7 +25281,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_ratio_label",
         "kind": "static_from",
-        "line": 464,
+        "line": 463,
         "name": "_ratio_label",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -25323,7 +25312,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_resolution_label",
         "kind": "static_from",
-        "line": 464,
+        "line": 463,
         "name": "_resolution_label",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -25354,7 +25343,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_resolve_naia_resolution",
         "kind": "static_from",
-        "line": 464,
+        "line": 463,
         "name": "_resolve_naia_resolution",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -25385,7 +25374,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.naia_nodes:EasyUseAnimaNAIARandomPrompt",
         "kind": "static_from",
-        "line": 487,
+        "line": 486,
         "name": "EasyUseAnimaNAIARandomPrompt",
         "optional": false,
         "requested": ".easyuse_anima.nodes.naia_nodes",
@@ -25416,7 +25405,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.naia_nodes:_bind_naia_node_runtime",
         "kind": "static_from",
-        "line": 487,
+        "line": 486,
         "name": "_bind_naia_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.naia_nodes",
@@ -25447,7 +25436,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.wildcard_nodes:EasyUseAnimaWildcard",
         "kind": "static_from",
-        "line": 491,
+        "line": 490,
         "name": "EasyUseAnimaWildcard",
         "optional": false,
         "requested": ".easyuse_anima.nodes.wildcard_nodes",
@@ -25478,7 +25467,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.wildcard_nodes:_bind_wildcard_node_runtime",
         "kind": "static_from",
-        "line": 491,
+        "line": 490,
         "name": "_bind_wildcard_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.wildcard_nodes",
@@ -25509,7 +25498,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_apply_lora_syntax_format",
         "kind": "static_from",
-        "line": 496,
+        "line": 495,
         "name": "_apply_lora_syntax_format",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -25540,7 +25529,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_dedupe_text_values",
         "kind": "static_from",
-        "line": 496,
+        "line": 495,
         "name": "_dedupe_text_values",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -25571,7 +25560,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_fallback_lora_path",
         "kind": "static_from",
-        "line": 496,
+        "line": 495,
         "name": "_fallback_lora_path",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -25602,7 +25591,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_get_lora_info",
         "kind": "static_from",
-        "line": 496,
+        "line": 495,
         "name": "_get_lora_info",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -25633,7 +25622,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_get_lora_manager_trigger_words",
         "kind": "static_from",
-        "line": 496,
+        "line": 495,
         "name": "_get_lora_manager_trigger_words",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -25664,7 +25653,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_load_lora_manager_metadata",
         "kind": "static_from",
-        "line": 496,
+        "line": 495,
         "name": "_load_lora_manager_metadata",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -25695,7 +25684,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_lora_combo_values",
         "kind": "static_from",
-        "line": 496,
+        "line": 495,
         "name": "_lora_combo_values",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -25726,7 +25715,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_lora_manager_trigger_words_from_metadata",
         "kind": "static_from",
-        "line": 496,
+        "line": 495,
         "name": "_lora_manager_trigger_words_from_metadata",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -25757,7 +25746,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_lora_model_exists",
         "kind": "static_from",
-        "line": 496,
+        "line": 495,
         "name": "_lora_model_exists",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -25788,7 +25777,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_lora_stack_name",
         "kind": "static_from",
-        "line": 496,
+        "line": 495,
         "name": "_lora_stack_name",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -25819,7 +25808,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_metadata_json_paths_for_lora",
         "kind": "static_from",
-        "line": 496,
+        "line": 495,
         "name": "_metadata_json_paths_for_lora",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -25850,7 +25839,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_missing_lora_display_name",
         "kind": "static_from",
-        "line": 496,
+        "line": 495,
         "name": "_missing_lora_display_name",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -25881,7 +25870,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_raise_missing_loras",
         "kind": "static_from",
-        "line": 496,
+        "line": 495,
         "name": "_raise_missing_loras",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -25912,7 +25901,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_trigger_words_from_value",
         "kind": "static_from",
-        "line": 496,
+        "line": 495,
         "name": "_trigger_words_from_value",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -25943,7 +25932,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_correct_style_prompt",
         "kind": "static_from",
-        "line": 512,
+        "line": 511,
         "name": "_correct_style_prompt",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -25974,7 +25963,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_format_strength",
         "kind": "static_from",
-        "line": 512,
+        "line": 511,
         "name": "_format_strength",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -26005,7 +25994,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_get_loras_list",
         "kind": "static_from",
-        "line": 512,
+        "line": 511,
         "name": "_get_loras_list",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -26036,7 +26025,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_load_profile_data",
         "kind": "static_from",
-        "line": 512,
+        "line": 511,
         "name": "_load_profile_data",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -26067,7 +26056,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_profile_key",
         "kind": "static_from",
-        "line": 512,
+        "line": 511,
         "name": "_profile_key",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -26098,7 +26087,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_select_profile_values",
         "kind": "static_from",
-        "line": 512,
+        "line": 511,
         "name": "_select_profile_values",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -26129,7 +26118,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_wrap_profile_index",
         "kind": "static_from",
-        "line": 512,
+        "line": 511,
         "name": "_wrap_profile_index",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -26160,7 +26149,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.lora_nodes:EasyUseAnimaLoraPreset",
         "kind": "static_from",
-        "line": 521,
+        "line": 520,
         "name": "EasyUseAnimaLoraPreset",
         "optional": false,
         "requested": ".easyuse_anima.nodes.lora_nodes",
@@ -26191,7 +26180,7 @@
         "conditional": true,
         "imported": ".anima_prompt:correct_prompt",
         "kind": "static_from",
-        "line": 524,
+        "line": 523,
         "name": "correct_prompt",
         "optional": false,
         "requested": ".anima_prompt",
@@ -26222,7 +26211,7 @@
         "conditional": true,
         "imported": ".anima_prompt:load_knowledge_base",
         "kind": "static_from",
-        "line": 524,
+        "line": 523,
         "name": "load_knowledge_base",
         "optional": false,
         "requested": ".anima_prompt",
@@ -26253,7 +26242,7 @@
         "conditional": true,
         "imported": ".anima_prompt.parser:parse_prompt",
         "kind": "static_from",
-        "line": 525,
+        "line": 524,
         "name": "parse_prompt",
         "optional": false,
         "requested": ".anima_prompt.parser",
@@ -26284,7 +26273,7 @@
         "conditional": true,
         "imported": ".settings:resolve_metadata_filter_words",
         "kind": "static_from",
-        "line": 526,
+        "line": 525,
         "name": "resolve_metadata_filter_words",
         "optional": false,
         "requested": ".settings",
@@ -26315,7 +26304,7 @@
         "conditional": true,
         "imported": ".settings:resolve_naia_settings",
         "kind": "static_from",
-        "line": 526,
+        "line": 525,
         "name": "resolve_naia_settings",
         "optional": false,
         "requested": ".settings",
@@ -26346,7 +26335,7 @@
         "conditional": true,
         "imported": ".settings:resolve_prompt_translation_settings",
         "kind": "static_from",
-        "line": 526,
+        "line": 525,
         "name": "resolve_prompt_translation_settings",
         "optional": false,
         "requested": ".settings",
@@ -26377,7 +26366,7 @@
         "conditional": true,
         "imported": ".prompt_translation:has_prompt_translation_markers",
         "kind": "static_from",
-        "line": 531,
+        "line": 530,
         "name": "has_prompt_translation_markers",
         "optional": false,
         "requested": ".prompt_translation",
@@ -26408,7 +26397,7 @@
         "conditional": true,
         "imported": ".prompt_translation:translate_prompt_markers",
         "kind": "static_from",
-        "line": 531,
+        "line": 530,
         "name": "translate_prompt_markers",
         "optional": false,
         "requested": ".prompt_translation",
@@ -26439,7 +26428,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:MAX_SEED",
         "kind": "static_from",
-        "line": 532,
+        "line": 531,
         "name": "MAX_SEED",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -26470,7 +26459,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "kind": "static_from",
-        "line": 532,
+        "line": 531,
         "name": "PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -26501,7 +26490,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:PUBLIC_MAX_SEED",
         "kind": "static_from",
-        "line": 532,
+        "line": 531,
         "name": "PUBLIC_MAX_SEED",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -26532,7 +26521,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_DECREMENT",
         "kind": "static_from",
-        "line": 532,
+        "line": 531,
         "name": "SEED_CONTROL_DECREMENT",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -26563,7 +26552,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_FIXED",
         "kind": "static_from",
-        "line": 532,
+        "line": 531,
         "name": "SEED_CONTROL_FIXED",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -26594,7 +26583,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_INCREMENT",
         "kind": "static_from",
-        "line": 532,
+        "line": 531,
         "name": "SEED_CONTROL_INCREMENT",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -26625,7 +26614,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_MODES",
         "kind": "static_from",
-        "line": 532,
+        "line": 531,
         "name": "SEED_CONTROL_MODES",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -26656,7 +26645,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_RANDOMIZE",
         "kind": "static_from",
-        "line": 532,
+        "line": 531,
         "name": "SEED_CONTROL_RANDOMIZE",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -26687,7 +26676,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:WILDCARD_MODE_FIXED",
         "kind": "static_from",
-        "line": 532,
+        "line": 531,
         "name": "WILDCARD_MODE_FIXED",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -26718,7 +26707,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:WILDCARD_MODE_POPULATE",
         "kind": "static_from",
-        "line": 532,
+        "line": 531,
         "name": "WILDCARD_MODE_POPULATE",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -26749,7 +26738,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:WILDCARD_MODE_SEQUENTIAL",
         "kind": "static_from",
-        "line": 532,
+        "line": 531,
         "name": "WILDCARD_MODE_SEQUENTIAL",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -26780,7 +26769,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:expand_wildcard_texts",
         "kind": "static_from",
-        "line": 532,
+        "line": 531,
         "name": "expand_wildcard_texts",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -26811,7 +26800,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:expand_wildcards",
         "kind": "static_from",
-        "line": 532,
+        "line": 531,
         "name": "expand_wildcards",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -26842,7 +26831,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:has_wildcard_syntax",
         "kind": "static_from",
-        "line": 532,
+        "line": 531,
         "name": "has_wildcard_syntax",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -26873,7 +26862,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:next_seed",
         "kind": "static_from",
-        "line": 532,
+        "line": 531,
         "name": "next_seed",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -26904,7 +26893,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:normalize_prompt_studio_wildcard_mode",
         "kind": "static_from",
-        "line": 532,
+        "line": 531,
         "name": "normalize_prompt_studio_wildcard_mode",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -26935,7 +26924,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:normalize_seed",
         "kind": "static_from",
-        "line": 532,
+        "line": 531,
         "name": "normalize_seed",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -26966,7 +26955,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:normalize_wildcard_mode",
         "kind": "static_from",
-        "line": 532,
+        "line": 531,
         "name": "normalize_wildcard_mode",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -26997,7 +26986,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:wildcard_sources_signature",
         "kind": "static_from",
-        "line": 532,
+        "line": 531,
         "name": "wildcard_sources_signature",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -27016,7 +27005,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -27031,7 +27020,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:AIO_FIRST_PASS_CACHE_MAX_ENTRIES",
         "kind": "static_from",
-        "line": 554,
+        "line": 553,
         "name": "AIO_FIRST_PASS_CACHE_MAX_ENTRIES",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -27050,7 +27039,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -27065,7 +27054,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_AIO_FIRST_PASS_CACHE",
         "kind": "static_from",
-        "line": 554,
+        "line": 553,
         "name": "_AIO_FIRST_PASS_CACHE",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -27084,7 +27073,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -27099,7 +27088,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_AIO_FIRST_PASS_CACHE_ORDER",
         "kind": "static_from",
-        "line": 554,
+        "line": 553,
         "name": "_AIO_FIRST_PASS_CACHE_ORDER",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -27118,7 +27107,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -27133,42 +27122,8 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_aio_first_pass_cache_key",
         "kind": "static_from",
-        "line": 554,
+        "line": 553,
         "name": "_aio_first_pass_cache_key",
-        "optional": false,
-        "requested": "easyuse_anima.aio.first_pass_cache",
-        "role": "compatibility_fallback",
-        "scope": "<module>",
-        "source": "nodes.py",
-        "target": "easyuse_anima/aio/first_pass_cache.py"
-      },
-      {
-        "alias": "_bind_aio_first_pass_cache_runtime",
-        "bound_name": "_bind_aio_first_pass_cache_runtime",
-        "branch_context": [
-          {
-            "branch": "except",
-            "catches_import_error": true,
-            "exceptions": [
-              "ImportError"
-            ],
-            "handler_line": 553,
-            "kind": "try",
-            "line": 9
-          }
-        ],
-        "classification": "compatibility_fallback",
-        "column": 4,
-        "compatibility_pair": {
-          "bound_name": "_bind_aio_first_pass_cache_runtime",
-          "target": "easyuse_anima/aio/first_pass_cache.py",
-          "try_line": 9
-        },
-        "conditional": true,
-        "imported": "easyuse_anima.aio.first_pass_cache:_bind_aio_first_pass_cache_runtime",
-        "kind": "static_from",
-        "line": 554,
-        "name": "_bind_aio_first_pass_cache_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
         "role": "compatibility_fallback",
@@ -27186,7 +27141,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -27201,7 +27156,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_clone_aio_cache_value",
         "kind": "static_from",
-        "line": 554,
+        "line": 553,
         "name": "_clone_aio_cache_value",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -27220,7 +27175,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -27235,7 +27190,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_get_aio_first_pass_cache",
         "kind": "static_from",
-        "line": 554,
+        "line": 553,
         "name": "_get_aio_first_pass_cache",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -27254,7 +27209,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -27269,7 +27224,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_put_aio_first_pass_cache",
         "kind": "static_from",
-        "line": 554,
+        "line": 553,
         "name": "_put_aio_first_pass_cache",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -27288,7 +27243,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -27303,7 +27258,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_bind_aio_legacy_generation_runtime",
         "kind": "static_from",
-        "line": 565,
+        "line": 563,
         "name": "_bind_aio_legacy_generation_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.legacy_generation",
@@ -27322,7 +27277,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -27337,7 +27292,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_detailer_stage",
         "kind": "static_from",
-        "line": 565,
+        "line": 563,
         "name": "_run_aio_detailer_stage",
         "optional": false,
         "requested": "easyuse_anima.aio.legacy_generation",
@@ -27356,7 +27311,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -27371,7 +27326,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_detailer_target",
         "kind": "static_from",
-        "line": 565,
+        "line": 563,
         "name": "_run_aio_detailer_target",
         "optional": false,
         "requested": "easyuse_anima.aio.legacy_generation",
@@ -27390,7 +27345,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -27405,7 +27360,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_highres_stage",
         "kind": "static_from",
-        "line": 565,
+        "line": 563,
         "name": "_run_aio_highres_stage",
         "optional": false,
         "requested": "easyuse_anima.aio.legacy_generation",
@@ -27424,7 +27379,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -27439,7 +27394,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_legacy_generation",
         "kind": "static_from",
-        "line": 565,
+        "line": 563,
         "name": "_run_aio_legacy_generation",
         "optional": false,
         "requested": "easyuse_anima.aio.legacy_generation",
@@ -27458,7 +27413,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -27473,7 +27428,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_resshift_upscale_stage",
         "kind": "static_from",
-        "line": 565,
+        "line": 563,
         "name": "_run_aio_resshift_upscale_stage",
         "optional": false,
         "requested": "easyuse_anima.aio.legacy_generation",
@@ -27492,7 +27447,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -27507,7 +27462,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_upscale_stage",
         "kind": "static_from",
-        "line": 565,
+        "line": 563,
         "name": "_run_aio_upscale_stage",
         "optional": false,
         "requested": "easyuse_anima.aio.legacy_generation",
@@ -27526,7 +27481,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -27541,7 +27496,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_usdu_upscale_stage",
         "kind": "static_from",
-        "line": 565,
+        "line": 563,
         "name": "_run_aio_usdu_upscale_stage",
         "optional": false,
         "requested": "easyuse_anima.aio.legacy_generation",
@@ -27560,7 +27515,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -27575,7 +27530,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEEDS",
         "kind": "static_from",
-        "line": 575,
+        "line": 573,
         "name": "AIO_SPECIAL_SEEDS",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -27594,7 +27549,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -27609,7 +27564,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEED_DECREMENT",
         "kind": "static_from",
-        "line": 575,
+        "line": 573,
         "name": "AIO_SPECIAL_SEED_DECREMENT",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -27628,7 +27583,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -27643,7 +27598,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEED_INCREMENT",
         "kind": "static_from",
-        "line": 575,
+        "line": 573,
         "name": "AIO_SPECIAL_SEED_INCREMENT",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -27662,7 +27617,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -27677,7 +27632,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEED_RANDOM",
         "kind": "static_from",
-        "line": 575,
+        "line": 573,
         "name": "AIO_SPECIAL_SEED_RANDOM",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -27696,7 +27651,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -27711,7 +27666,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_AIO_DETAILER_CUSTOM_RE",
         "kind": "static_from",
-        "line": 575,
+        "line": 573,
         "name": "_AIO_DETAILER_CUSTOM_RE",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -27730,7 +27685,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -27745,7 +27700,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_AIO_DETAILER_RESERVED_KEYS",
         "kind": "static_from",
-        "line": 575,
+        "line": 573,
         "name": "_AIO_DETAILER_RESERVED_KEYS",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -27764,7 +27719,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -27779,7 +27734,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_aio_detailer_has_enabled_targets",
         "kind": "static_from",
-        "line": 575,
+        "line": 573,
         "name": "_aio_detailer_has_enabled_targets",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -27798,7 +27753,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -27813,7 +27768,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_aio_detailer_target_defaults",
         "kind": "static_from",
-        "line": 575,
+        "line": 573,
         "name": "_aio_detailer_target_defaults",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -27832,7 +27787,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -27847,7 +27802,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_aio_detailer_target_order",
         "kind": "static_from",
-        "line": 575,
+        "line": 573,
         "name": "_aio_detailer_target_order",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -27866,7 +27821,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -27881,7 +27836,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_bind_aio_generation_normalization_runtime",
         "kind": "static_from",
-        "line": 575,
+        "line": 573,
         "name": "_bind_aio_generation_normalization_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -27900,7 +27855,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -27915,7 +27870,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_is_aio_detailer_target_name",
         "kind": "static_from",
-        "line": 575,
+        "line": 573,
         "name": "_is_aio_detailer_target_name",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -27934,7 +27889,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -27949,7 +27904,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_merge_versioned_settings",
         "kind": "static_from",
-        "line": 575,
+        "line": 573,
         "name": "_merge_versioned_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -27968,7 +27923,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -27983,7 +27938,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_dit_corrections_settings",
         "kind": "static_from",
-        "line": 575,
+        "line": 573,
         "name": "_normalize_aio_dit_corrections_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -28002,7 +27957,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -28017,7 +27972,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_generation_settings",
         "kind": "static_from",
-        "line": 575,
+        "line": 573,
         "name": "_normalize_aio_generation_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -28036,7 +27991,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -28051,7 +28006,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_seed",
         "kind": "static_from",
-        "line": 575,
+        "line": 573,
         "name": "_normalize_aio_seed",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -28070,7 +28025,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -28085,7 +28040,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_spectrum_settings",
         "kind": "static_from",
-        "line": 575,
+        "line": 573,
         "name": "_normalize_aio_spectrum_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -28104,7 +28059,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -28119,7 +28074,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_settings:round_trip_aio_generation_settings",
         "kind": "static_from",
-        "line": 593,
+        "line": 591,
         "name": "round_trip_aio_generation_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_settings",
@@ -28138,7 +28093,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -28153,7 +28108,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.usdu:_aio_usdu_auto_tile_dimension",
         "kind": "static_from",
-        "line": 596,
+        "line": 594,
         "name": "_aio_usdu_auto_tile_dimension",
         "optional": false,
         "requested": "easyuse_anima.aio.usdu",
@@ -28172,7 +28127,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -28187,7 +28142,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.usdu:_aio_usdu_tile_plan",
         "kind": "static_from",
-        "line": 596,
+        "line": 594,
         "name": "_aio_usdu_tile_plan",
         "optional": false,
         "requested": "easyuse_anima.aio.usdu",
@@ -28206,7 +28161,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -28221,7 +28176,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.usdu:_bind_aio_usdu_planning_runtime",
         "kind": "static_from",
-        "line": 596,
+        "line": 594,
         "name": "_bind_aio_usdu_planning_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.usdu",
@@ -28240,7 +28195,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -28255,7 +28210,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_aio_final_fit_size",
         "kind": "static_from",
-        "line": 601,
+        "line": 599,
         "name": "_aio_final_fit_size",
         "optional": false,
         "requested": "easyuse_anima.aio.postprocess",
@@ -28274,7 +28229,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -28289,7 +28244,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_apply_aio_final_fit",
         "kind": "static_from",
-        "line": 601,
+        "line": 599,
         "name": "_apply_aio_final_fit",
         "optional": false,
         "requested": "easyuse_anima.aio.postprocess",
@@ -28308,7 +28263,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -28323,7 +28278,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_bind_aio_postprocess_runtime",
         "kind": "static_from",
-        "line": 601,
+        "line": 599,
         "name": "_bind_aio_postprocess_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.postprocess",
@@ -28342,7 +28297,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -28357,7 +28312,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_resize_image_to_size_if_needed",
         "kind": "static_from",
-        "line": 601,
+        "line": 599,
         "name": "_resize_image_to_size_if_needed",
         "optional": false,
         "requested": "easyuse_anima.aio.postprocess",
@@ -28376,7 +28331,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -28391,7 +28346,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_run_aio_postprocess_stage",
         "kind": "static_from",
-        "line": 601,
+        "line": 599,
         "name": "_run_aio_postprocess_stage",
         "optional": false,
         "requested": "easyuse_anima.aio.postprocess",
@@ -28410,7 +28365,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -28425,7 +28380,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_prompt_data_fields_for_usdu",
         "kind": "static_from",
-        "line": 608,
+        "line": 606,
         "name": "_aio_prompt_data_fields_for_usdu",
         "optional": false,
         "requested": "easyuse_anima.aio.conditioning",
@@ -28444,7 +28399,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -28459,7 +28414,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_usdu_conditioning",
         "kind": "static_from",
-        "line": 608,
+        "line": 606,
         "name": "_aio_usdu_conditioning",
         "optional": false,
         "requested": "easyuse_anima.aio.conditioning",
@@ -28478,7 +28433,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -28493,7 +28448,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_usdu_prompt_without_general",
         "kind": "static_from",
-        "line": 608,
+        "line": 606,
         "name": "_aio_usdu_prompt_without_general",
         "optional": false,
         "requested": "easyuse_anima.aio.conditioning",
@@ -28512,7 +28467,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -28527,7 +28482,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_bind_aio_conditioning_runtime",
         "kind": "static_from",
-        "line": 608,
+        "line": 606,
         "name": "_bind_aio_conditioning_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.conditioning",
@@ -28546,7 +28501,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -28561,7 +28516,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_aio_lora_stack_signature",
         "kind": "static_from",
-        "line": 614,
+        "line": 612,
         "name": "_aio_lora_stack_signature",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -28580,7 +28535,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -28595,7 +28550,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_anima_dave_patch",
         "kind": "static_from",
-        "line": 614,
+        "line": 612,
         "name": "_apply_aio_anima_dave_patch",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -28614,7 +28569,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -28629,7 +28584,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_kj_model_patches",
         "kind": "static_from",
-        "line": 614,
+        "line": 612,
         "name": "_apply_aio_kj_model_patches",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -28648,7 +28603,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -28663,7 +28618,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_lora_stack",
         "kind": "static_from",
-        "line": 614,
+        "line": 612,
         "name": "_apply_aio_lora_stack",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -28682,7 +28637,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -28697,7 +28652,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_model_patches",
         "kind": "static_from",
-        "line": 614,
+        "line": 612,
         "name": "_apply_aio_model_patches",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -28716,7 +28671,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -28731,7 +28686,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_safe_pag_patch",
         "kind": "static_from",
-        "line": 614,
+        "line": 612,
         "name": "_apply_aio_safe_pag_patch",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -28750,7 +28705,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -28765,7 +28720,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_correction_patch_for_comfy_sampler",
         "kind": "static_from",
-        "line": 614,
+        "line": 612,
         "name": "_apply_aio_spectrum_correction_patch_for_comfy_sampler",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -28784,7 +28739,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -28799,7 +28754,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_forecast_patch_for_comfy_sampler",
         "kind": "static_from",
-        "line": 614,
+        "line": 612,
         "name": "_apply_aio_spectrum_forecast_patch_for_comfy_sampler",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -28818,7 +28773,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -28833,7 +28788,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_model_patches_for_comfy_sampler",
         "kind": "static_from",
-        "line": 614,
+        "line": 612,
         "name": "_apply_aio_spectrum_model_patches_for_comfy_sampler",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -28852,7 +28807,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -28867,7 +28822,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_bind_aio_model_preparation_runtime",
         "kind": "static_from",
-        "line": 614,
+        "line": 612,
         "name": "_bind_aio_model_preparation_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -28886,7 +28841,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -28901,7 +28856,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_cleanup_aio_ephemeral_model",
         "kind": "static_from",
-        "line": 614,
+        "line": 612,
         "name": "_cleanup_aio_ephemeral_model",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -28920,7 +28875,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -28935,7 +28890,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_normalize_aio_lora_stack",
         "kind": "static_from",
-        "line": 614,
+        "line": 612,
         "name": "_normalize_aio_lora_stack",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -28954,7 +28909,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -28969,7 +28924,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_patch_model_sampling_aura_flow",
         "kind": "static_from",
-        "line": 614,
+        "line": 612,
         "name": "_patch_model_sampling_aura_flow",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -28988,7 +28943,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -29003,7 +28958,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_aio_highres_effective_backend",
         "kind": "static_from",
-        "line": 629,
+        "line": 627,
         "name": "_aio_highres_effective_backend",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -29022,7 +28977,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -29037,7 +28992,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_aio_stage_sampler_settings",
         "kind": "static_from",
-        "line": 629,
+        "line": 627,
         "name": "_aio_stage_sampler_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -29056,7 +29011,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -29071,7 +29026,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_bind_aio_sampling_runtime",
         "kind": "static_from",
-        "line": 629,
+        "line": 627,
         "name": "_bind_aio_sampling_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -29090,7 +29045,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -29105,7 +29060,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_decode_latent_with_comfy",
         "kind": "static_from",
-        "line": 629,
+        "line": 627,
         "name": "_decode_latent_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -29124,7 +29079,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -29139,7 +29094,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_encode_image_with_comfy_vae",
         "kind": "static_from",
-        "line": 629,
+        "line": 627,
         "name": "_encode_image_with_comfy_vae",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -29158,7 +29113,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -29173,7 +29128,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_generate_empty_latent_with_comfy",
         "kind": "static_from",
-        "line": 629,
+        "line": 627,
         "name": "_generate_empty_latent_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -29192,7 +29147,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -29207,7 +29162,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_new_aio_random_seed",
         "kind": "static_from",
-        "line": 629,
+        "line": 627,
         "name": "_new_aio_random_seed",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -29226,7 +29181,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -29241,7 +29196,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_resolve_aio_runtime_seed",
         "kind": "static_from",
-        "line": 629,
+        "line": 627,
         "name": "_resolve_aio_runtime_seed",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -29260,7 +29215,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -29275,7 +29230,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_aio_backend",
         "kind": "static_from",
-        "line": 629,
+        "line": 627,
         "name": "_sample_latent_with_aio_backend",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -29294,7 +29249,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -29309,7 +29264,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_comfy",
         "kind": "static_from",
-        "line": 629,
+        "line": 627,
         "name": "_sample_latent_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -29328,7 +29283,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -29343,7 +29298,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_spectrum_mod_guidance_advanced",
         "kind": "static_from",
-        "line": 629,
+        "line": 627,
         "name": "_sample_latent_with_spectrum_mod_guidance_advanced",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -29362,7 +29317,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -29377,7 +29332,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_spectrum_spd",
         "kind": "static_from",
-        "line": 629,
+        "line": 627,
         "name": "_sample_latent_with_spectrum_spd",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -29396,7 +29351,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -29411,7 +29366,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_CACHE_FORMAT",
         "kind": "static_from",
-        "line": 643,
+        "line": 641,
         "name": "AIO_PREVIEW_CACHE_FORMAT",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -29430,7 +29385,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -29445,7 +29400,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_CACHE_QUALITY",
         "kind": "static_from",
-        "line": 643,
+        "line": 641,
         "name": "AIO_PREVIEW_CACHE_QUALITY",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -29464,7 +29419,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -29479,7 +29434,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_EVENT",
         "kind": "static_from",
-        "line": 643,
+        "line": 641,
         "name": "AIO_PREVIEW_EVENT",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -29498,7 +29453,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -29513,7 +29468,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_STAGE_LABELS",
         "kind": "static_from",
-        "line": 643,
+        "line": 641,
         "name": "AIO_PREVIEW_STAGE_LABELS",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -29532,7 +29487,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -29547,7 +29502,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_aio_preview_base_directory",
         "kind": "static_from",
-        "line": 643,
+        "line": 641,
         "name": "_aio_preview_base_directory",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -29566,7 +29521,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -29581,7 +29536,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_aio_preview_file_size_bytes",
         "kind": "static_from",
-        "line": 643,
+        "line": 641,
         "name": "_aio_preview_file_size_bytes",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -29600,7 +29555,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -29615,7 +29570,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_bind_aio_preview_runtime",
         "kind": "static_from",
-        "line": 643,
+        "line": 641,
         "name": "_bind_aio_preview_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -29634,7 +29589,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -29649,7 +29604,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_save_aio_temp_preview_image",
         "kind": "static_from",
-        "line": 643,
+        "line": 641,
         "name": "_save_aio_temp_preview_image",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -29668,7 +29623,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -29683,7 +29638,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_send_aio_preview_event",
         "kind": "static_from",
-        "line": 643,
+        "line": 641,
         "name": "_send_aio_preview_event",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -29702,7 +29657,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -29717,7 +29672,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_tag_aio_preview_images",
         "kind": "static_from",
-        "line": 643,
+        "line": 641,
         "name": "_tag_aio_preview_images",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -29736,7 +29691,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -29751,7 +29706,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_image_saver_additional_hashes",
         "kind": "static_from",
-        "line": 655,
+        "line": 653,
         "name": "_aio_image_saver_additional_hashes",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -29770,7 +29725,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -29785,7 +29740,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_image_saver_civitai_hash_fetcher_entries",
         "kind": "static_from",
-        "line": 655,
+        "line": 653,
         "name": "_aio_image_saver_civitai_hash_fetcher_entries",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -29804,7 +29759,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -29819,7 +29774,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_lora_metadata_name",
         "kind": "static_from",
-        "line": 655,
+        "line": 653,
         "name": "_aio_lora_metadata_name",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -29838,7 +29793,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -29853,7 +29808,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_prompt_with_lora_metadata",
         "kind": "static_from",
-        "line": 655,
+        "line": 653,
         "name": "_aio_prompt_with_lora_metadata",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -29872,7 +29827,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -29887,7 +29842,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_save_filename_prefix",
         "kind": "static_from",
-        "line": 655,
+        "line": 653,
         "name": "_aio_save_filename_prefix",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -29906,7 +29861,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -29921,7 +29876,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_bind_aio_output_runtime",
         "kind": "static_from",
-        "line": 655,
+        "line": 653,
         "name": "_bind_aio_output_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -29940,7 +29895,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -29955,7 +29910,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_normalize_aio_civitai_hash_fetchers",
         "kind": "static_from",
-        "line": 655,
+        "line": 653,
         "name": "_normalize_aio_civitai_hash_fetchers",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -29974,7 +29929,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -29989,7 +29944,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_normalize_aio_hash_bundles",
         "kind": "static_from",
-        "line": 655,
+        "line": 653,
         "name": "_normalize_aio_hash_bundles",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -30008,7 +29963,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -30023,7 +29978,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_save_image_with_comfy",
         "kind": "static_from",
-        "line": 655,
+        "line": 653,
         "name": "_save_image_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -30042,7 +29997,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -30057,7 +30012,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_save_image_with_image_saver",
         "kind": "static_from",
-        "line": 655,
+        "line": 653,
         "name": "_save_image_with_image_saver",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -30076,7 +30031,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -30091,7 +30046,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_bind_aio_resource_runtime",
         "kind": "static_from",
-        "line": 667,
+        "line": 665,
         "name": "_bind_aio_resource_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -30110,7 +30065,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -30125,7 +30080,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_clip_loader_types",
         "kind": "static_from",
-        "line": 667,
+        "line": 665,
         "name": "_comfy_clip_loader_types",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -30144,7 +30099,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -30159,7 +30114,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_diffusion_model_names",
         "kind": "static_from",
-        "line": 667,
+        "line": 665,
         "name": "_comfy_diffusion_model_names",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -30178,7 +30133,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -30193,7 +30148,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_text_encoder_names",
         "kind": "static_from",
-        "line": 667,
+        "line": 665,
         "name": "_comfy_text_encoder_names",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -30212,7 +30167,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -30227,7 +30182,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_vae_names",
         "kind": "static_from",
-        "line": 667,
+        "line": 665,
         "name": "_comfy_vae_names",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -30246,7 +30201,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -30261,7 +30216,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_aio_resources_from_input_context",
         "kind": "static_from",
-        "line": 667,
+        "line": 665,
         "name": "_load_aio_resources_from_input_context",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -30280,7 +30235,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -30295,7 +30250,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_aio_sam3_context",
         "kind": "static_from",
-        "line": 667,
+        "line": 665,
         "name": "_load_aio_sam3_context",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -30314,7 +30269,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -30329,7 +30284,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_checkpoint_with_comfy",
         "kind": "static_from",
-        "line": 667,
+        "line": 665,
         "name": "_load_checkpoint_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -30348,7 +30303,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -30363,7 +30318,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_clip_with_comfy",
         "kind": "static_from",
-        "line": 667,
+        "line": 665,
         "name": "_load_clip_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -30382,7 +30337,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -30397,7 +30352,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_diffusion_model_with_comfy",
         "kind": "static_from",
-        "line": 667,
+        "line": 665,
         "name": "_load_diffusion_model_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -30416,7 +30371,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -30431,7 +30386,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_upscale_model_with_comfy",
         "kind": "static_from",
-        "line": 667,
+        "line": 665,
         "name": "_load_upscale_model_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -30450,7 +30405,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -30465,7 +30420,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_vae_with_comfy",
         "kind": "static_from",
-        "line": 667,
+        "line": 665,
         "name": "_load_vae_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -30484,7 +30439,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -30499,7 +30454,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_normalize_aio_input_settings",
         "kind": "static_from",
-        "line": 667,
+        "line": 665,
         "name": "_normalize_aio_input_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -30518,7 +30473,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -30533,7 +30488,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_checkpoint_default",
         "kind": "static_from",
-        "line": 667,
+        "line": 665,
         "name": "_preferred_checkpoint_default",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -30552,7 +30507,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -30567,7 +30522,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_clip_type_default",
         "kind": "static_from",
-        "line": 667,
+        "line": 665,
         "name": "_preferred_clip_type_default",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -30586,7 +30541,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -30601,7 +30556,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_name_default",
         "kind": "static_from",
-        "line": 667,
+        "line": 665,
         "name": "_preferred_name_default",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -30620,7 +30575,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -30635,7 +30590,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_json_clone",
         "kind": "static_from",
-        "line": 685,
+        "line": 683,
         "name": "_json_clone",
         "optional": false,
         "requested": "easyuse_anima.common.serialization",
@@ -30654,7 +30609,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -30669,7 +30624,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_json_object",
         "kind": "static_from",
-        "line": 685,
+        "line": 683,
         "name": "_json_object",
         "optional": false,
         "requested": "easyuse_anima.common.serialization",
@@ -30688,7 +30643,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -30703,7 +30658,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_stable_change_key",
         "kind": "static_from",
-        "line": 685,
+        "line": 683,
         "name": "_stable_change_key",
         "optional": false,
         "requested": "easyuse_anima.common.serialization",
@@ -30722,7 +30677,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -30737,7 +30692,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_bool",
         "kind": "static_from",
-        "line": 690,
+        "line": 688,
         "name": "_as_bool",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -30756,7 +30711,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -30771,7 +30726,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_float",
         "kind": "static_from",
-        "line": 690,
+        "line": 688,
         "name": "_as_float",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -30790,7 +30745,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -30805,7 +30760,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_int",
         "kind": "static_from",
-        "line": 690,
+        "line": 688,
         "name": "_as_int",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -30824,7 +30779,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -30839,7 +30794,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_choice",
         "kind": "static_from",
-        "line": 690,
+        "line": 688,
         "name": "_choice",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -30858,7 +30813,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -30873,7 +30828,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_single_value",
         "kind": "static_from",
-        "line": 690,
+        "line": 688,
         "name": "_single_value",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -30892,7 +30847,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -30907,7 +30862,7 @@
         "conditional": true,
         "imported": "easyuse_anima.seed.compatibility:WILDCARD_QUEUE_MAX_SAFE_SEED",
         "kind": "static_from",
-        "line": 697,
+        "line": 695,
         "name": "WILDCARD_QUEUE_MAX_SAFE_SEED",
         "optional": false,
         "requested": "easyuse_anima.seed.compatibility",
@@ -30926,7 +30881,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -30941,7 +30896,7 @@
         "conditional": true,
         "imported": "easyuse_anima.seed.compatibility:WILDCARD_RESERVED_NEXT_SEED_INPUT",
         "kind": "static_from",
-        "line": 697,
+        "line": 695,
         "name": "WILDCARD_RESERVED_NEXT_SEED_INPUT",
         "optional": false,
         "requested": "easyuse_anima.seed.compatibility",
@@ -30960,7 +30915,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -30975,7 +30930,7 @@
         "conditional": true,
         "imported": "easyuse_anima.seed.compatibility:_consume_reserved_wildcard_next_seed",
         "kind": "static_from",
-        "line": 697,
+        "line": 695,
         "name": "_consume_reserved_wildcard_next_seed",
         "optional": false,
         "requested": "easyuse_anima.seed.compatibility",
@@ -30994,7 +30949,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -31009,7 +30964,7 @@
         "conditional": true,
         "imported": "easyuse_anima.workflow:_get_workflow_node",
         "kind": "static_from",
-        "line": 702,
+        "line": 700,
         "name": "_get_workflow_node",
         "optional": false,
         "requested": "easyuse_anima.workflow",
@@ -31028,7 +30983,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -31043,7 +30998,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_prompt_translation_change_key",
         "kind": "static_from",
-        "line": 703,
+        "line": 701,
         "name": "_prompt_translation_change_key",
         "optional": false,
         "requested": "easyuse_anima.prompt.correction",
@@ -31062,7 +31017,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -31077,7 +31032,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_split_tag_text",
         "kind": "static_from",
-        "line": 703,
+        "line": 701,
         "name": "_split_tag_text",
         "optional": false,
         "requested": "easyuse_anima.prompt.correction",
@@ -31096,7 +31051,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -31111,7 +31066,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_translate_prompt_text",
         "kind": "static_from",
-        "line": 703,
+        "line": 701,
         "name": "_translate_prompt_text",
         "optional": false,
         "requested": "easyuse_anima.prompt.correction",
@@ -31130,7 +31085,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -31145,7 +31100,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_HASH_COMMENT_RE",
         "kind": "static_from",
-        "line": 708,
+        "line": 706,
         "name": "_HASH_COMMENT_RE",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -31164,7 +31119,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -31179,7 +31134,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_INLINE_SPACE_RE",
         "kind": "static_from",
-        "line": 708,
+        "line": 706,
         "name": "_INLINE_SPACE_RE",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -31198,7 +31153,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -31213,7 +31168,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_WEIGHTED_TOKEN_RE",
         "kind": "static_from",
-        "line": 708,
+        "line": 706,
         "name": "_WEIGHTED_TOKEN_RE",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -31232,7 +31187,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -31247,7 +31202,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_correct_builder_prompt",
         "kind": "static_from",
-        "line": 708,
+        "line": 706,
         "name": "_correct_builder_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -31266,7 +31221,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -31281,7 +31236,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_filter_metadata_prompt",
         "kind": "static_from",
-        "line": 708,
+        "line": 706,
         "name": "_filter_metadata_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -31300,7 +31255,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -31315,7 +31270,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_join_prompt_tokens",
         "kind": "static_from",
-        "line": 708,
+        "line": 706,
         "name": "_join_prompt_tokens",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -31334,7 +31289,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -31349,7 +31304,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_metadata_filter_key",
         "kind": "static_from",
-        "line": 708,
+        "line": 706,
         "name": "_metadata_filter_key",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -31368,7 +31323,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -31383,7 +31338,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_metadata_filter_keys",
         "kind": "static_from",
-        "line": 708,
+        "line": 706,
         "name": "_metadata_filter_keys",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -31402,7 +31357,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -31417,7 +31372,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_prompt_tokens",
         "kind": "static_from",
-        "line": 708,
+        "line": 706,
         "name": "_prompt_tokens",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -31436,7 +31391,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -31451,7 +31406,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:PROMPT_DATA_TYPE",
         "kind": "static_from",
-        "line": 721,
+        "line": 719,
         "name": "PROMPT_DATA_TYPE",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -31470,7 +31425,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -31485,7 +31440,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_advanced_outputs_from_prompt_data",
         "kind": "static_from",
-        "line": 721,
+        "line": 719,
         "name": "_advanced_outputs_from_prompt_data",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -31504,7 +31459,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -31519,7 +31474,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_apply_prompt_data_overrides",
         "kind": "static_from",
-        "line": 721,
+        "line": 719,
         "name": "_apply_prompt_data_overrides",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -31538,7 +31493,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -31553,7 +31508,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_copy_prompt_data_for_update",
         "kind": "static_from",
-        "line": 721,
+        "line": 719,
         "name": "_copy_prompt_data_for_update",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -31572,7 +31527,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -31587,7 +31542,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_normalize_prompt_data",
         "kind": "static_from",
-        "line": 721,
+        "line": 719,
         "name": "_normalize_prompt_data",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -31606,7 +31561,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -31621,7 +31576,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_prompt_data_json_safe",
         "kind": "static_from",
-        "line": 721,
+        "line": 719,
         "name": "_prompt_data_json_safe",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -31640,7 +31595,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -31655,7 +31610,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_prompt_data_parameter_snapshot",
         "kind": "static_from",
-        "line": 721,
+        "line": 719,
         "name": "_prompt_data_parameter_snapshot",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -31674,7 +31629,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -31689,7 +31644,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_artist_field_prompt",
         "kind": "static_from",
-        "line": 739,
+        "line": 737,
         "name": "_advanced_artist_field_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -31708,7 +31663,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -31723,7 +31678,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_default_fields",
         "kind": "static_from",
-        "line": 739,
+        "line": 737,
         "name": "_advanced_default_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -31742,7 +31697,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -31757,7 +31712,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_enabled_naia_panes",
         "kind": "static_from",
-        "line": 739,
+        "line": 737,
         "name": "_advanced_enabled_naia_panes",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -31776,7 +31731,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -31791,7 +31746,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_enabled_pane_fields",
         "kind": "static_from",
-        "line": 739,
+        "line": 737,
         "name": "_advanced_enabled_pane_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -31810,7 +31765,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -31825,7 +31780,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_field_input_values",
         "kind": "static_from",
-        "line": 739,
+        "line": 737,
         "name": "_advanced_field_input_values",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -31844,7 +31799,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -31859,7 +31814,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_field_socket_name",
         "kind": "static_from",
-        "line": 739,
+        "line": 737,
         "name": "_advanced_field_socket_name",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -31878,7 +31833,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -31893,7 +31848,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_fields_json",
         "kind": "static_from",
-        "line": 739,
+        "line": 737,
         "name": "_advanced_fields_json",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -31912,7 +31867,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -31927,7 +31882,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_has_enabled_naia",
         "kind": "static_from",
-        "line": 739,
+        "line": 737,
         "name": "_advanced_has_enabled_naia",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -31946,7 +31901,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -31961,7 +31916,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_prompt_with_artist_override",
         "kind": "static_from",
-        "line": 739,
+        "line": 737,
         "name": "_advanced_prompt_with_artist_override",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -31980,7 +31935,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -31995,7 +31950,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_uses_naia_resolution",
         "kind": "static_from",
-        "line": 739,
+        "line": 737,
         "name": "_advanced_uses_naia_resolution",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -32014,7 +31969,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -32029,7 +31984,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_apply_advanced_field_inputs",
         "kind": "static_from",
-        "line": 739,
+        "line": 737,
         "name": "_apply_advanced_field_inputs",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -32048,7 +32003,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -32063,7 +32018,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_as_advanced_height",
         "kind": "static_from",
-        "line": 739,
+        "line": 737,
         "name": "_as_advanced_height",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -32082,7 +32037,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -32097,7 +32052,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_build_advanced_prompt_data",
         "kind": "static_from",
-        "line": 739,
+        "line": 737,
         "name": "_build_advanced_prompt_data",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -32116,7 +32071,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -32131,7 +32086,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_build_advanced_prompts",
         "kind": "static_from",
-        "line": 739,
+        "line": 737,
         "name": "_build_advanced_prompts",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -32150,7 +32105,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -32165,7 +32120,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_clone_advanced_fields",
         "kind": "static_from",
-        "line": 739,
+        "line": 737,
         "name": "_clone_advanced_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -32184,7 +32139,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -32199,7 +32154,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_correct_advanced_field_sequence",
         "kind": "static_from",
-        "line": 739,
+        "line": 737,
         "name": "_correct_advanced_field_sequence",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -32218,7 +32173,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -32233,7 +32188,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_expand_advanced_wildcard_fields",
         "kind": "static_from",
-        "line": 739,
+        "line": 737,
         "name": "_expand_advanced_wildcard_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -32252,7 +32207,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -32267,7 +32222,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_normalize_advanced_fields",
         "kind": "static_from",
-        "line": 739,
+        "line": 737,
         "name": "_normalize_advanced_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -32286,7 +32241,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -32301,7 +32256,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_normalize_prompt_studio_wildcard_seed_control",
         "kind": "static_from",
-        "line": 739,
+        "line": 737,
         "name": "_normalize_prompt_studio_wildcard_seed_control",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -32320,7 +32275,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -32335,7 +32290,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_set_naia_field_text",
         "kind": "static_from",
-        "line": 739,
+        "line": 737,
         "name": "_set_naia_field_text",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -32354,7 +32309,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -32369,7 +32324,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_translate_prompt_fields",
         "kind": "static_from",
-        "line": 739,
+        "line": 737,
         "name": "_translate_prompt_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -32388,7 +32343,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -32403,7 +32358,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_apply_regional_field_inputs",
         "kind": "static_from",
-        "line": 774,
+        "line": 772,
         "name": "_apply_regional_field_inputs",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -32422,7 +32377,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -32437,7 +32392,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_build_regional_outputs",
         "kind": "static_from",
-        "line": 774,
+        "line": 772,
         "name": "_build_regional_outputs",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -32456,7 +32411,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -32471,7 +32426,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_clone_regional_fields",
         "kind": "static_from",
-        "line": 774,
+        "line": 772,
         "name": "_clone_regional_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -32490,7 +32445,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -32505,7 +32460,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_conditioning_set_values",
         "kind": "static_from",
-        "line": 774,
+        "line": 772,
         "name": "_conditioning_set_values",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -32524,7 +32479,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -32539,7 +32494,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_mask_ids",
         "kind": "static_from",
-        "line": 774,
+        "line": 772,
         "name": "_normalize_mask_ids",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -32558,7 +32513,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -32573,7 +32528,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_regional_config",
         "kind": "static_from",
-        "line": 774,
+        "line": 772,
         "name": "_normalize_regional_config",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -32592,7 +32547,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -32607,7 +32562,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_regional_fields",
         "kind": "static_from",
-        "line": 774,
+        "line": 772,
         "name": "_normalize_regional_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -32626,7 +32581,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -32641,7 +32596,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_parse_json_object",
         "kind": "static_from",
-        "line": 774,
+        "line": 772,
         "name": "_parse_json_object",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -32660,7 +32615,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -32675,7 +32630,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_config_json",
         "kind": "static_from",
-        "line": 774,
+        "line": 772,
         "name": "_regional_config_json",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -32694,7 +32649,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -32709,7 +32664,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_fields_json",
         "kind": "static_from",
-        "line": 774,
+        "line": 772,
         "name": "_regional_fields_json",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -32728,7 +32683,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -32743,7 +32698,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_mask_bounds_area",
         "kind": "static_from",
-        "line": 774,
+        "line": 772,
         "name": "_regional_mask_bounds_area",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -32762,7 +32717,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -32777,7 +32732,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_payload_canvas",
         "kind": "static_from",
-        "line": 774,
+        "line": 772,
         "name": "_regional_payload_canvas",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -32796,7 +32751,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -32811,7 +32766,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_union_mask_for_ids",
         "kind": "static_from",
-        "line": 774,
+        "line": 772,
         "name": "_regional_union_mask_for_ids",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -32830,7 +32785,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -32845,7 +32800,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
         "kind": "static_from",
-        "line": 801,
+        "line": 799,
         "name": "ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -32864,7 +32819,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -32879,7 +32834,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODES",
         "kind": "static_from",
-        "line": 801,
+        "line": 799,
         "name": "ANIMA_MOD_GUIDANCE_MODES",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -32898,7 +32853,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -32913,7 +32868,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 801,
+        "line": 799,
         "name": "ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -32932,7 +32887,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -32947,7 +32902,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_PROFILE_OFF",
         "kind": "static_from",
-        "line": 801,
+        "line": 799,
         "name": "ANIMA_MOD_GUIDANCE_PROFILE_OFF",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -32966,7 +32921,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -32981,7 +32936,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_apply_spectrum_anima_mod_guidance",
         "kind": "static_from",
-        "line": 801,
+        "line": 799,
         "name": "_apply_spectrum_anima_mod_guidance",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -33000,7 +32955,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -33015,7 +32970,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_find_spectrum_anima_mod_guidance_class",
         "kind": "static_from",
-        "line": 801,
+        "line": 799,
         "name": "_find_spectrum_anima_mod_guidance_class",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -33034,7 +32989,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -33049,7 +33004,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_normalize_anima_mod_guidance_profile",
         "kind": "static_from",
-        "line": 801,
+        "line": 799,
         "name": "_normalize_anima_mod_guidance_profile",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -33068,7 +33023,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -33083,7 +33038,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_resolve_anima_mod_guidance_enabled",
         "kind": "static_from",
-        "line": 801,
+        "line": 799,
         "name": "_resolve_anima_mod_guidance_enabled",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -33102,7 +33057,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -33117,7 +33072,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
         "kind": "static_from",
-        "line": 816,
+        "line": 814,
         "name": "ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -33136,7 +33091,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -33151,7 +33106,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
         "kind": "static_from",
-        "line": 816,
+        "line": 814,
         "name": "ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -33170,7 +33125,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -33185,7 +33140,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
         "kind": "static_from",
-        "line": 816,
+        "line": 814,
         "name": "ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -33204,7 +33159,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -33219,7 +33174,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_EXACT_TOP_K",
         "kind": "static_from",
-        "line": 816,
+        "line": 814,
         "name": "ARTIST_MIX_DEFAULT_EXACT_TOP_K",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -33238,7 +33193,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -33253,7 +33208,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
         "kind": "static_from",
-        "line": 816,
+        "line": 814,
         "name": "ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -33272,7 +33227,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -33287,7 +33242,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_START_PERCENT",
         "kind": "static_from",
-        "line": 816,
+        "line": 814,
         "name": "ARTIST_MIX_DEFAULT_START_PERCENT",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -33306,7 +33261,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -33321,7 +33276,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
         "kind": "static_from",
-        "line": 816,
+        "line": 814,
         "name": "ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -33340,7 +33295,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -33355,7 +33310,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STYLE_GAIN",
         "kind": "static_from",
-        "line": 816,
+        "line": 814,
         "name": "ARTIST_MIX_DEFAULT_STYLE_GAIN",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -33374,7 +33329,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -33389,7 +33344,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_INPUT_MODES",
         "kind": "static_from",
-        "line": 816,
+        "line": 814,
         "name": "ARTIST_MIX_INPUT_MODES",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -33408,7 +33363,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -33423,7 +33378,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 816,
+        "line": 814,
         "name": "ARTIST_MIX_MODE_FROM_PROMPT_DATA",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -33442,7 +33397,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -33457,7 +33412,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_mix_inline_prompt",
         "kind": "static_from",
-        "line": 816,
+        "line": 814,
         "name": "_artist_mix_inline_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -33476,7 +33431,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -33491,7 +33446,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_mix_mode_tooltip",
         "kind": "static_from",
-        "line": 816,
+        "line": 814,
         "name": "_artist_mix_mode_tooltip",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -33510,7 +33465,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -33525,7 +33480,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_prompt_with_position",
         "kind": "static_from",
-        "line": 816,
+        "line": 814,
         "name": "_artist_prompt_with_position",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -33544,7 +33499,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -33559,7 +33514,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_tags_from_prompt",
         "kind": "static_from",
-        "line": 816,
+        "line": 814,
         "name": "_artist_tags_from_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -33578,7 +33533,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -33593,7 +33548,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_blend_conditionings",
         "kind": "static_from",
-        "line": 816,
+        "line": 814,
         "name": "_blend_conditionings",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -33612,7 +33567,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -33627,7 +33582,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bounded_artist_mix_float",
         "kind": "static_from",
-        "line": 816,
+        "line": 814,
         "name": "_bounded_artist_mix_float",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -33646,7 +33601,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -33661,7 +33616,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bounded_artist_mix_int",
         "kind": "static_from",
-        "line": 816,
+        "line": 814,
         "name": "_bounded_artist_mix_int",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -33680,7 +33635,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -33695,7 +33650,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_clustered",
         "kind": "static_from",
-        "line": 816,
+        "line": 814,
         "name": "_encode_artist_clustered",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -33714,7 +33669,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -33729,7 +33684,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_delta_rms",
         "kind": "static_from",
-        "line": 816,
+        "line": 814,
         "name": "_encode_artist_delta_rms",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -33748,7 +33703,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -33763,7 +33718,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_prompt_data_positive_conditioning",
         "kind": "static_from",
-        "line": 816,
+        "line": 814,
         "name": "_encode_prompt_data_positive_conditioning",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -33782,7 +33737,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -33797,7 +33752,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_join_artist_mix_source_prompts",
         "kind": "static_from",
-        "line": 816,
+        "line": 814,
         "name": "_join_artist_mix_source_prompts",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -33816,7 +33771,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -33831,7 +33786,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_normalize_artist_mix_mode",
         "kind": "static_from",
-        "line": 816,
+        "line": 814,
         "name": "_normalize_artist_mix_mode",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -33850,7 +33805,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -33865,7 +33820,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_normalize_artist_tag_position",
         "kind": "static_from",
-        "line": 816,
+        "line": 814,
         "name": "_normalize_artist_tag_position",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -33884,7 +33839,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -33899,7 +33854,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_parse_artist_mix_items",
         "kind": "static_from",
-        "line": 816,
+        "line": 814,
         "name": "_parse_artist_mix_items",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -33918,7 +33873,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -33933,7 +33888,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaArtistMixConditioning",
         "kind": "static_from",
-        "line": 895,
+        "line": 893,
         "name": "EasyUseAnimaArtistMixConditioning",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_data_nodes",
@@ -33952,7 +33907,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -33967,7 +33922,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataConditioning",
         "kind": "static_from",
-        "line": 895,
+        "line": 893,
         "name": "EasyUseAnimaPromptDataConditioning",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_data_nodes",
@@ -33986,7 +33941,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -34001,7 +33956,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataUnpack",
         "kind": "static_from",
-        "line": 895,
+        "line": 893,
         "name": "EasyUseAnimaPromptDataUnpack",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_data_nodes",
@@ -34020,7 +33975,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -34035,7 +33990,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_ANY_TYPE",
         "kind": "static_from",
-        "line": 900,
+        "line": 898,
         "name": "_ANY_TYPE",
         "optional": false,
         "requested": "easyuse_anima.nodes.input_types",
@@ -34054,7 +34009,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -34069,7 +34024,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_AnyType",
         "kind": "static_from",
-        "line": 900,
+        "line": 898,
         "name": "_AnyType",
         "optional": false,
         "requested": "easyuse_anima.nodes.input_types",
@@ -34088,7 +34043,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -34103,7 +34058,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_FlexibleOptionalInputType",
         "kind": "static_from",
-        "line": 900,
+        "line": 898,
         "name": "_FlexibleOptionalInputType",
         "optional": false,
         "requested": "easyuse_anima.nodes.input_types",
@@ -34122,7 +34077,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -34137,7 +34092,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvanced",
         "kind": "static_from",
-        "line": 905,
+        "line": 903,
         "name": "EasyUseAnimaPromptStudioAdvanced",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_advanced_nodes",
@@ -34156,7 +34111,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -34171,7 +34126,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvancedV2",
         "kind": "static_from",
-        "line": 905,
+        "line": 903,
         "name": "EasyUseAnimaPromptStudioAdvancedV2",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_advanced_nodes",
@@ -34190,7 +34145,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -34205,7 +34160,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:EasyUseAnimaAIOGenerator",
         "kind": "static_from",
-        "line": 910,
+        "line": 908,
         "name": "EasyUseAnimaAIOGenerator",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -34224,7 +34179,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -34239,7 +34194,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:EasyUseAnimaInput",
         "kind": "static_from",
-        "line": 910,
+        "line": 908,
         "name": "EasyUseAnimaInput",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -34258,7 +34213,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -34273,7 +34228,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_aio_generation_settings_json",
         "kind": "static_from",
-        "line": 910,
+        "line": 908,
         "name": "_aio_generation_settings_json",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -34292,7 +34247,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -34307,7 +34262,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_aio_input_settings_json",
         "kind": "static_from",
-        "line": 910,
+        "line": 908,
         "name": "_aio_input_settings_json",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -34326,7 +34281,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -34341,7 +34296,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_bind_aio_node_runtime",
         "kind": "static_from",
-        "line": 910,
+        "line": 908,
         "name": "_bind_aio_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -34360,7 +34315,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -34375,7 +34330,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_easy_use_anima_input_signature",
         "kind": "static_from",
-        "line": 910,
+        "line": 908,
         "name": "_easy_use_anima_input_signature",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -34394,7 +34349,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -34409,7 +34364,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_require_easy_use_anima_input",
         "kind": "static_from",
-        "line": 910,
+        "line": 908,
         "name": "_require_easy_use_anima_input",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -34428,7 +34383,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -34443,7 +34398,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_align_down",
         "kind": "static_from",
-        "line": 919,
+        "line": 917,
         "name": "_align_down",
         "optional": false,
         "requested": "easyuse_anima.image.geometry",
@@ -34462,7 +34417,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -34477,7 +34432,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_align_nearest",
         "kind": "static_from",
-        "line": 919,
+        "line": 917,
         "name": "_align_nearest",
         "optional": false,
         "requested": "easyuse_anima.image.geometry",
@@ -34496,7 +34451,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -34511,7 +34466,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_image_tensor_size",
         "kind": "static_from",
-        "line": 919,
+        "line": 917,
         "name": "_image_tensor_size",
         "optional": false,
         "requested": "easyuse_anima.image.geometry",
@@ -34530,7 +34485,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -34545,7 +34500,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_context_value",
         "kind": "static_from",
-        "line": 930,
+        "line": 928,
         "name": "_context_value",
         "optional": false,
         "requested": "easyuse_anima.image.sam3",
@@ -34564,7 +34519,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -34579,7 +34534,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_sam3_context",
         "kind": "static_from",
-        "line": 930,
+        "line": 928,
         "name": "_sam3_context",
         "optional": false,
         "requested": "easyuse_anima.image.sam3",
@@ -34598,7 +34553,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -34613,7 +34568,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_segs_has_items",
         "kind": "static_from",
-        "line": 930,
+        "line": 928,
         "name": "_segs_has_items",
         "optional": false,
         "requested": "easyuse_anima.image.sam3",
@@ -34632,7 +34587,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -34647,7 +34602,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:IMAGE_SCALE_MULTIPLES",
         "kind": "static_from",
-        "line": 942,
+        "line": 940,
         "name": "IMAGE_SCALE_MULTIPLES",
         "optional": false,
         "requested": "easyuse_anima.image.scaling",
@@ -34666,7 +34621,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -34681,7 +34636,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:IMAGE_UPSCALE_METHODS",
         "kind": "static_from",
-        "line": 942,
+        "line": 940,
         "name": "IMAGE_UPSCALE_METHODS",
         "optional": false,
         "requested": "easyuse_anima.image.scaling",
@@ -34700,7 +34655,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -34715,7 +34670,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_sampler_names",
         "kind": "static_from",
-        "line": 950,
+        "line": 948,
         "name": "_comfy_sampler_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -34734,7 +34689,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -34749,7 +34704,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_scheduler_names",
         "kind": "static_from",
-        "line": 950,
+        "line": 948,
         "name": "_comfy_scheduler_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -34768,7 +34723,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -34783,7 +34738,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_impact_scheduler_names",
         "kind": "static_from",
-        "line": 950,
+        "line": 948,
         "name": "_impact_scheduler_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -34802,7 +34757,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -34817,7 +34772,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_call_with_supported_kwargs",
         "kind": "static_from",
-        "line": 956,
+        "line": 954,
         "name": "_call_with_supported_kwargs",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.invocation",
@@ -34836,7 +34791,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -34851,7 +34806,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_common_upscale_image",
         "kind": "static_from",
-        "line": 956,
+        "line": 954,
         "name": "_common_upscale_image",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.invocation",
@@ -34870,7 +34825,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -34885,7 +34840,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_node_output_tuple",
         "kind": "static_from",
-        "line": 956,
+        "line": 954,
         "name": "_node_output_tuple",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.invocation",
@@ -34904,7 +34859,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -34919,7 +34874,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.wiring:resolve_comfy_host_helper",
         "kind": "static_from",
-        "line": 961,
+        "line": 959,
         "name": "resolve_comfy_host_helper",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.wiring",
@@ -34938,7 +34893,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -34953,7 +34908,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_clip_loader_types",
         "kind": "static_from",
-        "line": 964,
+        "line": 962,
         "name": "_comfy_clip_loader_types",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -34972,7 +34927,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -34987,7 +34942,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_diffusion_model_names",
         "kind": "static_from",
-        "line": 964,
+        "line": 962,
         "name": "_comfy_diffusion_model_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -35006,7 +34961,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -35021,7 +34976,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_text_encoder_names",
         "kind": "static_from",
-        "line": 964,
+        "line": 962,
         "name": "_comfy_text_encoder_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -35040,7 +34995,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -35055,7 +35010,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_vae_names",
         "kind": "static_from",
-        "line": 964,
+        "line": 962,
         "name": "_comfy_vae_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -35074,7 +35029,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -35089,7 +35044,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_folder_path_names",
         "kind": "static_from",
-        "line": 964,
+        "line": 962,
         "name": "_folder_path_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -35108,7 +35063,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -35123,7 +35078,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.image_nodes:EasyUseAnimaDetailerAlignHook",
         "kind": "static_from",
-        "line": 972,
+        "line": 970,
         "name": "EasyUseAnimaDetailerAlignHook",
         "optional": false,
         "requested": "easyuse_anima.nodes.image_nodes",
@@ -35142,7 +35097,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -35157,7 +35112,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.image_nodes:EasyUseAnimaImageScaleByMultiple",
         "kind": "static_from",
-        "line": 972,
+        "line": 970,
         "name": "EasyUseAnimaImageScaleByMultiple",
         "optional": false,
         "requested": "easyuse_anima.nodes.image_nodes",
@@ -35176,7 +35131,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -35191,7 +35146,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Context",
         "kind": "static_from",
-        "line": 976,
+        "line": 974,
         "name": "EasyUseAnimaSAM3Context",
         "optional": false,
         "requested": "easyuse_anima.nodes.sam3_nodes",
@@ -35210,7 +35165,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -35225,7 +35180,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Detailer",
         "kind": "static_from",
-        "line": 976,
+        "line": 974,
         "name": "EasyUseAnimaSAM3Detailer",
         "optional": false,
         "requested": "easyuse_anima.nodes.sam3_nodes",
@@ -35244,7 +35199,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -35259,7 +35214,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptBuilder",
         "kind": "static_from",
-        "line": 980,
+        "line": 978,
         "name": "EasyUseAnimaPromptBuilder",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -35278,7 +35233,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -35293,7 +35248,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrector",
         "kind": "static_from",
-        "line": 980,
+        "line": 978,
         "name": "EasyUseAnimaPromptCorrector",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -35312,7 +35267,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -35327,7 +35282,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrectorSimple",
         "kind": "static_from",
-        "line": 980,
+        "line": 978,
         "name": "EasyUseAnimaPromptCorrectorSimple",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -35346,7 +35301,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -35361,7 +35316,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptStudio",
         "kind": "static_from",
-        "line": 980,
+        "line": 978,
         "name": "EasyUseAnimaPromptStudio",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -35380,7 +35335,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -35395,7 +35350,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:EasyUseAnimaPromptStudioRegional",
         "kind": "static_from",
-        "line": 986,
+        "line": 984,
         "name": "EasyUseAnimaPromptStudioRegional",
         "optional": false,
         "requested": "easyuse_anima.nodes.regional_nodes",
@@ -35414,7 +35369,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -35429,7 +35384,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:EasyUseAnimaRegionalConditioning",
         "kind": "static_from",
-        "line": 986,
+        "line": 984,
         "name": "EasyUseAnimaRegionalConditioning",
         "optional": false,
         "requested": "easyuse_anima.nodes.regional_nodes",
@@ -35448,7 +35403,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -35463,7 +35418,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:LATENT_ALIGN",
         "kind": "static_from",
-        "line": 990,
+        "line": 988,
         "name": "LATENT_ALIGN",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -35482,7 +35437,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -35497,7 +35452,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_parse_random_response",
         "kind": "static_from",
-        "line": 990,
+        "line": 988,
         "name": "_parse_random_response",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -35516,7 +35471,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -35531,7 +35486,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_post_random",
         "kind": "static_from",
-        "line": 990,
+        "line": 988,
         "name": "_post_random",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -35550,7 +35505,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -35565,7 +35520,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_advanced_resolution_from_selection",
         "kind": "static_from",
-        "line": 1008,
+        "line": 1006,
         "name": "_advanced_resolution_from_selection",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -35584,7 +35539,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -35599,7 +35554,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_normalize_resolution_bucket",
         "kind": "static_from",
-        "line": 1008,
+        "line": 1006,
         "name": "_normalize_resolution_bucket",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -35618,7 +35573,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -35633,7 +35588,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_ratio_label",
         "kind": "static_from",
-        "line": 1008,
+        "line": 1006,
         "name": "_ratio_label",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -35652,7 +35607,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -35667,7 +35622,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolution_label",
         "kind": "static_from",
-        "line": 1008,
+        "line": 1006,
         "name": "_resolution_label",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -35686,7 +35641,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -35701,7 +35656,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolve_naia_resolution",
         "kind": "static_from",
-        "line": 1008,
+        "line": 1006,
         "name": "_resolve_naia_resolution",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -35720,7 +35675,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -35735,7 +35690,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.naia_nodes:EasyUseAnimaNAIARandomPrompt",
         "kind": "static_from",
-        "line": 1031,
+        "line": 1029,
         "name": "EasyUseAnimaNAIARandomPrompt",
         "optional": false,
         "requested": "easyuse_anima.nodes.naia_nodes",
@@ -35754,7 +35709,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -35769,7 +35724,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.naia_nodes:_bind_naia_node_runtime",
         "kind": "static_from",
-        "line": 1031,
+        "line": 1029,
         "name": "_bind_naia_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.naia_nodes",
@@ -35788,7 +35743,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -35803,7 +35758,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.wildcard_nodes:EasyUseAnimaWildcard",
         "kind": "static_from",
-        "line": 1035,
+        "line": 1033,
         "name": "EasyUseAnimaWildcard",
         "optional": false,
         "requested": "easyuse_anima.nodes.wildcard_nodes",
@@ -35822,7 +35777,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -35837,7 +35792,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.wildcard_nodes:_bind_wildcard_node_runtime",
         "kind": "static_from",
-        "line": 1035,
+        "line": 1033,
         "name": "_bind_wildcard_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.wildcard_nodes",
@@ -35856,7 +35811,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -35871,7 +35826,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_apply_lora_syntax_format",
         "kind": "static_from",
-        "line": 1040,
+        "line": 1038,
         "name": "_apply_lora_syntax_format",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -35890,7 +35845,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -35905,7 +35860,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_dedupe_text_values",
         "kind": "static_from",
-        "line": 1040,
+        "line": 1038,
         "name": "_dedupe_text_values",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -35924,7 +35879,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -35939,7 +35894,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_fallback_lora_path",
         "kind": "static_from",
-        "line": 1040,
+        "line": 1038,
         "name": "_fallback_lora_path",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -35958,7 +35913,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -35973,7 +35928,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_get_lora_info",
         "kind": "static_from",
-        "line": 1040,
+        "line": 1038,
         "name": "_get_lora_info",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -35992,7 +35947,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -36007,7 +35962,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_get_lora_manager_trigger_words",
         "kind": "static_from",
-        "line": 1040,
+        "line": 1038,
         "name": "_get_lora_manager_trigger_words",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -36026,7 +35981,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -36041,7 +35996,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_load_lora_manager_metadata",
         "kind": "static_from",
-        "line": 1040,
+        "line": 1038,
         "name": "_load_lora_manager_metadata",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -36060,7 +36015,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -36075,7 +36030,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_combo_values",
         "kind": "static_from",
-        "line": 1040,
+        "line": 1038,
         "name": "_lora_combo_values",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -36094,7 +36049,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -36109,7 +36064,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_manager_trigger_words_from_metadata",
         "kind": "static_from",
-        "line": 1040,
+        "line": 1038,
         "name": "_lora_manager_trigger_words_from_metadata",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -36128,7 +36083,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -36143,7 +36098,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_model_exists",
         "kind": "static_from",
-        "line": 1040,
+        "line": 1038,
         "name": "_lora_model_exists",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -36162,7 +36117,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -36177,7 +36132,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_stack_name",
         "kind": "static_from",
-        "line": 1040,
+        "line": 1038,
         "name": "_lora_stack_name",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -36196,7 +36151,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -36211,7 +36166,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_metadata_json_paths_for_lora",
         "kind": "static_from",
-        "line": 1040,
+        "line": 1038,
         "name": "_metadata_json_paths_for_lora",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -36230,7 +36185,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -36245,7 +36200,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_missing_lora_display_name",
         "kind": "static_from",
-        "line": 1040,
+        "line": 1038,
         "name": "_missing_lora_display_name",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -36264,7 +36219,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -36279,7 +36234,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_raise_missing_loras",
         "kind": "static_from",
-        "line": 1040,
+        "line": 1038,
         "name": "_raise_missing_loras",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -36298,7 +36253,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -36313,7 +36268,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_trigger_words_from_value",
         "kind": "static_from",
-        "line": 1040,
+        "line": 1038,
         "name": "_trigger_words_from_value",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -36332,7 +36287,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -36347,7 +36302,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_correct_style_prompt",
         "kind": "static_from",
-        "line": 1056,
+        "line": 1054,
         "name": "_correct_style_prompt",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -36366,7 +36321,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -36381,7 +36336,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_format_strength",
         "kind": "static_from",
-        "line": 1056,
+        "line": 1054,
         "name": "_format_strength",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -36400,7 +36355,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -36415,7 +36370,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_get_loras_list",
         "kind": "static_from",
-        "line": 1056,
+        "line": 1054,
         "name": "_get_loras_list",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -36434,7 +36389,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -36449,7 +36404,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_load_profile_data",
         "kind": "static_from",
-        "line": 1056,
+        "line": 1054,
         "name": "_load_profile_data",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -36468,7 +36423,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -36483,7 +36438,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_profile_key",
         "kind": "static_from",
-        "line": 1056,
+        "line": 1054,
         "name": "_profile_key",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -36502,7 +36457,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -36517,7 +36472,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_select_profile_values",
         "kind": "static_from",
-        "line": 1056,
+        "line": 1054,
         "name": "_select_profile_values",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -36536,7 +36491,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -36551,7 +36506,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_wrap_profile_index",
         "kind": "static_from",
-        "line": 1056,
+        "line": 1054,
         "name": "_wrap_profile_index",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -36570,7 +36525,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -36585,7 +36540,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.lora_nodes:EasyUseAnimaLoraPreset",
         "kind": "static_from",
-        "line": 1065,
+        "line": 1063,
         "name": "EasyUseAnimaLoraPreset",
         "optional": false,
         "requested": "easyuse_anima.nodes.lora_nodes",
@@ -36604,7 +36559,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -36619,7 +36574,7 @@
         "conditional": true,
         "imported": "anima_prompt:correct_prompt",
         "kind": "static_from",
-        "line": 1068,
+        "line": 1066,
         "name": "correct_prompt",
         "optional": false,
         "requested": "anima_prompt",
@@ -36638,7 +36593,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -36653,7 +36608,7 @@
         "conditional": true,
         "imported": "anima_prompt:load_knowledge_base",
         "kind": "static_from",
-        "line": 1068,
+        "line": 1066,
         "name": "load_knowledge_base",
         "optional": false,
         "requested": "anima_prompt",
@@ -36672,7 +36627,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -36687,7 +36642,7 @@
         "conditional": true,
         "imported": "anima_prompt.parser:parse_prompt",
         "kind": "static_from",
-        "line": 1069,
+        "line": 1067,
         "name": "parse_prompt",
         "optional": false,
         "requested": "anima_prompt.parser",
@@ -36706,7 +36661,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -36721,7 +36676,7 @@
         "conditional": true,
         "imported": "settings:resolve_metadata_filter_words",
         "kind": "static_from",
-        "line": 1070,
+        "line": 1068,
         "name": "resolve_metadata_filter_words",
         "optional": false,
         "requested": "settings",
@@ -36740,7 +36695,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -36755,7 +36710,7 @@
         "conditional": true,
         "imported": "settings:resolve_naia_settings",
         "kind": "static_from",
-        "line": 1070,
+        "line": 1068,
         "name": "resolve_naia_settings",
         "optional": false,
         "requested": "settings",
@@ -36774,7 +36729,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -36789,7 +36744,7 @@
         "conditional": true,
         "imported": "settings:resolve_prompt_translation_settings",
         "kind": "static_from",
-        "line": 1070,
+        "line": 1068,
         "name": "resolve_prompt_translation_settings",
         "optional": false,
         "requested": "settings",
@@ -36808,7 +36763,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -36823,7 +36778,7 @@
         "conditional": true,
         "imported": "prompt_translation:has_prompt_translation_markers",
         "kind": "static_from",
-        "line": 1075,
+        "line": 1073,
         "name": "has_prompt_translation_markers",
         "optional": false,
         "requested": "prompt_translation",
@@ -36842,7 +36797,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -36857,7 +36812,7 @@
         "conditional": true,
         "imported": "prompt_translation:translate_prompt_markers",
         "kind": "static_from",
-        "line": 1075,
+        "line": 1073,
         "name": "translate_prompt_markers",
         "optional": false,
         "requested": "prompt_translation",
@@ -36876,7 +36831,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -36891,7 +36846,7 @@
         "conditional": true,
         "imported": "wildcard_engine:MAX_SEED",
         "kind": "static_from",
-        "line": 1076,
+        "line": 1074,
         "name": "MAX_SEED",
         "optional": false,
         "requested": "wildcard_engine",
@@ -36910,7 +36865,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -36925,7 +36880,7 @@
         "conditional": true,
         "imported": "wildcard_engine:PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "kind": "static_from",
-        "line": 1076,
+        "line": 1074,
         "name": "PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "optional": false,
         "requested": "wildcard_engine",
@@ -36944,7 +36899,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -36959,7 +36914,7 @@
         "conditional": true,
         "imported": "wildcard_engine:PUBLIC_MAX_SEED",
         "kind": "static_from",
-        "line": 1076,
+        "line": 1074,
         "name": "PUBLIC_MAX_SEED",
         "optional": false,
         "requested": "wildcard_engine",
@@ -36978,7 +36933,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -36993,7 +36948,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_DECREMENT",
         "kind": "static_from",
-        "line": 1076,
+        "line": 1074,
         "name": "SEED_CONTROL_DECREMENT",
         "optional": false,
         "requested": "wildcard_engine",
@@ -37012,7 +36967,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -37027,7 +36982,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_FIXED",
         "kind": "static_from",
-        "line": 1076,
+        "line": 1074,
         "name": "SEED_CONTROL_FIXED",
         "optional": false,
         "requested": "wildcard_engine",
@@ -37046,7 +37001,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -37061,7 +37016,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_INCREMENT",
         "kind": "static_from",
-        "line": 1076,
+        "line": 1074,
         "name": "SEED_CONTROL_INCREMENT",
         "optional": false,
         "requested": "wildcard_engine",
@@ -37080,7 +37035,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -37095,7 +37050,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_MODES",
         "kind": "static_from",
-        "line": 1076,
+        "line": 1074,
         "name": "SEED_CONTROL_MODES",
         "optional": false,
         "requested": "wildcard_engine",
@@ -37114,7 +37069,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -37129,7 +37084,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_RANDOMIZE",
         "kind": "static_from",
-        "line": 1076,
+        "line": 1074,
         "name": "SEED_CONTROL_RANDOMIZE",
         "optional": false,
         "requested": "wildcard_engine",
@@ -37148,7 +37103,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -37163,7 +37118,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_FIXED",
         "kind": "static_from",
-        "line": 1076,
+        "line": 1074,
         "name": "WILDCARD_MODE_FIXED",
         "optional": false,
         "requested": "wildcard_engine",
@@ -37182,7 +37137,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -37197,7 +37152,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_POPULATE",
         "kind": "static_from",
-        "line": 1076,
+        "line": 1074,
         "name": "WILDCARD_MODE_POPULATE",
         "optional": false,
         "requested": "wildcard_engine",
@@ -37216,7 +37171,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -37231,7 +37186,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_SEQUENTIAL",
         "kind": "static_from",
-        "line": 1076,
+        "line": 1074,
         "name": "WILDCARD_MODE_SEQUENTIAL",
         "optional": false,
         "requested": "wildcard_engine",
@@ -37250,7 +37205,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -37265,7 +37220,7 @@
         "conditional": true,
         "imported": "wildcard_engine:expand_wildcard_texts",
         "kind": "static_from",
-        "line": 1076,
+        "line": 1074,
         "name": "expand_wildcard_texts",
         "optional": false,
         "requested": "wildcard_engine",
@@ -37284,7 +37239,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -37299,7 +37254,7 @@
         "conditional": true,
         "imported": "wildcard_engine:expand_wildcards",
         "kind": "static_from",
-        "line": 1076,
+        "line": 1074,
         "name": "expand_wildcards",
         "optional": false,
         "requested": "wildcard_engine",
@@ -37318,7 +37273,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -37333,7 +37288,7 @@
         "conditional": true,
         "imported": "wildcard_engine:has_wildcard_syntax",
         "kind": "static_from",
-        "line": 1076,
+        "line": 1074,
         "name": "has_wildcard_syntax",
         "optional": false,
         "requested": "wildcard_engine",
@@ -37352,7 +37307,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -37367,7 +37322,7 @@
         "conditional": true,
         "imported": "wildcard_engine:next_seed",
         "kind": "static_from",
-        "line": 1076,
+        "line": 1074,
         "name": "next_seed",
         "optional": false,
         "requested": "wildcard_engine",
@@ -37386,7 +37341,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -37401,7 +37356,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_prompt_studio_wildcard_mode",
         "kind": "static_from",
-        "line": 1076,
+        "line": 1074,
         "name": "normalize_prompt_studio_wildcard_mode",
         "optional": false,
         "requested": "wildcard_engine",
@@ -37420,7 +37375,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -37435,7 +37390,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_seed",
         "kind": "static_from",
-        "line": 1076,
+        "line": 1074,
         "name": "normalize_seed",
         "optional": false,
         "requested": "wildcard_engine",
@@ -37454,7 +37409,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -37469,7 +37424,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_wildcard_mode",
         "kind": "static_from",
-        "line": 1076,
+        "line": 1074,
         "name": "normalize_wildcard_mode",
         "optional": false,
         "requested": "wildcard_engine",
@@ -37488,7 +37443,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -37503,7 +37458,7 @@
         "conditional": true,
         "imported": "wildcard_engine:wildcard_sources_signature",
         "kind": "static_from",
-        "line": 1076,
+        "line": 1074,
         "name": "wildcard_sources_signature",
         "optional": false,
         "requested": "wildcard_engine",
@@ -39122,6 +39077,18 @@
         "to": "easyuse_anima/seed/__init__.py"
       },
       {
+        "from": "easyuse_anima/aio/first_pass_cache.py",
+        "to": "easyuse_anima/aio/model_preparation.py"
+      },
+      {
+        "from": "easyuse_anima/aio/first_pass_cache.py",
+        "to": "easyuse_anima/common/serialization.py"
+      },
+      {
+        "from": "easyuse_anima/aio/first_pass_cache.py",
+        "to": "easyuse_anima/prompt/data.py"
+      },
+      {
         "from": "easyuse_anima/aio/generation_detailer.py",
         "to": "easyuse_anima/aio/generation_sampling.py"
       },
@@ -40619,14 +40586,14 @@
       },
       {
         "is_package": false,
-        "loc": 145,
+        "loc": 125,
         "module": "easyuse_anima.aio.first_pass_cache",
-        "normalized_git_blob_sha1": "a9005240b4b07c9cba4a8f24474c924a74f06e92",
+        "normalized_git_blob_sha1": "872fc97c6a338c600cbc141faaaaf9d584d02c4a",
         "path": "easyuse_anima/aio/first_pass_cache.py",
         "top_level": {
           "class_count": 0,
-          "function_count": 7,
-          "global_count": 6
+          "function_count": 5,
+          "global_count": 4
         }
       },
       {
@@ -41447,9 +41414,9 @@
       },
       {
         "is_package": false,
-        "loc": 1662,
+        "loc": 1657,
         "module": "nodes",
-        "normalized_git_blob_sha1": "4821f36548243853249a7a24458a37469985c676",
+        "normalized_git_blob_sha1": "edcdc8681f64790736a790177ac80dadfda214b6",
         "path": "nodes.py",
         "top_level": {
           "class_count": 0,
@@ -42997,7 +42964,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -43006,7 +42973,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:AIO_FIRST_PASS_CACHE_MAX_ENTRIES",
         "kind": "static_from",
-        "line": 554,
+        "line": 553,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43020,7 +42987,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -43029,7 +42996,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_AIO_FIRST_PASS_CACHE",
         "kind": "static_from",
-        "line": 554,
+        "line": 553,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43043,7 +43010,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -43052,7 +43019,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_AIO_FIRST_PASS_CACHE_ORDER",
         "kind": "static_from",
-        "line": 554,
+        "line": 553,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43066,7 +43033,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -43075,7 +43042,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_aio_first_pass_cache_key",
         "kind": "static_from",
-        "line": 554,
+        "line": 553,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43089,30 +43056,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
-            "kind": "try",
-            "line": 9
-          }
-        ],
-        "classification": "compatibility_fallback",
-        "conditional": true,
-        "imported": "easyuse_anima.aio.first_pass_cache:_bind_aio_first_pass_cache_runtime",
-        "kind": "static_from",
-        "line": 554,
-        "optional": false,
-        "role": "compatibility_fallback",
-        "source": "nodes.py",
-        "target": "easyuse_anima/aio/first_pass_cache.py"
-      },
-      {
-        "branch_context": [
-          {
-            "branch": "except",
-            "catches_import_error": true,
-            "exceptions": [
-              "ImportError"
-            ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -43121,7 +43065,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_clone_aio_cache_value",
         "kind": "static_from",
-        "line": 554,
+        "line": 553,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43135,7 +43079,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -43144,7 +43088,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_get_aio_first_pass_cache",
         "kind": "static_from",
-        "line": 554,
+        "line": 553,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43158,7 +43102,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -43167,7 +43111,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_put_aio_first_pass_cache",
         "kind": "static_from",
-        "line": 554,
+        "line": 553,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43181,7 +43125,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -43190,7 +43134,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_bind_aio_legacy_generation_runtime",
         "kind": "static_from",
-        "line": 565,
+        "line": 563,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43204,7 +43148,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -43213,7 +43157,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_detailer_stage",
         "kind": "static_from",
-        "line": 565,
+        "line": 563,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43227,7 +43171,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -43236,7 +43180,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_detailer_target",
         "kind": "static_from",
-        "line": 565,
+        "line": 563,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43250,7 +43194,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -43259,7 +43203,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_highres_stage",
         "kind": "static_from",
-        "line": 565,
+        "line": 563,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43273,7 +43217,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -43282,7 +43226,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_legacy_generation",
         "kind": "static_from",
-        "line": 565,
+        "line": 563,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43296,7 +43240,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -43305,7 +43249,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_resshift_upscale_stage",
         "kind": "static_from",
-        "line": 565,
+        "line": 563,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43319,7 +43263,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -43328,7 +43272,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_upscale_stage",
         "kind": "static_from",
-        "line": 565,
+        "line": 563,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43342,7 +43286,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -43351,7 +43295,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_usdu_upscale_stage",
         "kind": "static_from",
-        "line": 565,
+        "line": 563,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43365,7 +43309,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -43374,7 +43318,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEEDS",
         "kind": "static_from",
-        "line": 575,
+        "line": 573,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43388,7 +43332,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -43397,7 +43341,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEED_DECREMENT",
         "kind": "static_from",
-        "line": 575,
+        "line": 573,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43411,7 +43355,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -43420,7 +43364,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEED_INCREMENT",
         "kind": "static_from",
-        "line": 575,
+        "line": 573,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43434,7 +43378,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -43443,7 +43387,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEED_RANDOM",
         "kind": "static_from",
-        "line": 575,
+        "line": 573,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43457,7 +43401,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -43466,7 +43410,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_AIO_DETAILER_CUSTOM_RE",
         "kind": "static_from",
-        "line": 575,
+        "line": 573,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43480,7 +43424,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -43489,7 +43433,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_AIO_DETAILER_RESERVED_KEYS",
         "kind": "static_from",
-        "line": 575,
+        "line": 573,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43503,7 +43447,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -43512,7 +43456,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_aio_detailer_has_enabled_targets",
         "kind": "static_from",
-        "line": 575,
+        "line": 573,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43526,7 +43470,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -43535,7 +43479,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_aio_detailer_target_defaults",
         "kind": "static_from",
-        "line": 575,
+        "line": 573,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43549,7 +43493,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -43558,7 +43502,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_aio_detailer_target_order",
         "kind": "static_from",
-        "line": 575,
+        "line": 573,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43572,7 +43516,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -43581,7 +43525,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_bind_aio_generation_normalization_runtime",
         "kind": "static_from",
-        "line": 575,
+        "line": 573,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43595,7 +43539,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -43604,7 +43548,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_is_aio_detailer_target_name",
         "kind": "static_from",
-        "line": 575,
+        "line": 573,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43618,7 +43562,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -43627,7 +43571,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_merge_versioned_settings",
         "kind": "static_from",
-        "line": 575,
+        "line": 573,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43641,7 +43585,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -43650,7 +43594,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_dit_corrections_settings",
         "kind": "static_from",
-        "line": 575,
+        "line": 573,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43664,7 +43608,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -43673,7 +43617,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_generation_settings",
         "kind": "static_from",
-        "line": 575,
+        "line": 573,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43687,7 +43631,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -43696,7 +43640,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_seed",
         "kind": "static_from",
-        "line": 575,
+        "line": 573,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43710,7 +43654,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -43719,7 +43663,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_spectrum_settings",
         "kind": "static_from",
-        "line": 575,
+        "line": 573,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43733,7 +43677,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -43742,7 +43686,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_settings:round_trip_aio_generation_settings",
         "kind": "static_from",
-        "line": 593,
+        "line": 591,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43756,7 +43700,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -43765,7 +43709,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.usdu:_aio_usdu_auto_tile_dimension",
         "kind": "static_from",
-        "line": 596,
+        "line": 594,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43779,7 +43723,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -43788,7 +43732,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.usdu:_aio_usdu_tile_plan",
         "kind": "static_from",
-        "line": 596,
+        "line": 594,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43802,7 +43746,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -43811,7 +43755,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.usdu:_bind_aio_usdu_planning_runtime",
         "kind": "static_from",
-        "line": 596,
+        "line": 594,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43825,7 +43769,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -43834,7 +43778,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_aio_final_fit_size",
         "kind": "static_from",
-        "line": 601,
+        "line": 599,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43848,7 +43792,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -43857,7 +43801,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_apply_aio_final_fit",
         "kind": "static_from",
-        "line": 601,
+        "line": 599,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43871,7 +43815,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -43880,7 +43824,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_bind_aio_postprocess_runtime",
         "kind": "static_from",
-        "line": 601,
+        "line": 599,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43894,7 +43838,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -43903,7 +43847,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_resize_image_to_size_if_needed",
         "kind": "static_from",
-        "line": 601,
+        "line": 599,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43917,7 +43861,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -43926,7 +43870,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_run_aio_postprocess_stage",
         "kind": "static_from",
-        "line": 601,
+        "line": 599,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43940,7 +43884,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -43949,7 +43893,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_prompt_data_fields_for_usdu",
         "kind": "static_from",
-        "line": 608,
+        "line": 606,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43963,7 +43907,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -43972,7 +43916,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_usdu_conditioning",
         "kind": "static_from",
-        "line": 608,
+        "line": 606,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43986,7 +43930,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -43995,7 +43939,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_usdu_prompt_without_general",
         "kind": "static_from",
-        "line": 608,
+        "line": 606,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44009,7 +43953,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -44018,7 +43962,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_bind_aio_conditioning_runtime",
         "kind": "static_from",
-        "line": 608,
+        "line": 606,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44032,7 +43976,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -44041,7 +43985,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_aio_lora_stack_signature",
         "kind": "static_from",
-        "line": 614,
+        "line": 612,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44055,7 +43999,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -44064,7 +44008,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_anima_dave_patch",
         "kind": "static_from",
-        "line": 614,
+        "line": 612,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44078,7 +44022,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -44087,7 +44031,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_kj_model_patches",
         "kind": "static_from",
-        "line": 614,
+        "line": 612,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44101,7 +44045,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -44110,7 +44054,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_lora_stack",
         "kind": "static_from",
-        "line": 614,
+        "line": 612,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44124,7 +44068,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -44133,7 +44077,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_model_patches",
         "kind": "static_from",
-        "line": 614,
+        "line": 612,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44147,7 +44091,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -44156,7 +44100,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_safe_pag_patch",
         "kind": "static_from",
-        "line": 614,
+        "line": 612,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44170,7 +44114,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -44179,7 +44123,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_correction_patch_for_comfy_sampler",
         "kind": "static_from",
-        "line": 614,
+        "line": 612,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44193,7 +44137,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -44202,7 +44146,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_forecast_patch_for_comfy_sampler",
         "kind": "static_from",
-        "line": 614,
+        "line": 612,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44216,7 +44160,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -44225,7 +44169,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_model_patches_for_comfy_sampler",
         "kind": "static_from",
-        "line": 614,
+        "line": 612,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44239,7 +44183,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -44248,7 +44192,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_bind_aio_model_preparation_runtime",
         "kind": "static_from",
-        "line": 614,
+        "line": 612,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44262,7 +44206,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -44271,7 +44215,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_cleanup_aio_ephemeral_model",
         "kind": "static_from",
-        "line": 614,
+        "line": 612,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44285,7 +44229,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -44294,7 +44238,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_normalize_aio_lora_stack",
         "kind": "static_from",
-        "line": 614,
+        "line": 612,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44308,7 +44252,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -44317,7 +44261,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_patch_model_sampling_aura_flow",
         "kind": "static_from",
-        "line": 614,
+        "line": 612,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44331,7 +44275,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -44340,7 +44284,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_aio_highres_effective_backend",
         "kind": "static_from",
-        "line": 629,
+        "line": 627,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44354,7 +44298,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -44363,7 +44307,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_aio_stage_sampler_settings",
         "kind": "static_from",
-        "line": 629,
+        "line": 627,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44377,7 +44321,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -44386,7 +44330,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_bind_aio_sampling_runtime",
         "kind": "static_from",
-        "line": 629,
+        "line": 627,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44400,7 +44344,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -44409,7 +44353,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_decode_latent_with_comfy",
         "kind": "static_from",
-        "line": 629,
+        "line": 627,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44423,7 +44367,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -44432,7 +44376,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_encode_image_with_comfy_vae",
         "kind": "static_from",
-        "line": 629,
+        "line": 627,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44446,7 +44390,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -44455,7 +44399,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_generate_empty_latent_with_comfy",
         "kind": "static_from",
-        "line": 629,
+        "line": 627,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44469,7 +44413,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -44478,7 +44422,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_new_aio_random_seed",
         "kind": "static_from",
-        "line": 629,
+        "line": 627,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44492,7 +44436,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -44501,7 +44445,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_resolve_aio_runtime_seed",
         "kind": "static_from",
-        "line": 629,
+        "line": 627,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44515,7 +44459,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -44524,7 +44468,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_aio_backend",
         "kind": "static_from",
-        "line": 629,
+        "line": 627,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44538,7 +44482,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -44547,7 +44491,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_comfy",
         "kind": "static_from",
-        "line": 629,
+        "line": 627,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44561,7 +44505,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -44570,7 +44514,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_spectrum_mod_guidance_advanced",
         "kind": "static_from",
-        "line": 629,
+        "line": 627,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44584,7 +44528,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -44593,7 +44537,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_spectrum_spd",
         "kind": "static_from",
-        "line": 629,
+        "line": 627,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44607,7 +44551,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -44616,7 +44560,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_CACHE_FORMAT",
         "kind": "static_from",
-        "line": 643,
+        "line": 641,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44630,7 +44574,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -44639,7 +44583,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_CACHE_QUALITY",
         "kind": "static_from",
-        "line": 643,
+        "line": 641,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44653,7 +44597,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -44662,7 +44606,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_EVENT",
         "kind": "static_from",
-        "line": 643,
+        "line": 641,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44676,7 +44620,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -44685,7 +44629,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_STAGE_LABELS",
         "kind": "static_from",
-        "line": 643,
+        "line": 641,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44699,7 +44643,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -44708,7 +44652,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_aio_preview_base_directory",
         "kind": "static_from",
-        "line": 643,
+        "line": 641,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44722,7 +44666,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -44731,7 +44675,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_aio_preview_file_size_bytes",
         "kind": "static_from",
-        "line": 643,
+        "line": 641,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44745,7 +44689,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -44754,7 +44698,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_bind_aio_preview_runtime",
         "kind": "static_from",
-        "line": 643,
+        "line": 641,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44768,7 +44712,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -44777,7 +44721,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_save_aio_temp_preview_image",
         "kind": "static_from",
-        "line": 643,
+        "line": 641,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44791,7 +44735,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -44800,7 +44744,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_send_aio_preview_event",
         "kind": "static_from",
-        "line": 643,
+        "line": 641,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44814,7 +44758,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -44823,7 +44767,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_tag_aio_preview_images",
         "kind": "static_from",
-        "line": 643,
+        "line": 641,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44837,7 +44781,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -44846,7 +44790,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_image_saver_additional_hashes",
         "kind": "static_from",
-        "line": 655,
+        "line": 653,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44860,7 +44804,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -44869,7 +44813,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_image_saver_civitai_hash_fetcher_entries",
         "kind": "static_from",
-        "line": 655,
+        "line": 653,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44883,7 +44827,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -44892,7 +44836,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_lora_metadata_name",
         "kind": "static_from",
-        "line": 655,
+        "line": 653,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44906,7 +44850,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -44915,7 +44859,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_prompt_with_lora_metadata",
         "kind": "static_from",
-        "line": 655,
+        "line": 653,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44929,7 +44873,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -44938,7 +44882,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_save_filename_prefix",
         "kind": "static_from",
-        "line": 655,
+        "line": 653,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44952,7 +44896,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -44961,7 +44905,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_bind_aio_output_runtime",
         "kind": "static_from",
-        "line": 655,
+        "line": 653,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44975,7 +44919,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -44984,7 +44928,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_normalize_aio_civitai_hash_fetchers",
         "kind": "static_from",
-        "line": 655,
+        "line": 653,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44998,7 +44942,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -45007,7 +44951,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_normalize_aio_hash_bundles",
         "kind": "static_from",
-        "line": 655,
+        "line": 653,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45021,7 +44965,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -45030,7 +44974,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_save_image_with_comfy",
         "kind": "static_from",
-        "line": 655,
+        "line": 653,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45044,7 +44988,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -45053,7 +44997,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_save_image_with_image_saver",
         "kind": "static_from",
-        "line": 655,
+        "line": 653,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45067,7 +45011,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -45076,7 +45020,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_bind_aio_resource_runtime",
         "kind": "static_from",
-        "line": 667,
+        "line": 665,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45090,7 +45034,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -45099,7 +45043,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_clip_loader_types",
         "kind": "static_from",
-        "line": 667,
+        "line": 665,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45113,7 +45057,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -45122,7 +45066,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_diffusion_model_names",
         "kind": "static_from",
-        "line": 667,
+        "line": 665,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45136,7 +45080,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -45145,7 +45089,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_text_encoder_names",
         "kind": "static_from",
-        "line": 667,
+        "line": 665,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45159,7 +45103,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -45168,7 +45112,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_vae_names",
         "kind": "static_from",
-        "line": 667,
+        "line": 665,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45182,7 +45126,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -45191,7 +45135,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_aio_resources_from_input_context",
         "kind": "static_from",
-        "line": 667,
+        "line": 665,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45205,7 +45149,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -45214,7 +45158,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_aio_sam3_context",
         "kind": "static_from",
-        "line": 667,
+        "line": 665,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45228,7 +45172,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -45237,7 +45181,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_checkpoint_with_comfy",
         "kind": "static_from",
-        "line": 667,
+        "line": 665,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45251,7 +45195,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -45260,7 +45204,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_clip_with_comfy",
         "kind": "static_from",
-        "line": 667,
+        "line": 665,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45274,7 +45218,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -45283,7 +45227,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_diffusion_model_with_comfy",
         "kind": "static_from",
-        "line": 667,
+        "line": 665,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45297,7 +45241,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -45306,7 +45250,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_upscale_model_with_comfy",
         "kind": "static_from",
-        "line": 667,
+        "line": 665,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45320,7 +45264,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -45329,7 +45273,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_vae_with_comfy",
         "kind": "static_from",
-        "line": 667,
+        "line": 665,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45343,7 +45287,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -45352,7 +45296,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_normalize_aio_input_settings",
         "kind": "static_from",
-        "line": 667,
+        "line": 665,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45366,7 +45310,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -45375,7 +45319,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_checkpoint_default",
         "kind": "static_from",
-        "line": 667,
+        "line": 665,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45389,7 +45333,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -45398,7 +45342,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_clip_type_default",
         "kind": "static_from",
-        "line": 667,
+        "line": 665,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45412,7 +45356,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -45421,7 +45365,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_name_default",
         "kind": "static_from",
-        "line": 667,
+        "line": 665,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45435,7 +45379,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -45444,7 +45388,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_json_clone",
         "kind": "static_from",
-        "line": 685,
+        "line": 683,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45458,7 +45402,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -45467,7 +45411,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_json_object",
         "kind": "static_from",
-        "line": 685,
+        "line": 683,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45481,7 +45425,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -45490,7 +45434,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_stable_change_key",
         "kind": "static_from",
-        "line": 685,
+        "line": 683,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45504,7 +45448,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -45513,7 +45457,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_bool",
         "kind": "static_from",
-        "line": 690,
+        "line": 688,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45527,7 +45471,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -45536,7 +45480,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_float",
         "kind": "static_from",
-        "line": 690,
+        "line": 688,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45550,7 +45494,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -45559,7 +45503,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_int",
         "kind": "static_from",
-        "line": 690,
+        "line": 688,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45573,7 +45517,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -45582,7 +45526,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_choice",
         "kind": "static_from",
-        "line": 690,
+        "line": 688,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45596,7 +45540,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -45605,7 +45549,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_single_value",
         "kind": "static_from",
-        "line": 690,
+        "line": 688,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45619,7 +45563,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -45628,7 +45572,7 @@
         "conditional": true,
         "imported": "easyuse_anima.seed.compatibility:WILDCARD_QUEUE_MAX_SAFE_SEED",
         "kind": "static_from",
-        "line": 697,
+        "line": 695,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45642,7 +45586,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -45651,7 +45595,7 @@
         "conditional": true,
         "imported": "easyuse_anima.seed.compatibility:WILDCARD_RESERVED_NEXT_SEED_INPUT",
         "kind": "static_from",
-        "line": 697,
+        "line": 695,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45665,7 +45609,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -45674,7 +45618,7 @@
         "conditional": true,
         "imported": "easyuse_anima.seed.compatibility:_consume_reserved_wildcard_next_seed",
         "kind": "static_from",
-        "line": 697,
+        "line": 695,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45688,7 +45632,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -45697,7 +45641,7 @@
         "conditional": true,
         "imported": "easyuse_anima.workflow:_get_workflow_node",
         "kind": "static_from",
-        "line": 702,
+        "line": 700,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45711,7 +45655,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -45720,7 +45664,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_prompt_translation_change_key",
         "kind": "static_from",
-        "line": 703,
+        "line": 701,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45734,7 +45678,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -45743,7 +45687,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_split_tag_text",
         "kind": "static_from",
-        "line": 703,
+        "line": 701,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45757,7 +45701,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -45766,7 +45710,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_translate_prompt_text",
         "kind": "static_from",
-        "line": 703,
+        "line": 701,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45780,7 +45724,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -45789,7 +45733,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_HASH_COMMENT_RE",
         "kind": "static_from",
-        "line": 708,
+        "line": 706,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45803,7 +45747,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -45812,7 +45756,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_INLINE_SPACE_RE",
         "kind": "static_from",
-        "line": 708,
+        "line": 706,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45826,7 +45770,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -45835,7 +45779,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_WEIGHTED_TOKEN_RE",
         "kind": "static_from",
-        "line": 708,
+        "line": 706,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45849,7 +45793,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -45858,7 +45802,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_correct_builder_prompt",
         "kind": "static_from",
-        "line": 708,
+        "line": 706,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45872,7 +45816,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -45881,7 +45825,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_filter_metadata_prompt",
         "kind": "static_from",
-        "line": 708,
+        "line": 706,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45895,7 +45839,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -45904,7 +45848,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_join_prompt_tokens",
         "kind": "static_from",
-        "line": 708,
+        "line": 706,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45918,7 +45862,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -45927,7 +45871,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_metadata_filter_key",
         "kind": "static_from",
-        "line": 708,
+        "line": 706,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45941,7 +45885,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -45950,7 +45894,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_metadata_filter_keys",
         "kind": "static_from",
-        "line": 708,
+        "line": 706,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45964,7 +45908,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -45973,7 +45917,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_prompt_tokens",
         "kind": "static_from",
-        "line": 708,
+        "line": 706,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45987,7 +45931,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -45996,7 +45940,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:PROMPT_DATA_TYPE",
         "kind": "static_from",
-        "line": 721,
+        "line": 719,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46010,7 +45954,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -46019,7 +45963,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_advanced_outputs_from_prompt_data",
         "kind": "static_from",
-        "line": 721,
+        "line": 719,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46033,7 +45977,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -46042,7 +45986,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_apply_prompt_data_overrides",
         "kind": "static_from",
-        "line": 721,
+        "line": 719,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46056,7 +46000,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -46065,7 +46009,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_copy_prompt_data_for_update",
         "kind": "static_from",
-        "line": 721,
+        "line": 719,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46079,7 +46023,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -46088,7 +46032,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_normalize_prompt_data",
         "kind": "static_from",
-        "line": 721,
+        "line": 719,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46102,7 +46046,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -46111,7 +46055,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_prompt_data_json_safe",
         "kind": "static_from",
-        "line": 721,
+        "line": 719,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46125,7 +46069,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -46134,7 +46078,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_prompt_data_parameter_snapshot",
         "kind": "static_from",
-        "line": 721,
+        "line": 719,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46148,7 +46092,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -46157,7 +46101,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_artist_field_prompt",
         "kind": "static_from",
-        "line": 739,
+        "line": 737,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46171,7 +46115,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -46180,7 +46124,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_default_fields",
         "kind": "static_from",
-        "line": 739,
+        "line": 737,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46194,7 +46138,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -46203,7 +46147,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_enabled_naia_panes",
         "kind": "static_from",
-        "line": 739,
+        "line": 737,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46217,7 +46161,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -46226,7 +46170,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_enabled_pane_fields",
         "kind": "static_from",
-        "line": 739,
+        "line": 737,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46240,7 +46184,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -46249,7 +46193,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_field_input_values",
         "kind": "static_from",
-        "line": 739,
+        "line": 737,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46263,7 +46207,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -46272,7 +46216,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_field_socket_name",
         "kind": "static_from",
-        "line": 739,
+        "line": 737,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46286,7 +46230,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -46295,7 +46239,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_fields_json",
         "kind": "static_from",
-        "line": 739,
+        "line": 737,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46309,7 +46253,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -46318,7 +46262,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_has_enabled_naia",
         "kind": "static_from",
-        "line": 739,
+        "line": 737,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46332,7 +46276,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -46341,7 +46285,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_prompt_with_artist_override",
         "kind": "static_from",
-        "line": 739,
+        "line": 737,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46355,7 +46299,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -46364,7 +46308,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_uses_naia_resolution",
         "kind": "static_from",
-        "line": 739,
+        "line": 737,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46378,7 +46322,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -46387,7 +46331,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_apply_advanced_field_inputs",
         "kind": "static_from",
-        "line": 739,
+        "line": 737,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46401,7 +46345,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -46410,7 +46354,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_as_advanced_height",
         "kind": "static_from",
-        "line": 739,
+        "line": 737,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46424,7 +46368,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -46433,7 +46377,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_build_advanced_prompt_data",
         "kind": "static_from",
-        "line": 739,
+        "line": 737,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46447,7 +46391,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -46456,7 +46400,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_build_advanced_prompts",
         "kind": "static_from",
-        "line": 739,
+        "line": 737,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46470,7 +46414,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -46479,7 +46423,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_clone_advanced_fields",
         "kind": "static_from",
-        "line": 739,
+        "line": 737,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46493,7 +46437,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -46502,7 +46446,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_correct_advanced_field_sequence",
         "kind": "static_from",
-        "line": 739,
+        "line": 737,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46516,7 +46460,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -46525,7 +46469,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_expand_advanced_wildcard_fields",
         "kind": "static_from",
-        "line": 739,
+        "line": 737,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46539,7 +46483,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -46548,7 +46492,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_normalize_advanced_fields",
         "kind": "static_from",
-        "line": 739,
+        "line": 737,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46562,7 +46506,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -46571,7 +46515,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_normalize_prompt_studio_wildcard_seed_control",
         "kind": "static_from",
-        "line": 739,
+        "line": 737,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46585,7 +46529,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -46594,7 +46538,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_set_naia_field_text",
         "kind": "static_from",
-        "line": 739,
+        "line": 737,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46608,7 +46552,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -46617,7 +46561,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_translate_prompt_fields",
         "kind": "static_from",
-        "line": 739,
+        "line": 737,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46631,7 +46575,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -46640,7 +46584,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_apply_regional_field_inputs",
         "kind": "static_from",
-        "line": 774,
+        "line": 772,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46654,7 +46598,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -46663,7 +46607,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_build_regional_outputs",
         "kind": "static_from",
-        "line": 774,
+        "line": 772,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46677,7 +46621,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -46686,7 +46630,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_clone_regional_fields",
         "kind": "static_from",
-        "line": 774,
+        "line": 772,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46700,7 +46644,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -46709,7 +46653,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_conditioning_set_values",
         "kind": "static_from",
-        "line": 774,
+        "line": 772,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46723,7 +46667,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -46732,7 +46676,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_mask_ids",
         "kind": "static_from",
-        "line": 774,
+        "line": 772,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46746,7 +46690,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -46755,7 +46699,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_regional_config",
         "kind": "static_from",
-        "line": 774,
+        "line": 772,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46769,7 +46713,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -46778,7 +46722,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_regional_fields",
         "kind": "static_from",
-        "line": 774,
+        "line": 772,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46792,7 +46736,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -46801,7 +46745,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_parse_json_object",
         "kind": "static_from",
-        "line": 774,
+        "line": 772,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46815,7 +46759,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -46824,7 +46768,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_config_json",
         "kind": "static_from",
-        "line": 774,
+        "line": 772,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46838,7 +46782,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -46847,7 +46791,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_fields_json",
         "kind": "static_from",
-        "line": 774,
+        "line": 772,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46861,7 +46805,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -46870,7 +46814,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_mask_bounds_area",
         "kind": "static_from",
-        "line": 774,
+        "line": 772,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46884,7 +46828,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -46893,7 +46837,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_payload_canvas",
         "kind": "static_from",
-        "line": 774,
+        "line": 772,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46907,7 +46851,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -46916,7 +46860,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_union_mask_for_ids",
         "kind": "static_from",
-        "line": 774,
+        "line": 772,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46930,7 +46874,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -46939,7 +46883,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
         "kind": "static_from",
-        "line": 801,
+        "line": 799,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46953,7 +46897,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -46962,7 +46906,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODES",
         "kind": "static_from",
-        "line": 801,
+        "line": 799,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46976,7 +46920,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -46985,7 +46929,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 801,
+        "line": 799,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46999,7 +46943,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -47008,7 +46952,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_PROFILE_OFF",
         "kind": "static_from",
-        "line": 801,
+        "line": 799,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47022,7 +46966,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -47031,7 +46975,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_apply_spectrum_anima_mod_guidance",
         "kind": "static_from",
-        "line": 801,
+        "line": 799,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47045,7 +46989,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -47054,7 +46998,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_find_spectrum_anima_mod_guidance_class",
         "kind": "static_from",
-        "line": 801,
+        "line": 799,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47068,7 +47012,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -47077,7 +47021,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_normalize_anima_mod_guidance_profile",
         "kind": "static_from",
-        "line": 801,
+        "line": 799,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47091,7 +47035,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -47100,7 +47044,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_resolve_anima_mod_guidance_enabled",
         "kind": "static_from",
-        "line": 801,
+        "line": 799,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47114,7 +47058,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -47123,7 +47067,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
         "kind": "static_from",
-        "line": 816,
+        "line": 814,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47137,7 +47081,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -47146,7 +47090,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
         "kind": "static_from",
-        "line": 816,
+        "line": 814,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47160,7 +47104,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -47169,7 +47113,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
         "kind": "static_from",
-        "line": 816,
+        "line": 814,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47183,7 +47127,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -47192,7 +47136,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_EXACT_TOP_K",
         "kind": "static_from",
-        "line": 816,
+        "line": 814,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47206,7 +47150,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -47215,7 +47159,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
         "kind": "static_from",
-        "line": 816,
+        "line": 814,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47229,7 +47173,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -47238,7 +47182,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_START_PERCENT",
         "kind": "static_from",
-        "line": 816,
+        "line": 814,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47252,7 +47196,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -47261,7 +47205,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
         "kind": "static_from",
-        "line": 816,
+        "line": 814,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47275,7 +47219,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -47284,7 +47228,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STYLE_GAIN",
         "kind": "static_from",
-        "line": 816,
+        "line": 814,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47298,7 +47242,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -47307,7 +47251,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_INPUT_MODES",
         "kind": "static_from",
-        "line": 816,
+        "line": 814,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47321,7 +47265,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -47330,7 +47274,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 816,
+        "line": 814,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47344,7 +47288,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -47353,7 +47297,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_mix_inline_prompt",
         "kind": "static_from",
-        "line": 816,
+        "line": 814,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47367,7 +47311,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -47376,7 +47320,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_mix_mode_tooltip",
         "kind": "static_from",
-        "line": 816,
+        "line": 814,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47390,7 +47334,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -47399,7 +47343,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_prompt_with_position",
         "kind": "static_from",
-        "line": 816,
+        "line": 814,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47413,7 +47357,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -47422,7 +47366,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_tags_from_prompt",
         "kind": "static_from",
-        "line": 816,
+        "line": 814,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47436,7 +47380,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -47445,7 +47389,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_blend_conditionings",
         "kind": "static_from",
-        "line": 816,
+        "line": 814,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47459,7 +47403,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -47468,7 +47412,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bounded_artist_mix_float",
         "kind": "static_from",
-        "line": 816,
+        "line": 814,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47482,7 +47426,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -47491,7 +47435,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bounded_artist_mix_int",
         "kind": "static_from",
-        "line": 816,
+        "line": 814,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47505,7 +47449,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -47514,7 +47458,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_clustered",
         "kind": "static_from",
-        "line": 816,
+        "line": 814,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47528,7 +47472,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -47537,7 +47481,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_delta_rms",
         "kind": "static_from",
-        "line": 816,
+        "line": 814,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47551,7 +47495,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -47560,7 +47504,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_prompt_data_positive_conditioning",
         "kind": "static_from",
-        "line": 816,
+        "line": 814,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47574,7 +47518,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -47583,7 +47527,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_join_artist_mix_source_prompts",
         "kind": "static_from",
-        "line": 816,
+        "line": 814,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47597,7 +47541,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -47606,7 +47550,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_normalize_artist_mix_mode",
         "kind": "static_from",
-        "line": 816,
+        "line": 814,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47620,7 +47564,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -47629,7 +47573,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_normalize_artist_tag_position",
         "kind": "static_from",
-        "line": 816,
+        "line": 814,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47643,7 +47587,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -47652,7 +47596,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_parse_artist_mix_items",
         "kind": "static_from",
-        "line": 816,
+        "line": 814,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47666,7 +47610,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -47675,7 +47619,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaArtistMixConditioning",
         "kind": "static_from",
-        "line": 895,
+        "line": 893,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47689,7 +47633,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -47698,7 +47642,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataConditioning",
         "kind": "static_from",
-        "line": 895,
+        "line": 893,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47712,7 +47656,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -47721,7 +47665,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataUnpack",
         "kind": "static_from",
-        "line": 895,
+        "line": 893,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47735,7 +47679,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -47744,7 +47688,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_ANY_TYPE",
         "kind": "static_from",
-        "line": 900,
+        "line": 898,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47758,7 +47702,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -47767,7 +47711,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_AnyType",
         "kind": "static_from",
-        "line": 900,
+        "line": 898,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47781,7 +47725,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -47790,7 +47734,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_FlexibleOptionalInputType",
         "kind": "static_from",
-        "line": 900,
+        "line": 898,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47804,7 +47748,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -47813,7 +47757,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvanced",
         "kind": "static_from",
-        "line": 905,
+        "line": 903,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47827,7 +47771,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -47836,7 +47780,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvancedV2",
         "kind": "static_from",
-        "line": 905,
+        "line": 903,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47850,7 +47794,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -47859,7 +47803,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:EasyUseAnimaAIOGenerator",
         "kind": "static_from",
-        "line": 910,
+        "line": 908,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47873,7 +47817,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -47882,7 +47826,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:EasyUseAnimaInput",
         "kind": "static_from",
-        "line": 910,
+        "line": 908,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47896,7 +47840,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -47905,7 +47849,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_aio_generation_settings_json",
         "kind": "static_from",
-        "line": 910,
+        "line": 908,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47919,7 +47863,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -47928,7 +47872,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_aio_input_settings_json",
         "kind": "static_from",
-        "line": 910,
+        "line": 908,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47942,7 +47886,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -47951,7 +47895,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_bind_aio_node_runtime",
         "kind": "static_from",
-        "line": 910,
+        "line": 908,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47965,7 +47909,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -47974,7 +47918,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_easy_use_anima_input_signature",
         "kind": "static_from",
-        "line": 910,
+        "line": 908,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47988,7 +47932,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -47997,7 +47941,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_require_easy_use_anima_input",
         "kind": "static_from",
-        "line": 910,
+        "line": 908,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48011,7 +47955,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -48020,7 +47964,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_align_down",
         "kind": "static_from",
-        "line": 919,
+        "line": 917,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48034,7 +47978,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -48043,7 +47987,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_align_nearest",
         "kind": "static_from",
-        "line": 919,
+        "line": 917,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48057,7 +48001,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -48066,7 +48010,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_image_tensor_size",
         "kind": "static_from",
-        "line": 919,
+        "line": 917,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48080,7 +48024,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -48089,7 +48033,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_context_value",
         "kind": "static_from",
-        "line": 930,
+        "line": 928,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48103,7 +48047,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -48112,7 +48056,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_sam3_context",
         "kind": "static_from",
-        "line": 930,
+        "line": 928,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48126,7 +48070,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -48135,7 +48079,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_segs_has_items",
         "kind": "static_from",
-        "line": 930,
+        "line": 928,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48149,7 +48093,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -48158,7 +48102,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:IMAGE_SCALE_MULTIPLES",
         "kind": "static_from",
-        "line": 942,
+        "line": 940,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48172,7 +48116,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -48181,7 +48125,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:IMAGE_UPSCALE_METHODS",
         "kind": "static_from",
-        "line": 942,
+        "line": 940,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48195,7 +48139,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -48204,7 +48148,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_sampler_names",
         "kind": "static_from",
-        "line": 950,
+        "line": 948,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48218,7 +48162,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -48227,7 +48171,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_scheduler_names",
         "kind": "static_from",
-        "line": 950,
+        "line": 948,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48241,7 +48185,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -48250,7 +48194,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_impact_scheduler_names",
         "kind": "static_from",
-        "line": 950,
+        "line": 948,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48264,7 +48208,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -48273,7 +48217,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_call_with_supported_kwargs",
         "kind": "static_from",
-        "line": 956,
+        "line": 954,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48287,7 +48231,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -48296,7 +48240,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_common_upscale_image",
         "kind": "static_from",
-        "line": 956,
+        "line": 954,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48310,7 +48254,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -48319,7 +48263,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_node_output_tuple",
         "kind": "static_from",
-        "line": 956,
+        "line": 954,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48333,7 +48277,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -48342,7 +48286,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.wiring:resolve_comfy_host_helper",
         "kind": "static_from",
-        "line": 961,
+        "line": 959,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48356,7 +48300,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -48365,7 +48309,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_clip_loader_types",
         "kind": "static_from",
-        "line": 964,
+        "line": 962,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48379,7 +48323,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -48388,7 +48332,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_diffusion_model_names",
         "kind": "static_from",
-        "line": 964,
+        "line": 962,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48402,7 +48346,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -48411,7 +48355,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_text_encoder_names",
         "kind": "static_from",
-        "line": 964,
+        "line": 962,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48425,7 +48369,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -48434,7 +48378,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_vae_names",
         "kind": "static_from",
-        "line": 964,
+        "line": 962,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48448,7 +48392,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -48457,7 +48401,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_folder_path_names",
         "kind": "static_from",
-        "line": 964,
+        "line": 962,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48471,7 +48415,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -48480,7 +48424,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.image_nodes:EasyUseAnimaDetailerAlignHook",
         "kind": "static_from",
-        "line": 972,
+        "line": 970,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48494,7 +48438,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -48503,7 +48447,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.image_nodes:EasyUseAnimaImageScaleByMultiple",
         "kind": "static_from",
-        "line": 972,
+        "line": 970,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48517,7 +48461,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -48526,7 +48470,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Context",
         "kind": "static_from",
-        "line": 976,
+        "line": 974,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48540,7 +48484,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -48549,7 +48493,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Detailer",
         "kind": "static_from",
-        "line": 976,
+        "line": 974,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48563,7 +48507,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -48572,7 +48516,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptBuilder",
         "kind": "static_from",
-        "line": 980,
+        "line": 978,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48586,7 +48530,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -48595,7 +48539,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrector",
         "kind": "static_from",
-        "line": 980,
+        "line": 978,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48609,7 +48553,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -48618,7 +48562,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrectorSimple",
         "kind": "static_from",
-        "line": 980,
+        "line": 978,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48632,7 +48576,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -48641,7 +48585,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptStudio",
         "kind": "static_from",
-        "line": 980,
+        "line": 978,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48655,7 +48599,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -48664,7 +48608,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:EasyUseAnimaPromptStudioRegional",
         "kind": "static_from",
-        "line": 986,
+        "line": 984,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48678,7 +48622,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -48687,7 +48631,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:EasyUseAnimaRegionalConditioning",
         "kind": "static_from",
-        "line": 986,
+        "line": 984,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48701,7 +48645,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -48710,7 +48654,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:LATENT_ALIGN",
         "kind": "static_from",
-        "line": 990,
+        "line": 988,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48724,7 +48668,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -48733,7 +48677,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_parse_random_response",
         "kind": "static_from",
-        "line": 990,
+        "line": 988,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48747,7 +48691,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -48756,7 +48700,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_post_random",
         "kind": "static_from",
-        "line": 990,
+        "line": 988,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48770,7 +48714,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -48779,7 +48723,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_advanced_resolution_from_selection",
         "kind": "static_from",
-        "line": 1008,
+        "line": 1006,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48793,7 +48737,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -48802,7 +48746,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_normalize_resolution_bucket",
         "kind": "static_from",
-        "line": 1008,
+        "line": 1006,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48816,7 +48760,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -48825,7 +48769,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_ratio_label",
         "kind": "static_from",
-        "line": 1008,
+        "line": 1006,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48839,7 +48783,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -48848,7 +48792,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolution_label",
         "kind": "static_from",
-        "line": 1008,
+        "line": 1006,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48862,7 +48806,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -48871,7 +48815,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolve_naia_resolution",
         "kind": "static_from",
-        "line": 1008,
+        "line": 1006,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48885,7 +48829,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -48894,7 +48838,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.naia_nodes:EasyUseAnimaNAIARandomPrompt",
         "kind": "static_from",
-        "line": 1031,
+        "line": 1029,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48908,7 +48852,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -48917,7 +48861,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.naia_nodes:_bind_naia_node_runtime",
         "kind": "static_from",
-        "line": 1031,
+        "line": 1029,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48931,7 +48875,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -48940,7 +48884,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.wildcard_nodes:EasyUseAnimaWildcard",
         "kind": "static_from",
-        "line": 1035,
+        "line": 1033,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48954,7 +48898,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -48963,7 +48907,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.wildcard_nodes:_bind_wildcard_node_runtime",
         "kind": "static_from",
-        "line": 1035,
+        "line": 1033,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48977,7 +48921,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -48986,7 +48930,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_apply_lora_syntax_format",
         "kind": "static_from",
-        "line": 1040,
+        "line": 1038,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49000,7 +48944,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -49009,7 +48953,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_dedupe_text_values",
         "kind": "static_from",
-        "line": 1040,
+        "line": 1038,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49023,7 +48967,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -49032,7 +48976,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_fallback_lora_path",
         "kind": "static_from",
-        "line": 1040,
+        "line": 1038,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49046,7 +48990,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -49055,7 +48999,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_get_lora_info",
         "kind": "static_from",
-        "line": 1040,
+        "line": 1038,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49069,7 +49013,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -49078,7 +49022,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_get_lora_manager_trigger_words",
         "kind": "static_from",
-        "line": 1040,
+        "line": 1038,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49092,7 +49036,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -49101,7 +49045,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_load_lora_manager_metadata",
         "kind": "static_from",
-        "line": 1040,
+        "line": 1038,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49115,7 +49059,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -49124,7 +49068,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_combo_values",
         "kind": "static_from",
-        "line": 1040,
+        "line": 1038,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49138,7 +49082,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -49147,7 +49091,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_manager_trigger_words_from_metadata",
         "kind": "static_from",
-        "line": 1040,
+        "line": 1038,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49161,7 +49105,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -49170,7 +49114,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_model_exists",
         "kind": "static_from",
-        "line": 1040,
+        "line": 1038,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49184,7 +49128,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -49193,7 +49137,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_stack_name",
         "kind": "static_from",
-        "line": 1040,
+        "line": 1038,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49207,7 +49151,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -49216,7 +49160,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_metadata_json_paths_for_lora",
         "kind": "static_from",
-        "line": 1040,
+        "line": 1038,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49230,7 +49174,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -49239,7 +49183,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_missing_lora_display_name",
         "kind": "static_from",
-        "line": 1040,
+        "line": 1038,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49253,7 +49197,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -49262,7 +49206,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_raise_missing_loras",
         "kind": "static_from",
-        "line": 1040,
+        "line": 1038,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49276,7 +49220,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -49285,7 +49229,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_trigger_words_from_value",
         "kind": "static_from",
-        "line": 1040,
+        "line": 1038,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49299,7 +49243,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -49308,7 +49252,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_correct_style_prompt",
         "kind": "static_from",
-        "line": 1056,
+        "line": 1054,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49322,7 +49266,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -49331,7 +49275,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_format_strength",
         "kind": "static_from",
-        "line": 1056,
+        "line": 1054,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49345,7 +49289,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -49354,7 +49298,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_get_loras_list",
         "kind": "static_from",
-        "line": 1056,
+        "line": 1054,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49368,7 +49312,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -49377,7 +49321,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_load_profile_data",
         "kind": "static_from",
-        "line": 1056,
+        "line": 1054,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49391,7 +49335,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -49400,7 +49344,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_profile_key",
         "kind": "static_from",
-        "line": 1056,
+        "line": 1054,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49414,7 +49358,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -49423,7 +49367,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_select_profile_values",
         "kind": "static_from",
-        "line": 1056,
+        "line": 1054,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49437,7 +49381,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -49446,7 +49390,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_wrap_profile_index",
         "kind": "static_from",
-        "line": 1056,
+        "line": 1054,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49460,7 +49404,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -49469,7 +49413,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.lora_nodes:EasyUseAnimaLoraPreset",
         "kind": "static_from",
-        "line": 1065,
+        "line": 1063,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49483,7 +49427,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -49492,7 +49436,7 @@
         "conditional": true,
         "imported": "anima_prompt:correct_prompt",
         "kind": "static_from",
-        "line": 1068,
+        "line": 1066,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49506,7 +49450,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -49515,7 +49459,7 @@
         "conditional": true,
         "imported": "anima_prompt:load_knowledge_base",
         "kind": "static_from",
-        "line": 1068,
+        "line": 1066,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49529,7 +49473,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -49538,7 +49482,7 @@
         "conditional": true,
         "imported": "anima_prompt.parser:parse_prompt",
         "kind": "static_from",
-        "line": 1069,
+        "line": 1067,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49552,7 +49496,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -49561,7 +49505,7 @@
         "conditional": true,
         "imported": "settings:resolve_metadata_filter_words",
         "kind": "static_from",
-        "line": 1070,
+        "line": 1068,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49575,7 +49519,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -49584,7 +49528,7 @@
         "conditional": true,
         "imported": "settings:resolve_naia_settings",
         "kind": "static_from",
-        "line": 1070,
+        "line": 1068,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49598,7 +49542,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -49607,7 +49551,7 @@
         "conditional": true,
         "imported": "settings:resolve_prompt_translation_settings",
         "kind": "static_from",
-        "line": 1070,
+        "line": 1068,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49621,7 +49565,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -49630,7 +49574,7 @@
         "conditional": true,
         "imported": "prompt_translation:has_prompt_translation_markers",
         "kind": "static_from",
-        "line": 1075,
+        "line": 1073,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49644,7 +49588,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -49653,7 +49597,7 @@
         "conditional": true,
         "imported": "prompt_translation:translate_prompt_markers",
         "kind": "static_from",
-        "line": 1075,
+        "line": 1073,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49667,7 +49611,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -49676,7 +49620,7 @@
         "conditional": true,
         "imported": "wildcard_engine:MAX_SEED",
         "kind": "static_from",
-        "line": 1076,
+        "line": 1074,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49690,7 +49634,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -49699,7 +49643,7 @@
         "conditional": true,
         "imported": "wildcard_engine:PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "kind": "static_from",
-        "line": 1076,
+        "line": 1074,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49713,7 +49657,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -49722,7 +49666,7 @@
         "conditional": true,
         "imported": "wildcard_engine:PUBLIC_MAX_SEED",
         "kind": "static_from",
-        "line": 1076,
+        "line": 1074,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49736,7 +49680,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -49745,7 +49689,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_DECREMENT",
         "kind": "static_from",
-        "line": 1076,
+        "line": 1074,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49759,7 +49703,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -49768,7 +49712,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_FIXED",
         "kind": "static_from",
-        "line": 1076,
+        "line": 1074,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49782,7 +49726,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -49791,7 +49735,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_INCREMENT",
         "kind": "static_from",
-        "line": 1076,
+        "line": 1074,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49805,7 +49749,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -49814,7 +49758,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_MODES",
         "kind": "static_from",
-        "line": 1076,
+        "line": 1074,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49828,7 +49772,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -49837,7 +49781,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_RANDOMIZE",
         "kind": "static_from",
-        "line": 1076,
+        "line": 1074,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49851,7 +49795,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -49860,7 +49804,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_FIXED",
         "kind": "static_from",
-        "line": 1076,
+        "line": 1074,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49874,7 +49818,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -49883,7 +49827,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_POPULATE",
         "kind": "static_from",
-        "line": 1076,
+        "line": 1074,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49897,7 +49841,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -49906,7 +49850,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_SEQUENTIAL",
         "kind": "static_from",
-        "line": 1076,
+        "line": 1074,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49920,7 +49864,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -49929,7 +49873,7 @@
         "conditional": true,
         "imported": "wildcard_engine:expand_wildcard_texts",
         "kind": "static_from",
-        "line": 1076,
+        "line": 1074,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49943,7 +49887,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -49952,7 +49896,7 @@
         "conditional": true,
         "imported": "wildcard_engine:expand_wildcards",
         "kind": "static_from",
-        "line": 1076,
+        "line": 1074,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49966,7 +49910,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -49975,7 +49919,7 @@
         "conditional": true,
         "imported": "wildcard_engine:has_wildcard_syntax",
         "kind": "static_from",
-        "line": 1076,
+        "line": 1074,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49989,7 +49933,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -49998,7 +49942,7 @@
         "conditional": true,
         "imported": "wildcard_engine:next_seed",
         "kind": "static_from",
-        "line": 1076,
+        "line": 1074,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50012,7 +49956,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -50021,7 +49965,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_prompt_studio_wildcard_mode",
         "kind": "static_from",
-        "line": 1076,
+        "line": 1074,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50035,7 +49979,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -50044,7 +49988,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_seed",
         "kind": "static_from",
-        "line": 1076,
+        "line": 1074,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50058,7 +50002,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -50067,7 +50011,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_wildcard_mode",
         "kind": "static_from",
-        "line": 1076,
+        "line": 1074,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50081,7 +50025,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 553,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -50090,7 +50034,7 @@
         "conditional": true,
         "imported": "wildcard_engine:wildcard_sources_signature",
         "kind": "static_from",
-        "line": 1076,
+        "line": 1074,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51148,31 +51092,9 @@
         "branch_context": [],
         "classification": "external",
         "conditional": false,
-        "imported": "collections.abc:Callable",
-        "kind": "static_from",
-        "line": 5,
-        "optional": false,
-        "role": "ordinary",
-        "source": "easyuse_anima/aio/first_pass_cache.py"
-      },
-      {
-        "branch_context": [],
-        "classification": "external",
-        "conditional": false,
         "imported": "typing:Any",
         "kind": "static_from",
-        "line": 6,
-        "optional": false,
-        "role": "ordinary",
-        "source": "easyuse_anima/aio/first_pass_cache.py"
-      },
-      {
-        "branch_context": [],
-        "classification": "external",
-        "conditional": false,
-        "imported": "typing:TypeAlias",
-        "kind": "static_from",
-        "line": 6,
+        "line": 5,
         "optional": false,
         "role": "ordinary",
         "source": "easyuse_anima/aio/first_pass_cache.py"
@@ -56820,16 +56742,7 @@
         "column": 9,
         "context": "assign:logger",
         "kind": "import_time_call",
-        "line": 1098,
-        "module": "nodes.py",
-        "scope": "<module>"
-      },
-      {
-        "callee": "_bind_aio_first_pass_cache_runtime",
-        "column": 0,
-        "context": "expression",
-        "kind": "import_time_call",
-        "line": 1590,
+        "line": 1096,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -56838,7 +56751,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1593,
+        "line": 1588,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -56847,7 +56760,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1599,
+        "line": 1594,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -56856,7 +56769,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1605,
+        "line": 1600,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -56865,7 +56778,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1608,
+        "line": 1603,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -56874,7 +56787,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1611,
+        "line": 1606,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -56883,7 +56796,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1617,
+        "line": 1612,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -56892,7 +56805,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1623,
+        "line": 1618,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -56901,7 +56814,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1629,
+        "line": 1624,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -56910,7 +56823,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1635,
+        "line": 1630,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -56919,7 +56832,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1641,
+        "line": 1636,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -56928,7 +56841,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1647,
+        "line": 1642,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -56937,7 +56850,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1650,
+        "line": 1645,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -56946,7 +56859,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1657,
+        "line": 1652,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -57286,13 +57199,13 @@
       },
       {
         "kind": "dict",
-        "line": 9,
+        "line": 12,
         "module": "easyuse_anima/aio/first_pass_cache.py",
         "name": "_AIO_FIRST_PASS_CACHE"
       },
       {
         "kind": "list",
-        "line": 10,
+        "line": 13,
         "module": "easyuse_anima/aio/first_pass_cache.py",
         "name": "_AIO_FIRST_PASS_CACHE_ORDER"
       },
@@ -57460,13 +57373,13 @@
       },
       {
         "kind": "dict",
-        "line": 1158,
+        "line": 1156,
         "module": "nodes.py",
         "name": "AIO_GENERATION_DEFAULT_SETTINGS"
       },
       {
         "kind": "dict",
-        "line": 1147,
+        "line": 1145,
         "module": "nodes.py",
         "name": "AIO_INPUT_DEFAULT_SETTINGS"
       },
@@ -57659,7 +57572,7 @@
           "mutable_container"
         ],
         "initializer": "Dict",
-        "line": 9,
+        "line": 12,
         "module": "easyuse_anima/aio/first_pass_cache.py",
         "name": "_AIO_FIRST_PASS_CACHE"
       },
@@ -57669,7 +57582,7 @@
           "mutable_container"
         ],
         "initializer": "List",
-        "line": 10,
+        "line": 13,
         "module": "easyuse_anima/aio/first_pass_cache.py",
         "name": "_AIO_FIRST_PASS_CACHE_ORDER"
       },

--- a/tests/fixtures/python_compatibility_surface.v1.json
+++ b/tests/fixtures/python_compatibility_surface.v1.json
@@ -73,7 +73,8 @@
       "B-11c30c2",
       "B-11c30c2a",
       "B-11c30c2b",
-      "B-11c30d"
+      "B-11c30d",
+      "B-11c30d1"
     ]
   },
   "enums": {
@@ -108,14 +109,14 @@
   "expected_counts": {
     "root_entrypoints": 3,
     "excluded_preamble_implementation_bindings": 5,
-    "nodes_canonical_bindings": 282,
+    "nodes_canonical_bindings": 281,
     "nodes_legacy_bindings": 27,
     "mapped_public_classes": 18,
     "unmapped_classes": 2,
     "root_residual_functions": 0,
     "root_residual_classes": 0,
     "root_residual_globals": 24,
-    "runtime_binders": 14,
+    "runtime_binders": 13,
     "direct_nodes_import_test_files": 21
   },
   "mapped_public_classes": [
@@ -150,7 +151,6 @@
     "sqrt": "math:sqrt"
   },
   "runtime_binders": [
-    "_bind_aio_first_pass_cache_runtime",
     "_bind_aio_legacy_generation_runtime",
     "_bind_aio_generation_normalization_runtime",
     "_bind_aio_usdu_planning_runtime",
@@ -171,9 +171,6 @@
     ],
     "AIO_FINAL_UPSCALE_BACKENDS": [
       "easyuse_anima.aio.generation_normalization"
-    ],
-    "AIO_FIRST_PASS_CACHE_MAX_ENTRIES": [
-      "easyuse_anima.aio.first_pass_cache"
     ],
     "AIO_GENERATION_DEFAULT_SETTINGS": [
       "easyuse_anima.aio.generation_normalization",
@@ -343,12 +340,6 @@
     "_AIO_DETAILER_RESERVED_KEYS": [
       "easyuse_anima.aio.generation_normalization"
     ],
-    "_AIO_FIRST_PASS_CACHE": [
-      "easyuse_anima.aio.first_pass_cache"
-    ],
-    "_AIO_FIRST_PASS_CACHE_ORDER": [
-      "easyuse_anima.aio.first_pass_cache"
-    ],
     "_adapter_comfy_clip_loader_types": [
       "easyuse_anima.aio.resources"
     ],
@@ -405,7 +396,6 @@
       "easyuse_anima.aio.output"
     ],
     "_aio_lora_stack_signature": [
-      "easyuse_anima.aio.first_pass_cache",
       "easyuse_anima.nodes.aio_nodes"
     ],
     "_aio_preview_base_directory": [
@@ -518,9 +508,6 @@
     ],
     "_cleanup_aio_ephemeral_model": [
       "easyuse_anima.aio.legacy_generation"
-    ],
-    "_clone_aio_cache_value": [
-      "easyuse_anima.aio.first_pass_cache"
     ],
     "_comfy_clip_loader_types": [
       "easyuse_anima.nodes.aio_nodes"
@@ -684,7 +671,6 @@
       "easyuse_anima.nodes.aio_nodes"
     ],
     "_prompt_data_json_safe": [
-      "easyuse_anima.aio.first_pass_cache",
       "easyuse_anima.aio.generation_normalization",
       "easyuse_anima.aio.legacy_generation",
       "easyuse_anima.aio.preview",
@@ -772,7 +758,6 @@
       "easyuse_anima.aio.preview"
     ],
     "_stable_change_key": [
-      "easyuse_anima.aio.first_pass_cache",
       "easyuse_anima.nodes.aio_nodes"
     ],
     "_tag_aio_preview_images": [
@@ -789,26 +774,25 @@
   },
   "runtime_binder_audit": {
     "summary": {
-      "binder_count": 14,
+      "binder_count": 13,
       "family_count": 2,
       "mode_counts": {
         "comfy_provider_then_root": 8,
-        "root_globals": 4,
+        "root_globals": 3,
         "explicit_callbacks": 2
       },
-      "unique_resolver_names": 192,
-      "unique_root_resolver_names": 187,
+      "unique_resolver_names": 188,
+      "unique_root_resolver_names": 183,
       "unique_provider_resolver_names": 5,
       "unique_direct_root_dependencies": 9,
       "direct_root_dependency_slots": 17,
       "provider_consumer_slots": 13,
       "provider_consumer_modules": 8,
-      "repository_replacement_names": 138,
-      "repository_replacement_files": 16
+      "repository_replacement_names": 134,
+      "repository_replacement_files": 15
     },
     "families": {
       "aio": [
-        "_bind_aio_first_pass_cache_runtime",
         "_bind_aio_legacy_generation_runtime",
         "_bind_aio_generation_normalization_runtime",
         "_bind_aio_usdu_planning_runtime",
@@ -835,34 +819,10 @@
         "B-11c30d5_legacy_orchestration",
         "B-11c30d6_node_adapter"
       ],
+      "retired_subgroups": [
+        "B-11c30d1_cache_state"
+      ],
       "subgroups": {
-        "B-11c30d1_cache_state": {
-          "binders": [
-            "_bind_aio_first_pass_cache_runtime"
-          ],
-          "mode_counts": {
-            "comfy_provider_then_root": 0,
-            "root_globals": 1
-          },
-          "bound_global_slots": 1,
-          "unique_bound_globals": [
-            "_RUNTIME_RESOLVER"
-          ],
-          "root_resolver_slots": 7,
-          "unique_root_resolver_names": 7,
-          "provider_resolver_slots": 0,
-          "unique_provider_resolver_names": 0,
-          "direct_root_dependency_slots": 0,
-          "unique_direct_root_dependencies": 0,
-          "repository_replacement_slots": 7,
-          "unique_repository_replacement_names": 7,
-          "repository_replacement_files": [
-            "tests/test_aio_first_pass_cache.py",
-            "tests/test_aio_legacy_generation.py",
-            "tests/test_aio_nodes.py",
-            "tests/test_aio_preview.py"
-          ]
-        },
         "B-11c30d2_normalization_planning": {
           "binders": [
             "_bind_aio_generation_normalization_runtime",
@@ -886,7 +846,6 @@
           "repository_replacement_slots": 37,
           "unique_repository_replacement_names": 31,
           "repository_replacement_files": [
-            "tests/test_aio_first_pass_cache.py",
             "tests/test_aio_generation_migrations.py",
             "tests/test_aio_generation_settings.py",
             "tests/test_aio_legacy_generation.py",
@@ -921,7 +880,6 @@
           "repository_replacement_slots": 47,
           "unique_repository_replacement_names": 44,
           "repository_replacement_files": [
-            "tests/test_aio_first_pass_cache.py",
             "tests/test_aio_generation_settings.py",
             "tests/test_aio_legacy_generation.py",
             "tests/test_aio_nodes.py",
@@ -988,7 +946,6 @@
           "repository_replacement_slots": 48,
           "unique_repository_replacement_names": 48,
           "repository_replacement_files": [
-            "tests/test_aio_first_pass_cache.py",
             "tests/test_aio_legacy_generation.py",
             "tests/test_aio_nodes.py",
             "tests/test_aio_output.py",
@@ -1019,7 +976,6 @@
           "repository_replacement_slots": 30,
           "unique_repository_replacement_names": 30,
           "repository_replacement_files": [
-            "tests/test_aio_first_pass_cache.py",
             "tests/test_aio_legacy_generation.py",
             "tests/test_aio_nodes.py",
             "tests/test_aio_output.py",
@@ -1083,7 +1039,6 @@
     "root_resolver_names": [
       "AIO_FINAL_FIT_MODES",
       "AIO_FINAL_UPSCALE_BACKENDS",
-      "AIO_FIRST_PASS_CACHE_MAX_ENTRIES",
       "AIO_GENERATION_DEFAULT_SETTINGS",
       "AIO_GENERATION_SETTINGS_SCHEMA",
       "AIO_GENERATION_SETTINGS_VERSION",
@@ -1135,8 +1090,6 @@
       "SEED_CONTROL_MODES",
       "_AIO_DETAILER_CUSTOM_RE",
       "_AIO_DETAILER_RESERVED_KEYS",
-      "_AIO_FIRST_PASS_CACHE",
-      "_AIO_FIRST_PASS_CACHE_ORDER",
       "_adapter_comfy_clip_loader_types",
       "_adapter_comfy_diffusion_model_names",
       "_adapter_comfy_text_encoder_names",
@@ -1186,7 +1139,6 @@
       "_call_with_supported_kwargs",
       "_choice",
       "_cleanup_aio_ephemeral_model",
-      "_clone_aio_cache_value",
       "_comfy_clip_loader_types",
       "_comfy_diffusion_model_names",
       "_comfy_sampler_names",
@@ -1277,9 +1229,6 @@
       "_require_custom_node_class"
     ],
     "repository_root_replacements": {
-      "AIO_FIRST_PASS_CACHE_MAX_ENTRIES": [
-        "tests/test_aio_first_pass_cache.py"
-      ],
       "AIO_GENERATION_DEFAULT_SETTINGS": [
         "tests/test_aio_output.py",
         "tests/test_node_contracts.py"
@@ -1348,12 +1297,6 @@
       "_AIO_DETAILER_RESERVED_KEYS": [
         "tests/test_node_contracts.py"
       ],
-      "_AIO_FIRST_PASS_CACHE": [
-        "tests/test_aio_first_pass_cache.py"
-      ],
-      "_AIO_FIRST_PASS_CACHE_ORDER": [
-        "tests/test_aio_first_pass_cache.py"
-      ],
       "_adapter_comfy_clip_loader_types": [
         "tests/test_node_contracts.py"
       ],
@@ -1401,7 +1344,6 @@
         "tests/test_aio_output.py"
       ],
       "_aio_lora_stack_signature": [
-        "tests/test_aio_first_pass_cache.py",
         "tests/test_aio_nodes.py"
       ],
       "_aio_preview_base_directory": [
@@ -1487,9 +1429,6 @@
       "_cleanup_aio_ephemeral_model": [
         "tests/test_aio_legacy_generation.py",
         "tests/test_aio_nodes.py"
-      ],
-      "_clone_aio_cache_value": [
-        "tests/test_aio_first_pass_cache.py"
       ],
       "_comfy_clip_loader_types": [
         "tests/test_aio_nodes.py",
@@ -1645,7 +1584,6 @@
         "tests/test_aio_nodes.py"
       ],
       "_prompt_data_json_safe": [
-        "tests/test_aio_first_pass_cache.py",
         "tests/test_aio_legacy_generation.py",
         "tests/test_aio_nodes.py",
         "tests/test_aio_preview.py"
@@ -1727,7 +1665,6 @@
         "tests/test_aio_preview.py"
       ],
       "_stable_change_key": [
-        "tests/test_aio_first_pass_cache.py",
         "tests/test_aio_nodes.py"
       ],
       "_tag_aio_preview_images": [
@@ -1762,48 +1699,6 @@
       ]
     },
     "entries": [
-      {
-        "binder": "_bind_aio_first_pass_cache_runtime",
-        "module": "easyuse_anima.aio.first_pass_cache",
-        "family": "aio",
-        "mode": "root_globals",
-        "root_observation": "call_time_resolver",
-        "root_keywords": [
-          "resolve_helper"
-        ],
-        "bound_globals": [
-          "_RUNTIME_RESOLVER"
-        ],
-        "direct_root_dependencies": [],
-        "resolver_names": [
-          "AIO_FIRST_PASS_CACHE_MAX_ENTRIES",
-          "_AIO_FIRST_PASS_CACHE",
-          "_AIO_FIRST_PASS_CACHE_ORDER",
-          "_aio_lora_stack_signature",
-          "_clone_aio_cache_value",
-          "_prompt_data_json_safe",
-          "_stable_change_key"
-        ],
-        "root_resolver_names": [
-          "AIO_FIRST_PASS_CACHE_MAX_ENTRIES",
-          "_AIO_FIRST_PASS_CACHE",
-          "_AIO_FIRST_PASS_CACHE_ORDER",
-          "_aio_lora_stack_signature",
-          "_clone_aio_cache_value",
-          "_prompt_data_json_safe",
-          "_stable_change_key"
-        ],
-        "provider_resolver_names": [],
-        "repository_replacement_names": [
-          "AIO_FIRST_PASS_CACHE_MAX_ENTRIES",
-          "_AIO_FIRST_PASS_CACHE",
-          "_AIO_FIRST_PASS_CACHE_ORDER",
-          "_aio_lora_stack_signature",
-          "_clone_aio_cache_value",
-          "_prompt_data_json_safe",
-          "_stable_change_key"
-        ]
-      },
       {
         "binder": "_bind_aio_legacy_generation_runtime",
         "module": "easyuse_anima.aio.legacy_generation",
@@ -3640,12 +3535,7 @@
       "id": "nodes_canonical_bindings:easyuse_anima.aio.first_pass_cache:transitional_private_seam",
       "surface": "nodes_canonical_bindings",
       "symbols": {
-        "AIO_FIRST_PASS_CACHE_MAX_ENTRIES": "AIO_FIRST_PASS_CACHE_MAX_ENTRIES",
-        "_AIO_FIRST_PASS_CACHE": "_AIO_FIRST_PASS_CACHE",
-        "_AIO_FIRST_PASS_CACHE_ORDER": "_AIO_FIRST_PASS_CACHE_ORDER",
         "_aio_first_pass_cache_key": "_aio_first_pass_cache_key",
-        "_bind_aio_first_pass_cache_runtime": "_bind_aio_first_pass_cache_runtime",
-        "_clone_aio_cache_value": "_clone_aio_cache_value",
         "_get_aio_first_pass_cache": "_get_aio_first_pass_cache",
         "_put_aio_first_pass_cache": "_put_aio_first_pass_cache"
       },
@@ -3659,13 +3549,9 @@
       "owner": "#184/#188",
       "first_release": null,
       "known_consumers": [
-        "nodes.py residual runtime",
-        "canonical runtime resolver: easyuse_anima.aio.first_pass_cache",
         "canonical runtime resolver: easyuse_anima.aio.legacy_generation"
       ],
       "evidence": [
-        "AST:nodes.py direct runtime load",
-        "AST:easyuse_anima.aio.first_pass_cache string runtime lookup",
         "AST:easyuse_anima.aio.legacy_generation string runtime lookup"
       ],
       "removal_gates": [
@@ -3674,6 +3560,38 @@
         "separate B-10b or B-11 rollback unit"
       ],
       "lifecycle_state": "transitional"
+    },
+    {
+      "id": "nodes_canonical_bindings:easyuse_anima.aio.first_pass_cache:unsupported_test_only",
+      "surface": "nodes_canonical_bindings",
+      "symbols": {
+        "AIO_FIRST_PASS_CACHE_MAX_ENTRIES": "AIO_FIRST_PASS_CACHE_MAX_ENTRIES",
+        "_AIO_FIRST_PASS_CACHE": "_AIO_FIRST_PASS_CACHE",
+        "_AIO_FIRST_PASS_CACHE_ORDER": "_AIO_FIRST_PASS_CACHE_ORDER",
+        "_clone_aio_cache_value": "_clone_aio_cache_value"
+      },
+      "classification": "unsupported_test_only",
+      "current_target": "nodes.py",
+      "canonical_target": "easyuse_anima.aio.first_pass_cache",
+      "target_state": "canonical",
+      "identity_requirement": "not_applicable",
+      "binding_shape": "direct_import",
+      "import_target": "easyuse_anima.aio.first_pass_cache",
+      "owner": "#184/#188",
+      "first_release": null,
+      "known_consumers": [
+        "repository tests may import this root name"
+      ],
+      "evidence": [
+        "AST:no nodes.py runtime load",
+        "test-only consumption is not public support evidence"
+      ],
+      "removal_gates": [
+        "test imports migrate to canonical targets",
+        "no production consumer evidence",
+        "separate B-10b removal review"
+      ],
+      "lifecycle_state": "unsupported"
     },
     {
       "id": "nodes_canonical_bindings:easyuse_anima.aio.generation_normalization:transitional_private_seam",
@@ -3852,14 +3770,12 @@
       "first_release": null,
       "known_consumers": [
         "nodes.py residual runtime",
-        "canonical runtime resolver: easyuse_anima.aio.first_pass_cache",
         "canonical runtime resolver: easyuse_anima.aio.legacy_generation",
         "canonical runtime resolver: easyuse_anima.aio.model_preparation",
         "canonical runtime resolver: easyuse_anima.nodes.aio_nodes"
       ],
       "evidence": [
         "AST:nodes.py direct runtime load",
-        "AST:easyuse_anima.aio.first_pass_cache string runtime lookup",
         "AST:easyuse_anima.aio.legacy_generation string runtime lookup",
         "AST:easyuse_anima.aio.model_preparation string runtime lookup",
         "AST:easyuse_anima.nodes.aio_nodes string runtime lookup"
@@ -4167,13 +4083,11 @@
       "owner": "#184/#188",
       "first_release": null,
       "known_consumers": [
-        "canonical runtime resolver: easyuse_anima.aio.first_pass_cache",
         "canonical runtime resolver: easyuse_anima.aio.generation_normalization",
         "canonical runtime resolver: easyuse_anima.aio.sampling",
         "canonical runtime resolver: easyuse_anima.nodes.aio_nodes"
       ],
       "evidence": [
-        "AST:easyuse_anima.aio.first_pass_cache string runtime lookup",
         "AST:easyuse_anima.aio.generation_normalization string runtime lookup",
         "AST:easyuse_anima.aio.sampling string runtime lookup",
         "AST:easyuse_anima.nodes.aio_nodes string runtime lookup"
@@ -5369,7 +5283,6 @@
       "first_release": null,
       "known_consumers": [
         "canonical runtime resolver: easyuse_anima.aio.conditioning",
-        "canonical runtime resolver: easyuse_anima.aio.first_pass_cache",
         "canonical runtime resolver: easyuse_anima.aio.generation_normalization",
         "canonical runtime resolver: easyuse_anima.aio.legacy_generation",
         "canonical runtime resolver: easyuse_anima.aio.preview",
@@ -5377,7 +5290,6 @@
       ],
       "evidence": [
         "AST:easyuse_anima.aio.conditioning string runtime lookup",
-        "AST:easyuse_anima.aio.first_pass_cache string runtime lookup",
         "AST:easyuse_anima.aio.generation_normalization string runtime lookup",
         "AST:easyuse_anima.aio.legacy_generation string runtime lookup",
         "AST:easyuse_anima.aio.preview string runtime lookup",

--- a/tests/test_aio_first_pass_cache.py
+++ b/tests/test_aio_first_pass_cache.py
@@ -15,6 +15,9 @@ class AIOFirstPassCacheMoveTests(unittest.TestCase):
         first_pass_cache._clear_aio_first_pass_cache()
 
     def test_root_state_and_functions_are_direct_canonical_aliases(self):
+        self.assertFalse(
+            hasattr(first_pass_cache, "_bind_aio_first_pass_cache_runtime")
+        )
         for name in (
             "AIO_FIRST_PASS_CACHE_MAX_ENTRIES",
             "_AIO_FIRST_PASS_CACHE",
@@ -68,10 +71,11 @@ class AIOFirstPassCacheMoveTests(unittest.TestCase):
             [("tensor", "detach"), ("tensor", "clone"), ("tensor-clone", "cpu")],
         )
 
-    def test_recursive_clone_re_resolves_root_helper_for_nested_items(self):
+    def test_recursive_clone_re_resolves_canonical_helper_for_nested_items(self):
         replacement = Mock(side_effect=lambda value: f"cloned:{value}")
-        with patch.object(nodes, "_clone_aio_cache_value", replacement):
-            result = first_pass_cache._clone_aio_cache_value({"a": 1, "b": 2})
+        clone_value = first_pass_cache._clone_aio_cache_value
+        with patch.object(first_pass_cache, "_clone_aio_cache_value", replacement):
+            result = clone_value({"a": 1, "b": 2})
 
         self.assertEqual(result, {"a": "cloned:1", "b": "cloned:2"})
         self.assertEqual([call.args for call in replacement.call_args_list], [(1,), (2,)])
@@ -99,9 +103,17 @@ class AIOFirstPassCacheMoveTests(unittest.TestCase):
             "save": {"excluded": True},
         }
         with (
-            patch.object(nodes, "_stable_change_key", side_effect=stable_change_key),
-            patch.object(nodes, "_prompt_data_json_safe", json_safe),
-            patch.object(nodes, "_aio_lora_stack_signature", lora_signature),
+            patch.object(
+                first_pass_cache,
+                "_stable_change_key",
+                side_effect=stable_change_key,
+            ),
+            patch.object(first_pass_cache, "_prompt_data_json_safe", json_safe),
+            patch.object(
+                first_pass_cache,
+                "_aio_lora_stack_signature",
+                lora_signature,
+            ),
         ):
             result = first_pass_cache._aio_first_pass_cache_key(
                 cache_scope=0,
@@ -156,8 +168,8 @@ class AIOFirstPassCacheMoveTests(unittest.TestCase):
         cache = {"empty": {}}
         order = ["empty"]
         with (
-            patch.object(nodes, "_AIO_FIRST_PASS_CACHE", cache),
-            patch.object(nodes, "_AIO_FIRST_PASS_CACHE_ORDER", order),
+            patch.object(first_pass_cache, "_AIO_FIRST_PASS_CACHE", cache),
+            patch.object(first_pass_cache, "_AIO_FIRST_PASS_CACHE_ORDER", order),
         ):
             self.assertIsNone(first_pass_cache._get_aio_first_pass_cache("empty"))
             self.assertEqual(order, ["empty"])
@@ -201,9 +213,9 @@ class AIOFirstPassCacheMoveTests(unittest.TestCase):
         cache = {}
         order = []
         with (
-            patch.object(nodes, "_AIO_FIRST_PASS_CACHE", cache),
-            patch.object(nodes, "_AIO_FIRST_PASS_CACHE_ORDER", order),
-            patch.object(nodes, "AIO_FIRST_PASS_CACHE_MAX_ENTRIES", 1),
+            patch.object(first_pass_cache, "_AIO_FIRST_PASS_CACHE", cache),
+            patch.object(first_pass_cache, "_AIO_FIRST_PASS_CACHE_ORDER", order),
+            patch.object(first_pass_cache, "AIO_FIRST_PASS_CACHE_MAX_ENTRIES", 1),
         ):
             first_pass_cache._put_aio_first_pass_cache("a", "latent-a", "image-a")
             first_pass_cache._put_aio_first_pass_cache("b", "latent-b", "image-b")

--- a/tests/test_nodes_module_analyzer.py
+++ b/tests/test_nodes_module_analyzer.py
@@ -73,12 +73,12 @@ def load_dynamic():
     def test_current_nodes_module_shape_matches_recorded_baseline(self):
         report = analyzer.analyze_path(ROOT / "nodes.py")
 
-        self.assertEqual(report["git_blob_sha1"], "4821f36548243853249a7a24458a37469985c676")
-        # B-11c30c2b retires the Advanced and Regional adapter binder imports
-        # and calls without changing the public class surface.
+        self.assertEqual(report["git_blob_sha1"], "edcdc8681f64790736a790177ac80dadfda214b6")
+        # B-11c30d1 retires only the AiO cache-state binder import and call
+        # without changing the public class surface.
         self.assertEqual(report["top_level"]["function_count"], 0)
         self.assertEqual(report["top_level"]["class_count"], 0)
-        self.assertEqual(report["line_count"], 1_662)
+        self.assertEqual(report["line_count"], 1_657)
         class_names = {item["name"] for item in report["top_level"]["classes"]}
         self.assertNotIn("EasyUseAnimaAIOGenerator", class_names)
         self.assertNotIn("EasyUseAnimaInput", class_names)

--- a/tests/test_python_compatibility_surface.py
+++ b/tests/test_python_compatibility_surface.py
@@ -99,7 +99,6 @@ PROMPT_NODE_ADAPTER_RETIRED_RUNTIME_BINDERS = (
 )
 RUNTIME_BINDER_FAMILIES = {
     "aio": (
-        "_bind_aio_first_pass_cache_runtime",
         "_bind_aio_legacy_generation_runtime",
         "_bind_aio_generation_normalization_runtime",
         "_bind_aio_usdu_planning_runtime",
@@ -143,6 +142,9 @@ AIO_RUNTIME_BINDER_SUBGROUPS = {
         "_bind_aio_node_runtime",
     ),
 }
+AIO_RUNTIME_RETIRED_SUBGROUPS = (
+    "B-11c30d1_cache_state",
+)
 AIO_RUNTIME_PREREQUISITE_MOVES = (
     {
         "id": "B-11c30d0a_output_settings_owner",
@@ -1721,9 +1723,14 @@ def _aio_runtime_split_gate(
         for entry in entries
         if entry["family"] == "aio"
     }
+    active_subgroups = {
+        subgroup: binders
+        for subgroup, binders in AIO_RUNTIME_BINDER_SUBGROUPS.items()
+        if subgroup not in AIO_RUNTIME_RETIRED_SUBGROUPS
+    }
     classified_binders = [
         binder
-        for binders in AIO_RUNTIME_BINDER_SUBGROUPS.values()
+        for binders in active_subgroups.values()
         for binder in binders
     ]
     if len(classified_binders) != len(set(classified_binders)):
@@ -1732,7 +1739,7 @@ def _aio_runtime_split_gate(
         raise AssertionError("AiO runtime binder subgroup classification is incomplete")
 
     subgroups = {}
-    for subgroup, binders in AIO_RUNTIME_BINDER_SUBGROUPS.items():
+    for subgroup, binders in active_subgroups.items():
         selected = [entry_by_binder[binder] for binder in binders]
         root_names = [
             name
@@ -1802,6 +1809,7 @@ def _aio_runtime_split_gate(
         })
     return {
         "subgroup_order": list(AIO_RUNTIME_BINDER_SUBGROUPS),
+        "retired_subgroups": list(AIO_RUNTIME_RETIRED_SUBGROUPS),
         "subgroups": subgroups,
         "prerequisite_moves": prerequisite_moves,
     }
@@ -2308,6 +2316,7 @@ def _build_document() -> dict[str, Any]:
                 "B-11c30c2a",
                 "B-11c30c2b",
                 "B-11c30d",
+                "B-11c30d1",
             ],
         },
         "enums": {
@@ -2320,14 +2329,14 @@ def _build_document() -> dict[str, Any]:
         "expected_counts": {
             "root_entrypoints": 3,
             "excluded_preamble_implementation_bindings": 5,
-            "nodes_canonical_bindings": 282,
+            "nodes_canonical_bindings": 281,
             "nodes_legacy_bindings": 27,
             "mapped_public_classes": 18,
             "unmapped_classes": 2,
             "root_residual_functions": 0,
             "root_residual_classes": 0,
             "root_residual_globals": 24,
-            "runtime_binders": 14,
+            "runtime_binders": 13,
             "direct_nodes_import_test_files": 21,
         },
         "mapped_public_classes": sorted(mapped_classes),
@@ -2559,7 +2568,7 @@ class PythonCompatibilitySurfaceTests(unittest.TestCase):
             len(self.document["direct_nodes_import_test_files"]),
             counts["direct_nodes_import_test_files"],
         )
-        self.assertEqual(len(set(self.document["runtime_binders"])), 14)
+        self.assertEqual(len(set(self.document["runtime_binders"])), 13)
         self.assertEqual(len(set(self.document["direct_nodes_import_test_files"])), 21)
 
     def test_runtime_binder_audit_covers_provider_and_root_names(self):
@@ -2567,22 +2576,22 @@ class PythonCompatibilitySurfaceTests(unittest.TestCase):
         self.assertEqual(
             audit["summary"],
             {
-                "binder_count": 14,
+                "binder_count": 13,
                 "family_count": 2,
                 "mode_counts": {
                     "comfy_provider_then_root": 8,
-                    "root_globals": 4,
+                    "root_globals": 3,
                     "explicit_callbacks": 2,
                 },
-                "unique_resolver_names": 192,
-                "unique_root_resolver_names": 187,
+                "unique_resolver_names": 188,
+                "unique_root_resolver_names": 183,
                 "unique_provider_resolver_names": 5,
                 "unique_direct_root_dependencies": 9,
                 "direct_root_dependency_slots": 17,
                 "provider_consumer_slots": 13,
                 "provider_consumer_modules": 8,
-                "repository_replacement_names": 138,
-                "repository_replacement_files": 16,
+                "repository_replacement_names": 134,
+                "repository_replacement_files": 15,
             },
         )
         self.assertEqual(
@@ -2656,6 +2665,10 @@ class PythonCompatibilitySurfaceTests(unittest.TestCase):
             list(AIO_RUNTIME_BINDER_SUBGROUPS),
         )
         self.assertEqual(
+            gate["retired_subgroups"],
+            list(AIO_RUNTIME_RETIRED_SUBGROUPS),
+        )
+        self.assertEqual(
             {
                 binder
                 for subgroup in gate["subgroups"].values()
@@ -2682,14 +2695,6 @@ class PythonCompatibilitySurfaceTests(unittest.TestCase):
         self.assertEqual(
             summaries,
             {
-                "B-11c30d1_cache_state": {
-                    "root_resolver_slots": 7,
-                    "unique_root_resolver_names": 7,
-                    "provider_resolver_slots": 0,
-                    "direct_root_dependency_slots": 0,
-                    "repository_replacement_slots": 7,
-                    "unique_repository_replacement_names": 7,
-                },
                 "B-11c30d2_normalization_planning": {
                     "root_resolver_slots": 72,
                     "unique_root_resolver_names": 66,
@@ -2806,6 +2811,9 @@ class PythonCompatibilitySurfaceTests(unittest.TestCase):
             "_bind_prompt_advanced_node_runtime": (
                 "easyuse_anima.nodes.prompt_advanced_nodes"
             ),
+            "_bind_aio_first_pass_cache_runtime": (
+                "easyuse_anima.aio.first_pass_cache"
+            ),
         }
         for binder, module in retired_modules.items():
             functions = {
@@ -2815,11 +2823,42 @@ class PythonCompatibilitySurfaceTests(unittest.TestCase):
             }
             with self.subTest(module=module, binder=binder):
                 self.assertNotIn(binder, functions)
+
+    def test_aio_cache_runtime_resolver_is_retired(self):
+        tree = _read_tree(_module_path("easyuse_anima.aio.first_pass_cache"))
+        top_level_names = {
+            target.id
+            for node in tree.body
+            if isinstance(node, (ast.Assign, ast.AnnAssign))
+            for target in (
+                node.targets
+                if isinstance(node, ast.Assign)
+                else [node.target]
+            )
+            if isinstance(target, ast.Name)
+        }
+        functions = {
+            node.name
+            for node in tree.body
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+        }
+        self.assertNotIn("_RUNTIME_RESOLVER", top_level_names)
+        self.assertNotIn("_runtime_helper", functions)
+        self.assertNotIn("_bind_aio_first_pass_cache_runtime", functions)
+        self.assertTrue(
+            {
+                "AIO_FIRST_PASS_CACHE_MAX_ENTRIES",
+                "_AIO_FIRST_PASS_CACHE",
+                "_AIO_FIRST_PASS_CACHE_ORDER",
+                "_clone_aio_cache_value",
+            }.isdisjoint(self.document["runtime_resolver_consumers"])
+        )
+
     def test_string_runtime_resolvers_keep_production_seams_transitional(self):
         representative = {
             "_run_aio_legacy_generation",
-            "_AIO_FIRST_PASS_CACHE",
-            "_AIO_FIRST_PASS_CACHE_ORDER",
+            "_aio_first_pass_cache_key",
+            "_get_aio_first_pass_cache",
             "_load_aio_resources_from_input_context",
             "_sample_latent_with_aio_backend",
             "_aio_generation_settings_json",


### PR DESCRIPTION
## 목적

B-11c30d1은 frozen AiO split gate의 첫 READY rollback unit입니다. first-pass cache의 단일 runtime binder만 제거하는 Move이며, #169 cache Behavior는 시작하지 않습니다.

기준선: `dev@7b25483c23fc3f430bf108fcb3ef23b6a64cd7e3`

## 작업 전 symbol/caller/alias/global-state inventory

- root `nodes.py`는 package/flat-import 양쪽에서 `_bind_aio_first_pass_cache_runtime`을 import하고 한 번 호출합니다.
- binder는 canonical module의 `_RUNTIME_RESOLVER` 한 슬롯을 설치합니다.
- resolver가 관찰하는 7개 이름:
  - module-owned: `AIO_FIRST_PASS_CACHE_MAX_ENTRIES`, `_AIO_FIRST_PASS_CACHE`, `_AIO_FIRST_PASS_CACHE_ORDER`, `_clone_aio_cache_value`
  - canonical cross-module: `_stable_change_key`, `_prompt_data_json_safe`, `_aio_lora_stack_signature`
- cross-module canonical owner:
  - `easyuse_anima.common.serialization`
  - `easyuse_anima.prompt.data`
  - `easyuse_anima.aio.model_preparation`
- root는 limit/state/clone/key/get/put의 direct canonical alias identity를 유지합니다.
- `_clear_aio_first_pass_cache` root alias는 B-10b7에서 이미 retirement되었으며 다시 추가하지 않습니다.
- 7개 replacement name은 네 test file에서 관찰되지만 cache owner를 root patch로 구동하는 파일은 `tests/test_aio_first_pass_cache.py` 하나입니다. 다른 세 파일의 replacement는 아직 활성인 binder family 소유입니다.
- mutable cache dict/order/limit, key field order, clone, falsey miss, LRU refresh, overwrite, oldest-first eviction은 #169 Behavior 경계입니다.

## 구현 결과

- root의 cache binder import 2개와 호출 1개를 제거했습니다.
- canonical cache module에서 binder, `_RUNTIME_RESOLVER`, `_runtime_helper`를 제거했습니다.
- module-owned limit/dict/order/recursive clone을 직접 사용합니다.
- stable key, Prompt Data JSON-safe, LoRA signature는 기존 canonical owner에서 직접 import합니다.
- root cache aliases의 exact identity는 유지됩니다.
- cache-specific test patch는 canonical owner로 이동했습니다. 다른 활성 binder family의 root replacement는 변경하지 않았습니다.
- incremental split gate는 d1만 retired로 표시하고 d2-d6을 정확한 active set으로 유지합니다.
- import graph상 cache module은 비순환 SCC이며 새 cycle이 없습니다.
- audit: 13 binders (provider-then-root 8, root-only 3, explicit callbacks 2), `nodes.py` 1,657 lines.

## 변경 파일

Production:

- `nodes.py`
- `easyuse_anima/aio/first_pass_cache.py`

Supporting:

- `tests/test_aio_first_pass_cache.py`
- `tests/test_python_compatibility_surface.py`
- `tests/fixtures/python_compatibility_surface.v1.json`
- `tests/test_nodes_module_analyzer.py`
- `tests/fixtures/python_backend_baseline.json`
- `docs/architecture/comfy-host-provider-bridge.md`
- `docs/architecture/python-backend-execution-roadmap.md`
- `docs/architecture/python-compatibility-shims.md`

## 금지 경계 확인

- cache key schema/version/order/value 변경 없음
- clone/copy, hit/miss, LRU, overwrite, eviction limit/order 변경 없음
- cache scope, stage metadata, 성능 정책 변경 없음
- root cache alias retirement 없음
- legacy-generation binder/caller 변경 없음
- d0a, d2-d6, Wildcard/NAIA, Contract, Behavior 결합 없음

## 검증

Focused:

- cache: 7 tests 통과
- compatibility surface: 16 tests 통과
- nodes analyzer: 4 tests 통과
- backend analyzer: 18 tests 통과

공식 full:

- Python unittest: 983 tests 통과 (29.489초)
- frontend: 114 JavaScript files 통과
- Pyright baseline: 72 files / 기존 14 errors / 신규 0
- import boundary: 6 groups / 0 violations
- Ruff: 기존 report-only 79 findings, 차단 없음
- `git diff --check`: 통과
- 전체 runner: 49.8초, 300초 제한 내 정상 종료

ComfyUI 표면: backend contract/package/static 검증. Live ComfyUI/browser smoke는 pure backend binder Move이므로 미실행.

## 남은 위험 및 후속

- d0a output-settings owner Move가 다음 READY 작업입니다.
- d0a 이후 d2-d4를 각각 별도 Move로 진행해야 합니다.
- cache 정책/성능 변경은 #169 Behavior로 계속 분리합니다.