### PR TITLE
B-11c30d3: retire AiO I/O-boundary binders

### DIFF
--- a/docs/architecture/comfy-host-provider-bridge.md
+++ b/docs/architecture/comfy-host-provider-bridge.md
@@ -1853,7 +1853,7 @@ Implementation result:
 
 ### B-11c30d3 — AiO I/O-boundary binder Move
 
-- **State:** READY; Draft PR pending
+- **State:** COMPLETE in PR #350
 - **Owner:** #184
 - **Behavior boundary:** #169
 - **Type:** Move
@@ -1931,6 +1931,23 @@ Forbidden:
   Wildcard/NAIA binder; and
 - combining Contract, Behavior, performance, or broad formatting cleanup.
 
+Result:
+
+- all three d3 binder definitions, resolver globals/helpers, and root
+  imports/calls are absent;
+- `easyuse_anima.aio.input_defaults` is the single pure owner of the mutable
+  input-default payload and its declarative choices; root aliases preserve
+  exact identity;
+- resource, preview, and output owners use direct canonical dependencies,
+  while optional I/O imports and E-07 Comfy host lookup retain call-time
+  observation;
+- d3 alone is retired. Seven binders remain: five AiO binders in d4 through d6
+  and two Wildcard/NAIA binders;
+- the compatibility surface contains 296 canonical root bindings, three
+  residual root globals, and 92 shipped and reachable Python modules; and
+- `nodes.py` is 1,182 lines, 11,481 fewer than the 12,663-line Phase A
+  baseline (90.7% removed).
+
 ### B-11d — Final root shim
 
 - **State:** BLOCKED by the remaining AiO and Wildcard/NAIA binder families
@@ -1980,8 +1997,8 @@ COMPLETE: B-11c30d AiO binder split gate / PR #346
 COMPLETE: B-11c30d1 AiO cache-state binder Move / PR #347
 COMPLETE: B-11c30d0a output-settings owner Move / PR #348
 COMPLETE: B-11c30d2 normalization/planning binder Move / PR #349
-READY:    B-11c30d3 I/O-boundary binder Move
-PLANNED:  B-11c30d4 execution-service Move
+COMPLETE: B-11c30d3 I/O-boundary binder Move / PR #350
+READY:    B-11c30d4 execution-service Move
 PLANNED:  B-11c30d0b input-context owner Move before d5-d6
 PLANNED:  B-11c30d5-d6 orchestration and node-adapter Moves
 BLOCKED:  B-11d final root shim

--- a/docs/architecture/comfy-host-provider-bridge.md
+++ b/docs/architecture/comfy-host-provider-bridge.md
@@ -1851,6 +1851,86 @@ Implementation result:
   observation time, USDU planning, postprocess resize/metadata/logging, schema,
   workflow, and stage behavior remain unchanged.
 
+### B-11c30d3 — AiO I/O-boundary binder Move
+
+- **State:** READY; Draft PR pending
+- **Owner:** #184
+- **Behavior boundary:** #169
+- **Type:** Move
+- **Base:** `dev@fab74ef45837f0b8d05fe4f6b723b557b41f9f53`
+
+Pre-edit inventory:
+
+- the frozen d3 subgroup contains exactly `_bind_aio_resource_runtime`,
+  `_bind_aio_preview_runtime`, and `_bind_aio_output_runtime`;
+- the three binders own only three `_RUNTIME_RESOLVER` slots. They account for
+  49 root-resolver slots over 46 unique names, four provider slots over
+  `_find_comfy_node_class` and `_require_custom_node_class`, three direct
+  `_resolve_comfy_host_helper` dependencies, and 45 repository replacement
+  slots over 43 names in eight test files;
+- resources owns input-settings normalization, Comfy resource lists/loaders,
+  SAM3 context loading, and input-context resource loading. Its stateless
+  dependencies already have canonical owners in common values, generation
+  normalization, Comfy resource/invocation adapters, SAM3, and the E-07 host
+  provider;
+- root still owns `AIO_INPUT_DEFAULT_SETTINGS` plus its input schema/version,
+  default resource candidates, CLIP types/devices, and UNet dtypes. The mutable
+  default payload and related declarative values move with exact identity to a
+  pure `easyuse_anima.aio.input_defaults` owner. The later d0b input-context
+  Move remains separate;
+- preview owns its stage/event/cache constants, filesystem/path inspection,
+  event dispatch, temporary WebP save, and PreviewImage fallback. Optional
+  `folder_paths`, NumPy, PIL, and PromptServer imports remain call-time, while
+  node lookup stays behind the E-07 provider;
+- output owns Image Saver/Civitai metadata adaptation and Comfy SaveImage
+  invocation. It consumes the existing generation-defaults, output-settings,
+  common values, LoRA formatting, seed-resolution, and E-07 provider owners
+  directly; and
+- d3-owner tests patch the canonical resource, preview, or output module.
+  Replacements used to drive d4 through d6 remain on their still-active binder
+  families.
+
+Allowed production files:
+
+```text
+nodes.py
+easyuse_anima/aio/input_defaults.py
+easyuse_anima/aio/resources.py
+easyuse_anima/aio/preview.py
+easyuse_anima/aio/output.py
+```
+
+Allowed supporting files are the focused resource/preview/output and direct
+adapter tests, the Python package/compatibility gate and fixture, the
+nodes/backend analyzer gate and fixture, and the three architecture documents.
+
+Exit:
+
+- all three d3 binder definitions, root imports/calls, `_RUNTIME_RESOLVER`
+  slots, and `_runtime_helper` functions are absent;
+- input defaults and resource-choice constants have one pure data owner and
+  root retains exact aliases to the same objects/values;
+- resources imports canonical stateless dependencies directly and resolves
+  only Comfy node lookup through the existing E-07 call-time provider;
+- preview and output use canonical helpers and direct same-module calls while
+  preserving optional dependency observation time and provider lookup;
+- tests that patched root only to drive a d3 owner patch the canonical owner;
+- d3 alone is marked retired while d4 through d6 remain the exact active AiO
+  groups; and
+- resource selection/loading, input payload order/values, preview paths/files,
+  event payloads, WebP/PNG fallback, output metadata, save arguments, schemas,
+  workflows, stage order, errors, and logs are unchanged.
+
+Forbidden:
+
+- changing input defaults, validation choices, loader selection, provider
+  interface or lookup order, optional dependency timing, preview/save formats,
+  metadata, filenames, event payloads, errors, schemas, workflows, seeds,
+  cache, model preparation, sampling, conditioning, or stage order;
+- moving the d0b input-context functions or retiring any d4 through d6 or
+  Wildcard/NAIA binder; and
+- combining Contract, Behavior, performance, or broad formatting cleanup.
+
 ### B-11d — Final root shim
 
 - **State:** BLOCKED by the remaining AiO and Wildcard/NAIA binder families
@@ -1900,7 +1980,8 @@ COMPLETE: B-11c30d AiO binder split gate / PR #346
 COMPLETE: B-11c30d1 AiO cache-state binder Move / PR #347
 COMPLETE: B-11c30d0a output-settings owner Move / PR #348
 COMPLETE: B-11c30d2 normalization/planning binder Move / PR #349
-PLANNED:  B-11c30d3-d4 I/O and execution-service Moves
+READY:    B-11c30d3 I/O-boundary binder Move
+PLANNED:  B-11c30d4 execution-service Move
 PLANNED:  B-11c30d0b input-context owner Move before d5-d6
 PLANNED:  B-11c30d5-d6 orchestration and node-adapter Moves
 BLOCKED:  B-11d final root shim

--- a/docs/architecture/python-backend-execution-roadmap.md
+++ b/docs/architecture/python-backend-execution-roadmap.md
@@ -1088,6 +1088,10 @@ unchanged. The separate legacy Wildcard unsupported alias remains for D-12.
     `_bind_aio_postprocess_runtime` in PR #349. Generation defaults have one
     pure owner, the E-07 max-resolution seam remains call-time provider-owned,
     and d3 through d6 plus Wildcard/NAIA remain separate rollback units.
+  - B-11c30d3 is the next READY Move. It is limited to the resource, preview,
+    and output binder subgroup. Input defaults move to a pure data owner,
+    optional I/O dependencies stay call-time, and Comfy node lookup remains
+    behind the existing E-07 provider. d0b and d4 through d6 remain separate.
   - The final B-11c cutover removes remaining root execution ownership and
     leaves the explicit supported `nodes.py` compatibility shim.
 - Add `easyuse_anima/registration.py` as pure mapping composition. It performs no

--- a/docs/architecture/python-backend-execution-roadmap.md
+++ b/docs/architecture/python-backend-execution-roadmap.md
@@ -137,7 +137,10 @@ merged PR, the owning issue's evidence record, and every stated exit gate.
   the mutable settings payload and choices out of root, generation
   normalization uses canonical helpers plus the E-07 max-resolution provider,
   and USDU/postprocess planning use direct canonical dependencies. Ten binders
-  remain across AiO and Wildcard/NAIA.
+  remain across AiO and Wildcard/NAIA. B-11c30d3 / PR #350 retires only the
+  resource, preview, and output binders. Input defaults now have one pure data
+  owner, while optional I/O imports and E-07 host lookup remain call-time.
+  Seven binders remain: five AiO and two Wildcard/NAIA.
 
 ### Current quality baseline
 
@@ -1088,10 +1091,12 @@ unchanged. The separate legacy Wildcard unsupported alias remains for D-12.
     `_bind_aio_postprocess_runtime` in PR #349. Generation defaults have one
     pure owner, the E-07 max-resolution seam remains call-time provider-owned,
     and d3 through d6 plus Wildcard/NAIA remain separate rollback units.
-  - B-11c30d3 is the next READY Move. It is limited to the resource, preview,
-    and output binder subgroup. Input defaults move to a pure data owner,
-    optional I/O dependencies stay call-time, and Comfy node lookup remains
-    behind the existing E-07 provider. d0b and d4 through d6 remain separate.
+  - B-11c30d3 retires only the resource, preview, and output binders in PR
+    #350. Input defaults move to a pure data owner, optional I/O dependencies
+    stay call-time, and Comfy node lookup remains behind the existing E-07
+    provider. The root shim falls to 1,182 lines and the audited package grows
+    to 92 shipped and reachable modules. d0b and d4 through d6 remain
+    separate; B-11c30d4 is the next READY Move.
   - The final B-11c cutover removes remaining root execution ownership and
     leaves the explicit supported `nodes.py` compatibility shim.
 - Add `easyuse_anima/registration.py` as pure mapping composition. It performs no

--- a/docs/architecture/python-compatibility-shims.md
+++ b/docs/architecture/python-compatibility-shims.md
@@ -924,7 +924,7 @@ convenience-node compatibility; it remains unmapped and is not public support.
 
 ### B-11c30d3 AiO I/O-boundary binder retirement
 
-- The planned Move contains exactly `_bind_aio_resource_runtime`,
+- PR #350 retires exactly `_bind_aio_resource_runtime`,
   `_bind_aio_preview_runtime`, and `_bind_aio_output_runtime`.
 - The pre-edit surface is 49 root-resolver slots over 46 names, four E-07
   provider slots, three direct root-helper dependencies, and 45 repository
@@ -941,6 +941,12 @@ convenience-node compatibility; it remains unmapped and is not public support.
   Root patches that drive d4 through d6 remain until those retirement units.
 - Resource discovery/loading, preview and save I/O, metadata/event payloads,
   filenames, errors, logs, schemas/workflows, and stage behavior are frozen.
+- The d3 binder definitions, resolver globals/helpers, and root imports/calls
+  are absent. Seven binders remain in two families: five AiO and two
+  Wildcard/NAIA. The active AiO split now contains only d4 through d6.
+- The compatibility inventory contains 296 canonical root bindings, three
+  residual root globals, 92 shipped and reachable Python modules, and a
+  1,182-line root shim.
 
 ### `nodes.py` public node-class surface
 

--- a/docs/architecture/python-compatibility-shims.md
+++ b/docs/architecture/python-compatibility-shims.md
@@ -922,6 +922,26 @@ convenience-node compatibility; it remains unmapped and is not public support.
 - Settings shape/order, normalization, seed semantics, tile/final-fit behavior,
   provider observation, schema/workflow, and stage order remain unchanged.
 
+### B-11c30d3 AiO I/O-boundary binder retirement
+
+- The planned Move contains exactly `_bind_aio_resource_runtime`,
+  `_bind_aio_preview_runtime`, and `_bind_aio_output_runtime`.
+- The pre-edit surface is 49 root-resolver slots over 46 names, four E-07
+  provider slots, three direct root-helper dependencies, and 45 repository
+  replacement slots over 43 names in eight files.
+- Mutable `AIO_INPUT_DEFAULT_SETTINGS` and its declarative input/resource
+  values move to one pure `easyuse_anima.aio.input_defaults` owner. Root
+  remains an exact compatibility alias; the d0b input-context Move does not
+  begin here.
+- Resource, preview, and output implementations import existing canonical
+  stateless owners directly. Comfy node lookup remains call-time
+  provider-owned, and optional filesystem/server/image dependencies retain
+  their current call-time imports and fallbacks.
+- Only d3-owner tests move their patch ownership to the canonical modules.
+  Root patches that drive d4 through d6 remain until those retirement units.
+- Resource discovery/loading, preview and save I/O, metadata/event payloads,
+  filenames, errors, logs, schemas/workflows, and stage behavior are frozen.
+
 ### `nodes.py` public node-class surface
 
 The confirmed 0.5.2 mapped classes are:

--- a/easyuse_anima/aio/input_defaults.py
+++ b/easyuse_anima/aio/input_defaults.py
@@ -1,0 +1,62 @@
+"""Declarative defaults for the AiO input context."""
+
+EASY_USE_ANIMA_INPUT_SCHEMA = "easy_use_anima_input"
+EASY_USE_ANIMA_INPUT_SETTINGS_VERSION = 1
+
+ANIMA_DEFAULT_DIFFUSION_MODEL_CANDIDATES = (
+    "anima-base-v1.0.safetensors",
+    "ANIMA\\anima_baseV10.safetensors",
+)
+ANIMA_DEFAULT_VAE_CANDIDATES = (
+    "qwen_image_vae.safetensors",
+)
+ANIMA_DEFAULT_CLIP_CANDIDATES = (
+    "qwen_3_06b_base.safetensors",
+)
+ANIMA_CLIP_TYPES = (
+    "stable_diffusion",
+    "stable_cascade",
+    "sd3",
+    "stable_audio",
+    "mochi",
+    "ltxv",
+    "pixart",
+    "cosmos",
+    "lumina2",
+    "wan",
+    "hidream",
+    "chroma",
+    "ace",
+    "omnigen2",
+    "qwen_image",
+    "hunyuan_image",
+    "flux2",
+    "ovis",
+    "longcat_image",
+    "cogvideox",
+    "lens",
+    "pixeldit",
+    "ideogram4",
+)
+ANIMA_UNET_WEIGHT_DTYPES = (
+    "default",
+    "fp8_e4m3fn",
+    "fp8_e4m3fn_fast",
+    "fp8_e5m2",
+)
+ANIMA_CLIP_DEVICES = ("default", "cpu")
+
+AIO_INPUT_DEFAULT_SETTINGS = {
+    "schema": EASY_USE_ANIMA_INPUT_SCHEMA,
+    "version": EASY_USE_ANIMA_INPUT_SETTINGS_VERSION,
+    "resources": {
+        "loader_mode": "split",
+        "clip_loader": "single",
+        "unet_weight_dtype": "default",
+        "clip_device": "default",
+    },
+    "metadata": {},
+}
+
+
+__all__ = ()

--- a/easyuse_anima/aio/output.py
+++ b/easyuse_anima/aio/output.py
@@ -2,35 +2,49 @@
 
 from __future__ import annotations
 
+import logging
 import os
-from collections.abc import Callable
-from typing import Any, TypeAlias
+from typing import Any
 
+from ..common.values import _as_bool, _as_float, _as_int, _single_value
+from ..infrastructure.comfy.wiring import resolve_comfy_host_helper
+from ..lora.preset import _format_strength
+from .generation_defaults import AIO_GENERATION_DEFAULT_SETTINGS
 from .output_settings import (
     _normalize_aio_civitai_hash_fetchers as _normalize_aio_civitai_hash_fetchers,
 )
 from .output_settings import (
     _normalize_aio_hash_bundles as _normalize_aio_hash_bundles,
 )
+from .sampling import _resolve_aio_runtime_seed
 
-_RuntimeResolver: TypeAlias = Callable[[str], Any]
-_RUNTIME_RESOLVER: _RuntimeResolver | None = None
-
-
-def _bind_aio_output_runtime(*, resolve_helper: _RuntimeResolver) -> None:
-    """Bind root compatibility helpers without importing the root module."""
-
-    global _RUNTIME_RESOLVER
-    _RUNTIME_RESOLVER = resolve_helper
+logger = logging.getLogger("ComfyUI-EasyUseAnima")
 
 
-def _runtime_helper(name: str) -> Any:
-    resolver = _RUNTIME_RESOLVER
-    if resolver is None:
-        raise RuntimeError(
-            f"[EasyUseAnima] AiO output runtime helper is not bound: {name}"
-        )
-    return resolver(name)
+def _missing_host_helper(name: str):
+    raise RuntimeError(
+        f"[EasyUseAnima] AiO output Comfy host helper is unavailable: {name}"
+    )
+
+
+def _find_comfy_node_class(node_id: str):
+    helper = resolve_comfy_host_helper(
+        "_find_comfy_node_class",
+        _missing_host_helper,
+    )
+    return helper(node_id)
+
+
+def _require_custom_node_class(
+    node_id: str,
+    node_pack: str,
+    install_hint: str,
+):
+    helper = resolve_comfy_host_helper(
+        "_require_custom_node_class",
+        _missing_host_helper,
+    )
+    return helper(node_id, node_pack, install_hint)
 
 
 def _aio_image_saver_civitai_hash_fetcher_entries(
@@ -38,15 +52,15 @@ def _aio_image_saver_civitai_hash_fetcher_entries(
 ) -> list[str]:
     fetcher_settings = [
         item
-        for item in _runtime_helper("_normalize_aio_civitai_hash_fetchers")(
+        for item in _normalize_aio_civitai_hash_fetchers(
             image_saver.get("civitai_hash_fetchers")
         )
-        if _runtime_helper("_as_bool")(item.get("enabled"), True)
+        if _as_bool(item.get("enabled"), True)
     ]
     if not fetcher_settings:
         return []
 
-    fetcher_cls = _runtime_helper("_require_custom_node_class")(
+    fetcher_cls = _require_custom_node_class(
         "Civitai Hash Fetcher (Image Saver)",
         "ComfyUI-Image-Saver",
         "Required for AiO Save Options > Civitai Hash Fetcher rows.",
@@ -72,7 +86,7 @@ def _aio_image_saver_civitai_hash_fetcher_entries(
         try:
             result = get_hash(username, model_name, version)
         except Exception as exc:
-            _runtime_helper("logger").warning(
+            logger.warning(
                 "[EasyUseAnima] Civitai Hash Fetcher failed for '%s/%s'%s; skipping metadata hash: %s",
                 username,
                 model_name,
@@ -80,14 +94,14 @@ def _aio_image_saver_civitai_hash_fetcher_entries(
                 exc,
             )
             continue
-        hash_value = _runtime_helper("_single_value")(result)
+        hash_value = _single_value(result)
         hash_text = str(hash_value or "").strip()
         if (
             not hash_text
             or hash_text.lower().startswith("error:")
             or hash_text.lower().startswith("no ")
         ):
-            _runtime_helper("logger").warning(
+            logger.warning(
                 "[EasyUseAnima] Civitai Hash Fetcher returned no usable hash for '%s/%s'%s; "
                 "skipping metadata hash: %s",
                 username,
@@ -106,12 +120,10 @@ def _aio_image_saver_additional_hashes(image_saver: dict[str, Any]) -> str:
     if base:
         parts.append(base)
     parts.extend(
-        _runtime_helper("_normalize_aio_hash_bundles")(
-            image_saver.get("additional_hash_bundles")
-        )
+        _normalize_aio_hash_bundles(image_saver.get("additional_hash_bundles"))
     )
     parts.extend(
-        _runtime_helper("_aio_image_saver_civitai_hash_fetcher_entries")(image_saver)
+        _aio_image_saver_civitai_hash_fetcher_entries(image_saver)
     )
     return ",".join(part for part in parts if part)
 
@@ -139,14 +151,10 @@ def _aio_prompt_with_lora_metadata(prompt: str, applied_loras) -> str:
     for item in applied_loras:
         if not isinstance(item, dict):
             continue
-        name = _runtime_helper("_aio_lora_metadata_name")(
-            str(item.get("name") or "")
-        )
+        name = _aio_lora_metadata_name(str(item.get("name") or ""))
         if not name:
             continue
-        strength = _runtime_helper("_format_strength")(
-            _runtime_helper("_as_float")(item.get("strength_model"), 1.0)
-        )
+        strength = _format_strength(_as_float(item.get("strength_model"), 1.0))
         tags.append(f"<lora:{name}:{strength}>")
     if not tags:
         return str(prompt or "")
@@ -161,7 +169,7 @@ def _save_image_with_comfy(
     workflow_prompt=None,
     extra_pnginfo=None,
 ):
-    save_cls = _runtime_helper("_find_comfy_node_class")("SaveImage")
+    save_cls = _find_comfy_node_class("SaveImage")
     if save_cls is None:
         raise RuntimeError("[EasyUseAnima] Could not find ComfyUI SaveImage.")
     saver = save_cls()
@@ -180,7 +188,7 @@ def _aio_save_filename_prefix(save_settings: dict[str, Any]) -> str:
     image_saver = save_settings.get("image_saver", {})
     if not isinstance(image_saver, dict):
         image_saver = {}
-    defaults = _runtime_helper("AIO_GENERATION_DEFAULT_SETTINGS")["save"]["image_saver"]
+    defaults = AIO_GENERATION_DEFAULT_SETTINGS["save"]["image_saver"]
     path = str(image_saver.get("path") or defaults["path"]).strip().strip("/\\")
     filename = str(image_saver.get("filename") or defaults["filename"]).strip().strip("/\\")
     if path and filename:
@@ -201,7 +209,7 @@ def _save_image_with_image_saver(
     workflow_prompt=None,
     extra_pnginfo=None,
 ):
-    image_saver_cls = _runtime_helper("_require_custom_node_class")(
+    image_saver_cls = _require_custom_node_class(
         "Image Saver",
         "ComfyUI-Image-Saver",
         "Repository: https://github.com/alexopus/ComfyUI-Image-Saver",
@@ -214,14 +222,14 @@ def _save_image_with_image_saver(
     image_saver = save_settings.get("image_saver", {})
     if not isinstance(image_saver, dict):
         image_saver = {}
-    defaults = _runtime_helper("AIO_GENERATION_DEFAULT_SETTINGS")["save"]["image_saver"]
+    defaults = AIO_GENERATION_DEFAULT_SETTINGS["save"]["image_saver"]
     modelname = str((resource_info or {}).get("unet_name") or "")
-    save_prompt_metadata = _runtime_helper("_as_bool")(
+    save_prompt_metadata = _as_bool(
         image_saver.get("save_prompt_metadata"),
         defaults["save_prompt_metadata"],
     )
     metadata_positive = (
-        _runtime_helper("_aio_prompt_with_lora_metadata")(
+        _aio_prompt_with_lora_metadata(
             str(positive_prompt or "unknown"), applied_loras
         )
         if save_prompt_metadata
@@ -233,60 +241,56 @@ def _save_image_with_image_saver(
         filename=str(image_saver.get("filename") or defaults["filename"]),
         path=str(image_saver.get("path") or defaults["path"]),
         extension=str(image_saver.get("extension") or defaults["extension"]),
-        steps=_runtime_helper("_as_int")(sampler_settings.get("steps"), 28),
-        cfg=_runtime_helper("_as_float")(sampler_settings.get("cfg"), 5.0),
+        steps=_as_int(sampler_settings.get("steps"), 28),
+        cfg=_as_float(sampler_settings.get("cfg"), 5.0),
         modelname=modelname,
         sampler_name=str(sampler_settings.get("sampler_name") or ""),
         scheduler_name=str(sampler_settings.get("scheduler") or "normal"),
         positive=metadata_positive,
         negative=metadata_negative,
-        seed_value=_runtime_helper("_resolve_aio_runtime_seed")(
-            sampler_settings.get("seed")
-        ),
-        width=_runtime_helper("_as_int")(width, 512),
-        height=_runtime_helper("_as_int")(height, 512),
-        lossless_webp=_runtime_helper("_as_bool")(
+        seed_value=_resolve_aio_runtime_seed(sampler_settings.get("seed")),
+        width=_as_int(width, 512),
+        height=_as_int(height, 512),
+        lossless_webp=_as_bool(
             image_saver.get("lossless_webp"), defaults["lossless_webp"]
         ),
         quality_jpeg_or_webp=max(
             1,
             min(
                 100,
-                _runtime_helper("_as_int")(
+                _as_int(
                     image_saver.get("quality_jpeg_or_webp"),
                     defaults["quality_jpeg_or_webp"],
                 ),
             ),
         ),
-        optimize_png=_runtime_helper("_as_bool")(
+        optimize_png=_as_bool(
             image_saver.get("optimize_png"), defaults["optimize_png"]
         ),
         counter=max(
             0,
-            _runtime_helper("_as_int")(
+            _as_int(
                 image_saver.get("counter"), defaults["counter"]
             ),
         ),
-        denoise=_runtime_helper("_as_float")(sampler_settings.get("denoise"), 1.0),
-        clip_skip=_runtime_helper("_as_int")(
+        denoise=_as_float(sampler_settings.get("denoise"), 1.0),
+        clip_skip=_as_int(
             image_saver.get("clip_skip"), defaults["clip_skip"]
         ),
         time_format=str(image_saver.get("time_format") or defaults["time_format"]),
-        save_workflow_as_json=_runtime_helper("_as_bool")(
+        save_workflow_as_json=_as_bool(
             image_saver.get("save_workflow_as_json"),
             defaults["save_workflow_as_json"],
         ),
-        embed_workflow=_runtime_helper("_as_bool")(
+        embed_workflow=_as_bool(
             image_saver.get("embed_workflow"), defaults["embed_workflow"]
         ),
-        additional_hashes=_runtime_helper("_aio_image_saver_additional_hashes")(
-            image_saver
-        ),
-        download_civitai_data=_runtime_helper("_as_bool")(
+        additional_hashes=_aio_image_saver_additional_hashes(image_saver),
+        download_civitai_data=_as_bool(
             image_saver.get("download_civitai_data"),
             defaults["download_civitai_data"],
         ),
-        easy_remix=_runtime_helper("_as_bool")(
+        easy_remix=_as_bool(
             image_saver.get("easy_remix"), defaults["easy_remix"]
         ),
         show_preview=False,

--- a/easyuse_anima/aio/preview.py
+++ b/easyuse_anima/aio/preview.py
@@ -2,10 +2,15 @@
 
 from __future__ import annotations
 
+import logging
 import os
 import random
-from collections.abc import Callable
-from typing import Any, TypeAlias
+from typing import Any
+
+from ..common.values import _single_value
+from ..image.geometry import _image_tensor_size
+from ..infrastructure.comfy.wiring import resolve_comfy_host_helper
+from ..prompt.data import _prompt_data_json_safe
 
 AIO_PREVIEW_STAGE_LABELS = {
     "first_pass": "First pass",
@@ -20,24 +25,21 @@ AIO_PREVIEW_EVENT = "easyuse-anima-aio-preview"
 AIO_PREVIEW_CACHE_FORMAT = "webp"
 AIO_PREVIEW_CACHE_QUALITY = 90
 
-_RuntimeResolver: TypeAlias = Callable[[str], Any]
-_RUNTIME_RESOLVER: _RuntimeResolver | None = None
+logger = logging.getLogger("ComfyUI-EasyUseAnima")
 
 
-def _bind_aio_preview_runtime(*, resolve_helper: _RuntimeResolver) -> None:
-    """Bind root compatibility helpers without importing the root module."""
+def _missing_host_helper(name: str):
+    raise RuntimeError(
+        f"[EasyUseAnima] AiO preview Comfy host helper is unavailable: {name}"
+    )
 
-    global _RUNTIME_RESOLVER
-    _RUNTIME_RESOLVER = resolve_helper
 
-
-def _runtime_helper(name: str) -> Any:
-    resolver = _RUNTIME_RESOLVER
-    if resolver is None:
-        raise RuntimeError(
-            f"[EasyUseAnima] AiO preview runtime helper is not bound: {name}"
-        )
-    return resolver(name)
+def _find_comfy_node_class(node_id: str):
+    helper = resolve_comfy_host_helper(
+        "_find_comfy_node_class",
+        _missing_host_helper,
+    )
+    return helper(node_id)
 
 
 def _aio_preview_base_directory(image_type: str) -> str:
@@ -57,9 +59,7 @@ def _aio_preview_file_size_bytes(image_info: dict[str, Any]) -> int:
     filename = str(image_info.get("filename") or "")
     if not filename:
         return 0
-    base_dir = _runtime_helper("_aio_preview_base_directory")(
-        str(image_info.get("type") or "output")
-    )
+    base_dir = _aio_preview_base_directory(str(image_info.get("type") or "output"))
     if not base_dir:
         return 0
     subfolder = str(image_info.get("subfolder") or "")
@@ -77,7 +77,7 @@ def _tag_aio_preview_images(
     width: int = 0,
     height: int = 0,
 ) -> list[dict[str, Any]]:
-    label = _runtime_helper("AIO_PREVIEW_STAGE_LABELS").get(stage, stage)
+    label = AIO_PREVIEW_STAGE_LABELS.get(stage, stage)
     tagged: list[dict[str, Any]] = []
     for image in images or ():
         if not isinstance(image, dict):
@@ -89,7 +89,7 @@ def _tag_aio_preview_images(
             item["width"] = int(width)
         if height > 0:
             item["height"] = int(height)
-        file_size = _runtime_helper("_aio_preview_file_size_bytes")(item)
+        file_size = _aio_preview_file_size_bytes(item)
         if file_size > 0:
             item["bytes"] = int(file_size)
         tagged.append(item)
@@ -102,7 +102,7 @@ def _send_aio_preview_event(
     stage: str,
     images: list[dict[str, Any]],
 ) -> None:
-    node_id = _runtime_helper("_single_value")(node_id)
+    node_id = _single_value(node_id)
     if node_id is None or not images:
         return
     try:
@@ -116,12 +116,12 @@ def _send_aio_preview_event(
             "node": str(node_id),
             "run_id": str(run_id),
             "stage": str(stage),
-            "images": _runtime_helper("_prompt_data_json_safe")(images),
+            "images": _prompt_data_json_safe(images),
         }
         client_id = getattr(prompt_server, "client_id", None)
-        send_sync(_runtime_helper("AIO_PREVIEW_EVENT"), payload, client_id)
+        send_sync(AIO_PREVIEW_EVENT, payload, client_id)
     except Exception as exc:
-        _runtime_helper("logger").debug(
+        logger.debug(
             "[EasyUseAnima] failed to send AiO preview event: %s", exc
         )
 
@@ -133,7 +133,7 @@ def _save_aio_temp_preview_image(
     workflow_prompt=None,
     extra_pnginfo=None,
 ) -> list[dict[str, Any]]:
-    width, height = _runtime_helper("_image_tensor_size")(image, 0, 0)
+    width, height = _image_tensor_size(image, 0, 0)
     try:
         import folder_paths  # type: ignore
         import numpy as np  # type: ignore
@@ -156,12 +156,15 @@ def _save_aio_temp_preview_image(
             filename_with_batch_num = filename.replace(
                 "%batch_num%", str(batch_number)
             )
-            file = f"{filename_with_batch_num}_{counter:05}_.{_runtime_helper('AIO_PREVIEW_CACHE_FORMAT')}"
+            file = (
+                f"{filename_with_batch_num}_{counter:05}_."
+                f"{AIO_PREVIEW_CACHE_FORMAT}"
+            )
             path = os.path.join(full_output_folder, file)
             img.save(
                 path,
                 format="WEBP",
-                quality=_runtime_helper("AIO_PREVIEW_CACHE_QUALITY"),
+                quality=AIO_PREVIEW_CACHE_QUALITY,
                 method=4,
             )
             results.append(
@@ -173,19 +176,19 @@ def _save_aio_temp_preview_image(
             )
             counter += 1
         if results:
-            return _runtime_helper("_tag_aio_preview_images")(
+            return _tag_aio_preview_images(
                 results, stage, width=width, height=height
             )
     except Exception as exc:
-        _runtime_helper("logger").warning(
+        logger.warning(
             "[EasyUseAnima] Failed to save AiO WebP preview stage %s; falling back to ComfyUI PreviewImage PNG: %s",
             stage,
             exc,
         )
 
-    preview_cls = _runtime_helper("_find_comfy_node_class")("PreviewImage")
+    preview_cls = _find_comfy_node_class("PreviewImage")
     if preview_cls is None:
-        _runtime_helper("logger").warning(
+        logger.warning(
             "[EasyUseAnima] Could not find ComfyUI PreviewImage for AiO preview stage %s.",
             stage,
         )
@@ -193,7 +196,7 @@ def _save_aio_temp_preview_image(
     saver = preview_cls()
     save_images = getattr(saver, "save_images", None)
     if save_images is None:
-        _runtime_helper("logger").warning(
+        logger.warning(
             "[EasyUseAnima] PreviewImage does not expose save_images() for AiO preview stage %s.",
             stage,
         )
@@ -209,14 +212,14 @@ def _save_aio_temp_preview_image(
         try:
             result = save_images(image)
         except Exception as exc:
-            _runtime_helper("logger").warning(
+            logger.warning(
                 "[EasyUseAnima] Failed to save AiO preview stage %s: %s",
                 stage,
                 exc,
             )
             return []
     except Exception as exc:
-        _runtime_helper("logger").warning(
+        logger.warning(
             "[EasyUseAnima] Failed to save AiO preview stage %s: %s", stage, exc
         )
         return []
@@ -225,7 +228,7 @@ def _save_aio_temp_preview_image(
     ui = result.get("ui", {})
     if not isinstance(ui, dict):
         return []
-    return _runtime_helper("_tag_aio_preview_images")(
+    return _tag_aio_preview_images(
         ui.get("images", []), stage, width=width, height=height
     )
 

--- a/easyuse_anima/aio/resources.py
+++ b/easyuse_anima/aio/resources.py
@@ -2,88 +2,112 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable
-from typing import Any, TypeAlias
+from typing import Any
 
-_RuntimeResolver: TypeAlias = Callable[[str], Any]
-_RUNTIME_RESOLVER: _RuntimeResolver | None = None
+from ..common.values import _as_int, _choice
+from ..image.sam3 import _sam3_context
+from ..infrastructure.comfy.invocation import _node_output_tuple
+from ..infrastructure.comfy.resources import (
+    _comfy_clip_loader_types as _adapter_comfy_clip_loader_types,
+)
+from ..infrastructure.comfy.resources import (
+    _comfy_diffusion_model_names as _adapter_comfy_diffusion_model_names,
+)
+from ..infrastructure.comfy.resources import (
+    _comfy_text_encoder_names as _adapter_comfy_text_encoder_names,
+)
+from ..infrastructure.comfy.resources import (
+    _comfy_vae_names as _adapter_comfy_vae_names,
+)
+from ..infrastructure.comfy.resources import _folder_path_names
+from ..infrastructure.comfy.wiring import resolve_comfy_host_helper
+from .generation_normalization import _merge_versioned_settings
+from .input_defaults import (
+    AIO_INPUT_DEFAULT_SETTINGS,
+    ANIMA_CLIP_DEVICES,
+    ANIMA_CLIP_TYPES,
+    ANIMA_DEFAULT_CLIP_CANDIDATES,
+    ANIMA_DEFAULT_DIFFUSION_MODEL_CANDIDATES,
+    ANIMA_DEFAULT_VAE_CANDIDATES,
+    ANIMA_UNET_WEIGHT_DTYPES,
+    EASY_USE_ANIMA_INPUT_SCHEMA,
+    EASY_USE_ANIMA_INPUT_SETTINGS_VERSION,
+)
 
 
-def _bind_aio_resource_runtime(*, resolve_helper: _RuntimeResolver) -> None:
-    """Bind root compatibility helpers without importing the root module."""
+def _missing_host_helper(name: str):
+    raise RuntimeError(
+        f"[EasyUseAnima] AiO resource Comfy host helper is unavailable: {name}"
+    )
 
-    global _RUNTIME_RESOLVER
-    _RUNTIME_RESOLVER = resolve_helper
 
-
-def _runtime_helper(name: str) -> Any:
-    resolver = _RUNTIME_RESOLVER
-    if resolver is None:
-        raise RuntimeError(
-            f"[EasyUseAnima] AiO resource runtime helper is not bound: {name}"
-        )
-    return resolver(name)
+def _find_comfy_node_class(node_id: str):
+    helper = resolve_comfy_host_helper(
+        "_find_comfy_node_class",
+        _missing_host_helper,
+    )
+    return helper(node_id)
 
 
 def _normalize_aio_input_settings(value) -> dict[str, Any]:
-    settings = _runtime_helper("_merge_versioned_settings")(
-        _runtime_helper("AIO_INPUT_DEFAULT_SETTINGS"),
+    settings = _merge_versioned_settings(
+        AIO_INPUT_DEFAULT_SETTINGS,
         value,
     )
-    settings["schema"] = _runtime_helper("EASY_USE_ANIMA_INPUT_SCHEMA")
-    settings["version"] = _runtime_helper("_as_int")(
+    settings["schema"] = EASY_USE_ANIMA_INPUT_SCHEMA
+    settings["version"] = _as_int(
         settings.get("version"),
-        _runtime_helper("EASY_USE_ANIMA_INPUT_SETTINGS_VERSION"),
+        EASY_USE_ANIMA_INPUT_SETTINGS_VERSION,
     )
     resources = settings.setdefault("resources", {})
     if not isinstance(resources, dict):
         resources = {}
         settings["resources"] = resources
     resources["loader_mode"] = "split"
-    resources["clip_loader"] = _runtime_helper("_choice")(
+    resources["clip_loader"] = _choice(
         resources.get("clip_loader"),
         ("single",),
         "single",
     )
-    resources["unet_weight_dtype"] = _runtime_helper("_choice")(
+    resources["unet_weight_dtype"] = _choice(
         resources.get("unet_weight_dtype"),
-        _runtime_helper("ANIMA_UNET_WEIGHT_DTYPES"),
+        ANIMA_UNET_WEIGHT_DTYPES,
         "default",
     )
-    resources["clip_device"] = _runtime_helper("_choice")(
+    resources["clip_device"] = _choice(
         resources.get("clip_device"),
-        _runtime_helper("ANIMA_CLIP_DEVICES"),
+        ANIMA_CLIP_DEVICES,
         "default",
     )
     return settings
 
 
 def _comfy_diffusion_model_names() -> list[str]:
-    return _runtime_helper("_adapter_comfy_diffusion_model_names")(
-        _runtime_helper("ANIMA_DEFAULT_DIFFUSION_MODEL_CANDIDATES"),
-        _runtime_helper("_folder_path_names"),
+    return _adapter_comfy_diffusion_model_names(
+        ANIMA_DEFAULT_DIFFUSION_MODEL_CANDIDATES,
+        _folder_path_names,
     )
 
 
 def _comfy_text_encoder_names() -> list[str]:
-    return _runtime_helper("_adapter_comfy_text_encoder_names")(
-        _runtime_helper("ANIMA_DEFAULT_CLIP_CANDIDATES"),
-        _runtime_helper("_folder_path_names"),
+    return _adapter_comfy_text_encoder_names(
+        ANIMA_DEFAULT_CLIP_CANDIDATES,
+        _folder_path_names,
     )
 
 
 def _comfy_vae_names() -> list[str]:
-    return _runtime_helper("_adapter_comfy_vae_names")(
-        _runtime_helper("ANIMA_DEFAULT_VAE_CANDIDATES"),
-        _runtime_helper("_find_comfy_node_class"),
-        _runtime_helper("_folder_path_names"),
+    return _adapter_comfy_vae_names(
+        ANIMA_DEFAULT_VAE_CANDIDATES,
+        _find_comfy_node_class,
+        _folder_path_names,
     )
 
 
 def _comfy_clip_loader_types() -> list[str]:
-    return _runtime_helper("_adapter_comfy_clip_loader_types")(
-        _runtime_helper("ANIMA_CLIP_TYPES"),
-        _runtime_helper("_find_comfy_node_class"),
+    return _adapter_comfy_clip_loader_types(
+        ANIMA_CLIP_TYPES,
+        _find_comfy_node_class,
     )
 
 
@@ -111,13 +135,11 @@ def _preferred_checkpoint_default(names: list[str], preferred: str) -> str:
 def _preferred_clip_type_default(names: list[str]) -> str:
     if "qwen_image" in names:
         return "qwen_image"
-    choice = _runtime_helper("_choice")
-    return choice("", names, "stable_diffusion")
+    return _choice("", names, "stable_diffusion")
 
 
 def _load_checkpoint_with_comfy(ckpt_name: str):
-    find_node_class = _runtime_helper("_find_comfy_node_class")
-    loader_cls = find_node_class("CheckpointLoaderSimple")
+    loader_cls = _find_comfy_node_class("CheckpointLoaderSimple")
     if loader_cls is None:
         raise RuntimeError("[EasyUseAnima] Could not find ComfyUI CheckpointLoaderSimple.")
     loader = loader_cls()
@@ -128,32 +150,28 @@ def _load_checkpoint_with_comfy(ckpt_name: str):
 
 
 def _load_diffusion_model_with_comfy(unet_name: str, weight_dtype: str = "default"):
-    find_node_class = _runtime_helper("_find_comfy_node_class")
-    loader_cls = find_node_class("UNETLoader")
+    loader_cls = _find_comfy_node_class("UNETLoader")
     if loader_cls is None:
         raise RuntimeError("[EasyUseAnima] Could not find ComfyUI UNETLoader.")
     loader = loader_cls()
     method = getattr(loader, "load_unet", None)
     if method is None:
         raise RuntimeError("[EasyUseAnima] UNETLoader does not expose load_unet.")
-    node_output_tuple = _runtime_helper("_node_output_tuple")
-    values = node_output_tuple(method(str(unet_name), str(weight_dtype or "default")))
+    values = _node_output_tuple(method(str(unet_name), str(weight_dtype or "default")))
     if not values:
         raise RuntimeError("[EasyUseAnima] UNETLoader returned no MODEL.")
     return values[0]
 
 
 def _load_vae_with_comfy(vae_name: str):
-    find_node_class = _runtime_helper("_find_comfy_node_class")
-    loader_cls = find_node_class("VAELoader")
+    loader_cls = _find_comfy_node_class("VAELoader")
     if loader_cls is None:
         raise RuntimeError("[EasyUseAnima] Could not find ComfyUI VAELoader.")
     loader = loader_cls()
     method = getattr(loader, "load_vae", None)
     if method is None:
         raise RuntimeError("[EasyUseAnima] VAELoader does not expose load_vae.")
-    node_output_tuple = _runtime_helper("_node_output_tuple")
-    values = node_output_tuple(method(str(vae_name)))
+    values = _node_output_tuple(method(str(vae_name)))
     if not values:
         raise RuntimeError("[EasyUseAnima] VAELoader returned no VAE.")
     return values[0]
@@ -164,16 +182,14 @@ def _load_clip_with_comfy(
     clip_type: str = "qwen_image",
     device: str = "default",
 ):
-    find_node_class = _runtime_helper("_find_comfy_node_class")
-    loader_cls = find_node_class("CLIPLoader")
+    loader_cls = _find_comfy_node_class("CLIPLoader")
     if loader_cls is None:
         raise RuntimeError("[EasyUseAnima] Could not find ComfyUI CLIPLoader.")
     loader = loader_cls()
     method = getattr(loader, "load_clip", None)
     if method is None:
         raise RuntimeError("[EasyUseAnima] CLIPLoader does not expose load_clip.")
-    node_output_tuple = _runtime_helper("_node_output_tuple")
-    values = node_output_tuple(
+    values = _node_output_tuple(
         method(
             str(clip_name),
             str(clip_type or "qwen_image"),
@@ -192,8 +208,7 @@ def _load_upscale_model_with_comfy(model_name: str):
             "[EasyUseAnima] USDU final upscale requires an upscale_model_name. "
             "Choose a model from ComfyUI models/upscale_models."
         )
-    find_node_class = _runtime_helper("_find_comfy_node_class")
-    loader_cls = find_node_class("UpscaleModelLoader")
+    loader_cls = _find_comfy_node_class("UpscaleModelLoader")
     if loader_cls is None:
         try:
             from comfy_extras.nodes_upscale_model import (  # pyright: ignore[reportMissingImports]
@@ -209,8 +224,7 @@ def _load_upscale_model_with_comfy(model_name: str):
     method = getattr(loader, "load_model", None) or getattr(loader, "execute", None)
     if method is None:
         raise RuntimeError("[EasyUseAnima] UpscaleModelLoader does not expose load_model().")
-    node_output_tuple = _runtime_helper("_node_output_tuple")
-    values = node_output_tuple(method(model_name))
+    values = _node_output_tuple(method(model_name))
     if not values:
         raise RuntimeError("[EasyUseAnima] UpscaleModelLoader returned no UPSCALE_MODEL.")
     return values[0]
@@ -221,18 +235,15 @@ def _load_aio_sam3_context(detailer_settings: dict[str, Any]) -> dict[str, Any]:
     if not isinstance(sam3, dict):
         sam3 = {}
     checkpoint = str(sam3.get("checkpoint") or "sam3.1_multiplex_fp16.safetensors")
-    load_checkpoint = _runtime_helper("_load_checkpoint_with_comfy")
-    model, clip, vae = load_checkpoint(checkpoint)
-    sam3_context = _runtime_helper("_sam3_context")
-    return sam3_context(model, clip, vae, checkpoint)
+    model, clip, vae = _load_checkpoint_with_comfy(checkpoint)
+    return _sam3_context(model, clip, vae, checkpoint)
 
 
 def _load_aio_resources_from_input_context(context: dict[str, Any]):
     resource_info = context.get("resource_info", {})
     if not isinstance(resource_info, dict):
         resource_info = {}
-    normalize_input_settings = _runtime_helper("_normalize_aio_input_settings")
-    settings = normalize_input_settings(context.get("input_settings", {}))
+    settings = _normalize_aio_input_settings(context.get("input_settings", {}))
     resources = settings.get("resources", {})
     if not isinstance(resources, dict):
         resources = {}
@@ -256,7 +267,7 @@ def _load_aio_resources_from_input_context(context: dict[str, Any]):
             + ", ".join(missing)
         )
 
-    model = _runtime_helper("_load_diffusion_model_with_comfy")(
+    model = _load_diffusion_model_with_comfy(
         unet_name,
         str(
             resources.get("unet_weight_dtype")
@@ -264,8 +275,8 @@ def _load_aio_resources_from_input_context(context: dict[str, Any]):
             or "default"
         ),
     )
-    vae = _runtime_helper("_load_vae_with_comfy")(vae_name)
-    clip = _runtime_helper("_load_clip_with_comfy")(
+    vae = _load_vae_with_comfy(vae_name)
+    clip = _load_clip_with_comfy(
         clip_name,
         clip_type,
         str(

--- a/nodes.py
+++ b/nodes.py
@@ -60,6 +60,17 @@ try:
     from .easyuse_anima.aio.generation_settings import (
         round_trip_aio_generation_settings as _round_trip_aio_generation_settings,
     )
+    from .easyuse_anima.aio.input_defaults import (
+        AIO_INPUT_DEFAULT_SETTINGS as AIO_INPUT_DEFAULT_SETTINGS,
+        ANIMA_CLIP_DEVICES as ANIMA_CLIP_DEVICES,
+        ANIMA_CLIP_TYPES as ANIMA_CLIP_TYPES,
+        ANIMA_DEFAULT_CLIP_CANDIDATES as ANIMA_DEFAULT_CLIP_CANDIDATES,
+        ANIMA_DEFAULT_DIFFUSION_MODEL_CANDIDATES as ANIMA_DEFAULT_DIFFUSION_MODEL_CANDIDATES,
+        ANIMA_DEFAULT_VAE_CANDIDATES as ANIMA_DEFAULT_VAE_CANDIDATES,
+        ANIMA_UNET_WEIGHT_DTYPES as ANIMA_UNET_WEIGHT_DTYPES,
+        EASY_USE_ANIMA_INPUT_SCHEMA as EASY_USE_ANIMA_INPUT_SCHEMA,
+        EASY_USE_ANIMA_INPUT_SETTINGS_VERSION as EASY_USE_ANIMA_INPUT_SETTINGS_VERSION,
+    )
     from .easyuse_anima.aio.usdu import (
         _aio_usdu_auto_tile_dimension as _aio_usdu_auto_tile_dimension,
         _aio_usdu_tile_plan as _aio_usdu_tile_plan,
@@ -112,7 +123,6 @@ try:
         AIO_PREVIEW_STAGE_LABELS as AIO_PREVIEW_STAGE_LABELS,
         _aio_preview_base_directory as _aio_preview_base_directory,
         _aio_preview_file_size_bytes as _aio_preview_file_size_bytes,
-        _bind_aio_preview_runtime as _bind_aio_preview_runtime,
         _save_aio_temp_preview_image as _save_aio_temp_preview_image,
         _send_aio_preview_event as _send_aio_preview_event,
         _tag_aio_preview_images as _tag_aio_preview_images,
@@ -123,7 +133,6 @@ try:
         _aio_lora_metadata_name as _aio_lora_metadata_name,
         _aio_prompt_with_lora_metadata as _aio_prompt_with_lora_metadata,
         _aio_save_filename_prefix as _aio_save_filename_prefix,
-        _bind_aio_output_runtime as _bind_aio_output_runtime,
         _save_image_with_comfy as _save_image_with_comfy,
         _save_image_with_image_saver as _save_image_with_image_saver,
     )
@@ -132,7 +141,6 @@ try:
         _normalize_aio_hash_bundles as _normalize_aio_hash_bundles,
     )
     from .easyuse_anima.aio.resources import (
-        _bind_aio_resource_runtime as _bind_aio_resource_runtime,
         _comfy_clip_loader_types as _comfy_clip_loader_types,
         _comfy_diffusion_model_names as _comfy_diffusion_model_names,
         _comfy_text_encoder_names as _comfy_text_encoder_names,
@@ -616,6 +624,17 @@ except ImportError:  # allows simple local import tests outside ComfyUI's packag
     from easyuse_anima.aio.generation_settings import (
         round_trip_aio_generation_settings as _round_trip_aio_generation_settings,
     )
+    from easyuse_anima.aio.input_defaults import (
+        AIO_INPUT_DEFAULT_SETTINGS as AIO_INPUT_DEFAULT_SETTINGS,
+        ANIMA_CLIP_DEVICES as ANIMA_CLIP_DEVICES,
+        ANIMA_CLIP_TYPES as ANIMA_CLIP_TYPES,
+        ANIMA_DEFAULT_CLIP_CANDIDATES as ANIMA_DEFAULT_CLIP_CANDIDATES,
+        ANIMA_DEFAULT_DIFFUSION_MODEL_CANDIDATES as ANIMA_DEFAULT_DIFFUSION_MODEL_CANDIDATES,
+        ANIMA_DEFAULT_VAE_CANDIDATES as ANIMA_DEFAULT_VAE_CANDIDATES,
+        ANIMA_UNET_WEIGHT_DTYPES as ANIMA_UNET_WEIGHT_DTYPES,
+        EASY_USE_ANIMA_INPUT_SCHEMA as EASY_USE_ANIMA_INPUT_SCHEMA,
+        EASY_USE_ANIMA_INPUT_SETTINGS_VERSION as EASY_USE_ANIMA_INPUT_SETTINGS_VERSION,
+    )
     from easyuse_anima.aio.usdu import (
         _aio_usdu_auto_tile_dimension as _aio_usdu_auto_tile_dimension,
         _aio_usdu_tile_plan as _aio_usdu_tile_plan,
@@ -668,7 +687,6 @@ except ImportError:  # allows simple local import tests outside ComfyUI's packag
         AIO_PREVIEW_STAGE_LABELS as AIO_PREVIEW_STAGE_LABELS,
         _aio_preview_base_directory as _aio_preview_base_directory,
         _aio_preview_file_size_bytes as _aio_preview_file_size_bytes,
-        _bind_aio_preview_runtime as _bind_aio_preview_runtime,
         _save_aio_temp_preview_image as _save_aio_temp_preview_image,
         _send_aio_preview_event as _send_aio_preview_event,
         _tag_aio_preview_images as _tag_aio_preview_images,
@@ -679,7 +697,6 @@ except ImportError:  # allows simple local import tests outside ComfyUI's packag
         _aio_lora_metadata_name as _aio_lora_metadata_name,
         _aio_prompt_with_lora_metadata as _aio_prompt_with_lora_metadata,
         _aio_save_filename_prefix as _aio_save_filename_prefix,
-        _bind_aio_output_runtime as _bind_aio_output_runtime,
         _save_image_with_comfy as _save_image_with_comfy,
         _save_image_with_image_saver as _save_image_with_image_saver,
     )
@@ -688,7 +705,6 @@ except ImportError:  # allows simple local import tests outside ComfyUI's packag
         _normalize_aio_hash_bundles as _normalize_aio_hash_bundles,
     )
     from easyuse_anima.aio.resources import (
-        _bind_aio_resource_runtime as _bind_aio_resource_runtime,
         _comfy_clip_loader_types as _comfy_clip_loader_types,
         _comfy_diffusion_model_names as _comfy_diffusion_model_names,
         _comfy_text_encoder_names as _comfy_text_encoder_names,
@@ -1121,71 +1137,10 @@ except ImportError:  # allows simple local import tests outside ComfyUI's packag
 logger = logging.getLogger("ComfyUI-EasyUseAnima")
 
 EASY_USE_ANIMA_INPUT_TYPE = "EASY_USE_ANIMA_INPUT"
-EASY_USE_ANIMA_INPUT_SCHEMA = "easy_use_anima_input"
-EASY_USE_ANIMA_INPUT_SETTINGS_VERSION = 1
-ANIMA_DEFAULT_DIFFUSION_MODEL_CANDIDATES = (
-    "anima-base-v1.0.safetensors",
-    "ANIMA\\anima_baseV10.safetensors",
-)
-ANIMA_DEFAULT_VAE_CANDIDATES = (
-    "qwen_image_vae.safetensors",
-)
-ANIMA_DEFAULT_CLIP_CANDIDATES = (
-    "qwen_3_06b_base.safetensors",
-)
-ANIMA_CLIP_TYPES = (
-    "stable_diffusion",
-    "stable_cascade",
-    "sd3",
-    "stable_audio",
-    "mochi",
-    "ltxv",
-    "pixart",
-    "cosmos",
-    "lumina2",
-    "wan",
-    "hidream",
-    "chroma",
-    "ace",
-    "omnigen2",
-    "qwen_image",
-    "hunyuan_image",
-    "flux2",
-    "ovis",
-    "longcat_image",
-    "cogvideox",
-    "lens",
-    "pixeldit",
-    "ideogram4",
-)
-ANIMA_UNET_WEIGHT_DTYPES = (
-    "default",
-    "fp8_e4m3fn",
-    "fp8_e4m3fn_fast",
-    "fp8_e5m2",
-)
-ANIMA_CLIP_DEVICES = ("default", "cpu")
-AIO_INPUT_DEFAULT_SETTINGS = {
-    "schema": EASY_USE_ANIMA_INPUT_SCHEMA,
-    "version": EASY_USE_ANIMA_INPUT_SETTINGS_VERSION,
-    "resources": {
-        "loader_mode": "split",
-        "clip_loader": "single",
-        "unet_weight_dtype": "default",
-        "clip_device": "default",
-    },
-    "metadata": {},
-}
 _TRIGGER_WORD_KEYS = ("trainedWords", "trained_words", "trigger_words", "activation_text")
 
 
 _bind_aio_legacy_generation_runtime(
-    resolve_helper=lambda name: _resolve_comfy_host_helper(
-        name,
-        lambda fallback_name: globals()[fallback_name],
-    ),
-)
-_bind_aio_resource_runtime(
     resolve_helper=lambda name: _resolve_comfy_host_helper(
         name,
         lambda fallback_name: globals()[fallback_name],
@@ -1198,18 +1153,6 @@ _bind_aio_model_preparation_runtime(
     ),
 )
 _bind_aio_sampling_runtime(
-    resolve_helper=lambda name: _resolve_comfy_host_helper(
-        name,
-        lambda fallback_name: globals()[fallback_name],
-    ),
-)
-_bind_aio_preview_runtime(
-    resolve_helper=lambda name: _resolve_comfy_host_helper(
-        name,
-        lambda fallback_name: globals()[fallback_name],
-    ),
-)
-_bind_aio_output_runtime(
     resolve_helper=lambda name: _resolve_comfy_host_helper(
         name,
         lambda fallback_name: globals()[fallback_name],

--- a/tests/fixtures/comfy_host_compatibility.v1.json
+++ b/tests/fixtures/comfy_host_compatibility.v1.json
@@ -178,17 +178,17 @@
         },
         {
           "module": "easyuse_anima.aio.output",
-          "binder": "_bind_aio_output_runtime",
+          "binder": null,
           "root_observation": "call_time"
         },
         {
           "module": "easyuse_anima.aio.preview",
-          "binder": "_bind_aio_preview_runtime",
+          "binder": null,
           "root_observation": "call_time"
         },
         {
           "module": "easyuse_anima.aio.resources",
-          "binder": "_bind_aio_resource_runtime",
+          "binder": null,
           "root_observation": "call_time"
         },
         {
@@ -378,7 +378,7 @@
         },
         {
           "module": "easyuse_anima.aio.output",
-          "binder": "_bind_aio_output_runtime",
+          "binder": null,
           "root_observation": "call_time"
         },
         {

--- a/tests/fixtures/python_backend_baseline.json
+++ b/tests/fixtures/python_backend_baseline.json
@@ -7521,6 +7521,23 @@
       },
       {
         "alias": null,
+        "bound_name": "logging",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "logging",
+        "kind": "static_import",
+        "line": 5,
+        "name": null,
+        "optional": false,
+        "requested": "logging",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/aio/output.py"
+      },
+      {
+        "alias": null,
         "bound_name": "os",
         "branch_context": [],
         "classification": "external",
@@ -7528,27 +7545,10 @@
         "conditional": false,
         "imported": "os",
         "kind": "static_import",
-        "line": 5,
+        "line": 6,
         "name": null,
         "optional": false,
         "requested": "os",
-        "role": "ordinary",
-        "scope": "<module>",
-        "source": "easyuse_anima/aio/output.py"
-      },
-      {
-        "alias": null,
-        "bound_name": "Callable",
-        "branch_context": [],
-        "classification": "external",
-        "column": 0,
-        "conditional": false,
-        "imported": "collections.abc:Callable",
-        "kind": "static_from",
-        "line": 6,
-        "name": "Callable",
-        "optional": false,
-        "requested": "collections.abc",
         "role": "ordinary",
         "scope": "<module>",
         "source": "easyuse_anima/aio/output.py"
@@ -7572,20 +7572,129 @@
       },
       {
         "alias": null,
-        "bound_name": "TypeAlias",
+        "bound_name": "_as_bool",
         "branch_context": [],
-        "classification": "external",
+        "classification": "internal",
         "column": 0,
         "conditional": false,
-        "imported": "typing:TypeAlias",
+        "imported": "..common.values:_as_bool",
         "kind": "static_from",
-        "line": 7,
-        "name": "TypeAlias",
+        "line": 9,
+        "name": "_as_bool",
         "optional": false,
-        "requested": "typing",
+        "requested": "..common.values",
         "role": "ordinary",
         "scope": "<module>",
-        "source": "easyuse_anima/aio/output.py"
+        "source": "easyuse_anima/aio/output.py",
+        "target": "easyuse_anima/common/values.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_as_float",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": "..common.values:_as_float",
+        "kind": "static_from",
+        "line": 9,
+        "name": "_as_float",
+        "optional": false,
+        "requested": "..common.values",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/aio/output.py",
+        "target": "easyuse_anima/common/values.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_as_int",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": "..common.values:_as_int",
+        "kind": "static_from",
+        "line": 9,
+        "name": "_as_int",
+        "optional": false,
+        "requested": "..common.values",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/aio/output.py",
+        "target": "easyuse_anima/common/values.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_single_value",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": "..common.values:_single_value",
+        "kind": "static_from",
+        "line": 9,
+        "name": "_single_value",
+        "optional": false,
+        "requested": "..common.values",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/aio/output.py",
+        "target": "easyuse_anima/common/values.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "resolve_comfy_host_helper",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": "..infrastructure.comfy.wiring:resolve_comfy_host_helper",
+        "kind": "static_from",
+        "line": 10,
+        "name": "resolve_comfy_host_helper",
+        "optional": false,
+        "requested": "..infrastructure.comfy.wiring",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/aio/output.py",
+        "target": "easyuse_anima/infrastructure/comfy/wiring.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_format_strength",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": "..lora.preset:_format_strength",
+        "kind": "static_from",
+        "line": 11,
+        "name": "_format_strength",
+        "optional": false,
+        "requested": "..lora.preset",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/aio/output.py",
+        "target": "easyuse_anima/lora/preset.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "AIO_GENERATION_DEFAULT_SETTINGS",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".generation_defaults:AIO_GENERATION_DEFAULT_SETTINGS",
+        "kind": "static_from",
+        "line": 12,
+        "name": "AIO_GENERATION_DEFAULT_SETTINGS",
+        "optional": false,
+        "requested": ".generation_defaults",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/aio/output.py",
+        "target": "easyuse_anima/aio/generation_defaults.py"
       },
       {
         "alias": "_normalize_aio_civitai_hash_fetchers",
@@ -7596,7 +7705,7 @@
         "conditional": false,
         "imported": ".output_settings:_normalize_aio_civitai_hash_fetchers",
         "kind": "static_from",
-        "line": 9,
+        "line": 13,
         "name": "_normalize_aio_civitai_hash_fetchers",
         "optional": false,
         "requested": ".output_settings",
@@ -7614,7 +7723,7 @@
         "conditional": false,
         "imported": ".output_settings:_normalize_aio_hash_bundles",
         "kind": "static_from",
-        "line": 12,
+        "line": 16,
         "name": "_normalize_aio_hash_bundles",
         "optional": false,
         "requested": ".output_settings",
@@ -7625,6 +7734,24 @@
       },
       {
         "alias": null,
+        "bound_name": "_resolve_aio_runtime_seed",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".sampling:_resolve_aio_runtime_seed",
+        "kind": "static_from",
+        "line": 19,
+        "name": "_resolve_aio_runtime_seed",
+        "optional": false,
+        "requested": ".sampling",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/aio/output.py",
+        "target": "easyuse_anima/aio/sampling.py"
+      },
+      {
+        "alias": null,
         "bound_name": "folder_paths",
         "branch_context": [
           {
@@ -7632,7 +7759,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 124
+            "line": 136
           }
         ],
         "classification": "external",
@@ -7640,7 +7767,7 @@
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 125,
+        "line": 137,
         "name": null,
         "optional": true,
         "requested": "folder_paths",
@@ -7930,6 +8057,23 @@
       },
       {
         "alias": null,
+        "bound_name": "logging",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "logging",
+        "kind": "static_import",
+        "line": 5,
+        "name": null,
+        "optional": false,
+        "requested": "logging",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/aio/preview.py"
+      },
+      {
+        "alias": null,
         "bound_name": "os",
         "branch_context": [],
         "classification": "external",
@@ -7937,7 +8081,7 @@
         "conditional": false,
         "imported": "os",
         "kind": "static_import",
-        "line": 5,
+        "line": 6,
         "name": null,
         "optional": false,
         "requested": "os",
@@ -7954,27 +8098,10 @@
         "conditional": false,
         "imported": "random",
         "kind": "static_import",
-        "line": 6,
+        "line": 7,
         "name": null,
         "optional": false,
         "requested": "random",
-        "role": "ordinary",
-        "scope": "<module>",
-        "source": "easyuse_anima/aio/preview.py"
-      },
-      {
-        "alias": null,
-        "bound_name": "Callable",
-        "branch_context": [],
-        "classification": "external",
-        "column": 0,
-        "conditional": false,
-        "imported": "collections.abc:Callable",
-        "kind": "static_from",
-        "line": 7,
-        "name": "Callable",
-        "optional": false,
-        "requested": "collections.abc",
         "role": "ordinary",
         "scope": "<module>",
         "source": "easyuse_anima/aio/preview.py"
@@ -7998,20 +8125,75 @@
       },
       {
         "alias": null,
-        "bound_name": "TypeAlias",
+        "bound_name": "_single_value",
         "branch_context": [],
-        "classification": "external",
+        "classification": "internal",
         "column": 0,
         "conditional": false,
-        "imported": "typing:TypeAlias",
+        "imported": "..common.values:_single_value",
         "kind": "static_from",
-        "line": 8,
-        "name": "TypeAlias",
+        "line": 10,
+        "name": "_single_value",
         "optional": false,
-        "requested": "typing",
+        "requested": "..common.values",
         "role": "ordinary",
         "scope": "<module>",
-        "source": "easyuse_anima/aio/preview.py"
+        "source": "easyuse_anima/aio/preview.py",
+        "target": "easyuse_anima/common/values.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_image_tensor_size",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": "..image.geometry:_image_tensor_size",
+        "kind": "static_from",
+        "line": 11,
+        "name": "_image_tensor_size",
+        "optional": false,
+        "requested": "..image.geometry",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/aio/preview.py",
+        "target": "easyuse_anima/image/geometry.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "resolve_comfy_host_helper",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": "..infrastructure.comfy.wiring:resolve_comfy_host_helper",
+        "kind": "static_from",
+        "line": 12,
+        "name": "resolve_comfy_host_helper",
+        "optional": false,
+        "requested": "..infrastructure.comfy.wiring",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/aio/preview.py",
+        "target": "easyuse_anima/infrastructure/comfy/wiring.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_prompt_data_json_safe",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": "..prompt.data:_prompt_data_json_safe",
+        "kind": "static_from",
+        "line": 13,
+        "name": "_prompt_data_json_safe",
+        "optional": false,
+        "requested": "..prompt.data",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/aio/preview.py",
+        "target": "easyuse_anima/prompt/data.py"
       },
       {
         "alias": null,
@@ -8022,7 +8204,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 44
+            "line": 46
           }
         ],
         "classification": "external",
@@ -8030,7 +8212,7 @@
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 45,
+        "line": 47,
         "name": null,
         "optional": true,
         "requested": "folder_paths",
@@ -8157,23 +8339,6 @@
       },
       {
         "alias": null,
-        "bound_name": "Callable",
-        "branch_context": [],
-        "classification": "external",
-        "column": 0,
-        "conditional": false,
-        "imported": "collections.abc:Callable",
-        "kind": "static_from",
-        "line": 5,
-        "name": "Callable",
-        "optional": false,
-        "requested": "collections.abc",
-        "role": "ordinary",
-        "scope": "<module>",
-        "source": "easyuse_anima/aio/resources.py"
-      },
-      {
-        "alias": null,
         "bound_name": "Any",
         "branch_context": [],
         "classification": "external",
@@ -8181,7 +8346,7 @@
         "conditional": false,
         "imported": "typing:Any",
         "kind": "static_from",
-        "line": 6,
+        "line": 5,
         "name": "Any",
         "optional": false,
         "requested": "typing",
@@ -8191,20 +8356,363 @@
       },
       {
         "alias": null,
-        "bound_name": "TypeAlias",
+        "bound_name": "_as_int",
         "branch_context": [],
-        "classification": "external",
+        "classification": "internal",
         "column": 0,
         "conditional": false,
-        "imported": "typing:TypeAlias",
+        "imported": "..common.values:_as_int",
         "kind": "static_from",
-        "line": 6,
-        "name": "TypeAlias",
+        "line": 7,
+        "name": "_as_int",
         "optional": false,
-        "requested": "typing",
+        "requested": "..common.values",
         "role": "ordinary",
         "scope": "<module>",
-        "source": "easyuse_anima/aio/resources.py"
+        "source": "easyuse_anima/aio/resources.py",
+        "target": "easyuse_anima/common/values.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_choice",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": "..common.values:_choice",
+        "kind": "static_from",
+        "line": 7,
+        "name": "_choice",
+        "optional": false,
+        "requested": "..common.values",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/aio/resources.py",
+        "target": "easyuse_anima/common/values.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_sam3_context",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": "..image.sam3:_sam3_context",
+        "kind": "static_from",
+        "line": 8,
+        "name": "_sam3_context",
+        "optional": false,
+        "requested": "..image.sam3",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/aio/resources.py",
+        "target": "easyuse_anima/image/sam3.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_node_output_tuple",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": "..infrastructure.comfy.invocation:_node_output_tuple",
+        "kind": "static_from",
+        "line": 9,
+        "name": "_node_output_tuple",
+        "optional": false,
+        "requested": "..infrastructure.comfy.invocation",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/aio/resources.py",
+        "target": "easyuse_anima/infrastructure/comfy/invocation.py"
+      },
+      {
+        "alias": "_adapter_comfy_clip_loader_types",
+        "bound_name": "_adapter_comfy_clip_loader_types",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": "..infrastructure.comfy.resources:_comfy_clip_loader_types",
+        "kind": "static_from",
+        "line": 10,
+        "name": "_comfy_clip_loader_types",
+        "optional": false,
+        "requested": "..infrastructure.comfy.resources",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/aio/resources.py",
+        "target": "easyuse_anima/infrastructure/comfy/resources.py"
+      },
+      {
+        "alias": "_adapter_comfy_diffusion_model_names",
+        "bound_name": "_adapter_comfy_diffusion_model_names",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": "..infrastructure.comfy.resources:_comfy_diffusion_model_names",
+        "kind": "static_from",
+        "line": 13,
+        "name": "_comfy_diffusion_model_names",
+        "optional": false,
+        "requested": "..infrastructure.comfy.resources",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/aio/resources.py",
+        "target": "easyuse_anima/infrastructure/comfy/resources.py"
+      },
+      {
+        "alias": "_adapter_comfy_text_encoder_names",
+        "bound_name": "_adapter_comfy_text_encoder_names",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": "..infrastructure.comfy.resources:_comfy_text_encoder_names",
+        "kind": "static_from",
+        "line": 16,
+        "name": "_comfy_text_encoder_names",
+        "optional": false,
+        "requested": "..infrastructure.comfy.resources",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/aio/resources.py",
+        "target": "easyuse_anima/infrastructure/comfy/resources.py"
+      },
+      {
+        "alias": "_adapter_comfy_vae_names",
+        "bound_name": "_adapter_comfy_vae_names",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": "..infrastructure.comfy.resources:_comfy_vae_names",
+        "kind": "static_from",
+        "line": 19,
+        "name": "_comfy_vae_names",
+        "optional": false,
+        "requested": "..infrastructure.comfy.resources",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/aio/resources.py",
+        "target": "easyuse_anima/infrastructure/comfy/resources.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_folder_path_names",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": "..infrastructure.comfy.resources:_folder_path_names",
+        "kind": "static_from",
+        "line": 22,
+        "name": "_folder_path_names",
+        "optional": false,
+        "requested": "..infrastructure.comfy.resources",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/aio/resources.py",
+        "target": "easyuse_anima/infrastructure/comfy/resources.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "resolve_comfy_host_helper",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": "..infrastructure.comfy.wiring:resolve_comfy_host_helper",
+        "kind": "static_from",
+        "line": 23,
+        "name": "resolve_comfy_host_helper",
+        "optional": false,
+        "requested": "..infrastructure.comfy.wiring",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/aio/resources.py",
+        "target": "easyuse_anima/infrastructure/comfy/wiring.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_merge_versioned_settings",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".generation_normalization:_merge_versioned_settings",
+        "kind": "static_from",
+        "line": 24,
+        "name": "_merge_versioned_settings",
+        "optional": false,
+        "requested": ".generation_normalization",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/aio/resources.py",
+        "target": "easyuse_anima/aio/generation_normalization.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "AIO_INPUT_DEFAULT_SETTINGS",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".input_defaults:AIO_INPUT_DEFAULT_SETTINGS",
+        "kind": "static_from",
+        "line": 25,
+        "name": "AIO_INPUT_DEFAULT_SETTINGS",
+        "optional": false,
+        "requested": ".input_defaults",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/aio/resources.py",
+        "target": "easyuse_anima/aio/input_defaults.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "ANIMA_CLIP_DEVICES",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".input_defaults:ANIMA_CLIP_DEVICES",
+        "kind": "static_from",
+        "line": 25,
+        "name": "ANIMA_CLIP_DEVICES",
+        "optional": false,
+        "requested": ".input_defaults",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/aio/resources.py",
+        "target": "easyuse_anima/aio/input_defaults.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "ANIMA_CLIP_TYPES",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".input_defaults:ANIMA_CLIP_TYPES",
+        "kind": "static_from",
+        "line": 25,
+        "name": "ANIMA_CLIP_TYPES",
+        "optional": false,
+        "requested": ".input_defaults",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/aio/resources.py",
+        "target": "easyuse_anima/aio/input_defaults.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "ANIMA_DEFAULT_CLIP_CANDIDATES",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".input_defaults:ANIMA_DEFAULT_CLIP_CANDIDATES",
+        "kind": "static_from",
+        "line": 25,
+        "name": "ANIMA_DEFAULT_CLIP_CANDIDATES",
+        "optional": false,
+        "requested": ".input_defaults",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/aio/resources.py",
+        "target": "easyuse_anima/aio/input_defaults.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "ANIMA_DEFAULT_DIFFUSION_MODEL_CANDIDATES",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".input_defaults:ANIMA_DEFAULT_DIFFUSION_MODEL_CANDIDATES",
+        "kind": "static_from",
+        "line": 25,
+        "name": "ANIMA_DEFAULT_DIFFUSION_MODEL_CANDIDATES",
+        "optional": false,
+        "requested": ".input_defaults",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/aio/resources.py",
+        "target": "easyuse_anima/aio/input_defaults.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "ANIMA_DEFAULT_VAE_CANDIDATES",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".input_defaults:ANIMA_DEFAULT_VAE_CANDIDATES",
+        "kind": "static_from",
+        "line": 25,
+        "name": "ANIMA_DEFAULT_VAE_CANDIDATES",
+        "optional": false,
+        "requested": ".input_defaults",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/aio/resources.py",
+        "target": "easyuse_anima/aio/input_defaults.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "ANIMA_UNET_WEIGHT_DTYPES",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".input_defaults:ANIMA_UNET_WEIGHT_DTYPES",
+        "kind": "static_from",
+        "line": 25,
+        "name": "ANIMA_UNET_WEIGHT_DTYPES",
+        "optional": false,
+        "requested": ".input_defaults",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/aio/resources.py",
+        "target": "easyuse_anima/aio/input_defaults.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "EASY_USE_ANIMA_INPUT_SCHEMA",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".input_defaults:EASY_USE_ANIMA_INPUT_SCHEMA",
+        "kind": "static_from",
+        "line": 25,
+        "name": "EASY_USE_ANIMA_INPUT_SCHEMA",
+        "optional": false,
+        "requested": ".input_defaults",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/aio/resources.py",
+        "target": "easyuse_anima/aio/input_defaults.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "EASY_USE_ANIMA_INPUT_SETTINGS_VERSION",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".input_defaults:EASY_USE_ANIMA_INPUT_SETTINGS_VERSION",
+        "kind": "static_from",
+        "line": 25,
+        "name": "EASY_USE_ANIMA_INPUT_SETTINGS_VERSION",
+        "optional": false,
+        "requested": ".input_defaults",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/aio/resources.py",
+        "target": "easyuse_anima/aio/input_defaults.py"
       },
       {
         "alias": null,
@@ -8213,7 +8721,7 @@
           {
             "branch": "body",
             "kind": "if",
-            "line": 197,
+            "line": 212,
             "type_checking": false
           },
           {
@@ -8221,7 +8729,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 198
+            "line": 213
           }
         ],
         "classification": "external",
@@ -8229,7 +8737,7 @@
         "conditional": true,
         "imported": "comfy_extras.nodes_upscale_model:UpscaleModelLoader",
         "kind": "static_from",
-        "line": 199,
+        "line": 214,
         "name": "UpscaleModelLoader",
         "optional": true,
         "requested": "comfy_extras.nodes_upscale_model",
@@ -20169,6 +20677,285 @@
         "target": "easyuse_anima/aio/generation_settings.py"
       },
       {
+        "alias": "AIO_INPUT_DEFAULT_SETTINGS",
+        "bound_name": "AIO_INPUT_DEFAULT_SETTINGS",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 8
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "AIO_INPUT_DEFAULT_SETTINGS",
+          "target": "easyuse_anima/aio/input_defaults.py",
+          "try_line": 8
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.aio.input_defaults:AIO_INPUT_DEFAULT_SETTINGS",
+        "kind": "static_from",
+        "line": 63,
+        "name": "AIO_INPUT_DEFAULT_SETTINGS",
+        "optional": false,
+        "requested": ".easyuse_anima.aio.input_defaults",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/aio/input_defaults.py"
+      },
+      {
+        "alias": "ANIMA_CLIP_DEVICES",
+        "bound_name": "ANIMA_CLIP_DEVICES",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 8
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "ANIMA_CLIP_DEVICES",
+          "target": "easyuse_anima/aio/input_defaults.py",
+          "try_line": 8
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.aio.input_defaults:ANIMA_CLIP_DEVICES",
+        "kind": "static_from",
+        "line": 63,
+        "name": "ANIMA_CLIP_DEVICES",
+        "optional": false,
+        "requested": ".easyuse_anima.aio.input_defaults",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/aio/input_defaults.py"
+      },
+      {
+        "alias": "ANIMA_CLIP_TYPES",
+        "bound_name": "ANIMA_CLIP_TYPES",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 8
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "ANIMA_CLIP_TYPES",
+          "target": "easyuse_anima/aio/input_defaults.py",
+          "try_line": 8
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.aio.input_defaults:ANIMA_CLIP_TYPES",
+        "kind": "static_from",
+        "line": 63,
+        "name": "ANIMA_CLIP_TYPES",
+        "optional": false,
+        "requested": ".easyuse_anima.aio.input_defaults",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/aio/input_defaults.py"
+      },
+      {
+        "alias": "ANIMA_DEFAULT_CLIP_CANDIDATES",
+        "bound_name": "ANIMA_DEFAULT_CLIP_CANDIDATES",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 8
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "ANIMA_DEFAULT_CLIP_CANDIDATES",
+          "target": "easyuse_anima/aio/input_defaults.py",
+          "try_line": 8
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.aio.input_defaults:ANIMA_DEFAULT_CLIP_CANDIDATES",
+        "kind": "static_from",
+        "line": 63,
+        "name": "ANIMA_DEFAULT_CLIP_CANDIDATES",
+        "optional": false,
+        "requested": ".easyuse_anima.aio.input_defaults",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/aio/input_defaults.py"
+      },
+      {
+        "alias": "ANIMA_DEFAULT_DIFFUSION_MODEL_CANDIDATES",
+        "bound_name": "ANIMA_DEFAULT_DIFFUSION_MODEL_CANDIDATES",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 8
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "ANIMA_DEFAULT_DIFFUSION_MODEL_CANDIDATES",
+          "target": "easyuse_anima/aio/input_defaults.py",
+          "try_line": 8
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.aio.input_defaults:ANIMA_DEFAULT_DIFFUSION_MODEL_CANDIDATES",
+        "kind": "static_from",
+        "line": 63,
+        "name": "ANIMA_DEFAULT_DIFFUSION_MODEL_CANDIDATES",
+        "optional": false,
+        "requested": ".easyuse_anima.aio.input_defaults",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/aio/input_defaults.py"
+      },
+      {
+        "alias": "ANIMA_DEFAULT_VAE_CANDIDATES",
+        "bound_name": "ANIMA_DEFAULT_VAE_CANDIDATES",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 8
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "ANIMA_DEFAULT_VAE_CANDIDATES",
+          "target": "easyuse_anima/aio/input_defaults.py",
+          "try_line": 8
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.aio.input_defaults:ANIMA_DEFAULT_VAE_CANDIDATES",
+        "kind": "static_from",
+        "line": 63,
+        "name": "ANIMA_DEFAULT_VAE_CANDIDATES",
+        "optional": false,
+        "requested": ".easyuse_anima.aio.input_defaults",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/aio/input_defaults.py"
+      },
+      {
+        "alias": "ANIMA_UNET_WEIGHT_DTYPES",
+        "bound_name": "ANIMA_UNET_WEIGHT_DTYPES",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 8
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "ANIMA_UNET_WEIGHT_DTYPES",
+          "target": "easyuse_anima/aio/input_defaults.py",
+          "try_line": 8
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.aio.input_defaults:ANIMA_UNET_WEIGHT_DTYPES",
+        "kind": "static_from",
+        "line": 63,
+        "name": "ANIMA_UNET_WEIGHT_DTYPES",
+        "optional": false,
+        "requested": ".easyuse_anima.aio.input_defaults",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/aio/input_defaults.py"
+      },
+      {
+        "alias": "EASY_USE_ANIMA_INPUT_SCHEMA",
+        "bound_name": "EASY_USE_ANIMA_INPUT_SCHEMA",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 8
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "EASY_USE_ANIMA_INPUT_SCHEMA",
+          "target": "easyuse_anima/aio/input_defaults.py",
+          "try_line": 8
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.aio.input_defaults:EASY_USE_ANIMA_INPUT_SCHEMA",
+        "kind": "static_from",
+        "line": 63,
+        "name": "EASY_USE_ANIMA_INPUT_SCHEMA",
+        "optional": false,
+        "requested": ".easyuse_anima.aio.input_defaults",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/aio/input_defaults.py"
+      },
+      {
+        "alias": "EASY_USE_ANIMA_INPUT_SETTINGS_VERSION",
+        "bound_name": "EASY_USE_ANIMA_INPUT_SETTINGS_VERSION",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 8
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "EASY_USE_ANIMA_INPUT_SETTINGS_VERSION",
+          "target": "easyuse_anima/aio/input_defaults.py",
+          "try_line": 8
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.aio.input_defaults:EASY_USE_ANIMA_INPUT_SETTINGS_VERSION",
+        "kind": "static_from",
+        "line": 63,
+        "name": "EASY_USE_ANIMA_INPUT_SETTINGS_VERSION",
+        "optional": false,
+        "requested": ".easyuse_anima.aio.input_defaults",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/aio/input_defaults.py"
+      },
+      {
         "alias": "_aio_usdu_auto_tile_dimension",
         "bound_name": "_aio_usdu_auto_tile_dimension",
         "branch_context": [
@@ -20190,7 +20977,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.usdu:_aio_usdu_auto_tile_dimension",
         "kind": "static_from",
-        "line": 63,
+        "line": 74,
         "name": "_aio_usdu_auto_tile_dimension",
         "optional": false,
         "requested": ".easyuse_anima.aio.usdu",
@@ -20221,7 +21008,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.usdu:_aio_usdu_tile_plan",
         "kind": "static_from",
-        "line": 63,
+        "line": 74,
         "name": "_aio_usdu_tile_plan",
         "optional": false,
         "requested": ".easyuse_anima.aio.usdu",
@@ -20252,7 +21039,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.postprocess:_aio_final_fit_size",
         "kind": "static_from",
-        "line": 67,
+        "line": 78,
         "name": "_aio_final_fit_size",
         "optional": false,
         "requested": ".easyuse_anima.aio.postprocess",
@@ -20283,7 +21070,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.postprocess:_apply_aio_final_fit",
         "kind": "static_from",
-        "line": 67,
+        "line": 78,
         "name": "_apply_aio_final_fit",
         "optional": false,
         "requested": ".easyuse_anima.aio.postprocess",
@@ -20314,7 +21101,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.postprocess:_resize_image_to_size_if_needed",
         "kind": "static_from",
-        "line": 67,
+        "line": 78,
         "name": "_resize_image_to_size_if_needed",
         "optional": false,
         "requested": ".easyuse_anima.aio.postprocess",
@@ -20345,7 +21132,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.postprocess:_run_aio_postprocess_stage",
         "kind": "static_from",
-        "line": 67,
+        "line": 78,
         "name": "_run_aio_postprocess_stage",
         "optional": false,
         "requested": ".easyuse_anima.aio.postprocess",
@@ -20376,7 +21163,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.conditioning:_aio_prompt_data_fields_for_usdu",
         "kind": "static_from",
-        "line": 73,
+        "line": 84,
         "name": "_aio_prompt_data_fields_for_usdu",
         "optional": false,
         "requested": ".easyuse_anima.aio.conditioning",
@@ -20407,7 +21194,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.conditioning:_aio_usdu_conditioning",
         "kind": "static_from",
-        "line": 73,
+        "line": 84,
         "name": "_aio_usdu_conditioning",
         "optional": false,
         "requested": ".easyuse_anima.aio.conditioning",
@@ -20438,7 +21225,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.conditioning:_aio_usdu_prompt_without_general",
         "kind": "static_from",
-        "line": 73,
+        "line": 84,
         "name": "_aio_usdu_prompt_without_general",
         "optional": false,
         "requested": ".easyuse_anima.aio.conditioning",
@@ -20469,7 +21256,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.conditioning:_bind_aio_conditioning_runtime",
         "kind": "static_from",
-        "line": 73,
+        "line": 84,
         "name": "_bind_aio_conditioning_runtime",
         "optional": false,
         "requested": ".easyuse_anima.aio.conditioning",
@@ -20500,7 +21287,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_aio_lora_stack_signature",
         "kind": "static_from",
-        "line": 79,
+        "line": 90,
         "name": "_aio_lora_stack_signature",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -20531,7 +21318,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_apply_aio_anima_dave_patch",
         "kind": "static_from",
-        "line": 79,
+        "line": 90,
         "name": "_apply_aio_anima_dave_patch",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -20562,7 +21349,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_apply_aio_kj_model_patches",
         "kind": "static_from",
-        "line": 79,
+        "line": 90,
         "name": "_apply_aio_kj_model_patches",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -20593,7 +21380,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_apply_aio_lora_stack",
         "kind": "static_from",
-        "line": 79,
+        "line": 90,
         "name": "_apply_aio_lora_stack",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -20624,7 +21411,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_apply_aio_model_patches",
         "kind": "static_from",
-        "line": 79,
+        "line": 90,
         "name": "_apply_aio_model_patches",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -20655,7 +21442,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_apply_aio_safe_pag_patch",
         "kind": "static_from",
-        "line": 79,
+        "line": 90,
         "name": "_apply_aio_safe_pag_patch",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -20686,7 +21473,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_apply_aio_spectrum_correction_patch_for_comfy_sampler",
         "kind": "static_from",
-        "line": 79,
+        "line": 90,
         "name": "_apply_aio_spectrum_correction_patch_for_comfy_sampler",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -20717,7 +21504,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_apply_aio_spectrum_forecast_patch_for_comfy_sampler",
         "kind": "static_from",
-        "line": 79,
+        "line": 90,
         "name": "_apply_aio_spectrum_forecast_patch_for_comfy_sampler",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -20748,7 +21535,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_apply_aio_spectrum_model_patches_for_comfy_sampler",
         "kind": "static_from",
-        "line": 79,
+        "line": 90,
         "name": "_apply_aio_spectrum_model_patches_for_comfy_sampler",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -20779,7 +21566,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_bind_aio_model_preparation_runtime",
         "kind": "static_from",
-        "line": 79,
+        "line": 90,
         "name": "_bind_aio_model_preparation_runtime",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -20810,7 +21597,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_cleanup_aio_ephemeral_model",
         "kind": "static_from",
-        "line": 79,
+        "line": 90,
         "name": "_cleanup_aio_ephemeral_model",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -20841,7 +21628,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_normalize_aio_lora_stack",
         "kind": "static_from",
-        "line": 79,
+        "line": 90,
         "name": "_normalize_aio_lora_stack",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -20872,7 +21659,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_patch_model_sampling_aura_flow",
         "kind": "static_from",
-        "line": 79,
+        "line": 90,
         "name": "_patch_model_sampling_aura_flow",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -20903,7 +21690,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_aio_highres_effective_backend",
         "kind": "static_from",
-        "line": 94,
+        "line": 105,
         "name": "_aio_highres_effective_backend",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -20934,7 +21721,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_aio_stage_sampler_settings",
         "kind": "static_from",
-        "line": 94,
+        "line": 105,
         "name": "_aio_stage_sampler_settings",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -20965,7 +21752,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_bind_aio_sampling_runtime",
         "kind": "static_from",
-        "line": 94,
+        "line": 105,
         "name": "_bind_aio_sampling_runtime",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -20996,7 +21783,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_decode_latent_with_comfy",
         "kind": "static_from",
-        "line": 94,
+        "line": 105,
         "name": "_decode_latent_with_comfy",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -21027,7 +21814,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_encode_image_with_comfy_vae",
         "kind": "static_from",
-        "line": 94,
+        "line": 105,
         "name": "_encode_image_with_comfy_vae",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -21058,7 +21845,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_generate_empty_latent_with_comfy",
         "kind": "static_from",
-        "line": 94,
+        "line": 105,
         "name": "_generate_empty_latent_with_comfy",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -21089,7 +21876,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_new_aio_random_seed",
         "kind": "static_from",
-        "line": 94,
+        "line": 105,
         "name": "_new_aio_random_seed",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -21120,7 +21907,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_resolve_aio_runtime_seed",
         "kind": "static_from",
-        "line": 94,
+        "line": 105,
         "name": "_resolve_aio_runtime_seed",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -21151,7 +21938,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_sample_latent_with_aio_backend",
         "kind": "static_from",
-        "line": 94,
+        "line": 105,
         "name": "_sample_latent_with_aio_backend",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -21182,7 +21969,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_sample_latent_with_comfy",
         "kind": "static_from",
-        "line": 94,
+        "line": 105,
         "name": "_sample_latent_with_comfy",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -21213,7 +22000,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_sample_latent_with_spectrum_mod_guidance_advanced",
         "kind": "static_from",
-        "line": 94,
+        "line": 105,
         "name": "_sample_latent_with_spectrum_mod_guidance_advanced",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -21244,7 +22031,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_sample_latent_with_spectrum_spd",
         "kind": "static_from",
-        "line": 94,
+        "line": 105,
         "name": "_sample_latent_with_spectrum_spd",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -21275,7 +22062,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.preview:AIO_PREVIEW_CACHE_FORMAT",
         "kind": "static_from",
-        "line": 108,
+        "line": 119,
         "name": "AIO_PREVIEW_CACHE_FORMAT",
         "optional": false,
         "requested": ".easyuse_anima.aio.preview",
@@ -21306,7 +22093,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.preview:AIO_PREVIEW_CACHE_QUALITY",
         "kind": "static_from",
-        "line": 108,
+        "line": 119,
         "name": "AIO_PREVIEW_CACHE_QUALITY",
         "optional": false,
         "requested": ".easyuse_anima.aio.preview",
@@ -21337,7 +22124,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.preview:AIO_PREVIEW_EVENT",
         "kind": "static_from",
-        "line": 108,
+        "line": 119,
         "name": "AIO_PREVIEW_EVENT",
         "optional": false,
         "requested": ".easyuse_anima.aio.preview",
@@ -21368,7 +22155,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.preview:AIO_PREVIEW_STAGE_LABELS",
         "kind": "static_from",
-        "line": 108,
+        "line": 119,
         "name": "AIO_PREVIEW_STAGE_LABELS",
         "optional": false,
         "requested": ".easyuse_anima.aio.preview",
@@ -21399,7 +22186,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.preview:_aio_preview_base_directory",
         "kind": "static_from",
-        "line": 108,
+        "line": 119,
         "name": "_aio_preview_base_directory",
         "optional": false,
         "requested": ".easyuse_anima.aio.preview",
@@ -21430,39 +22217,8 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.preview:_aio_preview_file_size_bytes",
         "kind": "static_from",
-        "line": 108,
+        "line": 119,
         "name": "_aio_preview_file_size_bytes",
-        "optional": false,
-        "requested": ".easyuse_anima.aio.preview",
-        "role": "compatibility_primary",
-        "scope": "<module>",
-        "source": "nodes.py",
-        "target": "easyuse_anima/aio/preview.py"
-      },
-      {
-        "alias": "_bind_aio_preview_runtime",
-        "bound_name": "_bind_aio_preview_runtime",
-        "branch_context": [
-          {
-            "branch": "body",
-            "handles_import_failure": true,
-            "has_import_fallback_handler": true,
-            "kind": "try",
-            "line": 8
-          }
-        ],
-        "classification": "internal",
-        "column": 4,
-        "compatibility_pair": {
-          "bound_name": "_bind_aio_preview_runtime",
-          "target": "easyuse_anima/aio/preview.py",
-          "try_line": 8
-        },
-        "conditional": true,
-        "imported": ".easyuse_anima.aio.preview:_bind_aio_preview_runtime",
-        "kind": "static_from",
-        "line": 108,
-        "name": "_bind_aio_preview_runtime",
         "optional": false,
         "requested": ".easyuse_anima.aio.preview",
         "role": "compatibility_primary",
@@ -21492,7 +22248,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.preview:_save_aio_temp_preview_image",
         "kind": "static_from",
-        "line": 108,
+        "line": 119,
         "name": "_save_aio_temp_preview_image",
         "optional": false,
         "requested": ".easyuse_anima.aio.preview",
@@ -21523,7 +22279,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.preview:_send_aio_preview_event",
         "kind": "static_from",
-        "line": 108,
+        "line": 119,
         "name": "_send_aio_preview_event",
         "optional": false,
         "requested": ".easyuse_anima.aio.preview",
@@ -21554,7 +22310,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.preview:_tag_aio_preview_images",
         "kind": "static_from",
-        "line": 108,
+        "line": 119,
         "name": "_tag_aio_preview_images",
         "optional": false,
         "requested": ".easyuse_anima.aio.preview",
@@ -21585,7 +22341,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.output:_aio_image_saver_additional_hashes",
         "kind": "static_from",
-        "line": 120,
+        "line": 130,
         "name": "_aio_image_saver_additional_hashes",
         "optional": false,
         "requested": ".easyuse_anima.aio.output",
@@ -21616,7 +22372,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.output:_aio_image_saver_civitai_hash_fetcher_entries",
         "kind": "static_from",
-        "line": 120,
+        "line": 130,
         "name": "_aio_image_saver_civitai_hash_fetcher_entries",
         "optional": false,
         "requested": ".easyuse_anima.aio.output",
@@ -21647,7 +22403,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.output:_aio_lora_metadata_name",
         "kind": "static_from",
-        "line": 120,
+        "line": 130,
         "name": "_aio_lora_metadata_name",
         "optional": false,
         "requested": ".easyuse_anima.aio.output",
@@ -21678,7 +22434,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.output:_aio_prompt_with_lora_metadata",
         "kind": "static_from",
-        "line": 120,
+        "line": 130,
         "name": "_aio_prompt_with_lora_metadata",
         "optional": false,
         "requested": ".easyuse_anima.aio.output",
@@ -21709,39 +22465,8 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.output:_aio_save_filename_prefix",
         "kind": "static_from",
-        "line": 120,
+        "line": 130,
         "name": "_aio_save_filename_prefix",
-        "optional": false,
-        "requested": ".easyuse_anima.aio.output",
-        "role": "compatibility_primary",
-        "scope": "<module>",
-        "source": "nodes.py",
-        "target": "easyuse_anima/aio/output.py"
-      },
-      {
-        "alias": "_bind_aio_output_runtime",
-        "bound_name": "_bind_aio_output_runtime",
-        "branch_context": [
-          {
-            "branch": "body",
-            "handles_import_failure": true,
-            "has_import_fallback_handler": true,
-            "kind": "try",
-            "line": 8
-          }
-        ],
-        "classification": "internal",
-        "column": 4,
-        "compatibility_pair": {
-          "bound_name": "_bind_aio_output_runtime",
-          "target": "easyuse_anima/aio/output.py",
-          "try_line": 8
-        },
-        "conditional": true,
-        "imported": ".easyuse_anima.aio.output:_bind_aio_output_runtime",
-        "kind": "static_from",
-        "line": 120,
-        "name": "_bind_aio_output_runtime",
         "optional": false,
         "requested": ".easyuse_anima.aio.output",
         "role": "compatibility_primary",
@@ -21771,7 +22496,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.output:_save_image_with_comfy",
         "kind": "static_from",
-        "line": 120,
+        "line": 130,
         "name": "_save_image_with_comfy",
         "optional": false,
         "requested": ".easyuse_anima.aio.output",
@@ -21802,7 +22527,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.output:_save_image_with_image_saver",
         "kind": "static_from",
-        "line": 120,
+        "line": 130,
         "name": "_save_image_with_image_saver",
         "optional": false,
         "requested": ".easyuse_anima.aio.output",
@@ -21833,7 +22558,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.output_settings:_normalize_aio_civitai_hash_fetchers",
         "kind": "static_from",
-        "line": 130,
+        "line": 139,
         "name": "_normalize_aio_civitai_hash_fetchers",
         "optional": false,
         "requested": ".easyuse_anima.aio.output_settings",
@@ -21864,7 +22589,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.output_settings:_normalize_aio_hash_bundles",
         "kind": "static_from",
-        "line": 130,
+        "line": 139,
         "name": "_normalize_aio_hash_bundles",
         "optional": false,
         "requested": ".easyuse_anima.aio.output_settings",
@@ -21872,37 +22597,6 @@
         "scope": "<module>",
         "source": "nodes.py",
         "target": "easyuse_anima/aio/output_settings.py"
-      },
-      {
-        "alias": "_bind_aio_resource_runtime",
-        "bound_name": "_bind_aio_resource_runtime",
-        "branch_context": [
-          {
-            "branch": "body",
-            "handles_import_failure": true,
-            "has_import_fallback_handler": true,
-            "kind": "try",
-            "line": 8
-          }
-        ],
-        "classification": "internal",
-        "column": 4,
-        "compatibility_pair": {
-          "bound_name": "_bind_aio_resource_runtime",
-          "target": "easyuse_anima/aio/resources.py",
-          "try_line": 8
-        },
-        "conditional": true,
-        "imported": ".easyuse_anima.aio.resources:_bind_aio_resource_runtime",
-        "kind": "static_from",
-        "line": 134,
-        "name": "_bind_aio_resource_runtime",
-        "optional": false,
-        "requested": ".easyuse_anima.aio.resources",
-        "role": "compatibility_primary",
-        "scope": "<module>",
-        "source": "nodes.py",
-        "target": "easyuse_anima/aio/resources.py"
       },
       {
         "alias": "_comfy_clip_loader_types",
@@ -21926,7 +22620,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_comfy_clip_loader_types",
         "kind": "static_from",
-        "line": 134,
+        "line": 143,
         "name": "_comfy_clip_loader_types",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -21957,7 +22651,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_comfy_diffusion_model_names",
         "kind": "static_from",
-        "line": 134,
+        "line": 143,
         "name": "_comfy_diffusion_model_names",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -21988,7 +22682,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_comfy_text_encoder_names",
         "kind": "static_from",
-        "line": 134,
+        "line": 143,
         "name": "_comfy_text_encoder_names",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -22019,7 +22713,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_comfy_vae_names",
         "kind": "static_from",
-        "line": 134,
+        "line": 143,
         "name": "_comfy_vae_names",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -22050,7 +22744,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_load_aio_resources_from_input_context",
         "kind": "static_from",
-        "line": 134,
+        "line": 143,
         "name": "_load_aio_resources_from_input_context",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -22081,7 +22775,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_load_aio_sam3_context",
         "kind": "static_from",
-        "line": 134,
+        "line": 143,
         "name": "_load_aio_sam3_context",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -22112,7 +22806,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_load_checkpoint_with_comfy",
         "kind": "static_from",
-        "line": 134,
+        "line": 143,
         "name": "_load_checkpoint_with_comfy",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -22143,7 +22837,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_load_clip_with_comfy",
         "kind": "static_from",
-        "line": 134,
+        "line": 143,
         "name": "_load_clip_with_comfy",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -22174,7 +22868,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_load_diffusion_model_with_comfy",
         "kind": "static_from",
-        "line": 134,
+        "line": 143,
         "name": "_load_diffusion_model_with_comfy",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -22205,7 +22899,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_load_upscale_model_with_comfy",
         "kind": "static_from",
-        "line": 134,
+        "line": 143,
         "name": "_load_upscale_model_with_comfy",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -22236,7 +22930,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_load_vae_with_comfy",
         "kind": "static_from",
-        "line": 134,
+        "line": 143,
         "name": "_load_vae_with_comfy",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -22267,7 +22961,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_normalize_aio_input_settings",
         "kind": "static_from",
-        "line": 134,
+        "line": 143,
         "name": "_normalize_aio_input_settings",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -22298,7 +22992,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_preferred_checkpoint_default",
         "kind": "static_from",
-        "line": 134,
+        "line": 143,
         "name": "_preferred_checkpoint_default",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -22329,7 +23023,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_preferred_clip_type_default",
         "kind": "static_from",
-        "line": 134,
+        "line": 143,
         "name": "_preferred_clip_type_default",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -22360,7 +23054,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_preferred_name_default",
         "kind": "static_from",
-        "line": 134,
+        "line": 143,
         "name": "_preferred_name_default",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -22391,7 +23085,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.common.serialization:_json_clone",
         "kind": "static_from",
-        "line": 152,
+        "line": 160,
         "name": "_json_clone",
         "optional": false,
         "requested": ".easyuse_anima.common.serialization",
@@ -22422,7 +23116,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.common.serialization:_json_object",
         "kind": "static_from",
-        "line": 152,
+        "line": 160,
         "name": "_json_object",
         "optional": false,
         "requested": ".easyuse_anima.common.serialization",
@@ -22453,7 +23147,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.common.serialization:_stable_change_key",
         "kind": "static_from",
-        "line": 152,
+        "line": 160,
         "name": "_stable_change_key",
         "optional": false,
         "requested": ".easyuse_anima.common.serialization",
@@ -22484,7 +23178,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.common.values:_as_bool",
         "kind": "static_from",
-        "line": 157,
+        "line": 165,
         "name": "_as_bool",
         "optional": false,
         "requested": ".easyuse_anima.common.values",
@@ -22515,7 +23209,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.common.values:_as_float",
         "kind": "static_from",
-        "line": 157,
+        "line": 165,
         "name": "_as_float",
         "optional": false,
         "requested": ".easyuse_anima.common.values",
@@ -22546,7 +23240,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.common.values:_as_int",
         "kind": "static_from",
-        "line": 157,
+        "line": 165,
         "name": "_as_int",
         "optional": false,
         "requested": ".easyuse_anima.common.values",
@@ -22577,7 +23271,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.common.values:_choice",
         "kind": "static_from",
-        "line": 157,
+        "line": 165,
         "name": "_choice",
         "optional": false,
         "requested": ".easyuse_anima.common.values",
@@ -22608,7 +23302,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.common.values:_single_value",
         "kind": "static_from",
-        "line": 157,
+        "line": 165,
         "name": "_single_value",
         "optional": false,
         "requested": ".easyuse_anima.common.values",
@@ -22639,7 +23333,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.seed.compatibility:WILDCARD_QUEUE_MAX_SAFE_SEED",
         "kind": "static_from",
-        "line": 164,
+        "line": 172,
         "name": "WILDCARD_QUEUE_MAX_SAFE_SEED",
         "optional": false,
         "requested": ".easyuse_anima.seed.compatibility",
@@ -22670,7 +23364,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.seed.compatibility:WILDCARD_RESERVED_NEXT_SEED_INPUT",
         "kind": "static_from",
-        "line": 164,
+        "line": 172,
         "name": "WILDCARD_RESERVED_NEXT_SEED_INPUT",
         "optional": false,
         "requested": ".easyuse_anima.seed.compatibility",
@@ -22701,7 +23395,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.seed.compatibility:_consume_reserved_wildcard_next_seed",
         "kind": "static_from",
-        "line": 164,
+        "line": 172,
         "name": "_consume_reserved_wildcard_next_seed",
         "optional": false,
         "requested": ".easyuse_anima.seed.compatibility",
@@ -22732,7 +23426,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.workflow:_get_workflow_node",
         "kind": "static_from",
-        "line": 169,
+        "line": 177,
         "name": "_get_workflow_node",
         "optional": false,
         "requested": ".easyuse_anima.workflow",
@@ -22763,7 +23457,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.correction:_prompt_translation_change_key",
         "kind": "static_from",
-        "line": 170,
+        "line": 178,
         "name": "_prompt_translation_change_key",
         "optional": false,
         "requested": ".easyuse_anima.prompt.correction",
@@ -22794,7 +23488,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.correction:_split_tag_text",
         "kind": "static_from",
-        "line": 170,
+        "line": 178,
         "name": "_split_tag_text",
         "optional": false,
         "requested": ".easyuse_anima.prompt.correction",
@@ -22825,7 +23519,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.correction:_translate_prompt_text",
         "kind": "static_from",
-        "line": 170,
+        "line": 178,
         "name": "_translate_prompt_text",
         "optional": false,
         "requested": ".easyuse_anima.prompt.correction",
@@ -22856,7 +23550,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_HASH_COMMENT_RE",
         "kind": "static_from",
-        "line": 175,
+        "line": 183,
         "name": "_HASH_COMMENT_RE",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -22887,7 +23581,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_INLINE_SPACE_RE",
         "kind": "static_from",
-        "line": 175,
+        "line": 183,
         "name": "_INLINE_SPACE_RE",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -22918,7 +23612,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_WEIGHTED_TOKEN_RE",
         "kind": "static_from",
-        "line": 175,
+        "line": 183,
         "name": "_WEIGHTED_TOKEN_RE",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -22949,7 +23643,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_correct_builder_prompt",
         "kind": "static_from",
-        "line": 175,
+        "line": 183,
         "name": "_correct_builder_prompt",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -22980,7 +23674,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_filter_metadata_prompt",
         "kind": "static_from",
-        "line": 175,
+        "line": 183,
         "name": "_filter_metadata_prompt",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -23011,7 +23705,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_join_prompt_tokens",
         "kind": "static_from",
-        "line": 175,
+        "line": 183,
         "name": "_join_prompt_tokens",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -23042,7 +23736,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_metadata_filter_key",
         "kind": "static_from",
-        "line": 175,
+        "line": 183,
         "name": "_metadata_filter_key",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -23073,7 +23767,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_metadata_filter_keys",
         "kind": "static_from",
-        "line": 175,
+        "line": 183,
         "name": "_metadata_filter_keys",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -23104,7 +23798,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_prompt_tokens",
         "kind": "static_from",
-        "line": 175,
+        "line": 183,
         "name": "_prompt_tokens",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -23135,7 +23829,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:PROMPT_DATA_TYPE",
         "kind": "static_from",
-        "line": 188,
+        "line": 196,
         "name": "PROMPT_DATA_TYPE",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -23166,7 +23860,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:_advanced_outputs_from_prompt_data",
         "kind": "static_from",
-        "line": 188,
+        "line": 196,
         "name": "_advanced_outputs_from_prompt_data",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -23197,7 +23891,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:_apply_prompt_data_overrides",
         "kind": "static_from",
-        "line": 188,
+        "line": 196,
         "name": "_apply_prompt_data_overrides",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -23228,7 +23922,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:_copy_prompt_data_for_update",
         "kind": "static_from",
-        "line": 188,
+        "line": 196,
         "name": "_copy_prompt_data_for_update",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -23259,7 +23953,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:_normalize_prompt_data",
         "kind": "static_from",
-        "line": 188,
+        "line": 196,
         "name": "_normalize_prompt_data",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -23290,7 +23984,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:_prompt_data_json_safe",
         "kind": "static_from",
-        "line": 188,
+        "line": 196,
         "name": "_prompt_data_json_safe",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -23321,7 +24015,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:_prompt_data_parameter_snapshot",
         "kind": "static_from",
-        "line": 188,
+        "line": 196,
         "name": "_prompt_data_parameter_snapshot",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -23352,7 +24046,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_artist_field_prompt",
         "kind": "static_from",
-        "line": 206,
+        "line": 214,
         "name": "_advanced_artist_field_prompt",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -23383,7 +24077,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_default_fields",
         "kind": "static_from",
-        "line": 206,
+        "line": 214,
         "name": "_advanced_default_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -23414,7 +24108,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_enabled_naia_panes",
         "kind": "static_from",
-        "line": 206,
+        "line": 214,
         "name": "_advanced_enabled_naia_panes",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -23445,7 +24139,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_enabled_pane_fields",
         "kind": "static_from",
-        "line": 206,
+        "line": 214,
         "name": "_advanced_enabled_pane_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -23476,7 +24170,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_field_input_values",
         "kind": "static_from",
-        "line": 206,
+        "line": 214,
         "name": "_advanced_field_input_values",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -23507,7 +24201,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_field_socket_name",
         "kind": "static_from",
-        "line": 206,
+        "line": 214,
         "name": "_advanced_field_socket_name",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -23538,7 +24232,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_fields_json",
         "kind": "static_from",
-        "line": 206,
+        "line": 214,
         "name": "_advanced_fields_json",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -23569,7 +24263,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_has_enabled_naia",
         "kind": "static_from",
-        "line": 206,
+        "line": 214,
         "name": "_advanced_has_enabled_naia",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -23600,7 +24294,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_prompt_with_artist_override",
         "kind": "static_from",
-        "line": 206,
+        "line": 214,
         "name": "_advanced_prompt_with_artist_override",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -23631,7 +24325,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_uses_naia_resolution",
         "kind": "static_from",
-        "line": 206,
+        "line": 214,
         "name": "_advanced_uses_naia_resolution",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -23662,7 +24356,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_apply_advanced_field_inputs",
         "kind": "static_from",
-        "line": 206,
+        "line": 214,
         "name": "_apply_advanced_field_inputs",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -23693,7 +24387,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_as_advanced_height",
         "kind": "static_from",
-        "line": 206,
+        "line": 214,
         "name": "_as_advanced_height",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -23724,7 +24418,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_build_advanced_prompt_data",
         "kind": "static_from",
-        "line": 206,
+        "line": 214,
         "name": "_build_advanced_prompt_data",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -23755,7 +24449,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_build_advanced_prompts",
         "kind": "static_from",
-        "line": 206,
+        "line": 214,
         "name": "_build_advanced_prompts",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -23786,7 +24480,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_clone_advanced_fields",
         "kind": "static_from",
-        "line": 206,
+        "line": 214,
         "name": "_clone_advanced_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -23817,7 +24511,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_correct_advanced_field_sequence",
         "kind": "static_from",
-        "line": 206,
+        "line": 214,
         "name": "_correct_advanced_field_sequence",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -23848,7 +24542,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_expand_advanced_wildcard_fields",
         "kind": "static_from",
-        "line": 206,
+        "line": 214,
         "name": "_expand_advanced_wildcard_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -23879,7 +24573,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_normalize_advanced_fields",
         "kind": "static_from",
-        "line": 206,
+        "line": 214,
         "name": "_normalize_advanced_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -23910,7 +24604,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_normalize_prompt_studio_wildcard_seed_control",
         "kind": "static_from",
-        "line": 206,
+        "line": 214,
         "name": "_normalize_prompt_studio_wildcard_seed_control",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -23941,7 +24635,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_set_naia_field_text",
         "kind": "static_from",
-        "line": 206,
+        "line": 214,
         "name": "_set_naia_field_text",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -23972,7 +24666,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_translate_prompt_fields",
         "kind": "static_from",
-        "line": 206,
+        "line": 214,
         "name": "_translate_prompt_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -24003,7 +24697,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_apply_regional_field_inputs",
         "kind": "static_from",
-        "line": 241,
+        "line": 249,
         "name": "_apply_regional_field_inputs",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -24034,7 +24728,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_build_regional_outputs",
         "kind": "static_from",
-        "line": 241,
+        "line": 249,
         "name": "_build_regional_outputs",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -24065,7 +24759,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_clone_regional_fields",
         "kind": "static_from",
-        "line": 241,
+        "line": 249,
         "name": "_clone_regional_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -24096,7 +24790,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_conditioning_set_values",
         "kind": "static_from",
-        "line": 241,
+        "line": 249,
         "name": "_conditioning_set_values",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -24127,7 +24821,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_normalize_mask_ids",
         "kind": "static_from",
-        "line": 241,
+        "line": 249,
         "name": "_normalize_mask_ids",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -24158,7 +24852,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_normalize_regional_config",
         "kind": "static_from",
-        "line": 241,
+        "line": 249,
         "name": "_normalize_regional_config",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -24189,7 +24883,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_normalize_regional_fields",
         "kind": "static_from",
-        "line": 241,
+        "line": 249,
         "name": "_normalize_regional_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -24220,7 +24914,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_parse_json_object",
         "kind": "static_from",
-        "line": 241,
+        "line": 249,
         "name": "_parse_json_object",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -24251,7 +24945,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_regional_config_json",
         "kind": "static_from",
-        "line": 241,
+        "line": 249,
         "name": "_regional_config_json",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -24282,7 +24976,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_regional_fields_json",
         "kind": "static_from",
-        "line": 241,
+        "line": 249,
         "name": "_regional_fields_json",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -24313,7 +25007,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_regional_mask_bounds_area",
         "kind": "static_from",
-        "line": 241,
+        "line": 249,
         "name": "_regional_mask_bounds_area",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -24344,7 +25038,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_regional_payload_canvas",
         "kind": "static_from",
-        "line": 241,
+        "line": 249,
         "name": "_regional_payload_canvas",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -24375,7 +25069,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_regional_union_mask_for_ids",
         "kind": "static_from",
-        "line": 241,
+        "line": 249,
         "name": "_regional_union_mask_for_ids",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -24406,7 +25100,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
         "kind": "static_from",
-        "line": 268,
+        "line": 276,
         "name": "ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -24437,7 +25131,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODES",
         "kind": "static_from",
-        "line": 268,
+        "line": 276,
         "name": "ANIMA_MOD_GUIDANCE_MODES",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -24468,7 +25162,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 268,
+        "line": 276,
         "name": "ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -24499,7 +25193,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_PROFILE_OFF",
         "kind": "static_from",
-        "line": 268,
+        "line": 276,
         "name": "ANIMA_MOD_GUIDANCE_PROFILE_OFF",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -24530,7 +25224,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:_apply_spectrum_anima_mod_guidance",
         "kind": "static_from",
-        "line": 268,
+        "line": 276,
         "name": "_apply_spectrum_anima_mod_guidance",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -24561,7 +25255,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:_find_spectrum_anima_mod_guidance_class",
         "kind": "static_from",
-        "line": 268,
+        "line": 276,
         "name": "_find_spectrum_anima_mod_guidance_class",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -24592,7 +25286,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:_normalize_anima_mod_guidance_profile",
         "kind": "static_from",
-        "line": 268,
+        "line": 276,
         "name": "_normalize_anima_mod_guidance_profile",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -24623,7 +25317,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:_resolve_anima_mod_guidance_enabled",
         "kind": "static_from",
-        "line": 268,
+        "line": 276,
         "name": "_resolve_anima_mod_guidance_enabled",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -24654,7 +25348,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
         "kind": "static_from",
-        "line": 283,
+        "line": 291,
         "name": "ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -24685,7 +25379,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
         "kind": "static_from",
-        "line": 283,
+        "line": 291,
         "name": "ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -24716,7 +25410,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
         "kind": "static_from",
-        "line": 283,
+        "line": 291,
         "name": "ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -24747,7 +25441,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_EXACT_TOP_K",
         "kind": "static_from",
-        "line": 283,
+        "line": 291,
         "name": "ARTIST_MIX_DEFAULT_EXACT_TOP_K",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -24778,7 +25472,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
         "kind": "static_from",
-        "line": 283,
+        "line": 291,
         "name": "ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -24809,7 +25503,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_START_PERCENT",
         "kind": "static_from",
-        "line": 283,
+        "line": 291,
         "name": "ARTIST_MIX_DEFAULT_START_PERCENT",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -24840,7 +25534,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
         "kind": "static_from",
-        "line": 283,
+        "line": 291,
         "name": "ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -24871,7 +25565,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STYLE_GAIN",
         "kind": "static_from",
-        "line": 283,
+        "line": 291,
         "name": "ARTIST_MIX_DEFAULT_STYLE_GAIN",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -24902,7 +25596,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_INPUT_MODES",
         "kind": "static_from",
-        "line": 283,
+        "line": 291,
         "name": "ARTIST_MIX_INPUT_MODES",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -24933,7 +25627,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 283,
+        "line": 291,
         "name": "ARTIST_MIX_MODE_FROM_PROMPT_DATA",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -24964,7 +25658,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_artist_mix_inline_prompt",
         "kind": "static_from",
-        "line": 283,
+        "line": 291,
         "name": "_artist_mix_inline_prompt",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -24995,7 +25689,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_artist_mix_mode_tooltip",
         "kind": "static_from",
-        "line": 283,
+        "line": 291,
         "name": "_artist_mix_mode_tooltip",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -25026,7 +25720,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_artist_prompt_with_position",
         "kind": "static_from",
-        "line": 283,
+        "line": 291,
         "name": "_artist_prompt_with_position",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -25057,7 +25751,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_artist_tags_from_prompt",
         "kind": "static_from",
-        "line": 283,
+        "line": 291,
         "name": "_artist_tags_from_prompt",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -25088,7 +25782,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_blend_conditionings",
         "kind": "static_from",
-        "line": 283,
+        "line": 291,
         "name": "_blend_conditionings",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -25119,7 +25813,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_bounded_artist_mix_float",
         "kind": "static_from",
-        "line": 283,
+        "line": 291,
         "name": "_bounded_artist_mix_float",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -25150,7 +25844,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_bounded_artist_mix_int",
         "kind": "static_from",
-        "line": 283,
+        "line": 291,
         "name": "_bounded_artist_mix_int",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -25181,7 +25875,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_encode_artist_clustered",
         "kind": "static_from",
-        "line": 283,
+        "line": 291,
         "name": "_encode_artist_clustered",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -25212,7 +25906,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_encode_artist_delta_rms",
         "kind": "static_from",
-        "line": 283,
+        "line": 291,
         "name": "_encode_artist_delta_rms",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -25243,7 +25937,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_encode_prompt_data_positive_conditioning",
         "kind": "static_from",
-        "line": 283,
+        "line": 291,
         "name": "_encode_prompt_data_positive_conditioning",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -25274,7 +25968,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_join_artist_mix_source_prompts",
         "kind": "static_from",
-        "line": 283,
+        "line": 291,
         "name": "_join_artist_mix_source_prompts",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -25305,7 +25999,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_normalize_artist_mix_mode",
         "kind": "static_from",
-        "line": 283,
+        "line": 291,
         "name": "_normalize_artist_mix_mode",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -25336,7 +26030,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_normalize_artist_tag_position",
         "kind": "static_from",
-        "line": 283,
+        "line": 291,
         "name": "_normalize_artist_tag_position",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -25367,7 +26061,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_parse_artist_mix_items",
         "kind": "static_from",
-        "line": 283,
+        "line": 291,
         "name": "_parse_artist_mix_items",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -25398,7 +26092,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaArtistMixConditioning",
         "kind": "static_from",
-        "line": 362,
+        "line": 370,
         "name": "EasyUseAnimaArtistMixConditioning",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_data_nodes",
@@ -25429,7 +26123,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataConditioning",
         "kind": "static_from",
-        "line": 362,
+        "line": 370,
         "name": "EasyUseAnimaPromptDataConditioning",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_data_nodes",
@@ -25460,7 +26154,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataUnpack",
         "kind": "static_from",
-        "line": 362,
+        "line": 370,
         "name": "EasyUseAnimaPromptDataUnpack",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_data_nodes",
@@ -25491,7 +26185,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.input_types:_ANY_TYPE",
         "kind": "static_from",
-        "line": 367,
+        "line": 375,
         "name": "_ANY_TYPE",
         "optional": false,
         "requested": ".easyuse_anima.nodes.input_types",
@@ -25522,7 +26216,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.input_types:_AnyType",
         "kind": "static_from",
-        "line": 367,
+        "line": 375,
         "name": "_AnyType",
         "optional": false,
         "requested": ".easyuse_anima.nodes.input_types",
@@ -25553,7 +26247,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.input_types:_FlexibleOptionalInputType",
         "kind": "static_from",
-        "line": 367,
+        "line": 375,
         "name": "_FlexibleOptionalInputType",
         "optional": false,
         "requested": ".easyuse_anima.nodes.input_types",
@@ -25584,7 +26278,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvanced",
         "kind": "static_from",
-        "line": 372,
+        "line": 380,
         "name": "EasyUseAnimaPromptStudioAdvanced",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_advanced_nodes",
@@ -25615,7 +26309,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvancedV2",
         "kind": "static_from",
-        "line": 372,
+        "line": 380,
         "name": "EasyUseAnimaPromptStudioAdvancedV2",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_advanced_nodes",
@@ -25646,7 +26340,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.aio_nodes:EasyUseAnimaAIOGenerator",
         "kind": "static_from",
-        "line": 377,
+        "line": 385,
         "name": "EasyUseAnimaAIOGenerator",
         "optional": false,
         "requested": ".easyuse_anima.nodes.aio_nodes",
@@ -25677,7 +26371,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.aio_nodes:EasyUseAnimaInput",
         "kind": "static_from",
-        "line": 377,
+        "line": 385,
         "name": "EasyUseAnimaInput",
         "optional": false,
         "requested": ".easyuse_anima.nodes.aio_nodes",
@@ -25708,7 +26402,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.aio_nodes:_aio_generation_settings_json",
         "kind": "static_from",
-        "line": 377,
+        "line": 385,
         "name": "_aio_generation_settings_json",
         "optional": false,
         "requested": ".easyuse_anima.nodes.aio_nodes",
@@ -25739,7 +26433,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.aio_nodes:_aio_input_settings_json",
         "kind": "static_from",
-        "line": 377,
+        "line": 385,
         "name": "_aio_input_settings_json",
         "optional": false,
         "requested": ".easyuse_anima.nodes.aio_nodes",
@@ -25770,7 +26464,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.aio_nodes:_bind_aio_node_runtime",
         "kind": "static_from",
-        "line": 377,
+        "line": 385,
         "name": "_bind_aio_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.aio_nodes",
@@ -25801,7 +26495,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.aio_nodes:_easy_use_anima_input_signature",
         "kind": "static_from",
-        "line": 377,
+        "line": 385,
         "name": "_easy_use_anima_input_signature",
         "optional": false,
         "requested": ".easyuse_anima.nodes.aio_nodes",
@@ -25832,7 +26526,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.aio_nodes:_require_easy_use_anima_input",
         "kind": "static_from",
-        "line": 377,
+        "line": 385,
         "name": "_require_easy_use_anima_input",
         "optional": false,
         "requested": ".easyuse_anima.nodes.aio_nodes",
@@ -25863,7 +26557,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.geometry:_align_down",
         "kind": "static_from",
-        "line": 386,
+        "line": 394,
         "name": "_align_down",
         "optional": false,
         "requested": ".easyuse_anima.image.geometry",
@@ -25894,7 +26588,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.geometry:_align_nearest",
         "kind": "static_from",
-        "line": 386,
+        "line": 394,
         "name": "_align_nearest",
         "optional": false,
         "requested": ".easyuse_anima.image.geometry",
@@ -25925,7 +26619,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.geometry:_image_tensor_size",
         "kind": "static_from",
-        "line": 386,
+        "line": 394,
         "name": "_image_tensor_size",
         "optional": false,
         "requested": ".easyuse_anima.image.geometry",
@@ -25956,7 +26650,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.sam3:_context_value",
         "kind": "static_from",
-        "line": 397,
+        "line": 405,
         "name": "_context_value",
         "optional": false,
         "requested": ".easyuse_anima.image.sam3",
@@ -25987,7 +26681,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.sam3:_sam3_context",
         "kind": "static_from",
-        "line": 397,
+        "line": 405,
         "name": "_sam3_context",
         "optional": false,
         "requested": ".easyuse_anima.image.sam3",
@@ -26018,7 +26712,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.sam3:_segs_has_items",
         "kind": "static_from",
-        "line": 397,
+        "line": 405,
         "name": "_segs_has_items",
         "optional": false,
         "requested": ".easyuse_anima.image.sam3",
@@ -26049,7 +26743,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.scaling:IMAGE_SCALE_MULTIPLES",
         "kind": "static_from",
-        "line": 409,
+        "line": 417,
         "name": "IMAGE_SCALE_MULTIPLES",
         "optional": false,
         "requested": ".easyuse_anima.image.scaling",
@@ -26080,7 +26774,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.scaling:IMAGE_UPSCALE_METHODS",
         "kind": "static_from",
-        "line": 409,
+        "line": 417,
         "name": "IMAGE_UPSCALE_METHODS",
         "optional": false,
         "requested": ".easyuse_anima.image.scaling",
@@ -26111,7 +26805,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_comfy_sampler_names",
         "kind": "static_from",
-        "line": 417,
+        "line": 425,
         "name": "_comfy_sampler_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -26142,7 +26836,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_comfy_scheduler_names",
         "kind": "static_from",
-        "line": 417,
+        "line": 425,
         "name": "_comfy_scheduler_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -26173,7 +26867,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_impact_scheduler_names",
         "kind": "static_from",
-        "line": 417,
+        "line": 425,
         "name": "_impact_scheduler_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -26204,7 +26898,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.invocation:_call_with_supported_kwargs",
         "kind": "static_from",
-        "line": 423,
+        "line": 431,
         "name": "_call_with_supported_kwargs",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.invocation",
@@ -26235,7 +26929,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.invocation:_common_upscale_image",
         "kind": "static_from",
-        "line": 423,
+        "line": 431,
         "name": "_common_upscale_image",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.invocation",
@@ -26266,7 +26960,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.invocation:_node_output_tuple",
         "kind": "static_from",
-        "line": 423,
+        "line": 431,
         "name": "_node_output_tuple",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.invocation",
@@ -26297,7 +26991,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.wiring:resolve_comfy_host_helper",
         "kind": "static_from",
-        "line": 428,
+        "line": 436,
         "name": "resolve_comfy_host_helper",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.wiring",
@@ -26328,7 +27022,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_comfy_clip_loader_types",
         "kind": "static_from",
-        "line": 431,
+        "line": 439,
         "name": "_comfy_clip_loader_types",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -26359,7 +27053,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_comfy_diffusion_model_names",
         "kind": "static_from",
-        "line": 431,
+        "line": 439,
         "name": "_comfy_diffusion_model_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -26390,7 +27084,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_comfy_text_encoder_names",
         "kind": "static_from",
-        "line": 431,
+        "line": 439,
         "name": "_comfy_text_encoder_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -26421,7 +27115,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_comfy_vae_names",
         "kind": "static_from",
-        "line": 431,
+        "line": 439,
         "name": "_comfy_vae_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -26452,7 +27146,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_folder_path_names",
         "kind": "static_from",
-        "line": 431,
+        "line": 439,
         "name": "_folder_path_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -26483,7 +27177,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.image_nodes:EasyUseAnimaDetailerAlignHook",
         "kind": "static_from",
-        "line": 439,
+        "line": 447,
         "name": "EasyUseAnimaDetailerAlignHook",
         "optional": false,
         "requested": ".easyuse_anima.nodes.image_nodes",
@@ -26514,7 +27208,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.image_nodes:EasyUseAnimaImageScaleByMultiple",
         "kind": "static_from",
-        "line": 439,
+        "line": 447,
         "name": "EasyUseAnimaImageScaleByMultiple",
         "optional": false,
         "requested": ".easyuse_anima.nodes.image_nodes",
@@ -26545,7 +27239,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Context",
         "kind": "static_from",
-        "line": 443,
+        "line": 451,
         "name": "EasyUseAnimaSAM3Context",
         "optional": false,
         "requested": ".easyuse_anima.nodes.sam3_nodes",
@@ -26576,7 +27270,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Detailer",
         "kind": "static_from",
-        "line": 443,
+        "line": 451,
         "name": "EasyUseAnimaSAM3Detailer",
         "optional": false,
         "requested": ".easyuse_anima.nodes.sam3_nodes",
@@ -26607,7 +27301,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptBuilder",
         "kind": "static_from",
-        "line": 447,
+        "line": 455,
         "name": "EasyUseAnimaPromptBuilder",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_nodes",
@@ -26638,7 +27332,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrector",
         "kind": "static_from",
-        "line": 447,
+        "line": 455,
         "name": "EasyUseAnimaPromptCorrector",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_nodes",
@@ -26669,7 +27363,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrectorSimple",
         "kind": "static_from",
-        "line": 447,
+        "line": 455,
         "name": "EasyUseAnimaPromptCorrectorSimple",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_nodes",
@@ -26700,7 +27394,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptStudio",
         "kind": "static_from",
-        "line": 447,
+        "line": 455,
         "name": "EasyUseAnimaPromptStudio",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_nodes",
@@ -26731,7 +27425,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.regional_nodes:EasyUseAnimaPromptStudioRegional",
         "kind": "static_from",
-        "line": 453,
+        "line": 461,
         "name": "EasyUseAnimaPromptStudioRegional",
         "optional": false,
         "requested": ".easyuse_anima.nodes.regional_nodes",
@@ -26762,7 +27456,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.regional_nodes:EasyUseAnimaRegionalConditioning",
         "kind": "static_from",
-        "line": 453,
+        "line": 461,
         "name": "EasyUseAnimaRegionalConditioning",
         "optional": false,
         "requested": ".easyuse_anima.nodes.regional_nodes",
@@ -26793,7 +27487,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.client:LATENT_ALIGN",
         "kind": "static_from",
-        "line": 457,
+        "line": 465,
         "name": "LATENT_ALIGN",
         "optional": false,
         "requested": ".easyuse_anima.naia.client",
@@ -26824,7 +27518,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.client:_parse_random_response",
         "kind": "static_from",
-        "line": 457,
+        "line": 465,
         "name": "_parse_random_response",
         "optional": false,
         "requested": ".easyuse_anima.naia.client",
@@ -26855,7 +27549,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.client:_post_random",
         "kind": "static_from",
-        "line": 457,
+        "line": 465,
         "name": "_post_random",
         "optional": false,
         "requested": ".easyuse_anima.naia.client",
@@ -26886,7 +27580,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_advanced_resolution_from_selection",
         "kind": "static_from",
-        "line": 475,
+        "line": 483,
         "name": "_advanced_resolution_from_selection",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -26917,7 +27611,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_normalize_resolution_bucket",
         "kind": "static_from",
-        "line": 475,
+        "line": 483,
         "name": "_normalize_resolution_bucket",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -26948,7 +27642,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_ratio_label",
         "kind": "static_from",
-        "line": 475,
+        "line": 483,
         "name": "_ratio_label",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -26979,7 +27673,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_resolution_label",
         "kind": "static_from",
-        "line": 475,
+        "line": 483,
         "name": "_resolution_label",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -27010,7 +27704,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_resolve_naia_resolution",
         "kind": "static_from",
-        "line": 475,
+        "line": 483,
         "name": "_resolve_naia_resolution",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -27041,7 +27735,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.naia_nodes:EasyUseAnimaNAIARandomPrompt",
         "kind": "static_from",
-        "line": 498,
+        "line": 506,
         "name": "EasyUseAnimaNAIARandomPrompt",
         "optional": false,
         "requested": ".easyuse_anima.nodes.naia_nodes",
@@ -27072,7 +27766,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.naia_nodes:_bind_naia_node_runtime",
         "kind": "static_from",
-        "line": 498,
+        "line": 506,
         "name": "_bind_naia_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.naia_nodes",
@@ -27103,7 +27797,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.wildcard_nodes:EasyUseAnimaWildcard",
         "kind": "static_from",
-        "line": 502,
+        "line": 510,
         "name": "EasyUseAnimaWildcard",
         "optional": false,
         "requested": ".easyuse_anima.nodes.wildcard_nodes",
@@ -27134,7 +27828,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.wildcard_nodes:_bind_wildcard_node_runtime",
         "kind": "static_from",
-        "line": 502,
+        "line": 510,
         "name": "_bind_wildcard_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.wildcard_nodes",
@@ -27165,7 +27859,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_apply_lora_syntax_format",
         "kind": "static_from",
-        "line": 507,
+        "line": 515,
         "name": "_apply_lora_syntax_format",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -27196,7 +27890,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_dedupe_text_values",
         "kind": "static_from",
-        "line": 507,
+        "line": 515,
         "name": "_dedupe_text_values",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -27227,7 +27921,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_fallback_lora_path",
         "kind": "static_from",
-        "line": 507,
+        "line": 515,
         "name": "_fallback_lora_path",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -27258,7 +27952,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_get_lora_info",
         "kind": "static_from",
-        "line": 507,
+        "line": 515,
         "name": "_get_lora_info",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -27289,7 +27983,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_get_lora_manager_trigger_words",
         "kind": "static_from",
-        "line": 507,
+        "line": 515,
         "name": "_get_lora_manager_trigger_words",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -27320,7 +28014,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_load_lora_manager_metadata",
         "kind": "static_from",
-        "line": 507,
+        "line": 515,
         "name": "_load_lora_manager_metadata",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -27351,7 +28045,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_lora_combo_values",
         "kind": "static_from",
-        "line": 507,
+        "line": 515,
         "name": "_lora_combo_values",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -27382,7 +28076,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_lora_manager_trigger_words_from_metadata",
         "kind": "static_from",
-        "line": 507,
+        "line": 515,
         "name": "_lora_manager_trigger_words_from_metadata",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -27413,7 +28107,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_lora_model_exists",
         "kind": "static_from",
-        "line": 507,
+        "line": 515,
         "name": "_lora_model_exists",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -27444,7 +28138,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_lora_stack_name",
         "kind": "static_from",
-        "line": 507,
+        "line": 515,
         "name": "_lora_stack_name",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -27475,7 +28169,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_metadata_json_paths_for_lora",
         "kind": "static_from",
-        "line": 507,
+        "line": 515,
         "name": "_metadata_json_paths_for_lora",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -27506,7 +28200,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_missing_lora_display_name",
         "kind": "static_from",
-        "line": 507,
+        "line": 515,
         "name": "_missing_lora_display_name",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -27537,7 +28231,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_raise_missing_loras",
         "kind": "static_from",
-        "line": 507,
+        "line": 515,
         "name": "_raise_missing_loras",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -27568,7 +28262,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_trigger_words_from_value",
         "kind": "static_from",
-        "line": 507,
+        "line": 515,
         "name": "_trigger_words_from_value",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -27599,7 +28293,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_correct_style_prompt",
         "kind": "static_from",
-        "line": 523,
+        "line": 531,
         "name": "_correct_style_prompt",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -27630,7 +28324,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_format_strength",
         "kind": "static_from",
-        "line": 523,
+        "line": 531,
         "name": "_format_strength",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -27661,7 +28355,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_get_loras_list",
         "kind": "static_from",
-        "line": 523,
+        "line": 531,
         "name": "_get_loras_list",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -27692,7 +28386,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_load_profile_data",
         "kind": "static_from",
-        "line": 523,
+        "line": 531,
         "name": "_load_profile_data",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -27723,7 +28417,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_profile_key",
         "kind": "static_from",
-        "line": 523,
+        "line": 531,
         "name": "_profile_key",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -27754,7 +28448,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_select_profile_values",
         "kind": "static_from",
-        "line": 523,
+        "line": 531,
         "name": "_select_profile_values",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -27785,7 +28479,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_wrap_profile_index",
         "kind": "static_from",
-        "line": 523,
+        "line": 531,
         "name": "_wrap_profile_index",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -27816,7 +28510,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.lora_nodes:EasyUseAnimaLoraPreset",
         "kind": "static_from",
-        "line": 532,
+        "line": 540,
         "name": "EasyUseAnimaLoraPreset",
         "optional": false,
         "requested": ".easyuse_anima.nodes.lora_nodes",
@@ -27847,7 +28541,7 @@
         "conditional": true,
         "imported": ".anima_prompt:correct_prompt",
         "kind": "static_from",
-        "line": 535,
+        "line": 543,
         "name": "correct_prompt",
         "optional": false,
         "requested": ".anima_prompt",
@@ -27878,7 +28572,7 @@
         "conditional": true,
         "imported": ".anima_prompt:load_knowledge_base",
         "kind": "static_from",
-        "line": 535,
+        "line": 543,
         "name": "load_knowledge_base",
         "optional": false,
         "requested": ".anima_prompt",
@@ -27909,7 +28603,7 @@
         "conditional": true,
         "imported": ".anima_prompt.parser:parse_prompt",
         "kind": "static_from",
-        "line": 536,
+        "line": 544,
         "name": "parse_prompt",
         "optional": false,
         "requested": ".anima_prompt.parser",
@@ -27940,7 +28634,7 @@
         "conditional": true,
         "imported": ".settings:resolve_metadata_filter_words",
         "kind": "static_from",
-        "line": 537,
+        "line": 545,
         "name": "resolve_metadata_filter_words",
         "optional": false,
         "requested": ".settings",
@@ -27971,7 +28665,7 @@
         "conditional": true,
         "imported": ".settings:resolve_naia_settings",
         "kind": "static_from",
-        "line": 537,
+        "line": 545,
         "name": "resolve_naia_settings",
         "optional": false,
         "requested": ".settings",
@@ -28002,7 +28696,7 @@
         "conditional": true,
         "imported": ".settings:resolve_prompt_translation_settings",
         "kind": "static_from",
-        "line": 537,
+        "line": 545,
         "name": "resolve_prompt_translation_settings",
         "optional": false,
         "requested": ".settings",
@@ -28033,7 +28727,7 @@
         "conditional": true,
         "imported": ".prompt_translation:has_prompt_translation_markers",
         "kind": "static_from",
-        "line": 542,
+        "line": 550,
         "name": "has_prompt_translation_markers",
         "optional": false,
         "requested": ".prompt_translation",
@@ -28064,7 +28758,7 @@
         "conditional": true,
         "imported": ".prompt_translation:translate_prompt_markers",
         "kind": "static_from",
-        "line": 542,
+        "line": 550,
         "name": "translate_prompt_markers",
         "optional": false,
         "requested": ".prompt_translation",
@@ -28095,7 +28789,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:MAX_SEED",
         "kind": "static_from",
-        "line": 543,
+        "line": 551,
         "name": "MAX_SEED",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -28126,7 +28820,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "kind": "static_from",
-        "line": 543,
+        "line": 551,
         "name": "PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -28157,7 +28851,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:PUBLIC_MAX_SEED",
         "kind": "static_from",
-        "line": 543,
+        "line": 551,
         "name": "PUBLIC_MAX_SEED",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -28188,7 +28882,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_DECREMENT",
         "kind": "static_from",
-        "line": 543,
+        "line": 551,
         "name": "SEED_CONTROL_DECREMENT",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -28219,7 +28913,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_FIXED",
         "kind": "static_from",
-        "line": 543,
+        "line": 551,
         "name": "SEED_CONTROL_FIXED",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -28250,7 +28944,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_INCREMENT",
         "kind": "static_from",
-        "line": 543,
+        "line": 551,
         "name": "SEED_CONTROL_INCREMENT",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -28281,7 +28975,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_MODES",
         "kind": "static_from",
-        "line": 543,
+        "line": 551,
         "name": "SEED_CONTROL_MODES",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -28312,7 +29006,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_RANDOMIZE",
         "kind": "static_from",
-        "line": 543,
+        "line": 551,
         "name": "SEED_CONTROL_RANDOMIZE",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -28343,7 +29037,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:WILDCARD_MODE_FIXED",
         "kind": "static_from",
-        "line": 543,
+        "line": 551,
         "name": "WILDCARD_MODE_FIXED",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -28374,7 +29068,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:WILDCARD_MODE_POPULATE",
         "kind": "static_from",
-        "line": 543,
+        "line": 551,
         "name": "WILDCARD_MODE_POPULATE",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -28405,7 +29099,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:WILDCARD_MODE_SEQUENTIAL",
         "kind": "static_from",
-        "line": 543,
+        "line": 551,
         "name": "WILDCARD_MODE_SEQUENTIAL",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -28436,7 +29130,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:expand_wildcard_texts",
         "kind": "static_from",
-        "line": 543,
+        "line": 551,
         "name": "expand_wildcard_texts",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -28467,7 +29161,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:expand_wildcards",
         "kind": "static_from",
-        "line": 543,
+        "line": 551,
         "name": "expand_wildcards",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -28498,7 +29192,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:has_wildcard_syntax",
         "kind": "static_from",
-        "line": 543,
+        "line": 551,
         "name": "has_wildcard_syntax",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -28529,7 +29223,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:next_seed",
         "kind": "static_from",
-        "line": 543,
+        "line": 551,
         "name": "next_seed",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -28560,7 +29254,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:normalize_prompt_studio_wildcard_mode",
         "kind": "static_from",
-        "line": 543,
+        "line": 551,
         "name": "normalize_prompt_studio_wildcard_mode",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -28591,7 +29285,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:normalize_seed",
         "kind": "static_from",
-        "line": 543,
+        "line": 551,
         "name": "normalize_seed",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -28622,7 +29316,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:normalize_wildcard_mode",
         "kind": "static_from",
-        "line": 543,
+        "line": 551,
         "name": "normalize_wildcard_mode",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -28653,7 +29347,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:wildcard_sources_signature",
         "kind": "static_from",
-        "line": 543,
+        "line": 551,
         "name": "wildcard_sources_signature",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -28672,7 +29366,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -28687,7 +29381,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:AIO_FIRST_PASS_CACHE_MAX_ENTRIES",
         "kind": "static_from",
-        "line": 565,
+        "line": 573,
         "name": "AIO_FIRST_PASS_CACHE_MAX_ENTRIES",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -28706,7 +29400,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -28721,7 +29415,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_AIO_FIRST_PASS_CACHE",
         "kind": "static_from",
-        "line": 565,
+        "line": 573,
         "name": "_AIO_FIRST_PASS_CACHE",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -28740,7 +29434,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -28755,7 +29449,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_AIO_FIRST_PASS_CACHE_ORDER",
         "kind": "static_from",
-        "line": 565,
+        "line": 573,
         "name": "_AIO_FIRST_PASS_CACHE_ORDER",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -28774,7 +29468,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -28789,7 +29483,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_aio_first_pass_cache_key",
         "kind": "static_from",
-        "line": 565,
+        "line": 573,
         "name": "_aio_first_pass_cache_key",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -28808,7 +29502,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -28823,7 +29517,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_clone_aio_cache_value",
         "kind": "static_from",
-        "line": 565,
+        "line": 573,
         "name": "_clone_aio_cache_value",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -28842,7 +29536,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -28857,7 +29551,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_get_aio_first_pass_cache",
         "kind": "static_from",
-        "line": 565,
+        "line": 573,
         "name": "_get_aio_first_pass_cache",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -28876,7 +29570,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -28891,7 +29585,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_put_aio_first_pass_cache",
         "kind": "static_from",
-        "line": 565,
+        "line": 573,
         "name": "_put_aio_first_pass_cache",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -28910,7 +29604,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -28925,7 +29619,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_bind_aio_legacy_generation_runtime",
         "kind": "static_from",
-        "line": 575,
+        "line": 583,
         "name": "_bind_aio_legacy_generation_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.legacy_generation",
@@ -28944,7 +29638,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -28959,7 +29653,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_detailer_stage",
         "kind": "static_from",
-        "line": 575,
+        "line": 583,
         "name": "_run_aio_detailer_stage",
         "optional": false,
         "requested": "easyuse_anima.aio.legacy_generation",
@@ -28978,7 +29672,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -28993,7 +29687,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_detailer_target",
         "kind": "static_from",
-        "line": 575,
+        "line": 583,
         "name": "_run_aio_detailer_target",
         "optional": false,
         "requested": "easyuse_anima.aio.legacy_generation",
@@ -29012,7 +29706,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -29027,7 +29721,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_highres_stage",
         "kind": "static_from",
-        "line": 575,
+        "line": 583,
         "name": "_run_aio_highres_stage",
         "optional": false,
         "requested": "easyuse_anima.aio.legacy_generation",
@@ -29046,7 +29740,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -29061,7 +29755,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_legacy_generation",
         "kind": "static_from",
-        "line": 575,
+        "line": 583,
         "name": "_run_aio_legacy_generation",
         "optional": false,
         "requested": "easyuse_anima.aio.legacy_generation",
@@ -29080,7 +29774,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -29095,7 +29789,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_resshift_upscale_stage",
         "kind": "static_from",
-        "line": 575,
+        "line": 583,
         "name": "_run_aio_resshift_upscale_stage",
         "optional": false,
         "requested": "easyuse_anima.aio.legacy_generation",
@@ -29114,7 +29808,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -29129,7 +29823,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_upscale_stage",
         "kind": "static_from",
-        "line": 575,
+        "line": 583,
         "name": "_run_aio_upscale_stage",
         "optional": false,
         "requested": "easyuse_anima.aio.legacy_generation",
@@ -29148,7 +29842,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -29163,7 +29857,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_usdu_upscale_stage",
         "kind": "static_from",
-        "line": 575,
+        "line": 583,
         "name": "_run_aio_usdu_upscale_stage",
         "optional": false,
         "requested": "easyuse_anima.aio.legacy_generation",
@@ -29182,7 +29876,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -29197,7 +29891,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_AIO_DETAILER_CUSTOM_RE",
         "kind": "static_from",
-        "line": 585,
+        "line": 593,
         "name": "_AIO_DETAILER_CUSTOM_RE",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -29216,7 +29910,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -29231,7 +29925,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_AIO_DETAILER_RESERVED_KEYS",
         "kind": "static_from",
-        "line": 585,
+        "line": 593,
         "name": "_AIO_DETAILER_RESERVED_KEYS",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -29250,7 +29944,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -29265,7 +29959,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_aio_detailer_has_enabled_targets",
         "kind": "static_from",
-        "line": 585,
+        "line": 593,
         "name": "_aio_detailer_has_enabled_targets",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -29284,7 +29978,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -29299,7 +29993,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_aio_detailer_target_defaults",
         "kind": "static_from",
-        "line": 585,
+        "line": 593,
         "name": "_aio_detailer_target_defaults",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -29318,7 +30012,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -29333,7 +30027,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_aio_detailer_target_order",
         "kind": "static_from",
-        "line": 585,
+        "line": 593,
         "name": "_aio_detailer_target_order",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -29352,7 +30046,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -29367,7 +30061,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_is_aio_detailer_target_name",
         "kind": "static_from",
-        "line": 585,
+        "line": 593,
         "name": "_is_aio_detailer_target_name",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -29386,7 +30080,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -29401,7 +30095,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_merge_versioned_settings",
         "kind": "static_from",
-        "line": 585,
+        "line": 593,
         "name": "_merge_versioned_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -29420,7 +30114,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -29435,7 +30129,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_dit_corrections_settings",
         "kind": "static_from",
-        "line": 585,
+        "line": 593,
         "name": "_normalize_aio_dit_corrections_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -29454,7 +30148,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -29469,7 +30163,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_generation_settings",
         "kind": "static_from",
-        "line": 585,
+        "line": 593,
         "name": "_normalize_aio_generation_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -29488,7 +30182,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -29503,7 +30197,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_seed",
         "kind": "static_from",
-        "line": 585,
+        "line": 593,
         "name": "_normalize_aio_seed",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -29522,7 +30216,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -29537,7 +30231,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_spectrum_settings",
         "kind": "static_from",
-        "line": 585,
+        "line": 593,
         "name": "_normalize_aio_spectrum_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -29556,7 +30250,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -29571,7 +30265,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_FINAL_FIT_MODES",
         "kind": "static_from",
-        "line": 598,
+        "line": 606,
         "name": "AIO_FINAL_FIT_MODES",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_defaults",
@@ -29590,7 +30284,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -29605,7 +30299,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_FINAL_UPSCALE_BACKENDS",
         "kind": "static_from",
-        "line": 598,
+        "line": 606,
         "name": "AIO_FINAL_UPSCALE_BACKENDS",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_defaults",
@@ -29624,7 +30318,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -29639,7 +30333,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_GENERATION_DEFAULT_SETTINGS",
         "kind": "static_from",
-        "line": 598,
+        "line": 606,
         "name": "AIO_GENERATION_DEFAULT_SETTINGS",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_defaults",
@@ -29658,7 +30352,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -29673,7 +30367,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_GENERATION_SETTINGS_SCHEMA",
         "kind": "static_from",
-        "line": 598,
+        "line": 606,
         "name": "AIO_GENERATION_SETTINGS_SCHEMA",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_defaults",
@@ -29692,7 +30386,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -29707,7 +30401,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_GENERATION_SETTINGS_VERSION",
         "kind": "static_from",
-        "line": 598,
+        "line": 606,
         "name": "AIO_GENERATION_SETTINGS_VERSION",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_defaults",
@@ -29726,7 +30420,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -29741,7 +30435,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_RESHIFT_DTYPES",
         "kind": "static_from",
-        "line": 598,
+        "line": 606,
         "name": "AIO_RESHIFT_DTYPES",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_defaults",
@@ -29760,7 +30454,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -29775,7 +30469,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_RESHIFT_SCALES",
         "kind": "static_from",
-        "line": 598,
+        "line": 606,
         "name": "AIO_RESHIFT_SCALES",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_defaults",
@@ -29794,7 +30488,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -29809,7 +30503,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_SPECIAL_SEEDS",
         "kind": "static_from",
-        "line": 598,
+        "line": 606,
         "name": "AIO_SPECIAL_SEEDS",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_defaults",
@@ -29828,7 +30522,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -29843,7 +30537,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_SPECIAL_SEED_DECREMENT",
         "kind": "static_from",
-        "line": 598,
+        "line": 606,
         "name": "AIO_SPECIAL_SEED_DECREMENT",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_defaults",
@@ -29862,7 +30556,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -29877,7 +30571,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_SPECIAL_SEED_INCREMENT",
         "kind": "static_from",
-        "line": 598,
+        "line": 606,
         "name": "AIO_SPECIAL_SEED_INCREMENT",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_defaults",
@@ -29896,7 +30590,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -29911,7 +30605,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_SPECIAL_SEED_RANDOM",
         "kind": "static_from",
-        "line": 598,
+        "line": 606,
         "name": "AIO_SPECIAL_SEED_RANDOM",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_defaults",
@@ -29930,7 +30624,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -29945,7 +30639,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_USDU_MODE_TYPES",
         "kind": "static_from",
-        "line": 598,
+        "line": 606,
         "name": "AIO_USDU_MODE_TYPES",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_defaults",
@@ -29964,7 +30658,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -29979,7 +30673,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_USDU_PROMPT_FULL",
         "kind": "static_from",
-        "line": 598,
+        "line": 606,
         "name": "AIO_USDU_PROMPT_FULL",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_defaults",
@@ -29998,7 +30692,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -30013,7 +30707,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_USDU_PROMPT_MODES",
         "kind": "static_from",
-        "line": 598,
+        "line": 606,
         "name": "AIO_USDU_PROMPT_MODES",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_defaults",
@@ -30032,7 +30726,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -30047,7 +30741,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_USDU_PROMPT_NO_GENERAL",
         "kind": "static_from",
-        "line": 598,
+        "line": 606,
         "name": "AIO_USDU_PROMPT_NO_GENERAL",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_defaults",
@@ -30066,7 +30760,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -30081,7 +30775,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_USDU_SEAM_FIX_MODES",
         "kind": "static_from",
-        "line": 598,
+        "line": 606,
         "name": "AIO_USDU_SEAM_FIX_MODES",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_defaults",
@@ -30100,7 +30794,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -30115,7 +30809,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_settings:round_trip_aio_generation_settings",
         "kind": "static_from",
-        "line": 616,
+        "line": 624,
         "name": "round_trip_aio_generation_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_settings",
@@ -30123,6 +30817,312 @@
         "scope": "<module>",
         "source": "nodes.py",
         "target": "easyuse_anima/aio/generation_settings.py"
+      },
+      {
+        "alias": "AIO_INPUT_DEFAULT_SETTINGS",
+        "bound_name": "AIO_INPUT_DEFAULT_SETTINGS",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 572,
+            "kind": "try",
+            "line": 8
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "AIO_INPUT_DEFAULT_SETTINGS",
+          "target": "easyuse_anima/aio/input_defaults.py",
+          "try_line": 8
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.aio.input_defaults:AIO_INPUT_DEFAULT_SETTINGS",
+        "kind": "static_from",
+        "line": 627,
+        "name": "AIO_INPUT_DEFAULT_SETTINGS",
+        "optional": false,
+        "requested": "easyuse_anima.aio.input_defaults",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/aio/input_defaults.py"
+      },
+      {
+        "alias": "ANIMA_CLIP_DEVICES",
+        "bound_name": "ANIMA_CLIP_DEVICES",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 572,
+            "kind": "try",
+            "line": 8
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "ANIMA_CLIP_DEVICES",
+          "target": "easyuse_anima/aio/input_defaults.py",
+          "try_line": 8
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.aio.input_defaults:ANIMA_CLIP_DEVICES",
+        "kind": "static_from",
+        "line": 627,
+        "name": "ANIMA_CLIP_DEVICES",
+        "optional": false,
+        "requested": "easyuse_anima.aio.input_defaults",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/aio/input_defaults.py"
+      },
+      {
+        "alias": "ANIMA_CLIP_TYPES",
+        "bound_name": "ANIMA_CLIP_TYPES",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 572,
+            "kind": "try",
+            "line": 8
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "ANIMA_CLIP_TYPES",
+          "target": "easyuse_anima/aio/input_defaults.py",
+          "try_line": 8
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.aio.input_defaults:ANIMA_CLIP_TYPES",
+        "kind": "static_from",
+        "line": 627,
+        "name": "ANIMA_CLIP_TYPES",
+        "optional": false,
+        "requested": "easyuse_anima.aio.input_defaults",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/aio/input_defaults.py"
+      },
+      {
+        "alias": "ANIMA_DEFAULT_CLIP_CANDIDATES",
+        "bound_name": "ANIMA_DEFAULT_CLIP_CANDIDATES",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 572,
+            "kind": "try",
+            "line": 8
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "ANIMA_DEFAULT_CLIP_CANDIDATES",
+          "target": "easyuse_anima/aio/input_defaults.py",
+          "try_line": 8
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.aio.input_defaults:ANIMA_DEFAULT_CLIP_CANDIDATES",
+        "kind": "static_from",
+        "line": 627,
+        "name": "ANIMA_DEFAULT_CLIP_CANDIDATES",
+        "optional": false,
+        "requested": "easyuse_anima.aio.input_defaults",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/aio/input_defaults.py"
+      },
+      {
+        "alias": "ANIMA_DEFAULT_DIFFUSION_MODEL_CANDIDATES",
+        "bound_name": "ANIMA_DEFAULT_DIFFUSION_MODEL_CANDIDATES",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 572,
+            "kind": "try",
+            "line": 8
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "ANIMA_DEFAULT_DIFFUSION_MODEL_CANDIDATES",
+          "target": "easyuse_anima/aio/input_defaults.py",
+          "try_line": 8
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.aio.input_defaults:ANIMA_DEFAULT_DIFFUSION_MODEL_CANDIDATES",
+        "kind": "static_from",
+        "line": 627,
+        "name": "ANIMA_DEFAULT_DIFFUSION_MODEL_CANDIDATES",
+        "optional": false,
+        "requested": "easyuse_anima.aio.input_defaults",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/aio/input_defaults.py"
+      },
+      {
+        "alias": "ANIMA_DEFAULT_VAE_CANDIDATES",
+        "bound_name": "ANIMA_DEFAULT_VAE_CANDIDATES",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 572,
+            "kind": "try",
+            "line": 8
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "ANIMA_DEFAULT_VAE_CANDIDATES",
+          "target": "easyuse_anima/aio/input_defaults.py",
+          "try_line": 8
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.aio.input_defaults:ANIMA_DEFAULT_VAE_CANDIDATES",
+        "kind": "static_from",
+        "line": 627,
+        "name": "ANIMA_DEFAULT_VAE_CANDIDATES",
+        "optional": false,
+        "requested": "easyuse_anima.aio.input_defaults",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/aio/input_defaults.py"
+      },
+      {
+        "alias": "ANIMA_UNET_WEIGHT_DTYPES",
+        "bound_name": "ANIMA_UNET_WEIGHT_DTYPES",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 572,
+            "kind": "try",
+            "line": 8
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "ANIMA_UNET_WEIGHT_DTYPES",
+          "target": "easyuse_anima/aio/input_defaults.py",
+          "try_line": 8
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.aio.input_defaults:ANIMA_UNET_WEIGHT_DTYPES",
+        "kind": "static_from",
+        "line": 627,
+        "name": "ANIMA_UNET_WEIGHT_DTYPES",
+        "optional": false,
+        "requested": "easyuse_anima.aio.input_defaults",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/aio/input_defaults.py"
+      },
+      {
+        "alias": "EASY_USE_ANIMA_INPUT_SCHEMA",
+        "bound_name": "EASY_USE_ANIMA_INPUT_SCHEMA",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 572,
+            "kind": "try",
+            "line": 8
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "EASY_USE_ANIMA_INPUT_SCHEMA",
+          "target": "easyuse_anima/aio/input_defaults.py",
+          "try_line": 8
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.aio.input_defaults:EASY_USE_ANIMA_INPUT_SCHEMA",
+        "kind": "static_from",
+        "line": 627,
+        "name": "EASY_USE_ANIMA_INPUT_SCHEMA",
+        "optional": false,
+        "requested": "easyuse_anima.aio.input_defaults",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/aio/input_defaults.py"
+      },
+      {
+        "alias": "EASY_USE_ANIMA_INPUT_SETTINGS_VERSION",
+        "bound_name": "EASY_USE_ANIMA_INPUT_SETTINGS_VERSION",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 572,
+            "kind": "try",
+            "line": 8
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "EASY_USE_ANIMA_INPUT_SETTINGS_VERSION",
+          "target": "easyuse_anima/aio/input_defaults.py",
+          "try_line": 8
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.aio.input_defaults:EASY_USE_ANIMA_INPUT_SETTINGS_VERSION",
+        "kind": "static_from",
+        "line": 627,
+        "name": "EASY_USE_ANIMA_INPUT_SETTINGS_VERSION",
+        "optional": false,
+        "requested": "easyuse_anima.aio.input_defaults",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/aio/input_defaults.py"
       },
       {
         "alias": "_aio_usdu_auto_tile_dimension",
@@ -30134,7 +31134,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -30149,7 +31149,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.usdu:_aio_usdu_auto_tile_dimension",
         "kind": "static_from",
-        "line": 619,
+        "line": 638,
         "name": "_aio_usdu_auto_tile_dimension",
         "optional": false,
         "requested": "easyuse_anima.aio.usdu",
@@ -30168,7 +31168,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -30183,7 +31183,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.usdu:_aio_usdu_tile_plan",
         "kind": "static_from",
-        "line": 619,
+        "line": 638,
         "name": "_aio_usdu_tile_plan",
         "optional": false,
         "requested": "easyuse_anima.aio.usdu",
@@ -30202,7 +31202,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -30217,7 +31217,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_aio_final_fit_size",
         "kind": "static_from",
-        "line": 623,
+        "line": 642,
         "name": "_aio_final_fit_size",
         "optional": false,
         "requested": "easyuse_anima.aio.postprocess",
@@ -30236,7 +31236,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -30251,7 +31251,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_apply_aio_final_fit",
         "kind": "static_from",
-        "line": 623,
+        "line": 642,
         "name": "_apply_aio_final_fit",
         "optional": false,
         "requested": "easyuse_anima.aio.postprocess",
@@ -30270,7 +31270,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -30285,7 +31285,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_resize_image_to_size_if_needed",
         "kind": "static_from",
-        "line": 623,
+        "line": 642,
         "name": "_resize_image_to_size_if_needed",
         "optional": false,
         "requested": "easyuse_anima.aio.postprocess",
@@ -30304,7 +31304,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -30319,7 +31319,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_run_aio_postprocess_stage",
         "kind": "static_from",
-        "line": 623,
+        "line": 642,
         "name": "_run_aio_postprocess_stage",
         "optional": false,
         "requested": "easyuse_anima.aio.postprocess",
@@ -30338,7 +31338,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -30353,7 +31353,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_prompt_data_fields_for_usdu",
         "kind": "static_from",
-        "line": 629,
+        "line": 648,
         "name": "_aio_prompt_data_fields_for_usdu",
         "optional": false,
         "requested": "easyuse_anima.aio.conditioning",
@@ -30372,7 +31372,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -30387,7 +31387,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_usdu_conditioning",
         "kind": "static_from",
-        "line": 629,
+        "line": 648,
         "name": "_aio_usdu_conditioning",
         "optional": false,
         "requested": "easyuse_anima.aio.conditioning",
@@ -30406,7 +31406,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -30421,7 +31421,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_usdu_prompt_without_general",
         "kind": "static_from",
-        "line": 629,
+        "line": 648,
         "name": "_aio_usdu_prompt_without_general",
         "optional": false,
         "requested": "easyuse_anima.aio.conditioning",
@@ -30440,7 +31440,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -30455,7 +31455,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_bind_aio_conditioning_runtime",
         "kind": "static_from",
-        "line": 629,
+        "line": 648,
         "name": "_bind_aio_conditioning_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.conditioning",
@@ -30474,7 +31474,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -30489,7 +31489,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_aio_lora_stack_signature",
         "kind": "static_from",
-        "line": 635,
+        "line": 654,
         "name": "_aio_lora_stack_signature",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -30508,7 +31508,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -30523,7 +31523,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_anima_dave_patch",
         "kind": "static_from",
-        "line": 635,
+        "line": 654,
         "name": "_apply_aio_anima_dave_patch",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -30542,7 +31542,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -30557,7 +31557,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_kj_model_patches",
         "kind": "static_from",
-        "line": 635,
+        "line": 654,
         "name": "_apply_aio_kj_model_patches",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -30576,7 +31576,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -30591,7 +31591,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_lora_stack",
         "kind": "static_from",
-        "line": 635,
+        "line": 654,
         "name": "_apply_aio_lora_stack",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -30610,7 +31610,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -30625,7 +31625,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_model_patches",
         "kind": "static_from",
-        "line": 635,
+        "line": 654,
         "name": "_apply_aio_model_patches",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -30644,7 +31644,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -30659,7 +31659,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_safe_pag_patch",
         "kind": "static_from",
-        "line": 635,
+        "line": 654,
         "name": "_apply_aio_safe_pag_patch",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -30678,7 +31678,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -30693,7 +31693,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_correction_patch_for_comfy_sampler",
         "kind": "static_from",
-        "line": 635,
+        "line": 654,
         "name": "_apply_aio_spectrum_correction_patch_for_comfy_sampler",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -30712,7 +31712,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -30727,7 +31727,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_forecast_patch_for_comfy_sampler",
         "kind": "static_from",
-        "line": 635,
+        "line": 654,
         "name": "_apply_aio_spectrum_forecast_patch_for_comfy_sampler",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -30746,7 +31746,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -30761,7 +31761,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_model_patches_for_comfy_sampler",
         "kind": "static_from",
-        "line": 635,
+        "line": 654,
         "name": "_apply_aio_spectrum_model_patches_for_comfy_sampler",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -30780,7 +31780,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -30795,7 +31795,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_bind_aio_model_preparation_runtime",
         "kind": "static_from",
-        "line": 635,
+        "line": 654,
         "name": "_bind_aio_model_preparation_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -30814,7 +31814,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -30829,7 +31829,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_cleanup_aio_ephemeral_model",
         "kind": "static_from",
-        "line": 635,
+        "line": 654,
         "name": "_cleanup_aio_ephemeral_model",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -30848,7 +31848,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -30863,7 +31863,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_normalize_aio_lora_stack",
         "kind": "static_from",
-        "line": 635,
+        "line": 654,
         "name": "_normalize_aio_lora_stack",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -30882,7 +31882,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -30897,7 +31897,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_patch_model_sampling_aura_flow",
         "kind": "static_from",
-        "line": 635,
+        "line": 654,
         "name": "_patch_model_sampling_aura_flow",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -30916,7 +31916,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -30931,7 +31931,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_aio_highres_effective_backend",
         "kind": "static_from",
-        "line": 650,
+        "line": 669,
         "name": "_aio_highres_effective_backend",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -30950,7 +31950,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -30965,7 +31965,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_aio_stage_sampler_settings",
         "kind": "static_from",
-        "line": 650,
+        "line": 669,
         "name": "_aio_stage_sampler_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -30984,7 +31984,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -30999,7 +31999,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_bind_aio_sampling_runtime",
         "kind": "static_from",
-        "line": 650,
+        "line": 669,
         "name": "_bind_aio_sampling_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -31018,7 +32018,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -31033,7 +32033,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_decode_latent_with_comfy",
         "kind": "static_from",
-        "line": 650,
+        "line": 669,
         "name": "_decode_latent_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -31052,7 +32052,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -31067,7 +32067,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_encode_image_with_comfy_vae",
         "kind": "static_from",
-        "line": 650,
+        "line": 669,
         "name": "_encode_image_with_comfy_vae",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -31086,7 +32086,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -31101,7 +32101,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_generate_empty_latent_with_comfy",
         "kind": "static_from",
-        "line": 650,
+        "line": 669,
         "name": "_generate_empty_latent_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -31120,7 +32120,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -31135,7 +32135,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_new_aio_random_seed",
         "kind": "static_from",
-        "line": 650,
+        "line": 669,
         "name": "_new_aio_random_seed",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -31154,7 +32154,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -31169,7 +32169,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_resolve_aio_runtime_seed",
         "kind": "static_from",
-        "line": 650,
+        "line": 669,
         "name": "_resolve_aio_runtime_seed",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -31188,7 +32188,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -31203,7 +32203,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_aio_backend",
         "kind": "static_from",
-        "line": 650,
+        "line": 669,
         "name": "_sample_latent_with_aio_backend",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -31222,7 +32222,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -31237,7 +32237,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_comfy",
         "kind": "static_from",
-        "line": 650,
+        "line": 669,
         "name": "_sample_latent_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -31256,7 +32256,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -31271,7 +32271,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_spectrum_mod_guidance_advanced",
         "kind": "static_from",
-        "line": 650,
+        "line": 669,
         "name": "_sample_latent_with_spectrum_mod_guidance_advanced",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -31290,7 +32290,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -31305,7 +32305,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_spectrum_spd",
         "kind": "static_from",
-        "line": 650,
+        "line": 669,
         "name": "_sample_latent_with_spectrum_spd",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -31324,7 +32324,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -31339,7 +32339,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_CACHE_FORMAT",
         "kind": "static_from",
-        "line": 664,
+        "line": 683,
         "name": "AIO_PREVIEW_CACHE_FORMAT",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -31358,7 +32358,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -31373,7 +32373,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_CACHE_QUALITY",
         "kind": "static_from",
-        "line": 664,
+        "line": 683,
         "name": "AIO_PREVIEW_CACHE_QUALITY",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -31392,7 +32392,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -31407,7 +32407,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_EVENT",
         "kind": "static_from",
-        "line": 664,
+        "line": 683,
         "name": "AIO_PREVIEW_EVENT",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -31426,7 +32426,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -31441,7 +32441,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_STAGE_LABELS",
         "kind": "static_from",
-        "line": 664,
+        "line": 683,
         "name": "AIO_PREVIEW_STAGE_LABELS",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -31460,7 +32460,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -31475,7 +32475,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_aio_preview_base_directory",
         "kind": "static_from",
-        "line": 664,
+        "line": 683,
         "name": "_aio_preview_base_directory",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -31494,7 +32494,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -31509,42 +32509,8 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_aio_preview_file_size_bytes",
         "kind": "static_from",
-        "line": 664,
+        "line": 683,
         "name": "_aio_preview_file_size_bytes",
-        "optional": false,
-        "requested": "easyuse_anima.aio.preview",
-        "role": "compatibility_fallback",
-        "scope": "<module>",
-        "source": "nodes.py",
-        "target": "easyuse_anima/aio/preview.py"
-      },
-      {
-        "alias": "_bind_aio_preview_runtime",
-        "bound_name": "_bind_aio_preview_runtime",
-        "branch_context": [
-          {
-            "branch": "except",
-            "catches_import_error": true,
-            "exceptions": [
-              "ImportError"
-            ],
-            "handler_line": 564,
-            "kind": "try",
-            "line": 8
-          }
-        ],
-        "classification": "compatibility_fallback",
-        "column": 4,
-        "compatibility_pair": {
-          "bound_name": "_bind_aio_preview_runtime",
-          "target": "easyuse_anima/aio/preview.py",
-          "try_line": 8
-        },
-        "conditional": true,
-        "imported": "easyuse_anima.aio.preview:_bind_aio_preview_runtime",
-        "kind": "static_from",
-        "line": 664,
-        "name": "_bind_aio_preview_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
         "role": "compatibility_fallback",
@@ -31562,7 +32528,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -31577,7 +32543,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_save_aio_temp_preview_image",
         "kind": "static_from",
-        "line": 664,
+        "line": 683,
         "name": "_save_aio_temp_preview_image",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -31596,7 +32562,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -31611,7 +32577,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_send_aio_preview_event",
         "kind": "static_from",
-        "line": 664,
+        "line": 683,
         "name": "_send_aio_preview_event",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -31630,7 +32596,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -31645,7 +32611,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_tag_aio_preview_images",
         "kind": "static_from",
-        "line": 664,
+        "line": 683,
         "name": "_tag_aio_preview_images",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -31664,7 +32630,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -31679,7 +32645,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_image_saver_additional_hashes",
         "kind": "static_from",
-        "line": 676,
+        "line": 694,
         "name": "_aio_image_saver_additional_hashes",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -31698,7 +32664,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -31713,7 +32679,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_image_saver_civitai_hash_fetcher_entries",
         "kind": "static_from",
-        "line": 676,
+        "line": 694,
         "name": "_aio_image_saver_civitai_hash_fetcher_entries",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -31732,7 +32698,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -31747,7 +32713,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_lora_metadata_name",
         "kind": "static_from",
-        "line": 676,
+        "line": 694,
         "name": "_aio_lora_metadata_name",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -31766,7 +32732,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -31781,7 +32747,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_prompt_with_lora_metadata",
         "kind": "static_from",
-        "line": 676,
+        "line": 694,
         "name": "_aio_prompt_with_lora_metadata",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -31800,7 +32766,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -31815,42 +32781,8 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_save_filename_prefix",
         "kind": "static_from",
-        "line": 676,
+        "line": 694,
         "name": "_aio_save_filename_prefix",
-        "optional": false,
-        "requested": "easyuse_anima.aio.output",
-        "role": "compatibility_fallback",
-        "scope": "<module>",
-        "source": "nodes.py",
-        "target": "easyuse_anima/aio/output.py"
-      },
-      {
-        "alias": "_bind_aio_output_runtime",
-        "bound_name": "_bind_aio_output_runtime",
-        "branch_context": [
-          {
-            "branch": "except",
-            "catches_import_error": true,
-            "exceptions": [
-              "ImportError"
-            ],
-            "handler_line": 564,
-            "kind": "try",
-            "line": 8
-          }
-        ],
-        "classification": "compatibility_fallback",
-        "column": 4,
-        "compatibility_pair": {
-          "bound_name": "_bind_aio_output_runtime",
-          "target": "easyuse_anima/aio/output.py",
-          "try_line": 8
-        },
-        "conditional": true,
-        "imported": "easyuse_anima.aio.output:_bind_aio_output_runtime",
-        "kind": "static_from",
-        "line": 676,
-        "name": "_bind_aio_output_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
         "role": "compatibility_fallback",
@@ -31868,7 +32800,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -31883,7 +32815,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_save_image_with_comfy",
         "kind": "static_from",
-        "line": 676,
+        "line": 694,
         "name": "_save_image_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -31902,7 +32834,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -31917,7 +32849,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_save_image_with_image_saver",
         "kind": "static_from",
-        "line": 676,
+        "line": 694,
         "name": "_save_image_with_image_saver",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -31936,7 +32868,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -31951,7 +32883,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output_settings:_normalize_aio_civitai_hash_fetchers",
         "kind": "static_from",
-        "line": 686,
+        "line": 703,
         "name": "_normalize_aio_civitai_hash_fetchers",
         "optional": false,
         "requested": "easyuse_anima.aio.output_settings",
@@ -31970,7 +32902,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -31985,7 +32917,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output_settings:_normalize_aio_hash_bundles",
         "kind": "static_from",
-        "line": 686,
+        "line": 703,
         "name": "_normalize_aio_hash_bundles",
         "optional": false,
         "requested": "easyuse_anima.aio.output_settings",
@@ -31993,40 +32925,6 @@
         "scope": "<module>",
         "source": "nodes.py",
         "target": "easyuse_anima/aio/output_settings.py"
-      },
-      {
-        "alias": "_bind_aio_resource_runtime",
-        "bound_name": "_bind_aio_resource_runtime",
-        "branch_context": [
-          {
-            "branch": "except",
-            "catches_import_error": true,
-            "exceptions": [
-              "ImportError"
-            ],
-            "handler_line": 564,
-            "kind": "try",
-            "line": 8
-          }
-        ],
-        "classification": "compatibility_fallback",
-        "column": 4,
-        "compatibility_pair": {
-          "bound_name": "_bind_aio_resource_runtime",
-          "target": "easyuse_anima/aio/resources.py",
-          "try_line": 8
-        },
-        "conditional": true,
-        "imported": "easyuse_anima.aio.resources:_bind_aio_resource_runtime",
-        "kind": "static_from",
-        "line": 690,
-        "name": "_bind_aio_resource_runtime",
-        "optional": false,
-        "requested": "easyuse_anima.aio.resources",
-        "role": "compatibility_fallback",
-        "scope": "<module>",
-        "source": "nodes.py",
-        "target": "easyuse_anima/aio/resources.py"
       },
       {
         "alias": "_comfy_clip_loader_types",
@@ -32038,7 +32936,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -32053,7 +32951,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_clip_loader_types",
         "kind": "static_from",
-        "line": 690,
+        "line": 707,
         "name": "_comfy_clip_loader_types",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -32072,7 +32970,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -32087,7 +32985,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_diffusion_model_names",
         "kind": "static_from",
-        "line": 690,
+        "line": 707,
         "name": "_comfy_diffusion_model_names",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -32106,7 +33004,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -32121,7 +33019,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_text_encoder_names",
         "kind": "static_from",
-        "line": 690,
+        "line": 707,
         "name": "_comfy_text_encoder_names",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -32140,7 +33038,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -32155,7 +33053,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_vae_names",
         "kind": "static_from",
-        "line": 690,
+        "line": 707,
         "name": "_comfy_vae_names",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -32174,7 +33072,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -32189,7 +33087,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_aio_resources_from_input_context",
         "kind": "static_from",
-        "line": 690,
+        "line": 707,
         "name": "_load_aio_resources_from_input_context",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -32208,7 +33106,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -32223,7 +33121,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_aio_sam3_context",
         "kind": "static_from",
-        "line": 690,
+        "line": 707,
         "name": "_load_aio_sam3_context",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -32242,7 +33140,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -32257,7 +33155,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_checkpoint_with_comfy",
         "kind": "static_from",
-        "line": 690,
+        "line": 707,
         "name": "_load_checkpoint_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -32276,7 +33174,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -32291,7 +33189,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_clip_with_comfy",
         "kind": "static_from",
-        "line": 690,
+        "line": 707,
         "name": "_load_clip_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -32310,7 +33208,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -32325,7 +33223,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_diffusion_model_with_comfy",
         "kind": "static_from",
-        "line": 690,
+        "line": 707,
         "name": "_load_diffusion_model_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -32344,7 +33242,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -32359,7 +33257,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_upscale_model_with_comfy",
         "kind": "static_from",
-        "line": 690,
+        "line": 707,
         "name": "_load_upscale_model_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -32378,7 +33276,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -32393,7 +33291,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_vae_with_comfy",
         "kind": "static_from",
-        "line": 690,
+        "line": 707,
         "name": "_load_vae_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -32412,7 +33310,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -32427,7 +33325,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_normalize_aio_input_settings",
         "kind": "static_from",
-        "line": 690,
+        "line": 707,
         "name": "_normalize_aio_input_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -32446,7 +33344,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -32461,7 +33359,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_checkpoint_default",
         "kind": "static_from",
-        "line": 690,
+        "line": 707,
         "name": "_preferred_checkpoint_default",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -32480,7 +33378,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -32495,7 +33393,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_clip_type_default",
         "kind": "static_from",
-        "line": 690,
+        "line": 707,
         "name": "_preferred_clip_type_default",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -32514,7 +33412,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -32529,7 +33427,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_name_default",
         "kind": "static_from",
-        "line": 690,
+        "line": 707,
         "name": "_preferred_name_default",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -32548,7 +33446,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -32563,7 +33461,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_json_clone",
         "kind": "static_from",
-        "line": 708,
+        "line": 724,
         "name": "_json_clone",
         "optional": false,
         "requested": "easyuse_anima.common.serialization",
@@ -32582,7 +33480,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -32597,7 +33495,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_json_object",
         "kind": "static_from",
-        "line": 708,
+        "line": 724,
         "name": "_json_object",
         "optional": false,
         "requested": "easyuse_anima.common.serialization",
@@ -32616,7 +33514,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -32631,7 +33529,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_stable_change_key",
         "kind": "static_from",
-        "line": 708,
+        "line": 724,
         "name": "_stable_change_key",
         "optional": false,
         "requested": "easyuse_anima.common.serialization",
@@ -32650,7 +33548,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -32665,7 +33563,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_bool",
         "kind": "static_from",
-        "line": 713,
+        "line": 729,
         "name": "_as_bool",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -32684,7 +33582,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -32699,7 +33597,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_float",
         "kind": "static_from",
-        "line": 713,
+        "line": 729,
         "name": "_as_float",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -32718,7 +33616,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -32733,7 +33631,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_int",
         "kind": "static_from",
-        "line": 713,
+        "line": 729,
         "name": "_as_int",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -32752,7 +33650,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -32767,7 +33665,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_choice",
         "kind": "static_from",
-        "line": 713,
+        "line": 729,
         "name": "_choice",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -32786,7 +33684,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -32801,7 +33699,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_single_value",
         "kind": "static_from",
-        "line": 713,
+        "line": 729,
         "name": "_single_value",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -32820,7 +33718,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -32835,7 +33733,7 @@
         "conditional": true,
         "imported": "easyuse_anima.seed.compatibility:WILDCARD_QUEUE_MAX_SAFE_SEED",
         "kind": "static_from",
-        "line": 720,
+        "line": 736,
         "name": "WILDCARD_QUEUE_MAX_SAFE_SEED",
         "optional": false,
         "requested": "easyuse_anima.seed.compatibility",
@@ -32854,7 +33752,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -32869,7 +33767,7 @@
         "conditional": true,
         "imported": "easyuse_anima.seed.compatibility:WILDCARD_RESERVED_NEXT_SEED_INPUT",
         "kind": "static_from",
-        "line": 720,
+        "line": 736,
         "name": "WILDCARD_RESERVED_NEXT_SEED_INPUT",
         "optional": false,
         "requested": "easyuse_anima.seed.compatibility",
@@ -32888,7 +33786,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -32903,7 +33801,7 @@
         "conditional": true,
         "imported": "easyuse_anima.seed.compatibility:_consume_reserved_wildcard_next_seed",
         "kind": "static_from",
-        "line": 720,
+        "line": 736,
         "name": "_consume_reserved_wildcard_next_seed",
         "optional": false,
         "requested": "easyuse_anima.seed.compatibility",
@@ -32922,7 +33820,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -32937,7 +33835,7 @@
         "conditional": true,
         "imported": "easyuse_anima.workflow:_get_workflow_node",
         "kind": "static_from",
-        "line": 725,
+        "line": 741,
         "name": "_get_workflow_node",
         "optional": false,
         "requested": "easyuse_anima.workflow",
@@ -32956,7 +33854,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -32971,7 +33869,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_prompt_translation_change_key",
         "kind": "static_from",
-        "line": 726,
+        "line": 742,
         "name": "_prompt_translation_change_key",
         "optional": false,
         "requested": "easyuse_anima.prompt.correction",
@@ -32990,7 +33888,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -33005,7 +33903,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_split_tag_text",
         "kind": "static_from",
-        "line": 726,
+        "line": 742,
         "name": "_split_tag_text",
         "optional": false,
         "requested": "easyuse_anima.prompt.correction",
@@ -33024,7 +33922,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -33039,7 +33937,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_translate_prompt_text",
         "kind": "static_from",
-        "line": 726,
+        "line": 742,
         "name": "_translate_prompt_text",
         "optional": false,
         "requested": "easyuse_anima.prompt.correction",
@@ -33058,7 +33956,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -33073,7 +33971,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_HASH_COMMENT_RE",
         "kind": "static_from",
-        "line": 731,
+        "line": 747,
         "name": "_HASH_COMMENT_RE",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -33092,7 +33990,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -33107,7 +34005,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_INLINE_SPACE_RE",
         "kind": "static_from",
-        "line": 731,
+        "line": 747,
         "name": "_INLINE_SPACE_RE",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -33126,7 +34024,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -33141,7 +34039,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_WEIGHTED_TOKEN_RE",
         "kind": "static_from",
-        "line": 731,
+        "line": 747,
         "name": "_WEIGHTED_TOKEN_RE",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -33160,7 +34058,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -33175,7 +34073,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_correct_builder_prompt",
         "kind": "static_from",
-        "line": 731,
+        "line": 747,
         "name": "_correct_builder_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -33194,7 +34092,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -33209,7 +34107,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_filter_metadata_prompt",
         "kind": "static_from",
-        "line": 731,
+        "line": 747,
         "name": "_filter_metadata_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -33228,7 +34126,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -33243,7 +34141,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_join_prompt_tokens",
         "kind": "static_from",
-        "line": 731,
+        "line": 747,
         "name": "_join_prompt_tokens",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -33262,7 +34160,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -33277,7 +34175,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_metadata_filter_key",
         "kind": "static_from",
-        "line": 731,
+        "line": 747,
         "name": "_metadata_filter_key",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -33296,7 +34194,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -33311,7 +34209,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_metadata_filter_keys",
         "kind": "static_from",
-        "line": 731,
+        "line": 747,
         "name": "_metadata_filter_keys",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -33330,7 +34228,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -33345,7 +34243,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_prompt_tokens",
         "kind": "static_from",
-        "line": 731,
+        "line": 747,
         "name": "_prompt_tokens",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -33364,7 +34262,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -33379,7 +34277,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:PROMPT_DATA_TYPE",
         "kind": "static_from",
-        "line": 744,
+        "line": 760,
         "name": "PROMPT_DATA_TYPE",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -33398,7 +34296,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -33413,7 +34311,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_advanced_outputs_from_prompt_data",
         "kind": "static_from",
-        "line": 744,
+        "line": 760,
         "name": "_advanced_outputs_from_prompt_data",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -33432,7 +34330,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -33447,7 +34345,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_apply_prompt_data_overrides",
         "kind": "static_from",
-        "line": 744,
+        "line": 760,
         "name": "_apply_prompt_data_overrides",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -33466,7 +34364,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -33481,7 +34379,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_copy_prompt_data_for_update",
         "kind": "static_from",
-        "line": 744,
+        "line": 760,
         "name": "_copy_prompt_data_for_update",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -33500,7 +34398,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -33515,7 +34413,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_normalize_prompt_data",
         "kind": "static_from",
-        "line": 744,
+        "line": 760,
         "name": "_normalize_prompt_data",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -33534,7 +34432,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -33549,7 +34447,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_prompt_data_json_safe",
         "kind": "static_from",
-        "line": 744,
+        "line": 760,
         "name": "_prompt_data_json_safe",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -33568,7 +34466,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -33583,7 +34481,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_prompt_data_parameter_snapshot",
         "kind": "static_from",
-        "line": 744,
+        "line": 760,
         "name": "_prompt_data_parameter_snapshot",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -33602,7 +34500,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -33617,7 +34515,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_artist_field_prompt",
         "kind": "static_from",
-        "line": 762,
+        "line": 778,
         "name": "_advanced_artist_field_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -33636,7 +34534,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -33651,7 +34549,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_default_fields",
         "kind": "static_from",
-        "line": 762,
+        "line": 778,
         "name": "_advanced_default_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -33670,7 +34568,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -33685,7 +34583,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_enabled_naia_panes",
         "kind": "static_from",
-        "line": 762,
+        "line": 778,
         "name": "_advanced_enabled_naia_panes",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -33704,7 +34602,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -33719,7 +34617,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_enabled_pane_fields",
         "kind": "static_from",
-        "line": 762,
+        "line": 778,
         "name": "_advanced_enabled_pane_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -33738,7 +34636,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -33753,7 +34651,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_field_input_values",
         "kind": "static_from",
-        "line": 762,
+        "line": 778,
         "name": "_advanced_field_input_values",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -33772,7 +34670,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -33787,7 +34685,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_field_socket_name",
         "kind": "static_from",
-        "line": 762,
+        "line": 778,
         "name": "_advanced_field_socket_name",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -33806,7 +34704,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -33821,7 +34719,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_fields_json",
         "kind": "static_from",
-        "line": 762,
+        "line": 778,
         "name": "_advanced_fields_json",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -33840,7 +34738,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -33855,7 +34753,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_has_enabled_naia",
         "kind": "static_from",
-        "line": 762,
+        "line": 778,
         "name": "_advanced_has_enabled_naia",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -33874,7 +34772,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -33889,7 +34787,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_prompt_with_artist_override",
         "kind": "static_from",
-        "line": 762,
+        "line": 778,
         "name": "_advanced_prompt_with_artist_override",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -33908,7 +34806,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -33923,7 +34821,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_uses_naia_resolution",
         "kind": "static_from",
-        "line": 762,
+        "line": 778,
         "name": "_advanced_uses_naia_resolution",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -33942,7 +34840,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -33957,7 +34855,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_apply_advanced_field_inputs",
         "kind": "static_from",
-        "line": 762,
+        "line": 778,
         "name": "_apply_advanced_field_inputs",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -33976,7 +34874,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -33991,7 +34889,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_as_advanced_height",
         "kind": "static_from",
-        "line": 762,
+        "line": 778,
         "name": "_as_advanced_height",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -34010,7 +34908,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -34025,7 +34923,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_build_advanced_prompt_data",
         "kind": "static_from",
-        "line": 762,
+        "line": 778,
         "name": "_build_advanced_prompt_data",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -34044,7 +34942,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -34059,7 +34957,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_build_advanced_prompts",
         "kind": "static_from",
-        "line": 762,
+        "line": 778,
         "name": "_build_advanced_prompts",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -34078,7 +34976,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -34093,7 +34991,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_clone_advanced_fields",
         "kind": "static_from",
-        "line": 762,
+        "line": 778,
         "name": "_clone_advanced_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -34112,7 +35010,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -34127,7 +35025,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_correct_advanced_field_sequence",
         "kind": "static_from",
-        "line": 762,
+        "line": 778,
         "name": "_correct_advanced_field_sequence",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -34146,7 +35044,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -34161,7 +35059,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_expand_advanced_wildcard_fields",
         "kind": "static_from",
-        "line": 762,
+        "line": 778,
         "name": "_expand_advanced_wildcard_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -34180,7 +35078,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -34195,7 +35093,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_normalize_advanced_fields",
         "kind": "static_from",
-        "line": 762,
+        "line": 778,
         "name": "_normalize_advanced_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -34214,7 +35112,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -34229,7 +35127,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_normalize_prompt_studio_wildcard_seed_control",
         "kind": "static_from",
-        "line": 762,
+        "line": 778,
         "name": "_normalize_prompt_studio_wildcard_seed_control",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -34248,7 +35146,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -34263,7 +35161,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_set_naia_field_text",
         "kind": "static_from",
-        "line": 762,
+        "line": 778,
         "name": "_set_naia_field_text",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -34282,7 +35180,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -34297,7 +35195,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_translate_prompt_fields",
         "kind": "static_from",
-        "line": 762,
+        "line": 778,
         "name": "_translate_prompt_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -34316,7 +35214,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -34331,7 +35229,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_apply_regional_field_inputs",
         "kind": "static_from",
-        "line": 797,
+        "line": 813,
         "name": "_apply_regional_field_inputs",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -34350,7 +35248,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -34365,7 +35263,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_build_regional_outputs",
         "kind": "static_from",
-        "line": 797,
+        "line": 813,
         "name": "_build_regional_outputs",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -34384,7 +35282,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -34399,7 +35297,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_clone_regional_fields",
         "kind": "static_from",
-        "line": 797,
+        "line": 813,
         "name": "_clone_regional_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -34418,7 +35316,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -34433,7 +35331,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_conditioning_set_values",
         "kind": "static_from",
-        "line": 797,
+        "line": 813,
         "name": "_conditioning_set_values",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -34452,7 +35350,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -34467,7 +35365,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_mask_ids",
         "kind": "static_from",
-        "line": 797,
+        "line": 813,
         "name": "_normalize_mask_ids",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -34486,7 +35384,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -34501,7 +35399,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_regional_config",
         "kind": "static_from",
-        "line": 797,
+        "line": 813,
         "name": "_normalize_regional_config",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -34520,7 +35418,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -34535,7 +35433,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_regional_fields",
         "kind": "static_from",
-        "line": 797,
+        "line": 813,
         "name": "_normalize_regional_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -34554,7 +35452,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -34569,7 +35467,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_parse_json_object",
         "kind": "static_from",
-        "line": 797,
+        "line": 813,
         "name": "_parse_json_object",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -34588,7 +35486,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -34603,7 +35501,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_config_json",
         "kind": "static_from",
-        "line": 797,
+        "line": 813,
         "name": "_regional_config_json",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -34622,7 +35520,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -34637,7 +35535,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_fields_json",
         "kind": "static_from",
-        "line": 797,
+        "line": 813,
         "name": "_regional_fields_json",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -34656,7 +35554,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -34671,7 +35569,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_mask_bounds_area",
         "kind": "static_from",
-        "line": 797,
+        "line": 813,
         "name": "_regional_mask_bounds_area",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -34690,7 +35588,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -34705,7 +35603,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_payload_canvas",
         "kind": "static_from",
-        "line": 797,
+        "line": 813,
         "name": "_regional_payload_canvas",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -34724,7 +35622,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -34739,7 +35637,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_union_mask_for_ids",
         "kind": "static_from",
-        "line": 797,
+        "line": 813,
         "name": "_regional_union_mask_for_ids",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -34758,7 +35656,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -34773,7 +35671,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
         "kind": "static_from",
-        "line": 824,
+        "line": 840,
         "name": "ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -34792,7 +35690,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -34807,7 +35705,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODES",
         "kind": "static_from",
-        "line": 824,
+        "line": 840,
         "name": "ANIMA_MOD_GUIDANCE_MODES",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -34826,7 +35724,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -34841,7 +35739,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 824,
+        "line": 840,
         "name": "ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -34860,7 +35758,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -34875,7 +35773,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_PROFILE_OFF",
         "kind": "static_from",
-        "line": 824,
+        "line": 840,
         "name": "ANIMA_MOD_GUIDANCE_PROFILE_OFF",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -34894,7 +35792,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -34909,7 +35807,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_apply_spectrum_anima_mod_guidance",
         "kind": "static_from",
-        "line": 824,
+        "line": 840,
         "name": "_apply_spectrum_anima_mod_guidance",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -34928,7 +35826,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -34943,7 +35841,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_find_spectrum_anima_mod_guidance_class",
         "kind": "static_from",
-        "line": 824,
+        "line": 840,
         "name": "_find_spectrum_anima_mod_guidance_class",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -34962,7 +35860,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -34977,7 +35875,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_normalize_anima_mod_guidance_profile",
         "kind": "static_from",
-        "line": 824,
+        "line": 840,
         "name": "_normalize_anima_mod_guidance_profile",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -34996,7 +35894,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -35011,7 +35909,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_resolve_anima_mod_guidance_enabled",
         "kind": "static_from",
-        "line": 824,
+        "line": 840,
         "name": "_resolve_anima_mod_guidance_enabled",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -35030,7 +35928,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -35045,7 +35943,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
         "kind": "static_from",
-        "line": 839,
+        "line": 855,
         "name": "ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -35064,7 +35962,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -35079,7 +35977,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
         "kind": "static_from",
-        "line": 839,
+        "line": 855,
         "name": "ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -35098,7 +35996,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -35113,7 +36011,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
         "kind": "static_from",
-        "line": 839,
+        "line": 855,
         "name": "ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -35132,7 +36030,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -35147,7 +36045,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_EXACT_TOP_K",
         "kind": "static_from",
-        "line": 839,
+        "line": 855,
         "name": "ARTIST_MIX_DEFAULT_EXACT_TOP_K",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -35166,7 +36064,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -35181,7 +36079,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
         "kind": "static_from",
-        "line": 839,
+        "line": 855,
         "name": "ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -35200,7 +36098,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -35215,7 +36113,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_START_PERCENT",
         "kind": "static_from",
-        "line": 839,
+        "line": 855,
         "name": "ARTIST_MIX_DEFAULT_START_PERCENT",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -35234,7 +36132,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -35249,7 +36147,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
         "kind": "static_from",
-        "line": 839,
+        "line": 855,
         "name": "ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -35268,7 +36166,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -35283,7 +36181,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STYLE_GAIN",
         "kind": "static_from",
-        "line": 839,
+        "line": 855,
         "name": "ARTIST_MIX_DEFAULT_STYLE_GAIN",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -35302,7 +36200,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -35317,7 +36215,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_INPUT_MODES",
         "kind": "static_from",
-        "line": 839,
+        "line": 855,
         "name": "ARTIST_MIX_INPUT_MODES",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -35336,7 +36234,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -35351,7 +36249,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 839,
+        "line": 855,
         "name": "ARTIST_MIX_MODE_FROM_PROMPT_DATA",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -35370,7 +36268,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -35385,7 +36283,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_mix_inline_prompt",
         "kind": "static_from",
-        "line": 839,
+        "line": 855,
         "name": "_artist_mix_inline_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -35404,7 +36302,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -35419,7 +36317,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_mix_mode_tooltip",
         "kind": "static_from",
-        "line": 839,
+        "line": 855,
         "name": "_artist_mix_mode_tooltip",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -35438,7 +36336,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -35453,7 +36351,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_prompt_with_position",
         "kind": "static_from",
-        "line": 839,
+        "line": 855,
         "name": "_artist_prompt_with_position",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -35472,7 +36370,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -35487,7 +36385,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_tags_from_prompt",
         "kind": "static_from",
-        "line": 839,
+        "line": 855,
         "name": "_artist_tags_from_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -35506,7 +36404,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -35521,7 +36419,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_blend_conditionings",
         "kind": "static_from",
-        "line": 839,
+        "line": 855,
         "name": "_blend_conditionings",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -35540,7 +36438,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -35555,7 +36453,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bounded_artist_mix_float",
         "kind": "static_from",
-        "line": 839,
+        "line": 855,
         "name": "_bounded_artist_mix_float",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -35574,7 +36472,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -35589,7 +36487,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bounded_artist_mix_int",
         "kind": "static_from",
-        "line": 839,
+        "line": 855,
         "name": "_bounded_artist_mix_int",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -35608,7 +36506,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -35623,7 +36521,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_clustered",
         "kind": "static_from",
-        "line": 839,
+        "line": 855,
         "name": "_encode_artist_clustered",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -35642,7 +36540,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -35657,7 +36555,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_delta_rms",
         "kind": "static_from",
-        "line": 839,
+        "line": 855,
         "name": "_encode_artist_delta_rms",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -35676,7 +36574,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -35691,7 +36589,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_prompt_data_positive_conditioning",
         "kind": "static_from",
-        "line": 839,
+        "line": 855,
         "name": "_encode_prompt_data_positive_conditioning",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -35710,7 +36608,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -35725,7 +36623,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_join_artist_mix_source_prompts",
         "kind": "static_from",
-        "line": 839,
+        "line": 855,
         "name": "_join_artist_mix_source_prompts",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -35744,7 +36642,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -35759,7 +36657,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_normalize_artist_mix_mode",
         "kind": "static_from",
-        "line": 839,
+        "line": 855,
         "name": "_normalize_artist_mix_mode",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -35778,7 +36676,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -35793,7 +36691,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_normalize_artist_tag_position",
         "kind": "static_from",
-        "line": 839,
+        "line": 855,
         "name": "_normalize_artist_tag_position",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -35812,7 +36710,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -35827,7 +36725,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_parse_artist_mix_items",
         "kind": "static_from",
-        "line": 839,
+        "line": 855,
         "name": "_parse_artist_mix_items",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -35846,7 +36744,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -35861,7 +36759,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaArtistMixConditioning",
         "kind": "static_from",
-        "line": 918,
+        "line": 934,
         "name": "EasyUseAnimaArtistMixConditioning",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_data_nodes",
@@ -35880,7 +36778,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -35895,7 +36793,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataConditioning",
         "kind": "static_from",
-        "line": 918,
+        "line": 934,
         "name": "EasyUseAnimaPromptDataConditioning",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_data_nodes",
@@ -35914,7 +36812,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -35929,7 +36827,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataUnpack",
         "kind": "static_from",
-        "line": 918,
+        "line": 934,
         "name": "EasyUseAnimaPromptDataUnpack",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_data_nodes",
@@ -35948,7 +36846,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -35963,7 +36861,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_ANY_TYPE",
         "kind": "static_from",
-        "line": 923,
+        "line": 939,
         "name": "_ANY_TYPE",
         "optional": false,
         "requested": "easyuse_anima.nodes.input_types",
@@ -35982,7 +36880,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -35997,7 +36895,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_AnyType",
         "kind": "static_from",
-        "line": 923,
+        "line": 939,
         "name": "_AnyType",
         "optional": false,
         "requested": "easyuse_anima.nodes.input_types",
@@ -36016,7 +36914,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -36031,7 +36929,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_FlexibleOptionalInputType",
         "kind": "static_from",
-        "line": 923,
+        "line": 939,
         "name": "_FlexibleOptionalInputType",
         "optional": false,
         "requested": "easyuse_anima.nodes.input_types",
@@ -36050,7 +36948,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -36065,7 +36963,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvanced",
         "kind": "static_from",
-        "line": 928,
+        "line": 944,
         "name": "EasyUseAnimaPromptStudioAdvanced",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_advanced_nodes",
@@ -36084,7 +36982,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -36099,7 +36997,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvancedV2",
         "kind": "static_from",
-        "line": 928,
+        "line": 944,
         "name": "EasyUseAnimaPromptStudioAdvancedV2",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_advanced_nodes",
@@ -36118,7 +37016,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -36133,7 +37031,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:EasyUseAnimaAIOGenerator",
         "kind": "static_from",
-        "line": 933,
+        "line": 949,
         "name": "EasyUseAnimaAIOGenerator",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -36152,7 +37050,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -36167,7 +37065,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:EasyUseAnimaInput",
         "kind": "static_from",
-        "line": 933,
+        "line": 949,
         "name": "EasyUseAnimaInput",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -36186,7 +37084,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -36201,7 +37099,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_aio_generation_settings_json",
         "kind": "static_from",
-        "line": 933,
+        "line": 949,
         "name": "_aio_generation_settings_json",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -36220,7 +37118,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -36235,7 +37133,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_aio_input_settings_json",
         "kind": "static_from",
-        "line": 933,
+        "line": 949,
         "name": "_aio_input_settings_json",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -36254,7 +37152,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -36269,7 +37167,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_bind_aio_node_runtime",
         "kind": "static_from",
-        "line": 933,
+        "line": 949,
         "name": "_bind_aio_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -36288,7 +37186,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -36303,7 +37201,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_easy_use_anima_input_signature",
         "kind": "static_from",
-        "line": 933,
+        "line": 949,
         "name": "_easy_use_anima_input_signature",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -36322,7 +37220,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -36337,7 +37235,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_require_easy_use_anima_input",
         "kind": "static_from",
-        "line": 933,
+        "line": 949,
         "name": "_require_easy_use_anima_input",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -36356,7 +37254,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -36371,7 +37269,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_align_down",
         "kind": "static_from",
-        "line": 942,
+        "line": 958,
         "name": "_align_down",
         "optional": false,
         "requested": "easyuse_anima.image.geometry",
@@ -36390,7 +37288,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -36405,7 +37303,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_align_nearest",
         "kind": "static_from",
-        "line": 942,
+        "line": 958,
         "name": "_align_nearest",
         "optional": false,
         "requested": "easyuse_anima.image.geometry",
@@ -36424,7 +37322,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -36439,7 +37337,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_image_tensor_size",
         "kind": "static_from",
-        "line": 942,
+        "line": 958,
         "name": "_image_tensor_size",
         "optional": false,
         "requested": "easyuse_anima.image.geometry",
@@ -36458,7 +37356,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -36473,7 +37371,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_context_value",
         "kind": "static_from",
-        "line": 953,
+        "line": 969,
         "name": "_context_value",
         "optional": false,
         "requested": "easyuse_anima.image.sam3",
@@ -36492,7 +37390,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -36507,7 +37405,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_sam3_context",
         "kind": "static_from",
-        "line": 953,
+        "line": 969,
         "name": "_sam3_context",
         "optional": false,
         "requested": "easyuse_anima.image.sam3",
@@ -36526,7 +37424,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -36541,7 +37439,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_segs_has_items",
         "kind": "static_from",
-        "line": 953,
+        "line": 969,
         "name": "_segs_has_items",
         "optional": false,
         "requested": "easyuse_anima.image.sam3",
@@ -36560,7 +37458,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -36575,7 +37473,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:IMAGE_SCALE_MULTIPLES",
         "kind": "static_from",
-        "line": 965,
+        "line": 981,
         "name": "IMAGE_SCALE_MULTIPLES",
         "optional": false,
         "requested": "easyuse_anima.image.scaling",
@@ -36594,7 +37492,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -36609,7 +37507,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:IMAGE_UPSCALE_METHODS",
         "kind": "static_from",
-        "line": 965,
+        "line": 981,
         "name": "IMAGE_UPSCALE_METHODS",
         "optional": false,
         "requested": "easyuse_anima.image.scaling",
@@ -36628,7 +37526,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -36643,7 +37541,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_sampler_names",
         "kind": "static_from",
-        "line": 973,
+        "line": 989,
         "name": "_comfy_sampler_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -36662,7 +37560,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -36677,7 +37575,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_scheduler_names",
         "kind": "static_from",
-        "line": 973,
+        "line": 989,
         "name": "_comfy_scheduler_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -36696,7 +37594,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -36711,7 +37609,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_impact_scheduler_names",
         "kind": "static_from",
-        "line": 973,
+        "line": 989,
         "name": "_impact_scheduler_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -36730,7 +37628,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -36745,7 +37643,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_call_with_supported_kwargs",
         "kind": "static_from",
-        "line": 979,
+        "line": 995,
         "name": "_call_with_supported_kwargs",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.invocation",
@@ -36764,7 +37662,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -36779,7 +37677,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_common_upscale_image",
         "kind": "static_from",
-        "line": 979,
+        "line": 995,
         "name": "_common_upscale_image",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.invocation",
@@ -36798,7 +37696,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -36813,7 +37711,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_node_output_tuple",
         "kind": "static_from",
-        "line": 979,
+        "line": 995,
         "name": "_node_output_tuple",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.invocation",
@@ -36832,7 +37730,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -36847,7 +37745,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.wiring:resolve_comfy_host_helper",
         "kind": "static_from",
-        "line": 984,
+        "line": 1000,
         "name": "resolve_comfy_host_helper",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.wiring",
@@ -36866,7 +37764,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -36881,7 +37779,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_clip_loader_types",
         "kind": "static_from",
-        "line": 987,
+        "line": 1003,
         "name": "_comfy_clip_loader_types",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -36900,7 +37798,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -36915,7 +37813,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_diffusion_model_names",
         "kind": "static_from",
-        "line": 987,
+        "line": 1003,
         "name": "_comfy_diffusion_model_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -36934,7 +37832,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -36949,7 +37847,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_text_encoder_names",
         "kind": "static_from",
-        "line": 987,
+        "line": 1003,
         "name": "_comfy_text_encoder_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -36968,7 +37866,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -36983,7 +37881,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_vae_names",
         "kind": "static_from",
-        "line": 987,
+        "line": 1003,
         "name": "_comfy_vae_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -37002,7 +37900,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -37017,7 +37915,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_folder_path_names",
         "kind": "static_from",
-        "line": 987,
+        "line": 1003,
         "name": "_folder_path_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -37036,7 +37934,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -37051,7 +37949,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.image_nodes:EasyUseAnimaDetailerAlignHook",
         "kind": "static_from",
-        "line": 995,
+        "line": 1011,
         "name": "EasyUseAnimaDetailerAlignHook",
         "optional": false,
         "requested": "easyuse_anima.nodes.image_nodes",
@@ -37070,7 +37968,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -37085,7 +37983,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.image_nodes:EasyUseAnimaImageScaleByMultiple",
         "kind": "static_from",
-        "line": 995,
+        "line": 1011,
         "name": "EasyUseAnimaImageScaleByMultiple",
         "optional": false,
         "requested": "easyuse_anima.nodes.image_nodes",
@@ -37104,7 +38002,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -37119,7 +38017,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Context",
         "kind": "static_from",
-        "line": 999,
+        "line": 1015,
         "name": "EasyUseAnimaSAM3Context",
         "optional": false,
         "requested": "easyuse_anima.nodes.sam3_nodes",
@@ -37138,7 +38036,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -37153,7 +38051,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Detailer",
         "kind": "static_from",
-        "line": 999,
+        "line": 1015,
         "name": "EasyUseAnimaSAM3Detailer",
         "optional": false,
         "requested": "easyuse_anima.nodes.sam3_nodes",
@@ -37172,7 +38070,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -37187,7 +38085,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptBuilder",
         "kind": "static_from",
-        "line": 1003,
+        "line": 1019,
         "name": "EasyUseAnimaPromptBuilder",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -37206,7 +38104,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -37221,7 +38119,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrector",
         "kind": "static_from",
-        "line": 1003,
+        "line": 1019,
         "name": "EasyUseAnimaPromptCorrector",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -37240,7 +38138,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -37255,7 +38153,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrectorSimple",
         "kind": "static_from",
-        "line": 1003,
+        "line": 1019,
         "name": "EasyUseAnimaPromptCorrectorSimple",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -37274,7 +38172,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -37289,7 +38187,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptStudio",
         "kind": "static_from",
-        "line": 1003,
+        "line": 1019,
         "name": "EasyUseAnimaPromptStudio",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -37308,7 +38206,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -37323,7 +38221,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:EasyUseAnimaPromptStudioRegional",
         "kind": "static_from",
-        "line": 1009,
+        "line": 1025,
         "name": "EasyUseAnimaPromptStudioRegional",
         "optional": false,
         "requested": "easyuse_anima.nodes.regional_nodes",
@@ -37342,7 +38240,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -37357,7 +38255,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:EasyUseAnimaRegionalConditioning",
         "kind": "static_from",
-        "line": 1009,
+        "line": 1025,
         "name": "EasyUseAnimaRegionalConditioning",
         "optional": false,
         "requested": "easyuse_anima.nodes.regional_nodes",
@@ -37376,7 +38274,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -37391,7 +38289,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:LATENT_ALIGN",
         "kind": "static_from",
-        "line": 1013,
+        "line": 1029,
         "name": "LATENT_ALIGN",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -37410,7 +38308,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -37425,7 +38323,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_parse_random_response",
         "kind": "static_from",
-        "line": 1013,
+        "line": 1029,
         "name": "_parse_random_response",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -37444,7 +38342,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -37459,7 +38357,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_post_random",
         "kind": "static_from",
-        "line": 1013,
+        "line": 1029,
         "name": "_post_random",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -37478,7 +38376,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -37493,7 +38391,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_advanced_resolution_from_selection",
         "kind": "static_from",
-        "line": 1031,
+        "line": 1047,
         "name": "_advanced_resolution_from_selection",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -37512,7 +38410,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -37527,7 +38425,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_normalize_resolution_bucket",
         "kind": "static_from",
-        "line": 1031,
+        "line": 1047,
         "name": "_normalize_resolution_bucket",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -37546,7 +38444,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -37561,7 +38459,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_ratio_label",
         "kind": "static_from",
-        "line": 1031,
+        "line": 1047,
         "name": "_ratio_label",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -37580,7 +38478,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -37595,7 +38493,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolution_label",
         "kind": "static_from",
-        "line": 1031,
+        "line": 1047,
         "name": "_resolution_label",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -37614,7 +38512,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -37629,7 +38527,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolve_naia_resolution",
         "kind": "static_from",
-        "line": 1031,
+        "line": 1047,
         "name": "_resolve_naia_resolution",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -37648,7 +38546,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -37663,7 +38561,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.naia_nodes:EasyUseAnimaNAIARandomPrompt",
         "kind": "static_from",
-        "line": 1054,
+        "line": 1070,
         "name": "EasyUseAnimaNAIARandomPrompt",
         "optional": false,
         "requested": "easyuse_anima.nodes.naia_nodes",
@@ -37682,7 +38580,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -37697,7 +38595,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.naia_nodes:_bind_naia_node_runtime",
         "kind": "static_from",
-        "line": 1054,
+        "line": 1070,
         "name": "_bind_naia_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.naia_nodes",
@@ -37716,7 +38614,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -37731,7 +38629,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.wildcard_nodes:EasyUseAnimaWildcard",
         "kind": "static_from",
-        "line": 1058,
+        "line": 1074,
         "name": "EasyUseAnimaWildcard",
         "optional": false,
         "requested": "easyuse_anima.nodes.wildcard_nodes",
@@ -37750,7 +38648,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -37765,7 +38663,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.wildcard_nodes:_bind_wildcard_node_runtime",
         "kind": "static_from",
-        "line": 1058,
+        "line": 1074,
         "name": "_bind_wildcard_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.wildcard_nodes",
@@ -37784,7 +38682,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -37799,7 +38697,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_apply_lora_syntax_format",
         "kind": "static_from",
-        "line": 1063,
+        "line": 1079,
         "name": "_apply_lora_syntax_format",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -37818,7 +38716,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -37833,7 +38731,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_dedupe_text_values",
         "kind": "static_from",
-        "line": 1063,
+        "line": 1079,
         "name": "_dedupe_text_values",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -37852,7 +38750,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -37867,7 +38765,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_fallback_lora_path",
         "kind": "static_from",
-        "line": 1063,
+        "line": 1079,
         "name": "_fallback_lora_path",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -37886,7 +38784,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -37901,7 +38799,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_get_lora_info",
         "kind": "static_from",
-        "line": 1063,
+        "line": 1079,
         "name": "_get_lora_info",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -37920,7 +38818,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -37935,7 +38833,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_get_lora_manager_trigger_words",
         "kind": "static_from",
-        "line": 1063,
+        "line": 1079,
         "name": "_get_lora_manager_trigger_words",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -37954,7 +38852,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -37969,7 +38867,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_load_lora_manager_metadata",
         "kind": "static_from",
-        "line": 1063,
+        "line": 1079,
         "name": "_load_lora_manager_metadata",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -37988,7 +38886,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -38003,7 +38901,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_combo_values",
         "kind": "static_from",
-        "line": 1063,
+        "line": 1079,
         "name": "_lora_combo_values",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -38022,7 +38920,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -38037,7 +38935,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_manager_trigger_words_from_metadata",
         "kind": "static_from",
-        "line": 1063,
+        "line": 1079,
         "name": "_lora_manager_trigger_words_from_metadata",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -38056,7 +38954,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -38071,7 +38969,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_model_exists",
         "kind": "static_from",
-        "line": 1063,
+        "line": 1079,
         "name": "_lora_model_exists",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -38090,7 +38988,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -38105,7 +39003,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_stack_name",
         "kind": "static_from",
-        "line": 1063,
+        "line": 1079,
         "name": "_lora_stack_name",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -38124,7 +39022,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -38139,7 +39037,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_metadata_json_paths_for_lora",
         "kind": "static_from",
-        "line": 1063,
+        "line": 1079,
         "name": "_metadata_json_paths_for_lora",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -38158,7 +39056,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -38173,7 +39071,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_missing_lora_display_name",
         "kind": "static_from",
-        "line": 1063,
+        "line": 1079,
         "name": "_missing_lora_display_name",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -38192,7 +39090,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -38207,7 +39105,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_raise_missing_loras",
         "kind": "static_from",
-        "line": 1063,
+        "line": 1079,
         "name": "_raise_missing_loras",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -38226,7 +39124,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -38241,7 +39139,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_trigger_words_from_value",
         "kind": "static_from",
-        "line": 1063,
+        "line": 1079,
         "name": "_trigger_words_from_value",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -38260,7 +39158,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -38275,7 +39173,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_correct_style_prompt",
         "kind": "static_from",
-        "line": 1079,
+        "line": 1095,
         "name": "_correct_style_prompt",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -38294,7 +39192,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -38309,7 +39207,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_format_strength",
         "kind": "static_from",
-        "line": 1079,
+        "line": 1095,
         "name": "_format_strength",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -38328,7 +39226,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -38343,7 +39241,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_get_loras_list",
         "kind": "static_from",
-        "line": 1079,
+        "line": 1095,
         "name": "_get_loras_list",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -38362,7 +39260,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -38377,7 +39275,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_load_profile_data",
         "kind": "static_from",
-        "line": 1079,
+        "line": 1095,
         "name": "_load_profile_data",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -38396,7 +39294,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -38411,7 +39309,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_profile_key",
         "kind": "static_from",
-        "line": 1079,
+        "line": 1095,
         "name": "_profile_key",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -38430,7 +39328,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -38445,7 +39343,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_select_profile_values",
         "kind": "static_from",
-        "line": 1079,
+        "line": 1095,
         "name": "_select_profile_values",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -38464,7 +39362,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -38479,7 +39377,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_wrap_profile_index",
         "kind": "static_from",
-        "line": 1079,
+        "line": 1095,
         "name": "_wrap_profile_index",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -38498,7 +39396,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -38513,7 +39411,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.lora_nodes:EasyUseAnimaLoraPreset",
         "kind": "static_from",
-        "line": 1088,
+        "line": 1104,
         "name": "EasyUseAnimaLoraPreset",
         "optional": false,
         "requested": "easyuse_anima.nodes.lora_nodes",
@@ -38532,7 +39430,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -38547,7 +39445,7 @@
         "conditional": true,
         "imported": "anima_prompt:correct_prompt",
         "kind": "static_from",
-        "line": 1091,
+        "line": 1107,
         "name": "correct_prompt",
         "optional": false,
         "requested": "anima_prompt",
@@ -38566,7 +39464,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -38581,7 +39479,7 @@
         "conditional": true,
         "imported": "anima_prompt:load_knowledge_base",
         "kind": "static_from",
-        "line": 1091,
+        "line": 1107,
         "name": "load_knowledge_base",
         "optional": false,
         "requested": "anima_prompt",
@@ -38600,7 +39498,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -38615,7 +39513,7 @@
         "conditional": true,
         "imported": "anima_prompt.parser:parse_prompt",
         "kind": "static_from",
-        "line": 1092,
+        "line": 1108,
         "name": "parse_prompt",
         "optional": false,
         "requested": "anima_prompt.parser",
@@ -38634,7 +39532,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -38649,7 +39547,7 @@
         "conditional": true,
         "imported": "settings:resolve_metadata_filter_words",
         "kind": "static_from",
-        "line": 1093,
+        "line": 1109,
         "name": "resolve_metadata_filter_words",
         "optional": false,
         "requested": "settings",
@@ -38668,7 +39566,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -38683,7 +39581,7 @@
         "conditional": true,
         "imported": "settings:resolve_naia_settings",
         "kind": "static_from",
-        "line": 1093,
+        "line": 1109,
         "name": "resolve_naia_settings",
         "optional": false,
         "requested": "settings",
@@ -38702,7 +39600,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -38717,7 +39615,7 @@
         "conditional": true,
         "imported": "settings:resolve_prompt_translation_settings",
         "kind": "static_from",
-        "line": 1093,
+        "line": 1109,
         "name": "resolve_prompt_translation_settings",
         "optional": false,
         "requested": "settings",
@@ -38736,7 +39634,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -38751,7 +39649,7 @@
         "conditional": true,
         "imported": "prompt_translation:has_prompt_translation_markers",
         "kind": "static_from",
-        "line": 1098,
+        "line": 1114,
         "name": "has_prompt_translation_markers",
         "optional": false,
         "requested": "prompt_translation",
@@ -38770,7 +39668,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -38785,7 +39683,7 @@
         "conditional": true,
         "imported": "prompt_translation:translate_prompt_markers",
         "kind": "static_from",
-        "line": 1098,
+        "line": 1114,
         "name": "translate_prompt_markers",
         "optional": false,
         "requested": "prompt_translation",
@@ -38804,7 +39702,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -38819,7 +39717,7 @@
         "conditional": true,
         "imported": "wildcard_engine:MAX_SEED",
         "kind": "static_from",
-        "line": 1099,
+        "line": 1115,
         "name": "MAX_SEED",
         "optional": false,
         "requested": "wildcard_engine",
@@ -38838,7 +39736,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -38853,7 +39751,7 @@
         "conditional": true,
         "imported": "wildcard_engine:PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "kind": "static_from",
-        "line": 1099,
+        "line": 1115,
         "name": "PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "optional": false,
         "requested": "wildcard_engine",
@@ -38872,7 +39770,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -38887,7 +39785,7 @@
         "conditional": true,
         "imported": "wildcard_engine:PUBLIC_MAX_SEED",
         "kind": "static_from",
-        "line": 1099,
+        "line": 1115,
         "name": "PUBLIC_MAX_SEED",
         "optional": false,
         "requested": "wildcard_engine",
@@ -38906,7 +39804,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -38921,7 +39819,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_DECREMENT",
         "kind": "static_from",
-        "line": 1099,
+        "line": 1115,
         "name": "SEED_CONTROL_DECREMENT",
         "optional": false,
         "requested": "wildcard_engine",
@@ -38940,7 +39838,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -38955,7 +39853,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_FIXED",
         "kind": "static_from",
-        "line": 1099,
+        "line": 1115,
         "name": "SEED_CONTROL_FIXED",
         "optional": false,
         "requested": "wildcard_engine",
@@ -38974,7 +39872,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -38989,7 +39887,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_INCREMENT",
         "kind": "static_from",
-        "line": 1099,
+        "line": 1115,
         "name": "SEED_CONTROL_INCREMENT",
         "optional": false,
         "requested": "wildcard_engine",
@@ -39008,7 +39906,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -39023,7 +39921,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_MODES",
         "kind": "static_from",
-        "line": 1099,
+        "line": 1115,
         "name": "SEED_CONTROL_MODES",
         "optional": false,
         "requested": "wildcard_engine",
@@ -39042,7 +39940,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -39057,7 +39955,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_RANDOMIZE",
         "kind": "static_from",
-        "line": 1099,
+        "line": 1115,
         "name": "SEED_CONTROL_RANDOMIZE",
         "optional": false,
         "requested": "wildcard_engine",
@@ -39076,7 +39974,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -39091,7 +39989,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_FIXED",
         "kind": "static_from",
-        "line": 1099,
+        "line": 1115,
         "name": "WILDCARD_MODE_FIXED",
         "optional": false,
         "requested": "wildcard_engine",
@@ -39110,7 +40008,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -39125,7 +40023,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_POPULATE",
         "kind": "static_from",
-        "line": 1099,
+        "line": 1115,
         "name": "WILDCARD_MODE_POPULATE",
         "optional": false,
         "requested": "wildcard_engine",
@@ -39144,7 +40042,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -39159,7 +40057,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_SEQUENTIAL",
         "kind": "static_from",
-        "line": 1099,
+        "line": 1115,
         "name": "WILDCARD_MODE_SEQUENTIAL",
         "optional": false,
         "requested": "wildcard_engine",
@@ -39178,7 +40076,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -39193,7 +40091,7 @@
         "conditional": true,
         "imported": "wildcard_engine:expand_wildcard_texts",
         "kind": "static_from",
-        "line": 1099,
+        "line": 1115,
         "name": "expand_wildcard_texts",
         "optional": false,
         "requested": "wildcard_engine",
@@ -39212,7 +40110,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -39227,7 +40125,7 @@
         "conditional": true,
         "imported": "wildcard_engine:expand_wildcards",
         "kind": "static_from",
-        "line": 1099,
+        "line": 1115,
         "name": "expand_wildcards",
         "optional": false,
         "requested": "wildcard_engine",
@@ -39246,7 +40144,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -39261,7 +40159,7 @@
         "conditional": true,
         "imported": "wildcard_engine:has_wildcard_syntax",
         "kind": "static_from",
-        "line": 1099,
+        "line": 1115,
         "name": "has_wildcard_syntax",
         "optional": false,
         "requested": "wildcard_engine",
@@ -39280,7 +40178,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -39295,7 +40193,7 @@
         "conditional": true,
         "imported": "wildcard_engine:next_seed",
         "kind": "static_from",
-        "line": 1099,
+        "line": 1115,
         "name": "next_seed",
         "optional": false,
         "requested": "wildcard_engine",
@@ -39314,7 +40212,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -39329,7 +40227,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_prompt_studio_wildcard_mode",
         "kind": "static_from",
-        "line": 1099,
+        "line": 1115,
         "name": "normalize_prompt_studio_wildcard_mode",
         "optional": false,
         "requested": "wildcard_engine",
@@ -39348,7 +40246,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -39363,7 +40261,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_seed",
         "kind": "static_from",
-        "line": 1099,
+        "line": 1115,
         "name": "normalize_seed",
         "optional": false,
         "requested": "wildcard_engine",
@@ -39382,7 +40280,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -39397,7 +40295,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_wildcard_mode",
         "kind": "static_from",
-        "line": 1099,
+        "line": 1115,
         "name": "normalize_wildcard_mode",
         "optional": false,
         "requested": "wildcard_engine",
@@ -39416,7 +40314,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -39431,7 +40329,7 @@
         "conditional": true,
         "imported": "wildcard_engine:wildcard_sources_signature",
         "kind": "static_from",
-        "line": 1099,
+        "line": 1115,
         "name": "wildcard_sources_signature",
         "optional": false,
         "requested": "wildcard_engine",
@@ -41179,7 +42077,27 @@
       },
       {
         "from": "easyuse_anima/aio/output.py",
+        "to": "easyuse_anima/aio/generation_defaults.py"
+      },
+      {
+        "from": "easyuse_anima/aio/output.py",
         "to": "easyuse_anima/aio/output_settings.py"
+      },
+      {
+        "from": "easyuse_anima/aio/output.py",
+        "to": "easyuse_anima/aio/sampling.py"
+      },
+      {
+        "from": "easyuse_anima/aio/output.py",
+        "to": "easyuse_anima/common/values.py"
+      },
+      {
+        "from": "easyuse_anima/aio/output.py",
+        "to": "easyuse_anima/infrastructure/comfy/wiring.py"
+      },
+      {
+        "from": "easyuse_anima/aio/output.py",
+        "to": "easyuse_anima/lora/preset.py"
       },
       {
         "from": "easyuse_anima/aio/output_settings.py",
@@ -41200,6 +42118,50 @@
       {
         "from": "easyuse_anima/aio/postprocess.py",
         "to": "easyuse_anima/naia/client.py"
+      },
+      {
+        "from": "easyuse_anima/aio/preview.py",
+        "to": "easyuse_anima/common/values.py"
+      },
+      {
+        "from": "easyuse_anima/aio/preview.py",
+        "to": "easyuse_anima/image/geometry.py"
+      },
+      {
+        "from": "easyuse_anima/aio/preview.py",
+        "to": "easyuse_anima/infrastructure/comfy/wiring.py"
+      },
+      {
+        "from": "easyuse_anima/aio/preview.py",
+        "to": "easyuse_anima/prompt/data.py"
+      },
+      {
+        "from": "easyuse_anima/aio/resources.py",
+        "to": "easyuse_anima/aio/generation_normalization.py"
+      },
+      {
+        "from": "easyuse_anima/aio/resources.py",
+        "to": "easyuse_anima/aio/input_defaults.py"
+      },
+      {
+        "from": "easyuse_anima/aio/resources.py",
+        "to": "easyuse_anima/common/values.py"
+      },
+      {
+        "from": "easyuse_anima/aio/resources.py",
+        "to": "easyuse_anima/image/sam3.py"
+      },
+      {
+        "from": "easyuse_anima/aio/resources.py",
+        "to": "easyuse_anima/infrastructure/comfy/invocation.py"
+      },
+      {
+        "from": "easyuse_anima/aio/resources.py",
+        "to": "easyuse_anima/infrastructure/comfy/resources.py"
+      },
+      {
+        "from": "easyuse_anima/aio/resources.py",
+        "to": "easyuse_anima/infrastructure/comfy/wiring.py"
       },
       {
         "from": "easyuse_anima/aio/usdu.py",
@@ -41735,6 +42697,10 @@
       },
       {
         "from": "nodes.py",
+        "to": "easyuse_anima/aio/input_defaults.py"
+      },
+      {
+        "from": "nodes.py",
         "to": "easyuse_anima/aio/legacy_generation.py"
       },
       {
@@ -42095,6 +43061,12 @@
         "cyclic": false,
         "modules": [
           "easyuse_anima/aio/generation_values.py"
+        ]
+      },
+      {
+        "cyclic": false,
+        "modules": [
+          "easyuse_anima/aio/input_defaults.py"
         ]
       },
       {
@@ -42491,7 +43463,7 @@
     ]
   },
   "inventory": {
-    "module_count": 91,
+    "module_count": 92,
     "modules": [
       {
         "is_package": true,
@@ -42795,6 +43767,18 @@
       },
       {
         "is_package": false,
+        "loc": 62,
+        "module": "easyuse_anima.aio.input_defaults",
+        "normalized_git_blob_sha1": "405b88bb1366f9a68844779dc17cb4ba0255b9a4",
+        "path": "easyuse_anima/aio/input_defaults.py",
+        "top_level": {
+          "class_count": 0,
+          "function_count": 0,
+          "global_count": 10
+        }
+      },
+      {
+        "is_package": false,
         "loc": 976,
         "module": "easyuse_anima.aio.legacy_generation",
         "normalized_git_blob_sha1": "a89b9902225b9c6844cf36d72edbc9a78bddd4a1",
@@ -42819,14 +43803,14 @@
       },
       {
         "is_package": false,
-        "loc": 299,
+        "loc": 303,
         "module": "easyuse_anima.aio.output",
-        "normalized_git_blob_sha1": "390407579549d17f0e887c7bf9c5b4151215eea1",
+        "normalized_git_blob_sha1": "a75a29177f2610c7d825303caad1e1e3cd229413",
         "path": "easyuse_anima/aio/output.py",
         "top_level": {
           "class_count": 0,
-          "function_count": 9,
-          "global_count": 3
+          "function_count": 10,
+          "global_count": 2
         }
       },
       {
@@ -42855,26 +43839,26 @@
       },
       {
         "is_package": false,
-        "loc": 233,
+        "loc": 236,
         "module": "easyuse_anima.aio.preview",
-        "normalized_git_blob_sha1": "cd89c5c82b2a51c041dca2c995892201d9895c1f",
+        "normalized_git_blob_sha1": "d0ca10ee0a6b34a64941711899e1534a3b60bb34",
         "path": "easyuse_anima/aio/preview.py",
         "top_level": {
           "class_count": 0,
           "function_count": 7,
-          "global_count": 7
+          "global_count": 6
         }
       },
       {
         "is_package": false,
-        "loc": 280,
+        "loc": 291,
         "module": "easyuse_anima.aio.resources",
-        "normalized_git_blob_sha1": "0ae47ad33deedf52edc9a65a2cab3b044ab8aa26",
+        "normalized_git_blob_sha1": "9ff098a3d36070b9ad87a8810b08dc7e5ac002a1",
         "path": "easyuse_anima/aio/resources.py",
         "top_level": {
           "class_count": 0,
           "function_count": 17,
-          "global_count": 3
+          "global_count": 1
         }
       },
       {
@@ -43527,14 +44511,14 @@
       },
       {
         "is_package": false,
-        "loc": 1239,
+        "loc": 1182,
         "module": "nodes",
-        "normalized_git_blob_sha1": "2c734092ef9aeae0e8226d89ab684313f9987a0f",
+        "normalized_git_blob_sha1": "40f7789cb9de0f3149fa2498ddd127d47067c405",
         "path": "nodes.py",
         "top_level": {
           "class_count": 0,
           "function_count": 0,
-          "global_count": 12
+          "global_count": 3
         }
       },
       {
@@ -45077,7 +46061,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -45086,7 +46070,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:AIO_FIRST_PASS_CACHE_MAX_ENTRIES",
         "kind": "static_from",
-        "line": 565,
+        "line": 573,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45100,7 +46084,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -45109,7 +46093,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_AIO_FIRST_PASS_CACHE",
         "kind": "static_from",
-        "line": 565,
+        "line": 573,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45123,7 +46107,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -45132,7 +46116,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_AIO_FIRST_PASS_CACHE_ORDER",
         "kind": "static_from",
-        "line": 565,
+        "line": 573,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45146,7 +46130,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -45155,7 +46139,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_aio_first_pass_cache_key",
         "kind": "static_from",
-        "line": 565,
+        "line": 573,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45169,7 +46153,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -45178,7 +46162,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_clone_aio_cache_value",
         "kind": "static_from",
-        "line": 565,
+        "line": 573,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45192,7 +46176,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -45201,7 +46185,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_get_aio_first_pass_cache",
         "kind": "static_from",
-        "line": 565,
+        "line": 573,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45215,7 +46199,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -45224,7 +46208,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_put_aio_first_pass_cache",
         "kind": "static_from",
-        "line": 565,
+        "line": 573,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45238,7 +46222,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -45247,7 +46231,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_bind_aio_legacy_generation_runtime",
         "kind": "static_from",
-        "line": 575,
+        "line": 583,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45261,7 +46245,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -45270,7 +46254,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_detailer_stage",
         "kind": "static_from",
-        "line": 575,
+        "line": 583,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45284,7 +46268,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -45293,7 +46277,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_detailer_target",
         "kind": "static_from",
-        "line": 575,
+        "line": 583,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45307,7 +46291,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -45316,7 +46300,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_highres_stage",
         "kind": "static_from",
-        "line": 575,
+        "line": 583,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45330,7 +46314,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -45339,7 +46323,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_legacy_generation",
         "kind": "static_from",
-        "line": 575,
+        "line": 583,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45353,7 +46337,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -45362,7 +46346,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_resshift_upscale_stage",
         "kind": "static_from",
-        "line": 575,
+        "line": 583,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45376,7 +46360,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -45385,7 +46369,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_upscale_stage",
         "kind": "static_from",
-        "line": 575,
+        "line": 583,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45399,7 +46383,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -45408,7 +46392,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_usdu_upscale_stage",
         "kind": "static_from",
-        "line": 575,
+        "line": 583,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45422,7 +46406,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -45431,7 +46415,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_AIO_DETAILER_CUSTOM_RE",
         "kind": "static_from",
-        "line": 585,
+        "line": 593,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45445,7 +46429,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -45454,7 +46438,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_AIO_DETAILER_RESERVED_KEYS",
         "kind": "static_from",
-        "line": 585,
+        "line": 593,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45468,7 +46452,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -45477,7 +46461,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_aio_detailer_has_enabled_targets",
         "kind": "static_from",
-        "line": 585,
+        "line": 593,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45491,7 +46475,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -45500,7 +46484,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_aio_detailer_target_defaults",
         "kind": "static_from",
-        "line": 585,
+        "line": 593,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45514,7 +46498,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -45523,7 +46507,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_aio_detailer_target_order",
         "kind": "static_from",
-        "line": 585,
+        "line": 593,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45537,7 +46521,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -45546,7 +46530,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_is_aio_detailer_target_name",
         "kind": "static_from",
-        "line": 585,
+        "line": 593,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45560,7 +46544,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -45569,7 +46553,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_merge_versioned_settings",
         "kind": "static_from",
-        "line": 585,
+        "line": 593,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45583,7 +46567,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -45592,7 +46576,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_dit_corrections_settings",
         "kind": "static_from",
-        "line": 585,
+        "line": 593,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45606,7 +46590,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -45615,7 +46599,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_generation_settings",
         "kind": "static_from",
-        "line": 585,
+        "line": 593,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45629,7 +46613,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -45638,7 +46622,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_seed",
         "kind": "static_from",
-        "line": 585,
+        "line": 593,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45652,7 +46636,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -45661,7 +46645,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_spectrum_settings",
         "kind": "static_from",
-        "line": 585,
+        "line": 593,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45675,7 +46659,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -45684,7 +46668,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_FINAL_FIT_MODES",
         "kind": "static_from",
-        "line": 598,
+        "line": 606,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45698,7 +46682,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -45707,7 +46691,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_FINAL_UPSCALE_BACKENDS",
         "kind": "static_from",
-        "line": 598,
+        "line": 606,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45721,7 +46705,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -45730,7 +46714,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_GENERATION_DEFAULT_SETTINGS",
         "kind": "static_from",
-        "line": 598,
+        "line": 606,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45744,7 +46728,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -45753,7 +46737,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_GENERATION_SETTINGS_SCHEMA",
         "kind": "static_from",
-        "line": 598,
+        "line": 606,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45767,7 +46751,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -45776,7 +46760,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_GENERATION_SETTINGS_VERSION",
         "kind": "static_from",
-        "line": 598,
+        "line": 606,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45790,7 +46774,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -45799,7 +46783,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_RESHIFT_DTYPES",
         "kind": "static_from",
-        "line": 598,
+        "line": 606,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45813,7 +46797,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -45822,7 +46806,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_RESHIFT_SCALES",
         "kind": "static_from",
-        "line": 598,
+        "line": 606,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45836,7 +46820,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -45845,7 +46829,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_SPECIAL_SEEDS",
         "kind": "static_from",
-        "line": 598,
+        "line": 606,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45859,7 +46843,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -45868,7 +46852,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_SPECIAL_SEED_DECREMENT",
         "kind": "static_from",
-        "line": 598,
+        "line": 606,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45882,7 +46866,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -45891,7 +46875,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_SPECIAL_SEED_INCREMENT",
         "kind": "static_from",
-        "line": 598,
+        "line": 606,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45905,7 +46889,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -45914,7 +46898,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_SPECIAL_SEED_RANDOM",
         "kind": "static_from",
-        "line": 598,
+        "line": 606,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45928,7 +46912,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -45937,7 +46921,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_USDU_MODE_TYPES",
         "kind": "static_from",
-        "line": 598,
+        "line": 606,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45951,7 +46935,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -45960,7 +46944,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_USDU_PROMPT_FULL",
         "kind": "static_from",
-        "line": 598,
+        "line": 606,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45974,7 +46958,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -45983,7 +46967,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_USDU_PROMPT_MODES",
         "kind": "static_from",
-        "line": 598,
+        "line": 606,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45997,7 +46981,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -46006,7 +46990,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_USDU_PROMPT_NO_GENERAL",
         "kind": "static_from",
-        "line": 598,
+        "line": 606,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46020,7 +47004,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -46029,7 +47013,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_USDU_SEAM_FIX_MODES",
         "kind": "static_from",
-        "line": 598,
+        "line": 606,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46043,7 +47027,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -46052,7 +47036,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_settings:round_trip_aio_generation_settings",
         "kind": "static_from",
-        "line": 616,
+        "line": 624,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46066,7 +47050,214 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
+            "kind": "try",
+            "line": 8
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.aio.input_defaults:AIO_INPUT_DEFAULT_SETTINGS",
+        "kind": "static_from",
+        "line": 627,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "nodes.py",
+        "target": "easyuse_anima/aio/input_defaults.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 572,
+            "kind": "try",
+            "line": 8
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.aio.input_defaults:ANIMA_CLIP_DEVICES",
+        "kind": "static_from",
+        "line": 627,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "nodes.py",
+        "target": "easyuse_anima/aio/input_defaults.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 572,
+            "kind": "try",
+            "line": 8
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.aio.input_defaults:ANIMA_CLIP_TYPES",
+        "kind": "static_from",
+        "line": 627,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "nodes.py",
+        "target": "easyuse_anima/aio/input_defaults.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 572,
+            "kind": "try",
+            "line": 8
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.aio.input_defaults:ANIMA_DEFAULT_CLIP_CANDIDATES",
+        "kind": "static_from",
+        "line": 627,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "nodes.py",
+        "target": "easyuse_anima/aio/input_defaults.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 572,
+            "kind": "try",
+            "line": 8
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.aio.input_defaults:ANIMA_DEFAULT_DIFFUSION_MODEL_CANDIDATES",
+        "kind": "static_from",
+        "line": 627,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "nodes.py",
+        "target": "easyuse_anima/aio/input_defaults.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 572,
+            "kind": "try",
+            "line": 8
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.aio.input_defaults:ANIMA_DEFAULT_VAE_CANDIDATES",
+        "kind": "static_from",
+        "line": 627,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "nodes.py",
+        "target": "easyuse_anima/aio/input_defaults.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 572,
+            "kind": "try",
+            "line": 8
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.aio.input_defaults:ANIMA_UNET_WEIGHT_DTYPES",
+        "kind": "static_from",
+        "line": 627,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "nodes.py",
+        "target": "easyuse_anima/aio/input_defaults.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 572,
+            "kind": "try",
+            "line": 8
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.aio.input_defaults:EASY_USE_ANIMA_INPUT_SCHEMA",
+        "kind": "static_from",
+        "line": 627,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "nodes.py",
+        "target": "easyuse_anima/aio/input_defaults.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 572,
+            "kind": "try",
+            "line": 8
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.aio.input_defaults:EASY_USE_ANIMA_INPUT_SETTINGS_VERSION",
+        "kind": "static_from",
+        "line": 627,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "nodes.py",
+        "target": "easyuse_anima/aio/input_defaults.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -46075,7 +47266,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.usdu:_aio_usdu_auto_tile_dimension",
         "kind": "static_from",
-        "line": 619,
+        "line": 638,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46089,7 +47280,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -46098,7 +47289,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.usdu:_aio_usdu_tile_plan",
         "kind": "static_from",
-        "line": 619,
+        "line": 638,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46112,7 +47303,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -46121,7 +47312,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_aio_final_fit_size",
         "kind": "static_from",
-        "line": 623,
+        "line": 642,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46135,7 +47326,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -46144,7 +47335,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_apply_aio_final_fit",
         "kind": "static_from",
-        "line": 623,
+        "line": 642,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46158,7 +47349,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -46167,7 +47358,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_resize_image_to_size_if_needed",
         "kind": "static_from",
-        "line": 623,
+        "line": 642,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46181,7 +47372,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -46190,7 +47381,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_run_aio_postprocess_stage",
         "kind": "static_from",
-        "line": 623,
+        "line": 642,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46204,7 +47395,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -46213,7 +47404,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_prompt_data_fields_for_usdu",
         "kind": "static_from",
-        "line": 629,
+        "line": 648,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46227,7 +47418,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -46236,7 +47427,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_usdu_conditioning",
         "kind": "static_from",
-        "line": 629,
+        "line": 648,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46250,7 +47441,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -46259,7 +47450,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_usdu_prompt_without_general",
         "kind": "static_from",
-        "line": 629,
+        "line": 648,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46273,7 +47464,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -46282,7 +47473,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_bind_aio_conditioning_runtime",
         "kind": "static_from",
-        "line": 629,
+        "line": 648,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46296,7 +47487,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -46305,7 +47496,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_aio_lora_stack_signature",
         "kind": "static_from",
-        "line": 635,
+        "line": 654,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46319,7 +47510,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -46328,7 +47519,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_anima_dave_patch",
         "kind": "static_from",
-        "line": 635,
+        "line": 654,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46342,7 +47533,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -46351,7 +47542,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_kj_model_patches",
         "kind": "static_from",
-        "line": 635,
+        "line": 654,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46365,7 +47556,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -46374,7 +47565,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_lora_stack",
         "kind": "static_from",
-        "line": 635,
+        "line": 654,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46388,7 +47579,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -46397,7 +47588,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_model_patches",
         "kind": "static_from",
-        "line": 635,
+        "line": 654,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46411,7 +47602,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -46420,7 +47611,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_safe_pag_patch",
         "kind": "static_from",
-        "line": 635,
+        "line": 654,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46434,7 +47625,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -46443,7 +47634,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_correction_patch_for_comfy_sampler",
         "kind": "static_from",
-        "line": 635,
+        "line": 654,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46457,7 +47648,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -46466,7 +47657,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_forecast_patch_for_comfy_sampler",
         "kind": "static_from",
-        "line": 635,
+        "line": 654,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46480,7 +47671,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -46489,7 +47680,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_model_patches_for_comfy_sampler",
         "kind": "static_from",
-        "line": 635,
+        "line": 654,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46503,7 +47694,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -46512,7 +47703,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_bind_aio_model_preparation_runtime",
         "kind": "static_from",
-        "line": 635,
+        "line": 654,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46526,7 +47717,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -46535,7 +47726,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_cleanup_aio_ephemeral_model",
         "kind": "static_from",
-        "line": 635,
+        "line": 654,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46549,7 +47740,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -46558,7 +47749,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_normalize_aio_lora_stack",
         "kind": "static_from",
-        "line": 635,
+        "line": 654,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46572,7 +47763,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -46581,7 +47772,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_patch_model_sampling_aura_flow",
         "kind": "static_from",
-        "line": 635,
+        "line": 654,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46595,7 +47786,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -46604,7 +47795,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_aio_highres_effective_backend",
         "kind": "static_from",
-        "line": 650,
+        "line": 669,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46618,7 +47809,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -46627,7 +47818,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_aio_stage_sampler_settings",
         "kind": "static_from",
-        "line": 650,
+        "line": 669,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46641,7 +47832,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -46650,7 +47841,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_bind_aio_sampling_runtime",
         "kind": "static_from",
-        "line": 650,
+        "line": 669,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46664,7 +47855,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -46673,7 +47864,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_decode_latent_with_comfy",
         "kind": "static_from",
-        "line": 650,
+        "line": 669,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46687,7 +47878,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -46696,7 +47887,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_encode_image_with_comfy_vae",
         "kind": "static_from",
-        "line": 650,
+        "line": 669,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46710,7 +47901,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -46719,7 +47910,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_generate_empty_latent_with_comfy",
         "kind": "static_from",
-        "line": 650,
+        "line": 669,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46733,7 +47924,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -46742,7 +47933,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_new_aio_random_seed",
         "kind": "static_from",
-        "line": 650,
+        "line": 669,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46756,7 +47947,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -46765,7 +47956,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_resolve_aio_runtime_seed",
         "kind": "static_from",
-        "line": 650,
+        "line": 669,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46779,7 +47970,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -46788,7 +47979,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_aio_backend",
         "kind": "static_from",
-        "line": 650,
+        "line": 669,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46802,7 +47993,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -46811,7 +48002,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_comfy",
         "kind": "static_from",
-        "line": 650,
+        "line": 669,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46825,7 +48016,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -46834,7 +48025,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_spectrum_mod_guidance_advanced",
         "kind": "static_from",
-        "line": 650,
+        "line": 669,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46848,7 +48039,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -46857,7 +48048,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_spectrum_spd",
         "kind": "static_from",
-        "line": 650,
+        "line": 669,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46871,7 +48062,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -46880,7 +48071,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_CACHE_FORMAT",
         "kind": "static_from",
-        "line": 664,
+        "line": 683,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46894,7 +48085,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -46903,7 +48094,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_CACHE_QUALITY",
         "kind": "static_from",
-        "line": 664,
+        "line": 683,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46917,7 +48108,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -46926,7 +48117,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_EVENT",
         "kind": "static_from",
-        "line": 664,
+        "line": 683,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46940,7 +48131,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -46949,7 +48140,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_STAGE_LABELS",
         "kind": "static_from",
-        "line": 664,
+        "line": 683,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46963,7 +48154,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -46972,7 +48163,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_aio_preview_base_directory",
         "kind": "static_from",
-        "line": 664,
+        "line": 683,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46986,7 +48177,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -46995,7 +48186,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_aio_preview_file_size_bytes",
         "kind": "static_from",
-        "line": 664,
+        "line": 683,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47009,30 +48200,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
-            "kind": "try",
-            "line": 8
-          }
-        ],
-        "classification": "compatibility_fallback",
-        "conditional": true,
-        "imported": "easyuse_anima.aio.preview:_bind_aio_preview_runtime",
-        "kind": "static_from",
-        "line": 664,
-        "optional": false,
-        "role": "compatibility_fallback",
-        "source": "nodes.py",
-        "target": "easyuse_anima/aio/preview.py"
-      },
-      {
-        "branch_context": [
-          {
-            "branch": "except",
-            "catches_import_error": true,
-            "exceptions": [
-              "ImportError"
-            ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -47041,7 +48209,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_save_aio_temp_preview_image",
         "kind": "static_from",
-        "line": 664,
+        "line": 683,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47055,7 +48223,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -47064,7 +48232,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_send_aio_preview_event",
         "kind": "static_from",
-        "line": 664,
+        "line": 683,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47078,7 +48246,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -47087,7 +48255,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_tag_aio_preview_images",
         "kind": "static_from",
-        "line": 664,
+        "line": 683,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47101,7 +48269,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -47110,7 +48278,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_image_saver_additional_hashes",
         "kind": "static_from",
-        "line": 676,
+        "line": 694,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47124,7 +48292,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -47133,7 +48301,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_image_saver_civitai_hash_fetcher_entries",
         "kind": "static_from",
-        "line": 676,
+        "line": 694,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47147,7 +48315,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -47156,7 +48324,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_lora_metadata_name",
         "kind": "static_from",
-        "line": 676,
+        "line": 694,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47170,7 +48338,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -47179,7 +48347,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_prompt_with_lora_metadata",
         "kind": "static_from",
-        "line": 676,
+        "line": 694,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47193,7 +48361,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -47202,7 +48370,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_save_filename_prefix",
         "kind": "static_from",
-        "line": 676,
+        "line": 694,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47216,30 +48384,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
-            "kind": "try",
-            "line": 8
-          }
-        ],
-        "classification": "compatibility_fallback",
-        "conditional": true,
-        "imported": "easyuse_anima.aio.output:_bind_aio_output_runtime",
-        "kind": "static_from",
-        "line": 676,
-        "optional": false,
-        "role": "compatibility_fallback",
-        "source": "nodes.py",
-        "target": "easyuse_anima/aio/output.py"
-      },
-      {
-        "branch_context": [
-          {
-            "branch": "except",
-            "catches_import_error": true,
-            "exceptions": [
-              "ImportError"
-            ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -47248,7 +48393,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_save_image_with_comfy",
         "kind": "static_from",
-        "line": 676,
+        "line": 694,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47262,7 +48407,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -47271,7 +48416,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_save_image_with_image_saver",
         "kind": "static_from",
-        "line": 676,
+        "line": 694,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47285,7 +48430,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -47294,7 +48439,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output_settings:_normalize_aio_civitai_hash_fetchers",
         "kind": "static_from",
-        "line": 686,
+        "line": 703,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47308,7 +48453,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -47317,7 +48462,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output_settings:_normalize_aio_hash_bundles",
         "kind": "static_from",
-        "line": 686,
+        "line": 703,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47331,30 +48476,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
-            "kind": "try",
-            "line": 8
-          }
-        ],
-        "classification": "compatibility_fallback",
-        "conditional": true,
-        "imported": "easyuse_anima.aio.resources:_bind_aio_resource_runtime",
-        "kind": "static_from",
-        "line": 690,
-        "optional": false,
-        "role": "compatibility_fallback",
-        "source": "nodes.py",
-        "target": "easyuse_anima/aio/resources.py"
-      },
-      {
-        "branch_context": [
-          {
-            "branch": "except",
-            "catches_import_error": true,
-            "exceptions": [
-              "ImportError"
-            ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -47363,7 +48485,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_clip_loader_types",
         "kind": "static_from",
-        "line": 690,
+        "line": 707,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47377,7 +48499,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -47386,7 +48508,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_diffusion_model_names",
         "kind": "static_from",
-        "line": 690,
+        "line": 707,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47400,7 +48522,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -47409,7 +48531,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_text_encoder_names",
         "kind": "static_from",
-        "line": 690,
+        "line": 707,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47423,7 +48545,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -47432,7 +48554,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_vae_names",
         "kind": "static_from",
-        "line": 690,
+        "line": 707,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47446,7 +48568,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -47455,7 +48577,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_aio_resources_from_input_context",
         "kind": "static_from",
-        "line": 690,
+        "line": 707,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47469,7 +48591,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -47478,7 +48600,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_aio_sam3_context",
         "kind": "static_from",
-        "line": 690,
+        "line": 707,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47492,7 +48614,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -47501,7 +48623,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_checkpoint_with_comfy",
         "kind": "static_from",
-        "line": 690,
+        "line": 707,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47515,7 +48637,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -47524,7 +48646,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_clip_with_comfy",
         "kind": "static_from",
-        "line": 690,
+        "line": 707,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47538,7 +48660,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -47547,7 +48669,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_diffusion_model_with_comfy",
         "kind": "static_from",
-        "line": 690,
+        "line": 707,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47561,7 +48683,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -47570,7 +48692,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_upscale_model_with_comfy",
         "kind": "static_from",
-        "line": 690,
+        "line": 707,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47584,7 +48706,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -47593,7 +48715,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_vae_with_comfy",
         "kind": "static_from",
-        "line": 690,
+        "line": 707,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47607,7 +48729,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -47616,7 +48738,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_normalize_aio_input_settings",
         "kind": "static_from",
-        "line": 690,
+        "line": 707,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47630,7 +48752,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -47639,7 +48761,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_checkpoint_default",
         "kind": "static_from",
-        "line": 690,
+        "line": 707,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47653,7 +48775,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -47662,7 +48784,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_clip_type_default",
         "kind": "static_from",
-        "line": 690,
+        "line": 707,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47676,7 +48798,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -47685,7 +48807,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_name_default",
         "kind": "static_from",
-        "line": 690,
+        "line": 707,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47699,7 +48821,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -47708,7 +48830,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_json_clone",
         "kind": "static_from",
-        "line": 708,
+        "line": 724,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47722,7 +48844,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -47731,7 +48853,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_json_object",
         "kind": "static_from",
-        "line": 708,
+        "line": 724,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47745,7 +48867,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -47754,7 +48876,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_stable_change_key",
         "kind": "static_from",
-        "line": 708,
+        "line": 724,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47768,7 +48890,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -47777,7 +48899,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_bool",
         "kind": "static_from",
-        "line": 713,
+        "line": 729,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47791,7 +48913,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -47800,7 +48922,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_float",
         "kind": "static_from",
-        "line": 713,
+        "line": 729,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47814,7 +48936,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -47823,7 +48945,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_int",
         "kind": "static_from",
-        "line": 713,
+        "line": 729,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47837,7 +48959,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -47846,7 +48968,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_choice",
         "kind": "static_from",
-        "line": 713,
+        "line": 729,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47860,7 +48982,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -47869,7 +48991,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_single_value",
         "kind": "static_from",
-        "line": 713,
+        "line": 729,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47883,7 +49005,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -47892,7 +49014,7 @@
         "conditional": true,
         "imported": "easyuse_anima.seed.compatibility:WILDCARD_QUEUE_MAX_SAFE_SEED",
         "kind": "static_from",
-        "line": 720,
+        "line": 736,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47906,7 +49028,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -47915,7 +49037,7 @@
         "conditional": true,
         "imported": "easyuse_anima.seed.compatibility:WILDCARD_RESERVED_NEXT_SEED_INPUT",
         "kind": "static_from",
-        "line": 720,
+        "line": 736,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47929,7 +49051,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -47938,7 +49060,7 @@
         "conditional": true,
         "imported": "easyuse_anima.seed.compatibility:_consume_reserved_wildcard_next_seed",
         "kind": "static_from",
-        "line": 720,
+        "line": 736,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47952,7 +49074,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -47961,7 +49083,7 @@
         "conditional": true,
         "imported": "easyuse_anima.workflow:_get_workflow_node",
         "kind": "static_from",
-        "line": 725,
+        "line": 741,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47975,7 +49097,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -47984,7 +49106,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_prompt_translation_change_key",
         "kind": "static_from",
-        "line": 726,
+        "line": 742,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47998,7 +49120,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -48007,7 +49129,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_split_tag_text",
         "kind": "static_from",
-        "line": 726,
+        "line": 742,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48021,7 +49143,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -48030,7 +49152,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_translate_prompt_text",
         "kind": "static_from",
-        "line": 726,
+        "line": 742,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48044,7 +49166,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -48053,7 +49175,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_HASH_COMMENT_RE",
         "kind": "static_from",
-        "line": 731,
+        "line": 747,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48067,7 +49189,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -48076,7 +49198,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_INLINE_SPACE_RE",
         "kind": "static_from",
-        "line": 731,
+        "line": 747,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48090,7 +49212,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -48099,7 +49221,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_WEIGHTED_TOKEN_RE",
         "kind": "static_from",
-        "line": 731,
+        "line": 747,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48113,7 +49235,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -48122,7 +49244,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_correct_builder_prompt",
         "kind": "static_from",
-        "line": 731,
+        "line": 747,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48136,7 +49258,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -48145,7 +49267,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_filter_metadata_prompt",
         "kind": "static_from",
-        "line": 731,
+        "line": 747,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48159,7 +49281,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -48168,7 +49290,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_join_prompt_tokens",
         "kind": "static_from",
-        "line": 731,
+        "line": 747,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48182,7 +49304,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -48191,7 +49313,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_metadata_filter_key",
         "kind": "static_from",
-        "line": 731,
+        "line": 747,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48205,7 +49327,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -48214,7 +49336,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_metadata_filter_keys",
         "kind": "static_from",
-        "line": 731,
+        "line": 747,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48228,7 +49350,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -48237,7 +49359,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_prompt_tokens",
         "kind": "static_from",
-        "line": 731,
+        "line": 747,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48251,7 +49373,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -48260,7 +49382,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:PROMPT_DATA_TYPE",
         "kind": "static_from",
-        "line": 744,
+        "line": 760,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48274,7 +49396,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -48283,7 +49405,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_advanced_outputs_from_prompt_data",
         "kind": "static_from",
-        "line": 744,
+        "line": 760,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48297,7 +49419,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -48306,7 +49428,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_apply_prompt_data_overrides",
         "kind": "static_from",
-        "line": 744,
+        "line": 760,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48320,7 +49442,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -48329,7 +49451,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_copy_prompt_data_for_update",
         "kind": "static_from",
-        "line": 744,
+        "line": 760,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48343,7 +49465,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -48352,7 +49474,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_normalize_prompt_data",
         "kind": "static_from",
-        "line": 744,
+        "line": 760,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48366,7 +49488,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -48375,7 +49497,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_prompt_data_json_safe",
         "kind": "static_from",
-        "line": 744,
+        "line": 760,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48389,7 +49511,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -48398,7 +49520,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_prompt_data_parameter_snapshot",
         "kind": "static_from",
-        "line": 744,
+        "line": 760,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48412,7 +49534,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -48421,7 +49543,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_artist_field_prompt",
         "kind": "static_from",
-        "line": 762,
+        "line": 778,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48435,7 +49557,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -48444,7 +49566,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_default_fields",
         "kind": "static_from",
-        "line": 762,
+        "line": 778,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48458,7 +49580,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -48467,7 +49589,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_enabled_naia_panes",
         "kind": "static_from",
-        "line": 762,
+        "line": 778,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48481,7 +49603,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -48490,7 +49612,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_enabled_pane_fields",
         "kind": "static_from",
-        "line": 762,
+        "line": 778,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48504,7 +49626,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -48513,7 +49635,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_field_input_values",
         "kind": "static_from",
-        "line": 762,
+        "line": 778,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48527,7 +49649,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -48536,7 +49658,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_field_socket_name",
         "kind": "static_from",
-        "line": 762,
+        "line": 778,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48550,7 +49672,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -48559,7 +49681,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_fields_json",
         "kind": "static_from",
-        "line": 762,
+        "line": 778,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48573,7 +49695,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -48582,7 +49704,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_has_enabled_naia",
         "kind": "static_from",
-        "line": 762,
+        "line": 778,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48596,7 +49718,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -48605,7 +49727,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_prompt_with_artist_override",
         "kind": "static_from",
-        "line": 762,
+        "line": 778,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48619,7 +49741,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -48628,7 +49750,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_uses_naia_resolution",
         "kind": "static_from",
-        "line": 762,
+        "line": 778,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48642,7 +49764,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -48651,7 +49773,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_apply_advanced_field_inputs",
         "kind": "static_from",
-        "line": 762,
+        "line": 778,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48665,7 +49787,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -48674,7 +49796,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_as_advanced_height",
         "kind": "static_from",
-        "line": 762,
+        "line": 778,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48688,7 +49810,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -48697,7 +49819,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_build_advanced_prompt_data",
         "kind": "static_from",
-        "line": 762,
+        "line": 778,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48711,7 +49833,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -48720,7 +49842,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_build_advanced_prompts",
         "kind": "static_from",
-        "line": 762,
+        "line": 778,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48734,7 +49856,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -48743,7 +49865,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_clone_advanced_fields",
         "kind": "static_from",
-        "line": 762,
+        "line": 778,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48757,7 +49879,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -48766,7 +49888,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_correct_advanced_field_sequence",
         "kind": "static_from",
-        "line": 762,
+        "line": 778,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48780,7 +49902,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -48789,7 +49911,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_expand_advanced_wildcard_fields",
         "kind": "static_from",
-        "line": 762,
+        "line": 778,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48803,7 +49925,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -48812,7 +49934,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_normalize_advanced_fields",
         "kind": "static_from",
-        "line": 762,
+        "line": 778,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48826,7 +49948,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -48835,7 +49957,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_normalize_prompt_studio_wildcard_seed_control",
         "kind": "static_from",
-        "line": 762,
+        "line": 778,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48849,7 +49971,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -48858,7 +49980,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_set_naia_field_text",
         "kind": "static_from",
-        "line": 762,
+        "line": 778,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48872,7 +49994,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -48881,7 +50003,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_translate_prompt_fields",
         "kind": "static_from",
-        "line": 762,
+        "line": 778,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48895,7 +50017,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -48904,7 +50026,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_apply_regional_field_inputs",
         "kind": "static_from",
-        "line": 797,
+        "line": 813,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48918,7 +50040,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -48927,7 +50049,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_build_regional_outputs",
         "kind": "static_from",
-        "line": 797,
+        "line": 813,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48941,7 +50063,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -48950,7 +50072,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_clone_regional_fields",
         "kind": "static_from",
-        "line": 797,
+        "line": 813,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48964,7 +50086,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -48973,7 +50095,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_conditioning_set_values",
         "kind": "static_from",
-        "line": 797,
+        "line": 813,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48987,7 +50109,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -48996,7 +50118,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_mask_ids",
         "kind": "static_from",
-        "line": 797,
+        "line": 813,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49010,7 +50132,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -49019,7 +50141,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_regional_config",
         "kind": "static_from",
-        "line": 797,
+        "line": 813,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49033,7 +50155,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -49042,7 +50164,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_regional_fields",
         "kind": "static_from",
-        "line": 797,
+        "line": 813,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49056,7 +50178,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -49065,7 +50187,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_parse_json_object",
         "kind": "static_from",
-        "line": 797,
+        "line": 813,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49079,7 +50201,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -49088,7 +50210,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_config_json",
         "kind": "static_from",
-        "line": 797,
+        "line": 813,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49102,7 +50224,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -49111,7 +50233,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_fields_json",
         "kind": "static_from",
-        "line": 797,
+        "line": 813,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49125,7 +50247,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -49134,7 +50256,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_mask_bounds_area",
         "kind": "static_from",
-        "line": 797,
+        "line": 813,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49148,7 +50270,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -49157,7 +50279,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_payload_canvas",
         "kind": "static_from",
-        "line": 797,
+        "line": 813,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49171,7 +50293,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -49180,7 +50302,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_union_mask_for_ids",
         "kind": "static_from",
-        "line": 797,
+        "line": 813,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49194,7 +50316,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -49203,7 +50325,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
         "kind": "static_from",
-        "line": 824,
+        "line": 840,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49217,7 +50339,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -49226,7 +50348,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODES",
         "kind": "static_from",
-        "line": 824,
+        "line": 840,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49240,7 +50362,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -49249,7 +50371,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 824,
+        "line": 840,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49263,7 +50385,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -49272,7 +50394,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_PROFILE_OFF",
         "kind": "static_from",
-        "line": 824,
+        "line": 840,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49286,7 +50408,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -49295,7 +50417,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_apply_spectrum_anima_mod_guidance",
         "kind": "static_from",
-        "line": 824,
+        "line": 840,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49309,7 +50431,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -49318,7 +50440,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_find_spectrum_anima_mod_guidance_class",
         "kind": "static_from",
-        "line": 824,
+        "line": 840,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49332,7 +50454,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -49341,7 +50463,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_normalize_anima_mod_guidance_profile",
         "kind": "static_from",
-        "line": 824,
+        "line": 840,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49355,7 +50477,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -49364,7 +50486,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_resolve_anima_mod_guidance_enabled",
         "kind": "static_from",
-        "line": 824,
+        "line": 840,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49378,7 +50500,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -49387,7 +50509,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
         "kind": "static_from",
-        "line": 839,
+        "line": 855,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49401,7 +50523,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -49410,7 +50532,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
         "kind": "static_from",
-        "line": 839,
+        "line": 855,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49424,7 +50546,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -49433,7 +50555,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
         "kind": "static_from",
-        "line": 839,
+        "line": 855,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49447,7 +50569,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -49456,7 +50578,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_EXACT_TOP_K",
         "kind": "static_from",
-        "line": 839,
+        "line": 855,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49470,7 +50592,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -49479,7 +50601,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
         "kind": "static_from",
-        "line": 839,
+        "line": 855,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49493,7 +50615,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -49502,7 +50624,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_START_PERCENT",
         "kind": "static_from",
-        "line": 839,
+        "line": 855,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49516,7 +50638,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -49525,7 +50647,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
         "kind": "static_from",
-        "line": 839,
+        "line": 855,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49539,7 +50661,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -49548,7 +50670,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STYLE_GAIN",
         "kind": "static_from",
-        "line": 839,
+        "line": 855,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49562,7 +50684,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -49571,7 +50693,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_INPUT_MODES",
         "kind": "static_from",
-        "line": 839,
+        "line": 855,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49585,7 +50707,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -49594,7 +50716,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 839,
+        "line": 855,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49608,7 +50730,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -49617,7 +50739,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_mix_inline_prompt",
         "kind": "static_from",
-        "line": 839,
+        "line": 855,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49631,7 +50753,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -49640,7 +50762,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_mix_mode_tooltip",
         "kind": "static_from",
-        "line": 839,
+        "line": 855,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49654,7 +50776,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -49663,7 +50785,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_prompt_with_position",
         "kind": "static_from",
-        "line": 839,
+        "line": 855,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49677,7 +50799,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -49686,7 +50808,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_tags_from_prompt",
         "kind": "static_from",
-        "line": 839,
+        "line": 855,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49700,7 +50822,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -49709,7 +50831,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_blend_conditionings",
         "kind": "static_from",
-        "line": 839,
+        "line": 855,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49723,7 +50845,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -49732,7 +50854,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bounded_artist_mix_float",
         "kind": "static_from",
-        "line": 839,
+        "line": 855,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49746,7 +50868,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -49755,7 +50877,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bounded_artist_mix_int",
         "kind": "static_from",
-        "line": 839,
+        "line": 855,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49769,7 +50891,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -49778,7 +50900,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_clustered",
         "kind": "static_from",
-        "line": 839,
+        "line": 855,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49792,7 +50914,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -49801,7 +50923,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_delta_rms",
         "kind": "static_from",
-        "line": 839,
+        "line": 855,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49815,7 +50937,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -49824,7 +50946,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_prompt_data_positive_conditioning",
         "kind": "static_from",
-        "line": 839,
+        "line": 855,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49838,7 +50960,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -49847,7 +50969,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_join_artist_mix_source_prompts",
         "kind": "static_from",
-        "line": 839,
+        "line": 855,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49861,7 +50983,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -49870,7 +50992,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_normalize_artist_mix_mode",
         "kind": "static_from",
-        "line": 839,
+        "line": 855,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49884,7 +51006,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -49893,7 +51015,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_normalize_artist_tag_position",
         "kind": "static_from",
-        "line": 839,
+        "line": 855,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49907,7 +51029,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -49916,7 +51038,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_parse_artist_mix_items",
         "kind": "static_from",
-        "line": 839,
+        "line": 855,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49930,7 +51052,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -49939,7 +51061,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaArtistMixConditioning",
         "kind": "static_from",
-        "line": 918,
+        "line": 934,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49953,7 +51075,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -49962,7 +51084,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataConditioning",
         "kind": "static_from",
-        "line": 918,
+        "line": 934,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49976,7 +51098,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -49985,7 +51107,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataUnpack",
         "kind": "static_from",
-        "line": 918,
+        "line": 934,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49999,7 +51121,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -50008,7 +51130,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_ANY_TYPE",
         "kind": "static_from",
-        "line": 923,
+        "line": 939,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50022,7 +51144,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -50031,7 +51153,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_AnyType",
         "kind": "static_from",
-        "line": 923,
+        "line": 939,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50045,7 +51167,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -50054,7 +51176,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_FlexibleOptionalInputType",
         "kind": "static_from",
-        "line": 923,
+        "line": 939,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50068,7 +51190,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -50077,7 +51199,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvanced",
         "kind": "static_from",
-        "line": 928,
+        "line": 944,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50091,7 +51213,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -50100,7 +51222,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvancedV2",
         "kind": "static_from",
-        "line": 928,
+        "line": 944,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50114,7 +51236,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -50123,7 +51245,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:EasyUseAnimaAIOGenerator",
         "kind": "static_from",
-        "line": 933,
+        "line": 949,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50137,7 +51259,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -50146,7 +51268,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:EasyUseAnimaInput",
         "kind": "static_from",
-        "line": 933,
+        "line": 949,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50160,7 +51282,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -50169,7 +51291,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_aio_generation_settings_json",
         "kind": "static_from",
-        "line": 933,
+        "line": 949,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50183,7 +51305,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -50192,7 +51314,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_aio_input_settings_json",
         "kind": "static_from",
-        "line": 933,
+        "line": 949,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50206,7 +51328,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -50215,7 +51337,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_bind_aio_node_runtime",
         "kind": "static_from",
-        "line": 933,
+        "line": 949,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50229,7 +51351,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -50238,7 +51360,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_easy_use_anima_input_signature",
         "kind": "static_from",
-        "line": 933,
+        "line": 949,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50252,7 +51374,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -50261,7 +51383,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_require_easy_use_anima_input",
         "kind": "static_from",
-        "line": 933,
+        "line": 949,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50275,7 +51397,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -50284,7 +51406,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_align_down",
         "kind": "static_from",
-        "line": 942,
+        "line": 958,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50298,7 +51420,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -50307,7 +51429,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_align_nearest",
         "kind": "static_from",
-        "line": 942,
+        "line": 958,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50321,7 +51443,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -50330,7 +51452,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_image_tensor_size",
         "kind": "static_from",
-        "line": 942,
+        "line": 958,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50344,7 +51466,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -50353,7 +51475,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_context_value",
         "kind": "static_from",
-        "line": 953,
+        "line": 969,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50367,7 +51489,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -50376,7 +51498,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_sam3_context",
         "kind": "static_from",
-        "line": 953,
+        "line": 969,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50390,7 +51512,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -50399,7 +51521,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_segs_has_items",
         "kind": "static_from",
-        "line": 953,
+        "line": 969,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50413,7 +51535,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -50422,7 +51544,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:IMAGE_SCALE_MULTIPLES",
         "kind": "static_from",
-        "line": 965,
+        "line": 981,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50436,7 +51558,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -50445,7 +51567,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:IMAGE_UPSCALE_METHODS",
         "kind": "static_from",
-        "line": 965,
+        "line": 981,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50459,7 +51581,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -50468,7 +51590,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_sampler_names",
         "kind": "static_from",
-        "line": 973,
+        "line": 989,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50482,7 +51604,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -50491,7 +51613,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_scheduler_names",
         "kind": "static_from",
-        "line": 973,
+        "line": 989,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50505,7 +51627,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -50514,7 +51636,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_impact_scheduler_names",
         "kind": "static_from",
-        "line": 973,
+        "line": 989,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50528,7 +51650,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -50537,7 +51659,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_call_with_supported_kwargs",
         "kind": "static_from",
-        "line": 979,
+        "line": 995,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50551,7 +51673,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -50560,7 +51682,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_common_upscale_image",
         "kind": "static_from",
-        "line": 979,
+        "line": 995,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50574,7 +51696,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -50583,7 +51705,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_node_output_tuple",
         "kind": "static_from",
-        "line": 979,
+        "line": 995,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50597,7 +51719,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -50606,7 +51728,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.wiring:resolve_comfy_host_helper",
         "kind": "static_from",
-        "line": 984,
+        "line": 1000,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50620,7 +51742,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -50629,7 +51751,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_clip_loader_types",
         "kind": "static_from",
-        "line": 987,
+        "line": 1003,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50643,7 +51765,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -50652,7 +51774,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_diffusion_model_names",
         "kind": "static_from",
-        "line": 987,
+        "line": 1003,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50666,7 +51788,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -50675,7 +51797,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_text_encoder_names",
         "kind": "static_from",
-        "line": 987,
+        "line": 1003,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50689,7 +51811,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -50698,7 +51820,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_vae_names",
         "kind": "static_from",
-        "line": 987,
+        "line": 1003,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50712,7 +51834,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -50721,7 +51843,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_folder_path_names",
         "kind": "static_from",
-        "line": 987,
+        "line": 1003,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50735,7 +51857,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -50744,7 +51866,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.image_nodes:EasyUseAnimaDetailerAlignHook",
         "kind": "static_from",
-        "line": 995,
+        "line": 1011,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50758,7 +51880,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -50767,7 +51889,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.image_nodes:EasyUseAnimaImageScaleByMultiple",
         "kind": "static_from",
-        "line": 995,
+        "line": 1011,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50781,7 +51903,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -50790,7 +51912,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Context",
         "kind": "static_from",
-        "line": 999,
+        "line": 1015,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50804,7 +51926,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -50813,7 +51935,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Detailer",
         "kind": "static_from",
-        "line": 999,
+        "line": 1015,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50827,7 +51949,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -50836,7 +51958,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptBuilder",
         "kind": "static_from",
-        "line": 1003,
+        "line": 1019,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50850,7 +51972,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -50859,7 +51981,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrector",
         "kind": "static_from",
-        "line": 1003,
+        "line": 1019,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50873,7 +51995,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -50882,7 +52004,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrectorSimple",
         "kind": "static_from",
-        "line": 1003,
+        "line": 1019,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50896,7 +52018,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -50905,7 +52027,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptStudio",
         "kind": "static_from",
-        "line": 1003,
+        "line": 1019,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50919,7 +52041,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -50928,7 +52050,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:EasyUseAnimaPromptStudioRegional",
         "kind": "static_from",
-        "line": 1009,
+        "line": 1025,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50942,7 +52064,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -50951,7 +52073,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:EasyUseAnimaRegionalConditioning",
         "kind": "static_from",
-        "line": 1009,
+        "line": 1025,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50965,7 +52087,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -50974,7 +52096,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:LATENT_ALIGN",
         "kind": "static_from",
-        "line": 1013,
+        "line": 1029,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50988,7 +52110,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -50997,7 +52119,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_parse_random_response",
         "kind": "static_from",
-        "line": 1013,
+        "line": 1029,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51011,7 +52133,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -51020,7 +52142,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_post_random",
         "kind": "static_from",
-        "line": 1013,
+        "line": 1029,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51034,7 +52156,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -51043,7 +52165,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_advanced_resolution_from_selection",
         "kind": "static_from",
-        "line": 1031,
+        "line": 1047,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51057,7 +52179,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -51066,7 +52188,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_normalize_resolution_bucket",
         "kind": "static_from",
-        "line": 1031,
+        "line": 1047,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51080,7 +52202,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -51089,7 +52211,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_ratio_label",
         "kind": "static_from",
-        "line": 1031,
+        "line": 1047,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51103,7 +52225,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -51112,7 +52234,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolution_label",
         "kind": "static_from",
-        "line": 1031,
+        "line": 1047,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51126,7 +52248,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -51135,7 +52257,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolve_naia_resolution",
         "kind": "static_from",
-        "line": 1031,
+        "line": 1047,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51149,7 +52271,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -51158,7 +52280,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.naia_nodes:EasyUseAnimaNAIARandomPrompt",
         "kind": "static_from",
-        "line": 1054,
+        "line": 1070,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51172,7 +52294,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -51181,7 +52303,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.naia_nodes:_bind_naia_node_runtime",
         "kind": "static_from",
-        "line": 1054,
+        "line": 1070,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51195,7 +52317,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -51204,7 +52326,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.wildcard_nodes:EasyUseAnimaWildcard",
         "kind": "static_from",
-        "line": 1058,
+        "line": 1074,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51218,7 +52340,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -51227,7 +52349,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.wildcard_nodes:_bind_wildcard_node_runtime",
         "kind": "static_from",
-        "line": 1058,
+        "line": 1074,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51241,7 +52363,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -51250,7 +52372,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_apply_lora_syntax_format",
         "kind": "static_from",
-        "line": 1063,
+        "line": 1079,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51264,7 +52386,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -51273,7 +52395,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_dedupe_text_values",
         "kind": "static_from",
-        "line": 1063,
+        "line": 1079,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51287,7 +52409,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -51296,7 +52418,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_fallback_lora_path",
         "kind": "static_from",
-        "line": 1063,
+        "line": 1079,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51310,7 +52432,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -51319,7 +52441,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_get_lora_info",
         "kind": "static_from",
-        "line": 1063,
+        "line": 1079,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51333,7 +52455,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -51342,7 +52464,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_get_lora_manager_trigger_words",
         "kind": "static_from",
-        "line": 1063,
+        "line": 1079,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51356,7 +52478,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -51365,7 +52487,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_load_lora_manager_metadata",
         "kind": "static_from",
-        "line": 1063,
+        "line": 1079,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51379,7 +52501,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -51388,7 +52510,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_combo_values",
         "kind": "static_from",
-        "line": 1063,
+        "line": 1079,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51402,7 +52524,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -51411,7 +52533,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_manager_trigger_words_from_metadata",
         "kind": "static_from",
-        "line": 1063,
+        "line": 1079,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51425,7 +52547,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -51434,7 +52556,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_model_exists",
         "kind": "static_from",
-        "line": 1063,
+        "line": 1079,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51448,7 +52570,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -51457,7 +52579,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_stack_name",
         "kind": "static_from",
-        "line": 1063,
+        "line": 1079,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51471,7 +52593,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -51480,7 +52602,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_metadata_json_paths_for_lora",
         "kind": "static_from",
-        "line": 1063,
+        "line": 1079,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51494,7 +52616,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -51503,7 +52625,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_missing_lora_display_name",
         "kind": "static_from",
-        "line": 1063,
+        "line": 1079,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51517,7 +52639,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -51526,7 +52648,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_raise_missing_loras",
         "kind": "static_from",
-        "line": 1063,
+        "line": 1079,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51540,7 +52662,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -51549,7 +52671,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_trigger_words_from_value",
         "kind": "static_from",
-        "line": 1063,
+        "line": 1079,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51563,7 +52685,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -51572,7 +52694,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_correct_style_prompt",
         "kind": "static_from",
-        "line": 1079,
+        "line": 1095,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51586,7 +52708,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -51595,7 +52717,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_format_strength",
         "kind": "static_from",
-        "line": 1079,
+        "line": 1095,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51609,7 +52731,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -51618,7 +52740,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_get_loras_list",
         "kind": "static_from",
-        "line": 1079,
+        "line": 1095,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51632,7 +52754,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -51641,7 +52763,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_load_profile_data",
         "kind": "static_from",
-        "line": 1079,
+        "line": 1095,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51655,7 +52777,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -51664,7 +52786,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_profile_key",
         "kind": "static_from",
-        "line": 1079,
+        "line": 1095,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51678,7 +52800,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -51687,7 +52809,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_select_profile_values",
         "kind": "static_from",
-        "line": 1079,
+        "line": 1095,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51701,7 +52823,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -51710,7 +52832,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_wrap_profile_index",
         "kind": "static_from",
-        "line": 1079,
+        "line": 1095,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51724,7 +52846,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -51733,7 +52855,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.lora_nodes:EasyUseAnimaLoraPreset",
         "kind": "static_from",
-        "line": 1088,
+        "line": 1104,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51747,7 +52869,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -51756,7 +52878,7 @@
         "conditional": true,
         "imported": "anima_prompt:correct_prompt",
         "kind": "static_from",
-        "line": 1091,
+        "line": 1107,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51770,7 +52892,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -51779,7 +52901,7 @@
         "conditional": true,
         "imported": "anima_prompt:load_knowledge_base",
         "kind": "static_from",
-        "line": 1091,
+        "line": 1107,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51793,7 +52915,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -51802,7 +52924,7 @@
         "conditional": true,
         "imported": "anima_prompt.parser:parse_prompt",
         "kind": "static_from",
-        "line": 1092,
+        "line": 1108,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51816,7 +52938,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -51825,7 +52947,7 @@
         "conditional": true,
         "imported": "settings:resolve_metadata_filter_words",
         "kind": "static_from",
-        "line": 1093,
+        "line": 1109,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51839,7 +52961,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -51848,7 +52970,7 @@
         "conditional": true,
         "imported": "settings:resolve_naia_settings",
         "kind": "static_from",
-        "line": 1093,
+        "line": 1109,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51862,7 +52984,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -51871,7 +52993,7 @@
         "conditional": true,
         "imported": "settings:resolve_prompt_translation_settings",
         "kind": "static_from",
-        "line": 1093,
+        "line": 1109,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51885,7 +53007,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -51894,7 +53016,7 @@
         "conditional": true,
         "imported": "prompt_translation:has_prompt_translation_markers",
         "kind": "static_from",
-        "line": 1098,
+        "line": 1114,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51908,7 +53030,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -51917,7 +53039,7 @@
         "conditional": true,
         "imported": "prompt_translation:translate_prompt_markers",
         "kind": "static_from",
-        "line": 1098,
+        "line": 1114,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51931,7 +53053,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -51940,7 +53062,7 @@
         "conditional": true,
         "imported": "wildcard_engine:MAX_SEED",
         "kind": "static_from",
-        "line": 1099,
+        "line": 1115,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51954,7 +53076,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -51963,7 +53085,7 @@
         "conditional": true,
         "imported": "wildcard_engine:PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "kind": "static_from",
-        "line": 1099,
+        "line": 1115,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51977,7 +53099,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -51986,7 +53108,7 @@
         "conditional": true,
         "imported": "wildcard_engine:PUBLIC_MAX_SEED",
         "kind": "static_from",
-        "line": 1099,
+        "line": 1115,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52000,7 +53122,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -52009,7 +53131,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_DECREMENT",
         "kind": "static_from",
-        "line": 1099,
+        "line": 1115,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52023,7 +53145,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -52032,7 +53154,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_FIXED",
         "kind": "static_from",
-        "line": 1099,
+        "line": 1115,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52046,7 +53168,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -52055,7 +53177,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_INCREMENT",
         "kind": "static_from",
-        "line": 1099,
+        "line": 1115,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52069,7 +53191,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -52078,7 +53200,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_MODES",
         "kind": "static_from",
-        "line": 1099,
+        "line": 1115,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52092,7 +53214,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -52101,7 +53223,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_RANDOMIZE",
         "kind": "static_from",
-        "line": 1099,
+        "line": 1115,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52115,7 +53237,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -52124,7 +53246,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_FIXED",
         "kind": "static_from",
-        "line": 1099,
+        "line": 1115,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52138,7 +53260,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -52147,7 +53269,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_POPULATE",
         "kind": "static_from",
-        "line": 1099,
+        "line": 1115,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52161,7 +53283,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -52170,7 +53292,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_SEQUENTIAL",
         "kind": "static_from",
-        "line": 1099,
+        "line": 1115,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52184,7 +53306,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -52193,7 +53315,7 @@
         "conditional": true,
         "imported": "wildcard_engine:expand_wildcard_texts",
         "kind": "static_from",
-        "line": 1099,
+        "line": 1115,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52207,7 +53329,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -52216,7 +53338,7 @@
         "conditional": true,
         "imported": "wildcard_engine:expand_wildcards",
         "kind": "static_from",
-        "line": 1099,
+        "line": 1115,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52230,7 +53352,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -52239,7 +53361,7 @@
         "conditional": true,
         "imported": "wildcard_engine:has_wildcard_syntax",
         "kind": "static_from",
-        "line": 1099,
+        "line": 1115,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52253,7 +53375,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -52262,7 +53384,7 @@
         "conditional": true,
         "imported": "wildcard_engine:next_seed",
         "kind": "static_from",
-        "line": 1099,
+        "line": 1115,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52276,7 +53398,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -52285,7 +53407,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_prompt_studio_wildcard_mode",
         "kind": "static_from",
-        "line": 1099,
+        "line": 1115,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52299,7 +53421,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -52308,7 +53430,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_seed",
         "kind": "static_from",
-        "line": 1099,
+        "line": 1115,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52322,7 +53444,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -52331,7 +53453,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_wildcard_mode",
         "kind": "static_from",
-        "line": 1099,
+        "line": 1115,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52345,7 +53467,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 564,
+            "handler_line": 572,
             "kind": "try",
             "line": 8
           }
@@ -52354,7 +53476,7 @@
         "conditional": true,
         "imported": "wildcard_engine:wildcard_sources_signature",
         "kind": "static_from",
-        "line": 1099,
+        "line": 1115,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53871,7 +54993,7 @@
         "branch_context": [],
         "classification": "external",
         "conditional": false,
-        "imported": "os",
+        "imported": "logging",
         "kind": "static_import",
         "line": 5,
         "optional": false,
@@ -53882,8 +55004,8 @@
         "branch_context": [],
         "classification": "external",
         "conditional": false,
-        "imported": "collections.abc:Callable",
-        "kind": "static_from",
+        "imported": "os",
+        "kind": "static_import",
         "line": 6,
         "optional": false,
         "role": "ordinary",
@@ -53901,31 +55023,20 @@
         "source": "easyuse_anima/aio/output.py"
       },
       {
-        "branch_context": [],
-        "classification": "external",
-        "conditional": false,
-        "imported": "typing:TypeAlias",
-        "kind": "static_from",
-        "line": 7,
-        "optional": false,
-        "role": "ordinary",
-        "source": "easyuse_anima/aio/output.py"
-      },
-      {
         "branch_context": [
           {
             "branch": "body",
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 124
+            "line": 136
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 125,
+        "line": 137,
         "optional": true,
         "role": "optional_dependency",
         "source": "easyuse_anima/aio/output.py"
@@ -54022,7 +55133,7 @@
         "branch_context": [],
         "classification": "external",
         "conditional": false,
-        "imported": "os",
+        "imported": "logging",
         "kind": "static_import",
         "line": 5,
         "optional": false,
@@ -54033,7 +55144,7 @@
         "branch_context": [],
         "classification": "external",
         "conditional": false,
-        "imported": "random",
+        "imported": "os",
         "kind": "static_import",
         "line": 6,
         "optional": false,
@@ -54044,8 +55155,8 @@
         "branch_context": [],
         "classification": "external",
         "conditional": false,
-        "imported": "collections.abc:Callable",
-        "kind": "static_from",
+        "imported": "random",
+        "kind": "static_import",
         "line": 7,
         "optional": false,
         "role": "ordinary",
@@ -54063,31 +55174,20 @@
         "source": "easyuse_anima/aio/preview.py"
       },
       {
-        "branch_context": [],
-        "classification": "external",
-        "conditional": false,
-        "imported": "typing:TypeAlias",
-        "kind": "static_from",
-        "line": 8,
-        "optional": false,
-        "role": "ordinary",
-        "source": "easyuse_anima/aio/preview.py"
-      },
-      {
         "branch_context": [
           {
             "branch": "body",
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 44
+            "line": 46
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 45,
+        "line": 47,
         "optional": true,
         "role": "optional_dependency",
         "source": "easyuse_anima/aio/preview.py"
@@ -54183,31 +55283,9 @@
         "branch_context": [],
         "classification": "external",
         "conditional": false,
-        "imported": "collections.abc:Callable",
-        "kind": "static_from",
-        "line": 5,
-        "optional": false,
-        "role": "ordinary",
-        "source": "easyuse_anima/aio/resources.py"
-      },
-      {
-        "branch_context": [],
-        "classification": "external",
-        "conditional": false,
         "imported": "typing:Any",
         "kind": "static_from",
-        "line": 6,
-        "optional": false,
-        "role": "ordinary",
-        "source": "easyuse_anima/aio/resources.py"
-      },
-      {
-        "branch_context": [],
-        "classification": "external",
-        "conditional": false,
-        "imported": "typing:TypeAlias",
-        "kind": "static_from",
-        "line": 6,
+        "line": 5,
         "optional": false,
         "role": "ordinary",
         "source": "easyuse_anima/aio/resources.py"
@@ -54217,7 +55295,7 @@
           {
             "branch": "body",
             "kind": "if",
-            "line": 197,
+            "line": 212,
             "type_checking": false
           },
           {
@@ -54225,14 +55303,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 198
+            "line": 213
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "comfy_extras.nodes_upscale_model:UpscaleModelLoader",
         "kind": "static_from",
-        "line": 199,
+        "line": 214,
         "optional": true,
         "role": "optional_dependency",
         "source": "easyuse_anima/aio/resources.py"
@@ -57005,14 +58083,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 124
+            "line": 136
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 125,
+        "line": 137,
         "optional": true,
         "role": "optional_dependency",
         "source": "easyuse_anima/aio/output.py"
@@ -57024,14 +58102,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 44
+            "line": 46
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 45,
+        "line": 47,
         "optional": true,
         "role": "optional_dependency",
         "source": "easyuse_anima/aio/preview.py"
@@ -57117,7 +58195,7 @@
           {
             "branch": "body",
             "kind": "if",
-            "line": 197,
+            "line": 212,
             "type_checking": false
           },
           {
@@ -57125,14 +58203,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 198
+            "line": 213
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "comfy_extras.nodes_upscale_model:UpscaleModelLoader",
         "kind": "static_from",
-        "line": 199,
+        "line": 214,
         "optional": true,
         "role": "optional_dependency",
         "source": "easyuse_anima/aio/resources.py"
@@ -57830,6 +58908,7 @@
       "easyuse_anima/aio/generation_sampling.py",
       "easyuse_anima/aio/generation_settings.py",
       "easyuse_anima/aio/generation_values.py",
+      "easyuse_anima/aio/input_defaults.py",
       "easyuse_anima/aio/legacy_generation.py",
       "easyuse_anima/aio/model_preparation.py",
       "easyuse_anima/aio/output.py",
@@ -57923,6 +59002,7 @@
       "easyuse_anima/aio/generation_sampling.py",
       "easyuse_anima/aio/generation_settings.py",
       "easyuse_anima/aio/generation_values.py",
+      "easyuse_anima/aio/input_defaults.py",
       "easyuse_anima/aio/legacy_generation.py",
       "easyuse_anima/aio/model_preparation.py",
       "easyuse_anima/aio/output.py",
@@ -58774,8 +59854,26 @@
         "column": 9,
         "context": "assign:logger",
         "kind": "import_time_call",
+        "line": 21,
+        "module": "easyuse_anima/aio/output.py",
+        "scope": "<module>"
+      },
+      {
+        "callee": "logging.getLogger",
+        "column": 9,
+        "context": "assign:logger",
+        "kind": "import_time_call",
         "line": 14,
         "module": "easyuse_anima/aio/postprocess.py",
+        "scope": "<module>"
+      },
+      {
+        "callee": "logging.getLogger",
+        "column": 9,
+        "context": "assign:logger",
+        "kind": "import_time_call",
+        "line": 28,
+        "module": "easyuse_anima/aio/preview.py",
         "scope": "<module>"
       },
       {
@@ -59053,7 +60151,7 @@
         "column": 9,
         "context": "assign:logger",
         "kind": "import_time_call",
-        "line": 1121,
+        "line": 1137,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -59062,16 +60160,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1182,
-        "module": "nodes.py",
-        "scope": "<module>"
-      },
-      {
-        "callee": "_bind_aio_resource_runtime",
-        "column": 0,
-        "context": "expression",
-        "kind": "import_time_call",
-        "line": 1188,
+        "line": 1143,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -59080,7 +60169,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1194,
+        "line": 1149,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -59089,25 +60178,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1200,
-        "module": "nodes.py",
-        "scope": "<module>"
-      },
-      {
-        "callee": "_bind_aio_preview_runtime",
-        "column": 0,
-        "context": "expression",
-        "kind": "import_time_call",
-        "line": 1206,
-        "module": "nodes.py",
-        "scope": "<module>"
-      },
-      {
-        "callee": "_bind_aio_output_runtime",
-        "column": 0,
-        "context": "expression",
-        "kind": "import_time_call",
-        "line": 1212,
+        "line": 1155,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -59116,7 +60187,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1218,
+        "line": 1161,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -59125,7 +60196,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1224,
+        "line": 1167,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -59134,7 +60205,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1227,
+        "line": 1170,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -59143,7 +60214,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1234,
+        "line": 1177,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -59513,7 +60584,13 @@
       },
       {
         "kind": "dict",
-        "line": 10,
+        "line": 49,
+        "module": "easyuse_anima/aio/input_defaults.py",
+        "name": "AIO_INPUT_DEFAULT_SETTINGS"
+      },
+      {
+        "kind": "dict",
+        "line": 15,
         "module": "easyuse_anima/aio/preview.py",
         "name": "AIO_PREVIEW_STAGE_LABELS"
       },
@@ -59660,12 +60737,6 @@
         "line": 65,
         "module": "easyuse_anima/seed/reservation.py",
         "name": "_LEGACY_SELECTION_BY_SEED"
-      },
-      {
-        "kind": "dict",
-        "line": 1168,
-        "module": "nodes.py",
-        "name": "AIO_INPUT_DEFAULT_SETTINGS"
       },
       {
         "kind": "set",

--- a/tests/fixtures/python_compatibility_surface.v1.json
+++ b/tests/fixtures/python_compatibility_surface.v1.json
@@ -111,14 +111,14 @@
   "expected_counts": {
     "root_entrypoints": 3,
     "excluded_preamble_implementation_bindings": 3,
-    "nodes_canonical_bindings": 290,
+    "nodes_canonical_bindings": 296,
     "nodes_legacy_bindings": 27,
     "mapped_public_classes": 18,
     "unmapped_classes": 2,
     "root_residual_functions": 0,
     "root_residual_classes": 0,
-    "root_residual_globals": 12,
-    "runtime_binders": 10,
+    "root_residual_globals": 3,
+    "runtime_binders": 7,
     "direct_nodes_import_test_files": 21
   },
   "mapped_public_classes": [
@@ -152,11 +152,8 @@
   },
   "runtime_binders": [
     "_bind_aio_legacy_generation_runtime",
-    "_bind_aio_resource_runtime",
     "_bind_aio_model_preparation_runtime",
     "_bind_aio_sampling_runtime",
-    "_bind_aio_preview_runtime",
-    "_bind_aio_output_runtime",
     "_bind_aio_conditioning_runtime",
     "_bind_aio_node_runtime",
     "_bind_wildcard_node_runtime",
@@ -164,24 +161,10 @@
   ],
   "runtime_resolver_consumers": {
     "AIO_GENERATION_DEFAULT_SETTINGS": [
-      "easyuse_anima.aio.output",
       "easyuse_anima.nodes.aio_nodes"
     ],
     "AIO_INPUT_DEFAULT_SETTINGS": [
-      "easyuse_anima.aio.resources",
       "easyuse_anima.nodes.aio_nodes"
-    ],
-    "AIO_PREVIEW_CACHE_FORMAT": [
-      "easyuse_anima.aio.preview"
-    ],
-    "AIO_PREVIEW_CACHE_QUALITY": [
-      "easyuse_anima.aio.preview"
-    ],
-    "AIO_PREVIEW_EVENT": [
-      "easyuse_anima.aio.preview"
-    ],
-    "AIO_PREVIEW_STAGE_LABELS": [
-      "easyuse_anima.aio.preview"
     ],
     "AIO_SPECIAL_SEEDS": [
       "easyuse_anima.aio.sampling",
@@ -194,22 +177,13 @@
     "AIO_USDU_PROMPT_NO_GENERAL": [
       "easyuse_anima.aio.conditioning"
     ],
-    "ANIMA_CLIP_DEVICES": [
-      "easyuse_anima.aio.resources"
-    ],
-    "ANIMA_CLIP_TYPES": [
-      "easyuse_anima.aio.resources"
-    ],
     "ANIMA_DEFAULT_CLIP_CANDIDATES": [
-      "easyuse_anima.aio.resources",
       "easyuse_anima.nodes.aio_nodes"
     ],
     "ANIMA_DEFAULT_DIFFUSION_MODEL_CANDIDATES": [
-      "easyuse_anima.aio.resources",
       "easyuse_anima.nodes.aio_nodes"
     ],
     "ANIMA_DEFAULT_VAE_CANDIDATES": [
-      "easyuse_anima.aio.resources",
       "easyuse_anima.nodes.aio_nodes"
     ],
     "ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE": [
@@ -219,15 +193,10 @@
       "easyuse_anima.aio.legacy_generation",
       "easyuse_anima.aio.sampling"
     ],
-    "ANIMA_UNET_WEIGHT_DTYPES": [
-      "easyuse_anima.aio.resources"
-    ],
     "EASY_USE_ANIMA_INPUT_SCHEMA": [
-      "easyuse_anima.aio.resources",
       "easyuse_anima.nodes.aio_nodes"
     ],
     "EASY_USE_ANIMA_INPUT_SETTINGS_VERSION": [
-      "easyuse_anima.aio.resources",
       "easyuse_anima.nodes.aio_nodes"
     ],
     "EASY_USE_ANIMA_INPUT_TYPE": [
@@ -247,18 +216,6 @@
     ],
     "SEED_CONTROL_FIXED": [
       "easyuse_anima.aio.sampling"
-    ],
-    "_adapter_comfy_clip_loader_types": [
-      "easyuse_anima.aio.resources"
-    ],
-    "_adapter_comfy_diffusion_model_names": [
-      "easyuse_anima.aio.resources"
-    ],
-    "_adapter_comfy_text_encoder_names": [
-      "easyuse_anima.aio.resources"
-    ],
-    "_adapter_comfy_vae_names": [
-      "easyuse_anima.aio.resources"
     ],
     "_advanced_artist_field_prompt": [
       "easyuse_anima.aio.conditioning"
@@ -284,32 +241,14 @@
     "_aio_highres_effective_backend": [
       "easyuse_anima.aio.legacy_generation"
     ],
-    "_aio_image_saver_additional_hashes": [
-      "easyuse_anima.aio.output"
-    ],
-    "_aio_image_saver_civitai_hash_fetcher_entries": [
-      "easyuse_anima.aio.output"
-    ],
     "_aio_input_settings_json": [
       "easyuse_anima.nodes.aio_nodes"
-    ],
-    "_aio_lora_metadata_name": [
-      "easyuse_anima.aio.output"
     ],
     "_aio_lora_stack_signature": [
       "easyuse_anima.nodes.aio_nodes"
     ],
-    "_aio_preview_base_directory": [
-      "easyuse_anima.aio.preview"
-    ],
-    "_aio_preview_file_size_bytes": [
-      "easyuse_anima.aio.preview"
-    ],
     "_aio_prompt_data_fields_for_usdu": [
       "easyuse_anima.aio.conditioning"
-    ],
-    "_aio_prompt_with_lora_metadata": [
-      "easyuse_anima.aio.output"
     ],
     "_aio_save_filename_prefix": [
       "easyuse_anima.aio.legacy_generation"
@@ -357,28 +296,21 @@
       "easyuse_anima.aio.conditioning",
       "easyuse_anima.aio.legacy_generation",
       "easyuse_anima.aio.model_preparation",
-      "easyuse_anima.aio.output",
       "easyuse_anima.aio.sampling"
     ],
     "_as_float": [
       "easyuse_anima.aio.legacy_generation",
       "easyuse_anima.aio.model_preparation",
-      "easyuse_anima.aio.output",
       "easyuse_anima.aio.sampling"
     ],
     "_as_int": [
       "easyuse_anima.aio.legacy_generation",
       "easyuse_anima.aio.model_preparation",
-      "easyuse_anima.aio.output",
-      "easyuse_anima.aio.resources",
       "easyuse_anima.aio.sampling"
     ],
     "_call_with_supported_kwargs": [
       "easyuse_anima.aio.model_preparation",
       "easyuse_anima.aio.sampling"
-    ],
-    "_choice": [
-      "easyuse_anima.aio.resources"
     ],
     "_cleanup_aio_ephemeral_model": [
       "easyuse_anima.aio.legacy_generation"
@@ -416,12 +348,6 @@
     "_encode_prompt_data_positive_conditioning": [
       "easyuse_anima.aio.legacy_generation"
     ],
-    "_folder_path_names": [
-      "easyuse_anima.aio.resources"
-    ],
-    "_format_strength": [
-      "easyuse_anima.aio.output"
-    ],
     "_generate_empty_latent_with_comfy": [
       "easyuse_anima.aio.legacy_generation"
     ],
@@ -429,8 +355,7 @@
       "easyuse_anima.aio.legacy_generation"
     ],
     "_image_tensor_size": [
-      "easyuse_anima.aio.legacy_generation",
-      "easyuse_anima.aio.preview"
+      "easyuse_anima.aio.legacy_generation"
     ],
     "_json_clone": [
       "easyuse_anima.aio.sampling",
@@ -442,26 +367,11 @@
     "_load_aio_sam3_context": [
       "easyuse_anima.aio.legacy_generation"
     ],
-    "_load_checkpoint_with_comfy": [
-      "easyuse_anima.aio.resources"
-    ],
-    "_load_clip_with_comfy": [
-      "easyuse_anima.aio.resources"
-    ],
-    "_load_diffusion_model_with_comfy": [
-      "easyuse_anima.aio.resources"
-    ],
     "_load_upscale_model_with_comfy": [
       "easyuse_anima.aio.legacy_generation"
     ],
-    "_load_vae_with_comfy": [
-      "easyuse_anima.aio.resources"
-    ],
     "_lora_stack_name": [
       "easyuse_anima.aio.model_preparation"
-    ],
-    "_merge_versioned_settings": [
-      "easyuse_anima.aio.resources"
     ],
     "_new_aio_random_seed": [
       "easyuse_anima.aio.sampling"
@@ -469,24 +379,16 @@
     "_node_output_tuple": [
       "easyuse_anima.aio.legacy_generation",
       "easyuse_anima.aio.model_preparation",
-      "easyuse_anima.aio.resources",
       "easyuse_anima.aio.sampling"
     ],
     "_normalize_advanced_fields": [
       "easyuse_anima.aio.conditioning"
     ],
-    "_normalize_aio_civitai_hash_fetchers": [
-      "easyuse_anima.aio.output"
-    ],
     "_normalize_aio_generation_settings": [
       "easyuse_anima.aio.legacy_generation",
       "easyuse_anima.nodes.aio_nodes"
     ],
-    "_normalize_aio_hash_bundles": [
-      "easyuse_anima.aio.output"
-    ],
     "_normalize_aio_input_settings": [
-      "easyuse_anima.aio.resources",
       "easyuse_anima.nodes.aio_nodes"
     ],
     "_normalize_aio_lora_stack": [
@@ -515,7 +417,6 @@
     ],
     "_prompt_data_json_safe": [
       "easyuse_anima.aio.legacy_generation",
-      "easyuse_anima.aio.preview",
       "easyuse_anima.nodes.aio_nodes"
     ],
     "_put_aio_first_pass_cache": [
@@ -529,7 +430,6 @@
     ],
     "_resolve_aio_runtime_seed": [
       "easyuse_anima.aio.legacy_generation",
-      "easyuse_anima.aio.output",
       "easyuse_anima.aio.sampling",
       "easyuse_anima.nodes.aio_nodes"
     ],
@@ -560,9 +460,6 @@
     "_run_aio_usdu_upscale_stage": [
       "easyuse_anima.aio.legacy_generation"
     ],
-    "_sam3_context": [
-      "easyuse_anima.aio.resources"
-    ],
     "_sample_latent_with_aio_backend": [
       "easyuse_anima.aio.legacy_generation"
     ],
@@ -591,51 +488,43 @@
       "easyuse_anima.aio.legacy_generation"
     ],
     "_single_value": [
-      "easyuse_anima.aio.legacy_generation",
-      "easyuse_anima.aio.output",
-      "easyuse_anima.aio.preview"
+      "easyuse_anima.aio.legacy_generation"
     ],
     "_stable_change_key": [
       "easyuse_anima.nodes.aio_nodes"
     ],
     "_tag_aio_preview_images": [
-      "easyuse_anima.aio.legacy_generation",
-      "easyuse_anima.aio.preview"
+      "easyuse_anima.aio.legacy_generation"
     ],
     "logger": [
       "easyuse_anima.aio.legacy_generation",
-      "easyuse_anima.aio.model_preparation",
-      "easyuse_anima.aio.output",
-      "easyuse_anima.aio.preview"
+      "easyuse_anima.aio.model_preparation"
     ]
   },
   "runtime_binder_audit": {
     "summary": {
-      "binder_count": 10,
+      "binder_count": 7,
       "family_count": 2,
       "mode_counts": {
-        "comfy_provider_then_root": 7,
+        "comfy_provider_then_root": 4,
         "root_globals": 1,
         "explicit_callbacks": 2
       },
-      "unique_resolver_names": 140,
-      "unique_root_resolver_names": 136,
+      "unique_resolver_names": 112,
+      "unique_root_resolver_names": 108,
       "unique_provider_resolver_names": 4,
       "unique_direct_root_dependencies": 9,
-      "direct_root_dependency_slots": 16,
-      "provider_consumer_slots": 12,
-      "provider_consumer_modules": 7,
-      "repository_replacement_names": 116,
-      "repository_replacement_files": 12
+      "direct_root_dependency_slots": 13,
+      "provider_consumer_slots": 8,
+      "provider_consumer_modules": 4,
+      "repository_replacement_names": 85,
+      "repository_replacement_files": 8
     },
     "families": {
       "aio": [
         "_bind_aio_legacy_generation_runtime",
-        "_bind_aio_resource_runtime",
         "_bind_aio_model_preparation_runtime",
         "_bind_aio_sampling_runtime",
-        "_bind_aio_preview_runtime",
-        "_bind_aio_output_runtime",
         "_bind_aio_conditioning_runtime",
         "_bind_aio_node_runtime"
       ],
@@ -655,42 +544,10 @@
       ],
       "retired_subgroups": [
         "B-11c30d1_cache_state",
-        "B-11c30d2_normalization_planning"
+        "B-11c30d2_normalization_planning",
+        "B-11c30d3_io_boundary"
       ],
       "subgroups": {
-        "B-11c30d3_io_boundary": {
-          "binders": [
-            "_bind_aio_resource_runtime",
-            "_bind_aio_preview_runtime",
-            "_bind_aio_output_runtime"
-          ],
-          "mode_counts": {
-            "comfy_provider_then_root": 3,
-            "root_globals": 0
-          },
-          "bound_global_slots": 3,
-          "unique_bound_globals": [
-            "_RUNTIME_RESOLVER"
-          ],
-          "root_resolver_slots": 49,
-          "unique_root_resolver_names": 46,
-          "provider_resolver_slots": 4,
-          "unique_provider_resolver_names": 2,
-          "direct_root_dependency_slots": 3,
-          "unique_direct_root_dependencies": 1,
-          "repository_replacement_slots": 45,
-          "unique_repository_replacement_names": 43,
-          "repository_replacement_files": [
-            "tests/test_aio_legacy_generation.py",
-            "tests/test_aio_nodes.py",
-            "tests/test_aio_output.py",
-            "tests/test_aio_preview.py",
-            "tests/test_aio_resources.py",
-            "tests/test_aio_sampling.py",
-            "tests/test_comfy_adapters.py",
-            "tests/test_node_contracts.py"
-          ]
-        },
         "B-11c30d4_execution_services": {
           "binders": [
             "_bind_aio_model_preparation_runtime",
@@ -711,15 +568,13 @@
           "unique_provider_resolver_names": 4,
           "direct_root_dependency_slots": 3,
           "unique_direct_root_dependencies": 1,
-          "repository_replacement_slots": 29,
-          "unique_repository_replacement_names": 24,
+          "repository_replacement_slots": 23,
+          "unique_repository_replacement_names": 21,
           "repository_replacement_files": [
             "tests/test_aio_conditioning.py",
             "tests/test_aio_legacy_generation.py",
             "tests/test_aio_model_preparation.py",
             "tests/test_aio_nodes.py",
-            "tests/test_aio_output.py",
-            "tests/test_aio_resources.py",
             "tests/test_aio_sampling.py",
             "tests/test_node_contracts.py"
           ]
@@ -742,14 +597,11 @@
           "unique_provider_resolver_names": 2,
           "direct_root_dependency_slots": 1,
           "unique_direct_root_dependencies": 1,
-          "repository_replacement_slots": 46,
-          "unique_repository_replacement_names": 46,
+          "repository_replacement_slots": 43,
+          "unique_repository_replacement_names": 43,
           "repository_replacement_files": [
             "tests/test_aio_legacy_generation.py",
             "tests/test_aio_nodes.py",
-            "tests/test_aio_output.py",
-            "tests/test_aio_preview.py",
-            "tests/test_aio_resources.py",
             "tests/test_aio_sampling.py",
             "tests/test_node_contracts.py"
           ]
@@ -772,14 +624,11 @@
           "unique_provider_resolver_names": 0,
           "direct_root_dependency_slots": 0,
           "unique_direct_root_dependencies": 0,
-          "repository_replacement_slots": 30,
-          "unique_repository_replacement_names": 30,
+          "repository_replacement_slots": 28,
+          "unique_repository_replacement_names": 28,
           "repository_replacement_files": [
             "tests/test_aio_legacy_generation.py",
             "tests/test_aio_nodes.py",
-            "tests/test_aio_output.py",
-            "tests/test_aio_preview.py",
-            "tests/test_aio_resources.py",
             "tests/test_aio_sampling.py",
             "tests/test_node_contracts.py"
           ]
@@ -838,21 +687,14 @@
     "root_resolver_names": [
       "AIO_GENERATION_DEFAULT_SETTINGS",
       "AIO_INPUT_DEFAULT_SETTINGS",
-      "AIO_PREVIEW_CACHE_FORMAT",
-      "AIO_PREVIEW_CACHE_QUALITY",
-      "AIO_PREVIEW_EVENT",
-      "AIO_PREVIEW_STAGE_LABELS",
       "AIO_SPECIAL_SEEDS",
       "AIO_USDU_PROMPT_FULL",
       "AIO_USDU_PROMPT_NO_GENERAL",
-      "ANIMA_CLIP_DEVICES",
-      "ANIMA_CLIP_TYPES",
       "ANIMA_DEFAULT_CLIP_CANDIDATES",
       "ANIMA_DEFAULT_DIFFUSION_MODEL_CANDIDATES",
       "ANIMA_DEFAULT_VAE_CANDIDATES",
       "ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
       "ANIMA_MOD_GUIDANCE_PROFILE_OFF",
-      "ANIMA_UNET_WEIGHT_DTYPES",
       "EASY_USE_ANIMA_INPUT_SCHEMA",
       "EASY_USE_ANIMA_INPUT_SETTINGS_VERSION",
       "EASY_USE_ANIMA_INPUT_TYPE",
@@ -861,10 +703,6 @@
       "MAX_SEED",
       "PROMPT_DATA_TYPE",
       "SEED_CONTROL_FIXED",
-      "_adapter_comfy_clip_loader_types",
-      "_adapter_comfy_diffusion_model_names",
-      "_adapter_comfy_text_encoder_names",
-      "_adapter_comfy_vae_names",
       "_advanced_artist_field_prompt",
       "_advanced_enabled_pane_fields",
       "_advanced_outputs_from_prompt_data",
@@ -873,15 +711,9 @@
       "_aio_first_pass_cache_key",
       "_aio_generation_settings_json",
       "_aio_highres_effective_backend",
-      "_aio_image_saver_additional_hashes",
-      "_aio_image_saver_civitai_hash_fetcher_entries",
       "_aio_input_settings_json",
-      "_aio_lora_metadata_name",
       "_aio_lora_stack_signature",
-      "_aio_preview_base_directory",
-      "_aio_preview_file_size_bytes",
       "_aio_prompt_data_fields_for_usdu",
-      "_aio_prompt_with_lora_metadata",
       "_aio_save_filename_prefix",
       "_aio_stage_sampler_settings",
       "_aio_usdu_conditioning",
@@ -900,7 +732,6 @@
       "_as_float",
       "_as_int",
       "_call_with_supported_kwargs",
-      "_choice",
       "_cleanup_aio_ephemeral_model",
       "_comfy_clip_loader_types",
       "_comfy_diffusion_model_names",
@@ -913,27 +744,18 @@
       "_easy_use_anima_input_signature",
       "_encode_image_with_comfy_vae",
       "_encode_prompt_data_positive_conditioning",
-      "_folder_path_names",
-      "_format_strength",
       "_generate_empty_latent_with_comfy",
       "_get_aio_first_pass_cache",
       "_image_tensor_size",
       "_json_clone",
       "_load_aio_resources_from_input_context",
       "_load_aio_sam3_context",
-      "_load_checkpoint_with_comfy",
-      "_load_clip_with_comfy",
-      "_load_diffusion_model_with_comfy",
       "_load_upscale_model_with_comfy",
-      "_load_vae_with_comfy",
       "_lora_stack_name",
-      "_merge_versioned_settings",
       "_new_aio_random_seed",
       "_node_output_tuple",
       "_normalize_advanced_fields",
-      "_normalize_aio_civitai_hash_fetchers",
       "_normalize_aio_generation_settings",
-      "_normalize_aio_hash_bundles",
       "_normalize_aio_input_settings",
       "_normalize_aio_lora_stack",
       "_normalize_aio_seed",
@@ -956,7 +778,6 @@
       "_run_aio_resshift_upscale_stage",
       "_run_aio_upscale_stage",
       "_run_aio_usdu_upscale_stage",
-      "_sam3_context",
       "_sample_latent_with_aio_backend",
       "_sample_latent_with_comfy",
       "_sample_latent_with_spectrum_mod_guidance_advanced",
@@ -981,51 +802,23 @@
     ],
     "repository_root_replacements": {
       "AIO_GENERATION_DEFAULT_SETTINGS": [
-        "tests/test_aio_output.py",
         "tests/test_node_contracts.py"
       ],
       "AIO_INPUT_DEFAULT_SETTINGS": [
         "tests/test_node_contracts.py"
       ],
-      "AIO_PREVIEW_CACHE_FORMAT": [
-        "tests/test_aio_preview.py"
-      ],
-      "AIO_PREVIEW_CACHE_QUALITY": [
-        "tests/test_aio_preview.py"
-      ],
-      "AIO_PREVIEW_EVENT": [
-        "tests/test_aio_preview.py"
-      ],
       "AIO_SPECIAL_SEEDS": [
         "tests/test_aio_nodes.py",
         "tests/test_node_contracts.py"
       ],
-      "ANIMA_CLIP_DEVICES": [
-        "tests/test_node_contracts.py"
-      ],
-      "ANIMA_CLIP_TYPES": [
-        "tests/test_node_contracts.py"
-      ],
       "ANIMA_DEFAULT_CLIP_CANDIDATES": [
-        "tests/test_aio_nodes.py",
-        "tests/test_node_contracts.py"
+        "tests/test_aio_nodes.py"
       ],
       "ANIMA_DEFAULT_DIFFUSION_MODEL_CANDIDATES": [
-        "tests/test_aio_nodes.py",
-        "tests/test_node_contracts.py"
+        "tests/test_aio_nodes.py"
       ],
       "ANIMA_DEFAULT_VAE_CANDIDATES": [
-        "tests/test_aio_nodes.py",
-        "tests/test_node_contracts.py"
-      ],
-      "ANIMA_UNET_WEIGHT_DTYPES": [
-        "tests/test_node_contracts.py"
-      ],
-      "EASY_USE_ANIMA_INPUT_SCHEMA": [
-        "tests/test_node_contracts.py"
-      ],
-      "EASY_USE_ANIMA_INPUT_SETTINGS_VERSION": [
-        "tests/test_node_contracts.py"
+        "tests/test_aio_nodes.py"
       ],
       "EASY_USE_ANIMA_INPUT_TYPE": [
         "tests/test_aio_nodes.py"
@@ -1035,18 +828,6 @@
       ],
       "PROMPT_DATA_TYPE": [
         "tests/test_aio_nodes.py"
-      ],
-      "_adapter_comfy_clip_loader_types": [
-        "tests/test_node_contracts.py"
-      ],
-      "_adapter_comfy_diffusion_model_names": [
-        "tests/test_node_contracts.py"
-      ],
-      "_adapter_comfy_text_encoder_names": [
-        "tests/test_node_contracts.py"
-      ],
-      "_adapter_comfy_vae_names": [
-        "tests/test_node_contracts.py"
       ],
       "_advanced_outputs_from_prompt_data": [
         "tests/test_aio_legacy_generation.py",
@@ -1064,29 +845,11 @@
       "_aio_highres_effective_backend": [
         "tests/test_aio_legacy_generation.py"
       ],
-      "_aio_image_saver_additional_hashes": [
-        "tests/test_aio_output.py"
-      ],
-      "_aio_image_saver_civitai_hash_fetcher_entries": [
-        "tests/test_aio_output.py"
-      ],
       "_aio_input_settings_json": [
         "tests/test_aio_nodes.py"
       ],
-      "_aio_lora_metadata_name": [
-        "tests/test_aio_output.py"
-      ],
       "_aio_lora_stack_signature": [
         "tests/test_aio_nodes.py"
-      ],
-      "_aio_preview_base_directory": [
-        "tests/test_aio_preview.py"
-      ],
-      "_aio_preview_file_size_bytes": [
-        "tests/test_aio_preview.py"
-      ],
-      "_aio_prompt_with_lora_metadata": [
-        "tests/test_aio_output.py"
       ],
       "_aio_save_filename_prefix": [
         "tests/test_aio_legacy_generation.py"
@@ -1131,16 +894,6 @@
       "_as_bool": [
         "tests/test_aio_legacy_generation.py"
       ],
-      "_as_float": [
-        "tests/test_aio_output.py"
-      ],
-      "_as_int": [
-        "tests/test_node_contracts.py"
-      ],
-      "_choice": [
-        "tests/test_aio_resources.py",
-        "tests/test_node_contracts.py"
-      ],
       "_cleanup_aio_ephemeral_model": [
         "tests/test_aio_legacy_generation.py",
         "tests/test_aio_nodes.py"
@@ -1179,13 +932,6 @@
         "tests/test_aio_legacy_generation.py",
         "tests/test_aio_nodes.py"
       ],
-      "_folder_path_names": [
-        "tests/test_comfy_adapters.py",
-        "tests/test_node_contracts.py"
-      ],
-      "_format_strength": [
-        "tests/test_aio_output.py"
-      ],
       "_generate_empty_latent_with_comfy": [
         "tests/test_aio_legacy_generation.py",
         "tests/test_aio_nodes.py"
@@ -1197,8 +943,7 @@
         "tests/test_node_contracts.py"
       ],
       "_image_tensor_size": [
-        "tests/test_aio_legacy_generation.py",
-        "tests/test_aio_preview.py"
+        "tests/test_aio_legacy_generation.py"
       ],
       "_json_clone": [
         "tests/test_aio_nodes.py"
@@ -1210,40 +955,18 @@
       "_load_aio_sam3_context": [
         "tests/test_aio_nodes.py"
       ],
-      "_load_checkpoint_with_comfy": [
-        "tests/test_aio_resources.py"
-      ],
-      "_load_clip_with_comfy": [
-        "tests/test_aio_resources.py"
-      ],
-      "_load_diffusion_model_with_comfy": [
-        "tests/test_aio_resources.py"
-      ],
       "_load_upscale_model_with_comfy": [
         "tests/test_aio_nodes.py"
       ],
-      "_load_vae_with_comfy": [
-        "tests/test_aio_resources.py"
-      ],
-      "_merge_versioned_settings": [
-        "tests/test_node_contracts.py"
-      ],
       "_new_aio_random_seed": [
         "tests/test_node_contracts.py"
-      ],
-      "_node_output_tuple": [
-        "tests/test_aio_resources.py"
       ],
       "_normalize_aio_generation_settings": [
         "tests/test_aio_legacy_generation.py",
         "tests/test_aio_nodes.py"
       ],
-      "_normalize_aio_hash_bundles": [
-        "tests/test_aio_output.py"
-      ],
       "_normalize_aio_input_settings": [
-        "tests/test_aio_nodes.py",
-        "tests/test_aio_resources.py"
+        "tests/test_aio_nodes.py"
       ],
       "_normalize_aio_lora_stack": [
         "tests/test_node_contracts.py"
@@ -1273,8 +996,7 @@
       ],
       "_prompt_data_json_safe": [
         "tests/test_aio_legacy_generation.py",
-        "tests/test_aio_nodes.py",
-        "tests/test_aio_preview.py"
+        "tests/test_aio_nodes.py"
       ],
       "_put_aio_first_pass_cache": [
         "tests/test_aio_legacy_generation.py"
@@ -1289,7 +1011,6 @@
       "_resolve_aio_runtime_seed": [
         "tests/test_aio_legacy_generation.py",
         "tests/test_aio_nodes.py",
-        "tests/test_aio_output.py",
         "tests/test_aio_sampling.py"
       ],
       "_resolve_anima_mod_guidance_enabled": [
@@ -1316,9 +1037,6 @@
       "_run_aio_upscale_stage": [
         "tests/test_aio_legacy_generation.py",
         "tests/test_aio_nodes.py"
-      ],
-      "_sam3_context": [
-        "tests/test_aio_resources.py"
       ],
       "_sample_latent_with_aio_backend": [
         "tests/test_aio_legacy_generation.py",
@@ -1348,15 +1066,13 @@
         "tests/test_aio_nodes.py"
       ],
       "_single_value": [
-        "tests/test_aio_legacy_generation.py",
-        "tests/test_aio_preview.py"
+        "tests/test_aio_legacy_generation.py"
       ],
       "_stable_change_key": [
         "tests/test_aio_nodes.py"
       ],
       "_tag_aio_preview_images": [
-        "tests/test_aio_legacy_generation.py",
-        "tests/test_aio_preview.py"
+        "tests/test_aio_legacy_generation.py"
       ],
       "expand_wildcards": [
         "tests/test_wildcards.py"
@@ -1531,8 +1247,6 @@
           "_apply_aio_spectrum_model_patches_for_comfy_sampler",
           "_apply_spectrum_anima_mod_guidance",
           "_as_bool",
-          "_as_float",
-          "_as_int",
           "_cleanup_aio_ephemeral_model",
           "_decode_latent_with_comfy",
           "_encode_image_with_comfy_vae",
@@ -1543,7 +1257,6 @@
           "_load_aio_resources_from_input_context",
           "_load_aio_sam3_context",
           "_load_upscale_model_with_comfy",
-          "_node_output_tuple",
           "_normalize_aio_generation_settings",
           "_normalize_anima_mod_guidance_profile",
           "_normalize_prompt_data",
@@ -1567,104 +1280,6 @@
           "_tag_aio_preview_images",
           "json",
           "random"
-        ]
-      },
-      {
-        "binder": "_bind_aio_resource_runtime",
-        "module": "easyuse_anima.aio.resources",
-        "family": "aio",
-        "mode": "comfy_provider_then_root",
-        "root_observation": "call_time_resolver",
-        "root_keywords": [
-          "resolve_helper"
-        ],
-        "bound_globals": [
-          "_RUNTIME_RESOLVER"
-        ],
-        "direct_root_dependencies": [
-          "_resolve_comfy_host_helper"
-        ],
-        "resolver_names": [
-          "AIO_INPUT_DEFAULT_SETTINGS",
-          "ANIMA_CLIP_DEVICES",
-          "ANIMA_CLIP_TYPES",
-          "ANIMA_DEFAULT_CLIP_CANDIDATES",
-          "ANIMA_DEFAULT_DIFFUSION_MODEL_CANDIDATES",
-          "ANIMA_DEFAULT_VAE_CANDIDATES",
-          "ANIMA_UNET_WEIGHT_DTYPES",
-          "EASY_USE_ANIMA_INPUT_SCHEMA",
-          "EASY_USE_ANIMA_INPUT_SETTINGS_VERSION",
-          "_adapter_comfy_clip_loader_types",
-          "_adapter_comfy_diffusion_model_names",
-          "_adapter_comfy_text_encoder_names",
-          "_adapter_comfy_vae_names",
-          "_as_int",
-          "_choice",
-          "_find_comfy_node_class",
-          "_folder_path_names",
-          "_load_checkpoint_with_comfy",
-          "_load_clip_with_comfy",
-          "_load_diffusion_model_with_comfy",
-          "_load_vae_with_comfy",
-          "_merge_versioned_settings",
-          "_node_output_tuple",
-          "_normalize_aio_input_settings",
-          "_sam3_context"
-        ],
-        "root_resolver_names": [
-          "AIO_INPUT_DEFAULT_SETTINGS",
-          "ANIMA_CLIP_DEVICES",
-          "ANIMA_CLIP_TYPES",
-          "ANIMA_DEFAULT_CLIP_CANDIDATES",
-          "ANIMA_DEFAULT_DIFFUSION_MODEL_CANDIDATES",
-          "ANIMA_DEFAULT_VAE_CANDIDATES",
-          "ANIMA_UNET_WEIGHT_DTYPES",
-          "EASY_USE_ANIMA_INPUT_SCHEMA",
-          "EASY_USE_ANIMA_INPUT_SETTINGS_VERSION",
-          "_adapter_comfy_clip_loader_types",
-          "_adapter_comfy_diffusion_model_names",
-          "_adapter_comfy_text_encoder_names",
-          "_adapter_comfy_vae_names",
-          "_as_int",
-          "_choice",
-          "_folder_path_names",
-          "_load_checkpoint_with_comfy",
-          "_load_clip_with_comfy",
-          "_load_diffusion_model_with_comfy",
-          "_load_vae_with_comfy",
-          "_merge_versioned_settings",
-          "_node_output_tuple",
-          "_normalize_aio_input_settings",
-          "_sam3_context"
-        ],
-        "provider_resolver_names": [
-          "_find_comfy_node_class"
-        ],
-        "repository_replacement_names": [
-          "AIO_INPUT_DEFAULT_SETTINGS",
-          "ANIMA_CLIP_DEVICES",
-          "ANIMA_CLIP_TYPES",
-          "ANIMA_DEFAULT_CLIP_CANDIDATES",
-          "ANIMA_DEFAULT_DIFFUSION_MODEL_CANDIDATES",
-          "ANIMA_DEFAULT_VAE_CANDIDATES",
-          "ANIMA_UNET_WEIGHT_DTYPES",
-          "EASY_USE_ANIMA_INPUT_SCHEMA",
-          "EASY_USE_ANIMA_INPUT_SETTINGS_VERSION",
-          "_adapter_comfy_clip_loader_types",
-          "_adapter_comfy_diffusion_model_names",
-          "_adapter_comfy_text_encoder_names",
-          "_adapter_comfy_vae_names",
-          "_as_int",
-          "_choice",
-          "_folder_path_names",
-          "_load_checkpoint_with_comfy",
-          "_load_clip_with_comfy",
-          "_load_diffusion_model_with_comfy",
-          "_load_vae_with_comfy",
-          "_merge_versioned_settings",
-          "_node_output_tuple",
-          "_normalize_aio_input_settings",
-          "_sam3_context"
         ]
       },
       {
@@ -1729,9 +1344,6 @@
           "_apply_aio_spectrum_correction_patch_for_comfy_sampler",
           "_apply_aio_spectrum_forecast_patch_for_comfy_sampler",
           "_as_bool",
-          "_as_float",
-          "_as_int",
-          "_node_output_tuple",
           "_normalize_aio_lora_stack",
           "_patch_model_sampling_aura_flow"
         ]
@@ -1803,11 +1415,8 @@
           "AIO_SPECIAL_SEEDS",
           "MAX_SEED",
           "_as_bool",
-          "_as_float",
-          "_as_int",
           "_json_clone",
           "_new_aio_random_seed",
-          "_node_output_tuple",
           "_normalize_aio_seed",
           "_normalize_anima_mod_guidance_profile",
           "_resolve_aio_runtime_seed",
@@ -1815,131 +1424,6 @@
           "_sample_latent_with_spectrum_mod_guidance_advanced",
           "_sample_latent_with_spectrum_spd",
           "random"
-        ]
-      },
-      {
-        "binder": "_bind_aio_preview_runtime",
-        "module": "easyuse_anima.aio.preview",
-        "family": "aio",
-        "mode": "comfy_provider_then_root",
-        "root_observation": "call_time_resolver",
-        "root_keywords": [
-          "resolve_helper"
-        ],
-        "bound_globals": [
-          "_RUNTIME_RESOLVER"
-        ],
-        "direct_root_dependencies": [
-          "_resolve_comfy_host_helper"
-        ],
-        "resolver_names": [
-          "AIO_PREVIEW_CACHE_FORMAT",
-          "AIO_PREVIEW_CACHE_QUALITY",
-          "AIO_PREVIEW_EVENT",
-          "AIO_PREVIEW_STAGE_LABELS",
-          "_aio_preview_base_directory",
-          "_aio_preview_file_size_bytes",
-          "_find_comfy_node_class",
-          "_image_tensor_size",
-          "_prompt_data_json_safe",
-          "_single_value",
-          "_tag_aio_preview_images",
-          "logger"
-        ],
-        "root_resolver_names": [
-          "AIO_PREVIEW_CACHE_FORMAT",
-          "AIO_PREVIEW_CACHE_QUALITY",
-          "AIO_PREVIEW_EVENT",
-          "AIO_PREVIEW_STAGE_LABELS",
-          "_aio_preview_base_directory",
-          "_aio_preview_file_size_bytes",
-          "_image_tensor_size",
-          "_prompt_data_json_safe",
-          "_single_value",
-          "_tag_aio_preview_images",
-          "logger"
-        ],
-        "provider_resolver_names": [
-          "_find_comfy_node_class"
-        ],
-        "repository_replacement_names": [
-          "AIO_PREVIEW_CACHE_FORMAT",
-          "AIO_PREVIEW_CACHE_QUALITY",
-          "AIO_PREVIEW_EVENT",
-          "_aio_preview_base_directory",
-          "_aio_preview_file_size_bytes",
-          "_image_tensor_size",
-          "_prompt_data_json_safe",
-          "_single_value",
-          "_tag_aio_preview_images"
-        ]
-      },
-      {
-        "binder": "_bind_aio_output_runtime",
-        "module": "easyuse_anima.aio.output",
-        "family": "aio",
-        "mode": "comfy_provider_then_root",
-        "root_observation": "call_time_resolver",
-        "root_keywords": [
-          "resolve_helper"
-        ],
-        "bound_globals": [
-          "_RUNTIME_RESOLVER"
-        ],
-        "direct_root_dependencies": [
-          "_resolve_comfy_host_helper"
-        ],
-        "resolver_names": [
-          "AIO_GENERATION_DEFAULT_SETTINGS",
-          "_aio_image_saver_additional_hashes",
-          "_aio_image_saver_civitai_hash_fetcher_entries",
-          "_aio_lora_metadata_name",
-          "_aio_prompt_with_lora_metadata",
-          "_as_bool",
-          "_as_float",
-          "_as_int",
-          "_find_comfy_node_class",
-          "_format_strength",
-          "_normalize_aio_civitai_hash_fetchers",
-          "_normalize_aio_hash_bundles",
-          "_require_custom_node_class",
-          "_resolve_aio_runtime_seed",
-          "_single_value",
-          "logger"
-        ],
-        "root_resolver_names": [
-          "AIO_GENERATION_DEFAULT_SETTINGS",
-          "_aio_image_saver_additional_hashes",
-          "_aio_image_saver_civitai_hash_fetcher_entries",
-          "_aio_lora_metadata_name",
-          "_aio_prompt_with_lora_metadata",
-          "_as_bool",
-          "_as_float",
-          "_as_int",
-          "_format_strength",
-          "_normalize_aio_civitai_hash_fetchers",
-          "_normalize_aio_hash_bundles",
-          "_resolve_aio_runtime_seed",
-          "_single_value",
-          "logger"
-        ],
-        "provider_resolver_names": [
-          "_find_comfy_node_class",
-          "_require_custom_node_class"
-        ],
-        "repository_replacement_names": [
-          "AIO_GENERATION_DEFAULT_SETTINGS",
-          "_aio_image_saver_additional_hashes",
-          "_aio_image_saver_civitai_hash_fetcher_entries",
-          "_aio_lora_metadata_name",
-          "_aio_prompt_with_lora_metadata",
-          "_as_bool",
-          "_as_float",
-          "_as_int",
-          "_format_strength",
-          "_normalize_aio_hash_bundles",
-          "_resolve_aio_runtime_seed",
-          "_single_value"
         ]
       },
       {
@@ -2076,8 +1560,6 @@
           "ANIMA_DEFAULT_CLIP_CANDIDATES",
           "ANIMA_DEFAULT_DIFFUSION_MODEL_CANDIDATES",
           "ANIMA_DEFAULT_VAE_CANDIDATES",
-          "EASY_USE_ANIMA_INPUT_SCHEMA",
-          "EASY_USE_ANIMA_INPUT_SETTINGS_VERSION",
           "EASY_USE_ANIMA_INPUT_TYPE",
           "PROMPT_DATA_TYPE",
           "_aio_generation_settings_json",
@@ -3038,14 +2520,12 @@
       "known_consumers": [
         "canonical runtime resolver: easyuse_anima.aio.conditioning",
         "canonical runtime resolver: easyuse_anima.aio.legacy_generation",
-        "canonical runtime resolver: easyuse_anima.aio.output",
         "canonical runtime resolver: easyuse_anima.aio.sampling",
         "canonical runtime resolver: easyuse_anima.nodes.aio_nodes"
       ],
       "evidence": [
         "AST:easyuse_anima.aio.conditioning string runtime lookup",
         "AST:easyuse_anima.aio.legacy_generation string runtime lookup",
-        "AST:easyuse_anima.aio.output string runtime lookup",
         "AST:easyuse_anima.aio.sampling string runtime lookup",
         "AST:easyuse_anima.nodes.aio_nodes string runtime lookup"
       ],
@@ -3102,7 +2582,6 @@
       "symbols": {
         "_aio_detailer_has_enabled_targets": "_aio_detailer_has_enabled_targets",
         "_aio_detailer_target_order": "_aio_detailer_target_order",
-        "_merge_versioned_settings": "_merge_versioned_settings",
         "_normalize_aio_generation_settings": "_normalize_aio_generation_settings",
         "_normalize_aio_seed": "_normalize_aio_seed"
       },
@@ -3117,13 +2596,11 @@
       "first_release": null,
       "known_consumers": [
         "canonical runtime resolver: easyuse_anima.aio.legacy_generation",
-        "canonical runtime resolver: easyuse_anima.aio.resources",
         "canonical runtime resolver: easyuse_anima.aio.sampling",
         "canonical runtime resolver: easyuse_anima.nodes.aio_nodes"
       ],
       "evidence": [
         "AST:easyuse_anima.aio.legacy_generation string runtime lookup",
-        "AST:easyuse_anima.aio.resources string runtime lookup",
         "AST:easyuse_anima.aio.sampling string runtime lookup",
         "AST:easyuse_anima.nodes.aio_nodes string runtime lookup"
       ],
@@ -3142,6 +2619,7 @@
         "_AIO_DETAILER_RESERVED_KEYS": "_AIO_DETAILER_RESERVED_KEYS",
         "_aio_detailer_target_defaults": "_aio_detailer_target_defaults",
         "_is_aio_detailer_target_name": "_is_aio_detailer_target_name",
+        "_merge_versioned_settings": "_merge_versioned_settings",
         "_normalize_aio_dit_corrections_settings": "_normalize_aio_dit_corrections_settings",
         "_normalize_aio_spectrum_settings": "_normalize_aio_spectrum_settings"
       },
@@ -3181,6 +2659,70 @@
       "identity_requirement": "not_applicable",
       "binding_shape": "direct_import",
       "import_target": "easyuse_anima.aio.generation_settings",
+      "owner": "#184/#188",
+      "first_release": null,
+      "known_consumers": [
+        "repository tests may import this root name"
+      ],
+      "evidence": [
+        "AST:no nodes.py runtime load",
+        "test-only consumption is not public support evidence"
+      ],
+      "removal_gates": [
+        "test imports migrate to canonical targets",
+        "no production consumer evidence",
+        "separate B-10b removal review"
+      ],
+      "lifecycle_state": "unsupported"
+    },
+    {
+      "id": "nodes_canonical_bindings:easyuse_anima.aio.input_defaults:transitional_private_seam",
+      "surface": "nodes_canonical_bindings",
+      "symbols": {
+        "AIO_INPUT_DEFAULT_SETTINGS": "AIO_INPUT_DEFAULT_SETTINGS",
+        "ANIMA_DEFAULT_CLIP_CANDIDATES": "ANIMA_DEFAULT_CLIP_CANDIDATES",
+        "ANIMA_DEFAULT_DIFFUSION_MODEL_CANDIDATES": "ANIMA_DEFAULT_DIFFUSION_MODEL_CANDIDATES",
+        "ANIMA_DEFAULT_VAE_CANDIDATES": "ANIMA_DEFAULT_VAE_CANDIDATES",
+        "EASY_USE_ANIMA_INPUT_SCHEMA": "EASY_USE_ANIMA_INPUT_SCHEMA",
+        "EASY_USE_ANIMA_INPUT_SETTINGS_VERSION": "EASY_USE_ANIMA_INPUT_SETTINGS_VERSION"
+      },
+      "classification": "transitional_private_seam",
+      "current_target": "nodes.py",
+      "canonical_target": "easyuse_anima.aio.input_defaults",
+      "target_state": "canonical",
+      "identity_requirement": "required",
+      "binding_shape": "direct_import",
+      "import_target": "easyuse_anima.aio.input_defaults",
+      "owner": "#184/#188",
+      "first_release": null,
+      "known_consumers": [
+        "canonical runtime resolver: easyuse_anima.nodes.aio_nodes"
+      ],
+      "evidence": [
+        "AST:easyuse_anima.nodes.aio_nodes string runtime lookup"
+      ],
+      "removal_gates": [
+        "canonical production consumer migration",
+        "focused monkeypatch and identity contract review",
+        "separate B-10b or B-11 rollback unit"
+      ],
+      "lifecycle_state": "transitional"
+    },
+    {
+      "id": "nodes_canonical_bindings:easyuse_anima.aio.input_defaults:unsupported_test_only",
+      "surface": "nodes_canonical_bindings",
+      "symbols": {
+        "ANIMA_CLIP_DEVICES": "ANIMA_CLIP_DEVICES",
+        "ANIMA_CLIP_TYPES": "ANIMA_CLIP_TYPES",
+        "ANIMA_UNET_WEIGHT_DTYPES": "ANIMA_UNET_WEIGHT_DTYPES"
+      },
+      "classification": "unsupported_test_only",
+      "current_target": "nodes.py",
+      "canonical_target": "easyuse_anima.aio.input_defaults",
+      "target_state": "canonical",
+      "identity_requirement": "not_applicable",
+      "binding_shape": "direct_import",
+      "import_target": "easyuse_anima.aio.input_defaults",
       "owner": "#184/#188",
       "first_release": null,
       "known_consumers": [
@@ -3286,12 +2828,7 @@
       "id": "nodes_canonical_bindings:easyuse_anima.aio.output:transitional_private_seam",
       "surface": "nodes_canonical_bindings",
       "symbols": {
-        "_aio_image_saver_additional_hashes": "_aio_image_saver_additional_hashes",
-        "_aio_image_saver_civitai_hash_fetcher_entries": "_aio_image_saver_civitai_hash_fetcher_entries",
-        "_aio_lora_metadata_name": "_aio_lora_metadata_name",
-        "_aio_prompt_with_lora_metadata": "_aio_prompt_with_lora_metadata",
         "_aio_save_filename_prefix": "_aio_save_filename_prefix",
-        "_bind_aio_output_runtime": "_bind_aio_output_runtime",
         "_save_image_with_comfy": "_save_image_with_comfy",
         "_save_image_with_image_saver": "_save_image_with_image_saver"
       },
@@ -3305,14 +2842,10 @@
       "owner": "#184/#188",
       "first_release": null,
       "known_consumers": [
-        "nodes.py residual runtime",
-        "canonical runtime resolver: easyuse_anima.aio.legacy_generation",
-        "canonical runtime resolver: easyuse_anima.aio.output"
+        "canonical runtime resolver: easyuse_anima.aio.legacy_generation"
       ],
       "evidence": [
-        "AST:nodes.py direct runtime load",
-        "AST:easyuse_anima.aio.legacy_generation string runtime lookup",
-        "AST:easyuse_anima.aio.output string runtime lookup"
+        "AST:easyuse_anima.aio.legacy_generation string runtime lookup"
       ],
       "removal_gates": [
         "canonical production consumer migration",
@@ -3322,33 +2855,66 @@
       "lifecycle_state": "transitional"
     },
     {
-      "id": "nodes_canonical_bindings:easyuse_anima.aio.output_settings:transitional_private_seam",
+      "id": "nodes_canonical_bindings:easyuse_anima.aio.output:unsupported_test_only",
+      "surface": "nodes_canonical_bindings",
+      "symbols": {
+        "_aio_image_saver_additional_hashes": "_aio_image_saver_additional_hashes",
+        "_aio_image_saver_civitai_hash_fetcher_entries": "_aio_image_saver_civitai_hash_fetcher_entries",
+        "_aio_lora_metadata_name": "_aio_lora_metadata_name",
+        "_aio_prompt_with_lora_metadata": "_aio_prompt_with_lora_metadata"
+      },
+      "classification": "unsupported_test_only",
+      "current_target": "nodes.py",
+      "canonical_target": "easyuse_anima.aio.output",
+      "target_state": "canonical",
+      "identity_requirement": "not_applicable",
+      "binding_shape": "direct_import",
+      "import_target": "easyuse_anima.aio.output",
+      "owner": "#184/#188",
+      "first_release": null,
+      "known_consumers": [
+        "repository tests may import this root name"
+      ],
+      "evidence": [
+        "AST:no nodes.py runtime load",
+        "test-only consumption is not public support evidence"
+      ],
+      "removal_gates": [
+        "test imports migrate to canonical targets",
+        "no production consumer evidence",
+        "separate B-10b removal review"
+      ],
+      "lifecycle_state": "unsupported"
+    },
+    {
+      "id": "nodes_canonical_bindings:easyuse_anima.aio.output_settings:unsupported_test_only",
       "surface": "nodes_canonical_bindings",
       "symbols": {
         "_normalize_aio_civitai_hash_fetchers": "_normalize_aio_civitai_hash_fetchers",
         "_normalize_aio_hash_bundles": "_normalize_aio_hash_bundles"
       },
-      "classification": "transitional_private_seam",
+      "classification": "unsupported_test_only",
       "current_target": "nodes.py",
       "canonical_target": "easyuse_anima.aio.output_settings",
       "target_state": "canonical",
-      "identity_requirement": "required",
+      "identity_requirement": "not_applicable",
       "binding_shape": "direct_import",
       "import_target": "easyuse_anima.aio.output_settings",
       "owner": "#184/#188",
       "first_release": null,
       "known_consumers": [
-        "canonical runtime resolver: easyuse_anima.aio.output"
+        "repository tests may import this root name"
       ],
       "evidence": [
-        "AST:easyuse_anima.aio.output string runtime lookup"
+        "AST:no nodes.py runtime load",
+        "test-only consumption is not public support evidence"
       ],
       "removal_gates": [
-        "canonical production consumer migration",
-        "focused monkeypatch and identity contract review",
-        "separate B-10b or B-11 rollback unit"
+        "test imports migrate to canonical targets",
+        "no production consumer evidence",
+        "separate B-10b removal review"
       ],
-      "lifecycle_state": "transitional"
+      "lifecycle_state": "unsupported"
     },
     {
       "id": "nodes_canonical_bindings:easyuse_anima.aio.postprocess:transitional_private_seam",
@@ -3413,13 +2979,6 @@
       "id": "nodes_canonical_bindings:easyuse_anima.aio.preview:transitional_private_seam",
       "surface": "nodes_canonical_bindings",
       "symbols": {
-        "AIO_PREVIEW_CACHE_FORMAT": "AIO_PREVIEW_CACHE_FORMAT",
-        "AIO_PREVIEW_CACHE_QUALITY": "AIO_PREVIEW_CACHE_QUALITY",
-        "AIO_PREVIEW_EVENT": "AIO_PREVIEW_EVENT",
-        "AIO_PREVIEW_STAGE_LABELS": "AIO_PREVIEW_STAGE_LABELS",
-        "_aio_preview_base_directory": "_aio_preview_base_directory",
-        "_aio_preview_file_size_bytes": "_aio_preview_file_size_bytes",
-        "_bind_aio_preview_runtime": "_bind_aio_preview_runtime",
         "_save_aio_temp_preview_image": "_save_aio_temp_preview_image",
         "_send_aio_preview_event": "_send_aio_preview_event",
         "_tag_aio_preview_images": "_tag_aio_preview_images"
@@ -3434,14 +2993,10 @@
       "owner": "#184/#188",
       "first_release": null,
       "known_consumers": [
-        "nodes.py residual runtime",
-        "canonical runtime resolver: easyuse_anima.aio.legacy_generation",
-        "canonical runtime resolver: easyuse_anima.aio.preview"
+        "canonical runtime resolver: easyuse_anima.aio.legacy_generation"
       ],
       "evidence": [
-        "AST:nodes.py direct runtime load",
-        "AST:easyuse_anima.aio.legacy_generation string runtime lookup",
-        "AST:easyuse_anima.aio.preview string runtime lookup"
+        "AST:easyuse_anima.aio.legacy_generation string runtime lookup"
       ],
       "removal_gates": [
         "canonical production consumer migration",
@@ -3451,21 +3006,50 @@
       "lifecycle_state": "transitional"
     },
     {
+      "id": "nodes_canonical_bindings:easyuse_anima.aio.preview:unsupported_test_only",
+      "surface": "nodes_canonical_bindings",
+      "symbols": {
+        "AIO_PREVIEW_CACHE_FORMAT": "AIO_PREVIEW_CACHE_FORMAT",
+        "AIO_PREVIEW_CACHE_QUALITY": "AIO_PREVIEW_CACHE_QUALITY",
+        "AIO_PREVIEW_EVENT": "AIO_PREVIEW_EVENT",
+        "AIO_PREVIEW_STAGE_LABELS": "AIO_PREVIEW_STAGE_LABELS",
+        "_aio_preview_base_directory": "_aio_preview_base_directory",
+        "_aio_preview_file_size_bytes": "_aio_preview_file_size_bytes"
+      },
+      "classification": "unsupported_test_only",
+      "current_target": "nodes.py",
+      "canonical_target": "easyuse_anima.aio.preview",
+      "target_state": "canonical",
+      "identity_requirement": "not_applicable",
+      "binding_shape": "direct_import",
+      "import_target": "easyuse_anima.aio.preview",
+      "owner": "#184/#188",
+      "first_release": null,
+      "known_consumers": [
+        "repository tests may import this root name"
+      ],
+      "evidence": [
+        "AST:no nodes.py runtime load",
+        "test-only consumption is not public support evidence"
+      ],
+      "removal_gates": [
+        "test imports migrate to canonical targets",
+        "no production consumer evidence",
+        "separate B-10b removal review"
+      ],
+      "lifecycle_state": "unsupported"
+    },
+    {
       "id": "nodes_canonical_bindings:easyuse_anima.aio.resources:transitional_private_seam",
       "surface": "nodes_canonical_bindings",
       "symbols": {
-        "_bind_aio_resource_runtime": "_bind_aio_resource_runtime",
         "_comfy_clip_loader_types": "_comfy_clip_loader_types",
         "_comfy_diffusion_model_names": "_comfy_diffusion_model_names",
         "_comfy_text_encoder_names": "_comfy_text_encoder_names",
         "_comfy_vae_names": "_comfy_vae_names",
         "_load_aio_resources_from_input_context": "_load_aio_resources_from_input_context",
         "_load_aio_sam3_context": "_load_aio_sam3_context",
-        "_load_checkpoint_with_comfy": "_load_checkpoint_with_comfy",
-        "_load_clip_with_comfy": "_load_clip_with_comfy",
-        "_load_diffusion_model_with_comfy": "_load_diffusion_model_with_comfy",
         "_load_upscale_model_with_comfy": "_load_upscale_model_with_comfy",
-        "_load_vae_with_comfy": "_load_vae_with_comfy",
         "_normalize_aio_input_settings": "_normalize_aio_input_settings",
         "_preferred_clip_type_default": "_preferred_clip_type_default",
         "_preferred_name_default": "_preferred_name_default"
@@ -3480,15 +3064,11 @@
       "owner": "#184/#188",
       "first_release": null,
       "known_consumers": [
-        "nodes.py residual runtime",
         "canonical runtime resolver: easyuse_anima.aio.legacy_generation",
-        "canonical runtime resolver: easyuse_anima.aio.resources",
         "canonical runtime resolver: easyuse_anima.nodes.aio_nodes"
       ],
       "evidence": [
-        "AST:nodes.py direct runtime load",
         "AST:easyuse_anima.aio.legacy_generation string runtime lookup",
-        "AST:easyuse_anima.aio.resources string runtime lookup",
         "AST:easyuse_anima.nodes.aio_nodes string runtime lookup"
       ],
       "removal_gates": [
@@ -3502,6 +3082,10 @@
       "id": "nodes_canonical_bindings:easyuse_anima.aio.resources:unsupported_test_only",
       "surface": "nodes_canonical_bindings",
       "symbols": {
+        "_load_checkpoint_with_comfy": "_load_checkpoint_with_comfy",
+        "_load_clip_with_comfy": "_load_clip_with_comfy",
+        "_load_diffusion_model_with_comfy": "_load_diffusion_model_with_comfy",
+        "_load_vae_with_comfy": "_load_vae_with_comfy",
         "_preferred_checkpoint_default": "_preferred_checkpoint_default"
       },
       "classification": "unsupported_test_only",
@@ -3556,14 +3140,12 @@
       "known_consumers": [
         "nodes.py residual runtime",
         "canonical runtime resolver: easyuse_anima.aio.legacy_generation",
-        "canonical runtime resolver: easyuse_anima.aio.output",
         "canonical runtime resolver: easyuse_anima.aio.sampling",
         "canonical runtime resolver: easyuse_anima.nodes.aio_nodes"
       ],
       "evidence": [
         "AST:nodes.py direct runtime load",
         "AST:easyuse_anima.aio.legacy_generation string runtime lookup",
-        "AST:easyuse_anima.aio.output string runtime lookup",
         "AST:easyuse_anima.aio.sampling string runtime lookup",
         "AST:easyuse_anima.nodes.aio_nodes string runtime lookup"
       ],
@@ -3698,7 +3280,6 @@
         "_as_bool": "_as_bool",
         "_as_float": "_as_float",
         "_as_int": "_as_int",
-        "_choice": "_choice",
         "_single_value": "_single_value"
       },
       "classification": "transitional_private_seam",
@@ -3714,18 +3295,12 @@
         "canonical runtime resolver: easyuse_anima.aio.conditioning",
         "canonical runtime resolver: easyuse_anima.aio.legacy_generation",
         "canonical runtime resolver: easyuse_anima.aio.model_preparation",
-        "canonical runtime resolver: easyuse_anima.aio.output",
-        "canonical runtime resolver: easyuse_anima.aio.preview",
-        "canonical runtime resolver: easyuse_anima.aio.resources",
         "canonical runtime resolver: easyuse_anima.aio.sampling"
       ],
       "evidence": [
         "AST:easyuse_anima.aio.conditioning string runtime lookup",
         "AST:easyuse_anima.aio.legacy_generation string runtime lookup",
         "AST:easyuse_anima.aio.model_preparation string runtime lookup",
-        "AST:easyuse_anima.aio.output string runtime lookup",
-        "AST:easyuse_anima.aio.preview string runtime lookup",
-        "AST:easyuse_anima.aio.resources string runtime lookup",
         "AST:easyuse_anima.aio.sampling string runtime lookup"
       ],
       "removal_gates": [
@@ -3734,6 +3309,35 @@
         "separate B-10b or B-11 rollback unit"
       ],
       "lifecycle_state": "transitional"
+    },
+    {
+      "id": "nodes_canonical_bindings:easyuse_anima.common.values:unsupported_test_only",
+      "surface": "nodes_canonical_bindings",
+      "symbols": {
+        "_choice": "_choice"
+      },
+      "classification": "unsupported_test_only",
+      "current_target": "nodes.py",
+      "canonical_target": "easyuse_anima.common.values",
+      "target_state": "canonical",
+      "identity_requirement": "not_applicable",
+      "binding_shape": "direct_import",
+      "import_target": "easyuse_anima.common.values",
+      "owner": "#184/#188",
+      "first_release": null,
+      "known_consumers": [
+        "repository tests may import this root name"
+      ],
+      "evidence": [
+        "AST:no nodes.py runtime load",
+        "test-only consumption is not public support evidence"
+      ],
+      "removal_gates": [
+        "test imports migrate to canonical targets",
+        "no production consumer evidence",
+        "separate B-10b removal review"
+      ],
+      "lifecycle_state": "unsupported"
     },
     {
       "id": "nodes_canonical_bindings:easyuse_anima.image.geometry:transitional_private_seam",
@@ -3751,12 +3355,10 @@
       "owner": "#184/#188",
       "first_release": null,
       "known_consumers": [
-        "canonical runtime resolver: easyuse_anima.aio.legacy_generation",
-        "canonical runtime resolver: easyuse_anima.aio.preview"
+        "canonical runtime resolver: easyuse_anima.aio.legacy_generation"
       ],
       "evidence": [
-        "AST:easyuse_anima.aio.legacy_generation string runtime lookup",
-        "AST:easyuse_anima.aio.preview string runtime lookup"
+        "AST:easyuse_anima.aio.legacy_generation string runtime lookup"
       ],
       "removal_gates": [
         "canonical production consumer migration",
@@ -3800,7 +3402,6 @@
       "surface": "nodes_canonical_bindings",
       "symbols": {
         "_context_value": "_context_value",
-        "_sam3_context": "_sam3_context",
         "_segs_has_items": "_segs_has_items"
       },
       "classification": "transitional_private_seam",
@@ -3813,12 +3414,10 @@
       "owner": "#184/#188",
       "first_release": null,
       "known_consumers": [
-        "canonical runtime resolver: easyuse_anima.aio.legacy_generation",
-        "canonical runtime resolver: easyuse_anima.aio.resources"
+        "canonical runtime resolver: easyuse_anima.aio.legacy_generation"
       ],
       "evidence": [
-        "AST:easyuse_anima.aio.legacy_generation string runtime lookup",
-        "AST:easyuse_anima.aio.resources string runtime lookup"
+        "AST:easyuse_anima.aio.legacy_generation string runtime lookup"
       ],
       "removal_gates": [
         "canonical production consumer migration",
@@ -3826,6 +3425,35 @@
         "separate B-10b or B-11 rollback unit"
       ],
       "lifecycle_state": "transitional"
+    },
+    {
+      "id": "nodes_canonical_bindings:easyuse_anima.image.sam3:unsupported_test_only",
+      "surface": "nodes_canonical_bindings",
+      "symbols": {
+        "_sam3_context": "_sam3_context"
+      },
+      "classification": "unsupported_test_only",
+      "current_target": "nodes.py",
+      "canonical_target": "easyuse_anima.image.sam3",
+      "target_state": "canonical",
+      "identity_requirement": "not_applicable",
+      "binding_shape": "direct_import",
+      "import_target": "easyuse_anima.image.sam3",
+      "owner": "#184/#188",
+      "first_release": null,
+      "known_consumers": [
+        "repository tests may import this root name"
+      ],
+      "evidence": [
+        "AST:no nodes.py runtime load",
+        "test-only consumption is not public support evidence"
+      ],
+      "removal_gates": [
+        "test imports migrate to canonical targets",
+        "no production consumer evidence",
+        "separate B-10b removal review"
+      ],
+      "lifecycle_state": "unsupported"
     },
     {
       "id": "nodes_canonical_bindings:easyuse_anima.image.scaling:unsupported_test_only",
@@ -3907,13 +3535,11 @@
       "known_consumers": [
         "canonical runtime resolver: easyuse_anima.aio.legacy_generation",
         "canonical runtime resolver: easyuse_anima.aio.model_preparation",
-        "canonical runtime resolver: easyuse_anima.aio.resources",
         "canonical runtime resolver: easyuse_anima.aio.sampling"
       ],
       "evidence": [
         "AST:easyuse_anima.aio.legacy_generation string runtime lookup",
         "AST:easyuse_anima.aio.model_preparation string runtime lookup",
-        "AST:easyuse_anima.aio.resources string runtime lookup",
         "AST:easyuse_anima.aio.sampling string runtime lookup"
       ],
       "removal_gates": [
@@ -3953,7 +3579,7 @@
       "lifecycle_state": "unsupported"
     },
     {
-      "id": "nodes_canonical_bindings:easyuse_anima.infrastructure.comfy.resources:transitional_private_seam",
+      "id": "nodes_canonical_bindings:easyuse_anima.infrastructure.comfy.resources:unsupported_test_only",
       "surface": "nodes_canonical_bindings",
       "symbols": {
         "_adapter_comfy_clip_loader_types": "_comfy_clip_loader_types",
@@ -3962,27 +3588,28 @@
         "_adapter_comfy_vae_names": "_comfy_vae_names",
         "_folder_path_names": "_folder_path_names"
       },
-      "classification": "transitional_private_seam",
+      "classification": "unsupported_test_only",
       "current_target": "nodes.py",
       "canonical_target": "easyuse_anima.infrastructure.comfy.resources",
       "target_state": "canonical",
-      "identity_requirement": "required",
+      "identity_requirement": "not_applicable",
       "binding_shape": "direct_import",
       "import_target": "easyuse_anima.infrastructure.comfy.resources",
       "owner": "#184/#188",
       "first_release": null,
       "known_consumers": [
-        "canonical runtime resolver: easyuse_anima.aio.resources"
+        "repository tests may import this root name"
       ],
       "evidence": [
-        "AST:easyuse_anima.aio.resources string runtime lookup"
+        "AST:no nodes.py runtime load",
+        "test-only consumption is not public support evidence"
       ],
       "removal_gates": [
-        "canonical production consumer migration",
-        "focused monkeypatch and identity contract review",
-        "separate B-10b or B-11 rollback unit"
+        "test imports migrate to canonical targets",
+        "no production consumer evidence",
+        "separate B-10b removal review"
       ],
-      "lifecycle_state": "transitional"
+      "lifecycle_state": "unsupported"
     },
     {
       "id": "nodes_canonical_bindings:easyuse_anima.infrastructure.comfy.wiring:transitional_private_seam",
@@ -4082,38 +3709,11 @@
       "lifecycle_state": "unsupported"
     },
     {
-      "id": "nodes_canonical_bindings:easyuse_anima.lora.preset:transitional_private_seam",
-      "surface": "nodes_canonical_bindings",
-      "symbols": {
-        "_format_strength": "_format_strength"
-      },
-      "classification": "transitional_private_seam",
-      "current_target": "nodes.py",
-      "canonical_target": "easyuse_anima.lora.preset",
-      "target_state": "canonical",
-      "identity_requirement": "required",
-      "binding_shape": "direct_import",
-      "import_target": "easyuse_anima.lora.preset",
-      "owner": "#184/#188",
-      "first_release": null,
-      "known_consumers": [
-        "canonical runtime resolver: easyuse_anima.aio.output"
-      ],
-      "evidence": [
-        "AST:easyuse_anima.aio.output string runtime lookup"
-      ],
-      "removal_gates": [
-        "canonical production consumer migration",
-        "focused monkeypatch and identity contract review",
-        "separate B-10b or B-11 rollback unit"
-      ],
-      "lifecycle_state": "transitional"
-    },
-    {
       "id": "nodes_canonical_bindings:easyuse_anima.lora.preset:unsupported_test_only",
       "surface": "nodes_canonical_bindings",
       "symbols": {
         "_correct_style_prompt": "_correct_style_prompt",
+        "_format_strength": "_format_strength",
         "_get_loras_list": "_get_loras_list",
         "_load_profile_data": "_load_profile_data",
         "_profile_key": "_profile_key",
@@ -4940,13 +4540,11 @@
       "known_consumers": [
         "canonical runtime resolver: easyuse_anima.aio.conditioning",
         "canonical runtime resolver: easyuse_anima.aio.legacy_generation",
-        "canonical runtime resolver: easyuse_anima.aio.preview",
         "canonical runtime resolver: easyuse_anima.nodes.aio_nodes"
       ],
       "evidence": [
         "AST:easyuse_anima.aio.conditioning string runtime lookup",
         "AST:easyuse_anima.aio.legacy_generation string runtime lookup",
-        "AST:easyuse_anima.aio.preview string runtime lookup",
         "AST:easyuse_anima.nodes.aio_nodes string runtime lookup"
       ],
       "removal_gates": [
@@ -5405,15 +5003,6 @@
       "surface": "nodes_root_residuals",
       "kind": "globals",
       "symbols": {
-        "AIO_INPUT_DEFAULT_SETTINGS": "AIO_INPUT_DEFAULT_SETTINGS",
-        "ANIMA_CLIP_DEVICES": "ANIMA_CLIP_DEVICES",
-        "ANIMA_CLIP_TYPES": "ANIMA_CLIP_TYPES",
-        "ANIMA_DEFAULT_CLIP_CANDIDATES": "ANIMA_DEFAULT_CLIP_CANDIDATES",
-        "ANIMA_DEFAULT_DIFFUSION_MODEL_CANDIDATES": "ANIMA_DEFAULT_DIFFUSION_MODEL_CANDIDATES",
-        "ANIMA_DEFAULT_VAE_CANDIDATES": "ANIMA_DEFAULT_VAE_CANDIDATES",
-        "ANIMA_UNET_WEIGHT_DTYPES": "ANIMA_UNET_WEIGHT_DTYPES",
-        "EASY_USE_ANIMA_INPUT_SCHEMA": "EASY_USE_ANIMA_INPUT_SCHEMA",
-        "EASY_USE_ANIMA_INPUT_SETTINGS_VERSION": "EASY_USE_ANIMA_INPUT_SETTINGS_VERSION",
         "EASY_USE_ANIMA_INPUT_TYPE": "EASY_USE_ANIMA_INPUT_TYPE",
         "_TRIGGER_WORD_KEYS": "_TRIGGER_WORD_KEYS",
         "logger": "logger"

--- a/tests/test_aio_output.py
+++ b/tests/test_aio_output.py
@@ -89,7 +89,7 @@ class AIOOutputMoveTests(unittest.TestCase):
                 "_require_custom_node_class",
                 return_value=Fetcher,
             ) as require,
-            patch.object(nodes.logger, "warning") as warning,
+            patch.object(output.logger, "warning") as warning,
         ):
             result = output._aio_image_saver_civitai_hash_fetcher_entries(settings)
 
@@ -126,10 +126,18 @@ class AIOOutputMoveTests(unittest.TestCase):
                     {"civitai_hash_fetchers": [{"enabled": True, "username": "u", "version": "v"}]}
                 )
 
-    def test_additional_hash_and_lora_metadata_re_resolve_root_helpers(self):
+    def test_additional_hash_and_lora_metadata_use_canonical_helpers(self):
         with (
-            patch.object(nodes, "_normalize_aio_hash_bundles", return_value=["Bundle:B"]),
-            patch.object(nodes, "_aio_image_saver_civitai_hash_fetcher_entries", return_value=["Model:C"]),
+            patch.object(
+                output,
+                "_normalize_aio_hash_bundles",
+                return_value=["Bundle:B"],
+            ),
+            patch.object(
+                output,
+                "_aio_image_saver_civitai_hash_fetcher_entries",
+                return_value=["Model:C"],
+            ),
         ):
             hashes = output._aio_image_saver_additional_hashes({
                 "additional_hashes": " Base:A, ",
@@ -146,9 +154,13 @@ class AIOOutputMoveTests(unittest.TestCase):
             self.assertEqual(output._aio_lora_metadata_name("styles/foo.safetensors"), "styles/foo")
 
         with (
-            patch.object(nodes, "_aio_lora_metadata_name", side_effect=lambda value: value.replace(".safetensors", "")),
-            patch.object(nodes, "_as_float", return_value=0.75),
-            patch.object(nodes, "_format_strength", return_value="0.75"),
+            patch.object(
+                output,
+                "_aio_lora_metadata_name",
+                side_effect=lambda value: value.replace(".safetensors", ""),
+            ),
+            patch.object(output, "_as_float", return_value=0.75),
+            patch.object(output, "_format_strength", return_value="0.75"),
         ):
             prompt = output._aio_prompt_with_lora_metadata(
                 "base", [{"name": "foo.safetensors", "strength_model": "0.75"}]
@@ -181,7 +193,7 @@ class AIOOutputMoveTests(unittest.TestCase):
 
     def test_filename_prefix_uses_call_time_defaults_without_path_drift(self):
         defaults = {"save": {"image_saver": {"path": "Default/Path", "filename": "default_name"}}}
-        with patch.object(nodes, "AIO_GENERATION_DEFAULT_SETTINGS", defaults):
+        with patch.object(output, "AIO_GENERATION_DEFAULT_SETTINGS", defaults):
             self.assertEqual(
                 output._aio_save_filename_prefix({"image_saver": {"path": " /Custom/ ", "filename": " frame "}}),
                 "Custom/frame",
@@ -215,9 +227,17 @@ class AIOOutputMoveTests(unittest.TestCase):
                 "_require_custom_node_class",
                 return_value=ImageSaver,
             ),
-            patch.object(nodes, "_resolve_aio_runtime_seed", seed),
-            patch.object(nodes, "_aio_prompt_with_lora_metadata", return_value="positive <lora:x:1>"),
-            patch.object(nodes, "_aio_image_saver_additional_hashes", return_value="Base:A,Model:B"),
+            patch.object(output, "_resolve_aio_runtime_seed", seed),
+            patch.object(
+                output,
+                "_aio_prompt_with_lora_metadata",
+                return_value="positive <lora:x:1>",
+            ),
+            patch.object(
+                output,
+                "_aio_image_saver_additional_hashes",
+                return_value="Base:A,Model:B",
+            ),
         ):
             result = output._save_image_with_image_saver(
                 images="images",

--- a/tests/test_aio_preview.py
+++ b/tests/test_aio_preview.py
@@ -43,7 +43,7 @@ class AIOPreviewMoveTests(unittest.TestCase):
     def test_file_size_re_resolves_root_base_directory_and_preserves_path_rules(self):
         replacement = Mock(return_value="preview-root")
         with (
-            patch.object(nodes, "_aio_preview_base_directory", replacement),
+            patch.object(preview, "_aio_preview_base_directory", replacement),
             patch.object(preview.os.path, "isfile", return_value=True) as isfile,
             patch.object(preview.os.path, "getsize", return_value=321) as getsize,
         ):
@@ -61,7 +61,7 @@ class AIOPreviewMoveTests(unittest.TestCase):
     def test_tagging_re_resolves_file_size_and_preserves_metadata_order(self):
         source = {"filename": "image.webp", "type": "temp"}
         file_size = Mock(return_value=1234)
-        with patch.object(nodes, "_aio_preview_file_size_bytes", file_size):
+        with patch.object(preview, "_aio_preview_file_size_bytes", file_size):
             tagged = preview._tag_aio_preview_images(
                 [source, "skip"], "highres", width=768, height=1024
             )
@@ -93,9 +93,9 @@ class AIOPreviewMoveTests(unittest.TestCase):
 
         with (
             patch.dict(sys.modules, {"server": server}),
-            patch.object(nodes, "_single_value", return_value=86),
-            patch.object(nodes, "_prompt_data_json_safe", json_safe),
-            patch.object(nodes, "AIO_PREVIEW_EVENT", "replacement-event"),
+            patch.object(preview, "_single_value", return_value=86),
+            patch.object(preview, "_prompt_data_json_safe", json_safe),
+            patch.object(preview, "AIO_PREVIEW_EVENT", "replacement-event"),
         ):
             preview._send_aio_preview_event(
                 [86], "run-1", "first_pass", [{"filename": "preview.webp"}]
@@ -113,7 +113,7 @@ class AIOPreviewMoveTests(unittest.TestCase):
         )
 
     def test_event_failure_is_debug_only_and_empty_inputs_do_not_import_server(self):
-        with patch.object(nodes, "_single_value", return_value=None):
+        with patch.object(preview, "_single_value", return_value=None):
             preview._send_aio_preview_event(None, "run", "final", [{"x": 1}])
 
         send_sync = Mock(side_effect=RuntimeError("send failed"))
@@ -123,8 +123,8 @@ class AIOPreviewMoveTests(unittest.TestCase):
         )
         with (
             patch.dict(sys.modules, {"server": server}),
-            patch.object(nodes, "_single_value", return_value=1),
-            patch.object(nodes.logger, "debug") as debug,
+            patch.object(preview, "_single_value", return_value=1),
+            patch.object(preview.logger, "debug") as debug,
         ):
             preview._send_aio_preview_event(1, "run", "final", [{"x": 1}])
 
@@ -169,10 +169,10 @@ class AIOPreviewMoveTests(unittest.TestCase):
 
         with (
             patch.dict(sys.modules, {"folder_paths": folder_paths, "numpy": numpy, "PIL": pil}),
-            patch.object(nodes, "_image_tensor_size", return_value=(640, 960)),
-            patch.object(nodes, "_tag_aio_preview_images", tag),
-            patch.object(nodes, "AIO_PREVIEW_CACHE_FORMAT", "webp"),
-            patch.object(nodes, "AIO_PREVIEW_CACHE_QUALITY", 90),
+            patch.object(preview, "_image_tensor_size", return_value=(640, 960)),
+            patch.object(preview, "_tag_aio_preview_images", tag),
+            patch.object(preview, "AIO_PREVIEW_CACHE_FORMAT", "webp"),
+            patch.object(preview, "AIO_PREVIEW_CACHE_QUALITY", 90),
             patch.object(preview.random, "choice", return_value="a"),
         ):
             result = preview._save_aio_temp_preview_image(
@@ -215,14 +215,14 @@ class AIOPreviewMoveTests(unittest.TestCase):
         tag = Mock(return_value=[{"fallback": True}])
         with (
             patch.dict(sys.modules, {"folder_paths": None}),
-            patch.object(nodes, "_image_tensor_size", return_value=(512, 768)),
+            patch.object(preview, "_image_tensor_size", return_value=(512, 768)),
             patch_comfy_helper(
                 nodes,
                 "_find_comfy_node_class",
                 return_value=PreviewImage,
             ),
-            patch.object(nodes, "_tag_aio_preview_images", tag),
-            patch.object(nodes.logger, "warning") as warning,
+            patch.object(preview, "_tag_aio_preview_images", tag),
+            patch.object(preview.logger, "warning") as warning,
         ):
             result = preview._save_aio_temp_preview_image(
                 "image",

--- a/tests/test_aio_resources.py
+++ b/tests/test_aio_resources.py
@@ -4,7 +4,7 @@ import unittest
 from unittest.mock import Mock, patch
 
 import nodes
-from easyuse_anima.aio import resources as aio_resources
+from easyuse_anima.aio import input_defaults, resources as aio_resources
 from easyuse_anima.infrastructure.comfy import capabilities
 from tests.comfy_host_fakes import patch_comfy_helper
 
@@ -27,6 +27,20 @@ class AIOResourceMoveTests(unittest.TestCase):
             with self.subTest(name=name):
                 self.assertIs(getattr(nodes, name), getattr(aio_resources, name))
 
+        for name in (
+            "AIO_INPUT_DEFAULT_SETTINGS",
+            "ANIMA_CLIP_DEVICES",
+            "ANIMA_CLIP_TYPES",
+            "ANIMA_DEFAULT_CLIP_CANDIDATES",
+            "ANIMA_DEFAULT_DIFFUSION_MODEL_CANDIDATES",
+            "ANIMA_DEFAULT_VAE_CANDIDATES",
+            "ANIMA_UNET_WEIGHT_DTYPES",
+            "EASY_USE_ANIMA_INPUT_SCHEMA",
+            "EASY_USE_ANIMA_INPUT_SETTINGS_VERSION",
+        ):
+            with self.subTest(name=name):
+                self.assertIs(getattr(nodes, name), getattr(input_defaults, name))
+
         self.assertFalse(hasattr(nodes, "_impact_core_module"))
         self.assertIs(nodes._impact_scheduler_names, capabilities._impact_scheduler_names)
 
@@ -48,7 +62,11 @@ class AIOResourceMoveTests(unittest.TestCase):
             "preferred",
         )
 
-        with patch.object(nodes, "_choice", return_value="stable_diffusion") as choice:
+        with patch.object(
+            aio_resources,
+            "_choice",
+            return_value="stable_diffusion",
+        ) as choice:
             self.assertEqual(
                 aio_resources._preferred_clip_type_default(["flux", "stable_diffusion"]),
                 "stable_diffusion",
@@ -90,7 +108,11 @@ class AIOResourceMoveTests(unittest.TestCase):
                 "_find_comfy_node_class",
                 side_effect=classes.get,
             ),
-            patch.object(nodes, "_node_output_tuple", side_effect=lambda value: tuple(value)) as output_tuple,
+            patch.object(
+                aio_resources,
+                "_node_output_tuple",
+                side_effect=lambda value: tuple(value),
+            ) as output_tuple,
         ):
             self.assertEqual(
                 aio_resources._load_checkpoint_with_comfy("checkpoint.safetensors"),
@@ -144,7 +166,11 @@ class AIOResourceMoveTests(unittest.TestCase):
                 "_find_comfy_node_class",
                 return_value=loader_cls,
             ),
-            patch.object(nodes, "_node_output_tuple", side_effect=lambda value: tuple(value)),
+            patch.object(
+                aio_resources,
+                "_node_output_tuple",
+                side_effect=lambda value: tuple(value),
+            ),
         ):
             self.assertEqual(
                 aio_resources._load_upscale_model_with_comfy("4x-model.pth"),
@@ -155,11 +181,15 @@ class AIOResourceMoveTests(unittest.TestCase):
     def test_sam3_bundle_uses_call_time_root_helpers(self):
         with (
             patch.object(
-                nodes,
+                aio_resources,
                 "_load_checkpoint_with_comfy",
                 return_value=("model", "clip", "vae"),
             ) as load_checkpoint,
-            patch.object(nodes, "_sam3_context", return_value={"context": True}) as sam3_context,
+            patch.object(
+                aio_resources,
+                "_sam3_context",
+                return_value={"context": True},
+            ) as sam3_context,
         ):
             result = aio_resources._load_aio_sam3_context(
                 {"sam3": {"checkpoint": "custom-sam3.safetensors"}}
@@ -197,7 +227,7 @@ class AIOResourceMoveTests(unittest.TestCase):
 
         with (
             patch.object(
-                nodes,
+                aio_resources,
                 "_normalize_aio_input_settings",
                 return_value={
                     "resources": {
@@ -207,12 +237,20 @@ class AIOResourceMoveTests(unittest.TestCase):
                 },
             ) as normalize,
             patch.object(
-                nodes,
+                aio_resources,
                 "_load_diffusion_model_with_comfy",
                 side_effect=record("model", "model"),
             ),
-            patch.object(nodes, "_load_vae_with_comfy", side_effect=record("vae", "vae")),
-            patch.object(nodes, "_load_clip_with_comfy", side_effect=record("clip", "clip")),
+            patch.object(
+                aio_resources,
+                "_load_vae_with_comfy",
+                side_effect=record("vae", "vae"),
+            ),
+            patch.object(
+                aio_resources,
+                "_load_clip_with_comfy",
+                side_effect=record("clip", "clip"),
+            ),
         ):
             result = aio_resources._load_aio_resources_from_input_context(context)
 
@@ -237,22 +275,26 @@ class AIOResourceMoveTests(unittest.TestCase):
         replacement_vae = Mock(return_value="replacement-vae")
 
         def load_model(*_args):
-            nodes._load_vae_with_comfy = replacement_vae
+            aio_resources._load_vae_with_comfy = replacement_vae
             return "model"
 
         with (
             patch.object(
-                nodes,
+                aio_resources,
                 "_normalize_aio_input_settings",
                 return_value={"resources": {}},
             ),
             patch.object(
-                nodes,
+                aio_resources,
                 "_load_diffusion_model_with_comfy",
                 side_effect=load_model,
             ),
-            patch.object(nodes, "_load_vae_with_comfy", return_value="stale-vae") as stale_vae,
-            patch.object(nodes, "_load_clip_with_comfy", return_value="clip"),
+            patch.object(
+                aio_resources,
+                "_load_vae_with_comfy",
+                return_value="stale-vae",
+            ) as stale_vae,
+            patch.object(aio_resources, "_load_clip_with_comfy", return_value="clip"),
         ):
             result = aio_resources._load_aio_resources_from_input_context(
                 {

--- a/tests/test_comfy_adapters.py
+++ b/tests/test_comfy_adapters.py
@@ -14,6 +14,7 @@ if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
 import nodes
+from easyuse_anima.aio import resources as aio_resources
 from easyuse_anima.infrastructure.comfy import capabilities, invocation, resources
 from easyuse_anima.nodes import sam3_nodes
 
@@ -415,20 +416,24 @@ class ComfyRootCompatibilityTests(unittest.TestCase):
             "sam3.1_multiplex_fp16.safetensors",
         )
 
-    def test_feature_specific_root_wrappers_inject_existing_constants_and_aliases(self):
+    def test_aio_resource_wrappers_inject_canonical_constants_and_aliases(self):
         folder_calls = []
 
         def folder_names(folder_name, fallback):
             folder_calls.append((folder_name, fallback))
             return fallback
 
-        with patch.object(nodes, "_folder_path_names", side_effect=folder_names):
+        with patch.object(
+            aio_resources,
+            "_folder_path_names",
+            side_effect=folder_names,
+        ):
             self.assertEqual(
-                nodes._comfy_diffusion_model_names(),
+                aio_resources._comfy_diffusion_model_names(),
                 list(nodes.ANIMA_DEFAULT_DIFFUSION_MODEL_CANDIDATES),
             )
             self.assertEqual(
-                nodes._comfy_text_encoder_names(),
+                aio_resources._comfy_text_encoder_names(),
                 list(nodes.ANIMA_DEFAULT_CLIP_CANDIDATES),
             )
         self.assertEqual(

--- a/tests/test_node_contracts.py
+++ b/tests/test_node_contracts.py
@@ -1595,40 +1595,25 @@ class AioResourceNameMoveContractTests(unittest.TestCase):
             events.append(("adapter_call", candidate_values, folder_lookup))
             return returned
 
-        def resolver(name):
-            events.append(name)
-            return getattr(root_module, name)
-
         with (
             patch.object(
-                root_module,
+                canonical_module,
                 "ANIMA_DEFAULT_DIFFUSION_MODEL_CANDIDATES",
                 candidates,
             ),
             patch.object(
-                root_module,
+                canonical_module,
                 "_adapter_comfy_diffusion_model_names",
                 adapter,
             ),
-            patch.object(root_module, "_folder_path_names", folder_names),
+            patch.object(canonical_module, "_folder_path_names", folder_names),
         ):
-            canonical_module._bind_aio_resource_runtime(resolve_helper=resolver)
-            try:
-                result = canonical_module._comfy_diffusion_model_names()
-            finally:
-                canonical_module._bind_aio_resource_runtime(
-                    resolve_helper=lambda name: getattr(root_module, name)
-                )
+            result = canonical_module._comfy_diffusion_model_names()
 
         self.assertIs(result, returned)
         self.assertEqual(
             events,
-            [
-                "_adapter_comfy_diffusion_model_names",
-                "ANIMA_DEFAULT_DIFFUSION_MODEL_CANDIDATES",
-                "_folder_path_names",
-                ("adapter_call", candidates, folder_names),
-            ],
+            [("adapter_call", candidates, folder_names)],
         )
 
     def test_root_alias_and_call_time_dependencies(self):
@@ -1659,36 +1644,25 @@ class AioResourceNameMoveContractTests(unittest.TestCase):
             events.append(("adapter_call", candidate_values, folder_lookup))
             return returned
 
-        def resolver(name):
-            events.append(name)
-            return getattr(root_module, name)
-
         with (
-            patch.object(root_module, "ANIMA_DEFAULT_CLIP_CANDIDATES", candidates),
             patch.object(
-                root_module,
+                canonical_module,
+                "ANIMA_DEFAULT_CLIP_CANDIDATES",
+                candidates,
+            ),
+            patch.object(
+                canonical_module,
                 "_adapter_comfy_text_encoder_names",
                 adapter,
             ),
-            patch.object(root_module, "_folder_path_names", folder_names),
+            patch.object(canonical_module, "_folder_path_names", folder_names),
         ):
-            canonical_module._bind_aio_resource_runtime(resolve_helper=resolver)
-            try:
-                result = canonical_module._comfy_text_encoder_names()
-            finally:
-                canonical_module._bind_aio_resource_runtime(
-                    resolve_helper=lambda name: getattr(root_module, name)
-                )
+            result = canonical_module._comfy_text_encoder_names()
 
         self.assertIs(result, returned)
         self.assertEqual(
             events,
-            [
-                "_adapter_comfy_text_encoder_names",
-                "ANIMA_DEFAULT_CLIP_CANDIDATES",
-                "_folder_path_names",
-                ("adapter_call", candidates, folder_names),
-            ],
+            [("adapter_call", candidates, folder_names)],
         )
 
     def test_text_encoder_root_alias_and_call_time_dependencies(self):
@@ -1731,52 +1705,26 @@ class AioResourceNameMoveContractTests(unittest.TestCase):
             )
             return returned
 
-        def resolver(name):
-            events.append(name)
-            return root_module._resolve_comfy_host_helper(
-                name,
-                lambda fallback_name: getattr(root_module, fallback_name),
-            )
-
-        def production_resolver(name):
-            return root_module._resolve_comfy_host_helper(
-                name,
-                lambda fallback_name: getattr(root_module, fallback_name),
-            )
-
         with (
-            patch.object(root_module, "ANIMA_DEFAULT_VAE_CANDIDATES", candidates),
-            patch.object(root_module, "_adapter_comfy_vae_names", adapter),
+            patch.object(
+                canonical_module,
+                "ANIMA_DEFAULT_VAE_CANDIDATES",
+                candidates,
+            ),
+            patch.object(canonical_module, "_adapter_comfy_vae_names", adapter),
             patch_comfy_helper(
                 root_module,
                 "_find_comfy_node_class",
                 find_node_class,
             ),
-            patch.object(root_module, "_folder_path_names", folder_names),
+            patch.object(canonical_module, "_folder_path_names", folder_names),
         ):
-            canonical_module._bind_aio_resource_runtime(resolve_helper=resolver)
-            try:
-                result = canonical_module._comfy_vae_names()
-            finally:
-                canonical_module._bind_aio_resource_runtime(
-                    resolve_helper=production_resolver
-                )
+            result = canonical_module._comfy_vae_names()
 
         self.assertIs(result, returned)
         self.assertEqual(
             events,
-            [
-                "_adapter_comfy_vae_names",
-                "ANIMA_DEFAULT_VAE_CANDIDATES",
-                "_find_comfy_node_class",
-                "_folder_path_names",
-                (
-                    "adapter_call",
-                    candidates,
-                    None,
-                    folder_names,
-                ),
-            ],
+            [("adapter_call", candidates, None, folder_names)],
         )
         self.assertEqual(find_calls, ["ContractProbe"])
 
@@ -1812,23 +1760,10 @@ class AioResourceNameMoveContractTests(unittest.TestCase):
             )
             return returned
 
-        def resolver(name):
-            events.append(name)
-            return root_module._resolve_comfy_host_helper(
-                name,
-                lambda fallback_name: getattr(root_module, fallback_name),
-            )
-
-        def production_resolver(name):
-            return root_module._resolve_comfy_host_helper(
-                name,
-                lambda fallback_name: getattr(root_module, fallback_name),
-            )
-
         with (
-            patch.object(root_module, "ANIMA_CLIP_TYPES", candidates),
+            patch.object(canonical_module, "ANIMA_CLIP_TYPES", candidates),
             patch.object(
-                root_module,
+                canonical_module,
                 "_adapter_comfy_clip_loader_types",
                 adapter,
             ),
@@ -1838,23 +1773,12 @@ class AioResourceNameMoveContractTests(unittest.TestCase):
                 find_node_class,
             ),
         ):
-            canonical_module._bind_aio_resource_runtime(resolve_helper=resolver)
-            try:
-                result = canonical_module._comfy_clip_loader_types()
-            finally:
-                canonical_module._bind_aio_resource_runtime(
-                    resolve_helper=production_resolver
-                )
+            result = canonical_module._comfy_clip_loader_types()
 
         self.assertIs(result, returned)
         self.assertEqual(
             events,
-            [
-                "_adapter_comfy_clip_loader_types",
-                "ANIMA_CLIP_TYPES",
-                "_find_comfy_node_class",
-                ("adapter_call", candidates, None),
-            ],
+            [("adapter_call", candidates, None)],
         )
         self.assertEqual(find_calls, ["ContractProbe"])
 
@@ -2092,17 +2016,29 @@ class AioInputSettingsNormalizerMoveContractTests(unittest.TestCase):
 
         with (
             patch.object(
-                root_module,
+                canonical_module,
                 "_merge_versioned_settings",
                 merge_versioned_settings,
             ),
-            patch.object(root_module, "AIO_INPUT_DEFAULT_SETTINGS", defaults),
-            patch.object(root_module, "EASY_USE_ANIMA_INPUT_SCHEMA", "input-schema"),
-            patch.object(root_module, "EASY_USE_ANIMA_INPUT_SETTINGS_VERSION", 7),
-            patch.object(root_module, "_as_int", as_int),
-            patch.object(root_module, "_choice", choice),
-            patch.object(root_module, "ANIMA_UNET_WEIGHT_DTYPES", ("dtype-a",)),
-            patch.object(root_module, "ANIMA_CLIP_DEVICES", ("device-a",)),
+            patch.object(canonical_module, "AIO_INPUT_DEFAULT_SETTINGS", defaults),
+            patch.object(
+                canonical_module,
+                "EASY_USE_ANIMA_INPUT_SCHEMA",
+                "input-schema",
+            ),
+            patch.object(
+                canonical_module,
+                "EASY_USE_ANIMA_INPUT_SETTINGS_VERSION",
+                7,
+            ),
+            patch.object(canonical_module, "_as_int", as_int),
+            patch.object(canonical_module, "_choice", choice),
+            patch.object(
+                canonical_module,
+                "ANIMA_UNET_WEIGHT_DTYPES",
+                ("dtype-a",),
+            ),
+            patch.object(canonical_module, "ANIMA_CLIP_DEVICES", ("device-a",)),
         ):
             result = canonical_module._normalize_aio_input_settings("payload")
 

--- a/tests/test_nodes_module_analyzer.py
+++ b/tests/test_nodes_module_analyzer.py
@@ -73,12 +73,12 @@ def load_dynamic():
     def test_current_nodes_module_shape_matches_recorded_baseline(self):
         report = analyzer.analyze_path(ROOT / "nodes.py")
 
-        self.assertEqual(report["git_blob_sha1"], "2c734092ef9aeae0e8226d89ab684313f9987a0f")
-        # B-11c30d2 moves declarative generation defaults and retires three
-        # planning binders without changing the public class surface.
+        self.assertEqual(report["git_blob_sha1"], "40f7789cb9de0f3149fa2498ddd127d47067c405")
+        # B-11c30d3 moves declarative input defaults and retires three
+        # I/O-boundary binders without changing the public class surface.
         self.assertEqual(report["top_level"]["function_count"], 0)
         self.assertEqual(report["top_level"]["class_count"], 0)
-        self.assertEqual(report["line_count"], 1_239)
+        self.assertEqual(report["line_count"], 1_182)
         class_names = {item["name"] for item in report["top_level"]["classes"]}
         self.assertNotIn("EasyUseAnimaAIOGenerator", class_names)
         self.assertNotIn("EasyUseAnimaInput", class_names)

--- a/tests/test_python_backend_analyzer.py
+++ b/tests/test_python_backend_analyzer.py
@@ -683,9 +683,9 @@ ignored/
 
         self.assertEqual(analyzer.render_json(report), expected_text)
         self.assertEqual(report["schema_version"], 2)
-        self.assertEqual(report["inventory"]["module_count"], 91)
-        self.assertEqual(len(report["registry"]["shipped_python_modules"]), 91)
-        self.assertEqual(len(report["registry"]["runtime_import_closure"]), 91)
+        self.assertEqual(report["inventory"]["module_count"], 92)
+        self.assertEqual(len(report["registry"]["shipped_python_modules"]), 92)
+        self.assertEqual(len(report["registry"]["runtime_import_closure"]), 92)
         self.assertEqual(report["registry"]["missing_internal_imports"], [])
         self.assertEqual(report["registry"]["unreachable_shipped_python_modules"], [])
         self.assertTrue(
@@ -701,6 +701,7 @@ ignored/
                 "easyuse_anima/aio/generation_detailer.py",
                 "easyuse_anima/aio/generation_defaults.py",
                 "easyuse_anima/aio/generation_output.py",
+                "easyuse_anima/aio/input_defaults.py",
                 "easyuse_anima/aio/generation_normalization.py",
                 "easyuse_anima/aio/generation_migrations.py",
                 "easyuse_anima/aio/generation_settings.py",

--- a/tests/test_python_compatibility_surface.py
+++ b/tests/test_python_compatibility_surface.py
@@ -98,11 +98,8 @@ PROMPT_NODE_ADAPTER_RETIRED_RUNTIME_BINDERS = (
 RUNTIME_BINDER_FAMILIES = {
     "aio": (
         "_bind_aio_legacy_generation_runtime",
-        "_bind_aio_resource_runtime",
         "_bind_aio_model_preparation_runtime",
         "_bind_aio_sampling_runtime",
-        "_bind_aio_preview_runtime",
-        "_bind_aio_output_runtime",
         "_bind_aio_conditioning_runtime",
         "_bind_aio_node_runtime",
     ),
@@ -140,6 +137,7 @@ AIO_RUNTIME_BINDER_SUBGROUPS = {
 AIO_RUNTIME_RETIRED_SUBGROUPS = (
     "B-11c30d1_cache_state",
     "B-11c30d2_normalization_planning",
+    "B-11c30d3_io_boundary",
 )
 AIO_RUNTIME_PREREQUISITE_MOVES = (
     {
@@ -2327,14 +2325,14 @@ def _build_document() -> dict[str, Any]:
         "expected_counts": {
             "root_entrypoints": 3,
             "excluded_preamble_implementation_bindings": 3,
-            "nodes_canonical_bindings": 290,
+            "nodes_canonical_bindings": 296,
             "nodes_legacy_bindings": 27,
             "mapped_public_classes": 18,
             "unmapped_classes": 2,
             "root_residual_functions": 0,
             "root_residual_classes": 0,
-            "root_residual_globals": 12,
-            "runtime_binders": 10,
+            "root_residual_globals": 3,
+            "runtime_binders": 7,
             "direct_nodes_import_test_files": 21,
         },
         "mapped_public_classes": sorted(mapped_classes),
@@ -2566,7 +2564,7 @@ class PythonCompatibilitySurfaceTests(unittest.TestCase):
             len(self.document["direct_nodes_import_test_files"]),
             counts["direct_nodes_import_test_files"],
         )
-        self.assertEqual(len(set(self.document["runtime_binders"])), 10)
+        self.assertEqual(len(set(self.document["runtime_binders"])), 7)
         self.assertEqual(len(set(self.document["direct_nodes_import_test_files"])), 21)
 
     def test_runtime_binder_audit_covers_provider_and_root_names(self):
@@ -2574,22 +2572,22 @@ class PythonCompatibilitySurfaceTests(unittest.TestCase):
         self.assertEqual(
             audit["summary"],
             {
-                "binder_count": 10,
+                "binder_count": 7,
                 "family_count": 2,
                 "mode_counts": {
-                    "comfy_provider_then_root": 7,
+                    "comfy_provider_then_root": 4,
                     "root_globals": 1,
                     "explicit_callbacks": 2,
                 },
-                "unique_resolver_names": 140,
-                "unique_root_resolver_names": 136,
+                "unique_resolver_names": 112,
+                "unique_root_resolver_names": 108,
                 "unique_provider_resolver_names": 4,
                 "unique_direct_root_dependencies": 9,
-                "direct_root_dependency_slots": 16,
-                "provider_consumer_slots": 12,
-                "provider_consumer_modules": 7,
-                "repository_replacement_names": 116,
-                "repository_replacement_files": 12,
+                "direct_root_dependency_slots": 13,
+                "provider_consumer_slots": 8,
+                "provider_consumer_modules": 4,
+                "repository_replacement_names": 85,
+                "repository_replacement_files": 8,
             },
         )
         self.assertEqual(
@@ -2694,37 +2692,29 @@ class PythonCompatibilitySurfaceTests(unittest.TestCase):
         self.assertEqual(
             summaries,
             {
-                "B-11c30d3_io_boundary": {
-                    "root_resolver_slots": 49,
-                    "unique_root_resolver_names": 46,
-                    "provider_resolver_slots": 4,
-                    "direct_root_dependency_slots": 3,
-                    "repository_replacement_slots": 45,
-                    "unique_repository_replacement_names": 43,
-                },
                 "B-11c30d4_execution_services": {
                     "root_resolver_slots": 43,
                     "unique_root_resolver_names": 37,
                     "provider_resolver_slots": 6,
                     "direct_root_dependency_slots": 3,
-                    "repository_replacement_slots": 29,
-                    "unique_repository_replacement_names": 24,
+                    "repository_replacement_slots": 23,
+                    "unique_repository_replacement_names": 21,
                 },
                 "B-11c30d5_legacy_orchestration": {
                     "root_resolver_slots": 59,
                     "unique_root_resolver_names": 59,
                     "provider_resolver_slots": 2,
                     "direct_root_dependency_slots": 1,
-                    "repository_replacement_slots": 46,
-                    "unique_repository_replacement_names": 46,
+                    "repository_replacement_slots": 43,
+                    "unique_repository_replacement_names": 43,
                 },
                 "B-11c30d6_node_adapter": {
                     "root_resolver_slots": 30,
                     "unique_root_resolver_names": 30,
                     "provider_resolver_slots": 0,
                     "direct_root_dependency_slots": 0,
-                    "repository_replacement_slots": 30,
-                    "unique_repository_replacement_names": 30,
+                    "repository_replacement_slots": 28,
+                    "unique_repository_replacement_names": 28,
                 },
             },
         )

--- a/tests/test_python_package_skeleton.py
+++ b/tests/test_python_package_skeleton.py
@@ -28,6 +28,7 @@ PACKAGE_MODULES = (
     "easyuse_anima.aio.generation_detailer",
     "easyuse_anima.aio.generation_output",
     "easyuse_anima.aio.generation_defaults",
+    "easyuse_anima.aio.input_defaults",
     "easyuse_anima.aio.generation_migrations",
     "easyuse_anima.aio.generation_settings",
     "easyuse_anima.aio.resources",


### PR DESCRIPTION
## 변경 요약

B-11c30d3 frozen subgroup의 resource, preview, output runtime binder 세 개만 퇴역시키는 **Move 전용 PR**입니다.

- `_bind_aio_resource_runtime`, `_bind_aio_preview_runtime`, `_bind_aio_output_runtime`과 각 `_RUNTIME_RESOLVER`/`_runtime_helper`를 제거했습니다.
- `AIO_INPUT_DEFAULT_SETTINGS`와 관련 선언값을 순수 `easyuse_anima.aio.input_defaults` owner로 이동하고 root는 동일 객체/값의 exact alias를 유지합니다.
- resource, preview, output은 기존 canonical owner를 직접 사용합니다.
- Comfy node lookup은 기존 E-07 call-time provider를 유지하고, `folder_paths`·NumPy·PIL·PromptServer 등 optional I/O import 시점도 유지합니다.
- d3 테스트 patch ownership만 canonical module로 이동했습니다. d0b, d4-d6, Wildcard/NAIA는 변경하지 않았습니다.

## 사전 inventory

- binders: 3개
  - `_bind_aio_resource_runtime`
  - `_bind_aio_preview_runtime`
  - `_bind_aio_output_runtime`
- state: 각 module의 `_RUNTIME_RESOLVER` 1개, 총 3개
- frozen cost: root resolver 49 slots / 46 unique names, provider 4 slots / 2 names, direct root dependency 3 slots / 1 name, repository replacement 45 slots / 43 names / 8 files
- provider: `_find_comfy_node_class`, `_require_custom_node_class`는 E-07 call-time provider 유지
- patch ownership: d3 owner를 구동하는 resource/preview/output 테스트만 canonical patch로 이동. d4-d6 테스트 seam은 유지

## 변경 결과

- 전체 runtime binder: 10개 → 7개
  - AiO 5개(d4-d6)
  - Wildcard/NAIA 2개
- root residual globals: 12개 → 3개
- canonical root bindings: 290개 → 296개
- shipped/reachable Python modules: 91개 → 92개
- `nodes.py`: 1,182 lines
- Phase A 12,663-line baseline 대비 11,481 lines, 약 90.7% 제거

## 주요 파일

Production:
- `nodes.py`
- `easyuse_anima/aio/input_defaults.py`
- `easyuse_anima/aio/resources.py`
- `easyuse_anima/aio/preview.py`
- `easyuse_anima/aio/output.py`

Supporting:
- focused resource/preview/output 및 direct adapter tests
- Python package/compatibility gate와 fixture
- nodes/backend analyzer gate와 fixture
- backend architecture 문서 3개

## 검증

- Focused unittest: 181 tests, 13.073s, 통과
- Canonical production owner targeted Ruff 0.15.22: 통과
- Official full (`tools/check_project.ps1 -Profile full`): 통과
  - Python compile: 통과
  - Ruff G-01 report-only: 기존 78 findings, blocking failure 없음
  - Pyright baseline ratchet: 통과 (75 files, 14 baseline errors, 신규 증가 없음)
  - Python import boundary: 6 completed groups, 0 violations
  - Python unittest: 983 tests, 30.159s, 통과
  - Frontend: 114 JavaScript files, TypeScript 6.0.3, 통과
  - `git diff --check`: 통과
- ComfyUI Codex test surface: repository full validation
- Live ComfyUI smoke: 미실행 (순수 Python Move, behavior/schema/workflow 변경 없음)

## 유지한 경계와 남은 위험

input defaults/choices, loader selection, provider interface/lookup order, optional dependency timing, preview/save formats, metadata, filenames, event payloads, errors, logs, schemas, workflows, seeds, cache, model preparation, sampling, conditioning, stage order는 변경하지 않았습니다.

`nodes.py`의 정적 Ruff unused 항목 일부는 아직 d4-d6 binder가 동적으로 소비하는 root compatibility alias입니다. G-01 report-only 부채로 유지하고 후속 retirement 경계에서 제거합니다.

Owner: #184
Behavior boundary: #169