### PR TITLE
B-11c30d0a: AiO output-settings owner Move

### DIFF
--- a/docs/architecture/comfy-host-provider-bridge.md
+++ b/docs/architecture/comfy-host-provider-bridge.md
@@ -1657,7 +1657,7 @@ Implementation result:
 
 ### B-11c30d0a — AiO output-settings owner Move
 
-- **State:** IN REVIEW
+- **State:** COMPLETE in PR #348
 - **Owner:** #184
 - **Behavior boundary:** #169
 - **Type:** Move
@@ -1722,6 +1722,23 @@ Forbidden:
 - retiring the generation-normalization or output binder; and
 - combining d2 through d6, d0b, Wildcard/NAIA, Contract, or Behavior work.
 
+Implementation result:
+
+- `easyuse_anima.aio.output_settings` is the sole definition owner for both
+  normalizers and directly imports canonical `_as_bool`;
+- `generation_normalization` imports both functions directly and no longer
+  resolves either name through its runtime binder;
+- `output` re-exports the exact owner objects while its save-time d3 binder
+  calls remain unchanged;
+- root imports both aliases directly from `output_settings` in package and
+  flat-import modes, preserving exact object identity;
+- the d2 gate drops two root-resolver slots and names plus one replacement slot
+  and name, while all 13 remaining binders and d3 through d6 stay active;
+- backend inventory grows from 89 to 90 shipped and reachable Python modules,
+  with no missing internal imports; and
+- one timeboxed focused process passes 82 output, generation, compatibility,
+  nodes-analyzer, and backend-analyzer tests in 10.495 seconds.
+
 ### B-11d — Final root shim
 
 - **State:** BLOCKED by the remaining AiO and Wildcard/NAIA binder families
@@ -1769,7 +1786,7 @@ COMPLETE: B-11c30c2a Prompt Data / Classic Prompt adapter Move / PR #342
 COMPLETE: B-11c30c2b Advanced / Regional adapter Move / PR #345
 COMPLETE: B-11c30d AiO binder split gate / PR #346
 COMPLETE: B-11c30d1 AiO cache-state binder Move / PR #347
-READY:    B-11c30d0a output-settings owner Move before d2-d4
+COMPLETE: B-11c30d0a output-settings owner Move / PR #348
 PLANNED:  B-11c30d2-d4 normalization, I/O, and execution-service Moves
 PLANNED:  B-11c30d0b input-context owner Move before d5-d6
 PLANNED:  B-11c30d5-d6 orchestration and node-adapter Moves

--- a/docs/architecture/comfy-host-provider-bridge.md
+++ b/docs/architecture/comfy-host-provider-bridge.md
@@ -1655,6 +1655,73 @@ Implementation result:
 - focused cache, compatibility, nodes-analyzer, and backend-analyzer validation
   passes 45 tests.
 
+### B-11c30d0a — AiO output-settings owner Move
+
+- **State:** IN REVIEW
+- **Owner:** #184
+- **Behavior boundary:** #169
+- **Type:** Move
+- **Base:** `dev@66825e966ba5715e59c9f0cacf539fc8ad19e694`
+
+Pre-edit inventory:
+
+- `_normalize_aio_hash_bundles` and
+  `_normalize_aio_civitai_hash_fetchers` are defined in
+  `easyuse_anima.aio.output`; neither owns mutable module or process state;
+- `easyuse_anima.aio.generation_normalization` resolves both names through its
+  root runtime binder before normalizing the image-saver settings, while
+  `easyuse_anima.aio.output` resolves both names through its own binder for
+  save-time metadata assembly;
+- root `nodes.py` imports both names from `easyuse_anima.aio.output` in package
+  and flat-import modes and exposes exact identity aliases;
+- `_normalize_aio_hash_bundles` depends only on JSON decoding and scalar/list
+  filtering. `_normalize_aio_civitai_hash_fetchers` additionally resolves root
+  `_as_bool` at call time; that root name is already an exact alias of the
+  stateless canonical `easyuse_anima.common.values._as_bool`;
+- direct function coverage is in `tests/test_aio_output.py`; normalized
+  image-saver settings are covered by `tests/test_aio_generation_settings.py`,
+  `tests/test_aio_nodes.py`, and `tests/test_aio_schema_contract.py`; and
+- the only test-only replacement seam owned by these functions patches root
+  `_as_bool`. It moves to the canonical owner seam when the runtime lookup is
+  replaced by a direct import. Save-time output helper replacements remain on
+  the still-active d3 binder and are not changed here.
+
+Allowed production files:
+
+```text
+nodes.py
+easyuse_anima/aio/output.py
+easyuse_anima/aio/output_settings.py
+easyuse_anima/aio/generation_normalization.py
+```
+
+Allowed supporting files are the focused output/generation tests, the Python
+compatibility gate and fixture, the nodes/backend analyzer gate and fixture,
+and the three architecture documents.
+
+Exit:
+
+- the two normalizers have one pure canonical owner in
+  `easyuse_anima.aio.output_settings`;
+- generation normalization imports them directly without creating the
+  generation-normalization → output → sampling → generation-normalization
+  cycle;
+- output may re-export the exact owner objects for local compatibility while
+  its d3 runtime binder remains active;
+- root aliases retain exact canonical object identity in both import modes;
+- normalization results, JSON fallback, filtering, field trimming, default
+  boolean conversion, schemas, save behavior, and error text are unchanged;
+  and
+- d2 through d4 are unblocked without retiring any binder in this Move.
+
+Forbidden:
+
+- changing the accepted settings shape, normalization output, save metadata,
+  dependency/provider behavior, errors, schemas, workflows, seeds, cache, or
+  stage order;
+- retiring the generation-normalization or output binder; and
+- combining d2 through d6, d0b, Wildcard/NAIA, Contract, or Behavior work.
+
 ### B-11d — Final root shim
 
 - **State:** BLOCKED by the remaining AiO and Wildcard/NAIA binder families

--- a/docs/architecture/python-backend-execution-roadmap.md
+++ b/docs/architecture/python-backend-execution-roadmap.md
@@ -31,7 +31,7 @@ merged PR, the owning issue's evidence record, and every stated exit gate.
 | Phase | Integrated snapshot / open implementation state | Remaining exit work |
 | --- | --- | --- |
 | A - baseline | Complete; #191 is closed | Keep fixtures and analyzers current during later moves |
-| B - `nodes.py` extraction | Integrated through B-11c30d / PR #346; B-11c30d1 completes in PR #347 | Execute d0a then the remaining frozen AiO Moves, followed by Wildcard/NAIA and the final root shim as separate rollback units |
+| B - `nodes.py` extraction | Integrated through B-11c30d1 / PR #347; B-11c30d0a completes in PR #348 | Execute d2-d4, then d0b and d5-d6, followed by Wildcard/NAIA and the final root shim as separate rollback units |
 | C - feature contracts/behavior | Partially complete through S167-01a / PR #344 | Continue #167 and #169 in separate Contract/Move/Behavior PRs |
 | D - root consolidation | Not started | Execute #186 feature by feature after the corresponding behavior contracts are stable |
 | E - runtime ownership | Partial: E-02a and E-07a/E-07b integrated | Continue #187 only where canonical feature owners and explicit contracts exist |
@@ -127,7 +127,11 @@ merged PR, the owning issue's evidence record, and every stated exit gate.
   existing serialization, Prompt Data, and LoRA-signature owners. The split
   gate marks d1 retired while keeping d2 through d6 active. Thirteen binders
   remain across AiO and Wildcard/NAIA; cache key, clone, hit/miss, LRU, limit,
-  and eviction behavior are unchanged.
+  and eviction behavior are unchanged. B-11c30d0a / PR #348 then moves only
+  the two output-settings normalizers to the pure
+  `easyuse_anima.aio.output_settings` owner. Generation normalization imports
+  them directly, root aliases retain identity, and the d2-d4 import cycle is
+  removed without retiring another binder or changing settings/save behavior.
 
 ### Current quality baseline
 
@@ -371,7 +375,7 @@ mechanical retirement series.
 | 11 | B-09b2 AiO generator adapter move | COMPLETE on `dev` | Move | #184 | PR #270 / `57d40b4` |
 | 12 | B-10a machine-readable compatibility audit | COMPLETE on `dev` | Contract/gate | #184/#188 | PR #271 / `3c7b857` |
 | 13 | B-10b private alias reduction | COMPLETE on `dev` through PR #291 / `c6b4680` | Contract/cleanup, split PRs | #184/#188 | Audited alias surface integrated |
-| 14 | B-11 registration/bootstrap/root shim | IN PROGRESS through B-11c30d1 PR #347; d0a is READY before d2-d4, and d0b precedes d5-d6 | Move/Contract, split PRs | #184 | Frozen AiO split gate; S167-01 contract |
+| 14 | B-11 registration/bootstrap/root shim | IN PROGRESS through B-11c30d0a PR #348; d2-d4 are next, and d0b precedes d5-d6 | Move/Contract, split PRs | #184 | Frozen AiO split gate; S167-01 contract |
 | 15 | S167 backend seed reservation series | S167-01 Contract COMPLETE in PR #343 and S167-01a consumer Move COMPLETE in PR #344; Behavior and Adapter remain | Contract then Move then Behavior | #167 | Canonical AiO/node seams |
 | 16 | A169 stage pipeline series | BLOCKED by #168 and B exit | Contract then Behavior | #169 | Typed config and mechanical AiO move |
 | 17 | A169 first-pass cache policy | BLOCKED by stage/cache ownership seam | Behavior | #169 | Mechanical cache move and benchmark harness |
@@ -1068,6 +1072,11 @@ unchanged. The separate legacy Wildcard unsupported alias remains for D-12.
     imports the three existing canonical helpers. Root cache aliases and all
     cache semantics remain unchanged. Thirteen AiO and Wildcard/NAIA binders
     remain.
+  - B-11c30d0a moves only `_normalize_aio_hash_bundles` and
+    `_normalize_aio_civitai_hash_fetchers` to
+    `easyuse_anima.aio.output_settings` in PR #348. Generation normalization
+    uses the pure owner directly, output re-exports the same objects, and root
+    aliases retain identity. No binder or settings/save behavior changes.
   - The final B-11c cutover removes remaining root execution ownership and
     leaves the explicit supported `nodes.py` compatibility shim.
 - Add `easyuse_anima/registration.py` as pure mapping composition. It performs no

--- a/docs/architecture/python-compatibility-shims.md
+++ b/docs/architecture/python-compatibility-shims.md
@@ -8,11 +8,12 @@
 - Policy: [ADR-002](adr-002-compatibility-shims.md)
 - Machine-readable audit:
   [`python_compatibility_surface.v1.json`](../../tests/fixtures/python_compatibility_surface.v1.json)
-- Current state: B-11a through B-11c30d / PR #346 are integrated in the
-  reviewed sequence, and B-11c30d1 / PR #347 retires only the AiO cache-state
-  binder. S167-01a / PR #344 supplies the canonical reserved-seed compatibility
-  consumer while retaining its root aliases. Thirteen AiO and Wildcard/NAIA
-  binders remain before the final root shim.
+- Current state: B-11a through B-11c30d1 / PR #347 are integrated in the
+  reviewed sequence, and B-11c30d0a / PR #348 moves only the two AiO
+  output-settings normalizers to their pure owner. S167-01a / PR #344 supplies
+  the canonical reserved-seed compatibility consumer while retaining its root
+  aliases. Thirteen AiO and Wildcard/NAIA binders remain before the final root
+  shim.
 
 This is an actionable registry, not a removal schedule. `N` means the first
 published Registry release containing both a canonical target and its root
@@ -881,6 +882,25 @@ convenience-node compatibility; it remains unmapped and is not public support.
 - Cache object identity, key schema/order, clone behavior, falsey miss, hit
   refresh, overwrite, limit 2, oldest-first eviction, stage metadata, and #169
   Behavior remain unchanged.
+
+### B-11c30d0a AiO output-settings owner Move
+
+- `_normalize_aio_hash_bundles` and
+  `_normalize_aio_civitai_hash_fetchers` have one definition owner in
+  `easyuse_anima.aio.output_settings`.
+- `easyuse_anima.aio.generation_normalization` imports both normalizers
+  directly, removing their two root runtime-resolver edges without retiring
+  the generation-normalization binder.
+- `easyuse_anima.aio.output` re-exports the same two objects and retains its
+  existing d3 save-time runtime calls. Root `nodes.py` imports the canonical
+  owner in both package and flat modes, so both root aliases preserve exact
+  identity.
+- The new owner directly imports stateless
+  `easyuse_anima.common.values._as_bool`; the previous test-only root patch seam
+  moves to the canonical owner.
+- Accepted settings, JSON fallback, row filtering and trimming, default boolean
+  conversion, schema/workflow, save metadata, provider/error behavior, seed,
+  cache, and stage order remain unchanged.
 
 ### `nodes.py` public node-class surface
 

--- a/easyuse_anima/aio/generation_normalization.py
+++ b/easyuse_anima/aio/generation_normalization.py
@@ -4,6 +4,11 @@ import re
 from collections.abc import Callable
 from typing import Any, TypeAlias
 
+from .output_settings import (
+    _normalize_aio_civitai_hash_fetchers,
+    _normalize_aio_hash_bundles,
+)
+
 _RuntimeResolver: TypeAlias = Callable[[str], Any]
 _RUNTIME_RESOLVER: _RuntimeResolver | None = None
 
@@ -415,9 +420,7 @@ def _normalize_aio_generation_settings(value) -> dict[str, Any]:
     _comfy_scheduler_names = _runtime_helper("_comfy_scheduler_names")
     _impact_scheduler_names = _runtime_helper("_impact_scheduler_names")
     _json_clone = _runtime_helper("_json_clone")
-    _normalize_aio_civitai_hash_fetchers = _runtime_helper("_normalize_aio_civitai_hash_fetchers")
     _normalize_aio_dit_corrections_settings = _runtime_helper("_normalize_aio_dit_corrections_settings")
-    _normalize_aio_hash_bundles = _runtime_helper("_normalize_aio_hash_bundles")
     _normalize_aio_seed = _runtime_helper("_normalize_aio_seed")
     _normalize_aio_spectrum_settings = _runtime_helper("_normalize_aio_spectrum_settings")
     _normalize_anima_mod_guidance_profile = _runtime_helper("_normalize_anima_mod_guidance_profile")

--- a/easyuse_anima/aio/output.py
+++ b/easyuse_anima/aio/output.py
@@ -2,10 +2,14 @@
 
 from __future__ import annotations
 
-import json
 import os
 from collections.abc import Callable
 from typing import Any, TypeAlias
+
+from .output_settings import (
+    _normalize_aio_civitai_hash_fetchers,
+    _normalize_aio_hash_bundles,
+)
 
 _RuntimeResolver: TypeAlias = Callable[[str], Any]
 _RUNTIME_RESOLVER: _RuntimeResolver | None = None
@@ -25,48 +29,6 @@ def _runtime_helper(name: str) -> Any:
             f"[EasyUseAnima] AiO output runtime helper is not bound: {name}"
         )
     return resolver(name)
-
-
-def _normalize_aio_hash_bundles(value) -> list[str]:
-    if isinstance(value, str):
-        try:
-            value = json.loads(value or "[]")
-        except json.JSONDecodeError:
-            value = [value]
-    if not isinstance(value, list):
-        return []
-    bundles: list[str] = []
-    for item in value:
-        text = str(item or "").strip(" ,\n\r\t")
-        if text:
-            bundles.append(text)
-    return bundles
-
-
-def _normalize_aio_civitai_hash_fetchers(value) -> list[dict[str, Any]]:
-    if isinstance(value, str):
-        try:
-            value = json.loads(value or "[]")
-        except json.JSONDecodeError:
-            value = []
-    if not isinstance(value, list):
-        return []
-    fetchers: list[dict[str, Any]] = []
-    for item in value:
-        if not isinstance(item, dict):
-            continue
-        username = str(item.get("username") or "").strip()
-        model_name = str(item.get("model_name") or "").strip()
-        version = str(item.get("version") or "").strip()
-        if not any((username, model_name, version)):
-            continue
-        fetchers.append({
-            "enabled": _runtime_helper("_as_bool")(item.get("enabled"), True),
-            "username": username,
-            "model_name": model_name,
-            "version": version,
-        })
-    return fetchers
 
 
 def _aio_image_saver_civitai_hash_fetcher_entries(

--- a/easyuse_anima/aio/output.py
+++ b/easyuse_anima/aio/output.py
@@ -7,8 +7,10 @@ from collections.abc import Callable
 from typing import Any, TypeAlias
 
 from .output_settings import (
-    _normalize_aio_civitai_hash_fetchers,
-    _normalize_aio_hash_bundles,
+    _normalize_aio_civitai_hash_fetchers as _normalize_aio_civitai_hash_fetchers,
+)
+from .output_settings import (
+    _normalize_aio_hash_bundles as _normalize_aio_hash_bundles,
 )
 
 _RuntimeResolver: TypeAlias = Callable[[str], Any]

--- a/easyuse_anima/aio/output_settings.py
+++ b/easyuse_anima/aio/output_settings.py
@@ -1,0 +1,53 @@
+"""Pure normalization helpers for AiO output settings."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from ..common.values import _as_bool
+
+
+def _normalize_aio_hash_bundles(value) -> list[str]:
+    if isinstance(value, str):
+        try:
+            value = json.loads(value or "[]")
+        except json.JSONDecodeError:
+            value = [value]
+    if not isinstance(value, list):
+        return []
+    bundles: list[str] = []
+    for item in value:
+        text = str(item or "").strip(" ,\n\r\t")
+        if text:
+            bundles.append(text)
+    return bundles
+
+
+def _normalize_aio_civitai_hash_fetchers(value) -> list[dict[str, Any]]:
+    if isinstance(value, str):
+        try:
+            value = json.loads(value or "[]")
+        except json.JSONDecodeError:
+            value = []
+    if not isinstance(value, list):
+        return []
+    fetchers: list[dict[str, Any]] = []
+    for item in value:
+        if not isinstance(item, dict):
+            continue
+        username = str(item.get("username") or "").strip()
+        model_name = str(item.get("model_name") or "").strip()
+        version = str(item.get("version") or "").strip()
+        if not any((username, model_name, version)):
+            continue
+        fetchers.append({
+            "enabled": _as_bool(item.get("enabled"), True),
+            "username": username,
+            "model_name": model_name,
+            "version": version,
+        })
+    return fetchers
+
+
+__all__ = ()

--- a/nodes.py
+++ b/nodes.py
@@ -114,10 +114,12 @@ try:
         _aio_prompt_with_lora_metadata as _aio_prompt_with_lora_metadata,
         _aio_save_filename_prefix as _aio_save_filename_prefix,
         _bind_aio_output_runtime as _bind_aio_output_runtime,
-        _normalize_aio_civitai_hash_fetchers as _normalize_aio_civitai_hash_fetchers,
-        _normalize_aio_hash_bundles as _normalize_aio_hash_bundles,
         _save_image_with_comfy as _save_image_with_comfy,
         _save_image_with_image_saver as _save_image_with_image_saver,
+    )
+    from .easyuse_anima.aio.output_settings import (
+        _normalize_aio_civitai_hash_fetchers as _normalize_aio_civitai_hash_fetchers,
+        _normalize_aio_hash_bundles as _normalize_aio_hash_bundles,
     )
     from .easyuse_anima.aio.resources import (
         _bind_aio_resource_runtime as _bind_aio_resource_runtime,
@@ -657,10 +659,12 @@ except ImportError:  # allows simple local import tests outside ComfyUI's packag
         _aio_prompt_with_lora_metadata as _aio_prompt_with_lora_metadata,
         _aio_save_filename_prefix as _aio_save_filename_prefix,
         _bind_aio_output_runtime as _bind_aio_output_runtime,
-        _normalize_aio_civitai_hash_fetchers as _normalize_aio_civitai_hash_fetchers,
-        _normalize_aio_hash_bundles as _normalize_aio_hash_bundles,
         _save_image_with_comfy as _save_image_with_comfy,
         _save_image_with_image_saver as _save_image_with_image_saver,
+    )
+    from easyuse_anima.aio.output_settings import (
+        _normalize_aio_civitai_hash_fetchers as _normalize_aio_civitai_hash_fetchers,
+        _normalize_aio_hash_bundles as _normalize_aio_hash_bundles,
     )
     from easyuse_anima.aio.resources import (
         _bind_aio_resource_runtime as _bind_aio_resource_runtime,

--- a/tests/fixtures/python_backend_baseline.json
+++ b/tests/fixtures/python_backend_baseline.json
@@ -6471,7 +6471,7 @@
         "source": "easyuse_anima/aio/output.py"
       },
       {
-        "alias": null,
+        "alias": "_normalize_aio_civitai_hash_fetchers",
         "bound_name": "_normalize_aio_civitai_hash_fetchers",
         "branch_context": [],
         "classification": "internal",
@@ -6489,7 +6489,7 @@
         "target": "easyuse_anima/aio/output_settings.py"
       },
       {
-        "alias": null,
+        "alias": "_normalize_aio_hash_bundles",
         "bound_name": "_normalize_aio_hash_bundles",
         "branch_context": [],
         "classification": "internal",
@@ -6497,7 +6497,7 @@
         "conditional": false,
         "imported": ".output_settings:_normalize_aio_hash_bundles",
         "kind": "static_from",
-        "line": 9,
+        "line": 12,
         "name": "_normalize_aio_hash_bundles",
         "optional": false,
         "requested": ".output_settings",
@@ -6515,7 +6515,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 122
+            "line": 124
           }
         ],
         "classification": "external",
@@ -6523,7 +6523,7 @@
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 123,
+        "line": 125,
         "name": null,
         "optional": true,
         "requested": "folder_paths",
@@ -40864,9 +40864,9 @@
       },
       {
         "is_package": false,
-        "loc": 297,
+        "loc": 299,
         "module": "easyuse_anima.aio.output",
-        "normalized_git_blob_sha1": "dd3bcb47670166a280060fb7d4f534e8b80ef77c",
+        "normalized_git_blob_sha1": "390407579549d17f0e887c7bf9c5b4151215eea1",
         "path": "easyuse_anima/aio/output.py",
         "top_level": {
           "class_count": 0,
@@ -51767,14 +51767,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 122
+            "line": 124
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 123,
+        "line": 125,
         "optional": true,
         "role": "optional_dependency",
         "source": "easyuse_anima/aio/output.py"
@@ -54887,14 +54887,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 122
+            "line": 124
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 123,
+        "line": 125,
         "optional": true,
         "role": "optional_dependency",
         "source": "easyuse_anima/aio/output.py"

--- a/tests/fixtures/python_backend_baseline.json
+++ b/tests/fixtures/python_backend_baseline.json
@@ -5286,6 +5286,42 @@
       },
       {
         "alias": null,
+        "bound_name": "_normalize_aio_civitai_hash_fetchers",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".output_settings:_normalize_aio_civitai_hash_fetchers",
+        "kind": "static_from",
+        "line": 7,
+        "name": "_normalize_aio_civitai_hash_fetchers",
+        "optional": false,
+        "requested": ".output_settings",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/aio/generation_normalization.py",
+        "target": "easyuse_anima/aio/output_settings.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_normalize_aio_hash_bundles",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".output_settings:_normalize_aio_hash_bundles",
+        "kind": "static_from",
+        "line": 7,
+        "name": "_normalize_aio_hash_bundles",
+        "optional": false,
+        "requested": ".output_settings",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/aio/generation_normalization.py",
+        "target": "easyuse_anima/aio/output_settings.py"
+      },
+      {
+        "alias": null,
         "bound_name": "annotations",
         "branch_context": [],
         "classification": "external",
@@ -6368,23 +6404,6 @@
       },
       {
         "alias": null,
-        "bound_name": "json",
-        "branch_context": [],
-        "classification": "external",
-        "column": 0,
-        "conditional": false,
-        "imported": "json",
-        "kind": "static_import",
-        "line": 5,
-        "name": null,
-        "optional": false,
-        "requested": "json",
-        "role": "ordinary",
-        "scope": "<module>",
-        "source": "easyuse_anima/aio/output.py"
-      },
-      {
-        "alias": null,
         "bound_name": "os",
         "branch_context": [],
         "classification": "external",
@@ -6392,7 +6411,7 @@
         "conditional": false,
         "imported": "os",
         "kind": "static_import",
-        "line": 6,
+        "line": 5,
         "name": null,
         "optional": false,
         "requested": "os",
@@ -6409,7 +6428,7 @@
         "conditional": false,
         "imported": "collections.abc:Callable",
         "kind": "static_from",
-        "line": 7,
+        "line": 6,
         "name": "Callable",
         "optional": false,
         "requested": "collections.abc",
@@ -6426,7 +6445,7 @@
         "conditional": false,
         "imported": "typing:Any",
         "kind": "static_from",
-        "line": 8,
+        "line": 7,
         "name": "Any",
         "optional": false,
         "requested": "typing",
@@ -6443,13 +6462,49 @@
         "conditional": false,
         "imported": "typing:TypeAlias",
         "kind": "static_from",
-        "line": 8,
+        "line": 7,
         "name": "TypeAlias",
         "optional": false,
         "requested": "typing",
         "role": "ordinary",
         "scope": "<module>",
         "source": "easyuse_anima/aio/output.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_normalize_aio_civitai_hash_fetchers",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".output_settings:_normalize_aio_civitai_hash_fetchers",
+        "kind": "static_from",
+        "line": 9,
+        "name": "_normalize_aio_civitai_hash_fetchers",
+        "optional": false,
+        "requested": ".output_settings",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/aio/output.py",
+        "target": "easyuse_anima/aio/output_settings.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_normalize_aio_hash_bundles",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".output_settings:_normalize_aio_hash_bundles",
+        "kind": "static_from",
+        "line": 9,
+        "name": "_normalize_aio_hash_bundles",
+        "optional": false,
+        "requested": ".output_settings",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/aio/output.py",
+        "target": "easyuse_anima/aio/output_settings.py"
       },
       {
         "alias": null,
@@ -6460,7 +6515,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 160
+            "line": 122
           }
         ],
         "classification": "external",
@@ -6468,13 +6523,82 @@
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 161,
+        "line": 123,
         "name": null,
         "optional": true,
         "requested": "folder_paths",
         "role": "optional_dependency",
         "scope": "_aio_lora_metadata_name",
         "source": "easyuse_anima/aio/output.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "annotations",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "__future__:annotations",
+        "kind": "static_from",
+        "line": 3,
+        "name": "annotations",
+        "optional": false,
+        "requested": "__future__",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/aio/output_settings.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "json",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "json",
+        "kind": "static_import",
+        "line": 5,
+        "name": null,
+        "optional": false,
+        "requested": "json",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/aio/output_settings.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "Any",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "typing:Any",
+        "kind": "static_from",
+        "line": 6,
+        "name": "Any",
+        "optional": false,
+        "requested": "typing",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/aio/output_settings.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_as_bool",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": "..common.values:_as_bool",
+        "kind": "static_from",
+        "line": 8,
+        "name": "_as_bool",
+        "optional": false,
+        "requested": "..common.values",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/aio/output_settings.py",
+        "target": "easyuse_anima/common/values.py"
       },
       {
         "alias": null,
@@ -20083,68 +20207,6 @@
         "target": "easyuse_anima/aio/output.py"
       },
       {
-        "alias": "_normalize_aio_civitai_hash_fetchers",
-        "bound_name": "_normalize_aio_civitai_hash_fetchers",
-        "branch_context": [
-          {
-            "branch": "body",
-            "handles_import_failure": true,
-            "has_import_fallback_handler": true,
-            "kind": "try",
-            "line": 9
-          }
-        ],
-        "classification": "internal",
-        "column": 4,
-        "compatibility_pair": {
-          "bound_name": "_normalize_aio_civitai_hash_fetchers",
-          "target": "easyuse_anima/aio/output.py",
-          "try_line": 9
-        },
-        "conditional": true,
-        "imported": ".easyuse_anima.aio.output:_normalize_aio_civitai_hash_fetchers",
-        "kind": "static_from",
-        "line": 110,
-        "name": "_normalize_aio_civitai_hash_fetchers",
-        "optional": false,
-        "requested": ".easyuse_anima.aio.output",
-        "role": "compatibility_primary",
-        "scope": "<module>",
-        "source": "nodes.py",
-        "target": "easyuse_anima/aio/output.py"
-      },
-      {
-        "alias": "_normalize_aio_hash_bundles",
-        "bound_name": "_normalize_aio_hash_bundles",
-        "branch_context": [
-          {
-            "branch": "body",
-            "handles_import_failure": true,
-            "has_import_fallback_handler": true,
-            "kind": "try",
-            "line": 9
-          }
-        ],
-        "classification": "internal",
-        "column": 4,
-        "compatibility_pair": {
-          "bound_name": "_normalize_aio_hash_bundles",
-          "target": "easyuse_anima/aio/output.py",
-          "try_line": 9
-        },
-        "conditional": true,
-        "imported": ".easyuse_anima.aio.output:_normalize_aio_hash_bundles",
-        "kind": "static_from",
-        "line": 110,
-        "name": "_normalize_aio_hash_bundles",
-        "optional": false,
-        "requested": ".easyuse_anima.aio.output",
-        "role": "compatibility_primary",
-        "scope": "<module>",
-        "source": "nodes.py",
-        "target": "easyuse_anima/aio/output.py"
-      },
-      {
         "alias": "_save_image_with_comfy",
         "bound_name": "_save_image_with_comfy",
         "branch_context": [
@@ -20207,6 +20269,68 @@
         "target": "easyuse_anima/aio/output.py"
       },
       {
+        "alias": "_normalize_aio_civitai_hash_fetchers",
+        "bound_name": "_normalize_aio_civitai_hash_fetchers",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 9
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "_normalize_aio_civitai_hash_fetchers",
+          "target": "easyuse_anima/aio/output_settings.py",
+          "try_line": 9
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.aio.output_settings:_normalize_aio_civitai_hash_fetchers",
+        "kind": "static_from",
+        "line": 120,
+        "name": "_normalize_aio_civitai_hash_fetchers",
+        "optional": false,
+        "requested": ".easyuse_anima.aio.output_settings",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/aio/output_settings.py"
+      },
+      {
+        "alias": "_normalize_aio_hash_bundles",
+        "bound_name": "_normalize_aio_hash_bundles",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 9
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "_normalize_aio_hash_bundles",
+          "target": "easyuse_anima/aio/output_settings.py",
+          "try_line": 9
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.aio.output_settings:_normalize_aio_hash_bundles",
+        "kind": "static_from",
+        "line": 120,
+        "name": "_normalize_aio_hash_bundles",
+        "optional": false,
+        "requested": ".easyuse_anima.aio.output_settings",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/aio/output_settings.py"
+      },
+      {
         "alias": "_bind_aio_resource_runtime",
         "bound_name": "_bind_aio_resource_runtime",
         "branch_context": [
@@ -20228,7 +20352,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_bind_aio_resource_runtime",
         "kind": "static_from",
-        "line": 122,
+        "line": 124,
         "name": "_bind_aio_resource_runtime",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -20259,7 +20383,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_comfy_clip_loader_types",
         "kind": "static_from",
-        "line": 122,
+        "line": 124,
         "name": "_comfy_clip_loader_types",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -20290,7 +20414,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_comfy_diffusion_model_names",
         "kind": "static_from",
-        "line": 122,
+        "line": 124,
         "name": "_comfy_diffusion_model_names",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -20321,7 +20445,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_comfy_text_encoder_names",
         "kind": "static_from",
-        "line": 122,
+        "line": 124,
         "name": "_comfy_text_encoder_names",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -20352,7 +20476,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_comfy_vae_names",
         "kind": "static_from",
-        "line": 122,
+        "line": 124,
         "name": "_comfy_vae_names",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -20383,7 +20507,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_load_aio_resources_from_input_context",
         "kind": "static_from",
-        "line": 122,
+        "line": 124,
         "name": "_load_aio_resources_from_input_context",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -20414,7 +20538,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_load_aio_sam3_context",
         "kind": "static_from",
-        "line": 122,
+        "line": 124,
         "name": "_load_aio_sam3_context",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -20445,7 +20569,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_load_checkpoint_with_comfy",
         "kind": "static_from",
-        "line": 122,
+        "line": 124,
         "name": "_load_checkpoint_with_comfy",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -20476,7 +20600,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_load_clip_with_comfy",
         "kind": "static_from",
-        "line": 122,
+        "line": 124,
         "name": "_load_clip_with_comfy",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -20507,7 +20631,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_load_diffusion_model_with_comfy",
         "kind": "static_from",
-        "line": 122,
+        "line": 124,
         "name": "_load_diffusion_model_with_comfy",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -20538,7 +20662,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_load_upscale_model_with_comfy",
         "kind": "static_from",
-        "line": 122,
+        "line": 124,
         "name": "_load_upscale_model_with_comfy",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -20569,7 +20693,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_load_vae_with_comfy",
         "kind": "static_from",
-        "line": 122,
+        "line": 124,
         "name": "_load_vae_with_comfy",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -20600,7 +20724,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_normalize_aio_input_settings",
         "kind": "static_from",
-        "line": 122,
+        "line": 124,
         "name": "_normalize_aio_input_settings",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -20631,7 +20755,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_preferred_checkpoint_default",
         "kind": "static_from",
-        "line": 122,
+        "line": 124,
         "name": "_preferred_checkpoint_default",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -20662,7 +20786,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_preferred_clip_type_default",
         "kind": "static_from",
-        "line": 122,
+        "line": 124,
         "name": "_preferred_clip_type_default",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -20693,7 +20817,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_preferred_name_default",
         "kind": "static_from",
-        "line": 122,
+        "line": 124,
         "name": "_preferred_name_default",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -20724,7 +20848,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.common.serialization:_json_clone",
         "kind": "static_from",
-        "line": 140,
+        "line": 142,
         "name": "_json_clone",
         "optional": false,
         "requested": ".easyuse_anima.common.serialization",
@@ -20755,7 +20879,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.common.serialization:_json_object",
         "kind": "static_from",
-        "line": 140,
+        "line": 142,
         "name": "_json_object",
         "optional": false,
         "requested": ".easyuse_anima.common.serialization",
@@ -20786,7 +20910,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.common.serialization:_stable_change_key",
         "kind": "static_from",
-        "line": 140,
+        "line": 142,
         "name": "_stable_change_key",
         "optional": false,
         "requested": ".easyuse_anima.common.serialization",
@@ -20817,7 +20941,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.common.values:_as_bool",
         "kind": "static_from",
-        "line": 145,
+        "line": 147,
         "name": "_as_bool",
         "optional": false,
         "requested": ".easyuse_anima.common.values",
@@ -20848,7 +20972,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.common.values:_as_float",
         "kind": "static_from",
-        "line": 145,
+        "line": 147,
         "name": "_as_float",
         "optional": false,
         "requested": ".easyuse_anima.common.values",
@@ -20879,7 +21003,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.common.values:_as_int",
         "kind": "static_from",
-        "line": 145,
+        "line": 147,
         "name": "_as_int",
         "optional": false,
         "requested": ".easyuse_anima.common.values",
@@ -20910,7 +21034,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.common.values:_choice",
         "kind": "static_from",
-        "line": 145,
+        "line": 147,
         "name": "_choice",
         "optional": false,
         "requested": ".easyuse_anima.common.values",
@@ -20941,7 +21065,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.common.values:_single_value",
         "kind": "static_from",
-        "line": 145,
+        "line": 147,
         "name": "_single_value",
         "optional": false,
         "requested": ".easyuse_anima.common.values",
@@ -20972,7 +21096,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.seed.compatibility:WILDCARD_QUEUE_MAX_SAFE_SEED",
         "kind": "static_from",
-        "line": 152,
+        "line": 154,
         "name": "WILDCARD_QUEUE_MAX_SAFE_SEED",
         "optional": false,
         "requested": ".easyuse_anima.seed.compatibility",
@@ -21003,7 +21127,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.seed.compatibility:WILDCARD_RESERVED_NEXT_SEED_INPUT",
         "kind": "static_from",
-        "line": 152,
+        "line": 154,
         "name": "WILDCARD_RESERVED_NEXT_SEED_INPUT",
         "optional": false,
         "requested": ".easyuse_anima.seed.compatibility",
@@ -21034,7 +21158,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.seed.compatibility:_consume_reserved_wildcard_next_seed",
         "kind": "static_from",
-        "line": 152,
+        "line": 154,
         "name": "_consume_reserved_wildcard_next_seed",
         "optional": false,
         "requested": ".easyuse_anima.seed.compatibility",
@@ -21065,7 +21189,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.workflow:_get_workflow_node",
         "kind": "static_from",
-        "line": 157,
+        "line": 159,
         "name": "_get_workflow_node",
         "optional": false,
         "requested": ".easyuse_anima.workflow",
@@ -21096,7 +21220,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.correction:_prompt_translation_change_key",
         "kind": "static_from",
-        "line": 158,
+        "line": 160,
         "name": "_prompt_translation_change_key",
         "optional": false,
         "requested": ".easyuse_anima.prompt.correction",
@@ -21127,7 +21251,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.correction:_split_tag_text",
         "kind": "static_from",
-        "line": 158,
+        "line": 160,
         "name": "_split_tag_text",
         "optional": false,
         "requested": ".easyuse_anima.prompt.correction",
@@ -21158,7 +21282,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.correction:_translate_prompt_text",
         "kind": "static_from",
-        "line": 158,
+        "line": 160,
         "name": "_translate_prompt_text",
         "optional": false,
         "requested": ".easyuse_anima.prompt.correction",
@@ -21189,7 +21313,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_HASH_COMMENT_RE",
         "kind": "static_from",
-        "line": 163,
+        "line": 165,
         "name": "_HASH_COMMENT_RE",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -21220,7 +21344,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_INLINE_SPACE_RE",
         "kind": "static_from",
-        "line": 163,
+        "line": 165,
         "name": "_INLINE_SPACE_RE",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -21251,7 +21375,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_WEIGHTED_TOKEN_RE",
         "kind": "static_from",
-        "line": 163,
+        "line": 165,
         "name": "_WEIGHTED_TOKEN_RE",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -21282,7 +21406,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_correct_builder_prompt",
         "kind": "static_from",
-        "line": 163,
+        "line": 165,
         "name": "_correct_builder_prompt",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -21313,7 +21437,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_filter_metadata_prompt",
         "kind": "static_from",
-        "line": 163,
+        "line": 165,
         "name": "_filter_metadata_prompt",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -21344,7 +21468,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_join_prompt_tokens",
         "kind": "static_from",
-        "line": 163,
+        "line": 165,
         "name": "_join_prompt_tokens",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -21375,7 +21499,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_metadata_filter_key",
         "kind": "static_from",
-        "line": 163,
+        "line": 165,
         "name": "_metadata_filter_key",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -21406,7 +21530,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_metadata_filter_keys",
         "kind": "static_from",
-        "line": 163,
+        "line": 165,
         "name": "_metadata_filter_keys",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -21437,7 +21561,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_prompt_tokens",
         "kind": "static_from",
-        "line": 163,
+        "line": 165,
         "name": "_prompt_tokens",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -21468,7 +21592,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:PROMPT_DATA_TYPE",
         "kind": "static_from",
-        "line": 176,
+        "line": 178,
         "name": "PROMPT_DATA_TYPE",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -21499,7 +21623,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:_advanced_outputs_from_prompt_data",
         "kind": "static_from",
-        "line": 176,
+        "line": 178,
         "name": "_advanced_outputs_from_prompt_data",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -21530,7 +21654,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:_apply_prompt_data_overrides",
         "kind": "static_from",
-        "line": 176,
+        "line": 178,
         "name": "_apply_prompt_data_overrides",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -21561,7 +21685,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:_copy_prompt_data_for_update",
         "kind": "static_from",
-        "line": 176,
+        "line": 178,
         "name": "_copy_prompt_data_for_update",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -21592,7 +21716,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:_normalize_prompt_data",
         "kind": "static_from",
-        "line": 176,
+        "line": 178,
         "name": "_normalize_prompt_data",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -21623,7 +21747,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:_prompt_data_json_safe",
         "kind": "static_from",
-        "line": 176,
+        "line": 178,
         "name": "_prompt_data_json_safe",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -21654,7 +21778,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:_prompt_data_parameter_snapshot",
         "kind": "static_from",
-        "line": 176,
+        "line": 178,
         "name": "_prompt_data_parameter_snapshot",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -21685,7 +21809,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_artist_field_prompt",
         "kind": "static_from",
-        "line": 194,
+        "line": 196,
         "name": "_advanced_artist_field_prompt",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -21716,7 +21840,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_default_fields",
         "kind": "static_from",
-        "line": 194,
+        "line": 196,
         "name": "_advanced_default_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -21747,7 +21871,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_enabled_naia_panes",
         "kind": "static_from",
-        "line": 194,
+        "line": 196,
         "name": "_advanced_enabled_naia_panes",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -21778,7 +21902,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_enabled_pane_fields",
         "kind": "static_from",
-        "line": 194,
+        "line": 196,
         "name": "_advanced_enabled_pane_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -21809,7 +21933,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_field_input_values",
         "kind": "static_from",
-        "line": 194,
+        "line": 196,
         "name": "_advanced_field_input_values",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -21840,7 +21964,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_field_socket_name",
         "kind": "static_from",
-        "line": 194,
+        "line": 196,
         "name": "_advanced_field_socket_name",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -21871,7 +21995,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_fields_json",
         "kind": "static_from",
-        "line": 194,
+        "line": 196,
         "name": "_advanced_fields_json",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -21902,7 +22026,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_has_enabled_naia",
         "kind": "static_from",
-        "line": 194,
+        "line": 196,
         "name": "_advanced_has_enabled_naia",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -21933,7 +22057,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_prompt_with_artist_override",
         "kind": "static_from",
-        "line": 194,
+        "line": 196,
         "name": "_advanced_prompt_with_artist_override",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -21964,7 +22088,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_uses_naia_resolution",
         "kind": "static_from",
-        "line": 194,
+        "line": 196,
         "name": "_advanced_uses_naia_resolution",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -21995,7 +22119,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_apply_advanced_field_inputs",
         "kind": "static_from",
-        "line": 194,
+        "line": 196,
         "name": "_apply_advanced_field_inputs",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -22026,7 +22150,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_as_advanced_height",
         "kind": "static_from",
-        "line": 194,
+        "line": 196,
         "name": "_as_advanced_height",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -22057,7 +22181,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_build_advanced_prompt_data",
         "kind": "static_from",
-        "line": 194,
+        "line": 196,
         "name": "_build_advanced_prompt_data",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -22088,7 +22212,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_build_advanced_prompts",
         "kind": "static_from",
-        "line": 194,
+        "line": 196,
         "name": "_build_advanced_prompts",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -22119,7 +22243,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_clone_advanced_fields",
         "kind": "static_from",
-        "line": 194,
+        "line": 196,
         "name": "_clone_advanced_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -22150,7 +22274,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_correct_advanced_field_sequence",
         "kind": "static_from",
-        "line": 194,
+        "line": 196,
         "name": "_correct_advanced_field_sequence",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -22181,7 +22305,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_expand_advanced_wildcard_fields",
         "kind": "static_from",
-        "line": 194,
+        "line": 196,
         "name": "_expand_advanced_wildcard_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -22212,7 +22336,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_normalize_advanced_fields",
         "kind": "static_from",
-        "line": 194,
+        "line": 196,
         "name": "_normalize_advanced_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -22243,7 +22367,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_normalize_prompt_studio_wildcard_seed_control",
         "kind": "static_from",
-        "line": 194,
+        "line": 196,
         "name": "_normalize_prompt_studio_wildcard_seed_control",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -22274,7 +22398,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_set_naia_field_text",
         "kind": "static_from",
-        "line": 194,
+        "line": 196,
         "name": "_set_naia_field_text",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -22305,7 +22429,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_translate_prompt_fields",
         "kind": "static_from",
-        "line": 194,
+        "line": 196,
         "name": "_translate_prompt_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -22336,7 +22460,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_apply_regional_field_inputs",
         "kind": "static_from",
-        "line": 229,
+        "line": 231,
         "name": "_apply_regional_field_inputs",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -22367,7 +22491,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_build_regional_outputs",
         "kind": "static_from",
-        "line": 229,
+        "line": 231,
         "name": "_build_regional_outputs",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -22398,7 +22522,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_clone_regional_fields",
         "kind": "static_from",
-        "line": 229,
+        "line": 231,
         "name": "_clone_regional_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -22429,7 +22553,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_conditioning_set_values",
         "kind": "static_from",
-        "line": 229,
+        "line": 231,
         "name": "_conditioning_set_values",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -22460,7 +22584,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_normalize_mask_ids",
         "kind": "static_from",
-        "line": 229,
+        "line": 231,
         "name": "_normalize_mask_ids",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -22491,7 +22615,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_normalize_regional_config",
         "kind": "static_from",
-        "line": 229,
+        "line": 231,
         "name": "_normalize_regional_config",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -22522,7 +22646,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_normalize_regional_fields",
         "kind": "static_from",
-        "line": 229,
+        "line": 231,
         "name": "_normalize_regional_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -22553,7 +22677,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_parse_json_object",
         "kind": "static_from",
-        "line": 229,
+        "line": 231,
         "name": "_parse_json_object",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -22584,7 +22708,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_regional_config_json",
         "kind": "static_from",
-        "line": 229,
+        "line": 231,
         "name": "_regional_config_json",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -22615,7 +22739,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_regional_fields_json",
         "kind": "static_from",
-        "line": 229,
+        "line": 231,
         "name": "_regional_fields_json",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -22646,7 +22770,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_regional_mask_bounds_area",
         "kind": "static_from",
-        "line": 229,
+        "line": 231,
         "name": "_regional_mask_bounds_area",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -22677,7 +22801,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_regional_payload_canvas",
         "kind": "static_from",
-        "line": 229,
+        "line": 231,
         "name": "_regional_payload_canvas",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -22708,7 +22832,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_regional_union_mask_for_ids",
         "kind": "static_from",
-        "line": 229,
+        "line": 231,
         "name": "_regional_union_mask_for_ids",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -22739,7 +22863,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
         "kind": "static_from",
-        "line": 256,
+        "line": 258,
         "name": "ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -22770,7 +22894,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODES",
         "kind": "static_from",
-        "line": 256,
+        "line": 258,
         "name": "ANIMA_MOD_GUIDANCE_MODES",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -22801,7 +22925,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 256,
+        "line": 258,
         "name": "ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -22832,7 +22956,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_PROFILE_OFF",
         "kind": "static_from",
-        "line": 256,
+        "line": 258,
         "name": "ANIMA_MOD_GUIDANCE_PROFILE_OFF",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -22863,7 +22987,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:_apply_spectrum_anima_mod_guidance",
         "kind": "static_from",
-        "line": 256,
+        "line": 258,
         "name": "_apply_spectrum_anima_mod_guidance",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -22894,7 +23018,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:_find_spectrum_anima_mod_guidance_class",
         "kind": "static_from",
-        "line": 256,
+        "line": 258,
         "name": "_find_spectrum_anima_mod_guidance_class",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -22925,7 +23049,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:_normalize_anima_mod_guidance_profile",
         "kind": "static_from",
-        "line": 256,
+        "line": 258,
         "name": "_normalize_anima_mod_guidance_profile",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -22956,7 +23080,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:_resolve_anima_mod_guidance_enabled",
         "kind": "static_from",
-        "line": 256,
+        "line": 258,
         "name": "_resolve_anima_mod_guidance_enabled",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -22987,7 +23111,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
         "kind": "static_from",
-        "line": 271,
+        "line": 273,
         "name": "ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -23018,7 +23142,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
         "kind": "static_from",
-        "line": 271,
+        "line": 273,
         "name": "ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -23049,7 +23173,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
         "kind": "static_from",
-        "line": 271,
+        "line": 273,
         "name": "ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -23080,7 +23204,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_EXACT_TOP_K",
         "kind": "static_from",
-        "line": 271,
+        "line": 273,
         "name": "ARTIST_MIX_DEFAULT_EXACT_TOP_K",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -23111,7 +23235,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
         "kind": "static_from",
-        "line": 271,
+        "line": 273,
         "name": "ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -23142,7 +23266,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_START_PERCENT",
         "kind": "static_from",
-        "line": 271,
+        "line": 273,
         "name": "ARTIST_MIX_DEFAULT_START_PERCENT",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -23173,7 +23297,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
         "kind": "static_from",
-        "line": 271,
+        "line": 273,
         "name": "ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -23204,7 +23328,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STYLE_GAIN",
         "kind": "static_from",
-        "line": 271,
+        "line": 273,
         "name": "ARTIST_MIX_DEFAULT_STYLE_GAIN",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -23235,7 +23359,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_INPUT_MODES",
         "kind": "static_from",
-        "line": 271,
+        "line": 273,
         "name": "ARTIST_MIX_INPUT_MODES",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -23266,7 +23390,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 271,
+        "line": 273,
         "name": "ARTIST_MIX_MODE_FROM_PROMPT_DATA",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -23297,7 +23421,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_artist_mix_inline_prompt",
         "kind": "static_from",
-        "line": 271,
+        "line": 273,
         "name": "_artist_mix_inline_prompt",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -23328,7 +23452,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_artist_mix_mode_tooltip",
         "kind": "static_from",
-        "line": 271,
+        "line": 273,
         "name": "_artist_mix_mode_tooltip",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -23359,7 +23483,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_artist_prompt_with_position",
         "kind": "static_from",
-        "line": 271,
+        "line": 273,
         "name": "_artist_prompt_with_position",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -23390,7 +23514,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_artist_tags_from_prompt",
         "kind": "static_from",
-        "line": 271,
+        "line": 273,
         "name": "_artist_tags_from_prompt",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -23421,7 +23545,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_blend_conditionings",
         "kind": "static_from",
-        "line": 271,
+        "line": 273,
         "name": "_blend_conditionings",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -23452,7 +23576,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_bounded_artist_mix_float",
         "kind": "static_from",
-        "line": 271,
+        "line": 273,
         "name": "_bounded_artist_mix_float",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -23483,7 +23607,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_bounded_artist_mix_int",
         "kind": "static_from",
-        "line": 271,
+        "line": 273,
         "name": "_bounded_artist_mix_int",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -23514,7 +23638,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_encode_artist_clustered",
         "kind": "static_from",
-        "line": 271,
+        "line": 273,
         "name": "_encode_artist_clustered",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -23545,7 +23669,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_encode_artist_delta_rms",
         "kind": "static_from",
-        "line": 271,
+        "line": 273,
         "name": "_encode_artist_delta_rms",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -23576,7 +23700,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_encode_prompt_data_positive_conditioning",
         "kind": "static_from",
-        "line": 271,
+        "line": 273,
         "name": "_encode_prompt_data_positive_conditioning",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -23607,7 +23731,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_join_artist_mix_source_prompts",
         "kind": "static_from",
-        "line": 271,
+        "line": 273,
         "name": "_join_artist_mix_source_prompts",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -23638,7 +23762,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_normalize_artist_mix_mode",
         "kind": "static_from",
-        "line": 271,
+        "line": 273,
         "name": "_normalize_artist_mix_mode",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -23669,7 +23793,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_normalize_artist_tag_position",
         "kind": "static_from",
-        "line": 271,
+        "line": 273,
         "name": "_normalize_artist_tag_position",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -23700,7 +23824,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_parse_artist_mix_items",
         "kind": "static_from",
-        "line": 271,
+        "line": 273,
         "name": "_parse_artist_mix_items",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -23731,7 +23855,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaArtistMixConditioning",
         "kind": "static_from",
-        "line": 350,
+        "line": 352,
         "name": "EasyUseAnimaArtistMixConditioning",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_data_nodes",
@@ -23762,7 +23886,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataConditioning",
         "kind": "static_from",
-        "line": 350,
+        "line": 352,
         "name": "EasyUseAnimaPromptDataConditioning",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_data_nodes",
@@ -23793,7 +23917,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataUnpack",
         "kind": "static_from",
-        "line": 350,
+        "line": 352,
         "name": "EasyUseAnimaPromptDataUnpack",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_data_nodes",
@@ -23824,7 +23948,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.input_types:_ANY_TYPE",
         "kind": "static_from",
-        "line": 355,
+        "line": 357,
         "name": "_ANY_TYPE",
         "optional": false,
         "requested": ".easyuse_anima.nodes.input_types",
@@ -23855,7 +23979,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.input_types:_AnyType",
         "kind": "static_from",
-        "line": 355,
+        "line": 357,
         "name": "_AnyType",
         "optional": false,
         "requested": ".easyuse_anima.nodes.input_types",
@@ -23886,7 +24010,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.input_types:_FlexibleOptionalInputType",
         "kind": "static_from",
-        "line": 355,
+        "line": 357,
         "name": "_FlexibleOptionalInputType",
         "optional": false,
         "requested": ".easyuse_anima.nodes.input_types",
@@ -23917,7 +24041,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvanced",
         "kind": "static_from",
-        "line": 360,
+        "line": 362,
         "name": "EasyUseAnimaPromptStudioAdvanced",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_advanced_nodes",
@@ -23948,7 +24072,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvancedV2",
         "kind": "static_from",
-        "line": 360,
+        "line": 362,
         "name": "EasyUseAnimaPromptStudioAdvancedV2",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_advanced_nodes",
@@ -23979,7 +24103,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.aio_nodes:EasyUseAnimaAIOGenerator",
         "kind": "static_from",
-        "line": 365,
+        "line": 367,
         "name": "EasyUseAnimaAIOGenerator",
         "optional": false,
         "requested": ".easyuse_anima.nodes.aio_nodes",
@@ -24010,7 +24134,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.aio_nodes:EasyUseAnimaInput",
         "kind": "static_from",
-        "line": 365,
+        "line": 367,
         "name": "EasyUseAnimaInput",
         "optional": false,
         "requested": ".easyuse_anima.nodes.aio_nodes",
@@ -24041,7 +24165,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.aio_nodes:_aio_generation_settings_json",
         "kind": "static_from",
-        "line": 365,
+        "line": 367,
         "name": "_aio_generation_settings_json",
         "optional": false,
         "requested": ".easyuse_anima.nodes.aio_nodes",
@@ -24072,7 +24196,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.aio_nodes:_aio_input_settings_json",
         "kind": "static_from",
-        "line": 365,
+        "line": 367,
         "name": "_aio_input_settings_json",
         "optional": false,
         "requested": ".easyuse_anima.nodes.aio_nodes",
@@ -24103,7 +24227,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.aio_nodes:_bind_aio_node_runtime",
         "kind": "static_from",
-        "line": 365,
+        "line": 367,
         "name": "_bind_aio_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.aio_nodes",
@@ -24134,7 +24258,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.aio_nodes:_easy_use_anima_input_signature",
         "kind": "static_from",
-        "line": 365,
+        "line": 367,
         "name": "_easy_use_anima_input_signature",
         "optional": false,
         "requested": ".easyuse_anima.nodes.aio_nodes",
@@ -24165,7 +24289,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.aio_nodes:_require_easy_use_anima_input",
         "kind": "static_from",
-        "line": 365,
+        "line": 367,
         "name": "_require_easy_use_anima_input",
         "optional": false,
         "requested": ".easyuse_anima.nodes.aio_nodes",
@@ -24196,7 +24320,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.geometry:_align_down",
         "kind": "static_from",
-        "line": 374,
+        "line": 376,
         "name": "_align_down",
         "optional": false,
         "requested": ".easyuse_anima.image.geometry",
@@ -24227,7 +24351,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.geometry:_align_nearest",
         "kind": "static_from",
-        "line": 374,
+        "line": 376,
         "name": "_align_nearest",
         "optional": false,
         "requested": ".easyuse_anima.image.geometry",
@@ -24258,7 +24382,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.geometry:_image_tensor_size",
         "kind": "static_from",
-        "line": 374,
+        "line": 376,
         "name": "_image_tensor_size",
         "optional": false,
         "requested": ".easyuse_anima.image.geometry",
@@ -24289,7 +24413,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.sam3:_context_value",
         "kind": "static_from",
-        "line": 385,
+        "line": 387,
         "name": "_context_value",
         "optional": false,
         "requested": ".easyuse_anima.image.sam3",
@@ -24320,7 +24444,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.sam3:_sam3_context",
         "kind": "static_from",
-        "line": 385,
+        "line": 387,
         "name": "_sam3_context",
         "optional": false,
         "requested": ".easyuse_anima.image.sam3",
@@ -24351,7 +24475,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.sam3:_segs_has_items",
         "kind": "static_from",
-        "line": 385,
+        "line": 387,
         "name": "_segs_has_items",
         "optional": false,
         "requested": ".easyuse_anima.image.sam3",
@@ -24382,7 +24506,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.scaling:IMAGE_SCALE_MULTIPLES",
         "kind": "static_from",
-        "line": 397,
+        "line": 399,
         "name": "IMAGE_SCALE_MULTIPLES",
         "optional": false,
         "requested": ".easyuse_anima.image.scaling",
@@ -24413,7 +24537,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.scaling:IMAGE_UPSCALE_METHODS",
         "kind": "static_from",
-        "line": 397,
+        "line": 399,
         "name": "IMAGE_UPSCALE_METHODS",
         "optional": false,
         "requested": ".easyuse_anima.image.scaling",
@@ -24444,7 +24568,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_comfy_sampler_names",
         "kind": "static_from",
-        "line": 405,
+        "line": 407,
         "name": "_comfy_sampler_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -24475,7 +24599,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_comfy_scheduler_names",
         "kind": "static_from",
-        "line": 405,
+        "line": 407,
         "name": "_comfy_scheduler_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -24506,7 +24630,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_impact_scheduler_names",
         "kind": "static_from",
-        "line": 405,
+        "line": 407,
         "name": "_impact_scheduler_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -24537,7 +24661,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.invocation:_call_with_supported_kwargs",
         "kind": "static_from",
-        "line": 411,
+        "line": 413,
         "name": "_call_with_supported_kwargs",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.invocation",
@@ -24568,7 +24692,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.invocation:_common_upscale_image",
         "kind": "static_from",
-        "line": 411,
+        "line": 413,
         "name": "_common_upscale_image",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.invocation",
@@ -24599,7 +24723,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.invocation:_node_output_tuple",
         "kind": "static_from",
-        "line": 411,
+        "line": 413,
         "name": "_node_output_tuple",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.invocation",
@@ -24630,7 +24754,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.wiring:resolve_comfy_host_helper",
         "kind": "static_from",
-        "line": 416,
+        "line": 418,
         "name": "resolve_comfy_host_helper",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.wiring",
@@ -24661,7 +24785,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_comfy_clip_loader_types",
         "kind": "static_from",
-        "line": 419,
+        "line": 421,
         "name": "_comfy_clip_loader_types",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -24692,7 +24816,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_comfy_diffusion_model_names",
         "kind": "static_from",
-        "line": 419,
+        "line": 421,
         "name": "_comfy_diffusion_model_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -24723,7 +24847,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_comfy_text_encoder_names",
         "kind": "static_from",
-        "line": 419,
+        "line": 421,
         "name": "_comfy_text_encoder_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -24754,7 +24878,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_comfy_vae_names",
         "kind": "static_from",
-        "line": 419,
+        "line": 421,
         "name": "_comfy_vae_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -24785,7 +24909,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_folder_path_names",
         "kind": "static_from",
-        "line": 419,
+        "line": 421,
         "name": "_folder_path_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -24816,7 +24940,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.image_nodes:EasyUseAnimaDetailerAlignHook",
         "kind": "static_from",
-        "line": 427,
+        "line": 429,
         "name": "EasyUseAnimaDetailerAlignHook",
         "optional": false,
         "requested": ".easyuse_anima.nodes.image_nodes",
@@ -24847,7 +24971,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.image_nodes:EasyUseAnimaImageScaleByMultiple",
         "kind": "static_from",
-        "line": 427,
+        "line": 429,
         "name": "EasyUseAnimaImageScaleByMultiple",
         "optional": false,
         "requested": ".easyuse_anima.nodes.image_nodes",
@@ -24878,7 +25002,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Context",
         "kind": "static_from",
-        "line": 431,
+        "line": 433,
         "name": "EasyUseAnimaSAM3Context",
         "optional": false,
         "requested": ".easyuse_anima.nodes.sam3_nodes",
@@ -24909,7 +25033,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Detailer",
         "kind": "static_from",
-        "line": 431,
+        "line": 433,
         "name": "EasyUseAnimaSAM3Detailer",
         "optional": false,
         "requested": ".easyuse_anima.nodes.sam3_nodes",
@@ -24940,7 +25064,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptBuilder",
         "kind": "static_from",
-        "line": 435,
+        "line": 437,
         "name": "EasyUseAnimaPromptBuilder",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_nodes",
@@ -24971,7 +25095,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrector",
         "kind": "static_from",
-        "line": 435,
+        "line": 437,
         "name": "EasyUseAnimaPromptCorrector",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_nodes",
@@ -25002,7 +25126,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrectorSimple",
         "kind": "static_from",
-        "line": 435,
+        "line": 437,
         "name": "EasyUseAnimaPromptCorrectorSimple",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_nodes",
@@ -25033,7 +25157,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptStudio",
         "kind": "static_from",
-        "line": 435,
+        "line": 437,
         "name": "EasyUseAnimaPromptStudio",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_nodes",
@@ -25064,7 +25188,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.regional_nodes:EasyUseAnimaPromptStudioRegional",
         "kind": "static_from",
-        "line": 441,
+        "line": 443,
         "name": "EasyUseAnimaPromptStudioRegional",
         "optional": false,
         "requested": ".easyuse_anima.nodes.regional_nodes",
@@ -25095,7 +25219,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.regional_nodes:EasyUseAnimaRegionalConditioning",
         "kind": "static_from",
-        "line": 441,
+        "line": 443,
         "name": "EasyUseAnimaRegionalConditioning",
         "optional": false,
         "requested": ".easyuse_anima.nodes.regional_nodes",
@@ -25126,7 +25250,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.client:LATENT_ALIGN",
         "kind": "static_from",
-        "line": 445,
+        "line": 447,
         "name": "LATENT_ALIGN",
         "optional": false,
         "requested": ".easyuse_anima.naia.client",
@@ -25157,7 +25281,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.client:_parse_random_response",
         "kind": "static_from",
-        "line": 445,
+        "line": 447,
         "name": "_parse_random_response",
         "optional": false,
         "requested": ".easyuse_anima.naia.client",
@@ -25188,7 +25312,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.client:_post_random",
         "kind": "static_from",
-        "line": 445,
+        "line": 447,
         "name": "_post_random",
         "optional": false,
         "requested": ".easyuse_anima.naia.client",
@@ -25219,7 +25343,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_advanced_resolution_from_selection",
         "kind": "static_from",
-        "line": 463,
+        "line": 465,
         "name": "_advanced_resolution_from_selection",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -25250,7 +25374,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_normalize_resolution_bucket",
         "kind": "static_from",
-        "line": 463,
+        "line": 465,
         "name": "_normalize_resolution_bucket",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -25281,7 +25405,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_ratio_label",
         "kind": "static_from",
-        "line": 463,
+        "line": 465,
         "name": "_ratio_label",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -25312,7 +25436,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_resolution_label",
         "kind": "static_from",
-        "line": 463,
+        "line": 465,
         "name": "_resolution_label",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -25343,7 +25467,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_resolve_naia_resolution",
         "kind": "static_from",
-        "line": 463,
+        "line": 465,
         "name": "_resolve_naia_resolution",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -25374,7 +25498,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.naia_nodes:EasyUseAnimaNAIARandomPrompt",
         "kind": "static_from",
-        "line": 486,
+        "line": 488,
         "name": "EasyUseAnimaNAIARandomPrompt",
         "optional": false,
         "requested": ".easyuse_anima.nodes.naia_nodes",
@@ -25405,7 +25529,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.naia_nodes:_bind_naia_node_runtime",
         "kind": "static_from",
-        "line": 486,
+        "line": 488,
         "name": "_bind_naia_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.naia_nodes",
@@ -25436,7 +25560,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.wildcard_nodes:EasyUseAnimaWildcard",
         "kind": "static_from",
-        "line": 490,
+        "line": 492,
         "name": "EasyUseAnimaWildcard",
         "optional": false,
         "requested": ".easyuse_anima.nodes.wildcard_nodes",
@@ -25467,7 +25591,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.wildcard_nodes:_bind_wildcard_node_runtime",
         "kind": "static_from",
-        "line": 490,
+        "line": 492,
         "name": "_bind_wildcard_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.wildcard_nodes",
@@ -25498,7 +25622,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_apply_lora_syntax_format",
         "kind": "static_from",
-        "line": 495,
+        "line": 497,
         "name": "_apply_lora_syntax_format",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -25529,7 +25653,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_dedupe_text_values",
         "kind": "static_from",
-        "line": 495,
+        "line": 497,
         "name": "_dedupe_text_values",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -25560,7 +25684,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_fallback_lora_path",
         "kind": "static_from",
-        "line": 495,
+        "line": 497,
         "name": "_fallback_lora_path",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -25591,7 +25715,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_get_lora_info",
         "kind": "static_from",
-        "line": 495,
+        "line": 497,
         "name": "_get_lora_info",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -25622,7 +25746,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_get_lora_manager_trigger_words",
         "kind": "static_from",
-        "line": 495,
+        "line": 497,
         "name": "_get_lora_manager_trigger_words",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -25653,7 +25777,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_load_lora_manager_metadata",
         "kind": "static_from",
-        "line": 495,
+        "line": 497,
         "name": "_load_lora_manager_metadata",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -25684,7 +25808,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_lora_combo_values",
         "kind": "static_from",
-        "line": 495,
+        "line": 497,
         "name": "_lora_combo_values",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -25715,7 +25839,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_lora_manager_trigger_words_from_metadata",
         "kind": "static_from",
-        "line": 495,
+        "line": 497,
         "name": "_lora_manager_trigger_words_from_metadata",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -25746,7 +25870,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_lora_model_exists",
         "kind": "static_from",
-        "line": 495,
+        "line": 497,
         "name": "_lora_model_exists",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -25777,7 +25901,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_lora_stack_name",
         "kind": "static_from",
-        "line": 495,
+        "line": 497,
         "name": "_lora_stack_name",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -25808,7 +25932,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_metadata_json_paths_for_lora",
         "kind": "static_from",
-        "line": 495,
+        "line": 497,
         "name": "_metadata_json_paths_for_lora",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -25839,7 +25963,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_missing_lora_display_name",
         "kind": "static_from",
-        "line": 495,
+        "line": 497,
         "name": "_missing_lora_display_name",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -25870,7 +25994,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_raise_missing_loras",
         "kind": "static_from",
-        "line": 495,
+        "line": 497,
         "name": "_raise_missing_loras",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -25901,7 +26025,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_trigger_words_from_value",
         "kind": "static_from",
-        "line": 495,
+        "line": 497,
         "name": "_trigger_words_from_value",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -25932,7 +26056,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_correct_style_prompt",
         "kind": "static_from",
-        "line": 511,
+        "line": 513,
         "name": "_correct_style_prompt",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -25963,7 +26087,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_format_strength",
         "kind": "static_from",
-        "line": 511,
+        "line": 513,
         "name": "_format_strength",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -25994,7 +26118,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_get_loras_list",
         "kind": "static_from",
-        "line": 511,
+        "line": 513,
         "name": "_get_loras_list",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -26025,7 +26149,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_load_profile_data",
         "kind": "static_from",
-        "line": 511,
+        "line": 513,
         "name": "_load_profile_data",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -26056,7 +26180,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_profile_key",
         "kind": "static_from",
-        "line": 511,
+        "line": 513,
         "name": "_profile_key",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -26087,7 +26211,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_select_profile_values",
         "kind": "static_from",
-        "line": 511,
+        "line": 513,
         "name": "_select_profile_values",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -26118,7 +26242,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_wrap_profile_index",
         "kind": "static_from",
-        "line": 511,
+        "line": 513,
         "name": "_wrap_profile_index",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -26149,7 +26273,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.lora_nodes:EasyUseAnimaLoraPreset",
         "kind": "static_from",
-        "line": 520,
+        "line": 522,
         "name": "EasyUseAnimaLoraPreset",
         "optional": false,
         "requested": ".easyuse_anima.nodes.lora_nodes",
@@ -26180,7 +26304,7 @@
         "conditional": true,
         "imported": ".anima_prompt:correct_prompt",
         "kind": "static_from",
-        "line": 523,
+        "line": 525,
         "name": "correct_prompt",
         "optional": false,
         "requested": ".anima_prompt",
@@ -26211,7 +26335,7 @@
         "conditional": true,
         "imported": ".anima_prompt:load_knowledge_base",
         "kind": "static_from",
-        "line": 523,
+        "line": 525,
         "name": "load_knowledge_base",
         "optional": false,
         "requested": ".anima_prompt",
@@ -26242,7 +26366,7 @@
         "conditional": true,
         "imported": ".anima_prompt.parser:parse_prompt",
         "kind": "static_from",
-        "line": 524,
+        "line": 526,
         "name": "parse_prompt",
         "optional": false,
         "requested": ".anima_prompt.parser",
@@ -26273,7 +26397,7 @@
         "conditional": true,
         "imported": ".settings:resolve_metadata_filter_words",
         "kind": "static_from",
-        "line": 525,
+        "line": 527,
         "name": "resolve_metadata_filter_words",
         "optional": false,
         "requested": ".settings",
@@ -26304,7 +26428,7 @@
         "conditional": true,
         "imported": ".settings:resolve_naia_settings",
         "kind": "static_from",
-        "line": 525,
+        "line": 527,
         "name": "resolve_naia_settings",
         "optional": false,
         "requested": ".settings",
@@ -26335,7 +26459,7 @@
         "conditional": true,
         "imported": ".settings:resolve_prompt_translation_settings",
         "kind": "static_from",
-        "line": 525,
+        "line": 527,
         "name": "resolve_prompt_translation_settings",
         "optional": false,
         "requested": ".settings",
@@ -26366,7 +26490,7 @@
         "conditional": true,
         "imported": ".prompt_translation:has_prompt_translation_markers",
         "kind": "static_from",
-        "line": 530,
+        "line": 532,
         "name": "has_prompt_translation_markers",
         "optional": false,
         "requested": ".prompt_translation",
@@ -26397,7 +26521,7 @@
         "conditional": true,
         "imported": ".prompt_translation:translate_prompt_markers",
         "kind": "static_from",
-        "line": 530,
+        "line": 532,
         "name": "translate_prompt_markers",
         "optional": false,
         "requested": ".prompt_translation",
@@ -26428,7 +26552,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:MAX_SEED",
         "kind": "static_from",
-        "line": 531,
+        "line": 533,
         "name": "MAX_SEED",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -26459,7 +26583,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "kind": "static_from",
-        "line": 531,
+        "line": 533,
         "name": "PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -26490,7 +26614,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:PUBLIC_MAX_SEED",
         "kind": "static_from",
-        "line": 531,
+        "line": 533,
         "name": "PUBLIC_MAX_SEED",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -26521,7 +26645,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_DECREMENT",
         "kind": "static_from",
-        "line": 531,
+        "line": 533,
         "name": "SEED_CONTROL_DECREMENT",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -26552,7 +26676,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_FIXED",
         "kind": "static_from",
-        "line": 531,
+        "line": 533,
         "name": "SEED_CONTROL_FIXED",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -26583,7 +26707,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_INCREMENT",
         "kind": "static_from",
-        "line": 531,
+        "line": 533,
         "name": "SEED_CONTROL_INCREMENT",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -26614,7 +26738,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_MODES",
         "kind": "static_from",
-        "line": 531,
+        "line": 533,
         "name": "SEED_CONTROL_MODES",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -26645,7 +26769,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_RANDOMIZE",
         "kind": "static_from",
-        "line": 531,
+        "line": 533,
         "name": "SEED_CONTROL_RANDOMIZE",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -26676,7 +26800,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:WILDCARD_MODE_FIXED",
         "kind": "static_from",
-        "line": 531,
+        "line": 533,
         "name": "WILDCARD_MODE_FIXED",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -26707,7 +26831,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:WILDCARD_MODE_POPULATE",
         "kind": "static_from",
-        "line": 531,
+        "line": 533,
         "name": "WILDCARD_MODE_POPULATE",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -26738,7 +26862,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:WILDCARD_MODE_SEQUENTIAL",
         "kind": "static_from",
-        "line": 531,
+        "line": 533,
         "name": "WILDCARD_MODE_SEQUENTIAL",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -26769,7 +26893,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:expand_wildcard_texts",
         "kind": "static_from",
-        "line": 531,
+        "line": 533,
         "name": "expand_wildcard_texts",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -26800,7 +26924,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:expand_wildcards",
         "kind": "static_from",
-        "line": 531,
+        "line": 533,
         "name": "expand_wildcards",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -26831,7 +26955,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:has_wildcard_syntax",
         "kind": "static_from",
-        "line": 531,
+        "line": 533,
         "name": "has_wildcard_syntax",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -26862,7 +26986,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:next_seed",
         "kind": "static_from",
-        "line": 531,
+        "line": 533,
         "name": "next_seed",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -26893,7 +27017,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:normalize_prompt_studio_wildcard_mode",
         "kind": "static_from",
-        "line": 531,
+        "line": 533,
         "name": "normalize_prompt_studio_wildcard_mode",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -26924,7 +27048,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:normalize_seed",
         "kind": "static_from",
-        "line": 531,
+        "line": 533,
         "name": "normalize_seed",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -26955,7 +27079,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:normalize_wildcard_mode",
         "kind": "static_from",
-        "line": 531,
+        "line": 533,
         "name": "normalize_wildcard_mode",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -26986,7 +27110,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:wildcard_sources_signature",
         "kind": "static_from",
-        "line": 531,
+        "line": 533,
         "name": "wildcard_sources_signature",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -27005,7 +27129,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -27020,7 +27144,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:AIO_FIRST_PASS_CACHE_MAX_ENTRIES",
         "kind": "static_from",
-        "line": 553,
+        "line": 555,
         "name": "AIO_FIRST_PASS_CACHE_MAX_ENTRIES",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -27039,7 +27163,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -27054,7 +27178,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_AIO_FIRST_PASS_CACHE",
         "kind": "static_from",
-        "line": 553,
+        "line": 555,
         "name": "_AIO_FIRST_PASS_CACHE",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -27073,7 +27197,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -27088,7 +27212,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_AIO_FIRST_PASS_CACHE_ORDER",
         "kind": "static_from",
-        "line": 553,
+        "line": 555,
         "name": "_AIO_FIRST_PASS_CACHE_ORDER",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -27107,7 +27231,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -27122,7 +27246,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_aio_first_pass_cache_key",
         "kind": "static_from",
-        "line": 553,
+        "line": 555,
         "name": "_aio_first_pass_cache_key",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -27141,7 +27265,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -27156,7 +27280,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_clone_aio_cache_value",
         "kind": "static_from",
-        "line": 553,
+        "line": 555,
         "name": "_clone_aio_cache_value",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -27175,7 +27299,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -27190,7 +27314,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_get_aio_first_pass_cache",
         "kind": "static_from",
-        "line": 553,
+        "line": 555,
         "name": "_get_aio_first_pass_cache",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -27209,7 +27333,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -27224,7 +27348,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_put_aio_first_pass_cache",
         "kind": "static_from",
-        "line": 553,
+        "line": 555,
         "name": "_put_aio_first_pass_cache",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -27243,7 +27367,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -27258,7 +27382,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_bind_aio_legacy_generation_runtime",
         "kind": "static_from",
-        "line": 563,
+        "line": 565,
         "name": "_bind_aio_legacy_generation_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.legacy_generation",
@@ -27277,7 +27401,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -27292,7 +27416,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_detailer_stage",
         "kind": "static_from",
-        "line": 563,
+        "line": 565,
         "name": "_run_aio_detailer_stage",
         "optional": false,
         "requested": "easyuse_anima.aio.legacy_generation",
@@ -27311,7 +27435,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -27326,7 +27450,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_detailer_target",
         "kind": "static_from",
-        "line": 563,
+        "line": 565,
         "name": "_run_aio_detailer_target",
         "optional": false,
         "requested": "easyuse_anima.aio.legacy_generation",
@@ -27345,7 +27469,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -27360,7 +27484,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_highres_stage",
         "kind": "static_from",
-        "line": 563,
+        "line": 565,
         "name": "_run_aio_highres_stage",
         "optional": false,
         "requested": "easyuse_anima.aio.legacy_generation",
@@ -27379,7 +27503,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -27394,7 +27518,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_legacy_generation",
         "kind": "static_from",
-        "line": 563,
+        "line": 565,
         "name": "_run_aio_legacy_generation",
         "optional": false,
         "requested": "easyuse_anima.aio.legacy_generation",
@@ -27413,7 +27537,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -27428,7 +27552,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_resshift_upscale_stage",
         "kind": "static_from",
-        "line": 563,
+        "line": 565,
         "name": "_run_aio_resshift_upscale_stage",
         "optional": false,
         "requested": "easyuse_anima.aio.legacy_generation",
@@ -27447,7 +27571,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -27462,7 +27586,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_upscale_stage",
         "kind": "static_from",
-        "line": 563,
+        "line": 565,
         "name": "_run_aio_upscale_stage",
         "optional": false,
         "requested": "easyuse_anima.aio.legacy_generation",
@@ -27481,7 +27605,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -27496,7 +27620,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_usdu_upscale_stage",
         "kind": "static_from",
-        "line": 563,
+        "line": 565,
         "name": "_run_aio_usdu_upscale_stage",
         "optional": false,
         "requested": "easyuse_anima.aio.legacy_generation",
@@ -27515,7 +27639,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -27530,7 +27654,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEEDS",
         "kind": "static_from",
-        "line": 573,
+        "line": 575,
         "name": "AIO_SPECIAL_SEEDS",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -27549,7 +27673,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -27564,7 +27688,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEED_DECREMENT",
         "kind": "static_from",
-        "line": 573,
+        "line": 575,
         "name": "AIO_SPECIAL_SEED_DECREMENT",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -27583,7 +27707,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -27598,7 +27722,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEED_INCREMENT",
         "kind": "static_from",
-        "line": 573,
+        "line": 575,
         "name": "AIO_SPECIAL_SEED_INCREMENT",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -27617,7 +27741,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -27632,7 +27756,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEED_RANDOM",
         "kind": "static_from",
-        "line": 573,
+        "line": 575,
         "name": "AIO_SPECIAL_SEED_RANDOM",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -27651,7 +27775,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -27666,7 +27790,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_AIO_DETAILER_CUSTOM_RE",
         "kind": "static_from",
-        "line": 573,
+        "line": 575,
         "name": "_AIO_DETAILER_CUSTOM_RE",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -27685,7 +27809,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -27700,7 +27824,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_AIO_DETAILER_RESERVED_KEYS",
         "kind": "static_from",
-        "line": 573,
+        "line": 575,
         "name": "_AIO_DETAILER_RESERVED_KEYS",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -27719,7 +27843,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -27734,7 +27858,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_aio_detailer_has_enabled_targets",
         "kind": "static_from",
-        "line": 573,
+        "line": 575,
         "name": "_aio_detailer_has_enabled_targets",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -27753,7 +27877,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -27768,7 +27892,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_aio_detailer_target_defaults",
         "kind": "static_from",
-        "line": 573,
+        "line": 575,
         "name": "_aio_detailer_target_defaults",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -27787,7 +27911,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -27802,7 +27926,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_aio_detailer_target_order",
         "kind": "static_from",
-        "line": 573,
+        "line": 575,
         "name": "_aio_detailer_target_order",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -27821,7 +27945,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -27836,7 +27960,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_bind_aio_generation_normalization_runtime",
         "kind": "static_from",
-        "line": 573,
+        "line": 575,
         "name": "_bind_aio_generation_normalization_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -27855,7 +27979,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -27870,7 +27994,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_is_aio_detailer_target_name",
         "kind": "static_from",
-        "line": 573,
+        "line": 575,
         "name": "_is_aio_detailer_target_name",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -27889,7 +28013,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -27904,7 +28028,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_merge_versioned_settings",
         "kind": "static_from",
-        "line": 573,
+        "line": 575,
         "name": "_merge_versioned_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -27923,7 +28047,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -27938,7 +28062,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_dit_corrections_settings",
         "kind": "static_from",
-        "line": 573,
+        "line": 575,
         "name": "_normalize_aio_dit_corrections_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -27957,7 +28081,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -27972,7 +28096,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_generation_settings",
         "kind": "static_from",
-        "line": 573,
+        "line": 575,
         "name": "_normalize_aio_generation_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -27991,7 +28115,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -28006,7 +28130,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_seed",
         "kind": "static_from",
-        "line": 573,
+        "line": 575,
         "name": "_normalize_aio_seed",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -28025,7 +28149,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -28040,7 +28164,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_spectrum_settings",
         "kind": "static_from",
-        "line": 573,
+        "line": 575,
         "name": "_normalize_aio_spectrum_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -28059,7 +28183,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -28074,7 +28198,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_settings:round_trip_aio_generation_settings",
         "kind": "static_from",
-        "line": 591,
+        "line": 593,
         "name": "round_trip_aio_generation_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_settings",
@@ -28093,7 +28217,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -28108,7 +28232,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.usdu:_aio_usdu_auto_tile_dimension",
         "kind": "static_from",
-        "line": 594,
+        "line": 596,
         "name": "_aio_usdu_auto_tile_dimension",
         "optional": false,
         "requested": "easyuse_anima.aio.usdu",
@@ -28127,7 +28251,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -28142,7 +28266,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.usdu:_aio_usdu_tile_plan",
         "kind": "static_from",
-        "line": 594,
+        "line": 596,
         "name": "_aio_usdu_tile_plan",
         "optional": false,
         "requested": "easyuse_anima.aio.usdu",
@@ -28161,7 +28285,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -28176,7 +28300,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.usdu:_bind_aio_usdu_planning_runtime",
         "kind": "static_from",
-        "line": 594,
+        "line": 596,
         "name": "_bind_aio_usdu_planning_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.usdu",
@@ -28195,7 +28319,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -28210,7 +28334,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_aio_final_fit_size",
         "kind": "static_from",
-        "line": 599,
+        "line": 601,
         "name": "_aio_final_fit_size",
         "optional": false,
         "requested": "easyuse_anima.aio.postprocess",
@@ -28229,7 +28353,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -28244,7 +28368,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_apply_aio_final_fit",
         "kind": "static_from",
-        "line": 599,
+        "line": 601,
         "name": "_apply_aio_final_fit",
         "optional": false,
         "requested": "easyuse_anima.aio.postprocess",
@@ -28263,7 +28387,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -28278,7 +28402,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_bind_aio_postprocess_runtime",
         "kind": "static_from",
-        "line": 599,
+        "line": 601,
         "name": "_bind_aio_postprocess_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.postprocess",
@@ -28297,7 +28421,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -28312,7 +28436,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_resize_image_to_size_if_needed",
         "kind": "static_from",
-        "line": 599,
+        "line": 601,
         "name": "_resize_image_to_size_if_needed",
         "optional": false,
         "requested": "easyuse_anima.aio.postprocess",
@@ -28331,7 +28455,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -28346,7 +28470,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_run_aio_postprocess_stage",
         "kind": "static_from",
-        "line": 599,
+        "line": 601,
         "name": "_run_aio_postprocess_stage",
         "optional": false,
         "requested": "easyuse_anima.aio.postprocess",
@@ -28365,7 +28489,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -28380,7 +28504,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_prompt_data_fields_for_usdu",
         "kind": "static_from",
-        "line": 606,
+        "line": 608,
         "name": "_aio_prompt_data_fields_for_usdu",
         "optional": false,
         "requested": "easyuse_anima.aio.conditioning",
@@ -28399,7 +28523,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -28414,7 +28538,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_usdu_conditioning",
         "kind": "static_from",
-        "line": 606,
+        "line": 608,
         "name": "_aio_usdu_conditioning",
         "optional": false,
         "requested": "easyuse_anima.aio.conditioning",
@@ -28433,7 +28557,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -28448,7 +28572,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_usdu_prompt_without_general",
         "kind": "static_from",
-        "line": 606,
+        "line": 608,
         "name": "_aio_usdu_prompt_without_general",
         "optional": false,
         "requested": "easyuse_anima.aio.conditioning",
@@ -28467,7 +28591,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -28482,7 +28606,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_bind_aio_conditioning_runtime",
         "kind": "static_from",
-        "line": 606,
+        "line": 608,
         "name": "_bind_aio_conditioning_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.conditioning",
@@ -28501,7 +28625,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -28516,7 +28640,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_aio_lora_stack_signature",
         "kind": "static_from",
-        "line": 612,
+        "line": 614,
         "name": "_aio_lora_stack_signature",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -28535,7 +28659,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -28550,7 +28674,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_anima_dave_patch",
         "kind": "static_from",
-        "line": 612,
+        "line": 614,
         "name": "_apply_aio_anima_dave_patch",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -28569,7 +28693,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -28584,7 +28708,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_kj_model_patches",
         "kind": "static_from",
-        "line": 612,
+        "line": 614,
         "name": "_apply_aio_kj_model_patches",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -28603,7 +28727,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -28618,7 +28742,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_lora_stack",
         "kind": "static_from",
-        "line": 612,
+        "line": 614,
         "name": "_apply_aio_lora_stack",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -28637,7 +28761,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -28652,7 +28776,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_model_patches",
         "kind": "static_from",
-        "line": 612,
+        "line": 614,
         "name": "_apply_aio_model_patches",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -28671,7 +28795,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -28686,7 +28810,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_safe_pag_patch",
         "kind": "static_from",
-        "line": 612,
+        "line": 614,
         "name": "_apply_aio_safe_pag_patch",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -28705,7 +28829,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -28720,7 +28844,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_correction_patch_for_comfy_sampler",
         "kind": "static_from",
-        "line": 612,
+        "line": 614,
         "name": "_apply_aio_spectrum_correction_patch_for_comfy_sampler",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -28739,7 +28863,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -28754,7 +28878,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_forecast_patch_for_comfy_sampler",
         "kind": "static_from",
-        "line": 612,
+        "line": 614,
         "name": "_apply_aio_spectrum_forecast_patch_for_comfy_sampler",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -28773,7 +28897,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -28788,7 +28912,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_model_patches_for_comfy_sampler",
         "kind": "static_from",
-        "line": 612,
+        "line": 614,
         "name": "_apply_aio_spectrum_model_patches_for_comfy_sampler",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -28807,7 +28931,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -28822,7 +28946,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_bind_aio_model_preparation_runtime",
         "kind": "static_from",
-        "line": 612,
+        "line": 614,
         "name": "_bind_aio_model_preparation_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -28841,7 +28965,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -28856,7 +28980,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_cleanup_aio_ephemeral_model",
         "kind": "static_from",
-        "line": 612,
+        "line": 614,
         "name": "_cleanup_aio_ephemeral_model",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -28875,7 +28999,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -28890,7 +29014,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_normalize_aio_lora_stack",
         "kind": "static_from",
-        "line": 612,
+        "line": 614,
         "name": "_normalize_aio_lora_stack",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -28909,7 +29033,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -28924,7 +29048,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_patch_model_sampling_aura_flow",
         "kind": "static_from",
-        "line": 612,
+        "line": 614,
         "name": "_patch_model_sampling_aura_flow",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -28943,7 +29067,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -28958,7 +29082,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_aio_highres_effective_backend",
         "kind": "static_from",
-        "line": 627,
+        "line": 629,
         "name": "_aio_highres_effective_backend",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -28977,7 +29101,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -28992,7 +29116,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_aio_stage_sampler_settings",
         "kind": "static_from",
-        "line": 627,
+        "line": 629,
         "name": "_aio_stage_sampler_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -29011,7 +29135,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -29026,7 +29150,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_bind_aio_sampling_runtime",
         "kind": "static_from",
-        "line": 627,
+        "line": 629,
         "name": "_bind_aio_sampling_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -29045,7 +29169,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -29060,7 +29184,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_decode_latent_with_comfy",
         "kind": "static_from",
-        "line": 627,
+        "line": 629,
         "name": "_decode_latent_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -29079,7 +29203,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -29094,7 +29218,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_encode_image_with_comfy_vae",
         "kind": "static_from",
-        "line": 627,
+        "line": 629,
         "name": "_encode_image_with_comfy_vae",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -29113,7 +29237,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -29128,7 +29252,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_generate_empty_latent_with_comfy",
         "kind": "static_from",
-        "line": 627,
+        "line": 629,
         "name": "_generate_empty_latent_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -29147,7 +29271,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -29162,7 +29286,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_new_aio_random_seed",
         "kind": "static_from",
-        "line": 627,
+        "line": 629,
         "name": "_new_aio_random_seed",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -29181,7 +29305,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -29196,7 +29320,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_resolve_aio_runtime_seed",
         "kind": "static_from",
-        "line": 627,
+        "line": 629,
         "name": "_resolve_aio_runtime_seed",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -29215,7 +29339,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -29230,7 +29354,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_aio_backend",
         "kind": "static_from",
-        "line": 627,
+        "line": 629,
         "name": "_sample_latent_with_aio_backend",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -29249,7 +29373,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -29264,7 +29388,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_comfy",
         "kind": "static_from",
-        "line": 627,
+        "line": 629,
         "name": "_sample_latent_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -29283,7 +29407,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -29298,7 +29422,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_spectrum_mod_guidance_advanced",
         "kind": "static_from",
-        "line": 627,
+        "line": 629,
         "name": "_sample_latent_with_spectrum_mod_guidance_advanced",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -29317,7 +29441,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -29332,7 +29456,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_spectrum_spd",
         "kind": "static_from",
-        "line": 627,
+        "line": 629,
         "name": "_sample_latent_with_spectrum_spd",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -29351,7 +29475,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -29366,7 +29490,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_CACHE_FORMAT",
         "kind": "static_from",
-        "line": 641,
+        "line": 643,
         "name": "AIO_PREVIEW_CACHE_FORMAT",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -29385,7 +29509,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -29400,7 +29524,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_CACHE_QUALITY",
         "kind": "static_from",
-        "line": 641,
+        "line": 643,
         "name": "AIO_PREVIEW_CACHE_QUALITY",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -29419,7 +29543,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -29434,7 +29558,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_EVENT",
         "kind": "static_from",
-        "line": 641,
+        "line": 643,
         "name": "AIO_PREVIEW_EVENT",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -29453,7 +29577,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -29468,7 +29592,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_STAGE_LABELS",
         "kind": "static_from",
-        "line": 641,
+        "line": 643,
         "name": "AIO_PREVIEW_STAGE_LABELS",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -29487,7 +29611,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -29502,7 +29626,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_aio_preview_base_directory",
         "kind": "static_from",
-        "line": 641,
+        "line": 643,
         "name": "_aio_preview_base_directory",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -29521,7 +29645,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -29536,7 +29660,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_aio_preview_file_size_bytes",
         "kind": "static_from",
-        "line": 641,
+        "line": 643,
         "name": "_aio_preview_file_size_bytes",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -29555,7 +29679,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -29570,7 +29694,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_bind_aio_preview_runtime",
         "kind": "static_from",
-        "line": 641,
+        "line": 643,
         "name": "_bind_aio_preview_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -29589,7 +29713,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -29604,7 +29728,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_save_aio_temp_preview_image",
         "kind": "static_from",
-        "line": 641,
+        "line": 643,
         "name": "_save_aio_temp_preview_image",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -29623,7 +29747,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -29638,7 +29762,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_send_aio_preview_event",
         "kind": "static_from",
-        "line": 641,
+        "line": 643,
         "name": "_send_aio_preview_event",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -29657,7 +29781,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -29672,7 +29796,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_tag_aio_preview_images",
         "kind": "static_from",
-        "line": 641,
+        "line": 643,
         "name": "_tag_aio_preview_images",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -29691,7 +29815,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -29706,7 +29830,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_image_saver_additional_hashes",
         "kind": "static_from",
-        "line": 653,
+        "line": 655,
         "name": "_aio_image_saver_additional_hashes",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -29725,7 +29849,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -29740,7 +29864,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_image_saver_civitai_hash_fetcher_entries",
         "kind": "static_from",
-        "line": 653,
+        "line": 655,
         "name": "_aio_image_saver_civitai_hash_fetcher_entries",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -29759,7 +29883,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -29774,7 +29898,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_lora_metadata_name",
         "kind": "static_from",
-        "line": 653,
+        "line": 655,
         "name": "_aio_lora_metadata_name",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -29793,7 +29917,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -29808,7 +29932,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_prompt_with_lora_metadata",
         "kind": "static_from",
-        "line": 653,
+        "line": 655,
         "name": "_aio_prompt_with_lora_metadata",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -29827,7 +29951,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -29842,7 +29966,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_save_filename_prefix",
         "kind": "static_from",
-        "line": 653,
+        "line": 655,
         "name": "_aio_save_filename_prefix",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -29861,7 +29985,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -29876,76 +30000,8 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_bind_aio_output_runtime",
         "kind": "static_from",
-        "line": 653,
+        "line": 655,
         "name": "_bind_aio_output_runtime",
-        "optional": false,
-        "requested": "easyuse_anima.aio.output",
-        "role": "compatibility_fallback",
-        "scope": "<module>",
-        "source": "nodes.py",
-        "target": "easyuse_anima/aio/output.py"
-      },
-      {
-        "alias": "_normalize_aio_civitai_hash_fetchers",
-        "bound_name": "_normalize_aio_civitai_hash_fetchers",
-        "branch_context": [
-          {
-            "branch": "except",
-            "catches_import_error": true,
-            "exceptions": [
-              "ImportError"
-            ],
-            "handler_line": 552,
-            "kind": "try",
-            "line": 9
-          }
-        ],
-        "classification": "compatibility_fallback",
-        "column": 4,
-        "compatibility_pair": {
-          "bound_name": "_normalize_aio_civitai_hash_fetchers",
-          "target": "easyuse_anima/aio/output.py",
-          "try_line": 9
-        },
-        "conditional": true,
-        "imported": "easyuse_anima.aio.output:_normalize_aio_civitai_hash_fetchers",
-        "kind": "static_from",
-        "line": 653,
-        "name": "_normalize_aio_civitai_hash_fetchers",
-        "optional": false,
-        "requested": "easyuse_anima.aio.output",
-        "role": "compatibility_fallback",
-        "scope": "<module>",
-        "source": "nodes.py",
-        "target": "easyuse_anima/aio/output.py"
-      },
-      {
-        "alias": "_normalize_aio_hash_bundles",
-        "bound_name": "_normalize_aio_hash_bundles",
-        "branch_context": [
-          {
-            "branch": "except",
-            "catches_import_error": true,
-            "exceptions": [
-              "ImportError"
-            ],
-            "handler_line": 552,
-            "kind": "try",
-            "line": 9
-          }
-        ],
-        "classification": "compatibility_fallback",
-        "column": 4,
-        "compatibility_pair": {
-          "bound_name": "_normalize_aio_hash_bundles",
-          "target": "easyuse_anima/aio/output.py",
-          "try_line": 9
-        },
-        "conditional": true,
-        "imported": "easyuse_anima.aio.output:_normalize_aio_hash_bundles",
-        "kind": "static_from",
-        "line": 653,
-        "name": "_normalize_aio_hash_bundles",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
         "role": "compatibility_fallback",
@@ -29963,7 +30019,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -29978,7 +30034,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_save_image_with_comfy",
         "kind": "static_from",
-        "line": 653,
+        "line": 655,
         "name": "_save_image_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -29997,7 +30053,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -30012,7 +30068,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_save_image_with_image_saver",
         "kind": "static_from",
-        "line": 653,
+        "line": 655,
         "name": "_save_image_with_image_saver",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -30020,6 +30076,74 @@
         "scope": "<module>",
         "source": "nodes.py",
         "target": "easyuse_anima/aio/output.py"
+      },
+      {
+        "alias": "_normalize_aio_civitai_hash_fetchers",
+        "bound_name": "_normalize_aio_civitai_hash_fetchers",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 554,
+            "kind": "try",
+            "line": 9
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "_normalize_aio_civitai_hash_fetchers",
+          "target": "easyuse_anima/aio/output_settings.py",
+          "try_line": 9
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.aio.output_settings:_normalize_aio_civitai_hash_fetchers",
+        "kind": "static_from",
+        "line": 665,
+        "name": "_normalize_aio_civitai_hash_fetchers",
+        "optional": false,
+        "requested": "easyuse_anima.aio.output_settings",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/aio/output_settings.py"
+      },
+      {
+        "alias": "_normalize_aio_hash_bundles",
+        "bound_name": "_normalize_aio_hash_bundles",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 554,
+            "kind": "try",
+            "line": 9
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "_normalize_aio_hash_bundles",
+          "target": "easyuse_anima/aio/output_settings.py",
+          "try_line": 9
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.aio.output_settings:_normalize_aio_hash_bundles",
+        "kind": "static_from",
+        "line": 665,
+        "name": "_normalize_aio_hash_bundles",
+        "optional": false,
+        "requested": "easyuse_anima.aio.output_settings",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/aio/output_settings.py"
       },
       {
         "alias": "_bind_aio_resource_runtime",
@@ -30031,7 +30155,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -30046,7 +30170,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_bind_aio_resource_runtime",
         "kind": "static_from",
-        "line": 665,
+        "line": 669,
         "name": "_bind_aio_resource_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -30065,7 +30189,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -30080,7 +30204,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_clip_loader_types",
         "kind": "static_from",
-        "line": 665,
+        "line": 669,
         "name": "_comfy_clip_loader_types",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -30099,7 +30223,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -30114,7 +30238,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_diffusion_model_names",
         "kind": "static_from",
-        "line": 665,
+        "line": 669,
         "name": "_comfy_diffusion_model_names",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -30133,7 +30257,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -30148,7 +30272,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_text_encoder_names",
         "kind": "static_from",
-        "line": 665,
+        "line": 669,
         "name": "_comfy_text_encoder_names",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -30167,7 +30291,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -30182,7 +30306,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_vae_names",
         "kind": "static_from",
-        "line": 665,
+        "line": 669,
         "name": "_comfy_vae_names",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -30201,7 +30325,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -30216,7 +30340,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_aio_resources_from_input_context",
         "kind": "static_from",
-        "line": 665,
+        "line": 669,
         "name": "_load_aio_resources_from_input_context",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -30235,7 +30359,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -30250,7 +30374,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_aio_sam3_context",
         "kind": "static_from",
-        "line": 665,
+        "line": 669,
         "name": "_load_aio_sam3_context",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -30269,7 +30393,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -30284,7 +30408,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_checkpoint_with_comfy",
         "kind": "static_from",
-        "line": 665,
+        "line": 669,
         "name": "_load_checkpoint_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -30303,7 +30427,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -30318,7 +30442,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_clip_with_comfy",
         "kind": "static_from",
-        "line": 665,
+        "line": 669,
         "name": "_load_clip_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -30337,7 +30461,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -30352,7 +30476,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_diffusion_model_with_comfy",
         "kind": "static_from",
-        "line": 665,
+        "line": 669,
         "name": "_load_diffusion_model_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -30371,7 +30495,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -30386,7 +30510,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_upscale_model_with_comfy",
         "kind": "static_from",
-        "line": 665,
+        "line": 669,
         "name": "_load_upscale_model_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -30405,7 +30529,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -30420,7 +30544,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_vae_with_comfy",
         "kind": "static_from",
-        "line": 665,
+        "line": 669,
         "name": "_load_vae_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -30439,7 +30563,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -30454,7 +30578,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_normalize_aio_input_settings",
         "kind": "static_from",
-        "line": 665,
+        "line": 669,
         "name": "_normalize_aio_input_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -30473,7 +30597,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -30488,7 +30612,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_checkpoint_default",
         "kind": "static_from",
-        "line": 665,
+        "line": 669,
         "name": "_preferred_checkpoint_default",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -30507,7 +30631,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -30522,7 +30646,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_clip_type_default",
         "kind": "static_from",
-        "line": 665,
+        "line": 669,
         "name": "_preferred_clip_type_default",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -30541,7 +30665,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -30556,7 +30680,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_name_default",
         "kind": "static_from",
-        "line": 665,
+        "line": 669,
         "name": "_preferred_name_default",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -30575,7 +30699,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -30590,7 +30714,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_json_clone",
         "kind": "static_from",
-        "line": 683,
+        "line": 687,
         "name": "_json_clone",
         "optional": false,
         "requested": "easyuse_anima.common.serialization",
@@ -30609,7 +30733,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -30624,7 +30748,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_json_object",
         "kind": "static_from",
-        "line": 683,
+        "line": 687,
         "name": "_json_object",
         "optional": false,
         "requested": "easyuse_anima.common.serialization",
@@ -30643,7 +30767,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -30658,7 +30782,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_stable_change_key",
         "kind": "static_from",
-        "line": 683,
+        "line": 687,
         "name": "_stable_change_key",
         "optional": false,
         "requested": "easyuse_anima.common.serialization",
@@ -30677,7 +30801,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -30692,7 +30816,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_bool",
         "kind": "static_from",
-        "line": 688,
+        "line": 692,
         "name": "_as_bool",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -30711,7 +30835,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -30726,7 +30850,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_float",
         "kind": "static_from",
-        "line": 688,
+        "line": 692,
         "name": "_as_float",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -30745,7 +30869,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -30760,7 +30884,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_int",
         "kind": "static_from",
-        "line": 688,
+        "line": 692,
         "name": "_as_int",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -30779,7 +30903,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -30794,7 +30918,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_choice",
         "kind": "static_from",
-        "line": 688,
+        "line": 692,
         "name": "_choice",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -30813,7 +30937,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -30828,7 +30952,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_single_value",
         "kind": "static_from",
-        "line": 688,
+        "line": 692,
         "name": "_single_value",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -30847,7 +30971,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -30862,7 +30986,7 @@
         "conditional": true,
         "imported": "easyuse_anima.seed.compatibility:WILDCARD_QUEUE_MAX_SAFE_SEED",
         "kind": "static_from",
-        "line": 695,
+        "line": 699,
         "name": "WILDCARD_QUEUE_MAX_SAFE_SEED",
         "optional": false,
         "requested": "easyuse_anima.seed.compatibility",
@@ -30881,7 +31005,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -30896,7 +31020,7 @@
         "conditional": true,
         "imported": "easyuse_anima.seed.compatibility:WILDCARD_RESERVED_NEXT_SEED_INPUT",
         "kind": "static_from",
-        "line": 695,
+        "line": 699,
         "name": "WILDCARD_RESERVED_NEXT_SEED_INPUT",
         "optional": false,
         "requested": "easyuse_anima.seed.compatibility",
@@ -30915,7 +31039,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -30930,7 +31054,7 @@
         "conditional": true,
         "imported": "easyuse_anima.seed.compatibility:_consume_reserved_wildcard_next_seed",
         "kind": "static_from",
-        "line": 695,
+        "line": 699,
         "name": "_consume_reserved_wildcard_next_seed",
         "optional": false,
         "requested": "easyuse_anima.seed.compatibility",
@@ -30949,7 +31073,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -30964,7 +31088,7 @@
         "conditional": true,
         "imported": "easyuse_anima.workflow:_get_workflow_node",
         "kind": "static_from",
-        "line": 700,
+        "line": 704,
         "name": "_get_workflow_node",
         "optional": false,
         "requested": "easyuse_anima.workflow",
@@ -30983,7 +31107,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -30998,7 +31122,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_prompt_translation_change_key",
         "kind": "static_from",
-        "line": 701,
+        "line": 705,
         "name": "_prompt_translation_change_key",
         "optional": false,
         "requested": "easyuse_anima.prompt.correction",
@@ -31017,7 +31141,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -31032,7 +31156,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_split_tag_text",
         "kind": "static_from",
-        "line": 701,
+        "line": 705,
         "name": "_split_tag_text",
         "optional": false,
         "requested": "easyuse_anima.prompt.correction",
@@ -31051,7 +31175,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -31066,7 +31190,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_translate_prompt_text",
         "kind": "static_from",
-        "line": 701,
+        "line": 705,
         "name": "_translate_prompt_text",
         "optional": false,
         "requested": "easyuse_anima.prompt.correction",
@@ -31085,7 +31209,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -31100,7 +31224,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_HASH_COMMENT_RE",
         "kind": "static_from",
-        "line": 706,
+        "line": 710,
         "name": "_HASH_COMMENT_RE",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -31119,7 +31243,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -31134,7 +31258,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_INLINE_SPACE_RE",
         "kind": "static_from",
-        "line": 706,
+        "line": 710,
         "name": "_INLINE_SPACE_RE",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -31153,7 +31277,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -31168,7 +31292,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_WEIGHTED_TOKEN_RE",
         "kind": "static_from",
-        "line": 706,
+        "line": 710,
         "name": "_WEIGHTED_TOKEN_RE",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -31187,7 +31311,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -31202,7 +31326,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_correct_builder_prompt",
         "kind": "static_from",
-        "line": 706,
+        "line": 710,
         "name": "_correct_builder_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -31221,7 +31345,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -31236,7 +31360,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_filter_metadata_prompt",
         "kind": "static_from",
-        "line": 706,
+        "line": 710,
         "name": "_filter_metadata_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -31255,7 +31379,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -31270,7 +31394,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_join_prompt_tokens",
         "kind": "static_from",
-        "line": 706,
+        "line": 710,
         "name": "_join_prompt_tokens",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -31289,7 +31413,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -31304,7 +31428,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_metadata_filter_key",
         "kind": "static_from",
-        "line": 706,
+        "line": 710,
         "name": "_metadata_filter_key",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -31323,7 +31447,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -31338,7 +31462,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_metadata_filter_keys",
         "kind": "static_from",
-        "line": 706,
+        "line": 710,
         "name": "_metadata_filter_keys",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -31357,7 +31481,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -31372,7 +31496,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_prompt_tokens",
         "kind": "static_from",
-        "line": 706,
+        "line": 710,
         "name": "_prompt_tokens",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -31391,7 +31515,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -31406,7 +31530,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:PROMPT_DATA_TYPE",
         "kind": "static_from",
-        "line": 719,
+        "line": 723,
         "name": "PROMPT_DATA_TYPE",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -31425,7 +31549,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -31440,7 +31564,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_advanced_outputs_from_prompt_data",
         "kind": "static_from",
-        "line": 719,
+        "line": 723,
         "name": "_advanced_outputs_from_prompt_data",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -31459,7 +31583,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -31474,7 +31598,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_apply_prompt_data_overrides",
         "kind": "static_from",
-        "line": 719,
+        "line": 723,
         "name": "_apply_prompt_data_overrides",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -31493,7 +31617,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -31508,7 +31632,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_copy_prompt_data_for_update",
         "kind": "static_from",
-        "line": 719,
+        "line": 723,
         "name": "_copy_prompt_data_for_update",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -31527,7 +31651,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -31542,7 +31666,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_normalize_prompt_data",
         "kind": "static_from",
-        "line": 719,
+        "line": 723,
         "name": "_normalize_prompt_data",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -31561,7 +31685,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -31576,7 +31700,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_prompt_data_json_safe",
         "kind": "static_from",
-        "line": 719,
+        "line": 723,
         "name": "_prompt_data_json_safe",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -31595,7 +31719,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -31610,7 +31734,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_prompt_data_parameter_snapshot",
         "kind": "static_from",
-        "line": 719,
+        "line": 723,
         "name": "_prompt_data_parameter_snapshot",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -31629,7 +31753,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -31644,7 +31768,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_artist_field_prompt",
         "kind": "static_from",
-        "line": 737,
+        "line": 741,
         "name": "_advanced_artist_field_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -31663,7 +31787,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -31678,7 +31802,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_default_fields",
         "kind": "static_from",
-        "line": 737,
+        "line": 741,
         "name": "_advanced_default_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -31697,7 +31821,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -31712,7 +31836,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_enabled_naia_panes",
         "kind": "static_from",
-        "line": 737,
+        "line": 741,
         "name": "_advanced_enabled_naia_panes",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -31731,7 +31855,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -31746,7 +31870,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_enabled_pane_fields",
         "kind": "static_from",
-        "line": 737,
+        "line": 741,
         "name": "_advanced_enabled_pane_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -31765,7 +31889,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -31780,7 +31904,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_field_input_values",
         "kind": "static_from",
-        "line": 737,
+        "line": 741,
         "name": "_advanced_field_input_values",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -31799,7 +31923,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -31814,7 +31938,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_field_socket_name",
         "kind": "static_from",
-        "line": 737,
+        "line": 741,
         "name": "_advanced_field_socket_name",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -31833,7 +31957,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -31848,7 +31972,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_fields_json",
         "kind": "static_from",
-        "line": 737,
+        "line": 741,
         "name": "_advanced_fields_json",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -31867,7 +31991,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -31882,7 +32006,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_has_enabled_naia",
         "kind": "static_from",
-        "line": 737,
+        "line": 741,
         "name": "_advanced_has_enabled_naia",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -31901,7 +32025,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -31916,7 +32040,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_prompt_with_artist_override",
         "kind": "static_from",
-        "line": 737,
+        "line": 741,
         "name": "_advanced_prompt_with_artist_override",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -31935,7 +32059,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -31950,7 +32074,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_uses_naia_resolution",
         "kind": "static_from",
-        "line": 737,
+        "line": 741,
         "name": "_advanced_uses_naia_resolution",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -31969,7 +32093,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -31984,7 +32108,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_apply_advanced_field_inputs",
         "kind": "static_from",
-        "line": 737,
+        "line": 741,
         "name": "_apply_advanced_field_inputs",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -32003,7 +32127,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -32018,7 +32142,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_as_advanced_height",
         "kind": "static_from",
-        "line": 737,
+        "line": 741,
         "name": "_as_advanced_height",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -32037,7 +32161,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -32052,7 +32176,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_build_advanced_prompt_data",
         "kind": "static_from",
-        "line": 737,
+        "line": 741,
         "name": "_build_advanced_prompt_data",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -32071,7 +32195,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -32086,7 +32210,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_build_advanced_prompts",
         "kind": "static_from",
-        "line": 737,
+        "line": 741,
         "name": "_build_advanced_prompts",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -32105,7 +32229,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -32120,7 +32244,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_clone_advanced_fields",
         "kind": "static_from",
-        "line": 737,
+        "line": 741,
         "name": "_clone_advanced_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -32139,7 +32263,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -32154,7 +32278,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_correct_advanced_field_sequence",
         "kind": "static_from",
-        "line": 737,
+        "line": 741,
         "name": "_correct_advanced_field_sequence",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -32173,7 +32297,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -32188,7 +32312,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_expand_advanced_wildcard_fields",
         "kind": "static_from",
-        "line": 737,
+        "line": 741,
         "name": "_expand_advanced_wildcard_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -32207,7 +32331,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -32222,7 +32346,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_normalize_advanced_fields",
         "kind": "static_from",
-        "line": 737,
+        "line": 741,
         "name": "_normalize_advanced_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -32241,7 +32365,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -32256,7 +32380,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_normalize_prompt_studio_wildcard_seed_control",
         "kind": "static_from",
-        "line": 737,
+        "line": 741,
         "name": "_normalize_prompt_studio_wildcard_seed_control",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -32275,7 +32399,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -32290,7 +32414,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_set_naia_field_text",
         "kind": "static_from",
-        "line": 737,
+        "line": 741,
         "name": "_set_naia_field_text",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -32309,7 +32433,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -32324,7 +32448,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_translate_prompt_fields",
         "kind": "static_from",
-        "line": 737,
+        "line": 741,
         "name": "_translate_prompt_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -32343,7 +32467,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -32358,7 +32482,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_apply_regional_field_inputs",
         "kind": "static_from",
-        "line": 772,
+        "line": 776,
         "name": "_apply_regional_field_inputs",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -32377,7 +32501,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -32392,7 +32516,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_build_regional_outputs",
         "kind": "static_from",
-        "line": 772,
+        "line": 776,
         "name": "_build_regional_outputs",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -32411,7 +32535,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -32426,7 +32550,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_clone_regional_fields",
         "kind": "static_from",
-        "line": 772,
+        "line": 776,
         "name": "_clone_regional_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -32445,7 +32569,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -32460,7 +32584,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_conditioning_set_values",
         "kind": "static_from",
-        "line": 772,
+        "line": 776,
         "name": "_conditioning_set_values",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -32479,7 +32603,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -32494,7 +32618,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_mask_ids",
         "kind": "static_from",
-        "line": 772,
+        "line": 776,
         "name": "_normalize_mask_ids",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -32513,7 +32637,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -32528,7 +32652,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_regional_config",
         "kind": "static_from",
-        "line": 772,
+        "line": 776,
         "name": "_normalize_regional_config",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -32547,7 +32671,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -32562,7 +32686,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_regional_fields",
         "kind": "static_from",
-        "line": 772,
+        "line": 776,
         "name": "_normalize_regional_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -32581,7 +32705,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -32596,7 +32720,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_parse_json_object",
         "kind": "static_from",
-        "line": 772,
+        "line": 776,
         "name": "_parse_json_object",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -32615,7 +32739,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -32630,7 +32754,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_config_json",
         "kind": "static_from",
-        "line": 772,
+        "line": 776,
         "name": "_regional_config_json",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -32649,7 +32773,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -32664,7 +32788,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_fields_json",
         "kind": "static_from",
-        "line": 772,
+        "line": 776,
         "name": "_regional_fields_json",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -32683,7 +32807,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -32698,7 +32822,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_mask_bounds_area",
         "kind": "static_from",
-        "line": 772,
+        "line": 776,
         "name": "_regional_mask_bounds_area",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -32717,7 +32841,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -32732,7 +32856,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_payload_canvas",
         "kind": "static_from",
-        "line": 772,
+        "line": 776,
         "name": "_regional_payload_canvas",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -32751,7 +32875,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -32766,7 +32890,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_union_mask_for_ids",
         "kind": "static_from",
-        "line": 772,
+        "line": 776,
         "name": "_regional_union_mask_for_ids",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -32785,7 +32909,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -32800,7 +32924,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
         "kind": "static_from",
-        "line": 799,
+        "line": 803,
         "name": "ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -32819,7 +32943,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -32834,7 +32958,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODES",
         "kind": "static_from",
-        "line": 799,
+        "line": 803,
         "name": "ANIMA_MOD_GUIDANCE_MODES",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -32853,7 +32977,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -32868,7 +32992,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 799,
+        "line": 803,
         "name": "ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -32887,7 +33011,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -32902,7 +33026,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_PROFILE_OFF",
         "kind": "static_from",
-        "line": 799,
+        "line": 803,
         "name": "ANIMA_MOD_GUIDANCE_PROFILE_OFF",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -32921,7 +33045,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -32936,7 +33060,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_apply_spectrum_anima_mod_guidance",
         "kind": "static_from",
-        "line": 799,
+        "line": 803,
         "name": "_apply_spectrum_anima_mod_guidance",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -32955,7 +33079,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -32970,7 +33094,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_find_spectrum_anima_mod_guidance_class",
         "kind": "static_from",
-        "line": 799,
+        "line": 803,
         "name": "_find_spectrum_anima_mod_guidance_class",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -32989,7 +33113,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -33004,7 +33128,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_normalize_anima_mod_guidance_profile",
         "kind": "static_from",
-        "line": 799,
+        "line": 803,
         "name": "_normalize_anima_mod_guidance_profile",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -33023,7 +33147,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -33038,7 +33162,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_resolve_anima_mod_guidance_enabled",
         "kind": "static_from",
-        "line": 799,
+        "line": 803,
         "name": "_resolve_anima_mod_guidance_enabled",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -33057,7 +33181,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -33072,7 +33196,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
         "kind": "static_from",
-        "line": 814,
+        "line": 818,
         "name": "ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -33091,7 +33215,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -33106,7 +33230,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
         "kind": "static_from",
-        "line": 814,
+        "line": 818,
         "name": "ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -33125,7 +33249,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -33140,7 +33264,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
         "kind": "static_from",
-        "line": 814,
+        "line": 818,
         "name": "ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -33159,7 +33283,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -33174,7 +33298,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_EXACT_TOP_K",
         "kind": "static_from",
-        "line": 814,
+        "line": 818,
         "name": "ARTIST_MIX_DEFAULT_EXACT_TOP_K",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -33193,7 +33317,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -33208,7 +33332,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
         "kind": "static_from",
-        "line": 814,
+        "line": 818,
         "name": "ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -33227,7 +33351,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -33242,7 +33366,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_START_PERCENT",
         "kind": "static_from",
-        "line": 814,
+        "line": 818,
         "name": "ARTIST_MIX_DEFAULT_START_PERCENT",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -33261,7 +33385,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -33276,7 +33400,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
         "kind": "static_from",
-        "line": 814,
+        "line": 818,
         "name": "ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -33295,7 +33419,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -33310,7 +33434,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STYLE_GAIN",
         "kind": "static_from",
-        "line": 814,
+        "line": 818,
         "name": "ARTIST_MIX_DEFAULT_STYLE_GAIN",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -33329,7 +33453,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -33344,7 +33468,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_INPUT_MODES",
         "kind": "static_from",
-        "line": 814,
+        "line": 818,
         "name": "ARTIST_MIX_INPUT_MODES",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -33363,7 +33487,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -33378,7 +33502,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 814,
+        "line": 818,
         "name": "ARTIST_MIX_MODE_FROM_PROMPT_DATA",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -33397,7 +33521,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -33412,7 +33536,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_mix_inline_prompt",
         "kind": "static_from",
-        "line": 814,
+        "line": 818,
         "name": "_artist_mix_inline_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -33431,7 +33555,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -33446,7 +33570,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_mix_mode_tooltip",
         "kind": "static_from",
-        "line": 814,
+        "line": 818,
         "name": "_artist_mix_mode_tooltip",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -33465,7 +33589,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -33480,7 +33604,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_prompt_with_position",
         "kind": "static_from",
-        "line": 814,
+        "line": 818,
         "name": "_artist_prompt_with_position",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -33499,7 +33623,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -33514,7 +33638,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_tags_from_prompt",
         "kind": "static_from",
-        "line": 814,
+        "line": 818,
         "name": "_artist_tags_from_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -33533,7 +33657,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -33548,7 +33672,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_blend_conditionings",
         "kind": "static_from",
-        "line": 814,
+        "line": 818,
         "name": "_blend_conditionings",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -33567,7 +33691,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -33582,7 +33706,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bounded_artist_mix_float",
         "kind": "static_from",
-        "line": 814,
+        "line": 818,
         "name": "_bounded_artist_mix_float",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -33601,7 +33725,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -33616,7 +33740,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bounded_artist_mix_int",
         "kind": "static_from",
-        "line": 814,
+        "line": 818,
         "name": "_bounded_artist_mix_int",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -33635,7 +33759,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -33650,7 +33774,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_clustered",
         "kind": "static_from",
-        "line": 814,
+        "line": 818,
         "name": "_encode_artist_clustered",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -33669,7 +33793,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -33684,7 +33808,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_delta_rms",
         "kind": "static_from",
-        "line": 814,
+        "line": 818,
         "name": "_encode_artist_delta_rms",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -33703,7 +33827,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -33718,7 +33842,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_prompt_data_positive_conditioning",
         "kind": "static_from",
-        "line": 814,
+        "line": 818,
         "name": "_encode_prompt_data_positive_conditioning",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -33737,7 +33861,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -33752,7 +33876,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_join_artist_mix_source_prompts",
         "kind": "static_from",
-        "line": 814,
+        "line": 818,
         "name": "_join_artist_mix_source_prompts",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -33771,7 +33895,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -33786,7 +33910,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_normalize_artist_mix_mode",
         "kind": "static_from",
-        "line": 814,
+        "line": 818,
         "name": "_normalize_artist_mix_mode",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -33805,7 +33929,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -33820,7 +33944,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_normalize_artist_tag_position",
         "kind": "static_from",
-        "line": 814,
+        "line": 818,
         "name": "_normalize_artist_tag_position",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -33839,7 +33963,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -33854,7 +33978,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_parse_artist_mix_items",
         "kind": "static_from",
-        "line": 814,
+        "line": 818,
         "name": "_parse_artist_mix_items",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -33873,7 +33997,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -33888,7 +34012,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaArtistMixConditioning",
         "kind": "static_from",
-        "line": 893,
+        "line": 897,
         "name": "EasyUseAnimaArtistMixConditioning",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_data_nodes",
@@ -33907,7 +34031,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -33922,7 +34046,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataConditioning",
         "kind": "static_from",
-        "line": 893,
+        "line": 897,
         "name": "EasyUseAnimaPromptDataConditioning",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_data_nodes",
@@ -33941,7 +34065,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -33956,7 +34080,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataUnpack",
         "kind": "static_from",
-        "line": 893,
+        "line": 897,
         "name": "EasyUseAnimaPromptDataUnpack",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_data_nodes",
@@ -33975,7 +34099,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -33990,7 +34114,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_ANY_TYPE",
         "kind": "static_from",
-        "line": 898,
+        "line": 902,
         "name": "_ANY_TYPE",
         "optional": false,
         "requested": "easyuse_anima.nodes.input_types",
@@ -34009,7 +34133,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -34024,7 +34148,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_AnyType",
         "kind": "static_from",
-        "line": 898,
+        "line": 902,
         "name": "_AnyType",
         "optional": false,
         "requested": "easyuse_anima.nodes.input_types",
@@ -34043,7 +34167,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -34058,7 +34182,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_FlexibleOptionalInputType",
         "kind": "static_from",
-        "line": 898,
+        "line": 902,
         "name": "_FlexibleOptionalInputType",
         "optional": false,
         "requested": "easyuse_anima.nodes.input_types",
@@ -34077,7 +34201,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -34092,7 +34216,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvanced",
         "kind": "static_from",
-        "line": 903,
+        "line": 907,
         "name": "EasyUseAnimaPromptStudioAdvanced",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_advanced_nodes",
@@ -34111,7 +34235,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -34126,7 +34250,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvancedV2",
         "kind": "static_from",
-        "line": 903,
+        "line": 907,
         "name": "EasyUseAnimaPromptStudioAdvancedV2",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_advanced_nodes",
@@ -34145,7 +34269,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -34160,7 +34284,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:EasyUseAnimaAIOGenerator",
         "kind": "static_from",
-        "line": 908,
+        "line": 912,
         "name": "EasyUseAnimaAIOGenerator",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -34179,7 +34303,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -34194,7 +34318,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:EasyUseAnimaInput",
         "kind": "static_from",
-        "line": 908,
+        "line": 912,
         "name": "EasyUseAnimaInput",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -34213,7 +34337,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -34228,7 +34352,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_aio_generation_settings_json",
         "kind": "static_from",
-        "line": 908,
+        "line": 912,
         "name": "_aio_generation_settings_json",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -34247,7 +34371,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -34262,7 +34386,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_aio_input_settings_json",
         "kind": "static_from",
-        "line": 908,
+        "line": 912,
         "name": "_aio_input_settings_json",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -34281,7 +34405,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -34296,7 +34420,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_bind_aio_node_runtime",
         "kind": "static_from",
-        "line": 908,
+        "line": 912,
         "name": "_bind_aio_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -34315,7 +34439,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -34330,7 +34454,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_easy_use_anima_input_signature",
         "kind": "static_from",
-        "line": 908,
+        "line": 912,
         "name": "_easy_use_anima_input_signature",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -34349,7 +34473,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -34364,7 +34488,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_require_easy_use_anima_input",
         "kind": "static_from",
-        "line": 908,
+        "line": 912,
         "name": "_require_easy_use_anima_input",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -34383,7 +34507,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -34398,7 +34522,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_align_down",
         "kind": "static_from",
-        "line": 917,
+        "line": 921,
         "name": "_align_down",
         "optional": false,
         "requested": "easyuse_anima.image.geometry",
@@ -34417,7 +34541,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -34432,7 +34556,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_align_nearest",
         "kind": "static_from",
-        "line": 917,
+        "line": 921,
         "name": "_align_nearest",
         "optional": false,
         "requested": "easyuse_anima.image.geometry",
@@ -34451,7 +34575,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -34466,7 +34590,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_image_tensor_size",
         "kind": "static_from",
-        "line": 917,
+        "line": 921,
         "name": "_image_tensor_size",
         "optional": false,
         "requested": "easyuse_anima.image.geometry",
@@ -34485,7 +34609,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -34500,7 +34624,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_context_value",
         "kind": "static_from",
-        "line": 928,
+        "line": 932,
         "name": "_context_value",
         "optional": false,
         "requested": "easyuse_anima.image.sam3",
@@ -34519,7 +34643,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -34534,7 +34658,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_sam3_context",
         "kind": "static_from",
-        "line": 928,
+        "line": 932,
         "name": "_sam3_context",
         "optional": false,
         "requested": "easyuse_anima.image.sam3",
@@ -34553,7 +34677,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -34568,7 +34692,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_segs_has_items",
         "kind": "static_from",
-        "line": 928,
+        "line": 932,
         "name": "_segs_has_items",
         "optional": false,
         "requested": "easyuse_anima.image.sam3",
@@ -34587,7 +34711,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -34602,7 +34726,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:IMAGE_SCALE_MULTIPLES",
         "kind": "static_from",
-        "line": 940,
+        "line": 944,
         "name": "IMAGE_SCALE_MULTIPLES",
         "optional": false,
         "requested": "easyuse_anima.image.scaling",
@@ -34621,7 +34745,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -34636,7 +34760,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:IMAGE_UPSCALE_METHODS",
         "kind": "static_from",
-        "line": 940,
+        "line": 944,
         "name": "IMAGE_UPSCALE_METHODS",
         "optional": false,
         "requested": "easyuse_anima.image.scaling",
@@ -34655,7 +34779,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -34670,7 +34794,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_sampler_names",
         "kind": "static_from",
-        "line": 948,
+        "line": 952,
         "name": "_comfy_sampler_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -34689,7 +34813,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -34704,7 +34828,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_scheduler_names",
         "kind": "static_from",
-        "line": 948,
+        "line": 952,
         "name": "_comfy_scheduler_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -34723,7 +34847,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -34738,7 +34862,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_impact_scheduler_names",
         "kind": "static_from",
-        "line": 948,
+        "line": 952,
         "name": "_impact_scheduler_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -34757,7 +34881,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -34772,7 +34896,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_call_with_supported_kwargs",
         "kind": "static_from",
-        "line": 954,
+        "line": 958,
         "name": "_call_with_supported_kwargs",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.invocation",
@@ -34791,7 +34915,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -34806,7 +34930,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_common_upscale_image",
         "kind": "static_from",
-        "line": 954,
+        "line": 958,
         "name": "_common_upscale_image",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.invocation",
@@ -34825,7 +34949,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -34840,7 +34964,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_node_output_tuple",
         "kind": "static_from",
-        "line": 954,
+        "line": 958,
         "name": "_node_output_tuple",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.invocation",
@@ -34859,7 +34983,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -34874,7 +34998,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.wiring:resolve_comfy_host_helper",
         "kind": "static_from",
-        "line": 959,
+        "line": 963,
         "name": "resolve_comfy_host_helper",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.wiring",
@@ -34893,7 +35017,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -34908,7 +35032,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_clip_loader_types",
         "kind": "static_from",
-        "line": 962,
+        "line": 966,
         "name": "_comfy_clip_loader_types",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -34927,7 +35051,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -34942,7 +35066,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_diffusion_model_names",
         "kind": "static_from",
-        "line": 962,
+        "line": 966,
         "name": "_comfy_diffusion_model_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -34961,7 +35085,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -34976,7 +35100,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_text_encoder_names",
         "kind": "static_from",
-        "line": 962,
+        "line": 966,
         "name": "_comfy_text_encoder_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -34995,7 +35119,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -35010,7 +35134,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_vae_names",
         "kind": "static_from",
-        "line": 962,
+        "line": 966,
         "name": "_comfy_vae_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -35029,7 +35153,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -35044,7 +35168,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_folder_path_names",
         "kind": "static_from",
-        "line": 962,
+        "line": 966,
         "name": "_folder_path_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -35063,7 +35187,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -35078,7 +35202,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.image_nodes:EasyUseAnimaDetailerAlignHook",
         "kind": "static_from",
-        "line": 970,
+        "line": 974,
         "name": "EasyUseAnimaDetailerAlignHook",
         "optional": false,
         "requested": "easyuse_anima.nodes.image_nodes",
@@ -35097,7 +35221,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -35112,7 +35236,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.image_nodes:EasyUseAnimaImageScaleByMultiple",
         "kind": "static_from",
-        "line": 970,
+        "line": 974,
         "name": "EasyUseAnimaImageScaleByMultiple",
         "optional": false,
         "requested": "easyuse_anima.nodes.image_nodes",
@@ -35131,7 +35255,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -35146,7 +35270,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Context",
         "kind": "static_from",
-        "line": 974,
+        "line": 978,
         "name": "EasyUseAnimaSAM3Context",
         "optional": false,
         "requested": "easyuse_anima.nodes.sam3_nodes",
@@ -35165,7 +35289,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -35180,7 +35304,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Detailer",
         "kind": "static_from",
-        "line": 974,
+        "line": 978,
         "name": "EasyUseAnimaSAM3Detailer",
         "optional": false,
         "requested": "easyuse_anima.nodes.sam3_nodes",
@@ -35199,7 +35323,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -35214,7 +35338,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptBuilder",
         "kind": "static_from",
-        "line": 978,
+        "line": 982,
         "name": "EasyUseAnimaPromptBuilder",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -35233,7 +35357,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -35248,7 +35372,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrector",
         "kind": "static_from",
-        "line": 978,
+        "line": 982,
         "name": "EasyUseAnimaPromptCorrector",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -35267,7 +35391,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -35282,7 +35406,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrectorSimple",
         "kind": "static_from",
-        "line": 978,
+        "line": 982,
         "name": "EasyUseAnimaPromptCorrectorSimple",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -35301,7 +35425,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -35316,7 +35440,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptStudio",
         "kind": "static_from",
-        "line": 978,
+        "line": 982,
         "name": "EasyUseAnimaPromptStudio",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -35335,7 +35459,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -35350,7 +35474,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:EasyUseAnimaPromptStudioRegional",
         "kind": "static_from",
-        "line": 984,
+        "line": 988,
         "name": "EasyUseAnimaPromptStudioRegional",
         "optional": false,
         "requested": "easyuse_anima.nodes.regional_nodes",
@@ -35369,7 +35493,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -35384,7 +35508,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:EasyUseAnimaRegionalConditioning",
         "kind": "static_from",
-        "line": 984,
+        "line": 988,
         "name": "EasyUseAnimaRegionalConditioning",
         "optional": false,
         "requested": "easyuse_anima.nodes.regional_nodes",
@@ -35403,7 +35527,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -35418,7 +35542,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:LATENT_ALIGN",
         "kind": "static_from",
-        "line": 988,
+        "line": 992,
         "name": "LATENT_ALIGN",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -35437,7 +35561,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -35452,7 +35576,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_parse_random_response",
         "kind": "static_from",
-        "line": 988,
+        "line": 992,
         "name": "_parse_random_response",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -35471,7 +35595,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -35486,7 +35610,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_post_random",
         "kind": "static_from",
-        "line": 988,
+        "line": 992,
         "name": "_post_random",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -35505,7 +35629,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -35520,7 +35644,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_advanced_resolution_from_selection",
         "kind": "static_from",
-        "line": 1006,
+        "line": 1010,
         "name": "_advanced_resolution_from_selection",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -35539,7 +35663,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -35554,7 +35678,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_normalize_resolution_bucket",
         "kind": "static_from",
-        "line": 1006,
+        "line": 1010,
         "name": "_normalize_resolution_bucket",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -35573,7 +35697,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -35588,7 +35712,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_ratio_label",
         "kind": "static_from",
-        "line": 1006,
+        "line": 1010,
         "name": "_ratio_label",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -35607,7 +35731,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -35622,7 +35746,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolution_label",
         "kind": "static_from",
-        "line": 1006,
+        "line": 1010,
         "name": "_resolution_label",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -35641,7 +35765,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -35656,7 +35780,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolve_naia_resolution",
         "kind": "static_from",
-        "line": 1006,
+        "line": 1010,
         "name": "_resolve_naia_resolution",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -35675,7 +35799,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -35690,7 +35814,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.naia_nodes:EasyUseAnimaNAIARandomPrompt",
         "kind": "static_from",
-        "line": 1029,
+        "line": 1033,
         "name": "EasyUseAnimaNAIARandomPrompt",
         "optional": false,
         "requested": "easyuse_anima.nodes.naia_nodes",
@@ -35709,7 +35833,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -35724,7 +35848,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.naia_nodes:_bind_naia_node_runtime",
         "kind": "static_from",
-        "line": 1029,
+        "line": 1033,
         "name": "_bind_naia_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.naia_nodes",
@@ -35743,7 +35867,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -35758,7 +35882,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.wildcard_nodes:EasyUseAnimaWildcard",
         "kind": "static_from",
-        "line": 1033,
+        "line": 1037,
         "name": "EasyUseAnimaWildcard",
         "optional": false,
         "requested": "easyuse_anima.nodes.wildcard_nodes",
@@ -35777,7 +35901,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -35792,7 +35916,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.wildcard_nodes:_bind_wildcard_node_runtime",
         "kind": "static_from",
-        "line": 1033,
+        "line": 1037,
         "name": "_bind_wildcard_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.wildcard_nodes",
@@ -35811,7 +35935,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -35826,7 +35950,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_apply_lora_syntax_format",
         "kind": "static_from",
-        "line": 1038,
+        "line": 1042,
         "name": "_apply_lora_syntax_format",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -35845,7 +35969,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -35860,7 +35984,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_dedupe_text_values",
         "kind": "static_from",
-        "line": 1038,
+        "line": 1042,
         "name": "_dedupe_text_values",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -35879,7 +36003,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -35894,7 +36018,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_fallback_lora_path",
         "kind": "static_from",
-        "line": 1038,
+        "line": 1042,
         "name": "_fallback_lora_path",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -35913,7 +36037,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -35928,7 +36052,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_get_lora_info",
         "kind": "static_from",
-        "line": 1038,
+        "line": 1042,
         "name": "_get_lora_info",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -35947,7 +36071,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -35962,7 +36086,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_get_lora_manager_trigger_words",
         "kind": "static_from",
-        "line": 1038,
+        "line": 1042,
         "name": "_get_lora_manager_trigger_words",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -35981,7 +36105,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -35996,7 +36120,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_load_lora_manager_metadata",
         "kind": "static_from",
-        "line": 1038,
+        "line": 1042,
         "name": "_load_lora_manager_metadata",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -36015,7 +36139,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -36030,7 +36154,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_combo_values",
         "kind": "static_from",
-        "line": 1038,
+        "line": 1042,
         "name": "_lora_combo_values",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -36049,7 +36173,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -36064,7 +36188,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_manager_trigger_words_from_metadata",
         "kind": "static_from",
-        "line": 1038,
+        "line": 1042,
         "name": "_lora_manager_trigger_words_from_metadata",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -36083,7 +36207,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -36098,7 +36222,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_model_exists",
         "kind": "static_from",
-        "line": 1038,
+        "line": 1042,
         "name": "_lora_model_exists",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -36117,7 +36241,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -36132,7 +36256,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_stack_name",
         "kind": "static_from",
-        "line": 1038,
+        "line": 1042,
         "name": "_lora_stack_name",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -36151,7 +36275,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -36166,7 +36290,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_metadata_json_paths_for_lora",
         "kind": "static_from",
-        "line": 1038,
+        "line": 1042,
         "name": "_metadata_json_paths_for_lora",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -36185,7 +36309,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -36200,7 +36324,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_missing_lora_display_name",
         "kind": "static_from",
-        "line": 1038,
+        "line": 1042,
         "name": "_missing_lora_display_name",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -36219,7 +36343,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -36234,7 +36358,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_raise_missing_loras",
         "kind": "static_from",
-        "line": 1038,
+        "line": 1042,
         "name": "_raise_missing_loras",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -36253,7 +36377,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -36268,7 +36392,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_trigger_words_from_value",
         "kind": "static_from",
-        "line": 1038,
+        "line": 1042,
         "name": "_trigger_words_from_value",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -36287,7 +36411,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -36302,7 +36426,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_correct_style_prompt",
         "kind": "static_from",
-        "line": 1054,
+        "line": 1058,
         "name": "_correct_style_prompt",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -36321,7 +36445,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -36336,7 +36460,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_format_strength",
         "kind": "static_from",
-        "line": 1054,
+        "line": 1058,
         "name": "_format_strength",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -36355,7 +36479,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -36370,7 +36494,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_get_loras_list",
         "kind": "static_from",
-        "line": 1054,
+        "line": 1058,
         "name": "_get_loras_list",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -36389,7 +36513,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -36404,7 +36528,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_load_profile_data",
         "kind": "static_from",
-        "line": 1054,
+        "line": 1058,
         "name": "_load_profile_data",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -36423,7 +36547,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -36438,7 +36562,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_profile_key",
         "kind": "static_from",
-        "line": 1054,
+        "line": 1058,
         "name": "_profile_key",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -36457,7 +36581,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -36472,7 +36596,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_select_profile_values",
         "kind": "static_from",
-        "line": 1054,
+        "line": 1058,
         "name": "_select_profile_values",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -36491,7 +36615,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -36506,7 +36630,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_wrap_profile_index",
         "kind": "static_from",
-        "line": 1054,
+        "line": 1058,
         "name": "_wrap_profile_index",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -36525,7 +36649,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -36540,7 +36664,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.lora_nodes:EasyUseAnimaLoraPreset",
         "kind": "static_from",
-        "line": 1063,
+        "line": 1067,
         "name": "EasyUseAnimaLoraPreset",
         "optional": false,
         "requested": "easyuse_anima.nodes.lora_nodes",
@@ -36559,7 +36683,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -36574,7 +36698,7 @@
         "conditional": true,
         "imported": "anima_prompt:correct_prompt",
         "kind": "static_from",
-        "line": 1066,
+        "line": 1070,
         "name": "correct_prompt",
         "optional": false,
         "requested": "anima_prompt",
@@ -36593,7 +36717,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -36608,7 +36732,7 @@
         "conditional": true,
         "imported": "anima_prompt:load_knowledge_base",
         "kind": "static_from",
-        "line": 1066,
+        "line": 1070,
         "name": "load_knowledge_base",
         "optional": false,
         "requested": "anima_prompt",
@@ -36627,7 +36751,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -36642,7 +36766,7 @@
         "conditional": true,
         "imported": "anima_prompt.parser:parse_prompt",
         "kind": "static_from",
-        "line": 1067,
+        "line": 1071,
         "name": "parse_prompt",
         "optional": false,
         "requested": "anima_prompt.parser",
@@ -36661,7 +36785,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -36676,7 +36800,7 @@
         "conditional": true,
         "imported": "settings:resolve_metadata_filter_words",
         "kind": "static_from",
-        "line": 1068,
+        "line": 1072,
         "name": "resolve_metadata_filter_words",
         "optional": false,
         "requested": "settings",
@@ -36695,7 +36819,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -36710,7 +36834,7 @@
         "conditional": true,
         "imported": "settings:resolve_naia_settings",
         "kind": "static_from",
-        "line": 1068,
+        "line": 1072,
         "name": "resolve_naia_settings",
         "optional": false,
         "requested": "settings",
@@ -36729,7 +36853,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -36744,7 +36868,7 @@
         "conditional": true,
         "imported": "settings:resolve_prompt_translation_settings",
         "kind": "static_from",
-        "line": 1068,
+        "line": 1072,
         "name": "resolve_prompt_translation_settings",
         "optional": false,
         "requested": "settings",
@@ -36763,7 +36887,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -36778,7 +36902,7 @@
         "conditional": true,
         "imported": "prompt_translation:has_prompt_translation_markers",
         "kind": "static_from",
-        "line": 1073,
+        "line": 1077,
         "name": "has_prompt_translation_markers",
         "optional": false,
         "requested": "prompt_translation",
@@ -36797,7 +36921,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -36812,7 +36936,7 @@
         "conditional": true,
         "imported": "prompt_translation:translate_prompt_markers",
         "kind": "static_from",
-        "line": 1073,
+        "line": 1077,
         "name": "translate_prompt_markers",
         "optional": false,
         "requested": "prompt_translation",
@@ -36831,7 +36955,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -36846,7 +36970,7 @@
         "conditional": true,
         "imported": "wildcard_engine:MAX_SEED",
         "kind": "static_from",
-        "line": 1074,
+        "line": 1078,
         "name": "MAX_SEED",
         "optional": false,
         "requested": "wildcard_engine",
@@ -36865,7 +36989,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -36880,7 +37004,7 @@
         "conditional": true,
         "imported": "wildcard_engine:PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "kind": "static_from",
-        "line": 1074,
+        "line": 1078,
         "name": "PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "optional": false,
         "requested": "wildcard_engine",
@@ -36899,7 +37023,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -36914,7 +37038,7 @@
         "conditional": true,
         "imported": "wildcard_engine:PUBLIC_MAX_SEED",
         "kind": "static_from",
-        "line": 1074,
+        "line": 1078,
         "name": "PUBLIC_MAX_SEED",
         "optional": false,
         "requested": "wildcard_engine",
@@ -36933,7 +37057,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -36948,7 +37072,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_DECREMENT",
         "kind": "static_from",
-        "line": 1074,
+        "line": 1078,
         "name": "SEED_CONTROL_DECREMENT",
         "optional": false,
         "requested": "wildcard_engine",
@@ -36967,7 +37091,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -36982,7 +37106,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_FIXED",
         "kind": "static_from",
-        "line": 1074,
+        "line": 1078,
         "name": "SEED_CONTROL_FIXED",
         "optional": false,
         "requested": "wildcard_engine",
@@ -37001,7 +37125,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -37016,7 +37140,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_INCREMENT",
         "kind": "static_from",
-        "line": 1074,
+        "line": 1078,
         "name": "SEED_CONTROL_INCREMENT",
         "optional": false,
         "requested": "wildcard_engine",
@@ -37035,7 +37159,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -37050,7 +37174,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_MODES",
         "kind": "static_from",
-        "line": 1074,
+        "line": 1078,
         "name": "SEED_CONTROL_MODES",
         "optional": false,
         "requested": "wildcard_engine",
@@ -37069,7 +37193,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -37084,7 +37208,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_RANDOMIZE",
         "kind": "static_from",
-        "line": 1074,
+        "line": 1078,
         "name": "SEED_CONTROL_RANDOMIZE",
         "optional": false,
         "requested": "wildcard_engine",
@@ -37103,7 +37227,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -37118,7 +37242,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_FIXED",
         "kind": "static_from",
-        "line": 1074,
+        "line": 1078,
         "name": "WILDCARD_MODE_FIXED",
         "optional": false,
         "requested": "wildcard_engine",
@@ -37137,7 +37261,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -37152,7 +37276,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_POPULATE",
         "kind": "static_from",
-        "line": 1074,
+        "line": 1078,
         "name": "WILDCARD_MODE_POPULATE",
         "optional": false,
         "requested": "wildcard_engine",
@@ -37171,7 +37295,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -37186,7 +37310,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_SEQUENTIAL",
         "kind": "static_from",
-        "line": 1074,
+        "line": 1078,
         "name": "WILDCARD_MODE_SEQUENTIAL",
         "optional": false,
         "requested": "wildcard_engine",
@@ -37205,7 +37329,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -37220,7 +37344,7 @@
         "conditional": true,
         "imported": "wildcard_engine:expand_wildcard_texts",
         "kind": "static_from",
-        "line": 1074,
+        "line": 1078,
         "name": "expand_wildcard_texts",
         "optional": false,
         "requested": "wildcard_engine",
@@ -37239,7 +37363,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -37254,7 +37378,7 @@
         "conditional": true,
         "imported": "wildcard_engine:expand_wildcards",
         "kind": "static_from",
-        "line": 1074,
+        "line": 1078,
         "name": "expand_wildcards",
         "optional": false,
         "requested": "wildcard_engine",
@@ -37273,7 +37397,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -37288,7 +37412,7 @@
         "conditional": true,
         "imported": "wildcard_engine:has_wildcard_syntax",
         "kind": "static_from",
-        "line": 1074,
+        "line": 1078,
         "name": "has_wildcard_syntax",
         "optional": false,
         "requested": "wildcard_engine",
@@ -37307,7 +37431,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -37322,7 +37446,7 @@
         "conditional": true,
         "imported": "wildcard_engine:next_seed",
         "kind": "static_from",
-        "line": 1074,
+        "line": 1078,
         "name": "next_seed",
         "optional": false,
         "requested": "wildcard_engine",
@@ -37341,7 +37465,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -37356,7 +37480,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_prompt_studio_wildcard_mode",
         "kind": "static_from",
-        "line": 1074,
+        "line": 1078,
         "name": "normalize_prompt_studio_wildcard_mode",
         "optional": false,
         "requested": "wildcard_engine",
@@ -37375,7 +37499,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -37390,7 +37514,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_seed",
         "kind": "static_from",
-        "line": 1074,
+        "line": 1078,
         "name": "normalize_seed",
         "optional": false,
         "requested": "wildcard_engine",
@@ -37409,7 +37533,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -37424,7 +37548,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_wildcard_mode",
         "kind": "static_from",
-        "line": 1074,
+        "line": 1078,
         "name": "normalize_wildcard_mode",
         "optional": false,
         "requested": "wildcard_engine",
@@ -37443,7 +37567,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -37458,7 +37582,7 @@
         "conditional": true,
         "imported": "wildcard_engine:wildcard_sources_signature",
         "kind": "static_from",
-        "line": 1074,
+        "line": 1078,
         "name": "wildcard_sources_signature",
         "optional": false,
         "requested": "wildcard_engine",
@@ -39109,6 +39233,10 @@
         "to": "easyuse_anima/aio/generation_values.py"
       },
       {
+        "from": "easyuse_anima/aio/generation_normalization.py",
+        "to": "easyuse_anima/aio/output_settings.py"
+      },
+      {
         "from": "easyuse_anima/aio/generation_output.py",
         "to": "easyuse_anima/aio/generation_values.py"
       },
@@ -39139,6 +39267,14 @@
       {
         "from": "easyuse_anima/aio/generation_settings.py",
         "to": "easyuse_anima/aio/generation_values.py"
+      },
+      {
+        "from": "easyuse_anima/aio/output.py",
+        "to": "easyuse_anima/aio/output_settings.py"
+      },
+      {
+        "from": "easyuse_anima/aio/output_settings.py",
+        "to": "easyuse_anima/common/values.py"
       },
       {
         "from": "easyuse_anima/bootstrap.py",
@@ -39674,6 +39810,10 @@
       },
       {
         "from": "nodes.py",
+        "to": "easyuse_anima/aio/output_settings.py"
+      },
+      {
+        "from": "nodes.py",
         "to": "easyuse_anima/aio/postprocess.py"
       },
       {
@@ -40030,6 +40170,12 @@
         "cyclic": false,
         "modules": [
           "easyuse_anima/aio/output.py"
+        ]
+      },
+      {
+        "cyclic": false,
+        "modules": [
+          "easyuse_anima/aio/output_settings.py"
         ]
       },
       {
@@ -40402,7 +40548,7 @@
     ]
   },
   "inventory": {
-    "module_count": 89,
+    "module_count": 90,
     "modules": [
       {
         "is_package": true,
@@ -40634,9 +40780,9 @@
       },
       {
         "is_package": false,
-        "loc": 1062,
+        "loc": 1065,
         "module": "easyuse_anima.aio.generation_normalization",
-        "normalized_git_blob_sha1": "73c8ce60419273558405ce1d0c1a87ac947e6ad5",
+        "normalized_git_blob_sha1": "3731d55879923843887d048f82676273908bb8a9",
         "path": "easyuse_anima/aio/generation_normalization.py",
         "top_level": {
           "class_count": 0,
@@ -40718,14 +40864,26 @@
       },
       {
         "is_package": false,
-        "loc": 335,
+        "loc": 297,
         "module": "easyuse_anima.aio.output",
-        "normalized_git_blob_sha1": "e46f6ecfe4bd74bcd80d851fdf25cff73f47e303",
+        "normalized_git_blob_sha1": "dd3bcb47670166a280060fb7d4f534e8b80ef77c",
         "path": "easyuse_anima/aio/output.py",
         "top_level": {
           "class_count": 0,
-          "function_count": 11,
+          "function_count": 9,
           "global_count": 3
+        }
+      },
+      {
+        "is_package": false,
+        "loc": 53,
+        "module": "easyuse_anima.aio.output_settings",
+        "normalized_git_blob_sha1": "95cd2aa5dbe9abac050c360285fc999a0fd22da3",
+        "path": "easyuse_anima/aio/output_settings.py",
+        "top_level": {
+          "class_count": 0,
+          "function_count": 2,
+          "global_count": 1
         }
       },
       {
@@ -41414,9 +41572,9 @@
       },
       {
         "is_package": false,
-        "loc": 1657,
+        "loc": 1661,
         "module": "nodes",
-        "normalized_git_blob_sha1": "edcdc8681f64790736a790177ac80dadfda214b6",
+        "normalized_git_blob_sha1": "76958b4111ef5a6400ab3e7e5c0f6b2afc77a432",
         "path": "nodes.py",
         "top_level": {
           "class_count": 0,
@@ -42964,7 +43122,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -42973,7 +43131,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:AIO_FIRST_PASS_CACHE_MAX_ENTRIES",
         "kind": "static_from",
-        "line": 553,
+        "line": 555,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42987,7 +43145,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -42996,7 +43154,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_AIO_FIRST_PASS_CACHE",
         "kind": "static_from",
-        "line": 553,
+        "line": 555,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43010,7 +43168,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -43019,7 +43177,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_AIO_FIRST_PASS_CACHE_ORDER",
         "kind": "static_from",
-        "line": 553,
+        "line": 555,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43033,7 +43191,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -43042,7 +43200,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_aio_first_pass_cache_key",
         "kind": "static_from",
-        "line": 553,
+        "line": 555,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43056,7 +43214,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -43065,7 +43223,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_clone_aio_cache_value",
         "kind": "static_from",
-        "line": 553,
+        "line": 555,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43079,7 +43237,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -43088,7 +43246,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_get_aio_first_pass_cache",
         "kind": "static_from",
-        "line": 553,
+        "line": 555,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43102,7 +43260,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -43111,7 +43269,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_put_aio_first_pass_cache",
         "kind": "static_from",
-        "line": 553,
+        "line": 555,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43125,7 +43283,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -43134,7 +43292,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_bind_aio_legacy_generation_runtime",
         "kind": "static_from",
-        "line": 563,
+        "line": 565,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43148,7 +43306,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -43157,7 +43315,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_detailer_stage",
         "kind": "static_from",
-        "line": 563,
+        "line": 565,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43171,7 +43329,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -43180,7 +43338,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_detailer_target",
         "kind": "static_from",
-        "line": 563,
+        "line": 565,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43194,7 +43352,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -43203,7 +43361,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_highres_stage",
         "kind": "static_from",
-        "line": 563,
+        "line": 565,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43217,7 +43375,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -43226,7 +43384,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_legacy_generation",
         "kind": "static_from",
-        "line": 563,
+        "line": 565,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43240,7 +43398,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -43249,7 +43407,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_resshift_upscale_stage",
         "kind": "static_from",
-        "line": 563,
+        "line": 565,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43263,7 +43421,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -43272,7 +43430,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_upscale_stage",
         "kind": "static_from",
-        "line": 563,
+        "line": 565,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43286,7 +43444,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -43295,7 +43453,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_usdu_upscale_stage",
         "kind": "static_from",
-        "line": 563,
+        "line": 565,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43309,7 +43467,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -43318,7 +43476,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEEDS",
         "kind": "static_from",
-        "line": 573,
+        "line": 575,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43332,7 +43490,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -43341,7 +43499,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEED_DECREMENT",
         "kind": "static_from",
-        "line": 573,
+        "line": 575,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43355,7 +43513,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -43364,7 +43522,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEED_INCREMENT",
         "kind": "static_from",
-        "line": 573,
+        "line": 575,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43378,7 +43536,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -43387,7 +43545,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEED_RANDOM",
         "kind": "static_from",
-        "line": 573,
+        "line": 575,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43401,7 +43559,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -43410,7 +43568,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_AIO_DETAILER_CUSTOM_RE",
         "kind": "static_from",
-        "line": 573,
+        "line": 575,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43424,7 +43582,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -43433,7 +43591,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_AIO_DETAILER_RESERVED_KEYS",
         "kind": "static_from",
-        "line": 573,
+        "line": 575,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43447,7 +43605,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -43456,7 +43614,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_aio_detailer_has_enabled_targets",
         "kind": "static_from",
-        "line": 573,
+        "line": 575,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43470,7 +43628,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -43479,7 +43637,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_aio_detailer_target_defaults",
         "kind": "static_from",
-        "line": 573,
+        "line": 575,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43493,7 +43651,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -43502,7 +43660,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_aio_detailer_target_order",
         "kind": "static_from",
-        "line": 573,
+        "line": 575,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43516,7 +43674,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -43525,7 +43683,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_bind_aio_generation_normalization_runtime",
         "kind": "static_from",
-        "line": 573,
+        "line": 575,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43539,7 +43697,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -43548,7 +43706,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_is_aio_detailer_target_name",
         "kind": "static_from",
-        "line": 573,
+        "line": 575,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43562,7 +43720,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -43571,7 +43729,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_merge_versioned_settings",
         "kind": "static_from",
-        "line": 573,
+        "line": 575,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43585,7 +43743,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -43594,7 +43752,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_dit_corrections_settings",
         "kind": "static_from",
-        "line": 573,
+        "line": 575,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43608,7 +43766,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -43617,7 +43775,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_generation_settings",
         "kind": "static_from",
-        "line": 573,
+        "line": 575,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43631,7 +43789,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -43640,7 +43798,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_seed",
         "kind": "static_from",
-        "line": 573,
+        "line": 575,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43654,7 +43812,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -43663,7 +43821,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_spectrum_settings",
         "kind": "static_from",
-        "line": 573,
+        "line": 575,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43677,7 +43835,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -43686,7 +43844,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_settings:round_trip_aio_generation_settings",
         "kind": "static_from",
-        "line": 591,
+        "line": 593,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43700,7 +43858,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -43709,7 +43867,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.usdu:_aio_usdu_auto_tile_dimension",
         "kind": "static_from",
-        "line": 594,
+        "line": 596,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43723,7 +43881,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -43732,7 +43890,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.usdu:_aio_usdu_tile_plan",
         "kind": "static_from",
-        "line": 594,
+        "line": 596,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43746,7 +43904,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -43755,7 +43913,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.usdu:_bind_aio_usdu_planning_runtime",
         "kind": "static_from",
-        "line": 594,
+        "line": 596,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43769,7 +43927,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -43778,7 +43936,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_aio_final_fit_size",
         "kind": "static_from",
-        "line": 599,
+        "line": 601,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43792,7 +43950,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -43801,7 +43959,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_apply_aio_final_fit",
         "kind": "static_from",
-        "line": 599,
+        "line": 601,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43815,7 +43973,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -43824,7 +43982,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_bind_aio_postprocess_runtime",
         "kind": "static_from",
-        "line": 599,
+        "line": 601,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43838,7 +43996,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -43847,7 +44005,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_resize_image_to_size_if_needed",
         "kind": "static_from",
-        "line": 599,
+        "line": 601,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43861,7 +44019,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -43870,7 +44028,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_run_aio_postprocess_stage",
         "kind": "static_from",
-        "line": 599,
+        "line": 601,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43884,7 +44042,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -43893,7 +44051,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_prompt_data_fields_for_usdu",
         "kind": "static_from",
-        "line": 606,
+        "line": 608,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43907,7 +44065,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -43916,7 +44074,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_usdu_conditioning",
         "kind": "static_from",
-        "line": 606,
+        "line": 608,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43930,7 +44088,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -43939,7 +44097,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_usdu_prompt_without_general",
         "kind": "static_from",
-        "line": 606,
+        "line": 608,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43953,7 +44111,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -43962,7 +44120,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_bind_aio_conditioning_runtime",
         "kind": "static_from",
-        "line": 606,
+        "line": 608,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43976,7 +44134,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -43985,7 +44143,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_aio_lora_stack_signature",
         "kind": "static_from",
-        "line": 612,
+        "line": 614,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43999,7 +44157,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -44008,7 +44166,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_anima_dave_patch",
         "kind": "static_from",
-        "line": 612,
+        "line": 614,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44022,7 +44180,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -44031,7 +44189,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_kj_model_patches",
         "kind": "static_from",
-        "line": 612,
+        "line": 614,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44045,7 +44203,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -44054,7 +44212,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_lora_stack",
         "kind": "static_from",
-        "line": 612,
+        "line": 614,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44068,7 +44226,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -44077,7 +44235,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_model_patches",
         "kind": "static_from",
-        "line": 612,
+        "line": 614,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44091,7 +44249,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -44100,7 +44258,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_safe_pag_patch",
         "kind": "static_from",
-        "line": 612,
+        "line": 614,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44114,7 +44272,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -44123,7 +44281,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_correction_patch_for_comfy_sampler",
         "kind": "static_from",
-        "line": 612,
+        "line": 614,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44137,7 +44295,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -44146,7 +44304,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_forecast_patch_for_comfy_sampler",
         "kind": "static_from",
-        "line": 612,
+        "line": 614,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44160,7 +44318,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -44169,7 +44327,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_model_patches_for_comfy_sampler",
         "kind": "static_from",
-        "line": 612,
+        "line": 614,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44183,7 +44341,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -44192,7 +44350,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_bind_aio_model_preparation_runtime",
         "kind": "static_from",
-        "line": 612,
+        "line": 614,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44206,7 +44364,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -44215,7 +44373,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_cleanup_aio_ephemeral_model",
         "kind": "static_from",
-        "line": 612,
+        "line": 614,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44229,7 +44387,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -44238,7 +44396,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_normalize_aio_lora_stack",
         "kind": "static_from",
-        "line": 612,
+        "line": 614,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44252,7 +44410,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -44261,7 +44419,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_patch_model_sampling_aura_flow",
         "kind": "static_from",
-        "line": 612,
+        "line": 614,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44275,7 +44433,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -44284,7 +44442,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_aio_highres_effective_backend",
         "kind": "static_from",
-        "line": 627,
+        "line": 629,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44298,7 +44456,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -44307,7 +44465,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_aio_stage_sampler_settings",
         "kind": "static_from",
-        "line": 627,
+        "line": 629,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44321,7 +44479,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -44330,7 +44488,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_bind_aio_sampling_runtime",
         "kind": "static_from",
-        "line": 627,
+        "line": 629,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44344,7 +44502,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -44353,7 +44511,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_decode_latent_with_comfy",
         "kind": "static_from",
-        "line": 627,
+        "line": 629,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44367,7 +44525,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -44376,7 +44534,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_encode_image_with_comfy_vae",
         "kind": "static_from",
-        "line": 627,
+        "line": 629,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44390,7 +44548,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -44399,7 +44557,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_generate_empty_latent_with_comfy",
         "kind": "static_from",
-        "line": 627,
+        "line": 629,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44413,7 +44571,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -44422,7 +44580,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_new_aio_random_seed",
         "kind": "static_from",
-        "line": 627,
+        "line": 629,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44436,7 +44594,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -44445,7 +44603,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_resolve_aio_runtime_seed",
         "kind": "static_from",
-        "line": 627,
+        "line": 629,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44459,7 +44617,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -44468,7 +44626,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_aio_backend",
         "kind": "static_from",
-        "line": 627,
+        "line": 629,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44482,7 +44640,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -44491,7 +44649,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_comfy",
         "kind": "static_from",
-        "line": 627,
+        "line": 629,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44505,7 +44663,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -44514,7 +44672,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_spectrum_mod_guidance_advanced",
         "kind": "static_from",
-        "line": 627,
+        "line": 629,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44528,7 +44686,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -44537,7 +44695,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_spectrum_spd",
         "kind": "static_from",
-        "line": 627,
+        "line": 629,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44551,7 +44709,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -44560,7 +44718,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_CACHE_FORMAT",
         "kind": "static_from",
-        "line": 641,
+        "line": 643,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44574,7 +44732,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -44583,7 +44741,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_CACHE_QUALITY",
         "kind": "static_from",
-        "line": 641,
+        "line": 643,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44597,7 +44755,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -44606,7 +44764,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_EVENT",
         "kind": "static_from",
-        "line": 641,
+        "line": 643,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44620,7 +44778,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -44629,7 +44787,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_STAGE_LABELS",
         "kind": "static_from",
-        "line": 641,
+        "line": 643,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44643,7 +44801,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -44652,7 +44810,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_aio_preview_base_directory",
         "kind": "static_from",
-        "line": 641,
+        "line": 643,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44666,7 +44824,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -44675,7 +44833,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_aio_preview_file_size_bytes",
         "kind": "static_from",
-        "line": 641,
+        "line": 643,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44689,7 +44847,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -44698,7 +44856,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_bind_aio_preview_runtime",
         "kind": "static_from",
-        "line": 641,
+        "line": 643,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44712,7 +44870,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -44721,7 +44879,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_save_aio_temp_preview_image",
         "kind": "static_from",
-        "line": 641,
+        "line": 643,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44735,7 +44893,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -44744,7 +44902,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_send_aio_preview_event",
         "kind": "static_from",
-        "line": 641,
+        "line": 643,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44758,7 +44916,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -44767,7 +44925,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_tag_aio_preview_images",
         "kind": "static_from",
-        "line": 641,
+        "line": 643,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44781,7 +44939,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -44790,7 +44948,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_image_saver_additional_hashes",
         "kind": "static_from",
-        "line": 653,
+        "line": 655,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44804,7 +44962,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -44813,7 +44971,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_image_saver_civitai_hash_fetcher_entries",
         "kind": "static_from",
-        "line": 653,
+        "line": 655,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44827,7 +44985,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -44836,7 +44994,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_lora_metadata_name",
         "kind": "static_from",
-        "line": 653,
+        "line": 655,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44850,7 +45008,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -44859,7 +45017,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_prompt_with_lora_metadata",
         "kind": "static_from",
-        "line": 653,
+        "line": 655,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44873,7 +45031,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -44882,7 +45040,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_save_filename_prefix",
         "kind": "static_from",
-        "line": 653,
+        "line": 655,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44896,7 +45054,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -44905,7 +45063,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_bind_aio_output_runtime",
         "kind": "static_from",
-        "line": 653,
+        "line": 655,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44919,53 +45077,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
-            "kind": "try",
-            "line": 9
-          }
-        ],
-        "classification": "compatibility_fallback",
-        "conditional": true,
-        "imported": "easyuse_anima.aio.output:_normalize_aio_civitai_hash_fetchers",
-        "kind": "static_from",
-        "line": 653,
-        "optional": false,
-        "role": "compatibility_fallback",
-        "source": "nodes.py",
-        "target": "easyuse_anima/aio/output.py"
-      },
-      {
-        "branch_context": [
-          {
-            "branch": "except",
-            "catches_import_error": true,
-            "exceptions": [
-              "ImportError"
-            ],
-            "handler_line": 552,
-            "kind": "try",
-            "line": 9
-          }
-        ],
-        "classification": "compatibility_fallback",
-        "conditional": true,
-        "imported": "easyuse_anima.aio.output:_normalize_aio_hash_bundles",
-        "kind": "static_from",
-        "line": 653,
-        "optional": false,
-        "role": "compatibility_fallback",
-        "source": "nodes.py",
-        "target": "easyuse_anima/aio/output.py"
-      },
-      {
-        "branch_context": [
-          {
-            "branch": "except",
-            "catches_import_error": true,
-            "exceptions": [
-              "ImportError"
-            ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -44974,7 +45086,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_save_image_with_comfy",
         "kind": "static_from",
-        "line": 653,
+        "line": 655,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44988,7 +45100,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -44997,7 +45109,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_save_image_with_image_saver",
         "kind": "static_from",
-        "line": 653,
+        "line": 655,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45011,7 +45123,53 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
+            "kind": "try",
+            "line": 9
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.aio.output_settings:_normalize_aio_civitai_hash_fetchers",
+        "kind": "static_from",
+        "line": 665,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "nodes.py",
+        "target": "easyuse_anima/aio/output_settings.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 554,
+            "kind": "try",
+            "line": 9
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.aio.output_settings:_normalize_aio_hash_bundles",
+        "kind": "static_from",
+        "line": 665,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "nodes.py",
+        "target": "easyuse_anima/aio/output_settings.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -45020,7 +45178,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_bind_aio_resource_runtime",
         "kind": "static_from",
-        "line": 665,
+        "line": 669,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45034,7 +45192,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -45043,7 +45201,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_clip_loader_types",
         "kind": "static_from",
-        "line": 665,
+        "line": 669,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45057,7 +45215,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -45066,7 +45224,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_diffusion_model_names",
         "kind": "static_from",
-        "line": 665,
+        "line": 669,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45080,7 +45238,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -45089,7 +45247,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_text_encoder_names",
         "kind": "static_from",
-        "line": 665,
+        "line": 669,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45103,7 +45261,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -45112,7 +45270,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_vae_names",
         "kind": "static_from",
-        "line": 665,
+        "line": 669,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45126,7 +45284,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -45135,7 +45293,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_aio_resources_from_input_context",
         "kind": "static_from",
-        "line": 665,
+        "line": 669,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45149,7 +45307,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -45158,7 +45316,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_aio_sam3_context",
         "kind": "static_from",
-        "line": 665,
+        "line": 669,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45172,7 +45330,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -45181,7 +45339,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_checkpoint_with_comfy",
         "kind": "static_from",
-        "line": 665,
+        "line": 669,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45195,7 +45353,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -45204,7 +45362,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_clip_with_comfy",
         "kind": "static_from",
-        "line": 665,
+        "line": 669,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45218,7 +45376,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -45227,7 +45385,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_diffusion_model_with_comfy",
         "kind": "static_from",
-        "line": 665,
+        "line": 669,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45241,7 +45399,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -45250,7 +45408,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_upscale_model_with_comfy",
         "kind": "static_from",
-        "line": 665,
+        "line": 669,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45264,7 +45422,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -45273,7 +45431,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_vae_with_comfy",
         "kind": "static_from",
-        "line": 665,
+        "line": 669,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45287,7 +45445,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -45296,7 +45454,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_normalize_aio_input_settings",
         "kind": "static_from",
-        "line": 665,
+        "line": 669,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45310,7 +45468,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -45319,7 +45477,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_checkpoint_default",
         "kind": "static_from",
-        "line": 665,
+        "line": 669,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45333,7 +45491,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -45342,7 +45500,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_clip_type_default",
         "kind": "static_from",
-        "line": 665,
+        "line": 669,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45356,7 +45514,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -45365,7 +45523,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_name_default",
         "kind": "static_from",
-        "line": 665,
+        "line": 669,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45379,7 +45537,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -45388,7 +45546,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_json_clone",
         "kind": "static_from",
-        "line": 683,
+        "line": 687,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45402,7 +45560,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -45411,7 +45569,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_json_object",
         "kind": "static_from",
-        "line": 683,
+        "line": 687,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45425,7 +45583,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -45434,7 +45592,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_stable_change_key",
         "kind": "static_from",
-        "line": 683,
+        "line": 687,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45448,7 +45606,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -45457,7 +45615,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_bool",
         "kind": "static_from",
-        "line": 688,
+        "line": 692,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45471,7 +45629,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -45480,7 +45638,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_float",
         "kind": "static_from",
-        "line": 688,
+        "line": 692,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45494,7 +45652,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -45503,7 +45661,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_int",
         "kind": "static_from",
-        "line": 688,
+        "line": 692,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45517,7 +45675,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -45526,7 +45684,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_choice",
         "kind": "static_from",
-        "line": 688,
+        "line": 692,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45540,7 +45698,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -45549,7 +45707,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_single_value",
         "kind": "static_from",
-        "line": 688,
+        "line": 692,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45563,7 +45721,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -45572,7 +45730,7 @@
         "conditional": true,
         "imported": "easyuse_anima.seed.compatibility:WILDCARD_QUEUE_MAX_SAFE_SEED",
         "kind": "static_from",
-        "line": 695,
+        "line": 699,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45586,7 +45744,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -45595,7 +45753,7 @@
         "conditional": true,
         "imported": "easyuse_anima.seed.compatibility:WILDCARD_RESERVED_NEXT_SEED_INPUT",
         "kind": "static_from",
-        "line": 695,
+        "line": 699,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45609,7 +45767,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -45618,7 +45776,7 @@
         "conditional": true,
         "imported": "easyuse_anima.seed.compatibility:_consume_reserved_wildcard_next_seed",
         "kind": "static_from",
-        "line": 695,
+        "line": 699,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45632,7 +45790,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -45641,7 +45799,7 @@
         "conditional": true,
         "imported": "easyuse_anima.workflow:_get_workflow_node",
         "kind": "static_from",
-        "line": 700,
+        "line": 704,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45655,7 +45813,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -45664,7 +45822,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_prompt_translation_change_key",
         "kind": "static_from",
-        "line": 701,
+        "line": 705,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45678,7 +45836,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -45687,7 +45845,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_split_tag_text",
         "kind": "static_from",
-        "line": 701,
+        "line": 705,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45701,7 +45859,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -45710,7 +45868,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_translate_prompt_text",
         "kind": "static_from",
-        "line": 701,
+        "line": 705,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45724,7 +45882,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -45733,7 +45891,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_HASH_COMMENT_RE",
         "kind": "static_from",
-        "line": 706,
+        "line": 710,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45747,7 +45905,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -45756,7 +45914,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_INLINE_SPACE_RE",
         "kind": "static_from",
-        "line": 706,
+        "line": 710,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45770,7 +45928,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -45779,7 +45937,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_WEIGHTED_TOKEN_RE",
         "kind": "static_from",
-        "line": 706,
+        "line": 710,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45793,7 +45951,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -45802,7 +45960,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_correct_builder_prompt",
         "kind": "static_from",
-        "line": 706,
+        "line": 710,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45816,7 +45974,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -45825,7 +45983,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_filter_metadata_prompt",
         "kind": "static_from",
-        "line": 706,
+        "line": 710,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45839,7 +45997,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -45848,7 +46006,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_join_prompt_tokens",
         "kind": "static_from",
-        "line": 706,
+        "line": 710,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45862,7 +46020,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -45871,7 +46029,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_metadata_filter_key",
         "kind": "static_from",
-        "line": 706,
+        "line": 710,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45885,7 +46043,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -45894,7 +46052,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_metadata_filter_keys",
         "kind": "static_from",
-        "line": 706,
+        "line": 710,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45908,7 +46066,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -45917,7 +46075,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_prompt_tokens",
         "kind": "static_from",
-        "line": 706,
+        "line": 710,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45931,7 +46089,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -45940,7 +46098,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:PROMPT_DATA_TYPE",
         "kind": "static_from",
-        "line": 719,
+        "line": 723,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45954,7 +46112,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -45963,7 +46121,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_advanced_outputs_from_prompt_data",
         "kind": "static_from",
-        "line": 719,
+        "line": 723,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45977,7 +46135,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -45986,7 +46144,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_apply_prompt_data_overrides",
         "kind": "static_from",
-        "line": 719,
+        "line": 723,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46000,7 +46158,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -46009,7 +46167,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_copy_prompt_data_for_update",
         "kind": "static_from",
-        "line": 719,
+        "line": 723,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46023,7 +46181,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -46032,7 +46190,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_normalize_prompt_data",
         "kind": "static_from",
-        "line": 719,
+        "line": 723,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46046,7 +46204,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -46055,7 +46213,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_prompt_data_json_safe",
         "kind": "static_from",
-        "line": 719,
+        "line": 723,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46069,7 +46227,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -46078,7 +46236,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_prompt_data_parameter_snapshot",
         "kind": "static_from",
-        "line": 719,
+        "line": 723,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46092,7 +46250,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -46101,7 +46259,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_artist_field_prompt",
         "kind": "static_from",
-        "line": 737,
+        "line": 741,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46115,7 +46273,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -46124,7 +46282,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_default_fields",
         "kind": "static_from",
-        "line": 737,
+        "line": 741,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46138,7 +46296,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -46147,7 +46305,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_enabled_naia_panes",
         "kind": "static_from",
-        "line": 737,
+        "line": 741,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46161,7 +46319,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -46170,7 +46328,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_enabled_pane_fields",
         "kind": "static_from",
-        "line": 737,
+        "line": 741,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46184,7 +46342,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -46193,7 +46351,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_field_input_values",
         "kind": "static_from",
-        "line": 737,
+        "line": 741,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46207,7 +46365,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -46216,7 +46374,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_field_socket_name",
         "kind": "static_from",
-        "line": 737,
+        "line": 741,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46230,7 +46388,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -46239,7 +46397,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_fields_json",
         "kind": "static_from",
-        "line": 737,
+        "line": 741,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46253,7 +46411,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -46262,7 +46420,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_has_enabled_naia",
         "kind": "static_from",
-        "line": 737,
+        "line": 741,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46276,7 +46434,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -46285,7 +46443,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_prompt_with_artist_override",
         "kind": "static_from",
-        "line": 737,
+        "line": 741,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46299,7 +46457,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -46308,7 +46466,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_uses_naia_resolution",
         "kind": "static_from",
-        "line": 737,
+        "line": 741,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46322,7 +46480,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -46331,7 +46489,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_apply_advanced_field_inputs",
         "kind": "static_from",
-        "line": 737,
+        "line": 741,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46345,7 +46503,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -46354,7 +46512,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_as_advanced_height",
         "kind": "static_from",
-        "line": 737,
+        "line": 741,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46368,7 +46526,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -46377,7 +46535,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_build_advanced_prompt_data",
         "kind": "static_from",
-        "line": 737,
+        "line": 741,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46391,7 +46549,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -46400,7 +46558,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_build_advanced_prompts",
         "kind": "static_from",
-        "line": 737,
+        "line": 741,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46414,7 +46572,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -46423,7 +46581,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_clone_advanced_fields",
         "kind": "static_from",
-        "line": 737,
+        "line": 741,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46437,7 +46595,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -46446,7 +46604,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_correct_advanced_field_sequence",
         "kind": "static_from",
-        "line": 737,
+        "line": 741,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46460,7 +46618,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -46469,7 +46627,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_expand_advanced_wildcard_fields",
         "kind": "static_from",
-        "line": 737,
+        "line": 741,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46483,7 +46641,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -46492,7 +46650,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_normalize_advanced_fields",
         "kind": "static_from",
-        "line": 737,
+        "line": 741,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46506,7 +46664,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -46515,7 +46673,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_normalize_prompt_studio_wildcard_seed_control",
         "kind": "static_from",
-        "line": 737,
+        "line": 741,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46529,7 +46687,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -46538,7 +46696,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_set_naia_field_text",
         "kind": "static_from",
-        "line": 737,
+        "line": 741,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46552,7 +46710,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -46561,7 +46719,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_translate_prompt_fields",
         "kind": "static_from",
-        "line": 737,
+        "line": 741,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46575,7 +46733,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -46584,7 +46742,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_apply_regional_field_inputs",
         "kind": "static_from",
-        "line": 772,
+        "line": 776,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46598,7 +46756,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -46607,7 +46765,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_build_regional_outputs",
         "kind": "static_from",
-        "line": 772,
+        "line": 776,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46621,7 +46779,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -46630,7 +46788,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_clone_regional_fields",
         "kind": "static_from",
-        "line": 772,
+        "line": 776,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46644,7 +46802,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -46653,7 +46811,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_conditioning_set_values",
         "kind": "static_from",
-        "line": 772,
+        "line": 776,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46667,7 +46825,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -46676,7 +46834,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_mask_ids",
         "kind": "static_from",
-        "line": 772,
+        "line": 776,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46690,7 +46848,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -46699,7 +46857,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_regional_config",
         "kind": "static_from",
-        "line": 772,
+        "line": 776,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46713,7 +46871,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -46722,7 +46880,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_regional_fields",
         "kind": "static_from",
-        "line": 772,
+        "line": 776,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46736,7 +46894,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -46745,7 +46903,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_parse_json_object",
         "kind": "static_from",
-        "line": 772,
+        "line": 776,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46759,7 +46917,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -46768,7 +46926,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_config_json",
         "kind": "static_from",
-        "line": 772,
+        "line": 776,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46782,7 +46940,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -46791,7 +46949,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_fields_json",
         "kind": "static_from",
-        "line": 772,
+        "line": 776,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46805,7 +46963,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -46814,7 +46972,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_mask_bounds_area",
         "kind": "static_from",
-        "line": 772,
+        "line": 776,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46828,7 +46986,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -46837,7 +46995,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_payload_canvas",
         "kind": "static_from",
-        "line": 772,
+        "line": 776,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46851,7 +47009,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -46860,7 +47018,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_union_mask_for_ids",
         "kind": "static_from",
-        "line": 772,
+        "line": 776,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46874,7 +47032,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -46883,7 +47041,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
         "kind": "static_from",
-        "line": 799,
+        "line": 803,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46897,7 +47055,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -46906,7 +47064,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODES",
         "kind": "static_from",
-        "line": 799,
+        "line": 803,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46920,7 +47078,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -46929,7 +47087,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 799,
+        "line": 803,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46943,7 +47101,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -46952,7 +47110,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_PROFILE_OFF",
         "kind": "static_from",
-        "line": 799,
+        "line": 803,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46966,7 +47124,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -46975,7 +47133,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_apply_spectrum_anima_mod_guidance",
         "kind": "static_from",
-        "line": 799,
+        "line": 803,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46989,7 +47147,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -46998,7 +47156,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_find_spectrum_anima_mod_guidance_class",
         "kind": "static_from",
-        "line": 799,
+        "line": 803,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47012,7 +47170,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -47021,7 +47179,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_normalize_anima_mod_guidance_profile",
         "kind": "static_from",
-        "line": 799,
+        "line": 803,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47035,7 +47193,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -47044,7 +47202,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_resolve_anima_mod_guidance_enabled",
         "kind": "static_from",
-        "line": 799,
+        "line": 803,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47058,7 +47216,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -47067,7 +47225,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
         "kind": "static_from",
-        "line": 814,
+        "line": 818,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47081,7 +47239,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -47090,7 +47248,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
         "kind": "static_from",
-        "line": 814,
+        "line": 818,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47104,7 +47262,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -47113,7 +47271,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
         "kind": "static_from",
-        "line": 814,
+        "line": 818,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47127,7 +47285,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -47136,7 +47294,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_EXACT_TOP_K",
         "kind": "static_from",
-        "line": 814,
+        "line": 818,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47150,7 +47308,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -47159,7 +47317,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
         "kind": "static_from",
-        "line": 814,
+        "line": 818,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47173,7 +47331,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -47182,7 +47340,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_START_PERCENT",
         "kind": "static_from",
-        "line": 814,
+        "line": 818,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47196,7 +47354,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -47205,7 +47363,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
         "kind": "static_from",
-        "line": 814,
+        "line": 818,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47219,7 +47377,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -47228,7 +47386,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STYLE_GAIN",
         "kind": "static_from",
-        "line": 814,
+        "line": 818,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47242,7 +47400,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -47251,7 +47409,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_INPUT_MODES",
         "kind": "static_from",
-        "line": 814,
+        "line": 818,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47265,7 +47423,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -47274,7 +47432,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 814,
+        "line": 818,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47288,7 +47446,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -47297,7 +47455,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_mix_inline_prompt",
         "kind": "static_from",
-        "line": 814,
+        "line": 818,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47311,7 +47469,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -47320,7 +47478,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_mix_mode_tooltip",
         "kind": "static_from",
-        "line": 814,
+        "line": 818,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47334,7 +47492,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -47343,7 +47501,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_prompt_with_position",
         "kind": "static_from",
-        "line": 814,
+        "line": 818,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47357,7 +47515,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -47366,7 +47524,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_tags_from_prompt",
         "kind": "static_from",
-        "line": 814,
+        "line": 818,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47380,7 +47538,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -47389,7 +47547,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_blend_conditionings",
         "kind": "static_from",
-        "line": 814,
+        "line": 818,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47403,7 +47561,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -47412,7 +47570,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bounded_artist_mix_float",
         "kind": "static_from",
-        "line": 814,
+        "line": 818,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47426,7 +47584,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -47435,7 +47593,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bounded_artist_mix_int",
         "kind": "static_from",
-        "line": 814,
+        "line": 818,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47449,7 +47607,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -47458,7 +47616,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_clustered",
         "kind": "static_from",
-        "line": 814,
+        "line": 818,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47472,7 +47630,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -47481,7 +47639,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_delta_rms",
         "kind": "static_from",
-        "line": 814,
+        "line": 818,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47495,7 +47653,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -47504,7 +47662,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_prompt_data_positive_conditioning",
         "kind": "static_from",
-        "line": 814,
+        "line": 818,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47518,7 +47676,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -47527,7 +47685,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_join_artist_mix_source_prompts",
         "kind": "static_from",
-        "line": 814,
+        "line": 818,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47541,7 +47699,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -47550,7 +47708,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_normalize_artist_mix_mode",
         "kind": "static_from",
-        "line": 814,
+        "line": 818,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47564,7 +47722,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -47573,7 +47731,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_normalize_artist_tag_position",
         "kind": "static_from",
-        "line": 814,
+        "line": 818,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47587,7 +47745,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -47596,7 +47754,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_parse_artist_mix_items",
         "kind": "static_from",
-        "line": 814,
+        "line": 818,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47610,7 +47768,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -47619,7 +47777,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaArtistMixConditioning",
         "kind": "static_from",
-        "line": 893,
+        "line": 897,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47633,7 +47791,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -47642,7 +47800,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataConditioning",
         "kind": "static_from",
-        "line": 893,
+        "line": 897,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47656,7 +47814,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -47665,7 +47823,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataUnpack",
         "kind": "static_from",
-        "line": 893,
+        "line": 897,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47679,7 +47837,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -47688,7 +47846,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_ANY_TYPE",
         "kind": "static_from",
-        "line": 898,
+        "line": 902,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47702,7 +47860,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -47711,7 +47869,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_AnyType",
         "kind": "static_from",
-        "line": 898,
+        "line": 902,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47725,7 +47883,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -47734,7 +47892,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_FlexibleOptionalInputType",
         "kind": "static_from",
-        "line": 898,
+        "line": 902,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47748,7 +47906,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -47757,7 +47915,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvanced",
         "kind": "static_from",
-        "line": 903,
+        "line": 907,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47771,7 +47929,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -47780,7 +47938,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvancedV2",
         "kind": "static_from",
-        "line": 903,
+        "line": 907,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47794,7 +47952,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -47803,7 +47961,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:EasyUseAnimaAIOGenerator",
         "kind": "static_from",
-        "line": 908,
+        "line": 912,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47817,7 +47975,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -47826,7 +47984,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:EasyUseAnimaInput",
         "kind": "static_from",
-        "line": 908,
+        "line": 912,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47840,7 +47998,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -47849,7 +48007,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_aio_generation_settings_json",
         "kind": "static_from",
-        "line": 908,
+        "line": 912,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47863,7 +48021,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -47872,7 +48030,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_aio_input_settings_json",
         "kind": "static_from",
-        "line": 908,
+        "line": 912,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47886,7 +48044,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -47895,7 +48053,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_bind_aio_node_runtime",
         "kind": "static_from",
-        "line": 908,
+        "line": 912,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47909,7 +48067,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -47918,7 +48076,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_easy_use_anima_input_signature",
         "kind": "static_from",
-        "line": 908,
+        "line": 912,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47932,7 +48090,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -47941,7 +48099,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_require_easy_use_anima_input",
         "kind": "static_from",
-        "line": 908,
+        "line": 912,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47955,7 +48113,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -47964,7 +48122,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_align_down",
         "kind": "static_from",
-        "line": 917,
+        "line": 921,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47978,7 +48136,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -47987,7 +48145,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_align_nearest",
         "kind": "static_from",
-        "line": 917,
+        "line": 921,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48001,7 +48159,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -48010,7 +48168,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_image_tensor_size",
         "kind": "static_from",
-        "line": 917,
+        "line": 921,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48024,7 +48182,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -48033,7 +48191,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_context_value",
         "kind": "static_from",
-        "line": 928,
+        "line": 932,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48047,7 +48205,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -48056,7 +48214,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_sam3_context",
         "kind": "static_from",
-        "line": 928,
+        "line": 932,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48070,7 +48228,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -48079,7 +48237,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_segs_has_items",
         "kind": "static_from",
-        "line": 928,
+        "line": 932,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48093,7 +48251,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -48102,7 +48260,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:IMAGE_SCALE_MULTIPLES",
         "kind": "static_from",
-        "line": 940,
+        "line": 944,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48116,7 +48274,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -48125,7 +48283,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:IMAGE_UPSCALE_METHODS",
         "kind": "static_from",
-        "line": 940,
+        "line": 944,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48139,7 +48297,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -48148,7 +48306,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_sampler_names",
         "kind": "static_from",
-        "line": 948,
+        "line": 952,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48162,7 +48320,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -48171,7 +48329,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_scheduler_names",
         "kind": "static_from",
-        "line": 948,
+        "line": 952,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48185,7 +48343,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -48194,7 +48352,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_impact_scheduler_names",
         "kind": "static_from",
-        "line": 948,
+        "line": 952,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48208,7 +48366,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -48217,7 +48375,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_call_with_supported_kwargs",
         "kind": "static_from",
-        "line": 954,
+        "line": 958,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48231,7 +48389,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -48240,7 +48398,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_common_upscale_image",
         "kind": "static_from",
-        "line": 954,
+        "line": 958,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48254,7 +48412,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -48263,7 +48421,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_node_output_tuple",
         "kind": "static_from",
-        "line": 954,
+        "line": 958,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48277,7 +48435,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -48286,7 +48444,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.wiring:resolve_comfy_host_helper",
         "kind": "static_from",
-        "line": 959,
+        "line": 963,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48300,7 +48458,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -48309,7 +48467,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_clip_loader_types",
         "kind": "static_from",
-        "line": 962,
+        "line": 966,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48323,7 +48481,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -48332,7 +48490,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_diffusion_model_names",
         "kind": "static_from",
-        "line": 962,
+        "line": 966,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48346,7 +48504,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -48355,7 +48513,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_text_encoder_names",
         "kind": "static_from",
-        "line": 962,
+        "line": 966,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48369,7 +48527,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -48378,7 +48536,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_vae_names",
         "kind": "static_from",
-        "line": 962,
+        "line": 966,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48392,7 +48550,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -48401,7 +48559,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_folder_path_names",
         "kind": "static_from",
-        "line": 962,
+        "line": 966,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48415,7 +48573,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -48424,7 +48582,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.image_nodes:EasyUseAnimaDetailerAlignHook",
         "kind": "static_from",
-        "line": 970,
+        "line": 974,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48438,7 +48596,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -48447,7 +48605,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.image_nodes:EasyUseAnimaImageScaleByMultiple",
         "kind": "static_from",
-        "line": 970,
+        "line": 974,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48461,7 +48619,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -48470,7 +48628,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Context",
         "kind": "static_from",
-        "line": 974,
+        "line": 978,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48484,7 +48642,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -48493,7 +48651,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Detailer",
         "kind": "static_from",
-        "line": 974,
+        "line": 978,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48507,7 +48665,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -48516,7 +48674,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptBuilder",
         "kind": "static_from",
-        "line": 978,
+        "line": 982,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48530,7 +48688,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -48539,7 +48697,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrector",
         "kind": "static_from",
-        "line": 978,
+        "line": 982,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48553,7 +48711,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -48562,7 +48720,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrectorSimple",
         "kind": "static_from",
-        "line": 978,
+        "line": 982,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48576,7 +48734,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -48585,7 +48743,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptStudio",
         "kind": "static_from",
-        "line": 978,
+        "line": 982,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48599,7 +48757,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -48608,7 +48766,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:EasyUseAnimaPromptStudioRegional",
         "kind": "static_from",
-        "line": 984,
+        "line": 988,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48622,7 +48780,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -48631,7 +48789,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:EasyUseAnimaRegionalConditioning",
         "kind": "static_from",
-        "line": 984,
+        "line": 988,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48645,7 +48803,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -48654,7 +48812,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:LATENT_ALIGN",
         "kind": "static_from",
-        "line": 988,
+        "line": 992,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48668,7 +48826,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -48677,7 +48835,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_parse_random_response",
         "kind": "static_from",
-        "line": 988,
+        "line": 992,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48691,7 +48849,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -48700,7 +48858,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_post_random",
         "kind": "static_from",
-        "line": 988,
+        "line": 992,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48714,7 +48872,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -48723,7 +48881,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_advanced_resolution_from_selection",
         "kind": "static_from",
-        "line": 1006,
+        "line": 1010,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48737,7 +48895,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -48746,7 +48904,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_normalize_resolution_bucket",
         "kind": "static_from",
-        "line": 1006,
+        "line": 1010,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48760,7 +48918,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -48769,7 +48927,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_ratio_label",
         "kind": "static_from",
-        "line": 1006,
+        "line": 1010,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48783,7 +48941,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -48792,7 +48950,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolution_label",
         "kind": "static_from",
-        "line": 1006,
+        "line": 1010,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48806,7 +48964,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -48815,7 +48973,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolve_naia_resolution",
         "kind": "static_from",
-        "line": 1006,
+        "line": 1010,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48829,7 +48987,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -48838,7 +48996,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.naia_nodes:EasyUseAnimaNAIARandomPrompt",
         "kind": "static_from",
-        "line": 1029,
+        "line": 1033,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48852,7 +49010,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -48861,7 +49019,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.naia_nodes:_bind_naia_node_runtime",
         "kind": "static_from",
-        "line": 1029,
+        "line": 1033,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48875,7 +49033,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -48884,7 +49042,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.wildcard_nodes:EasyUseAnimaWildcard",
         "kind": "static_from",
-        "line": 1033,
+        "line": 1037,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48898,7 +49056,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -48907,7 +49065,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.wildcard_nodes:_bind_wildcard_node_runtime",
         "kind": "static_from",
-        "line": 1033,
+        "line": 1037,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48921,7 +49079,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -48930,7 +49088,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_apply_lora_syntax_format",
         "kind": "static_from",
-        "line": 1038,
+        "line": 1042,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48944,7 +49102,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -48953,7 +49111,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_dedupe_text_values",
         "kind": "static_from",
-        "line": 1038,
+        "line": 1042,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48967,7 +49125,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -48976,7 +49134,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_fallback_lora_path",
         "kind": "static_from",
-        "line": 1038,
+        "line": 1042,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48990,7 +49148,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -48999,7 +49157,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_get_lora_info",
         "kind": "static_from",
-        "line": 1038,
+        "line": 1042,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49013,7 +49171,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -49022,7 +49180,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_get_lora_manager_trigger_words",
         "kind": "static_from",
-        "line": 1038,
+        "line": 1042,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49036,7 +49194,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -49045,7 +49203,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_load_lora_manager_metadata",
         "kind": "static_from",
-        "line": 1038,
+        "line": 1042,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49059,7 +49217,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -49068,7 +49226,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_combo_values",
         "kind": "static_from",
-        "line": 1038,
+        "line": 1042,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49082,7 +49240,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -49091,7 +49249,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_manager_trigger_words_from_metadata",
         "kind": "static_from",
-        "line": 1038,
+        "line": 1042,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49105,7 +49263,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -49114,7 +49272,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_model_exists",
         "kind": "static_from",
-        "line": 1038,
+        "line": 1042,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49128,7 +49286,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -49137,7 +49295,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_stack_name",
         "kind": "static_from",
-        "line": 1038,
+        "line": 1042,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49151,7 +49309,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -49160,7 +49318,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_metadata_json_paths_for_lora",
         "kind": "static_from",
-        "line": 1038,
+        "line": 1042,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49174,7 +49332,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -49183,7 +49341,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_missing_lora_display_name",
         "kind": "static_from",
-        "line": 1038,
+        "line": 1042,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49197,7 +49355,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -49206,7 +49364,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_raise_missing_loras",
         "kind": "static_from",
-        "line": 1038,
+        "line": 1042,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49220,7 +49378,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -49229,7 +49387,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_trigger_words_from_value",
         "kind": "static_from",
-        "line": 1038,
+        "line": 1042,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49243,7 +49401,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -49252,7 +49410,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_correct_style_prompt",
         "kind": "static_from",
-        "line": 1054,
+        "line": 1058,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49266,7 +49424,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -49275,7 +49433,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_format_strength",
         "kind": "static_from",
-        "line": 1054,
+        "line": 1058,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49289,7 +49447,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -49298,7 +49456,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_get_loras_list",
         "kind": "static_from",
-        "line": 1054,
+        "line": 1058,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49312,7 +49470,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -49321,7 +49479,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_load_profile_data",
         "kind": "static_from",
-        "line": 1054,
+        "line": 1058,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49335,7 +49493,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -49344,7 +49502,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_profile_key",
         "kind": "static_from",
-        "line": 1054,
+        "line": 1058,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49358,7 +49516,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -49367,7 +49525,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_select_profile_values",
         "kind": "static_from",
-        "line": 1054,
+        "line": 1058,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49381,7 +49539,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -49390,7 +49548,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_wrap_profile_index",
         "kind": "static_from",
-        "line": 1054,
+        "line": 1058,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49404,7 +49562,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -49413,7 +49571,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.lora_nodes:EasyUseAnimaLoraPreset",
         "kind": "static_from",
-        "line": 1063,
+        "line": 1067,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49427,7 +49585,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -49436,7 +49594,7 @@
         "conditional": true,
         "imported": "anima_prompt:correct_prompt",
         "kind": "static_from",
-        "line": 1066,
+        "line": 1070,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49450,7 +49608,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -49459,7 +49617,7 @@
         "conditional": true,
         "imported": "anima_prompt:load_knowledge_base",
         "kind": "static_from",
-        "line": 1066,
+        "line": 1070,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49473,7 +49631,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -49482,7 +49640,7 @@
         "conditional": true,
         "imported": "anima_prompt.parser:parse_prompt",
         "kind": "static_from",
-        "line": 1067,
+        "line": 1071,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49496,7 +49654,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -49505,7 +49663,7 @@
         "conditional": true,
         "imported": "settings:resolve_metadata_filter_words",
         "kind": "static_from",
-        "line": 1068,
+        "line": 1072,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49519,7 +49677,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -49528,7 +49686,7 @@
         "conditional": true,
         "imported": "settings:resolve_naia_settings",
         "kind": "static_from",
-        "line": 1068,
+        "line": 1072,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49542,7 +49700,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -49551,7 +49709,7 @@
         "conditional": true,
         "imported": "settings:resolve_prompt_translation_settings",
         "kind": "static_from",
-        "line": 1068,
+        "line": 1072,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49565,7 +49723,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -49574,7 +49732,7 @@
         "conditional": true,
         "imported": "prompt_translation:has_prompt_translation_markers",
         "kind": "static_from",
-        "line": 1073,
+        "line": 1077,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49588,7 +49746,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -49597,7 +49755,7 @@
         "conditional": true,
         "imported": "prompt_translation:translate_prompt_markers",
         "kind": "static_from",
-        "line": 1073,
+        "line": 1077,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49611,7 +49769,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -49620,7 +49778,7 @@
         "conditional": true,
         "imported": "wildcard_engine:MAX_SEED",
         "kind": "static_from",
-        "line": 1074,
+        "line": 1078,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49634,7 +49792,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -49643,7 +49801,7 @@
         "conditional": true,
         "imported": "wildcard_engine:PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "kind": "static_from",
-        "line": 1074,
+        "line": 1078,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49657,7 +49815,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -49666,7 +49824,7 @@
         "conditional": true,
         "imported": "wildcard_engine:PUBLIC_MAX_SEED",
         "kind": "static_from",
-        "line": 1074,
+        "line": 1078,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49680,7 +49838,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -49689,7 +49847,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_DECREMENT",
         "kind": "static_from",
-        "line": 1074,
+        "line": 1078,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49703,7 +49861,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -49712,7 +49870,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_FIXED",
         "kind": "static_from",
-        "line": 1074,
+        "line": 1078,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49726,7 +49884,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -49735,7 +49893,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_INCREMENT",
         "kind": "static_from",
-        "line": 1074,
+        "line": 1078,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49749,7 +49907,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -49758,7 +49916,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_MODES",
         "kind": "static_from",
-        "line": 1074,
+        "line": 1078,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49772,7 +49930,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -49781,7 +49939,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_RANDOMIZE",
         "kind": "static_from",
-        "line": 1074,
+        "line": 1078,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49795,7 +49953,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -49804,7 +49962,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_FIXED",
         "kind": "static_from",
-        "line": 1074,
+        "line": 1078,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49818,7 +49976,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -49827,7 +49985,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_POPULATE",
         "kind": "static_from",
-        "line": 1074,
+        "line": 1078,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49841,7 +49999,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -49850,7 +50008,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_SEQUENTIAL",
         "kind": "static_from",
-        "line": 1074,
+        "line": 1078,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49864,7 +50022,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -49873,7 +50031,7 @@
         "conditional": true,
         "imported": "wildcard_engine:expand_wildcard_texts",
         "kind": "static_from",
-        "line": 1074,
+        "line": 1078,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49887,7 +50045,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -49896,7 +50054,7 @@
         "conditional": true,
         "imported": "wildcard_engine:expand_wildcards",
         "kind": "static_from",
-        "line": 1074,
+        "line": 1078,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49910,7 +50068,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -49919,7 +50077,7 @@
         "conditional": true,
         "imported": "wildcard_engine:has_wildcard_syntax",
         "kind": "static_from",
-        "line": 1074,
+        "line": 1078,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49933,7 +50091,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -49942,7 +50100,7 @@
         "conditional": true,
         "imported": "wildcard_engine:next_seed",
         "kind": "static_from",
-        "line": 1074,
+        "line": 1078,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49956,7 +50114,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -49965,7 +50123,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_prompt_studio_wildcard_mode",
         "kind": "static_from",
-        "line": 1074,
+        "line": 1078,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49979,7 +50137,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -49988,7 +50146,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_seed",
         "kind": "static_from",
-        "line": 1074,
+        "line": 1078,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50002,7 +50160,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -50011,7 +50169,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_wildcard_mode",
         "kind": "static_from",
-        "line": 1074,
+        "line": 1078,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50025,7 +50183,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 554,
             "kind": "try",
             "line": 9
           }
@@ -50034,7 +50192,7 @@
         "conditional": true,
         "imported": "wildcard_engine:wildcard_sources_signature",
         "kind": "static_from",
-        "line": 1074,
+        "line": 1078,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51562,7 +51720,7 @@
         "branch_context": [],
         "classification": "external",
         "conditional": false,
-        "imported": "json",
+        "imported": "os",
         "kind": "static_import",
         "line": 5,
         "optional": false,
@@ -51573,20 +51731,9 @@
         "branch_context": [],
         "classification": "external",
         "conditional": false,
-        "imported": "os",
-        "kind": "static_import",
-        "line": 6,
-        "optional": false,
-        "role": "ordinary",
-        "source": "easyuse_anima/aio/output.py"
-      },
-      {
-        "branch_context": [],
-        "classification": "external",
-        "conditional": false,
         "imported": "collections.abc:Callable",
         "kind": "static_from",
-        "line": 7,
+        "line": 6,
         "optional": false,
         "role": "ordinary",
         "source": "easyuse_anima/aio/output.py"
@@ -51597,7 +51744,7 @@
         "conditional": false,
         "imported": "typing:Any",
         "kind": "static_from",
-        "line": 8,
+        "line": 7,
         "optional": false,
         "role": "ordinary",
         "source": "easyuse_anima/aio/output.py"
@@ -51608,7 +51755,7 @@
         "conditional": false,
         "imported": "typing:TypeAlias",
         "kind": "static_from",
-        "line": 8,
+        "line": 7,
         "optional": false,
         "role": "ordinary",
         "source": "easyuse_anima/aio/output.py"
@@ -51620,17 +51767,50 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 160
+            "line": 122
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 161,
+        "line": 123,
         "optional": true,
         "role": "optional_dependency",
         "source": "easyuse_anima/aio/output.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "__future__:annotations",
+        "kind": "static_from",
+        "line": 3,
+        "optional": false,
+        "role": "ordinary",
+        "source": "easyuse_anima/aio/output_settings.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "json",
+        "kind": "static_import",
+        "line": 5,
+        "optional": false,
+        "role": "ordinary",
+        "source": "easyuse_anima/aio/output_settings.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "typing:Any",
+        "kind": "static_from",
+        "line": 6,
+        "optional": false,
+        "role": "ordinary",
+        "source": "easyuse_anima/aio/output_settings.py"
       },
       {
         "branch_context": [],
@@ -54707,14 +54887,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 160
+            "line": 122
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 161,
+        "line": 123,
         "optional": true,
         "role": "optional_dependency",
         "source": "easyuse_anima/aio/output.py"
@@ -55534,6 +55714,7 @@
       "easyuse_anima/aio/legacy_generation.py",
       "easyuse_anima/aio/model_preparation.py",
       "easyuse_anima/aio/output.py",
+      "easyuse_anima/aio/output_settings.py",
       "easyuse_anima/aio/postprocess.py",
       "easyuse_anima/aio/preview.py",
       "easyuse_anima/aio/resources.py",
@@ -55625,6 +55806,7 @@
       "easyuse_anima/aio/legacy_generation.py",
       "easyuse_anima/aio/model_preparation.py",
       "easyuse_anima/aio/output.py",
+      "easyuse_anima/aio/output_settings.py",
       "easyuse_anima/aio/postprocess.py",
       "easyuse_anima/aio/preview.py",
       "easyuse_anima/aio/resources.py",
@@ -56355,7 +56537,7 @@
         "column": 26,
         "context": "assign:_AIO_DETAILER_CUSTOM_RE",
         "kind": "import_time_call",
-        "line": 40,
+        "line": 45,
         "module": "easyuse_anima/aio/generation_normalization.py",
         "scope": "<module>"
       },
@@ -56742,7 +56924,7 @@
         "column": 9,
         "context": "assign:logger",
         "kind": "import_time_call",
-        "line": 1096,
+        "line": 1100,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -56751,7 +56933,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1588,
+        "line": 1592,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -56760,7 +56942,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1594,
+        "line": 1598,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -56769,7 +56951,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1600,
+        "line": 1604,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -56778,7 +56960,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1603,
+        "line": 1607,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -56787,7 +56969,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1606,
+        "line": 1610,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -56796,7 +56978,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1612,
+        "line": 1616,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -56805,7 +56987,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1618,
+        "line": 1622,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -56814,7 +56996,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1624,
+        "line": 1628,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -56823,7 +57005,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1630,
+        "line": 1634,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -56832,7 +57014,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1636,
+        "line": 1640,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -56841,7 +57023,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1642,
+        "line": 1646,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -56850,7 +57032,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1645,
+        "line": 1649,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -56859,7 +57041,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1652,
+        "line": 1656,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -57211,13 +57393,13 @@
       },
       {
         "kind": "set",
-        "line": 33,
+        "line": 38,
         "module": "easyuse_anima/aio/generation_normalization.py",
         "name": "AIO_SPECIAL_SEEDS"
       },
       {
         "kind": "set",
-        "line": 39,
+        "line": 44,
         "module": "easyuse_anima/aio/generation_normalization.py",
         "name": "_AIO_DETAILER_RESERVED_KEYS"
       },
@@ -57373,13 +57555,13 @@
       },
       {
         "kind": "dict",
-        "line": 1156,
+        "line": 1160,
         "module": "nodes.py",
         "name": "AIO_GENERATION_DEFAULT_SETTINGS"
       },
       {
         "kind": "dict",
-        "line": 1145,
+        "line": 1149,
         "module": "nodes.py",
         "name": "AIO_INPUT_DEFAULT_SETTINGS"
       },

--- a/tests/fixtures/python_compatibility_surface.v1.json
+++ b/tests/fixtures/python_compatibility_surface.v1.json
@@ -74,7 +74,8 @@
       "B-11c30c2a",
       "B-11c30c2b",
       "B-11c30d",
-      "B-11c30d1"
+      "B-11c30d1",
+      "B-11c30d0a"
     ]
   },
   "enums": {
@@ -623,7 +624,6 @@
       "easyuse_anima.aio.conditioning"
     ],
     "_normalize_aio_civitai_hash_fetchers": [
-      "easyuse_anima.aio.generation_normalization",
       "easyuse_anima.aio.output"
     ],
     "_normalize_aio_dit_corrections_settings": [
@@ -634,7 +634,6 @@
       "easyuse_anima.nodes.aio_nodes"
     ],
     "_normalize_aio_hash_bundles": [
-      "easyuse_anima.aio.generation_normalization",
       "easyuse_anima.aio.output"
     ],
     "_normalize_aio_input_settings": [
@@ -837,14 +836,14 @@
           "unique_bound_globals": [
             "_RUNTIME_RESOLVER"
           ],
-          "root_resolver_slots": 72,
-          "unique_root_resolver_names": 66,
+          "root_resolver_slots": 70,
+          "unique_root_resolver_names": 64,
           "provider_resolver_slots": 1,
           "unique_provider_resolver_names": 1,
           "direct_root_dependency_slots": 1,
           "unique_direct_root_dependencies": 1,
-          "repository_replacement_slots": 37,
-          "unique_repository_replacement_names": 31,
+          "repository_replacement_slots": 36,
+          "unique_repository_replacement_names": 30,
           "repository_replacement_files": [
             "tests/test_aio_generation_migrations.py",
             "tests/test_aio_generation_settings.py",
@@ -1410,7 +1409,6 @@
       ],
       "_as_bool": [
         "tests/test_aio_legacy_generation.py",
-        "tests/test_aio_output.py",
         "tests/test_node_contracts.py"
       ],
       "_as_float": [
@@ -1956,9 +1954,7 @@
           "_is_aio_detailer_target_name",
           "_json_clone",
           "_json_object",
-          "_normalize_aio_civitai_hash_fetchers",
           "_normalize_aio_dit_corrections_settings",
-          "_normalize_aio_hash_bundles",
           "_normalize_aio_seed",
           "_normalize_aio_spectrum_settings",
           "_normalize_anima_mod_guidance_profile",
@@ -2012,9 +2008,7 @@
           "_is_aio_detailer_target_name",
           "_json_clone",
           "_json_object",
-          "_normalize_aio_civitai_hash_fetchers",
           "_normalize_aio_dit_corrections_settings",
-          "_normalize_aio_hash_bundles",
           "_normalize_aio_seed",
           "_normalize_aio_spectrum_settings",
           "_normalize_anima_mod_guidance_profile",
@@ -2040,7 +2034,6 @@
           "_impact_scheduler_names",
           "_is_aio_detailer_target_name",
           "_json_clone",
-          "_normalize_aio_hash_bundles",
           "_normalize_aio_seed",
           "_normalize_anima_mod_guidance_profile",
           "_prompt_data_json_safe"
@@ -3797,8 +3790,6 @@
         "_aio_prompt_with_lora_metadata": "_aio_prompt_with_lora_metadata",
         "_aio_save_filename_prefix": "_aio_save_filename_prefix",
         "_bind_aio_output_runtime": "_bind_aio_output_runtime",
-        "_normalize_aio_civitai_hash_fetchers": "_normalize_aio_civitai_hash_fetchers",
-        "_normalize_aio_hash_bundles": "_normalize_aio_hash_bundles",
         "_save_image_with_comfy": "_save_image_with_comfy",
         "_save_image_with_image_saver": "_save_image_with_image_saver"
       },
@@ -3813,14 +3804,41 @@
       "first_release": null,
       "known_consumers": [
         "nodes.py residual runtime",
-        "canonical runtime resolver: easyuse_anima.aio.generation_normalization",
         "canonical runtime resolver: easyuse_anima.aio.legacy_generation",
         "canonical runtime resolver: easyuse_anima.aio.output"
       ],
       "evidence": [
         "AST:nodes.py direct runtime load",
-        "AST:easyuse_anima.aio.generation_normalization string runtime lookup",
         "AST:easyuse_anima.aio.legacy_generation string runtime lookup",
+        "AST:easyuse_anima.aio.output string runtime lookup"
+      ],
+      "removal_gates": [
+        "canonical production consumer migration",
+        "focused monkeypatch and identity contract review",
+        "separate B-10b or B-11 rollback unit"
+      ],
+      "lifecycle_state": "transitional"
+    },
+    {
+      "id": "nodes_canonical_bindings:easyuse_anima.aio.output_settings:transitional_private_seam",
+      "surface": "nodes_canonical_bindings",
+      "symbols": {
+        "_normalize_aio_civitai_hash_fetchers": "_normalize_aio_civitai_hash_fetchers",
+        "_normalize_aio_hash_bundles": "_normalize_aio_hash_bundles"
+      },
+      "classification": "transitional_private_seam",
+      "current_target": "nodes.py",
+      "canonical_target": "easyuse_anima.aio.output_settings",
+      "target_state": "canonical",
+      "identity_requirement": "required",
+      "binding_shape": "direct_import",
+      "import_target": "easyuse_anima.aio.output_settings",
+      "owner": "#184/#188",
+      "first_release": null,
+      "known_consumers": [
+        "canonical runtime resolver: easyuse_anima.aio.output"
+      ],
+      "evidence": [
         "AST:easyuse_anima.aio.output string runtime lookup"
       ],
       "removal_gates": [

--- a/tests/test_aio_output.py
+++ b/tests/test_aio_output.py
@@ -6,7 +6,7 @@ import unittest
 from unittest.mock import Mock, patch
 
 import nodes
-from easyuse_anima.aio import output
+from easyuse_anima.aio import output, output_settings
 from tests.comfy_host_fakes import patch_comfy_helper
 
 
@@ -15,6 +15,12 @@ class AIOOutputMoveTests(unittest.TestCase):
         for name in (
             "_normalize_aio_hash_bundles",
             "_normalize_aio_civitai_hash_fetchers",
+        ):
+            with self.subTest(name=name):
+                self.assertIs(getattr(nodes, name), getattr(output_settings, name))
+                self.assertIs(getattr(output, name), getattr(output_settings, name))
+
+        for name in (
             "_aio_image_saver_civitai_hash_fetcher_entries",
             "_aio_image_saver_additional_hashes",
             "_aio_lora_metadata_name",
@@ -26,9 +32,9 @@ class AIOOutputMoveTests(unittest.TestCase):
             with self.subTest(name=name):
                 self.assertIs(getattr(nodes, name), getattr(output, name))
 
-    def test_normalizers_preserve_json_fallback_filtering_and_root_bool_seam(self):
-        self.assertEqual(output._normalize_aio_hash_bundles(" raw, "), ["raw"])
-        self.assertEqual(output._normalize_aio_hash_bundles('"json-string"'), [])
+    def test_normalizers_preserve_json_fallback_filtering_and_canonical_bool_seam(self):
+        self.assertEqual(output_settings._normalize_aio_hash_bundles(" raw, "), ["raw"])
+        self.assertEqual(output_settings._normalize_aio_hash_bundles('"json-string"'), [])
 
         bool_calls = []
 
@@ -36,8 +42,8 @@ class AIOOutputMoveTests(unittest.TestCase):
             bool_calls.append((value, default))
             return value == "yes"
 
-        with patch.object(nodes, "_as_bool", side_effect=as_bool):
-            result = output._normalize_aio_civitai_hash_fetchers([
+        with patch.object(output_settings, "_as_bool", side_effect=as_bool):
+            result = output_settings._normalize_aio_civitai_hash_fetchers([
                 {"enabled": "yes", "username": " user ", "model_name": " model ", "version": " v1 "},
                 {"enabled": "no", "version": "only-version"},
                 {"ignored": True},
@@ -52,7 +58,7 @@ class AIOOutputMoveTests(unittest.TestCase):
             ],
         )
         self.assertEqual(bool_calls, [("yes", True), ("no", True)])
-        self.assertEqual(output._normalize_aio_civitai_hash_fetchers("not-json"), [])
+        self.assertEqual(output_settings._normalize_aio_civitai_hash_fetchers("not-json"), [])
 
     def test_civitai_hashes_preserve_order_success_and_soft_skip_paths(self):
         calls = []

--- a/tests/test_nodes_module_analyzer.py
+++ b/tests/test_nodes_module_analyzer.py
@@ -73,12 +73,12 @@ def load_dynamic():
     def test_current_nodes_module_shape_matches_recorded_baseline(self):
         report = analyzer.analyze_path(ROOT / "nodes.py")
 
-        self.assertEqual(report["git_blob_sha1"], "edcdc8681f64790736a790177ac80dadfda214b6")
-        # B-11c30d1 retires only the AiO cache-state binder import and call
-        # without changing the public class surface.
+        self.assertEqual(report["git_blob_sha1"], "76958b4111ef5a6400ab3e7e5c0f6b2afc77a432")
+        # B-11c30d0a redirects two root aliases to their pure output-settings
+        # owner without changing the public class surface.
         self.assertEqual(report["top_level"]["function_count"], 0)
         self.assertEqual(report["top_level"]["class_count"], 0)
-        self.assertEqual(report["line_count"], 1_657)
+        self.assertEqual(report["line_count"], 1_661)
         class_names = {item["name"] for item in report["top_level"]["classes"]}
         self.assertNotIn("EasyUseAnimaAIOGenerator", class_names)
         self.assertNotIn("EasyUseAnimaInput", class_names)

--- a/tests/test_python_backend_analyzer.py
+++ b/tests/test_python_backend_analyzer.py
@@ -683,9 +683,9 @@ ignored/
 
         self.assertEqual(analyzer.render_json(report), expected_text)
         self.assertEqual(report["schema_version"], 2)
-        self.assertEqual(report["inventory"]["module_count"], 89)
-        self.assertEqual(len(report["registry"]["shipped_python_modules"]), 89)
-        self.assertEqual(len(report["registry"]["runtime_import_closure"]), 89)
+        self.assertEqual(report["inventory"]["module_count"], 90)
+        self.assertEqual(len(report["registry"]["shipped_python_modules"]), 90)
+        self.assertEqual(len(report["registry"]["runtime_import_closure"]), 90)
         self.assertEqual(report["registry"]["missing_internal_imports"], [])
         self.assertEqual(report["registry"]["unreachable_shipped_python_modules"], [])
         self.assertTrue(
@@ -705,6 +705,7 @@ ignored/
                 "easyuse_anima/aio/generation_settings.py",
                 "easyuse_anima/aio/model_preparation.py",
                 "easyuse_anima/aio/output.py",
+                "easyuse_anima/aio/output_settings.py",
                 "easyuse_anima/aio/postprocess.py",
                 "easyuse_anima/aio/preview.py",
                 "easyuse_anima/aio/resources.py",

--- a/tests/test_python_compatibility_surface.py
+++ b/tests/test_python_compatibility_surface.py
@@ -2317,6 +2317,7 @@ def _build_document() -> dict[str, Any]:
                 "B-11c30c2b",
                 "B-11c30d",
                 "B-11c30d1",
+                "B-11c30d0a",
             ],
         },
         "enums": {
@@ -2696,12 +2697,12 @@ class PythonCompatibilitySurfaceTests(unittest.TestCase):
             summaries,
             {
                 "B-11c30d2_normalization_planning": {
-                    "root_resolver_slots": 72,
-                    "unique_root_resolver_names": 66,
+                    "root_resolver_slots": 70,
+                    "unique_root_resolver_names": 64,
                     "provider_resolver_slots": 1,
                     "direct_root_dependency_slots": 1,
-                    "repository_replacement_slots": 37,
-                    "unique_repository_replacement_names": 31,
+                    "repository_replacement_slots": 36,
+                    "unique_repository_replacement_names": 30,
                 },
                 "B-11c30d3_io_boundary": {
                     "root_resolver_slots": 49,


### PR DESCRIPTION
## 변경 요약

B-11c30d0a의 순수 owner Move입니다. AiO 출력 설정 normalizer 두 개를 `easyuse_anima.aio.output_settings`로 옮겨 d2-d4의 직접 import 순환을 해소했습니다. binder·동작·스키마는 변경하지 않습니다.

## 사전 inventory

- symbols: `_normalize_aio_hash_bundles`, `_normalize_aio_civitai_hash_fetchers`
- source: `easyuse_anima.aio.output`
- target: `easyuse_anima.aio.output_settings`
- callers:
  - `easyuse_anima.aio.generation_normalization`: 기존 root runtime resolver 조회
  - `easyuse_anima.aio.output`: save-time metadata 조합의 기존 root runtime resolver 조회
- aliases: `nodes.py` package/flat import 경로의 exact identity alias
- global state: 두 함수 자체의 mutable state 없음
- dependency: Civitai row의 `enabled` 변환은 이미 canonical인 `easyuse_anima.common.values._as_bool`로 직접 연결
- test seam: normalizer의 root `_as_bool` patch만 canonical owner patch로 이동. d3 save-time helper patch는 유지

## 구현 결과

- 새 순수 owner가 두 함수의 유일한 정의를 소유
- generation normalization은 owner를 직접 import하여 resolver edge 2개 제거
- output은 explicit re-export로 동일 객체를 유지하며 d3 runtime call은 변경하지 않음
- root는 두 import 모드 모두 owner를 직접 re-export하여 identity 유지
- d2 gate: root resolver slot/name 각각 2개 감소, replacement slot/name 각각 1개 감소
- 남은 binder 13개와 d3-d6 상태는 그대로 유지
- shipped/reachable Python module 90개, missing internal import 0

## Allowed-file boundary

Production:
- `nodes.py`
- `easyuse_anima/aio/output.py`
- `easyuse_anima/aio/output_settings.py`
- `easyuse_anima/aio/generation_normalization.py`

Supporting:
- focused output/generation tests
- Python compatibility gate/fixture
- nodes/backend analyzer gate/fixture
- backend architecture 문서 3개

## 금지 경계 확인

normalization 결과, JSON fallback, filtering, schema/workflow, save metadata, provider/error, seed/cache/stage는 변경하지 않았습니다. generation-normalization/output binder를 퇴역하지 않았고 d0b, d2-d6, Wildcard/NAIA, Contract, Behavior를 섞지 않았습니다.

## 검증

- focused 통합: 82 tests, 10.495s, 통과
- official full (구현 커밋 `090e930`, 300s 제한): 50.3s, 통과
  - Python unittest: 983 tests, 29.583s
  - frontend: 114 JavaScript files
  - Pyright: 73 files, 기존 14 errors, 신규 0
  - import boundary: 6 groups, 0 violations
  - git diff check: 통과
- full의 report-only Ruff가 explicit re-export 2개를 신규 F401로 표시해 최종 head에서 redundant alias로 정리
  - targeted Ruff: All checks passed
  - 후속 focused output/compatibility/backend-analyzer: 49 tests, 7.787s, 통과
  - full은 중복 실행하지 않음
- Live ComfyUI smoke: 순수 Python owner Move라 실행하지 않음

## 라벨

- `type: chore`
- `area: backend`
- `status: ready`

Owner: #184
Behavior boundary: #169