### PR TITLE
B-11c30d4: retire AiO execution-service binders

### DIFF
--- a/docs/architecture/comfy-host-provider-bridge.md
+++ b/docs/architecture/comfy-host-provider-bridge.md
@@ -1948,6 +1948,138 @@ Result:
 - `nodes.py` is 1,182 lines, 11,481 fewer than the 12,663-line Phase A
   baseline (90.7% removed).
 
+### B-11c30d4 — AiO execution-service binder Move
+
+- **State:** READY; Draft PR pending
+- **Owner:** #184
+- **Behavior boundary:** #168 and #169
+- **Type:** Move
+- **Base:** `dev@62e92e16b38b2b9cf521df474eaae7ccc1bf1ec8`
+
+Pre-edit inventory:
+
+- the frozen d4 subgroup contains exactly
+  `_bind_aio_model_preparation_runtime`, `_bind_aio_sampling_runtime`, and
+  `_bind_aio_conditioning_runtime`;
+- the three binders own only three `_RUNTIME_RESOLVER` globals. They account
+  for 43 root-resolver slots over 37 unique names, six provider slots over
+  `_find_comfy_node_class`, `_require_custom_node_class`,
+  `_require_any_custom_node_class`, and `_encode_with_comfy_clip`, three direct
+  `_resolve_comfy_host_helper` dependencies, and 23 repository replacement
+  slots over 21 names in six test files;
+- model preparation has fourteen root-resolver names, three provider names,
+  and one direct E-07 bridge. It owns twelve root identity aliases covering
+  AuraFlow, KJ, DAVE, Safe PAG, Spectrum model patches, LoRA normalization and
+  application, signature construction, and ephemeral-model cleanup;
+- sampling has nineteen root-resolver names, two provider names, and one direct
+  E-07 bridge. It owns eleven root identity aliases covering random/effective
+  seeds, latent creation, Comfy/Spectrum sampling, VAE encode/decode, stage
+  sampler settings, and highres backend selection;
+- conditioning has ten root-resolver names, one provider name, and one direct
+  E-07 bridge. It owns three root identity aliases covering Prompt Data field
+  selection, the no-general prompt, and USDU conditioning;
+- root imports all 26 canonical functions as exact package/flat aliases and
+  imports/calls each binder once during module initialization;
+- `easyuse_anima.aio.legacy_generation` is the production caller of the d4
+  execution functions through its still-active d5 resolver. Direct d4 owner
+  tests currently patch root to affect same-module calls, while d5/d6 tests
+  also patch root aliases for their still-active binders; and
+- model-management, Comfy node, Spectrum, KJ, DAVE, Safe PAG, seed, LoRA,
+  Prompt Data, and CLIP behavior already have canonical stateless/provider
+  owners. No new data, service, or callback contract is required.
+
+Exact root-resolver names:
+
+```text
+model_preparation:
+  _apply_aio_anima_dave_patch
+  _apply_aio_kj_model_patches
+  _apply_aio_safe_pag_patch
+  _apply_aio_spectrum_correction_patch_for_comfy_sampler
+  _apply_aio_spectrum_forecast_patch_for_comfy_sampler
+  _as_bool
+  _as_float
+  _as_int
+  _call_with_supported_kwargs
+  _lora_stack_name
+  _node_output_tuple
+  _normalize_aio_lora_stack
+  _patch_model_sampling_aura_flow
+  logger
+
+sampling:
+  AIO_SPECIAL_SEEDS
+  ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE
+  ANIMA_MOD_GUIDANCE_PROFILE_OFF
+  MAX_SEED
+  SEED_CONTROL_FIXED
+  _as_bool
+  _as_float
+  _as_int
+  _call_with_supported_kwargs
+  _json_clone
+  _new_aio_random_seed
+  _node_output_tuple
+  _normalize_aio_seed
+  _normalize_anima_mod_guidance_profile
+  _resolve_aio_runtime_seed
+  _sample_latent_with_comfy
+  _sample_latent_with_spectrum_mod_guidance_advanced
+  _sample_latent_with_spectrum_spd
+  random
+
+conditioning:
+  AIO_USDU_PROMPT_FULL
+  AIO_USDU_PROMPT_NO_GENERAL
+  _advanced_artist_field_prompt
+  _advanced_enabled_pane_fields
+  _aio_prompt_data_fields_for_usdu
+  _aio_usdu_prompt_without_general
+  _as_bool
+  _correct_advanced_field_sequence
+  _normalize_advanced_fields
+  _normalize_prompt_data
+```
+
+Allowed production files:
+
+```text
+nodes.py
+easyuse_anima/aio/model_preparation.py
+easyuse_anima/aio/sampling.py
+easyuse_anima/aio/conditioning.py
+```
+
+Allowed supporting files are the focused d4 owner/caller tests, Comfy-host and
+Python compatibility gates/fixtures, nodes/backend analyzer gates/fixtures,
+and the three architecture documents.
+
+Exit:
+
+- all three d4 binder definitions, root imports/calls, `_RUNTIME_RESOLVER`
+  globals, and `_runtime_helper` functions are absent;
+- the three canonical modules import existing stateless owners directly, use
+  direct same-module calls, and resolve only their existing E-07 host seams at
+  call time;
+- root keeps exact aliases for all 26 canonical execution functions;
+- only d4 owner tests move their patch ownership to canonical modules. Root
+  replacements that drive the still-active d5/d6 binders remain;
+- d4 alone is retired while d5 and d6 remain the exact active AiO groups; and
+- all model patch/cleanup, LoRA, seed, sampler/Spectrum, VAE, stage-setting,
+  Prompt Data, conditioning, provider, error, log, schema, workflow, cache,
+  and stage behavior remains unchanged.
+
+Forbidden:
+
+- changing patch order/kwargs, LoRA normalization/application, cleanup timing,
+  seed/random semantics, backend selection, sampler/Spectrum/VAE invocation,
+  SPD Euler normalization, stage sampler settings, prompt field selection,
+  quality fallback, CLIP text, provider lookup, errors/logs, schemas,
+  workflows, cache, or stage order;
+- retiring d5, d6, or Wildcard/NAIA binders, or beginning d0b; and
+- combining Contract, Behavior, performance, dependency, or broad formatting
+  cleanup.
+
 ### B-11d — Final root shim
 
 - **State:** BLOCKED by the remaining AiO and Wildcard/NAIA binder families

--- a/docs/architecture/comfy-host-provider-bridge.md
+++ b/docs/architecture/comfy-host-provider-bridge.md
@@ -1950,7 +1950,7 @@ Result:
 
 ### B-11c30d4 — AiO execution-service binder Move
 
-- **State:** READY; Draft PR pending
+- **State:** COMPLETE in PR #351
 - **Owner:** #184
 - **Behavior boundary:** #168 and #169
 - **Type:** Move
@@ -2080,6 +2080,22 @@ Forbidden:
 - combining Contract, Behavior, performance, dependency, or broad formatting
   cleanup.
 
+Result:
+
+- all three d4 binder definitions, resolver globals/helpers, and root
+  imports/calls are absent;
+- model preparation, sampling, and conditioning use direct canonical
+  stateless dependencies and same-module calls. The four existing E-07 host
+  seams retain call-time provider observation;
+- all 26 root execution aliases retain exact canonical identity, while only
+  d4 owner tests moved patch ownership to canonical modules;
+- d4 alone is retired. Four binders remain: the d5 legacy orchestrator, d6 node
+  adapter, and two Wildcard/NAIA callback binders;
+- the compatibility surface contains 293 canonical root bindings, three
+  residual root globals, and 92 shipped and reachable Python modules; and
+- `nodes.py` is 1,158 lines, 11,505 fewer than the 12,663-line Phase A
+  baseline (90.9% removed).
+
 ### B-11d — Final root shim
 
 - **State:** BLOCKED by the remaining AiO and Wildcard/NAIA binder families
@@ -2130,8 +2146,8 @@ COMPLETE: B-11c30d1 AiO cache-state binder Move / PR #347
 COMPLETE: B-11c30d0a output-settings owner Move / PR #348
 COMPLETE: B-11c30d2 normalization/planning binder Move / PR #349
 COMPLETE: B-11c30d3 I/O-boundary binder Move / PR #350
-READY:    B-11c30d4 execution-service Move
-PLANNED:  B-11c30d0b input-context owner Move before d5-d6
+COMPLETE: B-11c30d4 execution-service Move / PR #351
+READY:    B-11c30d0b input-context owner Move before d5-d6
 PLANNED:  B-11c30d5-d6 orchestration and node-adapter Moves
 BLOCKED:  B-11d final root shim
 

--- a/docs/architecture/python-backend-execution-roadmap.md
+++ b/docs/architecture/python-backend-execution-roadmap.md
@@ -1097,6 +1097,11 @@ unchanged. The separate legacy Wildcard unsupported alias remains for D-12.
     provider. The root shim falls to 1,182 lines and the audited package grows
     to 92 shipped and reachable modules. d0b and d4 through d6 remain
     separate; B-11c30d4 is the next READY Move.
+  - B-11c30d4 is limited to the model-preparation, sampling, and conditioning
+    binder subgroup. The Move consumes existing common, Prompt, LoRA, seed,
+    invocation, and E-07 owners; it creates no new contract. Patch order,
+    seed/sampler behavior, provider observation, errors/logs, workflows,
+    cache, and stage order remain frozen. d0b and d5-d6 stay separate.
   - The final B-11c cutover removes remaining root execution ownership and
     leaves the explicit supported `nodes.py` compatibility shim.
 - Add `easyuse_anima/registration.py` as pure mapping composition. It performs no

--- a/docs/architecture/python-backend-execution-roadmap.md
+++ b/docs/architecture/python-backend-execution-roadmap.md
@@ -140,7 +140,10 @@ merged PR, the owning issue's evidence record, and every stated exit gate.
   remain across AiO and Wildcard/NAIA. B-11c30d3 / PR #350 retires only the
   resource, preview, and output binders. Input defaults now have one pure data
   owner, while optional I/O imports and E-07 host lookup remain call-time.
-  Seven binders remain: five AiO and two Wildcard/NAIA.
+  Seven binders remain: five AiO and two Wildcard/NAIA. B-11c30d4 / PR #351
+  retires only model preparation, sampling, and conditioning. Four binders
+  remain: the d5 orchestrator, d6 node adapter, and two Wildcard/NAIA callback
+  binders.
 
 ### Current quality baseline
 
@@ -1097,11 +1100,12 @@ unchanged. The separate legacy Wildcard unsupported alias remains for D-12.
     provider. The root shim falls to 1,182 lines and the audited package grows
     to 92 shipped and reachable modules. d0b and d4 through d6 remain
     separate; B-11c30d4 is the next READY Move.
-  - B-11c30d4 is limited to the model-preparation, sampling, and conditioning
-    binder subgroup. The Move consumes existing common, Prompt, LoRA, seed,
-    invocation, and E-07 owners; it creates no new contract. Patch order,
-    seed/sampler behavior, provider observation, errors/logs, workflows,
-    cache, and stage order remain frozen. d0b and d5-d6 stay separate.
+  - B-11c30d4 retires only the model-preparation, sampling, and conditioning
+    binder subgroup in PR #351. The Move consumes existing common, Prompt,
+    LoRA, seed, invocation, and E-07 owners and creates no new contract. Patch
+    order, seed/sampler behavior, provider observation, errors/logs,
+    workflows, cache, and stage order remain frozen. The root shim falls to
+    1,158 lines. B-11c30d0b is the next READY Move before d5-d6.
   - The final B-11c cutover removes remaining root execution ownership and
     leaves the explicit supported `nodes.py` compatibility shim.
 - Add `easyuse_anima/registration.py` as pure mapping composition. It performs no

--- a/docs/architecture/python-compatibility-shims.md
+++ b/docs/architecture/python-compatibility-shims.md
@@ -950,7 +950,7 @@ convenience-node compatibility; it remains unmapped and is not public support.
 
 ### B-11c30d4 AiO execution-service binder retirement
 
-- The planned Move contains exactly `_bind_aio_model_preparation_runtime`,
+- PR #351 retires exactly `_bind_aio_model_preparation_runtime`,
   `_bind_aio_sampling_runtime`, and `_bind_aio_conditioning_runtime`.
 - The current surface is 43 root-resolver slots over 37 names, six E-07
   provider slots over four names, three direct root-helper dependencies, and
@@ -969,6 +969,11 @@ convenience-node compatibility; it remains unmapped and is not public support.
   VAE encode/decode, stage settings, Prompt Data selection, CLIP conditioning,
   provider timing, errors/logs, schemas/workflows, cache, and stage behavior
   are frozen.
+- The d4 binder definitions, resolver globals/helpers, and root imports/calls
+  are absent. Four binders remain: d5, d6, and the two Wildcard/NAIA callbacks.
+- The compatibility inventory contains 293 canonical root bindings, three
+  residual root globals, 92 shipped and reachable Python modules, and a
+  1,158-line root shim.
 
 ### `nodes.py` public node-class surface
 

--- a/docs/architecture/python-compatibility-shims.md
+++ b/docs/architecture/python-compatibility-shims.md
@@ -948,6 +948,28 @@ convenience-node compatibility; it remains unmapped and is not public support.
   residual root globals, 92 shipped and reachable Python modules, and a
   1,182-line root shim.
 
+### B-11c30d4 AiO execution-service binder retirement
+
+- The planned Move contains exactly `_bind_aio_model_preparation_runtime`,
+  `_bind_aio_sampling_runtime`, and `_bind_aio_conditioning_runtime`.
+- The current surface is 43 root-resolver slots over 37 names, six E-07
+  provider slots over four names, three direct root-helper dependencies, and
+  23 repository replacement slots over 21 names in six files.
+- The three binders own only three `_RUNTIME_RESOLVER` globals. Root imports
+  all 26 canonical execution functions as exact package/flat aliases and calls
+  each binder once.
+- Model preparation consumes existing common-value, Comfy invocation, LoRA,
+  and E-07 owners. Sampling consumes common serialization/value, generation
+  default/normalization, Prompt conditioning, seed, invocation, and E-07
+  owners. Conditioning consumes common value, Prompt Data/Advanced,
+  generation-default, and E-07 owners.
+- Same-module calls become direct and only d4 owner tests move patch ownership
+  to the canonical modules. Root replacements that drive d5/d6 remain.
+- Model patches/cleanup, LoRA, random/effective seeds, Comfy/Spectrum sampling,
+  VAE encode/decode, stage settings, Prompt Data selection, CLIP conditioning,
+  provider timing, errors/logs, schemas/workflows, cache, and stage behavior
+  are frozen.
+
 ### `nodes.py` public node-class surface
 
 The confirmed 0.5.2 mapped classes are:

--- a/easyuse_anima/aio/conditioning.py
+++ b/easyuse_anima/aio/conditioning.py
@@ -2,35 +2,40 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable
-from typing import Any, TypeAlias
+from typing import Any
 
-_RuntimeResolver: TypeAlias = Callable[[str], Any]
-_RUNTIME_RESOLVER: _RuntimeResolver | None = None
+from ..common.values import _as_bool
+from ..infrastructure.comfy.wiring import resolve_comfy_host_helper
+from ..prompt.advanced import (
+    _advanced_artist_field_prompt,
+    _advanced_enabled_pane_fields,
+    _correct_advanced_field_sequence,
+    _normalize_advanced_fields,
+)
+from ..prompt.data import _normalize_prompt_data
+from .generation_defaults import AIO_USDU_PROMPT_FULL, AIO_USDU_PROMPT_NO_GENERAL
 
 
-def _bind_aio_conditioning_runtime(*, resolve_helper: _RuntimeResolver) -> None:
-    """Bind root compatibility helpers without importing the root module."""
+def _missing_host_helper(name: str):
+    raise RuntimeError(
+        f"[EasyUseAnima] AiO conditioning Comfy host helper is unavailable: {name}"
+    )
 
-    global _RUNTIME_RESOLVER
-    _RUNTIME_RESOLVER = resolve_helper
 
-
-def _runtime_helper(name: str) -> Any:
-    resolver = _RUNTIME_RESOLVER
-    if resolver is None:
-        raise RuntimeError(
-            f"[EasyUseAnima] AiO conditioning runtime helper is not bound: {name}"
-        )
-    return resolver(name)
+def _encode_with_comfy_clip(clip, text: str):
+    helper = resolve_comfy_host_helper(
+        "_encode_with_comfy_clip",
+        _missing_host_helper,
+    )
+    return helper(clip, text)
 
 
 def _aio_prompt_data_fields_for_usdu(prompt_data: str | dict | None) -> list[dict]:
-    data = _runtime_helper("_normalize_prompt_data")(prompt_data)
+    data = _normalize_prompt_data(prompt_data)
     fields = data.get("fields")
     if not isinstance(fields, list):
         fields = data.get("saved_fields")
-    return _runtime_helper("_normalize_advanced_fields")(fields)
+    return _normalize_advanced_fields(fields)
 
 
 def _aio_usdu_prompt_without_general(
@@ -38,7 +43,7 @@ def _aio_usdu_prompt_without_general(
     pane: str,
     include_quality: bool,
 ) -> tuple[str, bool]:
-    fields = _runtime_helper("_aio_prompt_data_fields_for_usdu")(prompt_data)
+    fields = _aio_prompt_data_fields_for_usdu(prompt_data)
     if not fields:
         return "", False
     allowed_types = {"artist", "trigger"}
@@ -46,20 +51,18 @@ def _aio_usdu_prompt_without_general(
         allowed_types.add("quality")
     selected = [
         field
-        for field in _runtime_helper("_advanced_enabled_pane_fields")(fields, pane)
+        for field in _advanced_enabled_pane_fields(fields, pane)
         if field.get("type") in allowed_types
     ]
     if not selected:
         return "", True
-    artist_prompt = _runtime_helper("_advanced_artist_field_prompt")(selected, pane)
-    force_pin_triggers = _runtime_helper("_as_bool")(
-        _runtime_helper("_normalize_prompt_data")(prompt_data).get(
-            "pin_trigger_tags_to_front"
-        ),
+    artist_prompt = _advanced_artist_field_prompt(selected, pane)
+    force_pin_triggers = _as_bool(
+        _normalize_prompt_data(prompt_data).get("pin_trigger_tags_to_front"),
         False,
     )
     return (
-        _runtime_helper("_correct_advanced_field_sequence")(
+        _correct_advanced_field_sequence(
             selected,
             include_quality=include_quality,
             artist_overrides=artist_prompt,
@@ -80,45 +83,37 @@ def _aio_usdu_conditioning(
     exclude_positive_quality: bool = False,
     exclude_negative_quality: bool = False,
 ):
-    prompt_full = _runtime_helper("AIO_USDU_PROMPT_FULL")
-    prompt_no_general = _runtime_helper("AIO_USDU_PROMPT_NO_GENERAL")
+    prompt_full = AIO_USDU_PROMPT_FULL
+    prompt_no_general = AIO_USDU_PROMPT_NO_GENERAL
     prompt_mode = str(usdu_settings.get("prompt_mode") or prompt_full)
     if prompt_mode == "quality_tags_only":
         prompt_mode = prompt_no_general
     if prompt_mode != prompt_no_general:
         return positive, negative
-    prompt, has_fields = _runtime_helper("_aio_usdu_prompt_without_general")(
+    prompt, has_fields = _aio_usdu_prompt_without_general(
         prompt_data,
         "positive",
-        include_quality=not _runtime_helper("_as_bool")(
-            exclude_positive_quality, False
-        ),
+        include_quality=not _as_bool(exclude_positive_quality, False),
     )
-    negative_prompt, has_negative_fields = _runtime_helper(
-        "_aio_usdu_prompt_without_general"
-    )(
+    negative_prompt, has_negative_fields = _aio_usdu_prompt_without_general(
         prompt_data,
         "negative",
-        include_quality=not _runtime_helper("_as_bool")(
-            exclude_negative_quality, False
-        ),
+        include_quality=not _as_bool(exclude_negative_quality, False),
     )
     if not has_fields and not prompt:
         prompt = (
             ""
-            if _runtime_helper("_as_bool")(exclude_positive_quality, False)
+            if _as_bool(exclude_positive_quality, False)
             else str(quality_tags or "highres, best quality")
         )
     if not has_negative_fields and not negative_prompt:
         negative_prompt = (
             ""
-            if _runtime_helper("_as_bool")(exclude_negative_quality, False)
+            if _as_bool(exclude_negative_quality, False)
             else str(quality_neg or "")
         )
-    positive_conditioning = _runtime_helper("_encode_with_comfy_clip")(clip, prompt)
-    negative_conditioning = _runtime_helper("_encode_with_comfy_clip")(
-        clip, negative_prompt
-    )
+    positive_conditioning = _encode_with_comfy_clip(clip, prompt)
+    negative_conditioning = _encode_with_comfy_clip(clip, negative_prompt)
     return positive_conditioning, negative_conditioning
 
 

--- a/easyuse_anima/aio/model_preparation.py
+++ b/easyuse_anima/aio/model_preparation.py
@@ -3,32 +3,60 @@
 from __future__ import annotations
 
 import json
-from collections.abc import Callable
-from typing import Any, TypeAlias
+import logging
+from typing import Any
 
-_RuntimeResolver: TypeAlias = Callable[[str], Any]
-_RUNTIME_RESOLVER: _RuntimeResolver | None = None
+from ..common.values import _as_bool, _as_float, _as_int
+from ..infrastructure.comfy.invocation import (
+    _call_with_supported_kwargs,
+    _node_output_tuple,
+)
+from ..infrastructure.comfy.wiring import resolve_comfy_host_helper
+from ..lora.metadata import _lora_stack_name
+
+logger = logging.getLogger("ComfyUI-EasyUseAnima")
 
 
-def _bind_aio_model_preparation_runtime(*, resolve_helper: _RuntimeResolver) -> None:
-    """Bind root compatibility helpers without importing the root module."""
+def _missing_host_helper(name: str):
+    raise RuntimeError(
+        f"[EasyUseAnima] AiO model preparation Comfy host helper is unavailable: {name}"
+    )
 
-    global _RUNTIME_RESOLVER
-    _RUNTIME_RESOLVER = resolve_helper
+
+def _find_comfy_node_class(node_id: str):
+    helper = resolve_comfy_host_helper(
+        "_find_comfy_node_class",
+        _missing_host_helper,
+    )
+    return helper(node_id)
 
 
-def _runtime_helper(name: str) -> Any:
-    resolver = _RUNTIME_RESOLVER
-    if resolver is None:
-        raise RuntimeError(
-            f"[EasyUseAnima] AiO model preparation runtime helper is not bound: {name}"
-        )
-    return resolver(name)
+def _require_custom_node_class(
+    node_id: str,
+    node_pack: str,
+    install_hint: str,
+):
+    helper = resolve_comfy_host_helper(
+        "_require_custom_node_class",
+        _missing_host_helper,
+    )
+    return helper(node_id, node_pack, install_hint)
+
+
+def _require_any_custom_node_class(
+    node_ids: tuple[str, ...],
+    node_pack: str,
+    install_hint: str,
+):
+    helper = resolve_comfy_host_helper(
+        "_require_any_custom_node_class",
+        _missing_host_helper,
+    )
+    return helper(node_ids, node_pack, install_hint)
 
 
 def _patch_model_sampling_aura_flow(model, aura_settings: dict[str, Any]):
-    find_node_class = _runtime_helper("_find_comfy_node_class")
-    aura_cls = find_node_class("ModelSamplingAuraFlow")
+    aura_cls = _find_comfy_node_class("ModelSamplingAuraFlow")
     if aura_cls is None:
         raise RuntimeError(
             "[EasyUseAnima] Missing required core node 'ModelSamplingAuraFlow'. "
@@ -40,9 +68,9 @@ def _patch_model_sampling_aura_flow(model, aura_settings: dict[str, Any]):
         raise RuntimeError("[EasyUseAnima] ModelSamplingAuraFlow does not expose patch_aura().")
     result = patch(
         model,
-        _runtime_helper("_as_float")(aura_settings.get("shift"), 3.0),
+        _as_float(aura_settings.get("shift"), 3.0),
     )
-    values = _runtime_helper("_node_output_tuple")(result)
+    values = _node_output_tuple(result)
     if not values:
         raise RuntimeError("[EasyUseAnima] ModelSamplingAuraFlow returned no MODEL.")
     return values[0]
@@ -51,32 +79,28 @@ def _patch_model_sampling_aura_flow(model, aura_settings: dict[str, Any]):
 def _apply_aio_kj_model_patches(model, kj_settings: dict[str, Any]):
     patched = model
     if kj_settings.get("fp16_accumulation"):
-        torch_settings_cls = _runtime_helper("_require_custom_node_class")(
+        torch_settings_cls = _require_custom_node_class(
             "ModelPatchTorchSettings",
             "ComfyUI-KJNodes",
             "Repository: https://github.com/kijai/ComfyUI-KJNodes",
         )
-        values = _runtime_helper("_node_output_tuple")(
-            torch_settings_cls().patch(patched, True)
-        )
+        values = _node_output_tuple(torch_settings_cls().patch(patched, True))
         if not values:
             raise RuntimeError("[EasyUseAnima] ModelPatchTorchSettings returned no MODEL.")
         patched = values[0]
 
     sage_attention = str(kj_settings.get("sage_attention") or "disabled")
     if sage_attention != "disabled":
-        sage_cls = _runtime_helper("_require_custom_node_class")(
+        sage_cls = _require_custom_node_class(
             "PathchSageAttentionKJ",
             "ComfyUI-KJNodes",
             "Repository: https://github.com/kijai/ComfyUI-KJNodes",
         )
-        values = _runtime_helper("_node_output_tuple")(
+        values = _node_output_tuple(
             sage_cls().patch(
                 patched,
                 sage_attention,
-                _runtime_helper("_as_bool")(
-                    kj_settings.get("sage_allow_compile"), False
-                ),
+                _as_bool(kj_settings.get("sage_allow_compile"), False),
             )
         )
         if not values:
@@ -85,32 +109,24 @@ def _apply_aio_kj_model_patches(model, kj_settings: dict[str, Any]):
 
     compile_settings = kj_settings.get("torch_compile", {})
     if isinstance(compile_settings, dict) and compile_settings.get("enabled"):
-        compile_cls = _runtime_helper("_require_custom_node_class")(
+        compile_cls = _require_custom_node_class(
             "TorchCompileModelAdvanced",
             "ComfyUI-KJNodes",
             "Repository: https://github.com/kijai/ComfyUI-KJNodes",
         )
-        values = _runtime_helper("_node_output_tuple")(
+        values = _node_output_tuple(
             compile_cls().patch(
                 patched,
                 str(compile_settings.get("backend") or "inductor"),
-                _runtime_helper("_as_bool")(
-                    compile_settings.get("fullgraph"), False
-                ),
+                _as_bool(compile_settings.get("fullgraph"), False),
                 str(compile_settings.get("mode") or "default"),
                 str(compile_settings.get("dynamic") or "auto"),
-                _runtime_helper("_as_int")(
-                    compile_settings.get("dynamo_cache_size_limit"), 64
-                ),
-                _runtime_helper("_as_bool")(
+                _as_int(compile_settings.get("dynamo_cache_size_limit"), 64),
+                _as_bool(
                     compile_settings.get("compile_transformer_blocks_only"), True
                 ),
-                _runtime_helper("_as_bool")(
-                    compile_settings.get("debug_compile_keys"), False
-                ),
-                _runtime_helper("_as_bool")(
-                    compile_settings.get("disable_dynamic_vram"), False
-                ),
+                _as_bool(compile_settings.get("debug_compile_keys"), False),
+                _as_bool(compile_settings.get("disable_dynamic_vram"), False),
             )
         )
         if not values:
@@ -123,29 +139,25 @@ def _apply_aio_model_patches(model, settings: dict[str, Any]):
     model_patches = settings.get("model_patches", {})
     if not isinstance(model_patches, dict):
         return model
-    patched = _runtime_helper("_patch_model_sampling_aura_flow")(
+    patched = _patch_model_sampling_aura_flow(
         model,
         model_patches.get("aura_flow", {})
         if isinstance(model_patches.get("aura_flow"), dict)
         else {},
     )
     dave_settings = model_patches.get("dave", {})
-    if isinstance(dave_settings, dict) and _runtime_helper("_as_bool")(
+    if isinstance(dave_settings, dict) and _as_bool(
         dave_settings.get("enabled"), False
     ):
-        patched = _runtime_helper("_apply_aio_anima_dave_patch")(
-            patched, dave_settings
-        )
+        patched = _apply_aio_anima_dave_patch(patched, dave_settings)
     safe_pag_settings = model_patches.get("safe_pag", {})
-    if isinstance(safe_pag_settings, dict) and _runtime_helper("_as_bool")(
+    if isinstance(safe_pag_settings, dict) and _as_bool(
         safe_pag_settings.get("enabled"), False
     ):
-        patched = _runtime_helper("_apply_aio_safe_pag_patch")(
-            patched, safe_pag_settings
-        )
+        patched = _apply_aio_safe_pag_patch(patched, safe_pag_settings)
     kj_settings = model_patches.get("kj", {})
     if isinstance(kj_settings, dict):
-        patched = _runtime_helper("_apply_aio_kj_model_patches")(patched, kj_settings)
+        patched = _apply_aio_kj_model_patches(patched, kj_settings)
     return patched
 
 
@@ -180,11 +192,11 @@ def _normalize_aio_lora_stack(lora_stack) -> list[tuple[str, float, float]]:
             continue
         entries.append(
             (
-                _runtime_helper("_lora_stack_name")(name),
-                _runtime_helper("_as_float")(model_strength, 1.0),
-                _runtime_helper("_as_float")(
+                _lora_stack_name(name),
+                _as_float(model_strength, 1.0),
+                _as_float(
                     clip_strength,
-                    _runtime_helper("_as_float")(model_strength, 1.0),
+                    _as_float(model_strength, 1.0),
                 ),
             )
         )
@@ -198,19 +210,18 @@ def _aio_lora_stack_signature(lora_stack) -> list[dict[str, Any]]:
             "strength_model": model_strength,
             "strength_clip": clip_strength,
         }
-        for name, model_strength, clip_strength in _runtime_helper(
-            "_normalize_aio_lora_stack"
-        )(lora_stack)
+        for name, model_strength, clip_strength in _normalize_aio_lora_stack(
+            lora_stack
+        )
     ]
 
 
 def _apply_aio_lora_stack(model, clip, lora_stack):
-    entries = _runtime_helper("_normalize_aio_lora_stack")(lora_stack)
+    entries = _normalize_aio_lora_stack(lora_stack)
     if not entries:
         return model, clip, []
 
-    find_node_class = _runtime_helper("_find_comfy_node_class")
-    loader_cls = find_node_class("LoraLoader")
+    loader_cls = _find_comfy_node_class("LoraLoader")
     if loader_cls is None:
         raise RuntimeError("[EasyUseAnima] Could not find ComfyUI core LoraLoader.")
     loader = loader_cls()
@@ -224,8 +235,7 @@ def _apply_aio_lora_stack(model, clip, lora_stack):
     for name, model_strength, clip_strength in entries:
         if model_strength == 0 and clip_strength == 0:
             continue
-        node_output_tuple = _runtime_helper("_node_output_tuple")
-        values = node_output_tuple(
+        values = _node_output_tuple(
             load_lora(patched_model, patched_clip, name, model_strength, clip_strength)
         )
         if len(values) < 2:
@@ -242,7 +252,7 @@ def _apply_aio_lora_stack(model, clip, lora_stack):
 
 
 def _apply_aio_anima_dave_patch(model, dave_settings: dict[str, Any]):
-    dave_cls = _runtime_helper("_require_custom_node_class")(
+    dave_cls = _require_custom_node_class(
         "AnimaDAVE",
         "ComfyUI-Anima-DAVE",
         "Repository: https://github.com/sorryhyun/ComfyUI-Anima-DAVE",
@@ -256,17 +266,17 @@ def _apply_aio_anima_dave_patch(model, dave_settings: dict[str, Any]):
     result = patch(
         model,
         str(dave_settings.get("mask") or "dave_alpha.npz"),
-        _runtime_helper("_as_float")(dave_settings.get("strength"), 0.30),
-        _runtime_helper("_as_float")(dave_settings.get("tau"), 0.10),
+        _as_float(dave_settings.get("strength"), 0.30),
+        _as_float(dave_settings.get("tau"), 0.10),
     )
-    values = _runtime_helper("_node_output_tuple")(result)
+    values = _node_output_tuple(result)
     if not values:
         raise RuntimeError("[EasyUseAnima] AnimaDAVE returned no MODEL.")
     return values[0]
 
 
 def _apply_aio_safe_pag_patch(model, safe_pag_settings: dict[str, Any]):
-    safe_pag_cls = _runtime_helper("_require_custom_node_class")(
+    safe_pag_cls = _require_custom_node_class(
         "AnimaSafePAG",
         "Anima Safe PAG",
         "Repository: https://github.com/iljung1106/comfyui-anima-safe-pag",
@@ -275,20 +285,16 @@ def _apply_aio_safe_pag_patch(model, safe_pag_settings: dict[str, Any]):
         safe_pag_settings = {}
     result = safe_pag_cls().patch(
         model,
-        _runtime_helper("_as_float")(safe_pag_settings.get("scale"), 4.0),
+        _as_float(safe_pag_settings.get("scale"), 4.0),
         str(safe_pag_settings.get("block_indices") or "18"),
-        _runtime_helper("_as_float")(
-            safe_pag_settings.get("perturbation_strength"), 0.75
-        ),
+        _as_float(safe_pag_settings.get("perturbation_strength"), 0.75),
         str(safe_pag_settings.get("head_indices") or ""),
-        _runtime_helper("_as_float")(
-            safe_pag_settings.get("start_percent"), 0.0
-        ),
-        _runtime_helper("_as_float")(safe_pag_settings.get("end_percent"), 0.7),
-        _runtime_helper("_as_float")(safe_pag_settings.get("rescale"), 0.2),
+        _as_float(safe_pag_settings.get("start_percent"), 0.0),
+        _as_float(safe_pag_settings.get("end_percent"), 0.7),
+        _as_float(safe_pag_settings.get("rescale"), 0.2),
         str(safe_pag_settings.get("rescale_mode") or "full"),
     )
-    values = _runtime_helper("_node_output_tuple")(result)
+    values = _node_output_tuple(result)
     if not values:
         raise RuntimeError("[EasyUseAnima] AnimaSafePAG returned no MODEL.")
     return values[0]
@@ -303,7 +309,7 @@ def _cleanup_aio_ephemeral_model(model, base_model=None) -> None:
             detach(unpatch_all=False)
             return
         except Exception as exc:
-            _runtime_helper("logger").debug(
+            logger.debug(
                 "[EasyUseAnima] failed to detach ephemeral AiO model clone: %s", exc
             )
     try:
@@ -314,7 +320,7 @@ def _cleanup_aio_ephemeral_model(model, base_model=None) -> None:
             unload(model, unload_additional_models=True)
             return
     except Exception as exc:
-        _runtime_helper("logger").debug(
+        logger.debug(
             "[EasyUseAnima] failed to unload ephemeral AiO model clone: %s", exc
         )
 
@@ -326,55 +332,51 @@ def _apply_aio_spectrum_correction_patch_for_comfy_sampler(
     sampler_settings: dict[str, Any],
 ):
     corrections = sampler_settings.get("dit_corrections", {})
-    if not isinstance(corrections, dict) or not _runtime_helper("_as_bool")(
+    if not isinstance(corrections, dict) or not _as_bool(
         corrections.get("enabled"), False
     ):
         return model
-    patch_cls = _runtime_helper("_require_custom_node_class")(
+    patch_cls = _require_custom_node_class(
         "DiTCFGFSGPatch",
         "ComfyUI-Spectrum-KSampler",
         "Repository: https://github.com/blepping/ComfyUI-Spectrum-KSampler",
     )
-    use_smc = _runtime_helper("_as_bool")(corrections.get("smc_cfg"), False)
-    use_cfgpp = _runtime_helper("_as_bool")(corrections.get("cfgpp"), False)
-    use_fsg = _runtime_helper("_as_bool")(corrections.get("fsg"), False)
-    values = _runtime_helper("_node_output_tuple")(
+    use_smc = _as_bool(corrections.get("smc_cfg"), False)
+    use_cfgpp = _as_bool(corrections.get("cfgpp"), False)
+    use_fsg = _as_bool(corrections.get("fsg"), False)
+    values = _node_output_tuple(
         patch_cls().patch(
             model,
             True,
             str(corrections.get("dcw_mode") or "off"),
-            _runtime_helper("_as_float")(corrections.get("dcw_lambda"), 0.01),
+            _as_float(corrections.get("dcw_lambda"), 0.01),
             str(corrections.get("dcw_band_mask") or "LL"),
             str(corrections.get("dcw_calibrator") or "(auto-download default)"),
             use_smc,
-            _runtime_helper("_as_float")(corrections.get("adaptive_smc_alpha"), 0.0)
+            _as_float(corrections.get("adaptive_smc_alpha"), 0.0)
             if use_smc
             else 0.0,
-            _runtime_helper("_as_float")(corrections.get("smc_cfg_lambda"), 6.0)
+            _as_float(corrections.get("smc_cfg_lambda"), 6.0)
             if use_smc
             else 0.0,
             use_cfgpp,
-            _runtime_helper("_as_float")(corrections.get("cfgpp_lambda"), 0.0)
+            _as_float(corrections.get("cfgpp_lambda"), 0.0)
             if use_cfgpp
             else 0.0,
             use_fsg,
-            _runtime_helper("_as_float")(corrections.get("fsg_band_lo"), 0.59),
-            _runtime_helper("_as_float")(corrections.get("fsg_band_hi"), 0.75),
-            _runtime_helper("_as_int")(corrections.get("fsg_k"), 3),
-            _runtime_helper("_as_float")(corrections.get("fsg_d_sigma"), 0.1),
-            _runtime_helper("_as_float")(corrections.get("fsg_gamma"), 0.0),
-            _runtime_helper("_as_bool")(
-                corrections.get("replace_existing_cfg"), False
-            ),
-            steps=_runtime_helper("_as_int")(sampler_settings.get("steps"), 28),
-            cfg=_runtime_helper("_as_float")(sampler_settings.get("cfg"), 5.0),
+            _as_float(corrections.get("fsg_band_lo"), 0.59),
+            _as_float(corrections.get("fsg_band_hi"), 0.75),
+            _as_int(corrections.get("fsg_k"), 3),
+            _as_float(corrections.get("fsg_d_sigma"), 0.1),
+            _as_float(corrections.get("fsg_gamma"), 0.0),
+            _as_bool(corrections.get("replace_existing_cfg"), False),
+            steps=_as_int(sampler_settings.get("steps"), 28),
+            cfg=_as_float(sampler_settings.get("cfg"), 5.0),
             sampler_name=str(
                 sampler_settings.get("sampler_name") or "euler_ancestral"
             ),
             scheduler=str(sampler_settings.get("scheduler") or "normal"),
-            denoise=_runtime_helper("_as_float")(
-                sampler_settings.get("denoise"), 1.0
-            ),
+            denoise=_as_float(sampler_settings.get("denoise"), 1.0),
             clip=clip,
             positive=positive,
         )
@@ -389,11 +391,11 @@ def _apply_aio_spectrum_forecast_patch_for_comfy_sampler(
     sampler_settings: dict[str, Any],
 ):
     spectrum = sampler_settings.get("spectrum", {})
-    if not isinstance(spectrum, dict) or not _runtime_helper("_as_bool")(
+    if not isinstance(spectrum, dict) or not _as_bool(
         spectrum.get("enabled"), False
     ):
         return model
-    node_id, patch_cls = _runtime_helper("_require_any_custom_node_class")(
+    node_id, patch_cls = _require_any_custom_node_class(
         ("DiTSpectrumPatchAdvanced", "DiTSpectrumPatch"),
         "ComfyUI-Spectrum-KSampler",
         "Repository: https://github.com/blepping/ComfyUI-Spectrum-KSampler",
@@ -404,38 +406,22 @@ def _apply_aio_spectrum_forecast_patch_for_comfy_sampler(
         raise RuntimeError(f"[EasyUseAnima] {node_id} does not expose patch().")
     patch_kwargs = {
         "model": model,
-        "steps": _runtime_helper("_as_int")(sampler_settings.get("steps"), 28),
-        "window_size": _runtime_helper("_as_float")(
-            spectrum.get("window_size"), 2.0
-        ),
-        "flex_window": _runtime_helper("_as_float")(
-            spectrum.get("flex_window"), 0.25
-        ),
-        "warmup_steps": _runtime_helper("_as_int")(
-            spectrum.get("warmup_steps"), 6
-        ),
-        "tail_actual_steps": _runtime_helper("_as_int")(
-            spectrum.get("tail_actual_steps"), 3
-        ),
-        "blend_w": _runtime_helper("_as_float")(spectrum.get("blend_w"), 0.3),
-        "cheby_degree": _runtime_helper("_as_int")(
-            spectrum.get("cheby_degree"), 3
-        ),
-        "ridge_lambda": _runtime_helper("_as_float")(
-            spectrum.get("ridge_lambda"), 0.1
-        ),
-        "history_size": _runtime_helper("_as_int")(
-            spectrum.get("history_size"), 100
-        ),
+        "steps": _as_int(sampler_settings.get("steps"), 28),
+        "window_size": _as_float(spectrum.get("window_size"), 2.0),
+        "flex_window": _as_float(spectrum.get("flex_window"), 0.25),
+        "warmup_steps": _as_int(spectrum.get("warmup_steps"), 6),
+        "tail_actual_steps": _as_int(spectrum.get("tail_actual_steps"), 3),
+        "blend_w": _as_float(spectrum.get("blend_w"), 0.3),
+        "cheby_degree": _as_int(spectrum.get("cheby_degree"), 3),
+        "ridge_lambda": _as_float(spectrum.get("ridge_lambda"), 0.1),
+        "history_size": _as_int(spectrum.get("history_size"), 100),
         "enabled": True,
-        "one_sampler_only": _runtime_helper("_as_bool")(
-            spectrum.get("one_sampler_only"), False
-        ),
-        "verbose": _runtime_helper("_as_bool")(spectrum.get("verbose"), False),
+        "one_sampler_only": _as_bool(spectrum.get("one_sampler_only"), False),
+        "verbose": _as_bool(spectrum.get("verbose"), False),
         "compat_policy": str(spectrum.get("compat_policy") or "conservative"),
     }
-    values = _runtime_helper("_node_output_tuple")(
-        _runtime_helper("_call_with_supported_kwargs")(
+    values = _node_output_tuple(
+        _call_with_supported_kwargs(
             patch,
             (),
             patch_kwargs,
@@ -453,15 +439,13 @@ def _apply_aio_spectrum_model_patches_for_comfy_sampler(
     positive,
     sampler_settings: dict[str, Any],
 ):
-    patched = _runtime_helper(
-        "_apply_aio_spectrum_correction_patch_for_comfy_sampler"
-    )(
+    patched = _apply_aio_spectrum_correction_patch_for_comfy_sampler(
         model,
         clip,
         positive,
         sampler_settings,
     )
-    return _runtime_helper("_apply_aio_spectrum_forecast_patch_for_comfy_sampler")(
+    return _apply_aio_spectrum_forecast_patch_for_comfy_sampler(
         patched,
         sampler_settings,
     )

--- a/easyuse_anima/aio/sampling.py
+++ b/easyuse_anima/aio/sampling.py
@@ -2,43 +2,65 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable
-from typing import Any, TypeAlias
+import random
+from typing import Any
 
-_RuntimeResolver: TypeAlias = Callable[[str], Any]
-_RUNTIME_RESOLVER: _RuntimeResolver | None = None
+from ..common.serialization import _json_clone
+from ..common.values import _as_bool, _as_float, _as_int
+from ..infrastructure.comfy.invocation import (
+    _call_with_supported_kwargs,
+    _node_output_tuple,
+)
+from ..infrastructure.comfy.wiring import resolve_comfy_host_helper
+from ..prompt.conditioning import (
+    ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE,
+    ANIMA_MOD_GUIDANCE_PROFILE_OFF,
+    _normalize_anima_mod_guidance_profile,
+)
+from ..seed.reservation import SEED_CONTROL_FIXED
+from .generation_defaults import AIO_SPECIAL_SEEDS
+from .generation_normalization import MAX_SEED, _normalize_aio_seed
 
 
-def _bind_aio_sampling_runtime(*, resolve_helper: _RuntimeResolver) -> None:
-    """Bind root compatibility helpers without importing the root module."""
+def _missing_host_helper(name: str):
+    raise RuntimeError(
+        f"[EasyUseAnima] AiO sampling Comfy host helper is unavailable: {name}"
+    )
 
-    global _RUNTIME_RESOLVER
-    _RUNTIME_RESOLVER = resolve_helper
+
+def _find_comfy_node_class(node_id: str):
+    helper = resolve_comfy_host_helper(
+        "_find_comfy_node_class",
+        _missing_host_helper,
+    )
+    return helper(node_id)
 
 
-def _runtime_helper(name: str) -> Any:
-    resolver = _RUNTIME_RESOLVER
-    if resolver is None:
-        raise RuntimeError(
-            f"[EasyUseAnima] AiO sampling runtime helper is not bound: {name}"
-        )
-    return resolver(name)
+def _require_custom_node_class(
+    node_id: str,
+    node_pack: str,
+    install_hint: str,
+):
+    helper = resolve_comfy_host_helper(
+        "_require_custom_node_class",
+        _missing_host_helper,
+    )
+    return helper(node_id, node_pack, install_hint)
 
 
 def _new_aio_random_seed() -> int:
-    random_module = _runtime_helper("random")
-    return random_module.randint(0, _runtime_helper("MAX_SEED"))
+    return random.randint(0, MAX_SEED)
 
 
 def _resolve_aio_runtime_seed(value) -> int:
-    seed = _runtime_helper("_normalize_aio_seed")(value)
-    if seed in _runtime_helper("AIO_SPECIAL_SEEDS"):
-        return _runtime_helper("_new_aio_random_seed")()
-    return max(0, min(_runtime_helper("MAX_SEED"), seed))
+    seed = _normalize_aio_seed(value)
+    if seed in AIO_SPECIAL_SEEDS:
+        return _new_aio_random_seed()
+    return max(0, min(MAX_SEED, seed))
 
 
 def _generate_empty_latent_with_comfy(width: int, height: int):
-    latent_cls = _runtime_helper("_find_comfy_node_class")("EmptyLatentImage")
+    latent_cls = _find_comfy_node_class("EmptyLatentImage")
     if latent_cls is None:
         raise RuntimeError("[EasyUseAnima] Could not find ComfyUI EmptyLatentImage.")
     latent_node = latent_cls()
@@ -48,7 +70,7 @@ def _generate_empty_latent_with_comfy(width: int, height: int):
             "[EasyUseAnima] EmptyLatentImage does not expose generate()."
         )
     result = generate(max(16, int(width)), max(16, int(height)), 1)
-    values = _runtime_helper("_node_output_tuple")(result)
+    values = _node_output_tuple(result)
     if not values:
         raise RuntimeError("[EasyUseAnima] EmptyLatentImage returned no LATENT.")
     return values[0]
@@ -66,7 +88,7 @@ def _sample_latent_with_comfy(
     latent_image,
     denoise: float,
 ):
-    sampler_cls = _runtime_helper("_find_comfy_node_class")("KSampler")
+    sampler_cls = _find_comfy_node_class("KSampler")
     if sampler_cls is None:
         raise RuntimeError("[EasyUseAnima] Could not find ComfyUI KSampler.")
     sampler = sampler_cls()
@@ -75,7 +97,7 @@ def _sample_latent_with_comfy(
         raise RuntimeError("[EasyUseAnima] KSampler does not expose sample().")
     result = sample(
         model,
-        _runtime_helper("_resolve_aio_runtime_seed")(seed),
+        _resolve_aio_runtime_seed(seed),
         max(1, int(steps)),
         float(cfg),
         str(sampler_name),
@@ -85,7 +107,7 @@ def _sample_latent_with_comfy(
         latent_image,
         float(denoise),
     )
-    values = _runtime_helper("_node_output_tuple")(result)
+    values = _node_output_tuple(result)
     if not values:
         raise RuntimeError("[EasyUseAnima] KSampler returned no LATENT.")
     return values[0]
@@ -103,7 +125,7 @@ def _sample_latent_with_spectrum_mod_guidance_advanced(
     quality_tags: str,
     quality_neg: str,
 ):
-    sampler_cls = _runtime_helper("_require_custom_node_class")(
+    sampler_cls = _require_custom_node_class(
         "SpectrumKSamplerAdvanced",
         "ComfyUI-Spectrum-KSampler",
         "Repository: https://github.com/blepping/ComfyUI-Spectrum-KSampler",
@@ -114,38 +136,34 @@ def _sample_latent_with_spectrum_mod_guidance_advanced(
     corrections = sampler_settings.get("dit_corrections", {})
     if not isinstance(corrections, dict):
         corrections = {}
-    use_corrections = _runtime_helper("_as_bool")(corrections.get("enabled"), False)
-    use_smc = use_corrections and _runtime_helper("_as_bool")(
+    use_corrections = _as_bool(corrections.get("enabled"), False)
+    use_smc = use_corrections and _as_bool(
         corrections.get("smc_cfg"), False
     )
-    use_cfgpp = use_corrections and _runtime_helper("_as_bool")(
+    use_cfgpp = use_corrections and _as_bool(
         corrections.get("cfgpp"), False
     )
-    use_fsg = use_corrections and _runtime_helper("_as_bool")(
+    use_fsg = use_corrections and _as_bool(
         corrections.get("fsg"), False
     )
     advanced_mod = mod_guidance_settings.get("advanced", {})
     if not isinstance(advanced_mod, dict):
         advanced_mod = {}
-    profile = _runtime_helper("_normalize_anima_mod_guidance_profile")(
+    profile = _normalize_anima_mod_guidance_profile(
         mod_guidance_settings.get(
-            "profile", _runtime_helper("ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE")
+            "profile", ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE
         )
     )
-    mod_w = _runtime_helper("_as_float")(advanced_mod.get("mod_w"), 3.0)
-    if not use_mod_guidance or profile == _runtime_helper(
-        "ANIMA_MOD_GUIDANCE_PROFILE_OFF"
-    ):
+    mod_w = _as_float(advanced_mod.get("mod_w"), 3.0)
+    if not use_mod_guidance or profile == ANIMA_MOD_GUIDANCE_PROFILE_OFF:
         mod_w = 0.0
     sampler = sampler_cls()
     sampler_kwargs = {
         "model": model,
         "clip": clip,
-        "seed": _runtime_helper("_resolve_aio_runtime_seed")(
-            sampler_settings.get("seed")
-        ),
-        "steps": _runtime_helper("_as_int")(sampler_settings.get("steps"), 28),
-        "cfg": _runtime_helper("_as_float")(sampler_settings.get("cfg"), 5.0),
+        "seed": _resolve_aio_runtime_seed(sampler_settings.get("seed")),
+        "steps": _as_int(sampler_settings.get("steps"), 28),
+        "cfg": _as_float(sampler_settings.get("cfg"), 5.0),
         "sampler_name": str(sampler_settings.get("sampler_name") or "euler_ancestral"),
         "scheduler": str(sampler_settings.get("scheduler") or "normal"),
         "positive": positive,
@@ -155,30 +173,22 @@ def _sample_latent_with_spectrum_mod_guidance_advanced(
         "quality_tags": str(quality_tags or advanced_mod.get("quality_tags") or ""),
         "mod_w": mod_w,
         "quality_neg": str(quality_neg or ""),
-        "mod_start_layer": _runtime_helper("_as_int")(
-            advanced_mod.get("mod_start_layer"), 8
-        ),
-        "mod_end_layer": _runtime_helper("_as_int")(
-            advanced_mod.get("mod_end_layer"), 27
-        ),
-        "mod_taper": _runtime_helper("_as_int")(advanced_mod.get("mod_taper"), 0),
-        "mod_taper_scale": _runtime_helper("_as_float")(
-            advanced_mod.get("mod_taper_scale"), 0.25
-        ),
-        "mod_final_w": _runtime_helper("_as_float")(
-            advanced_mod.get("mod_final_w"), 0.0
-        ),
-        "denoise": _runtime_helper("_as_float")(sampler_settings.get("denoise"), 1.0),
-        "window_size": _runtime_helper("_as_float")(spectrum.get("window_size"), 2.0),
-        "flex_window": _runtime_helper("_as_float")(spectrum.get("flex_window"), 0.25),
-        "warmup_steps": _runtime_helper("_as_int")(spectrum.get("warmup_steps"), 6),
-        "blend_w": _runtime_helper("_as_float")(spectrum.get("blend_w"), 0.3),
-        "cheby_degree": _runtime_helper("_as_int")(spectrum.get("cheby_degree"), 3),
-        "ridge_lambda": _runtime_helper("_as_float")(spectrum.get("ridge_lambda"), 0.1),
+        "mod_start_layer": _as_int(advanced_mod.get("mod_start_layer"), 8),
+        "mod_end_layer": _as_int(advanced_mod.get("mod_end_layer"), 27),
+        "mod_taper": _as_int(advanced_mod.get("mod_taper"), 0),
+        "mod_taper_scale": _as_float(advanced_mod.get("mod_taper_scale"), 0.25),
+        "mod_final_w": _as_float(advanced_mod.get("mod_final_w"), 0.0),
+        "denoise": _as_float(sampler_settings.get("denoise"), 1.0),
+        "window_size": _as_float(spectrum.get("window_size"), 2.0),
+        "flex_window": _as_float(spectrum.get("flex_window"), 0.25),
+        "warmup_steps": _as_int(spectrum.get("warmup_steps"), 6),
+        "blend_w": _as_float(spectrum.get("blend_w"), 0.3),
+        "cheby_degree": _as_int(spectrum.get("cheby_degree"), 3),
+        "ridge_lambda": _as_float(spectrum.get("ridge_lambda"), 0.1),
         "dcw_mode": str(corrections.get("dcw_mode") or "off")
         if use_corrections
         else "off",
-        "dcw_lambda": _runtime_helper("_as_float")(corrections.get("dcw_lambda"), 0.01)
+        "dcw_lambda": _as_float(corrections.get("dcw_lambda"), 0.01)
         if use_corrections
         else 0.0,
         "dcw_band_mask": str(corrections.get("dcw_band_mask") or "LL")
@@ -187,39 +197,29 @@ def _sample_latent_with_spectrum_mod_guidance_advanced(
         "dcw_calibrator": str(
             corrections.get("dcw_calibrator") or "(auto-download default)"
         ),
-        "cfgpp_lambda": _runtime_helper("_as_float")(
-            corrections.get("cfgpp_lambda"), 0.0
-        )
+        "cfgpp_lambda": _as_float(corrections.get("cfgpp_lambda"), 0.0)
         if use_cfgpp
         else 0.0,
         "fsg": use_fsg,
-        "fsg_band_lo": _runtime_helper("_as_float")(
-            corrections.get("fsg_band_lo"), 0.59
-        )
+        "fsg_band_lo": _as_float(corrections.get("fsg_band_lo"), 0.59)
         if use_fsg
         else 0.59,
-        "fsg_band_hi": _runtime_helper("_as_float")(
-            corrections.get("fsg_band_hi"), 0.75
-        )
+        "fsg_band_hi": _as_float(corrections.get("fsg_band_hi"), 0.75)
         if use_fsg
         else 0.75,
-        "fsg_k": _runtime_helper("_as_int")(corrections.get("fsg_k"), 3)
+        "fsg_k": _as_int(corrections.get("fsg_k"), 3)
         if use_fsg
         else 3,
-        "fsg_d_sigma": _runtime_helper("_as_float")(corrections.get("fsg_d_sigma"), 0.1)
+        "fsg_d_sigma": _as_float(corrections.get("fsg_d_sigma"), 0.1)
         if use_fsg
         else 0.1,
-        "fsg_gamma": _runtime_helper("_as_float")(corrections.get("fsg_gamma"), 0.0)
+        "fsg_gamma": _as_float(corrections.get("fsg_gamma"), 0.0)
         if use_fsg
         else 0.0,
-        "adaptive_smc_alpha": _runtime_helper("_as_float")(
-            corrections.get("adaptive_smc_alpha"), 0.0
-        )
+        "adaptive_smc_alpha": _as_float(corrections.get("adaptive_smc_alpha"), 0.0)
         if use_smc
         else 0.0,
-        "smc_cfg_lambda": _runtime_helper("_as_float")(
-            corrections.get("smc_cfg_lambda"), 5.0
-        )
+        "smc_cfg_lambda": _as_float(corrections.get("smc_cfg_lambda"), 5.0)
         if use_smc
         else 0.0,
     }
@@ -229,8 +229,8 @@ def _sample_latent_with_spectrum_mod_guidance_advanced(
             text_key = str(key or "")
             if text_key and text_key not in sampler_kwargs:
                 sampler_kwargs[text_key] = value
-    values = _runtime_helper("_node_output_tuple")(
-        _runtime_helper("_call_with_supported_kwargs")(
+    values = _node_output_tuple(
+        _call_with_supported_kwargs(
             sampler.sample,
             (),
             sampler_kwargs,
@@ -251,7 +251,7 @@ def _sample_latent_with_spectrum_spd(
     negative,
     latent_image,
 ):
-    spd_cls = _runtime_helper("_require_custom_node_class")(
+    spd_cls = _require_custom_node_class(
         "SpectrumSPDKSampler",
         "ComfyUI-Spectrum-KSampler",
         "Repository: https://github.com/blepping/ComfyUI-Spectrum-KSampler",
@@ -265,23 +265,19 @@ def _sample_latent_with_spectrum_spd(
     sampler = spd_cls()
     sampler_kwargs = {
         "model": model,
-        "seed": _runtime_helper("_resolve_aio_runtime_seed")(
-            sampler_settings.get("seed")
-        ),
-        "steps": _runtime_helper("_as_int")(sampler_settings.get("steps"), 28),
-        "cfg": _runtime_helper("_as_float")(sampler_settings.get("cfg"), 5.0),
+        "seed": _resolve_aio_runtime_seed(sampler_settings.get("seed")),
+        "steps": _as_int(sampler_settings.get("steps"), 28),
+        "cfg": _as_float(sampler_settings.get("cfg"), 5.0),
         "sampler_name": sampler_name,
         "scheduler": str(sampler_settings.get("scheduler") or "simple"),
         "positive": positive,
         "negative": negative,
         "latent_image": latent_image,
         "split_mode": str(spd.get("split_mode") or "single"),
-        "spd_scale": _runtime_helper("_as_float")(spd.get("scale"), 0.5),
-        "spd_sigma": _runtime_helper("_as_float")(spd.get("sigma"), 0.7),
-        "denoise": _runtime_helper("_as_float")(sampler_settings.get("denoise"), 1.0),
-        "adaptive_smc_alpha": _runtime_helper("_as_float")(
-            spd.get("adaptive_smc_alpha"), 0.0
-        ),
+        "spd_scale": _as_float(spd.get("scale"), 0.5),
+        "spd_sigma": _as_float(spd.get("sigma"), 0.7),
+        "denoise": _as_float(sampler_settings.get("denoise"), 1.0),
+        "adaptive_smc_alpha": _as_float(spd.get("adaptive_smc_alpha"), 0.0),
     }
     extra = sampler_settings.get("spd_extra")
     if isinstance(extra, dict):
@@ -289,8 +285,8 @@ def _sample_latent_with_spectrum_spd(
             text_key = str(key or "")
             if text_key and text_key not in sampler_kwargs:
                 sampler_kwargs[text_key] = value
-    values = _runtime_helper("_node_output_tuple")(
-        _runtime_helper("_call_with_supported_kwargs")(
+    values = _node_output_tuple(
+        _call_with_supported_kwargs(
             sampler.sample,
             (),
             sampler_kwargs,
@@ -316,7 +312,7 @@ def _sample_latent_with_aio_backend(
 ):
     backend = str(sampler_settings.get("backend") or "comfy_ksampler")
     if backend == "spectrum_mod_guidance_advanced":
-        return _runtime_helper("_sample_latent_with_spectrum_mod_guidance_advanced")(
+        return _sample_latent_with_spectrum_mod_guidance_advanced(
             model,
             clip,
             sampler_settings,
@@ -329,14 +325,14 @@ def _sample_latent_with_aio_backend(
             quality_neg,
         )
     if backend == "spectrum_spd_speed":
-        return _runtime_helper("_sample_latent_with_spectrum_spd")(
+        return _sample_latent_with_spectrum_spd(
             model,
             sampler_settings,
             positive,
             negative,
             latent_image,
         )
-    return _runtime_helper("_sample_latent_with_comfy")(
+    return _sample_latent_with_comfy(
         model,
         sampler_settings["seed"],
         sampler_settings["steps"],
@@ -351,7 +347,7 @@ def _sample_latent_with_aio_backend(
 
 
 def _decode_latent_with_comfy(vae, samples):
-    decoder_cls = _runtime_helper("_find_comfy_node_class")("VAEDecode")
+    decoder_cls = _find_comfy_node_class("VAEDecode")
     if decoder_cls is None:
         raise RuntimeError("[EasyUseAnima] Could not find ComfyUI VAEDecode.")
     decoder = decoder_cls()
@@ -359,21 +355,21 @@ def _decode_latent_with_comfy(vae, samples):
     if decode is None:
         raise RuntimeError("[EasyUseAnima] VAEDecode does not expose decode().")
     result = decode(vae, samples)
-    values = _runtime_helper("_node_output_tuple")(result)
+    values = _node_output_tuple(result)
     if not values:
         raise RuntimeError("[EasyUseAnima] VAEDecode returned no IMAGE.")
     return values[0]
 
 
 def _encode_image_with_comfy_vae(vae, image):
-    encoder_cls = _runtime_helper("_find_comfy_node_class")("VAEEncode")
+    encoder_cls = _find_comfy_node_class("VAEEncode")
     if encoder_cls is None:
         raise RuntimeError("[EasyUseAnima] Could not find ComfyUI VAEEncode.")
     encoder = encoder_cls()
     encode = getattr(encoder, "encode", None)
     if encode is None:
         raise RuntimeError("[EasyUseAnima] VAEEncode does not expose encode().")
-    values = _runtime_helper("_node_output_tuple")(encode(vae, image))
+    values = _node_output_tuple(encode(vae, image))
     if not values:
         raise RuntimeError("[EasyUseAnima] VAEEncode returned no LATENT.")
     return values[0]
@@ -386,7 +382,7 @@ def _aio_stage_sampler_settings(
     scheduler_default: str,
     inherit_backend: bool = False,
 ) -> dict[str, Any]:
-    inherit_sampler = _runtime_helper("_as_bool")(
+    inherit_sampler = _as_bool(
         stage_settings.get("inherit_sampler_settings"), False
     )
     inherited_spd_fallback = False
@@ -403,18 +399,18 @@ def _aio_stage_sampler_settings(
         backend = "comfy_ksampler"
     return {
         "backend": backend,
-        "seed": _runtime_helper("_resolve_aio_runtime_seed")(base_sampler.get("seed")),
-        "seed_after_generate": _runtime_helper("SEED_CONTROL_FIXED"),
-        "steps": _runtime_helper("_as_int")(
+        "seed": _resolve_aio_runtime_seed(base_sampler.get("seed")),
+        "seed_after_generate": SEED_CONTROL_FIXED,
+        "steps": _as_int(
             stage_settings.get("steps"),
-            _runtime_helper("_as_int")(base_sampler.get("steps"), 28),
+            _as_int(base_sampler.get("steps"), 28),
         ),
         "cfg": (
-            _runtime_helper("_as_float")(base_sampler.get("cfg"), 5.0)
+            _as_float(base_sampler.get("cfg"), 5.0)
             if inherit_sampler
-            else _runtime_helper("_as_float")(
+            else _as_float(
                 stage_settings.get("cfg"),
-                _runtime_helper("_as_float")(base_sampler.get("cfg"), 5.0),
+                _as_float(base_sampler.get("cfg"), 5.0),
             )
         ),
         "sampler_name": (
@@ -435,14 +431,10 @@ def _aio_stage_sampler_settings(
             if inherit_sampler
             else str(stage_settings.get("scheduler") or scheduler_default)
         ),
-        "denoise": _runtime_helper("_as_float")(stage_settings.get("denoise"), 1.0),
-        "spectrum": _runtime_helper("_json_clone")(
-            stage_settings.get("spectrum") or {}
-        ),
-        "dit_corrections": _runtime_helper("_json_clone")(
-            stage_settings.get("dit_corrections") or {}
-        ),
-        "spd": _runtime_helper("_json_clone")(stage_settings.get("spd") or {}),
+        "denoise": _as_float(stage_settings.get("denoise"), 1.0),
+        "spectrum": _json_clone(stage_settings.get("spectrum") or {}),
+        "dit_corrections": _json_clone(stage_settings.get("dit_corrections") or {}),
+        "spd": _json_clone(stage_settings.get("spd") or {}),
         "spectrum_extra": {},
         "spd_extra": {},
     }
@@ -452,11 +444,9 @@ def _aio_highres_effective_backend(
     sampler_settings: dict[str, Any],
     highres_settings: dict[str, Any],
 ) -> str:
-    if not _runtime_helper("_as_bool")(highres_settings.get("enabled"), False):
+    if not _as_bool(highres_settings.get("enabled"), False):
         return ""
-    if _runtime_helper("_as_bool")(
-        highres_settings.get("inherit_sampler_settings"), False
-    ):
+    if _as_bool(highres_settings.get("inherit_sampler_settings"), False):
         backend = str(sampler_settings.get("backend") or "comfy_ksampler")
         return "comfy_ksampler" if backend == "spectrum_spd_speed" else backend
     return "comfy_ksampler"

--- a/nodes.py
+++ b/nodes.py
@@ -85,7 +85,6 @@ try:
         _aio_prompt_data_fields_for_usdu as _aio_prompt_data_fields_for_usdu,
         _aio_usdu_conditioning as _aio_usdu_conditioning,
         _aio_usdu_prompt_without_general as _aio_usdu_prompt_without_general,
-        _bind_aio_conditioning_runtime as _bind_aio_conditioning_runtime,
     )
     from .easyuse_anima.aio.model_preparation import (
         _aio_lora_stack_signature as _aio_lora_stack_signature,
@@ -97,7 +96,6 @@ try:
         _apply_aio_spectrum_correction_patch_for_comfy_sampler as _apply_aio_spectrum_correction_patch_for_comfy_sampler,
         _apply_aio_spectrum_forecast_patch_for_comfy_sampler as _apply_aio_spectrum_forecast_patch_for_comfy_sampler,
         _apply_aio_spectrum_model_patches_for_comfy_sampler as _apply_aio_spectrum_model_patches_for_comfy_sampler,
-        _bind_aio_model_preparation_runtime as _bind_aio_model_preparation_runtime,
         _cleanup_aio_ephemeral_model as _cleanup_aio_ephemeral_model,
         _normalize_aio_lora_stack as _normalize_aio_lora_stack,
         _patch_model_sampling_aura_flow as _patch_model_sampling_aura_flow,
@@ -105,7 +103,6 @@ try:
     from .easyuse_anima.aio.sampling import (
         _aio_highres_effective_backend as _aio_highres_effective_backend,
         _aio_stage_sampler_settings as _aio_stage_sampler_settings,
-        _bind_aio_sampling_runtime as _bind_aio_sampling_runtime,
         _decode_latent_with_comfy as _decode_latent_with_comfy,
         _encode_image_with_comfy_vae as _encode_image_with_comfy_vae,
         _generate_empty_latent_with_comfy as _generate_empty_latent_with_comfy,
@@ -649,7 +646,6 @@ except ImportError:  # allows simple local import tests outside ComfyUI's packag
         _aio_prompt_data_fields_for_usdu as _aio_prompt_data_fields_for_usdu,
         _aio_usdu_conditioning as _aio_usdu_conditioning,
         _aio_usdu_prompt_without_general as _aio_usdu_prompt_without_general,
-        _bind_aio_conditioning_runtime as _bind_aio_conditioning_runtime,
     )
     from easyuse_anima.aio.model_preparation import (
         _aio_lora_stack_signature as _aio_lora_stack_signature,
@@ -661,7 +657,6 @@ except ImportError:  # allows simple local import tests outside ComfyUI's packag
         _apply_aio_spectrum_correction_patch_for_comfy_sampler as _apply_aio_spectrum_correction_patch_for_comfy_sampler,
         _apply_aio_spectrum_forecast_patch_for_comfy_sampler as _apply_aio_spectrum_forecast_patch_for_comfy_sampler,
         _apply_aio_spectrum_model_patches_for_comfy_sampler as _apply_aio_spectrum_model_patches_for_comfy_sampler,
-        _bind_aio_model_preparation_runtime as _bind_aio_model_preparation_runtime,
         _cleanup_aio_ephemeral_model as _cleanup_aio_ephemeral_model,
         _normalize_aio_lora_stack as _normalize_aio_lora_stack,
         _patch_model_sampling_aura_flow as _patch_model_sampling_aura_flow,
@@ -669,7 +664,6 @@ except ImportError:  # allows simple local import tests outside ComfyUI's packag
     from easyuse_anima.aio.sampling import (
         _aio_highres_effective_backend as _aio_highres_effective_backend,
         _aio_stage_sampler_settings as _aio_stage_sampler_settings,
-        _bind_aio_sampling_runtime as _bind_aio_sampling_runtime,
         _decode_latent_with_comfy as _decode_latent_with_comfy,
         _encode_image_with_comfy_vae as _encode_image_with_comfy_vae,
         _generate_empty_latent_with_comfy as _generate_empty_latent_with_comfy,
@@ -1141,24 +1135,6 @@ _TRIGGER_WORD_KEYS = ("trainedWords", "trained_words", "trigger_words", "activat
 
 
 _bind_aio_legacy_generation_runtime(
-    resolve_helper=lambda name: _resolve_comfy_host_helper(
-        name,
-        lambda fallback_name: globals()[fallback_name],
-    ),
-)
-_bind_aio_model_preparation_runtime(
-    resolve_helper=lambda name: _resolve_comfy_host_helper(
-        name,
-        lambda fallback_name: globals()[fallback_name],
-    ),
-)
-_bind_aio_sampling_runtime(
-    resolve_helper=lambda name: _resolve_comfy_host_helper(
-        name,
-        lambda fallback_name: globals()[fallback_name],
-    ),
-)
-_bind_aio_conditioning_runtime(
     resolve_helper=lambda name: _resolve_comfy_host_helper(
         name,
         lambda fallback_name: globals()[fallback_name],

--- a/tests/fixtures/comfy_host_compatibility.v1.json
+++ b/tests/fixtures/comfy_host_compatibility.v1.json
@@ -103,7 +103,7 @@
       "production_consumers": [
         {
           "module": "easyuse_anima.aio.conditioning",
-          "binder": "_bind_aio_conditioning_runtime",
+          "binder": null,
           "root_observation": "call_time"
         },
         {
@@ -173,7 +173,7 @@
       "production_consumers": [
         {
           "module": "easyuse_anima.aio.model_preparation",
-          "binder": "_bind_aio_model_preparation_runtime",
+          "binder": null,
           "root_observation": "call_time"
         },
         {
@@ -193,7 +193,7 @@
         },
         {
           "module": "easyuse_anima.aio.sampling",
-          "binder": "_bind_aio_sampling_runtime",
+          "binder": null,
           "root_observation": "call_time"
         },
         {
@@ -325,7 +325,7 @@
       "production_consumers": [
         {
           "module": "easyuse_anima.aio.model_preparation",
-          "binder": "_bind_aio_model_preparation_runtime",
+          "binder": null,
           "root_observation": "call_time"
         }
       ],
@@ -373,7 +373,7 @@
         },
         {
           "module": "easyuse_anima.aio.model_preparation",
-          "binder": "_bind_aio_model_preparation_runtime",
+          "binder": null,
           "root_observation": "call_time"
         },
         {
@@ -383,7 +383,7 @@
         },
         {
           "module": "easyuse_anima.aio.sampling",
-          "binder": "_bind_aio_sampling_runtime",
+          "binder": null,
           "root_observation": "call_time"
         }
       ],

--- a/tests/fixtures/python_backend_baseline.json
+++ b/tests/fixtures/python_backend_baseline.json
@@ -4444,23 +4444,6 @@
       },
       {
         "alias": null,
-        "bound_name": "Callable",
-        "branch_context": [],
-        "classification": "external",
-        "column": 0,
-        "conditional": false,
-        "imported": "collections.abc:Callable",
-        "kind": "static_from",
-        "line": 5,
-        "name": "Callable",
-        "optional": false,
-        "requested": "collections.abc",
-        "role": "ordinary",
-        "scope": "<module>",
-        "source": "easyuse_anima/aio/conditioning.py"
-      },
-      {
-        "alias": null,
         "bound_name": "Any",
         "branch_context": [],
         "classification": "external",
@@ -4468,7 +4451,7 @@
         "conditional": false,
         "imported": "typing:Any",
         "kind": "static_from",
-        "line": 6,
+        "line": 5,
         "name": "Any",
         "optional": false,
         "requested": "typing",
@@ -4478,20 +4461,165 @@
       },
       {
         "alias": null,
-        "bound_name": "TypeAlias",
+        "bound_name": "_as_bool",
         "branch_context": [],
-        "classification": "external",
+        "classification": "internal",
         "column": 0,
         "conditional": false,
-        "imported": "typing:TypeAlias",
+        "imported": "..common.values:_as_bool",
         "kind": "static_from",
-        "line": 6,
-        "name": "TypeAlias",
+        "line": 7,
+        "name": "_as_bool",
         "optional": false,
-        "requested": "typing",
+        "requested": "..common.values",
         "role": "ordinary",
         "scope": "<module>",
-        "source": "easyuse_anima/aio/conditioning.py"
+        "source": "easyuse_anima/aio/conditioning.py",
+        "target": "easyuse_anima/common/values.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "resolve_comfy_host_helper",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": "..infrastructure.comfy.wiring:resolve_comfy_host_helper",
+        "kind": "static_from",
+        "line": 8,
+        "name": "resolve_comfy_host_helper",
+        "optional": false,
+        "requested": "..infrastructure.comfy.wiring",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/aio/conditioning.py",
+        "target": "easyuse_anima/infrastructure/comfy/wiring.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_advanced_artist_field_prompt",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": "..prompt.advanced:_advanced_artist_field_prompt",
+        "kind": "static_from",
+        "line": 9,
+        "name": "_advanced_artist_field_prompt",
+        "optional": false,
+        "requested": "..prompt.advanced",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/aio/conditioning.py",
+        "target": "easyuse_anima/prompt/advanced.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_advanced_enabled_pane_fields",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": "..prompt.advanced:_advanced_enabled_pane_fields",
+        "kind": "static_from",
+        "line": 9,
+        "name": "_advanced_enabled_pane_fields",
+        "optional": false,
+        "requested": "..prompt.advanced",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/aio/conditioning.py",
+        "target": "easyuse_anima/prompt/advanced.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_correct_advanced_field_sequence",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": "..prompt.advanced:_correct_advanced_field_sequence",
+        "kind": "static_from",
+        "line": 9,
+        "name": "_correct_advanced_field_sequence",
+        "optional": false,
+        "requested": "..prompt.advanced",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/aio/conditioning.py",
+        "target": "easyuse_anima/prompt/advanced.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_normalize_advanced_fields",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": "..prompt.advanced:_normalize_advanced_fields",
+        "kind": "static_from",
+        "line": 9,
+        "name": "_normalize_advanced_fields",
+        "optional": false,
+        "requested": "..prompt.advanced",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/aio/conditioning.py",
+        "target": "easyuse_anima/prompt/advanced.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_normalize_prompt_data",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": "..prompt.data:_normalize_prompt_data",
+        "kind": "static_from",
+        "line": 15,
+        "name": "_normalize_prompt_data",
+        "optional": false,
+        "requested": "..prompt.data",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/aio/conditioning.py",
+        "target": "easyuse_anima/prompt/data.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "AIO_USDU_PROMPT_FULL",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".generation_defaults:AIO_USDU_PROMPT_FULL",
+        "kind": "static_from",
+        "line": 16,
+        "name": "AIO_USDU_PROMPT_FULL",
+        "optional": false,
+        "requested": ".generation_defaults",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/aio/conditioning.py",
+        "target": "easyuse_anima/aio/generation_defaults.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "AIO_USDU_PROMPT_NO_GENERAL",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".generation_defaults:AIO_USDU_PROMPT_NO_GENERAL",
+        "kind": "static_from",
+        "line": 16,
+        "name": "AIO_USDU_PROMPT_NO_GENERAL",
+        "optional": false,
+        "requested": ".generation_defaults",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/aio/conditioning.py",
+        "target": "easyuse_anima/aio/generation_defaults.py"
       },
       {
         "alias": null,
@@ -7428,17 +7556,17 @@
       },
       {
         "alias": null,
-        "bound_name": "Callable",
+        "bound_name": "logging",
         "branch_context": [],
         "classification": "external",
         "column": 0,
         "conditional": false,
-        "imported": "collections.abc:Callable",
-        "kind": "static_from",
+        "imported": "logging",
+        "kind": "static_import",
         "line": 6,
-        "name": "Callable",
+        "name": null,
         "optional": false,
-        "requested": "collections.abc",
+        "requested": "logging",
         "role": "ordinary",
         "scope": "<module>",
         "source": "easyuse_anima/aio/model_preparation.py"
@@ -7462,20 +7590,129 @@
       },
       {
         "alias": null,
-        "bound_name": "TypeAlias",
+        "bound_name": "_as_bool",
         "branch_context": [],
-        "classification": "external",
+        "classification": "internal",
         "column": 0,
         "conditional": false,
-        "imported": "typing:TypeAlias",
+        "imported": "..common.values:_as_bool",
         "kind": "static_from",
-        "line": 7,
-        "name": "TypeAlias",
+        "line": 9,
+        "name": "_as_bool",
         "optional": false,
-        "requested": "typing",
+        "requested": "..common.values",
         "role": "ordinary",
         "scope": "<module>",
-        "source": "easyuse_anima/aio/model_preparation.py"
+        "source": "easyuse_anima/aio/model_preparation.py",
+        "target": "easyuse_anima/common/values.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_as_float",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": "..common.values:_as_float",
+        "kind": "static_from",
+        "line": 9,
+        "name": "_as_float",
+        "optional": false,
+        "requested": "..common.values",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/aio/model_preparation.py",
+        "target": "easyuse_anima/common/values.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_as_int",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": "..common.values:_as_int",
+        "kind": "static_from",
+        "line": 9,
+        "name": "_as_int",
+        "optional": false,
+        "requested": "..common.values",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/aio/model_preparation.py",
+        "target": "easyuse_anima/common/values.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_call_with_supported_kwargs",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": "..infrastructure.comfy.invocation:_call_with_supported_kwargs",
+        "kind": "static_from",
+        "line": 10,
+        "name": "_call_with_supported_kwargs",
+        "optional": false,
+        "requested": "..infrastructure.comfy.invocation",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/aio/model_preparation.py",
+        "target": "easyuse_anima/infrastructure/comfy/invocation.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_node_output_tuple",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": "..infrastructure.comfy.invocation:_node_output_tuple",
+        "kind": "static_from",
+        "line": 10,
+        "name": "_node_output_tuple",
+        "optional": false,
+        "requested": "..infrastructure.comfy.invocation",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/aio/model_preparation.py",
+        "target": "easyuse_anima/infrastructure/comfy/invocation.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "resolve_comfy_host_helper",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": "..infrastructure.comfy.wiring:resolve_comfy_host_helper",
+        "kind": "static_from",
+        "line": 14,
+        "name": "resolve_comfy_host_helper",
+        "optional": false,
+        "requested": "..infrastructure.comfy.wiring",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/aio/model_preparation.py",
+        "target": "easyuse_anima/infrastructure/comfy/wiring.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_lora_stack_name",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": "..lora.metadata:_lora_stack_name",
+        "kind": "static_from",
+        "line": 15,
+        "name": "_lora_stack_name",
+        "optional": false,
+        "requested": "..lora.metadata",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/aio/model_preparation.py",
+        "target": "easyuse_anima/lora/metadata.py"
       },
       {
         "alias": "model_management",
@@ -7486,7 +7723,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 309
+            "line": 315
           }
         ],
         "classification": "external",
@@ -7494,7 +7731,7 @@
         "conditional": true,
         "imported": "comfy.model_management",
         "kind": "static_import",
-        "line": 310,
+        "line": 316,
         "name": null,
         "optional": true,
         "requested": "comfy.model_management",
@@ -8764,17 +9001,17 @@
       },
       {
         "alias": null,
-        "bound_name": "Callable",
+        "bound_name": "random",
         "branch_context": [],
         "classification": "external",
         "column": 0,
         "conditional": false,
-        "imported": "collections.abc:Callable",
-        "kind": "static_from",
+        "imported": "random",
+        "kind": "static_import",
         "line": 5,
-        "name": "Callable",
+        "name": null,
         "optional": false,
-        "requested": "collections.abc",
+        "requested": "random",
         "role": "ordinary",
         "scope": "<module>",
         "source": "easyuse_anima/aio/sampling.py"
@@ -8798,20 +9035,255 @@
       },
       {
         "alias": null,
-        "bound_name": "TypeAlias",
+        "bound_name": "_json_clone",
         "branch_context": [],
-        "classification": "external",
+        "classification": "internal",
         "column": 0,
         "conditional": false,
-        "imported": "typing:TypeAlias",
+        "imported": "..common.serialization:_json_clone",
         "kind": "static_from",
-        "line": 6,
-        "name": "TypeAlias",
+        "line": 8,
+        "name": "_json_clone",
         "optional": false,
-        "requested": "typing",
+        "requested": "..common.serialization",
         "role": "ordinary",
         "scope": "<module>",
-        "source": "easyuse_anima/aio/sampling.py"
+        "source": "easyuse_anima/aio/sampling.py",
+        "target": "easyuse_anima/common/serialization.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_as_bool",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": "..common.values:_as_bool",
+        "kind": "static_from",
+        "line": 9,
+        "name": "_as_bool",
+        "optional": false,
+        "requested": "..common.values",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/aio/sampling.py",
+        "target": "easyuse_anima/common/values.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_as_float",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": "..common.values:_as_float",
+        "kind": "static_from",
+        "line": 9,
+        "name": "_as_float",
+        "optional": false,
+        "requested": "..common.values",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/aio/sampling.py",
+        "target": "easyuse_anima/common/values.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_as_int",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": "..common.values:_as_int",
+        "kind": "static_from",
+        "line": 9,
+        "name": "_as_int",
+        "optional": false,
+        "requested": "..common.values",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/aio/sampling.py",
+        "target": "easyuse_anima/common/values.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_call_with_supported_kwargs",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": "..infrastructure.comfy.invocation:_call_with_supported_kwargs",
+        "kind": "static_from",
+        "line": 10,
+        "name": "_call_with_supported_kwargs",
+        "optional": false,
+        "requested": "..infrastructure.comfy.invocation",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/aio/sampling.py",
+        "target": "easyuse_anima/infrastructure/comfy/invocation.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_node_output_tuple",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": "..infrastructure.comfy.invocation:_node_output_tuple",
+        "kind": "static_from",
+        "line": 10,
+        "name": "_node_output_tuple",
+        "optional": false,
+        "requested": "..infrastructure.comfy.invocation",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/aio/sampling.py",
+        "target": "easyuse_anima/infrastructure/comfy/invocation.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "resolve_comfy_host_helper",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": "..infrastructure.comfy.wiring:resolve_comfy_host_helper",
+        "kind": "static_from",
+        "line": 14,
+        "name": "resolve_comfy_host_helper",
+        "optional": false,
+        "requested": "..infrastructure.comfy.wiring",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/aio/sampling.py",
+        "target": "easyuse_anima/infrastructure/comfy/wiring.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": "..prompt.conditioning:ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
+        "kind": "static_from",
+        "line": 15,
+        "name": "ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
+        "optional": false,
+        "requested": "..prompt.conditioning",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/aio/sampling.py",
+        "target": "easyuse_anima/prompt/conditioning.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "ANIMA_MOD_GUIDANCE_PROFILE_OFF",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": "..prompt.conditioning:ANIMA_MOD_GUIDANCE_PROFILE_OFF",
+        "kind": "static_from",
+        "line": 15,
+        "name": "ANIMA_MOD_GUIDANCE_PROFILE_OFF",
+        "optional": false,
+        "requested": "..prompt.conditioning",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/aio/sampling.py",
+        "target": "easyuse_anima/prompt/conditioning.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_normalize_anima_mod_guidance_profile",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": "..prompt.conditioning:_normalize_anima_mod_guidance_profile",
+        "kind": "static_from",
+        "line": 15,
+        "name": "_normalize_anima_mod_guidance_profile",
+        "optional": false,
+        "requested": "..prompt.conditioning",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/aio/sampling.py",
+        "target": "easyuse_anima/prompt/conditioning.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "SEED_CONTROL_FIXED",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": "..seed.reservation:SEED_CONTROL_FIXED",
+        "kind": "static_from",
+        "line": 20,
+        "name": "SEED_CONTROL_FIXED",
+        "optional": false,
+        "requested": "..seed.reservation",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/aio/sampling.py",
+        "target": "easyuse_anima/seed/reservation.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "AIO_SPECIAL_SEEDS",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".generation_defaults:AIO_SPECIAL_SEEDS",
+        "kind": "static_from",
+        "line": 21,
+        "name": "AIO_SPECIAL_SEEDS",
+        "optional": false,
+        "requested": ".generation_defaults",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/aio/sampling.py",
+        "target": "easyuse_anima/aio/generation_defaults.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "MAX_SEED",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".generation_normalization:MAX_SEED",
+        "kind": "static_from",
+        "line": 22,
+        "name": "MAX_SEED",
+        "optional": false,
+        "requested": ".generation_normalization",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/aio/sampling.py",
+        "target": "easyuse_anima/aio/generation_normalization.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_normalize_aio_seed",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".generation_normalization:_normalize_aio_seed",
+        "kind": "static_from",
+        "line": 22,
+        "name": "_normalize_aio_seed",
+        "optional": false,
+        "requested": ".generation_normalization",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/aio/sampling.py",
+        "target": "easyuse_anima/aio/generation_normalization.py"
       },
       {
         "alias": null,
@@ -21235,37 +21707,6 @@
         "target": "easyuse_anima/aio/conditioning.py"
       },
       {
-        "alias": "_bind_aio_conditioning_runtime",
-        "bound_name": "_bind_aio_conditioning_runtime",
-        "branch_context": [
-          {
-            "branch": "body",
-            "handles_import_failure": true,
-            "has_import_fallback_handler": true,
-            "kind": "try",
-            "line": 8
-          }
-        ],
-        "classification": "internal",
-        "column": 4,
-        "compatibility_pair": {
-          "bound_name": "_bind_aio_conditioning_runtime",
-          "target": "easyuse_anima/aio/conditioning.py",
-          "try_line": 8
-        },
-        "conditional": true,
-        "imported": ".easyuse_anima.aio.conditioning:_bind_aio_conditioning_runtime",
-        "kind": "static_from",
-        "line": 84,
-        "name": "_bind_aio_conditioning_runtime",
-        "optional": false,
-        "requested": ".easyuse_anima.aio.conditioning",
-        "role": "compatibility_primary",
-        "scope": "<module>",
-        "source": "nodes.py",
-        "target": "easyuse_anima/aio/conditioning.py"
-      },
-      {
         "alias": "_aio_lora_stack_signature",
         "bound_name": "_aio_lora_stack_signature",
         "branch_context": [
@@ -21287,7 +21728,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_aio_lora_stack_signature",
         "kind": "static_from",
-        "line": 90,
+        "line": 89,
         "name": "_aio_lora_stack_signature",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -21318,7 +21759,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_apply_aio_anima_dave_patch",
         "kind": "static_from",
-        "line": 90,
+        "line": 89,
         "name": "_apply_aio_anima_dave_patch",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -21349,7 +21790,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_apply_aio_kj_model_patches",
         "kind": "static_from",
-        "line": 90,
+        "line": 89,
         "name": "_apply_aio_kj_model_patches",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -21380,7 +21821,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_apply_aio_lora_stack",
         "kind": "static_from",
-        "line": 90,
+        "line": 89,
         "name": "_apply_aio_lora_stack",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -21411,7 +21852,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_apply_aio_model_patches",
         "kind": "static_from",
-        "line": 90,
+        "line": 89,
         "name": "_apply_aio_model_patches",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -21442,7 +21883,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_apply_aio_safe_pag_patch",
         "kind": "static_from",
-        "line": 90,
+        "line": 89,
         "name": "_apply_aio_safe_pag_patch",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -21473,7 +21914,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_apply_aio_spectrum_correction_patch_for_comfy_sampler",
         "kind": "static_from",
-        "line": 90,
+        "line": 89,
         "name": "_apply_aio_spectrum_correction_patch_for_comfy_sampler",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -21504,7 +21945,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_apply_aio_spectrum_forecast_patch_for_comfy_sampler",
         "kind": "static_from",
-        "line": 90,
+        "line": 89,
         "name": "_apply_aio_spectrum_forecast_patch_for_comfy_sampler",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -21535,39 +21976,8 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_apply_aio_spectrum_model_patches_for_comfy_sampler",
         "kind": "static_from",
-        "line": 90,
+        "line": 89,
         "name": "_apply_aio_spectrum_model_patches_for_comfy_sampler",
-        "optional": false,
-        "requested": ".easyuse_anima.aio.model_preparation",
-        "role": "compatibility_primary",
-        "scope": "<module>",
-        "source": "nodes.py",
-        "target": "easyuse_anima/aio/model_preparation.py"
-      },
-      {
-        "alias": "_bind_aio_model_preparation_runtime",
-        "bound_name": "_bind_aio_model_preparation_runtime",
-        "branch_context": [
-          {
-            "branch": "body",
-            "handles_import_failure": true,
-            "has_import_fallback_handler": true,
-            "kind": "try",
-            "line": 8
-          }
-        ],
-        "classification": "internal",
-        "column": 4,
-        "compatibility_pair": {
-          "bound_name": "_bind_aio_model_preparation_runtime",
-          "target": "easyuse_anima/aio/model_preparation.py",
-          "try_line": 8
-        },
-        "conditional": true,
-        "imported": ".easyuse_anima.aio.model_preparation:_bind_aio_model_preparation_runtime",
-        "kind": "static_from",
-        "line": 90,
-        "name": "_bind_aio_model_preparation_runtime",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
         "role": "compatibility_primary",
@@ -21597,7 +22007,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_cleanup_aio_ephemeral_model",
         "kind": "static_from",
-        "line": 90,
+        "line": 89,
         "name": "_cleanup_aio_ephemeral_model",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -21628,7 +22038,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_normalize_aio_lora_stack",
         "kind": "static_from",
-        "line": 90,
+        "line": 89,
         "name": "_normalize_aio_lora_stack",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -21659,7 +22069,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_patch_model_sampling_aura_flow",
         "kind": "static_from",
-        "line": 90,
+        "line": 89,
         "name": "_patch_model_sampling_aura_flow",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -21690,7 +22100,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_aio_highres_effective_backend",
         "kind": "static_from",
-        "line": 105,
+        "line": 103,
         "name": "_aio_highres_effective_backend",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -21721,39 +22131,8 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_aio_stage_sampler_settings",
         "kind": "static_from",
-        "line": 105,
+        "line": 103,
         "name": "_aio_stage_sampler_settings",
-        "optional": false,
-        "requested": ".easyuse_anima.aio.sampling",
-        "role": "compatibility_primary",
-        "scope": "<module>",
-        "source": "nodes.py",
-        "target": "easyuse_anima/aio/sampling.py"
-      },
-      {
-        "alias": "_bind_aio_sampling_runtime",
-        "bound_name": "_bind_aio_sampling_runtime",
-        "branch_context": [
-          {
-            "branch": "body",
-            "handles_import_failure": true,
-            "has_import_fallback_handler": true,
-            "kind": "try",
-            "line": 8
-          }
-        ],
-        "classification": "internal",
-        "column": 4,
-        "compatibility_pair": {
-          "bound_name": "_bind_aio_sampling_runtime",
-          "target": "easyuse_anima/aio/sampling.py",
-          "try_line": 8
-        },
-        "conditional": true,
-        "imported": ".easyuse_anima.aio.sampling:_bind_aio_sampling_runtime",
-        "kind": "static_from",
-        "line": 105,
-        "name": "_bind_aio_sampling_runtime",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
         "role": "compatibility_primary",
@@ -21783,7 +22162,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_decode_latent_with_comfy",
         "kind": "static_from",
-        "line": 105,
+        "line": 103,
         "name": "_decode_latent_with_comfy",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -21814,7 +22193,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_encode_image_with_comfy_vae",
         "kind": "static_from",
-        "line": 105,
+        "line": 103,
         "name": "_encode_image_with_comfy_vae",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -21845,7 +22224,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_generate_empty_latent_with_comfy",
         "kind": "static_from",
-        "line": 105,
+        "line": 103,
         "name": "_generate_empty_latent_with_comfy",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -21876,7 +22255,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_new_aio_random_seed",
         "kind": "static_from",
-        "line": 105,
+        "line": 103,
         "name": "_new_aio_random_seed",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -21907,7 +22286,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_resolve_aio_runtime_seed",
         "kind": "static_from",
-        "line": 105,
+        "line": 103,
         "name": "_resolve_aio_runtime_seed",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -21938,7 +22317,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_sample_latent_with_aio_backend",
         "kind": "static_from",
-        "line": 105,
+        "line": 103,
         "name": "_sample_latent_with_aio_backend",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -21969,7 +22348,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_sample_latent_with_comfy",
         "kind": "static_from",
-        "line": 105,
+        "line": 103,
         "name": "_sample_latent_with_comfy",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -22000,7 +22379,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_sample_latent_with_spectrum_mod_guidance_advanced",
         "kind": "static_from",
-        "line": 105,
+        "line": 103,
         "name": "_sample_latent_with_spectrum_mod_guidance_advanced",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -22031,7 +22410,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_sample_latent_with_spectrum_spd",
         "kind": "static_from",
-        "line": 105,
+        "line": 103,
         "name": "_sample_latent_with_spectrum_spd",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -22062,7 +22441,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.preview:AIO_PREVIEW_CACHE_FORMAT",
         "kind": "static_from",
-        "line": 119,
+        "line": 116,
         "name": "AIO_PREVIEW_CACHE_FORMAT",
         "optional": false,
         "requested": ".easyuse_anima.aio.preview",
@@ -22093,7 +22472,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.preview:AIO_PREVIEW_CACHE_QUALITY",
         "kind": "static_from",
-        "line": 119,
+        "line": 116,
         "name": "AIO_PREVIEW_CACHE_QUALITY",
         "optional": false,
         "requested": ".easyuse_anima.aio.preview",
@@ -22124,7 +22503,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.preview:AIO_PREVIEW_EVENT",
         "kind": "static_from",
-        "line": 119,
+        "line": 116,
         "name": "AIO_PREVIEW_EVENT",
         "optional": false,
         "requested": ".easyuse_anima.aio.preview",
@@ -22155,7 +22534,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.preview:AIO_PREVIEW_STAGE_LABELS",
         "kind": "static_from",
-        "line": 119,
+        "line": 116,
         "name": "AIO_PREVIEW_STAGE_LABELS",
         "optional": false,
         "requested": ".easyuse_anima.aio.preview",
@@ -22186,7 +22565,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.preview:_aio_preview_base_directory",
         "kind": "static_from",
-        "line": 119,
+        "line": 116,
         "name": "_aio_preview_base_directory",
         "optional": false,
         "requested": ".easyuse_anima.aio.preview",
@@ -22217,7 +22596,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.preview:_aio_preview_file_size_bytes",
         "kind": "static_from",
-        "line": 119,
+        "line": 116,
         "name": "_aio_preview_file_size_bytes",
         "optional": false,
         "requested": ".easyuse_anima.aio.preview",
@@ -22248,7 +22627,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.preview:_save_aio_temp_preview_image",
         "kind": "static_from",
-        "line": 119,
+        "line": 116,
         "name": "_save_aio_temp_preview_image",
         "optional": false,
         "requested": ".easyuse_anima.aio.preview",
@@ -22279,7 +22658,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.preview:_send_aio_preview_event",
         "kind": "static_from",
-        "line": 119,
+        "line": 116,
         "name": "_send_aio_preview_event",
         "optional": false,
         "requested": ".easyuse_anima.aio.preview",
@@ -22310,7 +22689,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.preview:_tag_aio_preview_images",
         "kind": "static_from",
-        "line": 119,
+        "line": 116,
         "name": "_tag_aio_preview_images",
         "optional": false,
         "requested": ".easyuse_anima.aio.preview",
@@ -22341,7 +22720,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.output:_aio_image_saver_additional_hashes",
         "kind": "static_from",
-        "line": 130,
+        "line": 127,
         "name": "_aio_image_saver_additional_hashes",
         "optional": false,
         "requested": ".easyuse_anima.aio.output",
@@ -22372,7 +22751,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.output:_aio_image_saver_civitai_hash_fetcher_entries",
         "kind": "static_from",
-        "line": 130,
+        "line": 127,
         "name": "_aio_image_saver_civitai_hash_fetcher_entries",
         "optional": false,
         "requested": ".easyuse_anima.aio.output",
@@ -22403,7 +22782,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.output:_aio_lora_metadata_name",
         "kind": "static_from",
-        "line": 130,
+        "line": 127,
         "name": "_aio_lora_metadata_name",
         "optional": false,
         "requested": ".easyuse_anima.aio.output",
@@ -22434,7 +22813,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.output:_aio_prompt_with_lora_metadata",
         "kind": "static_from",
-        "line": 130,
+        "line": 127,
         "name": "_aio_prompt_with_lora_metadata",
         "optional": false,
         "requested": ".easyuse_anima.aio.output",
@@ -22465,7 +22844,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.output:_aio_save_filename_prefix",
         "kind": "static_from",
-        "line": 130,
+        "line": 127,
         "name": "_aio_save_filename_prefix",
         "optional": false,
         "requested": ".easyuse_anima.aio.output",
@@ -22496,7 +22875,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.output:_save_image_with_comfy",
         "kind": "static_from",
-        "line": 130,
+        "line": 127,
         "name": "_save_image_with_comfy",
         "optional": false,
         "requested": ".easyuse_anima.aio.output",
@@ -22527,7 +22906,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.output:_save_image_with_image_saver",
         "kind": "static_from",
-        "line": 130,
+        "line": 127,
         "name": "_save_image_with_image_saver",
         "optional": false,
         "requested": ".easyuse_anima.aio.output",
@@ -22558,7 +22937,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.output_settings:_normalize_aio_civitai_hash_fetchers",
         "kind": "static_from",
-        "line": 139,
+        "line": 136,
         "name": "_normalize_aio_civitai_hash_fetchers",
         "optional": false,
         "requested": ".easyuse_anima.aio.output_settings",
@@ -22589,7 +22968,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.output_settings:_normalize_aio_hash_bundles",
         "kind": "static_from",
-        "line": 139,
+        "line": 136,
         "name": "_normalize_aio_hash_bundles",
         "optional": false,
         "requested": ".easyuse_anima.aio.output_settings",
@@ -22620,7 +22999,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_comfy_clip_loader_types",
         "kind": "static_from",
-        "line": 143,
+        "line": 140,
         "name": "_comfy_clip_loader_types",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -22651,7 +23030,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_comfy_diffusion_model_names",
         "kind": "static_from",
-        "line": 143,
+        "line": 140,
         "name": "_comfy_diffusion_model_names",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -22682,7 +23061,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_comfy_text_encoder_names",
         "kind": "static_from",
-        "line": 143,
+        "line": 140,
         "name": "_comfy_text_encoder_names",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -22713,7 +23092,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_comfy_vae_names",
         "kind": "static_from",
-        "line": 143,
+        "line": 140,
         "name": "_comfy_vae_names",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -22744,7 +23123,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_load_aio_resources_from_input_context",
         "kind": "static_from",
-        "line": 143,
+        "line": 140,
         "name": "_load_aio_resources_from_input_context",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -22775,7 +23154,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_load_aio_sam3_context",
         "kind": "static_from",
-        "line": 143,
+        "line": 140,
         "name": "_load_aio_sam3_context",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -22806,7 +23185,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_load_checkpoint_with_comfy",
         "kind": "static_from",
-        "line": 143,
+        "line": 140,
         "name": "_load_checkpoint_with_comfy",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -22837,7 +23216,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_load_clip_with_comfy",
         "kind": "static_from",
-        "line": 143,
+        "line": 140,
         "name": "_load_clip_with_comfy",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -22868,7 +23247,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_load_diffusion_model_with_comfy",
         "kind": "static_from",
-        "line": 143,
+        "line": 140,
         "name": "_load_diffusion_model_with_comfy",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -22899,7 +23278,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_load_upscale_model_with_comfy",
         "kind": "static_from",
-        "line": 143,
+        "line": 140,
         "name": "_load_upscale_model_with_comfy",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -22930,7 +23309,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_load_vae_with_comfy",
         "kind": "static_from",
-        "line": 143,
+        "line": 140,
         "name": "_load_vae_with_comfy",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -22961,7 +23340,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_normalize_aio_input_settings",
         "kind": "static_from",
-        "line": 143,
+        "line": 140,
         "name": "_normalize_aio_input_settings",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -22992,7 +23371,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_preferred_checkpoint_default",
         "kind": "static_from",
-        "line": 143,
+        "line": 140,
         "name": "_preferred_checkpoint_default",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -23023,7 +23402,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_preferred_clip_type_default",
         "kind": "static_from",
-        "line": 143,
+        "line": 140,
         "name": "_preferred_clip_type_default",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -23054,7 +23433,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_preferred_name_default",
         "kind": "static_from",
-        "line": 143,
+        "line": 140,
         "name": "_preferred_name_default",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -23085,7 +23464,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.common.serialization:_json_clone",
         "kind": "static_from",
-        "line": 160,
+        "line": 157,
         "name": "_json_clone",
         "optional": false,
         "requested": ".easyuse_anima.common.serialization",
@@ -23116,7 +23495,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.common.serialization:_json_object",
         "kind": "static_from",
-        "line": 160,
+        "line": 157,
         "name": "_json_object",
         "optional": false,
         "requested": ".easyuse_anima.common.serialization",
@@ -23147,7 +23526,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.common.serialization:_stable_change_key",
         "kind": "static_from",
-        "line": 160,
+        "line": 157,
         "name": "_stable_change_key",
         "optional": false,
         "requested": ".easyuse_anima.common.serialization",
@@ -23178,7 +23557,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.common.values:_as_bool",
         "kind": "static_from",
-        "line": 165,
+        "line": 162,
         "name": "_as_bool",
         "optional": false,
         "requested": ".easyuse_anima.common.values",
@@ -23209,7 +23588,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.common.values:_as_float",
         "kind": "static_from",
-        "line": 165,
+        "line": 162,
         "name": "_as_float",
         "optional": false,
         "requested": ".easyuse_anima.common.values",
@@ -23240,7 +23619,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.common.values:_as_int",
         "kind": "static_from",
-        "line": 165,
+        "line": 162,
         "name": "_as_int",
         "optional": false,
         "requested": ".easyuse_anima.common.values",
@@ -23271,7 +23650,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.common.values:_choice",
         "kind": "static_from",
-        "line": 165,
+        "line": 162,
         "name": "_choice",
         "optional": false,
         "requested": ".easyuse_anima.common.values",
@@ -23302,7 +23681,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.common.values:_single_value",
         "kind": "static_from",
-        "line": 165,
+        "line": 162,
         "name": "_single_value",
         "optional": false,
         "requested": ".easyuse_anima.common.values",
@@ -23333,7 +23712,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.seed.compatibility:WILDCARD_QUEUE_MAX_SAFE_SEED",
         "kind": "static_from",
-        "line": 172,
+        "line": 169,
         "name": "WILDCARD_QUEUE_MAX_SAFE_SEED",
         "optional": false,
         "requested": ".easyuse_anima.seed.compatibility",
@@ -23364,7 +23743,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.seed.compatibility:WILDCARD_RESERVED_NEXT_SEED_INPUT",
         "kind": "static_from",
-        "line": 172,
+        "line": 169,
         "name": "WILDCARD_RESERVED_NEXT_SEED_INPUT",
         "optional": false,
         "requested": ".easyuse_anima.seed.compatibility",
@@ -23395,7 +23774,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.seed.compatibility:_consume_reserved_wildcard_next_seed",
         "kind": "static_from",
-        "line": 172,
+        "line": 169,
         "name": "_consume_reserved_wildcard_next_seed",
         "optional": false,
         "requested": ".easyuse_anima.seed.compatibility",
@@ -23426,7 +23805,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.workflow:_get_workflow_node",
         "kind": "static_from",
-        "line": 177,
+        "line": 174,
         "name": "_get_workflow_node",
         "optional": false,
         "requested": ".easyuse_anima.workflow",
@@ -23457,7 +23836,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.correction:_prompt_translation_change_key",
         "kind": "static_from",
-        "line": 178,
+        "line": 175,
         "name": "_prompt_translation_change_key",
         "optional": false,
         "requested": ".easyuse_anima.prompt.correction",
@@ -23488,7 +23867,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.correction:_split_tag_text",
         "kind": "static_from",
-        "line": 178,
+        "line": 175,
         "name": "_split_tag_text",
         "optional": false,
         "requested": ".easyuse_anima.prompt.correction",
@@ -23519,7 +23898,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.correction:_translate_prompt_text",
         "kind": "static_from",
-        "line": 178,
+        "line": 175,
         "name": "_translate_prompt_text",
         "optional": false,
         "requested": ".easyuse_anima.prompt.correction",
@@ -23550,7 +23929,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_HASH_COMMENT_RE",
         "kind": "static_from",
-        "line": 183,
+        "line": 180,
         "name": "_HASH_COMMENT_RE",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -23581,7 +23960,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_INLINE_SPACE_RE",
         "kind": "static_from",
-        "line": 183,
+        "line": 180,
         "name": "_INLINE_SPACE_RE",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -23612,7 +23991,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_WEIGHTED_TOKEN_RE",
         "kind": "static_from",
-        "line": 183,
+        "line": 180,
         "name": "_WEIGHTED_TOKEN_RE",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -23643,7 +24022,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_correct_builder_prompt",
         "kind": "static_from",
-        "line": 183,
+        "line": 180,
         "name": "_correct_builder_prompt",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -23674,7 +24053,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_filter_metadata_prompt",
         "kind": "static_from",
-        "line": 183,
+        "line": 180,
         "name": "_filter_metadata_prompt",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -23705,7 +24084,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_join_prompt_tokens",
         "kind": "static_from",
-        "line": 183,
+        "line": 180,
         "name": "_join_prompt_tokens",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -23736,7 +24115,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_metadata_filter_key",
         "kind": "static_from",
-        "line": 183,
+        "line": 180,
         "name": "_metadata_filter_key",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -23767,7 +24146,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_metadata_filter_keys",
         "kind": "static_from",
-        "line": 183,
+        "line": 180,
         "name": "_metadata_filter_keys",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -23798,7 +24177,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_prompt_tokens",
         "kind": "static_from",
-        "line": 183,
+        "line": 180,
         "name": "_prompt_tokens",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -23829,7 +24208,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:PROMPT_DATA_TYPE",
         "kind": "static_from",
-        "line": 196,
+        "line": 193,
         "name": "PROMPT_DATA_TYPE",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -23860,7 +24239,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:_advanced_outputs_from_prompt_data",
         "kind": "static_from",
-        "line": 196,
+        "line": 193,
         "name": "_advanced_outputs_from_prompt_data",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -23891,7 +24270,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:_apply_prompt_data_overrides",
         "kind": "static_from",
-        "line": 196,
+        "line": 193,
         "name": "_apply_prompt_data_overrides",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -23922,7 +24301,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:_copy_prompt_data_for_update",
         "kind": "static_from",
-        "line": 196,
+        "line": 193,
         "name": "_copy_prompt_data_for_update",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -23953,7 +24332,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:_normalize_prompt_data",
         "kind": "static_from",
-        "line": 196,
+        "line": 193,
         "name": "_normalize_prompt_data",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -23984,7 +24363,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:_prompt_data_json_safe",
         "kind": "static_from",
-        "line": 196,
+        "line": 193,
         "name": "_prompt_data_json_safe",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -24015,7 +24394,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:_prompt_data_parameter_snapshot",
         "kind": "static_from",
-        "line": 196,
+        "line": 193,
         "name": "_prompt_data_parameter_snapshot",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -24046,7 +24425,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_artist_field_prompt",
         "kind": "static_from",
-        "line": 214,
+        "line": 211,
         "name": "_advanced_artist_field_prompt",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -24077,7 +24456,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_default_fields",
         "kind": "static_from",
-        "line": 214,
+        "line": 211,
         "name": "_advanced_default_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -24108,7 +24487,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_enabled_naia_panes",
         "kind": "static_from",
-        "line": 214,
+        "line": 211,
         "name": "_advanced_enabled_naia_panes",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -24139,7 +24518,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_enabled_pane_fields",
         "kind": "static_from",
-        "line": 214,
+        "line": 211,
         "name": "_advanced_enabled_pane_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -24170,7 +24549,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_field_input_values",
         "kind": "static_from",
-        "line": 214,
+        "line": 211,
         "name": "_advanced_field_input_values",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -24201,7 +24580,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_field_socket_name",
         "kind": "static_from",
-        "line": 214,
+        "line": 211,
         "name": "_advanced_field_socket_name",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -24232,7 +24611,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_fields_json",
         "kind": "static_from",
-        "line": 214,
+        "line": 211,
         "name": "_advanced_fields_json",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -24263,7 +24642,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_has_enabled_naia",
         "kind": "static_from",
-        "line": 214,
+        "line": 211,
         "name": "_advanced_has_enabled_naia",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -24294,7 +24673,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_prompt_with_artist_override",
         "kind": "static_from",
-        "line": 214,
+        "line": 211,
         "name": "_advanced_prompt_with_artist_override",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -24325,7 +24704,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_uses_naia_resolution",
         "kind": "static_from",
-        "line": 214,
+        "line": 211,
         "name": "_advanced_uses_naia_resolution",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -24356,7 +24735,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_apply_advanced_field_inputs",
         "kind": "static_from",
-        "line": 214,
+        "line": 211,
         "name": "_apply_advanced_field_inputs",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -24387,7 +24766,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_as_advanced_height",
         "kind": "static_from",
-        "line": 214,
+        "line": 211,
         "name": "_as_advanced_height",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -24418,7 +24797,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_build_advanced_prompt_data",
         "kind": "static_from",
-        "line": 214,
+        "line": 211,
         "name": "_build_advanced_prompt_data",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -24449,7 +24828,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_build_advanced_prompts",
         "kind": "static_from",
-        "line": 214,
+        "line": 211,
         "name": "_build_advanced_prompts",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -24480,7 +24859,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_clone_advanced_fields",
         "kind": "static_from",
-        "line": 214,
+        "line": 211,
         "name": "_clone_advanced_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -24511,7 +24890,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_correct_advanced_field_sequence",
         "kind": "static_from",
-        "line": 214,
+        "line": 211,
         "name": "_correct_advanced_field_sequence",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -24542,7 +24921,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_expand_advanced_wildcard_fields",
         "kind": "static_from",
-        "line": 214,
+        "line": 211,
         "name": "_expand_advanced_wildcard_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -24573,7 +24952,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_normalize_advanced_fields",
         "kind": "static_from",
-        "line": 214,
+        "line": 211,
         "name": "_normalize_advanced_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -24604,7 +24983,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_normalize_prompt_studio_wildcard_seed_control",
         "kind": "static_from",
-        "line": 214,
+        "line": 211,
         "name": "_normalize_prompt_studio_wildcard_seed_control",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -24635,7 +25014,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_set_naia_field_text",
         "kind": "static_from",
-        "line": 214,
+        "line": 211,
         "name": "_set_naia_field_text",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -24666,7 +25045,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_translate_prompt_fields",
         "kind": "static_from",
-        "line": 214,
+        "line": 211,
         "name": "_translate_prompt_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -24697,7 +25076,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_apply_regional_field_inputs",
         "kind": "static_from",
-        "line": 249,
+        "line": 246,
         "name": "_apply_regional_field_inputs",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -24728,7 +25107,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_build_regional_outputs",
         "kind": "static_from",
-        "line": 249,
+        "line": 246,
         "name": "_build_regional_outputs",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -24759,7 +25138,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_clone_regional_fields",
         "kind": "static_from",
-        "line": 249,
+        "line": 246,
         "name": "_clone_regional_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -24790,7 +25169,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_conditioning_set_values",
         "kind": "static_from",
-        "line": 249,
+        "line": 246,
         "name": "_conditioning_set_values",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -24821,7 +25200,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_normalize_mask_ids",
         "kind": "static_from",
-        "line": 249,
+        "line": 246,
         "name": "_normalize_mask_ids",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -24852,7 +25231,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_normalize_regional_config",
         "kind": "static_from",
-        "line": 249,
+        "line": 246,
         "name": "_normalize_regional_config",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -24883,7 +25262,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_normalize_regional_fields",
         "kind": "static_from",
-        "line": 249,
+        "line": 246,
         "name": "_normalize_regional_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -24914,7 +25293,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_parse_json_object",
         "kind": "static_from",
-        "line": 249,
+        "line": 246,
         "name": "_parse_json_object",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -24945,7 +25324,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_regional_config_json",
         "kind": "static_from",
-        "line": 249,
+        "line": 246,
         "name": "_regional_config_json",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -24976,7 +25355,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_regional_fields_json",
         "kind": "static_from",
-        "line": 249,
+        "line": 246,
         "name": "_regional_fields_json",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -25007,7 +25386,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_regional_mask_bounds_area",
         "kind": "static_from",
-        "line": 249,
+        "line": 246,
         "name": "_regional_mask_bounds_area",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -25038,7 +25417,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_regional_payload_canvas",
         "kind": "static_from",
-        "line": 249,
+        "line": 246,
         "name": "_regional_payload_canvas",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -25069,7 +25448,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_regional_union_mask_for_ids",
         "kind": "static_from",
-        "line": 249,
+        "line": 246,
         "name": "_regional_union_mask_for_ids",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -25100,7 +25479,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
         "kind": "static_from",
-        "line": 276,
+        "line": 273,
         "name": "ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -25131,7 +25510,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODES",
         "kind": "static_from",
-        "line": 276,
+        "line": 273,
         "name": "ANIMA_MOD_GUIDANCE_MODES",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -25162,7 +25541,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 276,
+        "line": 273,
         "name": "ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -25193,7 +25572,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_PROFILE_OFF",
         "kind": "static_from",
-        "line": 276,
+        "line": 273,
         "name": "ANIMA_MOD_GUIDANCE_PROFILE_OFF",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -25224,7 +25603,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:_apply_spectrum_anima_mod_guidance",
         "kind": "static_from",
-        "line": 276,
+        "line": 273,
         "name": "_apply_spectrum_anima_mod_guidance",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -25255,7 +25634,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:_find_spectrum_anima_mod_guidance_class",
         "kind": "static_from",
-        "line": 276,
+        "line": 273,
         "name": "_find_spectrum_anima_mod_guidance_class",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -25286,7 +25665,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:_normalize_anima_mod_guidance_profile",
         "kind": "static_from",
-        "line": 276,
+        "line": 273,
         "name": "_normalize_anima_mod_guidance_profile",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -25317,7 +25696,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:_resolve_anima_mod_guidance_enabled",
         "kind": "static_from",
-        "line": 276,
+        "line": 273,
         "name": "_resolve_anima_mod_guidance_enabled",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -25348,7 +25727,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
         "kind": "static_from",
-        "line": 291,
+        "line": 288,
         "name": "ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -25379,7 +25758,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
         "kind": "static_from",
-        "line": 291,
+        "line": 288,
         "name": "ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -25410,7 +25789,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
         "kind": "static_from",
-        "line": 291,
+        "line": 288,
         "name": "ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -25441,7 +25820,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_EXACT_TOP_K",
         "kind": "static_from",
-        "line": 291,
+        "line": 288,
         "name": "ARTIST_MIX_DEFAULT_EXACT_TOP_K",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -25472,7 +25851,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
         "kind": "static_from",
-        "line": 291,
+        "line": 288,
         "name": "ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -25503,7 +25882,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_START_PERCENT",
         "kind": "static_from",
-        "line": 291,
+        "line": 288,
         "name": "ARTIST_MIX_DEFAULT_START_PERCENT",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -25534,7 +25913,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
         "kind": "static_from",
-        "line": 291,
+        "line": 288,
         "name": "ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -25565,7 +25944,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STYLE_GAIN",
         "kind": "static_from",
-        "line": 291,
+        "line": 288,
         "name": "ARTIST_MIX_DEFAULT_STYLE_GAIN",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -25596,7 +25975,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_INPUT_MODES",
         "kind": "static_from",
-        "line": 291,
+        "line": 288,
         "name": "ARTIST_MIX_INPUT_MODES",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -25627,7 +26006,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 291,
+        "line": 288,
         "name": "ARTIST_MIX_MODE_FROM_PROMPT_DATA",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -25658,7 +26037,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_artist_mix_inline_prompt",
         "kind": "static_from",
-        "line": 291,
+        "line": 288,
         "name": "_artist_mix_inline_prompt",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -25689,7 +26068,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_artist_mix_mode_tooltip",
         "kind": "static_from",
-        "line": 291,
+        "line": 288,
         "name": "_artist_mix_mode_tooltip",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -25720,7 +26099,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_artist_prompt_with_position",
         "kind": "static_from",
-        "line": 291,
+        "line": 288,
         "name": "_artist_prompt_with_position",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -25751,7 +26130,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_artist_tags_from_prompt",
         "kind": "static_from",
-        "line": 291,
+        "line": 288,
         "name": "_artist_tags_from_prompt",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -25782,7 +26161,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_blend_conditionings",
         "kind": "static_from",
-        "line": 291,
+        "line": 288,
         "name": "_blend_conditionings",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -25813,7 +26192,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_bounded_artist_mix_float",
         "kind": "static_from",
-        "line": 291,
+        "line": 288,
         "name": "_bounded_artist_mix_float",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -25844,7 +26223,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_bounded_artist_mix_int",
         "kind": "static_from",
-        "line": 291,
+        "line": 288,
         "name": "_bounded_artist_mix_int",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -25875,7 +26254,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_encode_artist_clustered",
         "kind": "static_from",
-        "line": 291,
+        "line": 288,
         "name": "_encode_artist_clustered",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -25906,7 +26285,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_encode_artist_delta_rms",
         "kind": "static_from",
-        "line": 291,
+        "line": 288,
         "name": "_encode_artist_delta_rms",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -25937,7 +26316,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_encode_prompt_data_positive_conditioning",
         "kind": "static_from",
-        "line": 291,
+        "line": 288,
         "name": "_encode_prompt_data_positive_conditioning",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -25968,7 +26347,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_join_artist_mix_source_prompts",
         "kind": "static_from",
-        "line": 291,
+        "line": 288,
         "name": "_join_artist_mix_source_prompts",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -25999,7 +26378,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_normalize_artist_mix_mode",
         "kind": "static_from",
-        "line": 291,
+        "line": 288,
         "name": "_normalize_artist_mix_mode",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -26030,7 +26409,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_normalize_artist_tag_position",
         "kind": "static_from",
-        "line": 291,
+        "line": 288,
         "name": "_normalize_artist_tag_position",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -26061,7 +26440,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_parse_artist_mix_items",
         "kind": "static_from",
-        "line": 291,
+        "line": 288,
         "name": "_parse_artist_mix_items",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -26092,7 +26471,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaArtistMixConditioning",
         "kind": "static_from",
-        "line": 370,
+        "line": 367,
         "name": "EasyUseAnimaArtistMixConditioning",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_data_nodes",
@@ -26123,7 +26502,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataConditioning",
         "kind": "static_from",
-        "line": 370,
+        "line": 367,
         "name": "EasyUseAnimaPromptDataConditioning",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_data_nodes",
@@ -26154,7 +26533,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataUnpack",
         "kind": "static_from",
-        "line": 370,
+        "line": 367,
         "name": "EasyUseAnimaPromptDataUnpack",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_data_nodes",
@@ -26185,7 +26564,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.input_types:_ANY_TYPE",
         "kind": "static_from",
-        "line": 375,
+        "line": 372,
         "name": "_ANY_TYPE",
         "optional": false,
         "requested": ".easyuse_anima.nodes.input_types",
@@ -26216,7 +26595,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.input_types:_AnyType",
         "kind": "static_from",
-        "line": 375,
+        "line": 372,
         "name": "_AnyType",
         "optional": false,
         "requested": ".easyuse_anima.nodes.input_types",
@@ -26247,7 +26626,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.input_types:_FlexibleOptionalInputType",
         "kind": "static_from",
-        "line": 375,
+        "line": 372,
         "name": "_FlexibleOptionalInputType",
         "optional": false,
         "requested": ".easyuse_anima.nodes.input_types",
@@ -26278,7 +26657,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvanced",
         "kind": "static_from",
-        "line": 380,
+        "line": 377,
         "name": "EasyUseAnimaPromptStudioAdvanced",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_advanced_nodes",
@@ -26309,7 +26688,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvancedV2",
         "kind": "static_from",
-        "line": 380,
+        "line": 377,
         "name": "EasyUseAnimaPromptStudioAdvancedV2",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_advanced_nodes",
@@ -26340,7 +26719,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.aio_nodes:EasyUseAnimaAIOGenerator",
         "kind": "static_from",
-        "line": 385,
+        "line": 382,
         "name": "EasyUseAnimaAIOGenerator",
         "optional": false,
         "requested": ".easyuse_anima.nodes.aio_nodes",
@@ -26371,7 +26750,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.aio_nodes:EasyUseAnimaInput",
         "kind": "static_from",
-        "line": 385,
+        "line": 382,
         "name": "EasyUseAnimaInput",
         "optional": false,
         "requested": ".easyuse_anima.nodes.aio_nodes",
@@ -26402,7 +26781,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.aio_nodes:_aio_generation_settings_json",
         "kind": "static_from",
-        "line": 385,
+        "line": 382,
         "name": "_aio_generation_settings_json",
         "optional": false,
         "requested": ".easyuse_anima.nodes.aio_nodes",
@@ -26433,7 +26812,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.aio_nodes:_aio_input_settings_json",
         "kind": "static_from",
-        "line": 385,
+        "line": 382,
         "name": "_aio_input_settings_json",
         "optional": false,
         "requested": ".easyuse_anima.nodes.aio_nodes",
@@ -26464,7 +26843,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.aio_nodes:_bind_aio_node_runtime",
         "kind": "static_from",
-        "line": 385,
+        "line": 382,
         "name": "_bind_aio_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.aio_nodes",
@@ -26495,7 +26874,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.aio_nodes:_easy_use_anima_input_signature",
         "kind": "static_from",
-        "line": 385,
+        "line": 382,
         "name": "_easy_use_anima_input_signature",
         "optional": false,
         "requested": ".easyuse_anima.nodes.aio_nodes",
@@ -26526,7 +26905,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.aio_nodes:_require_easy_use_anima_input",
         "kind": "static_from",
-        "line": 385,
+        "line": 382,
         "name": "_require_easy_use_anima_input",
         "optional": false,
         "requested": ".easyuse_anima.nodes.aio_nodes",
@@ -26557,7 +26936,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.geometry:_align_down",
         "kind": "static_from",
-        "line": 394,
+        "line": 391,
         "name": "_align_down",
         "optional": false,
         "requested": ".easyuse_anima.image.geometry",
@@ -26588,7 +26967,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.geometry:_align_nearest",
         "kind": "static_from",
-        "line": 394,
+        "line": 391,
         "name": "_align_nearest",
         "optional": false,
         "requested": ".easyuse_anima.image.geometry",
@@ -26619,7 +26998,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.geometry:_image_tensor_size",
         "kind": "static_from",
-        "line": 394,
+        "line": 391,
         "name": "_image_tensor_size",
         "optional": false,
         "requested": ".easyuse_anima.image.geometry",
@@ -26650,7 +27029,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.sam3:_context_value",
         "kind": "static_from",
-        "line": 405,
+        "line": 402,
         "name": "_context_value",
         "optional": false,
         "requested": ".easyuse_anima.image.sam3",
@@ -26681,7 +27060,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.sam3:_sam3_context",
         "kind": "static_from",
-        "line": 405,
+        "line": 402,
         "name": "_sam3_context",
         "optional": false,
         "requested": ".easyuse_anima.image.sam3",
@@ -26712,7 +27091,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.sam3:_segs_has_items",
         "kind": "static_from",
-        "line": 405,
+        "line": 402,
         "name": "_segs_has_items",
         "optional": false,
         "requested": ".easyuse_anima.image.sam3",
@@ -26743,7 +27122,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.scaling:IMAGE_SCALE_MULTIPLES",
         "kind": "static_from",
-        "line": 417,
+        "line": 414,
         "name": "IMAGE_SCALE_MULTIPLES",
         "optional": false,
         "requested": ".easyuse_anima.image.scaling",
@@ -26774,7 +27153,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.scaling:IMAGE_UPSCALE_METHODS",
         "kind": "static_from",
-        "line": 417,
+        "line": 414,
         "name": "IMAGE_UPSCALE_METHODS",
         "optional": false,
         "requested": ".easyuse_anima.image.scaling",
@@ -26805,7 +27184,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_comfy_sampler_names",
         "kind": "static_from",
-        "line": 425,
+        "line": 422,
         "name": "_comfy_sampler_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -26836,7 +27215,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_comfy_scheduler_names",
         "kind": "static_from",
-        "line": 425,
+        "line": 422,
         "name": "_comfy_scheduler_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -26867,7 +27246,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_impact_scheduler_names",
         "kind": "static_from",
-        "line": 425,
+        "line": 422,
         "name": "_impact_scheduler_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -26898,7 +27277,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.invocation:_call_with_supported_kwargs",
         "kind": "static_from",
-        "line": 431,
+        "line": 428,
         "name": "_call_with_supported_kwargs",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.invocation",
@@ -26929,7 +27308,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.invocation:_common_upscale_image",
         "kind": "static_from",
-        "line": 431,
+        "line": 428,
         "name": "_common_upscale_image",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.invocation",
@@ -26960,7 +27339,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.invocation:_node_output_tuple",
         "kind": "static_from",
-        "line": 431,
+        "line": 428,
         "name": "_node_output_tuple",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.invocation",
@@ -26991,7 +27370,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.wiring:resolve_comfy_host_helper",
         "kind": "static_from",
-        "line": 436,
+        "line": 433,
         "name": "resolve_comfy_host_helper",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.wiring",
@@ -27022,7 +27401,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_comfy_clip_loader_types",
         "kind": "static_from",
-        "line": 439,
+        "line": 436,
         "name": "_comfy_clip_loader_types",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -27053,7 +27432,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_comfy_diffusion_model_names",
         "kind": "static_from",
-        "line": 439,
+        "line": 436,
         "name": "_comfy_diffusion_model_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -27084,7 +27463,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_comfy_text_encoder_names",
         "kind": "static_from",
-        "line": 439,
+        "line": 436,
         "name": "_comfy_text_encoder_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -27115,7 +27494,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_comfy_vae_names",
         "kind": "static_from",
-        "line": 439,
+        "line": 436,
         "name": "_comfy_vae_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -27146,7 +27525,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_folder_path_names",
         "kind": "static_from",
-        "line": 439,
+        "line": 436,
         "name": "_folder_path_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -27177,7 +27556,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.image_nodes:EasyUseAnimaDetailerAlignHook",
         "kind": "static_from",
-        "line": 447,
+        "line": 444,
         "name": "EasyUseAnimaDetailerAlignHook",
         "optional": false,
         "requested": ".easyuse_anima.nodes.image_nodes",
@@ -27208,7 +27587,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.image_nodes:EasyUseAnimaImageScaleByMultiple",
         "kind": "static_from",
-        "line": 447,
+        "line": 444,
         "name": "EasyUseAnimaImageScaleByMultiple",
         "optional": false,
         "requested": ".easyuse_anima.nodes.image_nodes",
@@ -27239,7 +27618,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Context",
         "kind": "static_from",
-        "line": 451,
+        "line": 448,
         "name": "EasyUseAnimaSAM3Context",
         "optional": false,
         "requested": ".easyuse_anima.nodes.sam3_nodes",
@@ -27270,7 +27649,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Detailer",
         "kind": "static_from",
-        "line": 451,
+        "line": 448,
         "name": "EasyUseAnimaSAM3Detailer",
         "optional": false,
         "requested": ".easyuse_anima.nodes.sam3_nodes",
@@ -27301,7 +27680,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptBuilder",
         "kind": "static_from",
-        "line": 455,
+        "line": 452,
         "name": "EasyUseAnimaPromptBuilder",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_nodes",
@@ -27332,7 +27711,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrector",
         "kind": "static_from",
-        "line": 455,
+        "line": 452,
         "name": "EasyUseAnimaPromptCorrector",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_nodes",
@@ -27363,7 +27742,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrectorSimple",
         "kind": "static_from",
-        "line": 455,
+        "line": 452,
         "name": "EasyUseAnimaPromptCorrectorSimple",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_nodes",
@@ -27394,7 +27773,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptStudio",
         "kind": "static_from",
-        "line": 455,
+        "line": 452,
         "name": "EasyUseAnimaPromptStudio",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_nodes",
@@ -27425,7 +27804,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.regional_nodes:EasyUseAnimaPromptStudioRegional",
         "kind": "static_from",
-        "line": 461,
+        "line": 458,
         "name": "EasyUseAnimaPromptStudioRegional",
         "optional": false,
         "requested": ".easyuse_anima.nodes.regional_nodes",
@@ -27456,7 +27835,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.regional_nodes:EasyUseAnimaRegionalConditioning",
         "kind": "static_from",
-        "line": 461,
+        "line": 458,
         "name": "EasyUseAnimaRegionalConditioning",
         "optional": false,
         "requested": ".easyuse_anima.nodes.regional_nodes",
@@ -27487,7 +27866,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.client:LATENT_ALIGN",
         "kind": "static_from",
-        "line": 465,
+        "line": 462,
         "name": "LATENT_ALIGN",
         "optional": false,
         "requested": ".easyuse_anima.naia.client",
@@ -27518,7 +27897,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.client:_parse_random_response",
         "kind": "static_from",
-        "line": 465,
+        "line": 462,
         "name": "_parse_random_response",
         "optional": false,
         "requested": ".easyuse_anima.naia.client",
@@ -27549,7 +27928,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.client:_post_random",
         "kind": "static_from",
-        "line": 465,
+        "line": 462,
         "name": "_post_random",
         "optional": false,
         "requested": ".easyuse_anima.naia.client",
@@ -27580,7 +27959,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_advanced_resolution_from_selection",
         "kind": "static_from",
-        "line": 483,
+        "line": 480,
         "name": "_advanced_resolution_from_selection",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -27611,7 +27990,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_normalize_resolution_bucket",
         "kind": "static_from",
-        "line": 483,
+        "line": 480,
         "name": "_normalize_resolution_bucket",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -27642,7 +28021,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_ratio_label",
         "kind": "static_from",
-        "line": 483,
+        "line": 480,
         "name": "_ratio_label",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -27673,7 +28052,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_resolution_label",
         "kind": "static_from",
-        "line": 483,
+        "line": 480,
         "name": "_resolution_label",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -27704,7 +28083,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_resolve_naia_resolution",
         "kind": "static_from",
-        "line": 483,
+        "line": 480,
         "name": "_resolve_naia_resolution",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -27735,7 +28114,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.naia_nodes:EasyUseAnimaNAIARandomPrompt",
         "kind": "static_from",
-        "line": 506,
+        "line": 503,
         "name": "EasyUseAnimaNAIARandomPrompt",
         "optional": false,
         "requested": ".easyuse_anima.nodes.naia_nodes",
@@ -27766,7 +28145,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.naia_nodes:_bind_naia_node_runtime",
         "kind": "static_from",
-        "line": 506,
+        "line": 503,
         "name": "_bind_naia_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.naia_nodes",
@@ -27797,7 +28176,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.wildcard_nodes:EasyUseAnimaWildcard",
         "kind": "static_from",
-        "line": 510,
+        "line": 507,
         "name": "EasyUseAnimaWildcard",
         "optional": false,
         "requested": ".easyuse_anima.nodes.wildcard_nodes",
@@ -27828,7 +28207,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.wildcard_nodes:_bind_wildcard_node_runtime",
         "kind": "static_from",
-        "line": 510,
+        "line": 507,
         "name": "_bind_wildcard_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.wildcard_nodes",
@@ -27859,7 +28238,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_apply_lora_syntax_format",
         "kind": "static_from",
-        "line": 515,
+        "line": 512,
         "name": "_apply_lora_syntax_format",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -27890,7 +28269,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_dedupe_text_values",
         "kind": "static_from",
-        "line": 515,
+        "line": 512,
         "name": "_dedupe_text_values",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -27921,7 +28300,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_fallback_lora_path",
         "kind": "static_from",
-        "line": 515,
+        "line": 512,
         "name": "_fallback_lora_path",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -27952,7 +28331,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_get_lora_info",
         "kind": "static_from",
-        "line": 515,
+        "line": 512,
         "name": "_get_lora_info",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -27983,7 +28362,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_get_lora_manager_trigger_words",
         "kind": "static_from",
-        "line": 515,
+        "line": 512,
         "name": "_get_lora_manager_trigger_words",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -28014,7 +28393,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_load_lora_manager_metadata",
         "kind": "static_from",
-        "line": 515,
+        "line": 512,
         "name": "_load_lora_manager_metadata",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -28045,7 +28424,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_lora_combo_values",
         "kind": "static_from",
-        "line": 515,
+        "line": 512,
         "name": "_lora_combo_values",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -28076,7 +28455,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_lora_manager_trigger_words_from_metadata",
         "kind": "static_from",
-        "line": 515,
+        "line": 512,
         "name": "_lora_manager_trigger_words_from_metadata",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -28107,7 +28486,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_lora_model_exists",
         "kind": "static_from",
-        "line": 515,
+        "line": 512,
         "name": "_lora_model_exists",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -28138,7 +28517,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_lora_stack_name",
         "kind": "static_from",
-        "line": 515,
+        "line": 512,
         "name": "_lora_stack_name",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -28169,7 +28548,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_metadata_json_paths_for_lora",
         "kind": "static_from",
-        "line": 515,
+        "line": 512,
         "name": "_metadata_json_paths_for_lora",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -28200,7 +28579,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_missing_lora_display_name",
         "kind": "static_from",
-        "line": 515,
+        "line": 512,
         "name": "_missing_lora_display_name",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -28231,7 +28610,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_raise_missing_loras",
         "kind": "static_from",
-        "line": 515,
+        "line": 512,
         "name": "_raise_missing_loras",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -28262,7 +28641,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_trigger_words_from_value",
         "kind": "static_from",
-        "line": 515,
+        "line": 512,
         "name": "_trigger_words_from_value",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -28293,7 +28672,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_correct_style_prompt",
         "kind": "static_from",
-        "line": 531,
+        "line": 528,
         "name": "_correct_style_prompt",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -28324,7 +28703,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_format_strength",
         "kind": "static_from",
-        "line": 531,
+        "line": 528,
         "name": "_format_strength",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -28355,7 +28734,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_get_loras_list",
         "kind": "static_from",
-        "line": 531,
+        "line": 528,
         "name": "_get_loras_list",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -28386,7 +28765,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_load_profile_data",
         "kind": "static_from",
-        "line": 531,
+        "line": 528,
         "name": "_load_profile_data",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -28417,7 +28796,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_profile_key",
         "kind": "static_from",
-        "line": 531,
+        "line": 528,
         "name": "_profile_key",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -28448,7 +28827,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_select_profile_values",
         "kind": "static_from",
-        "line": 531,
+        "line": 528,
         "name": "_select_profile_values",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -28479,7 +28858,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_wrap_profile_index",
         "kind": "static_from",
-        "line": 531,
+        "line": 528,
         "name": "_wrap_profile_index",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -28510,7 +28889,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.lora_nodes:EasyUseAnimaLoraPreset",
         "kind": "static_from",
-        "line": 540,
+        "line": 537,
         "name": "EasyUseAnimaLoraPreset",
         "optional": false,
         "requested": ".easyuse_anima.nodes.lora_nodes",
@@ -28541,7 +28920,7 @@
         "conditional": true,
         "imported": ".anima_prompt:correct_prompt",
         "kind": "static_from",
-        "line": 543,
+        "line": 540,
         "name": "correct_prompt",
         "optional": false,
         "requested": ".anima_prompt",
@@ -28572,7 +28951,7 @@
         "conditional": true,
         "imported": ".anima_prompt:load_knowledge_base",
         "kind": "static_from",
-        "line": 543,
+        "line": 540,
         "name": "load_knowledge_base",
         "optional": false,
         "requested": ".anima_prompt",
@@ -28603,7 +28982,7 @@
         "conditional": true,
         "imported": ".anima_prompt.parser:parse_prompt",
         "kind": "static_from",
-        "line": 544,
+        "line": 541,
         "name": "parse_prompt",
         "optional": false,
         "requested": ".anima_prompt.parser",
@@ -28634,7 +29013,7 @@
         "conditional": true,
         "imported": ".settings:resolve_metadata_filter_words",
         "kind": "static_from",
-        "line": 545,
+        "line": 542,
         "name": "resolve_metadata_filter_words",
         "optional": false,
         "requested": ".settings",
@@ -28665,7 +29044,7 @@
         "conditional": true,
         "imported": ".settings:resolve_naia_settings",
         "kind": "static_from",
-        "line": 545,
+        "line": 542,
         "name": "resolve_naia_settings",
         "optional": false,
         "requested": ".settings",
@@ -28696,7 +29075,7 @@
         "conditional": true,
         "imported": ".settings:resolve_prompt_translation_settings",
         "kind": "static_from",
-        "line": 545,
+        "line": 542,
         "name": "resolve_prompt_translation_settings",
         "optional": false,
         "requested": ".settings",
@@ -28727,7 +29106,7 @@
         "conditional": true,
         "imported": ".prompt_translation:has_prompt_translation_markers",
         "kind": "static_from",
-        "line": 550,
+        "line": 547,
         "name": "has_prompt_translation_markers",
         "optional": false,
         "requested": ".prompt_translation",
@@ -28758,7 +29137,7 @@
         "conditional": true,
         "imported": ".prompt_translation:translate_prompt_markers",
         "kind": "static_from",
-        "line": 550,
+        "line": 547,
         "name": "translate_prompt_markers",
         "optional": false,
         "requested": ".prompt_translation",
@@ -28789,7 +29168,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:MAX_SEED",
         "kind": "static_from",
-        "line": 551,
+        "line": 548,
         "name": "MAX_SEED",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -28820,7 +29199,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "kind": "static_from",
-        "line": 551,
+        "line": 548,
         "name": "PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -28851,7 +29230,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:PUBLIC_MAX_SEED",
         "kind": "static_from",
-        "line": 551,
+        "line": 548,
         "name": "PUBLIC_MAX_SEED",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -28882,7 +29261,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_DECREMENT",
         "kind": "static_from",
-        "line": 551,
+        "line": 548,
         "name": "SEED_CONTROL_DECREMENT",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -28913,7 +29292,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_FIXED",
         "kind": "static_from",
-        "line": 551,
+        "line": 548,
         "name": "SEED_CONTROL_FIXED",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -28944,7 +29323,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_INCREMENT",
         "kind": "static_from",
-        "line": 551,
+        "line": 548,
         "name": "SEED_CONTROL_INCREMENT",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -28975,7 +29354,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_MODES",
         "kind": "static_from",
-        "line": 551,
+        "line": 548,
         "name": "SEED_CONTROL_MODES",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -29006,7 +29385,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_RANDOMIZE",
         "kind": "static_from",
-        "line": 551,
+        "line": 548,
         "name": "SEED_CONTROL_RANDOMIZE",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -29037,7 +29416,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:WILDCARD_MODE_FIXED",
         "kind": "static_from",
-        "line": 551,
+        "line": 548,
         "name": "WILDCARD_MODE_FIXED",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -29068,7 +29447,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:WILDCARD_MODE_POPULATE",
         "kind": "static_from",
-        "line": 551,
+        "line": 548,
         "name": "WILDCARD_MODE_POPULATE",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -29099,7 +29478,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:WILDCARD_MODE_SEQUENTIAL",
         "kind": "static_from",
-        "line": 551,
+        "line": 548,
         "name": "WILDCARD_MODE_SEQUENTIAL",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -29130,7 +29509,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:expand_wildcard_texts",
         "kind": "static_from",
-        "line": 551,
+        "line": 548,
         "name": "expand_wildcard_texts",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -29161,7 +29540,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:expand_wildcards",
         "kind": "static_from",
-        "line": 551,
+        "line": 548,
         "name": "expand_wildcards",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -29192,7 +29571,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:has_wildcard_syntax",
         "kind": "static_from",
-        "line": 551,
+        "line": 548,
         "name": "has_wildcard_syntax",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -29223,7 +29602,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:next_seed",
         "kind": "static_from",
-        "line": 551,
+        "line": 548,
         "name": "next_seed",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -29254,7 +29633,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:normalize_prompt_studio_wildcard_mode",
         "kind": "static_from",
-        "line": 551,
+        "line": 548,
         "name": "normalize_prompt_studio_wildcard_mode",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -29285,7 +29664,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:normalize_seed",
         "kind": "static_from",
-        "line": 551,
+        "line": 548,
         "name": "normalize_seed",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -29316,7 +29695,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:normalize_wildcard_mode",
         "kind": "static_from",
-        "line": 551,
+        "line": 548,
         "name": "normalize_wildcard_mode",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -29347,7 +29726,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:wildcard_sources_signature",
         "kind": "static_from",
-        "line": 551,
+        "line": 548,
         "name": "wildcard_sources_signature",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -29366,7 +29745,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -29381,7 +29760,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:AIO_FIRST_PASS_CACHE_MAX_ENTRIES",
         "kind": "static_from",
-        "line": 573,
+        "line": 570,
         "name": "AIO_FIRST_PASS_CACHE_MAX_ENTRIES",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -29400,7 +29779,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -29415,7 +29794,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_AIO_FIRST_PASS_CACHE",
         "kind": "static_from",
-        "line": 573,
+        "line": 570,
         "name": "_AIO_FIRST_PASS_CACHE",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -29434,7 +29813,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -29449,7 +29828,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_AIO_FIRST_PASS_CACHE_ORDER",
         "kind": "static_from",
-        "line": 573,
+        "line": 570,
         "name": "_AIO_FIRST_PASS_CACHE_ORDER",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -29468,7 +29847,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -29483,7 +29862,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_aio_first_pass_cache_key",
         "kind": "static_from",
-        "line": 573,
+        "line": 570,
         "name": "_aio_first_pass_cache_key",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -29502,7 +29881,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -29517,7 +29896,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_clone_aio_cache_value",
         "kind": "static_from",
-        "line": 573,
+        "line": 570,
         "name": "_clone_aio_cache_value",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -29536,7 +29915,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -29551,7 +29930,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_get_aio_first_pass_cache",
         "kind": "static_from",
-        "line": 573,
+        "line": 570,
         "name": "_get_aio_first_pass_cache",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -29570,7 +29949,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -29585,7 +29964,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_put_aio_first_pass_cache",
         "kind": "static_from",
-        "line": 573,
+        "line": 570,
         "name": "_put_aio_first_pass_cache",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -29604,7 +29983,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -29619,7 +29998,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_bind_aio_legacy_generation_runtime",
         "kind": "static_from",
-        "line": 583,
+        "line": 580,
         "name": "_bind_aio_legacy_generation_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.legacy_generation",
@@ -29638,7 +30017,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -29653,7 +30032,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_detailer_stage",
         "kind": "static_from",
-        "line": 583,
+        "line": 580,
         "name": "_run_aio_detailer_stage",
         "optional": false,
         "requested": "easyuse_anima.aio.legacy_generation",
@@ -29672,7 +30051,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -29687,7 +30066,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_detailer_target",
         "kind": "static_from",
-        "line": 583,
+        "line": 580,
         "name": "_run_aio_detailer_target",
         "optional": false,
         "requested": "easyuse_anima.aio.legacy_generation",
@@ -29706,7 +30085,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -29721,7 +30100,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_highres_stage",
         "kind": "static_from",
-        "line": 583,
+        "line": 580,
         "name": "_run_aio_highres_stage",
         "optional": false,
         "requested": "easyuse_anima.aio.legacy_generation",
@@ -29740,7 +30119,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -29755,7 +30134,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_legacy_generation",
         "kind": "static_from",
-        "line": 583,
+        "line": 580,
         "name": "_run_aio_legacy_generation",
         "optional": false,
         "requested": "easyuse_anima.aio.legacy_generation",
@@ -29774,7 +30153,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -29789,7 +30168,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_resshift_upscale_stage",
         "kind": "static_from",
-        "line": 583,
+        "line": 580,
         "name": "_run_aio_resshift_upscale_stage",
         "optional": false,
         "requested": "easyuse_anima.aio.legacy_generation",
@@ -29808,7 +30187,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -29823,7 +30202,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_upscale_stage",
         "kind": "static_from",
-        "line": 583,
+        "line": 580,
         "name": "_run_aio_upscale_stage",
         "optional": false,
         "requested": "easyuse_anima.aio.legacy_generation",
@@ -29842,7 +30221,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -29857,7 +30236,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_usdu_upscale_stage",
         "kind": "static_from",
-        "line": 583,
+        "line": 580,
         "name": "_run_aio_usdu_upscale_stage",
         "optional": false,
         "requested": "easyuse_anima.aio.legacy_generation",
@@ -29876,7 +30255,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -29891,7 +30270,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_AIO_DETAILER_CUSTOM_RE",
         "kind": "static_from",
-        "line": 593,
+        "line": 590,
         "name": "_AIO_DETAILER_CUSTOM_RE",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -29910,7 +30289,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -29925,7 +30304,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_AIO_DETAILER_RESERVED_KEYS",
         "kind": "static_from",
-        "line": 593,
+        "line": 590,
         "name": "_AIO_DETAILER_RESERVED_KEYS",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -29944,7 +30323,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -29959,7 +30338,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_aio_detailer_has_enabled_targets",
         "kind": "static_from",
-        "line": 593,
+        "line": 590,
         "name": "_aio_detailer_has_enabled_targets",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -29978,7 +30357,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -29993,7 +30372,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_aio_detailer_target_defaults",
         "kind": "static_from",
-        "line": 593,
+        "line": 590,
         "name": "_aio_detailer_target_defaults",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -30012,7 +30391,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -30027,7 +30406,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_aio_detailer_target_order",
         "kind": "static_from",
-        "line": 593,
+        "line": 590,
         "name": "_aio_detailer_target_order",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -30046,7 +30425,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -30061,7 +30440,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_is_aio_detailer_target_name",
         "kind": "static_from",
-        "line": 593,
+        "line": 590,
         "name": "_is_aio_detailer_target_name",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -30080,7 +30459,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -30095,7 +30474,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_merge_versioned_settings",
         "kind": "static_from",
-        "line": 593,
+        "line": 590,
         "name": "_merge_versioned_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -30114,7 +30493,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -30129,7 +30508,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_dit_corrections_settings",
         "kind": "static_from",
-        "line": 593,
+        "line": 590,
         "name": "_normalize_aio_dit_corrections_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -30148,7 +30527,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -30163,7 +30542,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_generation_settings",
         "kind": "static_from",
-        "line": 593,
+        "line": 590,
         "name": "_normalize_aio_generation_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -30182,7 +30561,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -30197,7 +30576,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_seed",
         "kind": "static_from",
-        "line": 593,
+        "line": 590,
         "name": "_normalize_aio_seed",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -30216,7 +30595,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -30231,7 +30610,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_spectrum_settings",
         "kind": "static_from",
-        "line": 593,
+        "line": 590,
         "name": "_normalize_aio_spectrum_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -30250,7 +30629,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -30265,7 +30644,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_FINAL_FIT_MODES",
         "kind": "static_from",
-        "line": 606,
+        "line": 603,
         "name": "AIO_FINAL_FIT_MODES",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_defaults",
@@ -30284,7 +30663,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -30299,7 +30678,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_FINAL_UPSCALE_BACKENDS",
         "kind": "static_from",
-        "line": 606,
+        "line": 603,
         "name": "AIO_FINAL_UPSCALE_BACKENDS",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_defaults",
@@ -30318,7 +30697,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -30333,7 +30712,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_GENERATION_DEFAULT_SETTINGS",
         "kind": "static_from",
-        "line": 606,
+        "line": 603,
         "name": "AIO_GENERATION_DEFAULT_SETTINGS",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_defaults",
@@ -30352,7 +30731,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -30367,7 +30746,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_GENERATION_SETTINGS_SCHEMA",
         "kind": "static_from",
-        "line": 606,
+        "line": 603,
         "name": "AIO_GENERATION_SETTINGS_SCHEMA",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_defaults",
@@ -30386,7 +30765,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -30401,7 +30780,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_GENERATION_SETTINGS_VERSION",
         "kind": "static_from",
-        "line": 606,
+        "line": 603,
         "name": "AIO_GENERATION_SETTINGS_VERSION",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_defaults",
@@ -30420,7 +30799,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -30435,7 +30814,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_RESHIFT_DTYPES",
         "kind": "static_from",
-        "line": 606,
+        "line": 603,
         "name": "AIO_RESHIFT_DTYPES",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_defaults",
@@ -30454,7 +30833,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -30469,7 +30848,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_RESHIFT_SCALES",
         "kind": "static_from",
-        "line": 606,
+        "line": 603,
         "name": "AIO_RESHIFT_SCALES",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_defaults",
@@ -30488,7 +30867,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -30503,7 +30882,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_SPECIAL_SEEDS",
         "kind": "static_from",
-        "line": 606,
+        "line": 603,
         "name": "AIO_SPECIAL_SEEDS",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_defaults",
@@ -30522,7 +30901,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -30537,7 +30916,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_SPECIAL_SEED_DECREMENT",
         "kind": "static_from",
-        "line": 606,
+        "line": 603,
         "name": "AIO_SPECIAL_SEED_DECREMENT",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_defaults",
@@ -30556,7 +30935,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -30571,7 +30950,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_SPECIAL_SEED_INCREMENT",
         "kind": "static_from",
-        "line": 606,
+        "line": 603,
         "name": "AIO_SPECIAL_SEED_INCREMENT",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_defaults",
@@ -30590,7 +30969,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -30605,7 +30984,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_SPECIAL_SEED_RANDOM",
         "kind": "static_from",
-        "line": 606,
+        "line": 603,
         "name": "AIO_SPECIAL_SEED_RANDOM",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_defaults",
@@ -30624,7 +31003,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -30639,7 +31018,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_USDU_MODE_TYPES",
         "kind": "static_from",
-        "line": 606,
+        "line": 603,
         "name": "AIO_USDU_MODE_TYPES",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_defaults",
@@ -30658,7 +31037,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -30673,7 +31052,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_USDU_PROMPT_FULL",
         "kind": "static_from",
-        "line": 606,
+        "line": 603,
         "name": "AIO_USDU_PROMPT_FULL",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_defaults",
@@ -30692,7 +31071,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -30707,7 +31086,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_USDU_PROMPT_MODES",
         "kind": "static_from",
-        "line": 606,
+        "line": 603,
         "name": "AIO_USDU_PROMPT_MODES",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_defaults",
@@ -30726,7 +31105,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -30741,7 +31120,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_USDU_PROMPT_NO_GENERAL",
         "kind": "static_from",
-        "line": 606,
+        "line": 603,
         "name": "AIO_USDU_PROMPT_NO_GENERAL",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_defaults",
@@ -30760,7 +31139,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -30775,7 +31154,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_USDU_SEAM_FIX_MODES",
         "kind": "static_from",
-        "line": 606,
+        "line": 603,
         "name": "AIO_USDU_SEAM_FIX_MODES",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_defaults",
@@ -30794,7 +31173,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -30809,7 +31188,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_settings:round_trip_aio_generation_settings",
         "kind": "static_from",
-        "line": 624,
+        "line": 621,
         "name": "round_trip_aio_generation_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_settings",
@@ -30828,7 +31207,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -30843,7 +31222,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.input_defaults:AIO_INPUT_DEFAULT_SETTINGS",
         "kind": "static_from",
-        "line": 627,
+        "line": 624,
         "name": "AIO_INPUT_DEFAULT_SETTINGS",
         "optional": false,
         "requested": "easyuse_anima.aio.input_defaults",
@@ -30862,7 +31241,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -30877,7 +31256,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.input_defaults:ANIMA_CLIP_DEVICES",
         "kind": "static_from",
-        "line": 627,
+        "line": 624,
         "name": "ANIMA_CLIP_DEVICES",
         "optional": false,
         "requested": "easyuse_anima.aio.input_defaults",
@@ -30896,7 +31275,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -30911,7 +31290,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.input_defaults:ANIMA_CLIP_TYPES",
         "kind": "static_from",
-        "line": 627,
+        "line": 624,
         "name": "ANIMA_CLIP_TYPES",
         "optional": false,
         "requested": "easyuse_anima.aio.input_defaults",
@@ -30930,7 +31309,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -30945,7 +31324,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.input_defaults:ANIMA_DEFAULT_CLIP_CANDIDATES",
         "kind": "static_from",
-        "line": 627,
+        "line": 624,
         "name": "ANIMA_DEFAULT_CLIP_CANDIDATES",
         "optional": false,
         "requested": "easyuse_anima.aio.input_defaults",
@@ -30964,7 +31343,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -30979,7 +31358,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.input_defaults:ANIMA_DEFAULT_DIFFUSION_MODEL_CANDIDATES",
         "kind": "static_from",
-        "line": 627,
+        "line": 624,
         "name": "ANIMA_DEFAULT_DIFFUSION_MODEL_CANDIDATES",
         "optional": false,
         "requested": "easyuse_anima.aio.input_defaults",
@@ -30998,7 +31377,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -31013,7 +31392,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.input_defaults:ANIMA_DEFAULT_VAE_CANDIDATES",
         "kind": "static_from",
-        "line": 627,
+        "line": 624,
         "name": "ANIMA_DEFAULT_VAE_CANDIDATES",
         "optional": false,
         "requested": "easyuse_anima.aio.input_defaults",
@@ -31032,7 +31411,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -31047,7 +31426,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.input_defaults:ANIMA_UNET_WEIGHT_DTYPES",
         "kind": "static_from",
-        "line": 627,
+        "line": 624,
         "name": "ANIMA_UNET_WEIGHT_DTYPES",
         "optional": false,
         "requested": "easyuse_anima.aio.input_defaults",
@@ -31066,7 +31445,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -31081,7 +31460,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.input_defaults:EASY_USE_ANIMA_INPUT_SCHEMA",
         "kind": "static_from",
-        "line": 627,
+        "line": 624,
         "name": "EASY_USE_ANIMA_INPUT_SCHEMA",
         "optional": false,
         "requested": "easyuse_anima.aio.input_defaults",
@@ -31100,7 +31479,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -31115,7 +31494,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.input_defaults:EASY_USE_ANIMA_INPUT_SETTINGS_VERSION",
         "kind": "static_from",
-        "line": 627,
+        "line": 624,
         "name": "EASY_USE_ANIMA_INPUT_SETTINGS_VERSION",
         "optional": false,
         "requested": "easyuse_anima.aio.input_defaults",
@@ -31134,7 +31513,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -31149,7 +31528,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.usdu:_aio_usdu_auto_tile_dimension",
         "kind": "static_from",
-        "line": 638,
+        "line": 635,
         "name": "_aio_usdu_auto_tile_dimension",
         "optional": false,
         "requested": "easyuse_anima.aio.usdu",
@@ -31168,7 +31547,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -31183,7 +31562,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.usdu:_aio_usdu_tile_plan",
         "kind": "static_from",
-        "line": 638,
+        "line": 635,
         "name": "_aio_usdu_tile_plan",
         "optional": false,
         "requested": "easyuse_anima.aio.usdu",
@@ -31202,7 +31581,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -31217,7 +31596,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_aio_final_fit_size",
         "kind": "static_from",
-        "line": 642,
+        "line": 639,
         "name": "_aio_final_fit_size",
         "optional": false,
         "requested": "easyuse_anima.aio.postprocess",
@@ -31236,7 +31615,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -31251,7 +31630,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_apply_aio_final_fit",
         "kind": "static_from",
-        "line": 642,
+        "line": 639,
         "name": "_apply_aio_final_fit",
         "optional": false,
         "requested": "easyuse_anima.aio.postprocess",
@@ -31270,7 +31649,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -31285,7 +31664,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_resize_image_to_size_if_needed",
         "kind": "static_from",
-        "line": 642,
+        "line": 639,
         "name": "_resize_image_to_size_if_needed",
         "optional": false,
         "requested": "easyuse_anima.aio.postprocess",
@@ -31304,7 +31683,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -31319,7 +31698,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_run_aio_postprocess_stage",
         "kind": "static_from",
-        "line": 642,
+        "line": 639,
         "name": "_run_aio_postprocess_stage",
         "optional": false,
         "requested": "easyuse_anima.aio.postprocess",
@@ -31338,7 +31717,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -31353,7 +31732,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_prompt_data_fields_for_usdu",
         "kind": "static_from",
-        "line": 648,
+        "line": 645,
         "name": "_aio_prompt_data_fields_for_usdu",
         "optional": false,
         "requested": "easyuse_anima.aio.conditioning",
@@ -31372,7 +31751,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -31387,7 +31766,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_usdu_conditioning",
         "kind": "static_from",
-        "line": 648,
+        "line": 645,
         "name": "_aio_usdu_conditioning",
         "optional": false,
         "requested": "easyuse_anima.aio.conditioning",
@@ -31406,7 +31785,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -31421,42 +31800,8 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_usdu_prompt_without_general",
         "kind": "static_from",
-        "line": 648,
+        "line": 645,
         "name": "_aio_usdu_prompt_without_general",
-        "optional": false,
-        "requested": "easyuse_anima.aio.conditioning",
-        "role": "compatibility_fallback",
-        "scope": "<module>",
-        "source": "nodes.py",
-        "target": "easyuse_anima/aio/conditioning.py"
-      },
-      {
-        "alias": "_bind_aio_conditioning_runtime",
-        "bound_name": "_bind_aio_conditioning_runtime",
-        "branch_context": [
-          {
-            "branch": "except",
-            "catches_import_error": true,
-            "exceptions": [
-              "ImportError"
-            ],
-            "handler_line": 572,
-            "kind": "try",
-            "line": 8
-          }
-        ],
-        "classification": "compatibility_fallback",
-        "column": 4,
-        "compatibility_pair": {
-          "bound_name": "_bind_aio_conditioning_runtime",
-          "target": "easyuse_anima/aio/conditioning.py",
-          "try_line": 8
-        },
-        "conditional": true,
-        "imported": "easyuse_anima.aio.conditioning:_bind_aio_conditioning_runtime",
-        "kind": "static_from",
-        "line": 648,
-        "name": "_bind_aio_conditioning_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.conditioning",
         "role": "compatibility_fallback",
@@ -31474,7 +31819,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -31489,7 +31834,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_aio_lora_stack_signature",
         "kind": "static_from",
-        "line": 654,
+        "line": 650,
         "name": "_aio_lora_stack_signature",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -31508,7 +31853,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -31523,7 +31868,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_anima_dave_patch",
         "kind": "static_from",
-        "line": 654,
+        "line": 650,
         "name": "_apply_aio_anima_dave_patch",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -31542,7 +31887,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -31557,7 +31902,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_kj_model_patches",
         "kind": "static_from",
-        "line": 654,
+        "line": 650,
         "name": "_apply_aio_kj_model_patches",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -31576,7 +31921,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -31591,7 +31936,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_lora_stack",
         "kind": "static_from",
-        "line": 654,
+        "line": 650,
         "name": "_apply_aio_lora_stack",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -31610,7 +31955,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -31625,7 +31970,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_model_patches",
         "kind": "static_from",
-        "line": 654,
+        "line": 650,
         "name": "_apply_aio_model_patches",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -31644,7 +31989,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -31659,7 +32004,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_safe_pag_patch",
         "kind": "static_from",
-        "line": 654,
+        "line": 650,
         "name": "_apply_aio_safe_pag_patch",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -31678,7 +32023,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -31693,7 +32038,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_correction_patch_for_comfy_sampler",
         "kind": "static_from",
-        "line": 654,
+        "line": 650,
         "name": "_apply_aio_spectrum_correction_patch_for_comfy_sampler",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -31712,7 +32057,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -31727,7 +32072,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_forecast_patch_for_comfy_sampler",
         "kind": "static_from",
-        "line": 654,
+        "line": 650,
         "name": "_apply_aio_spectrum_forecast_patch_for_comfy_sampler",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -31746,7 +32091,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -31761,42 +32106,8 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_model_patches_for_comfy_sampler",
         "kind": "static_from",
-        "line": 654,
+        "line": 650,
         "name": "_apply_aio_spectrum_model_patches_for_comfy_sampler",
-        "optional": false,
-        "requested": "easyuse_anima.aio.model_preparation",
-        "role": "compatibility_fallback",
-        "scope": "<module>",
-        "source": "nodes.py",
-        "target": "easyuse_anima/aio/model_preparation.py"
-      },
-      {
-        "alias": "_bind_aio_model_preparation_runtime",
-        "bound_name": "_bind_aio_model_preparation_runtime",
-        "branch_context": [
-          {
-            "branch": "except",
-            "catches_import_error": true,
-            "exceptions": [
-              "ImportError"
-            ],
-            "handler_line": 572,
-            "kind": "try",
-            "line": 8
-          }
-        ],
-        "classification": "compatibility_fallback",
-        "column": 4,
-        "compatibility_pair": {
-          "bound_name": "_bind_aio_model_preparation_runtime",
-          "target": "easyuse_anima/aio/model_preparation.py",
-          "try_line": 8
-        },
-        "conditional": true,
-        "imported": "easyuse_anima.aio.model_preparation:_bind_aio_model_preparation_runtime",
-        "kind": "static_from",
-        "line": 654,
-        "name": "_bind_aio_model_preparation_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
         "role": "compatibility_fallback",
@@ -31814,7 +32125,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -31829,7 +32140,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_cleanup_aio_ephemeral_model",
         "kind": "static_from",
-        "line": 654,
+        "line": 650,
         "name": "_cleanup_aio_ephemeral_model",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -31848,7 +32159,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -31863,7 +32174,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_normalize_aio_lora_stack",
         "kind": "static_from",
-        "line": 654,
+        "line": 650,
         "name": "_normalize_aio_lora_stack",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -31882,7 +32193,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -31897,7 +32208,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_patch_model_sampling_aura_flow",
         "kind": "static_from",
-        "line": 654,
+        "line": 650,
         "name": "_patch_model_sampling_aura_flow",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -31916,7 +32227,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -31931,7 +32242,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_aio_highres_effective_backend",
         "kind": "static_from",
-        "line": 669,
+        "line": 664,
         "name": "_aio_highres_effective_backend",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -31950,7 +32261,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -31965,42 +32276,8 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_aio_stage_sampler_settings",
         "kind": "static_from",
-        "line": 669,
+        "line": 664,
         "name": "_aio_stage_sampler_settings",
-        "optional": false,
-        "requested": "easyuse_anima.aio.sampling",
-        "role": "compatibility_fallback",
-        "scope": "<module>",
-        "source": "nodes.py",
-        "target": "easyuse_anima/aio/sampling.py"
-      },
-      {
-        "alias": "_bind_aio_sampling_runtime",
-        "bound_name": "_bind_aio_sampling_runtime",
-        "branch_context": [
-          {
-            "branch": "except",
-            "catches_import_error": true,
-            "exceptions": [
-              "ImportError"
-            ],
-            "handler_line": 572,
-            "kind": "try",
-            "line": 8
-          }
-        ],
-        "classification": "compatibility_fallback",
-        "column": 4,
-        "compatibility_pair": {
-          "bound_name": "_bind_aio_sampling_runtime",
-          "target": "easyuse_anima/aio/sampling.py",
-          "try_line": 8
-        },
-        "conditional": true,
-        "imported": "easyuse_anima.aio.sampling:_bind_aio_sampling_runtime",
-        "kind": "static_from",
-        "line": 669,
-        "name": "_bind_aio_sampling_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
         "role": "compatibility_fallback",
@@ -32018,7 +32295,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -32033,7 +32310,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_decode_latent_with_comfy",
         "kind": "static_from",
-        "line": 669,
+        "line": 664,
         "name": "_decode_latent_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -32052,7 +32329,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -32067,7 +32344,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_encode_image_with_comfy_vae",
         "kind": "static_from",
-        "line": 669,
+        "line": 664,
         "name": "_encode_image_with_comfy_vae",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -32086,7 +32363,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -32101,7 +32378,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_generate_empty_latent_with_comfy",
         "kind": "static_from",
-        "line": 669,
+        "line": 664,
         "name": "_generate_empty_latent_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -32120,7 +32397,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -32135,7 +32412,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_new_aio_random_seed",
         "kind": "static_from",
-        "line": 669,
+        "line": 664,
         "name": "_new_aio_random_seed",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -32154,7 +32431,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -32169,7 +32446,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_resolve_aio_runtime_seed",
         "kind": "static_from",
-        "line": 669,
+        "line": 664,
         "name": "_resolve_aio_runtime_seed",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -32188,7 +32465,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -32203,7 +32480,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_aio_backend",
         "kind": "static_from",
-        "line": 669,
+        "line": 664,
         "name": "_sample_latent_with_aio_backend",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -32222,7 +32499,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -32237,7 +32514,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_comfy",
         "kind": "static_from",
-        "line": 669,
+        "line": 664,
         "name": "_sample_latent_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -32256,7 +32533,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -32271,7 +32548,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_spectrum_mod_guidance_advanced",
         "kind": "static_from",
-        "line": 669,
+        "line": 664,
         "name": "_sample_latent_with_spectrum_mod_guidance_advanced",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -32290,7 +32567,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -32305,7 +32582,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_spectrum_spd",
         "kind": "static_from",
-        "line": 669,
+        "line": 664,
         "name": "_sample_latent_with_spectrum_spd",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -32324,7 +32601,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -32339,7 +32616,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_CACHE_FORMAT",
         "kind": "static_from",
-        "line": 683,
+        "line": 677,
         "name": "AIO_PREVIEW_CACHE_FORMAT",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -32358,7 +32635,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -32373,7 +32650,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_CACHE_QUALITY",
         "kind": "static_from",
-        "line": 683,
+        "line": 677,
         "name": "AIO_PREVIEW_CACHE_QUALITY",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -32392,7 +32669,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -32407,7 +32684,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_EVENT",
         "kind": "static_from",
-        "line": 683,
+        "line": 677,
         "name": "AIO_PREVIEW_EVENT",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -32426,7 +32703,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -32441,7 +32718,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_STAGE_LABELS",
         "kind": "static_from",
-        "line": 683,
+        "line": 677,
         "name": "AIO_PREVIEW_STAGE_LABELS",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -32460,7 +32737,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -32475,7 +32752,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_aio_preview_base_directory",
         "kind": "static_from",
-        "line": 683,
+        "line": 677,
         "name": "_aio_preview_base_directory",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -32494,7 +32771,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -32509,7 +32786,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_aio_preview_file_size_bytes",
         "kind": "static_from",
-        "line": 683,
+        "line": 677,
         "name": "_aio_preview_file_size_bytes",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -32528,7 +32805,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -32543,7 +32820,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_save_aio_temp_preview_image",
         "kind": "static_from",
-        "line": 683,
+        "line": 677,
         "name": "_save_aio_temp_preview_image",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -32562,7 +32839,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -32577,7 +32854,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_send_aio_preview_event",
         "kind": "static_from",
-        "line": 683,
+        "line": 677,
         "name": "_send_aio_preview_event",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -32596,7 +32873,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -32611,7 +32888,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_tag_aio_preview_images",
         "kind": "static_from",
-        "line": 683,
+        "line": 677,
         "name": "_tag_aio_preview_images",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -32630,7 +32907,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -32645,7 +32922,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_image_saver_additional_hashes",
         "kind": "static_from",
-        "line": 694,
+        "line": 688,
         "name": "_aio_image_saver_additional_hashes",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -32664,7 +32941,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -32679,7 +32956,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_image_saver_civitai_hash_fetcher_entries",
         "kind": "static_from",
-        "line": 694,
+        "line": 688,
         "name": "_aio_image_saver_civitai_hash_fetcher_entries",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -32698,7 +32975,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -32713,7 +32990,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_lora_metadata_name",
         "kind": "static_from",
-        "line": 694,
+        "line": 688,
         "name": "_aio_lora_metadata_name",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -32732,7 +33009,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -32747,7 +33024,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_prompt_with_lora_metadata",
         "kind": "static_from",
-        "line": 694,
+        "line": 688,
         "name": "_aio_prompt_with_lora_metadata",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -32766,7 +33043,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -32781,7 +33058,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_save_filename_prefix",
         "kind": "static_from",
-        "line": 694,
+        "line": 688,
         "name": "_aio_save_filename_prefix",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -32800,7 +33077,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -32815,7 +33092,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_save_image_with_comfy",
         "kind": "static_from",
-        "line": 694,
+        "line": 688,
         "name": "_save_image_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -32834,7 +33111,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -32849,7 +33126,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_save_image_with_image_saver",
         "kind": "static_from",
-        "line": 694,
+        "line": 688,
         "name": "_save_image_with_image_saver",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -32868,7 +33145,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -32883,7 +33160,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output_settings:_normalize_aio_civitai_hash_fetchers",
         "kind": "static_from",
-        "line": 703,
+        "line": 697,
         "name": "_normalize_aio_civitai_hash_fetchers",
         "optional": false,
         "requested": "easyuse_anima.aio.output_settings",
@@ -32902,7 +33179,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -32917,7 +33194,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output_settings:_normalize_aio_hash_bundles",
         "kind": "static_from",
-        "line": 703,
+        "line": 697,
         "name": "_normalize_aio_hash_bundles",
         "optional": false,
         "requested": "easyuse_anima.aio.output_settings",
@@ -32936,7 +33213,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -32951,7 +33228,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_clip_loader_types",
         "kind": "static_from",
-        "line": 707,
+        "line": 701,
         "name": "_comfy_clip_loader_types",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -32970,7 +33247,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -32985,7 +33262,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_diffusion_model_names",
         "kind": "static_from",
-        "line": 707,
+        "line": 701,
         "name": "_comfy_diffusion_model_names",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -33004,7 +33281,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -33019,7 +33296,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_text_encoder_names",
         "kind": "static_from",
-        "line": 707,
+        "line": 701,
         "name": "_comfy_text_encoder_names",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -33038,7 +33315,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -33053,7 +33330,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_vae_names",
         "kind": "static_from",
-        "line": 707,
+        "line": 701,
         "name": "_comfy_vae_names",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -33072,7 +33349,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -33087,7 +33364,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_aio_resources_from_input_context",
         "kind": "static_from",
-        "line": 707,
+        "line": 701,
         "name": "_load_aio_resources_from_input_context",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -33106,7 +33383,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -33121,7 +33398,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_aio_sam3_context",
         "kind": "static_from",
-        "line": 707,
+        "line": 701,
         "name": "_load_aio_sam3_context",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -33140,7 +33417,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -33155,7 +33432,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_checkpoint_with_comfy",
         "kind": "static_from",
-        "line": 707,
+        "line": 701,
         "name": "_load_checkpoint_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -33174,7 +33451,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -33189,7 +33466,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_clip_with_comfy",
         "kind": "static_from",
-        "line": 707,
+        "line": 701,
         "name": "_load_clip_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -33208,7 +33485,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -33223,7 +33500,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_diffusion_model_with_comfy",
         "kind": "static_from",
-        "line": 707,
+        "line": 701,
         "name": "_load_diffusion_model_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -33242,7 +33519,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -33257,7 +33534,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_upscale_model_with_comfy",
         "kind": "static_from",
-        "line": 707,
+        "line": 701,
         "name": "_load_upscale_model_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -33276,7 +33553,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -33291,7 +33568,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_vae_with_comfy",
         "kind": "static_from",
-        "line": 707,
+        "line": 701,
         "name": "_load_vae_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -33310,7 +33587,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -33325,7 +33602,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_normalize_aio_input_settings",
         "kind": "static_from",
-        "line": 707,
+        "line": 701,
         "name": "_normalize_aio_input_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -33344,7 +33621,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -33359,7 +33636,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_checkpoint_default",
         "kind": "static_from",
-        "line": 707,
+        "line": 701,
         "name": "_preferred_checkpoint_default",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -33378,7 +33655,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -33393,7 +33670,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_clip_type_default",
         "kind": "static_from",
-        "line": 707,
+        "line": 701,
         "name": "_preferred_clip_type_default",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -33412,7 +33689,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -33427,7 +33704,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_name_default",
         "kind": "static_from",
-        "line": 707,
+        "line": 701,
         "name": "_preferred_name_default",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -33446,7 +33723,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -33461,7 +33738,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_json_clone",
         "kind": "static_from",
-        "line": 724,
+        "line": 718,
         "name": "_json_clone",
         "optional": false,
         "requested": "easyuse_anima.common.serialization",
@@ -33480,7 +33757,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -33495,7 +33772,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_json_object",
         "kind": "static_from",
-        "line": 724,
+        "line": 718,
         "name": "_json_object",
         "optional": false,
         "requested": "easyuse_anima.common.serialization",
@@ -33514,7 +33791,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -33529,7 +33806,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_stable_change_key",
         "kind": "static_from",
-        "line": 724,
+        "line": 718,
         "name": "_stable_change_key",
         "optional": false,
         "requested": "easyuse_anima.common.serialization",
@@ -33548,7 +33825,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -33563,7 +33840,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_bool",
         "kind": "static_from",
-        "line": 729,
+        "line": 723,
         "name": "_as_bool",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -33582,7 +33859,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -33597,7 +33874,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_float",
         "kind": "static_from",
-        "line": 729,
+        "line": 723,
         "name": "_as_float",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -33616,7 +33893,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -33631,7 +33908,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_int",
         "kind": "static_from",
-        "line": 729,
+        "line": 723,
         "name": "_as_int",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -33650,7 +33927,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -33665,7 +33942,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_choice",
         "kind": "static_from",
-        "line": 729,
+        "line": 723,
         "name": "_choice",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -33684,7 +33961,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -33699,7 +33976,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_single_value",
         "kind": "static_from",
-        "line": 729,
+        "line": 723,
         "name": "_single_value",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -33718,7 +33995,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -33733,7 +34010,7 @@
         "conditional": true,
         "imported": "easyuse_anima.seed.compatibility:WILDCARD_QUEUE_MAX_SAFE_SEED",
         "kind": "static_from",
-        "line": 736,
+        "line": 730,
         "name": "WILDCARD_QUEUE_MAX_SAFE_SEED",
         "optional": false,
         "requested": "easyuse_anima.seed.compatibility",
@@ -33752,7 +34029,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -33767,7 +34044,7 @@
         "conditional": true,
         "imported": "easyuse_anima.seed.compatibility:WILDCARD_RESERVED_NEXT_SEED_INPUT",
         "kind": "static_from",
-        "line": 736,
+        "line": 730,
         "name": "WILDCARD_RESERVED_NEXT_SEED_INPUT",
         "optional": false,
         "requested": "easyuse_anima.seed.compatibility",
@@ -33786,7 +34063,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -33801,7 +34078,7 @@
         "conditional": true,
         "imported": "easyuse_anima.seed.compatibility:_consume_reserved_wildcard_next_seed",
         "kind": "static_from",
-        "line": 736,
+        "line": 730,
         "name": "_consume_reserved_wildcard_next_seed",
         "optional": false,
         "requested": "easyuse_anima.seed.compatibility",
@@ -33820,7 +34097,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -33835,7 +34112,7 @@
         "conditional": true,
         "imported": "easyuse_anima.workflow:_get_workflow_node",
         "kind": "static_from",
-        "line": 741,
+        "line": 735,
         "name": "_get_workflow_node",
         "optional": false,
         "requested": "easyuse_anima.workflow",
@@ -33854,7 +34131,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -33869,7 +34146,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_prompt_translation_change_key",
         "kind": "static_from",
-        "line": 742,
+        "line": 736,
         "name": "_prompt_translation_change_key",
         "optional": false,
         "requested": "easyuse_anima.prompt.correction",
@@ -33888,7 +34165,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -33903,7 +34180,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_split_tag_text",
         "kind": "static_from",
-        "line": 742,
+        "line": 736,
         "name": "_split_tag_text",
         "optional": false,
         "requested": "easyuse_anima.prompt.correction",
@@ -33922,7 +34199,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -33937,7 +34214,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_translate_prompt_text",
         "kind": "static_from",
-        "line": 742,
+        "line": 736,
         "name": "_translate_prompt_text",
         "optional": false,
         "requested": "easyuse_anima.prompt.correction",
@@ -33956,7 +34233,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -33971,7 +34248,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_HASH_COMMENT_RE",
         "kind": "static_from",
-        "line": 747,
+        "line": 741,
         "name": "_HASH_COMMENT_RE",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -33990,7 +34267,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -34005,7 +34282,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_INLINE_SPACE_RE",
         "kind": "static_from",
-        "line": 747,
+        "line": 741,
         "name": "_INLINE_SPACE_RE",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -34024,7 +34301,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -34039,7 +34316,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_WEIGHTED_TOKEN_RE",
         "kind": "static_from",
-        "line": 747,
+        "line": 741,
         "name": "_WEIGHTED_TOKEN_RE",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -34058,7 +34335,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -34073,7 +34350,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_correct_builder_prompt",
         "kind": "static_from",
-        "line": 747,
+        "line": 741,
         "name": "_correct_builder_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -34092,7 +34369,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -34107,7 +34384,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_filter_metadata_prompt",
         "kind": "static_from",
-        "line": 747,
+        "line": 741,
         "name": "_filter_metadata_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -34126,7 +34403,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -34141,7 +34418,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_join_prompt_tokens",
         "kind": "static_from",
-        "line": 747,
+        "line": 741,
         "name": "_join_prompt_tokens",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -34160,7 +34437,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -34175,7 +34452,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_metadata_filter_key",
         "kind": "static_from",
-        "line": 747,
+        "line": 741,
         "name": "_metadata_filter_key",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -34194,7 +34471,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -34209,7 +34486,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_metadata_filter_keys",
         "kind": "static_from",
-        "line": 747,
+        "line": 741,
         "name": "_metadata_filter_keys",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -34228,7 +34505,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -34243,7 +34520,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_prompt_tokens",
         "kind": "static_from",
-        "line": 747,
+        "line": 741,
         "name": "_prompt_tokens",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -34262,7 +34539,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -34277,7 +34554,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:PROMPT_DATA_TYPE",
         "kind": "static_from",
-        "line": 760,
+        "line": 754,
         "name": "PROMPT_DATA_TYPE",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -34296,7 +34573,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -34311,7 +34588,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_advanced_outputs_from_prompt_data",
         "kind": "static_from",
-        "line": 760,
+        "line": 754,
         "name": "_advanced_outputs_from_prompt_data",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -34330,7 +34607,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -34345,7 +34622,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_apply_prompt_data_overrides",
         "kind": "static_from",
-        "line": 760,
+        "line": 754,
         "name": "_apply_prompt_data_overrides",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -34364,7 +34641,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -34379,7 +34656,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_copy_prompt_data_for_update",
         "kind": "static_from",
-        "line": 760,
+        "line": 754,
         "name": "_copy_prompt_data_for_update",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -34398,7 +34675,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -34413,7 +34690,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_normalize_prompt_data",
         "kind": "static_from",
-        "line": 760,
+        "line": 754,
         "name": "_normalize_prompt_data",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -34432,7 +34709,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -34447,7 +34724,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_prompt_data_json_safe",
         "kind": "static_from",
-        "line": 760,
+        "line": 754,
         "name": "_prompt_data_json_safe",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -34466,7 +34743,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -34481,7 +34758,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_prompt_data_parameter_snapshot",
         "kind": "static_from",
-        "line": 760,
+        "line": 754,
         "name": "_prompt_data_parameter_snapshot",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -34500,7 +34777,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -34515,7 +34792,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_artist_field_prompt",
         "kind": "static_from",
-        "line": 778,
+        "line": 772,
         "name": "_advanced_artist_field_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -34534,7 +34811,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -34549,7 +34826,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_default_fields",
         "kind": "static_from",
-        "line": 778,
+        "line": 772,
         "name": "_advanced_default_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -34568,7 +34845,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -34583,7 +34860,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_enabled_naia_panes",
         "kind": "static_from",
-        "line": 778,
+        "line": 772,
         "name": "_advanced_enabled_naia_panes",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -34602,7 +34879,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -34617,7 +34894,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_enabled_pane_fields",
         "kind": "static_from",
-        "line": 778,
+        "line": 772,
         "name": "_advanced_enabled_pane_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -34636,7 +34913,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -34651,7 +34928,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_field_input_values",
         "kind": "static_from",
-        "line": 778,
+        "line": 772,
         "name": "_advanced_field_input_values",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -34670,7 +34947,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -34685,7 +34962,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_field_socket_name",
         "kind": "static_from",
-        "line": 778,
+        "line": 772,
         "name": "_advanced_field_socket_name",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -34704,7 +34981,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -34719,7 +34996,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_fields_json",
         "kind": "static_from",
-        "line": 778,
+        "line": 772,
         "name": "_advanced_fields_json",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -34738,7 +35015,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -34753,7 +35030,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_has_enabled_naia",
         "kind": "static_from",
-        "line": 778,
+        "line": 772,
         "name": "_advanced_has_enabled_naia",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -34772,7 +35049,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -34787,7 +35064,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_prompt_with_artist_override",
         "kind": "static_from",
-        "line": 778,
+        "line": 772,
         "name": "_advanced_prompt_with_artist_override",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -34806,7 +35083,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -34821,7 +35098,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_uses_naia_resolution",
         "kind": "static_from",
-        "line": 778,
+        "line": 772,
         "name": "_advanced_uses_naia_resolution",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -34840,7 +35117,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -34855,7 +35132,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_apply_advanced_field_inputs",
         "kind": "static_from",
-        "line": 778,
+        "line": 772,
         "name": "_apply_advanced_field_inputs",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -34874,7 +35151,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -34889,7 +35166,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_as_advanced_height",
         "kind": "static_from",
-        "line": 778,
+        "line": 772,
         "name": "_as_advanced_height",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -34908,7 +35185,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -34923,7 +35200,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_build_advanced_prompt_data",
         "kind": "static_from",
-        "line": 778,
+        "line": 772,
         "name": "_build_advanced_prompt_data",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -34942,7 +35219,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -34957,7 +35234,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_build_advanced_prompts",
         "kind": "static_from",
-        "line": 778,
+        "line": 772,
         "name": "_build_advanced_prompts",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -34976,7 +35253,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -34991,7 +35268,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_clone_advanced_fields",
         "kind": "static_from",
-        "line": 778,
+        "line": 772,
         "name": "_clone_advanced_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -35010,7 +35287,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -35025,7 +35302,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_correct_advanced_field_sequence",
         "kind": "static_from",
-        "line": 778,
+        "line": 772,
         "name": "_correct_advanced_field_sequence",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -35044,7 +35321,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -35059,7 +35336,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_expand_advanced_wildcard_fields",
         "kind": "static_from",
-        "line": 778,
+        "line": 772,
         "name": "_expand_advanced_wildcard_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -35078,7 +35355,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -35093,7 +35370,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_normalize_advanced_fields",
         "kind": "static_from",
-        "line": 778,
+        "line": 772,
         "name": "_normalize_advanced_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -35112,7 +35389,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -35127,7 +35404,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_normalize_prompt_studio_wildcard_seed_control",
         "kind": "static_from",
-        "line": 778,
+        "line": 772,
         "name": "_normalize_prompt_studio_wildcard_seed_control",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -35146,7 +35423,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -35161,7 +35438,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_set_naia_field_text",
         "kind": "static_from",
-        "line": 778,
+        "line": 772,
         "name": "_set_naia_field_text",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -35180,7 +35457,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -35195,7 +35472,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_translate_prompt_fields",
         "kind": "static_from",
-        "line": 778,
+        "line": 772,
         "name": "_translate_prompt_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -35214,7 +35491,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -35229,7 +35506,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_apply_regional_field_inputs",
         "kind": "static_from",
-        "line": 813,
+        "line": 807,
         "name": "_apply_regional_field_inputs",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -35248,7 +35525,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -35263,7 +35540,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_build_regional_outputs",
         "kind": "static_from",
-        "line": 813,
+        "line": 807,
         "name": "_build_regional_outputs",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -35282,7 +35559,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -35297,7 +35574,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_clone_regional_fields",
         "kind": "static_from",
-        "line": 813,
+        "line": 807,
         "name": "_clone_regional_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -35316,7 +35593,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -35331,7 +35608,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_conditioning_set_values",
         "kind": "static_from",
-        "line": 813,
+        "line": 807,
         "name": "_conditioning_set_values",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -35350,7 +35627,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -35365,7 +35642,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_mask_ids",
         "kind": "static_from",
-        "line": 813,
+        "line": 807,
         "name": "_normalize_mask_ids",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -35384,7 +35661,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -35399,7 +35676,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_regional_config",
         "kind": "static_from",
-        "line": 813,
+        "line": 807,
         "name": "_normalize_regional_config",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -35418,7 +35695,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -35433,7 +35710,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_regional_fields",
         "kind": "static_from",
-        "line": 813,
+        "line": 807,
         "name": "_normalize_regional_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -35452,7 +35729,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -35467,7 +35744,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_parse_json_object",
         "kind": "static_from",
-        "line": 813,
+        "line": 807,
         "name": "_parse_json_object",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -35486,7 +35763,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -35501,7 +35778,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_config_json",
         "kind": "static_from",
-        "line": 813,
+        "line": 807,
         "name": "_regional_config_json",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -35520,7 +35797,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -35535,7 +35812,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_fields_json",
         "kind": "static_from",
-        "line": 813,
+        "line": 807,
         "name": "_regional_fields_json",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -35554,7 +35831,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -35569,7 +35846,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_mask_bounds_area",
         "kind": "static_from",
-        "line": 813,
+        "line": 807,
         "name": "_regional_mask_bounds_area",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -35588,7 +35865,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -35603,7 +35880,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_payload_canvas",
         "kind": "static_from",
-        "line": 813,
+        "line": 807,
         "name": "_regional_payload_canvas",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -35622,7 +35899,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -35637,7 +35914,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_union_mask_for_ids",
         "kind": "static_from",
-        "line": 813,
+        "line": 807,
         "name": "_regional_union_mask_for_ids",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -35656,7 +35933,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -35671,7 +35948,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
         "kind": "static_from",
-        "line": 840,
+        "line": 834,
         "name": "ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -35690,7 +35967,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -35705,7 +35982,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODES",
         "kind": "static_from",
-        "line": 840,
+        "line": 834,
         "name": "ANIMA_MOD_GUIDANCE_MODES",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -35724,7 +36001,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -35739,7 +36016,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 840,
+        "line": 834,
         "name": "ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -35758,7 +36035,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -35773,7 +36050,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_PROFILE_OFF",
         "kind": "static_from",
-        "line": 840,
+        "line": 834,
         "name": "ANIMA_MOD_GUIDANCE_PROFILE_OFF",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -35792,7 +36069,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -35807,7 +36084,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_apply_spectrum_anima_mod_guidance",
         "kind": "static_from",
-        "line": 840,
+        "line": 834,
         "name": "_apply_spectrum_anima_mod_guidance",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -35826,7 +36103,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -35841,7 +36118,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_find_spectrum_anima_mod_guidance_class",
         "kind": "static_from",
-        "line": 840,
+        "line": 834,
         "name": "_find_spectrum_anima_mod_guidance_class",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -35860,7 +36137,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -35875,7 +36152,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_normalize_anima_mod_guidance_profile",
         "kind": "static_from",
-        "line": 840,
+        "line": 834,
         "name": "_normalize_anima_mod_guidance_profile",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -35894,7 +36171,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -35909,7 +36186,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_resolve_anima_mod_guidance_enabled",
         "kind": "static_from",
-        "line": 840,
+        "line": 834,
         "name": "_resolve_anima_mod_guidance_enabled",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -35928,7 +36205,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -35943,7 +36220,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
         "kind": "static_from",
-        "line": 855,
+        "line": 849,
         "name": "ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -35962,7 +36239,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -35977,7 +36254,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
         "kind": "static_from",
-        "line": 855,
+        "line": 849,
         "name": "ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -35996,7 +36273,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -36011,7 +36288,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
         "kind": "static_from",
-        "line": 855,
+        "line": 849,
         "name": "ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -36030,7 +36307,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -36045,7 +36322,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_EXACT_TOP_K",
         "kind": "static_from",
-        "line": 855,
+        "line": 849,
         "name": "ARTIST_MIX_DEFAULT_EXACT_TOP_K",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -36064,7 +36341,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -36079,7 +36356,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
         "kind": "static_from",
-        "line": 855,
+        "line": 849,
         "name": "ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -36098,7 +36375,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -36113,7 +36390,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_START_PERCENT",
         "kind": "static_from",
-        "line": 855,
+        "line": 849,
         "name": "ARTIST_MIX_DEFAULT_START_PERCENT",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -36132,7 +36409,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -36147,7 +36424,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
         "kind": "static_from",
-        "line": 855,
+        "line": 849,
         "name": "ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -36166,7 +36443,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -36181,7 +36458,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STYLE_GAIN",
         "kind": "static_from",
-        "line": 855,
+        "line": 849,
         "name": "ARTIST_MIX_DEFAULT_STYLE_GAIN",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -36200,7 +36477,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -36215,7 +36492,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_INPUT_MODES",
         "kind": "static_from",
-        "line": 855,
+        "line": 849,
         "name": "ARTIST_MIX_INPUT_MODES",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -36234,7 +36511,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -36249,7 +36526,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 855,
+        "line": 849,
         "name": "ARTIST_MIX_MODE_FROM_PROMPT_DATA",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -36268,7 +36545,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -36283,7 +36560,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_mix_inline_prompt",
         "kind": "static_from",
-        "line": 855,
+        "line": 849,
         "name": "_artist_mix_inline_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -36302,7 +36579,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -36317,7 +36594,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_mix_mode_tooltip",
         "kind": "static_from",
-        "line": 855,
+        "line": 849,
         "name": "_artist_mix_mode_tooltip",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -36336,7 +36613,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -36351,7 +36628,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_prompt_with_position",
         "kind": "static_from",
-        "line": 855,
+        "line": 849,
         "name": "_artist_prompt_with_position",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -36370,7 +36647,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -36385,7 +36662,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_tags_from_prompt",
         "kind": "static_from",
-        "line": 855,
+        "line": 849,
         "name": "_artist_tags_from_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -36404,7 +36681,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -36419,7 +36696,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_blend_conditionings",
         "kind": "static_from",
-        "line": 855,
+        "line": 849,
         "name": "_blend_conditionings",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -36438,7 +36715,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -36453,7 +36730,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bounded_artist_mix_float",
         "kind": "static_from",
-        "line": 855,
+        "line": 849,
         "name": "_bounded_artist_mix_float",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -36472,7 +36749,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -36487,7 +36764,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bounded_artist_mix_int",
         "kind": "static_from",
-        "line": 855,
+        "line": 849,
         "name": "_bounded_artist_mix_int",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -36506,7 +36783,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -36521,7 +36798,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_clustered",
         "kind": "static_from",
-        "line": 855,
+        "line": 849,
         "name": "_encode_artist_clustered",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -36540,7 +36817,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -36555,7 +36832,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_delta_rms",
         "kind": "static_from",
-        "line": 855,
+        "line": 849,
         "name": "_encode_artist_delta_rms",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -36574,7 +36851,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -36589,7 +36866,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_prompt_data_positive_conditioning",
         "kind": "static_from",
-        "line": 855,
+        "line": 849,
         "name": "_encode_prompt_data_positive_conditioning",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -36608,7 +36885,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -36623,7 +36900,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_join_artist_mix_source_prompts",
         "kind": "static_from",
-        "line": 855,
+        "line": 849,
         "name": "_join_artist_mix_source_prompts",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -36642,7 +36919,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -36657,7 +36934,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_normalize_artist_mix_mode",
         "kind": "static_from",
-        "line": 855,
+        "line": 849,
         "name": "_normalize_artist_mix_mode",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -36676,7 +36953,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -36691,7 +36968,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_normalize_artist_tag_position",
         "kind": "static_from",
-        "line": 855,
+        "line": 849,
         "name": "_normalize_artist_tag_position",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -36710,7 +36987,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -36725,7 +37002,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_parse_artist_mix_items",
         "kind": "static_from",
-        "line": 855,
+        "line": 849,
         "name": "_parse_artist_mix_items",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -36744,7 +37021,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -36759,7 +37036,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaArtistMixConditioning",
         "kind": "static_from",
-        "line": 934,
+        "line": 928,
         "name": "EasyUseAnimaArtistMixConditioning",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_data_nodes",
@@ -36778,7 +37055,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -36793,7 +37070,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataConditioning",
         "kind": "static_from",
-        "line": 934,
+        "line": 928,
         "name": "EasyUseAnimaPromptDataConditioning",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_data_nodes",
@@ -36812,7 +37089,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -36827,7 +37104,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataUnpack",
         "kind": "static_from",
-        "line": 934,
+        "line": 928,
         "name": "EasyUseAnimaPromptDataUnpack",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_data_nodes",
@@ -36846,7 +37123,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -36861,7 +37138,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_ANY_TYPE",
         "kind": "static_from",
-        "line": 939,
+        "line": 933,
         "name": "_ANY_TYPE",
         "optional": false,
         "requested": "easyuse_anima.nodes.input_types",
@@ -36880,7 +37157,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -36895,7 +37172,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_AnyType",
         "kind": "static_from",
-        "line": 939,
+        "line": 933,
         "name": "_AnyType",
         "optional": false,
         "requested": "easyuse_anima.nodes.input_types",
@@ -36914,7 +37191,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -36929,7 +37206,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_FlexibleOptionalInputType",
         "kind": "static_from",
-        "line": 939,
+        "line": 933,
         "name": "_FlexibleOptionalInputType",
         "optional": false,
         "requested": "easyuse_anima.nodes.input_types",
@@ -36948,7 +37225,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -36963,7 +37240,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvanced",
         "kind": "static_from",
-        "line": 944,
+        "line": 938,
         "name": "EasyUseAnimaPromptStudioAdvanced",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_advanced_nodes",
@@ -36982,7 +37259,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -36997,7 +37274,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvancedV2",
         "kind": "static_from",
-        "line": 944,
+        "line": 938,
         "name": "EasyUseAnimaPromptStudioAdvancedV2",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_advanced_nodes",
@@ -37016,7 +37293,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -37031,7 +37308,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:EasyUseAnimaAIOGenerator",
         "kind": "static_from",
-        "line": 949,
+        "line": 943,
         "name": "EasyUseAnimaAIOGenerator",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -37050,7 +37327,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -37065,7 +37342,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:EasyUseAnimaInput",
         "kind": "static_from",
-        "line": 949,
+        "line": 943,
         "name": "EasyUseAnimaInput",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -37084,7 +37361,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -37099,7 +37376,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_aio_generation_settings_json",
         "kind": "static_from",
-        "line": 949,
+        "line": 943,
         "name": "_aio_generation_settings_json",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -37118,7 +37395,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -37133,7 +37410,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_aio_input_settings_json",
         "kind": "static_from",
-        "line": 949,
+        "line": 943,
         "name": "_aio_input_settings_json",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -37152,7 +37429,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -37167,7 +37444,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_bind_aio_node_runtime",
         "kind": "static_from",
-        "line": 949,
+        "line": 943,
         "name": "_bind_aio_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -37186,7 +37463,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -37201,7 +37478,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_easy_use_anima_input_signature",
         "kind": "static_from",
-        "line": 949,
+        "line": 943,
         "name": "_easy_use_anima_input_signature",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -37220,7 +37497,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -37235,7 +37512,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_require_easy_use_anima_input",
         "kind": "static_from",
-        "line": 949,
+        "line": 943,
         "name": "_require_easy_use_anima_input",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -37254,7 +37531,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -37269,7 +37546,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_align_down",
         "kind": "static_from",
-        "line": 958,
+        "line": 952,
         "name": "_align_down",
         "optional": false,
         "requested": "easyuse_anima.image.geometry",
@@ -37288,7 +37565,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -37303,7 +37580,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_align_nearest",
         "kind": "static_from",
-        "line": 958,
+        "line": 952,
         "name": "_align_nearest",
         "optional": false,
         "requested": "easyuse_anima.image.geometry",
@@ -37322,7 +37599,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -37337,7 +37614,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_image_tensor_size",
         "kind": "static_from",
-        "line": 958,
+        "line": 952,
         "name": "_image_tensor_size",
         "optional": false,
         "requested": "easyuse_anima.image.geometry",
@@ -37356,7 +37633,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -37371,7 +37648,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_context_value",
         "kind": "static_from",
-        "line": 969,
+        "line": 963,
         "name": "_context_value",
         "optional": false,
         "requested": "easyuse_anima.image.sam3",
@@ -37390,7 +37667,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -37405,7 +37682,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_sam3_context",
         "kind": "static_from",
-        "line": 969,
+        "line": 963,
         "name": "_sam3_context",
         "optional": false,
         "requested": "easyuse_anima.image.sam3",
@@ -37424,7 +37701,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -37439,7 +37716,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_segs_has_items",
         "kind": "static_from",
-        "line": 969,
+        "line": 963,
         "name": "_segs_has_items",
         "optional": false,
         "requested": "easyuse_anima.image.sam3",
@@ -37458,7 +37735,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -37473,7 +37750,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:IMAGE_SCALE_MULTIPLES",
         "kind": "static_from",
-        "line": 981,
+        "line": 975,
         "name": "IMAGE_SCALE_MULTIPLES",
         "optional": false,
         "requested": "easyuse_anima.image.scaling",
@@ -37492,7 +37769,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -37507,7 +37784,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:IMAGE_UPSCALE_METHODS",
         "kind": "static_from",
-        "line": 981,
+        "line": 975,
         "name": "IMAGE_UPSCALE_METHODS",
         "optional": false,
         "requested": "easyuse_anima.image.scaling",
@@ -37526,7 +37803,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -37541,7 +37818,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_sampler_names",
         "kind": "static_from",
-        "line": 989,
+        "line": 983,
         "name": "_comfy_sampler_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -37560,7 +37837,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -37575,7 +37852,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_scheduler_names",
         "kind": "static_from",
-        "line": 989,
+        "line": 983,
         "name": "_comfy_scheduler_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -37594,7 +37871,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -37609,7 +37886,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_impact_scheduler_names",
         "kind": "static_from",
-        "line": 989,
+        "line": 983,
         "name": "_impact_scheduler_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -37628,7 +37905,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -37643,7 +37920,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_call_with_supported_kwargs",
         "kind": "static_from",
-        "line": 995,
+        "line": 989,
         "name": "_call_with_supported_kwargs",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.invocation",
@@ -37662,7 +37939,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -37677,7 +37954,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_common_upscale_image",
         "kind": "static_from",
-        "line": 995,
+        "line": 989,
         "name": "_common_upscale_image",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.invocation",
@@ -37696,7 +37973,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -37711,7 +37988,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_node_output_tuple",
         "kind": "static_from",
-        "line": 995,
+        "line": 989,
         "name": "_node_output_tuple",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.invocation",
@@ -37730,7 +38007,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -37745,7 +38022,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.wiring:resolve_comfy_host_helper",
         "kind": "static_from",
-        "line": 1000,
+        "line": 994,
         "name": "resolve_comfy_host_helper",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.wiring",
@@ -37764,7 +38041,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -37779,7 +38056,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_clip_loader_types",
         "kind": "static_from",
-        "line": 1003,
+        "line": 997,
         "name": "_comfy_clip_loader_types",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -37798,7 +38075,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -37813,7 +38090,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_diffusion_model_names",
         "kind": "static_from",
-        "line": 1003,
+        "line": 997,
         "name": "_comfy_diffusion_model_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -37832,7 +38109,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -37847,7 +38124,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_text_encoder_names",
         "kind": "static_from",
-        "line": 1003,
+        "line": 997,
         "name": "_comfy_text_encoder_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -37866,7 +38143,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -37881,7 +38158,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_vae_names",
         "kind": "static_from",
-        "line": 1003,
+        "line": 997,
         "name": "_comfy_vae_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -37900,7 +38177,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -37915,7 +38192,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_folder_path_names",
         "kind": "static_from",
-        "line": 1003,
+        "line": 997,
         "name": "_folder_path_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -37934,7 +38211,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -37949,7 +38226,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.image_nodes:EasyUseAnimaDetailerAlignHook",
         "kind": "static_from",
-        "line": 1011,
+        "line": 1005,
         "name": "EasyUseAnimaDetailerAlignHook",
         "optional": false,
         "requested": "easyuse_anima.nodes.image_nodes",
@@ -37968,7 +38245,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -37983,7 +38260,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.image_nodes:EasyUseAnimaImageScaleByMultiple",
         "kind": "static_from",
-        "line": 1011,
+        "line": 1005,
         "name": "EasyUseAnimaImageScaleByMultiple",
         "optional": false,
         "requested": "easyuse_anima.nodes.image_nodes",
@@ -38002,7 +38279,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -38017,7 +38294,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Context",
         "kind": "static_from",
-        "line": 1015,
+        "line": 1009,
         "name": "EasyUseAnimaSAM3Context",
         "optional": false,
         "requested": "easyuse_anima.nodes.sam3_nodes",
@@ -38036,7 +38313,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -38051,7 +38328,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Detailer",
         "kind": "static_from",
-        "line": 1015,
+        "line": 1009,
         "name": "EasyUseAnimaSAM3Detailer",
         "optional": false,
         "requested": "easyuse_anima.nodes.sam3_nodes",
@@ -38070,7 +38347,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -38085,7 +38362,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptBuilder",
         "kind": "static_from",
-        "line": 1019,
+        "line": 1013,
         "name": "EasyUseAnimaPromptBuilder",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -38104,7 +38381,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -38119,7 +38396,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrector",
         "kind": "static_from",
-        "line": 1019,
+        "line": 1013,
         "name": "EasyUseAnimaPromptCorrector",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -38138,7 +38415,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -38153,7 +38430,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrectorSimple",
         "kind": "static_from",
-        "line": 1019,
+        "line": 1013,
         "name": "EasyUseAnimaPromptCorrectorSimple",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -38172,7 +38449,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -38187,7 +38464,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptStudio",
         "kind": "static_from",
-        "line": 1019,
+        "line": 1013,
         "name": "EasyUseAnimaPromptStudio",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -38206,7 +38483,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -38221,7 +38498,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:EasyUseAnimaPromptStudioRegional",
         "kind": "static_from",
-        "line": 1025,
+        "line": 1019,
         "name": "EasyUseAnimaPromptStudioRegional",
         "optional": false,
         "requested": "easyuse_anima.nodes.regional_nodes",
@@ -38240,7 +38517,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -38255,7 +38532,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:EasyUseAnimaRegionalConditioning",
         "kind": "static_from",
-        "line": 1025,
+        "line": 1019,
         "name": "EasyUseAnimaRegionalConditioning",
         "optional": false,
         "requested": "easyuse_anima.nodes.regional_nodes",
@@ -38274,7 +38551,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -38289,7 +38566,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:LATENT_ALIGN",
         "kind": "static_from",
-        "line": 1029,
+        "line": 1023,
         "name": "LATENT_ALIGN",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -38308,7 +38585,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -38323,7 +38600,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_parse_random_response",
         "kind": "static_from",
-        "line": 1029,
+        "line": 1023,
         "name": "_parse_random_response",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -38342,7 +38619,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -38357,7 +38634,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_post_random",
         "kind": "static_from",
-        "line": 1029,
+        "line": 1023,
         "name": "_post_random",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -38376,7 +38653,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -38391,7 +38668,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_advanced_resolution_from_selection",
         "kind": "static_from",
-        "line": 1047,
+        "line": 1041,
         "name": "_advanced_resolution_from_selection",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -38410,7 +38687,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -38425,7 +38702,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_normalize_resolution_bucket",
         "kind": "static_from",
-        "line": 1047,
+        "line": 1041,
         "name": "_normalize_resolution_bucket",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -38444,7 +38721,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -38459,7 +38736,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_ratio_label",
         "kind": "static_from",
-        "line": 1047,
+        "line": 1041,
         "name": "_ratio_label",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -38478,7 +38755,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -38493,7 +38770,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolution_label",
         "kind": "static_from",
-        "line": 1047,
+        "line": 1041,
         "name": "_resolution_label",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -38512,7 +38789,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -38527,7 +38804,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolve_naia_resolution",
         "kind": "static_from",
-        "line": 1047,
+        "line": 1041,
         "name": "_resolve_naia_resolution",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -38546,7 +38823,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -38561,7 +38838,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.naia_nodes:EasyUseAnimaNAIARandomPrompt",
         "kind": "static_from",
-        "line": 1070,
+        "line": 1064,
         "name": "EasyUseAnimaNAIARandomPrompt",
         "optional": false,
         "requested": "easyuse_anima.nodes.naia_nodes",
@@ -38580,7 +38857,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -38595,7 +38872,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.naia_nodes:_bind_naia_node_runtime",
         "kind": "static_from",
-        "line": 1070,
+        "line": 1064,
         "name": "_bind_naia_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.naia_nodes",
@@ -38614,7 +38891,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -38629,7 +38906,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.wildcard_nodes:EasyUseAnimaWildcard",
         "kind": "static_from",
-        "line": 1074,
+        "line": 1068,
         "name": "EasyUseAnimaWildcard",
         "optional": false,
         "requested": "easyuse_anima.nodes.wildcard_nodes",
@@ -38648,7 +38925,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -38663,7 +38940,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.wildcard_nodes:_bind_wildcard_node_runtime",
         "kind": "static_from",
-        "line": 1074,
+        "line": 1068,
         "name": "_bind_wildcard_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.wildcard_nodes",
@@ -38682,7 +38959,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -38697,7 +38974,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_apply_lora_syntax_format",
         "kind": "static_from",
-        "line": 1079,
+        "line": 1073,
         "name": "_apply_lora_syntax_format",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -38716,7 +38993,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -38731,7 +39008,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_dedupe_text_values",
         "kind": "static_from",
-        "line": 1079,
+        "line": 1073,
         "name": "_dedupe_text_values",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -38750,7 +39027,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -38765,7 +39042,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_fallback_lora_path",
         "kind": "static_from",
-        "line": 1079,
+        "line": 1073,
         "name": "_fallback_lora_path",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -38784,7 +39061,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -38799,7 +39076,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_get_lora_info",
         "kind": "static_from",
-        "line": 1079,
+        "line": 1073,
         "name": "_get_lora_info",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -38818,7 +39095,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -38833,7 +39110,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_get_lora_manager_trigger_words",
         "kind": "static_from",
-        "line": 1079,
+        "line": 1073,
         "name": "_get_lora_manager_trigger_words",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -38852,7 +39129,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -38867,7 +39144,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_load_lora_manager_metadata",
         "kind": "static_from",
-        "line": 1079,
+        "line": 1073,
         "name": "_load_lora_manager_metadata",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -38886,7 +39163,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -38901,7 +39178,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_combo_values",
         "kind": "static_from",
-        "line": 1079,
+        "line": 1073,
         "name": "_lora_combo_values",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -38920,7 +39197,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -38935,7 +39212,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_manager_trigger_words_from_metadata",
         "kind": "static_from",
-        "line": 1079,
+        "line": 1073,
         "name": "_lora_manager_trigger_words_from_metadata",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -38954,7 +39231,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -38969,7 +39246,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_model_exists",
         "kind": "static_from",
-        "line": 1079,
+        "line": 1073,
         "name": "_lora_model_exists",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -38988,7 +39265,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -39003,7 +39280,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_stack_name",
         "kind": "static_from",
-        "line": 1079,
+        "line": 1073,
         "name": "_lora_stack_name",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -39022,7 +39299,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -39037,7 +39314,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_metadata_json_paths_for_lora",
         "kind": "static_from",
-        "line": 1079,
+        "line": 1073,
         "name": "_metadata_json_paths_for_lora",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -39056,7 +39333,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -39071,7 +39348,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_missing_lora_display_name",
         "kind": "static_from",
-        "line": 1079,
+        "line": 1073,
         "name": "_missing_lora_display_name",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -39090,7 +39367,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -39105,7 +39382,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_raise_missing_loras",
         "kind": "static_from",
-        "line": 1079,
+        "line": 1073,
         "name": "_raise_missing_loras",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -39124,7 +39401,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -39139,7 +39416,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_trigger_words_from_value",
         "kind": "static_from",
-        "line": 1079,
+        "line": 1073,
         "name": "_trigger_words_from_value",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -39158,7 +39435,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -39173,7 +39450,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_correct_style_prompt",
         "kind": "static_from",
-        "line": 1095,
+        "line": 1089,
         "name": "_correct_style_prompt",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -39192,7 +39469,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -39207,7 +39484,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_format_strength",
         "kind": "static_from",
-        "line": 1095,
+        "line": 1089,
         "name": "_format_strength",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -39226,7 +39503,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -39241,7 +39518,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_get_loras_list",
         "kind": "static_from",
-        "line": 1095,
+        "line": 1089,
         "name": "_get_loras_list",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -39260,7 +39537,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -39275,7 +39552,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_load_profile_data",
         "kind": "static_from",
-        "line": 1095,
+        "line": 1089,
         "name": "_load_profile_data",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -39294,7 +39571,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -39309,7 +39586,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_profile_key",
         "kind": "static_from",
-        "line": 1095,
+        "line": 1089,
         "name": "_profile_key",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -39328,7 +39605,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -39343,7 +39620,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_select_profile_values",
         "kind": "static_from",
-        "line": 1095,
+        "line": 1089,
         "name": "_select_profile_values",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -39362,7 +39639,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -39377,7 +39654,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_wrap_profile_index",
         "kind": "static_from",
-        "line": 1095,
+        "line": 1089,
         "name": "_wrap_profile_index",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -39396,7 +39673,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -39411,7 +39688,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.lora_nodes:EasyUseAnimaLoraPreset",
         "kind": "static_from",
-        "line": 1104,
+        "line": 1098,
         "name": "EasyUseAnimaLoraPreset",
         "optional": false,
         "requested": "easyuse_anima.nodes.lora_nodes",
@@ -39430,7 +39707,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -39445,7 +39722,7 @@
         "conditional": true,
         "imported": "anima_prompt:correct_prompt",
         "kind": "static_from",
-        "line": 1107,
+        "line": 1101,
         "name": "correct_prompt",
         "optional": false,
         "requested": "anima_prompt",
@@ -39464,7 +39741,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -39479,7 +39756,7 @@
         "conditional": true,
         "imported": "anima_prompt:load_knowledge_base",
         "kind": "static_from",
-        "line": 1107,
+        "line": 1101,
         "name": "load_knowledge_base",
         "optional": false,
         "requested": "anima_prompt",
@@ -39498,7 +39775,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -39513,7 +39790,7 @@
         "conditional": true,
         "imported": "anima_prompt.parser:parse_prompt",
         "kind": "static_from",
-        "line": 1108,
+        "line": 1102,
         "name": "parse_prompt",
         "optional": false,
         "requested": "anima_prompt.parser",
@@ -39532,7 +39809,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -39547,7 +39824,7 @@
         "conditional": true,
         "imported": "settings:resolve_metadata_filter_words",
         "kind": "static_from",
-        "line": 1109,
+        "line": 1103,
         "name": "resolve_metadata_filter_words",
         "optional": false,
         "requested": "settings",
@@ -39566,7 +39843,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -39581,7 +39858,7 @@
         "conditional": true,
         "imported": "settings:resolve_naia_settings",
         "kind": "static_from",
-        "line": 1109,
+        "line": 1103,
         "name": "resolve_naia_settings",
         "optional": false,
         "requested": "settings",
@@ -39600,7 +39877,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -39615,7 +39892,7 @@
         "conditional": true,
         "imported": "settings:resolve_prompt_translation_settings",
         "kind": "static_from",
-        "line": 1109,
+        "line": 1103,
         "name": "resolve_prompt_translation_settings",
         "optional": false,
         "requested": "settings",
@@ -39634,7 +39911,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -39649,7 +39926,7 @@
         "conditional": true,
         "imported": "prompt_translation:has_prompt_translation_markers",
         "kind": "static_from",
-        "line": 1114,
+        "line": 1108,
         "name": "has_prompt_translation_markers",
         "optional": false,
         "requested": "prompt_translation",
@@ -39668,7 +39945,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -39683,7 +39960,7 @@
         "conditional": true,
         "imported": "prompt_translation:translate_prompt_markers",
         "kind": "static_from",
-        "line": 1114,
+        "line": 1108,
         "name": "translate_prompt_markers",
         "optional": false,
         "requested": "prompt_translation",
@@ -39702,7 +39979,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -39717,7 +39994,7 @@
         "conditional": true,
         "imported": "wildcard_engine:MAX_SEED",
         "kind": "static_from",
-        "line": 1115,
+        "line": 1109,
         "name": "MAX_SEED",
         "optional": false,
         "requested": "wildcard_engine",
@@ -39736,7 +40013,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -39751,7 +40028,7 @@
         "conditional": true,
         "imported": "wildcard_engine:PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "kind": "static_from",
-        "line": 1115,
+        "line": 1109,
         "name": "PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "optional": false,
         "requested": "wildcard_engine",
@@ -39770,7 +40047,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -39785,7 +40062,7 @@
         "conditional": true,
         "imported": "wildcard_engine:PUBLIC_MAX_SEED",
         "kind": "static_from",
-        "line": 1115,
+        "line": 1109,
         "name": "PUBLIC_MAX_SEED",
         "optional": false,
         "requested": "wildcard_engine",
@@ -39804,7 +40081,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -39819,7 +40096,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_DECREMENT",
         "kind": "static_from",
-        "line": 1115,
+        "line": 1109,
         "name": "SEED_CONTROL_DECREMENT",
         "optional": false,
         "requested": "wildcard_engine",
@@ -39838,7 +40115,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -39853,7 +40130,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_FIXED",
         "kind": "static_from",
-        "line": 1115,
+        "line": 1109,
         "name": "SEED_CONTROL_FIXED",
         "optional": false,
         "requested": "wildcard_engine",
@@ -39872,7 +40149,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -39887,7 +40164,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_INCREMENT",
         "kind": "static_from",
-        "line": 1115,
+        "line": 1109,
         "name": "SEED_CONTROL_INCREMENT",
         "optional": false,
         "requested": "wildcard_engine",
@@ -39906,7 +40183,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -39921,7 +40198,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_MODES",
         "kind": "static_from",
-        "line": 1115,
+        "line": 1109,
         "name": "SEED_CONTROL_MODES",
         "optional": false,
         "requested": "wildcard_engine",
@@ -39940,7 +40217,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -39955,7 +40232,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_RANDOMIZE",
         "kind": "static_from",
-        "line": 1115,
+        "line": 1109,
         "name": "SEED_CONTROL_RANDOMIZE",
         "optional": false,
         "requested": "wildcard_engine",
@@ -39974,7 +40251,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -39989,7 +40266,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_FIXED",
         "kind": "static_from",
-        "line": 1115,
+        "line": 1109,
         "name": "WILDCARD_MODE_FIXED",
         "optional": false,
         "requested": "wildcard_engine",
@@ -40008,7 +40285,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -40023,7 +40300,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_POPULATE",
         "kind": "static_from",
-        "line": 1115,
+        "line": 1109,
         "name": "WILDCARD_MODE_POPULATE",
         "optional": false,
         "requested": "wildcard_engine",
@@ -40042,7 +40319,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -40057,7 +40334,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_SEQUENTIAL",
         "kind": "static_from",
-        "line": 1115,
+        "line": 1109,
         "name": "WILDCARD_MODE_SEQUENTIAL",
         "optional": false,
         "requested": "wildcard_engine",
@@ -40076,7 +40353,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -40091,7 +40368,7 @@
         "conditional": true,
         "imported": "wildcard_engine:expand_wildcard_texts",
         "kind": "static_from",
-        "line": 1115,
+        "line": 1109,
         "name": "expand_wildcard_texts",
         "optional": false,
         "requested": "wildcard_engine",
@@ -40110,7 +40387,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -40125,7 +40402,7 @@
         "conditional": true,
         "imported": "wildcard_engine:expand_wildcards",
         "kind": "static_from",
-        "line": 1115,
+        "line": 1109,
         "name": "expand_wildcards",
         "optional": false,
         "requested": "wildcard_engine",
@@ -40144,7 +40421,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -40159,7 +40436,7 @@
         "conditional": true,
         "imported": "wildcard_engine:has_wildcard_syntax",
         "kind": "static_from",
-        "line": 1115,
+        "line": 1109,
         "name": "has_wildcard_syntax",
         "optional": false,
         "requested": "wildcard_engine",
@@ -40178,7 +40455,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -40193,7 +40470,7 @@
         "conditional": true,
         "imported": "wildcard_engine:next_seed",
         "kind": "static_from",
-        "line": 1115,
+        "line": 1109,
         "name": "next_seed",
         "optional": false,
         "requested": "wildcard_engine",
@@ -40212,7 +40489,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -40227,7 +40504,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_prompt_studio_wildcard_mode",
         "kind": "static_from",
-        "line": 1115,
+        "line": 1109,
         "name": "normalize_prompt_studio_wildcard_mode",
         "optional": false,
         "requested": "wildcard_engine",
@@ -40246,7 +40523,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -40261,7 +40538,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_seed",
         "kind": "static_from",
-        "line": 1115,
+        "line": 1109,
         "name": "normalize_seed",
         "optional": false,
         "requested": "wildcard_engine",
@@ -40280,7 +40557,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -40295,7 +40572,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_wildcard_mode",
         "kind": "static_from",
-        "line": 1115,
+        "line": 1109,
         "name": "normalize_wildcard_mode",
         "optional": false,
         "requested": "wildcard_engine",
@@ -40314,7 +40591,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -40329,7 +40606,7 @@
         "conditional": true,
         "imported": "wildcard_engine:wildcard_sources_signature",
         "kind": "static_from",
-        "line": 1115,
+        "line": 1109,
         "name": "wildcard_sources_signature",
         "optional": false,
         "requested": "wildcard_engine",
@@ -41948,6 +42225,26 @@
         "to": "easyuse_anima/seed/__init__.py"
       },
       {
+        "from": "easyuse_anima/aio/conditioning.py",
+        "to": "easyuse_anima/aio/generation_defaults.py"
+      },
+      {
+        "from": "easyuse_anima/aio/conditioning.py",
+        "to": "easyuse_anima/common/values.py"
+      },
+      {
+        "from": "easyuse_anima/aio/conditioning.py",
+        "to": "easyuse_anima/infrastructure/comfy/wiring.py"
+      },
+      {
+        "from": "easyuse_anima/aio/conditioning.py",
+        "to": "easyuse_anima/prompt/advanced.py"
+      },
+      {
+        "from": "easyuse_anima/aio/conditioning.py",
+        "to": "easyuse_anima/prompt/data.py"
+      },
+      {
         "from": "easyuse_anima/aio/first_pass_cache.py",
         "to": "easyuse_anima/aio/model_preparation.py"
       },
@@ -42076,6 +42373,22 @@
         "to": "easyuse_anima/aio/generation_values.py"
       },
       {
+        "from": "easyuse_anima/aio/model_preparation.py",
+        "to": "easyuse_anima/common/values.py"
+      },
+      {
+        "from": "easyuse_anima/aio/model_preparation.py",
+        "to": "easyuse_anima/infrastructure/comfy/invocation.py"
+      },
+      {
+        "from": "easyuse_anima/aio/model_preparation.py",
+        "to": "easyuse_anima/infrastructure/comfy/wiring.py"
+      },
+      {
+        "from": "easyuse_anima/aio/model_preparation.py",
+        "to": "easyuse_anima/lora/metadata.py"
+      },
+      {
         "from": "easyuse_anima/aio/output.py",
         "to": "easyuse_anima/aio/generation_defaults.py"
       },
@@ -42162,6 +42475,38 @@
       {
         "from": "easyuse_anima/aio/resources.py",
         "to": "easyuse_anima/infrastructure/comfy/wiring.py"
+      },
+      {
+        "from": "easyuse_anima/aio/sampling.py",
+        "to": "easyuse_anima/aio/generation_defaults.py"
+      },
+      {
+        "from": "easyuse_anima/aio/sampling.py",
+        "to": "easyuse_anima/aio/generation_normalization.py"
+      },
+      {
+        "from": "easyuse_anima/aio/sampling.py",
+        "to": "easyuse_anima/common/serialization.py"
+      },
+      {
+        "from": "easyuse_anima/aio/sampling.py",
+        "to": "easyuse_anima/common/values.py"
+      },
+      {
+        "from": "easyuse_anima/aio/sampling.py",
+        "to": "easyuse_anima/infrastructure/comfy/invocation.py"
+      },
+      {
+        "from": "easyuse_anima/aio/sampling.py",
+        "to": "easyuse_anima/infrastructure/comfy/wiring.py"
+      },
+      {
+        "from": "easyuse_anima/aio/sampling.py",
+        "to": "easyuse_anima/prompt/conditioning.py"
+      },
+      {
+        "from": "easyuse_anima/aio/sampling.py",
+        "to": "easyuse_anima/seed/reservation.py"
       },
       {
         "from": "easyuse_anima/aio/usdu.py",
@@ -43635,14 +43980,14 @@
       },
       {
         "is_package": false,
-        "loc": 125,
+        "loc": 120,
         "module": "easyuse_anima.aio.conditioning",
-        "normalized_git_blob_sha1": "2fcbc6aa6830259b7c1f45f360fd32ffb7356fc9",
+        "normalized_git_blob_sha1": "b3cf519f9abad98538514c65310fc220e5a742e9",
         "path": "easyuse_anima/aio/conditioning.py",
         "top_level": {
           "class_count": 0,
           "function_count": 5,
-          "global_count": 3
+          "global_count": 1
         }
       },
       {
@@ -43791,14 +44136,14 @@
       },
       {
         "is_package": false,
-        "loc": 470,
+        "loc": 454,
         "module": "easyuse_anima.aio.model_preparation",
-        "normalized_git_blob_sha1": "8b645baae71ac86cc4ba9c5427c0781d644670d7",
+        "normalized_git_blob_sha1": "5614a46e49e8b459ec59d89fe0b42ade8e875064",
         "path": "easyuse_anima/aio/model_preparation.py",
         "top_level": {
           "class_count": 0,
-          "function_count": 14,
-          "global_count": 3
+          "function_count": 16,
+          "global_count": 2
         }
       },
       {
@@ -43863,14 +44208,14 @@
       },
       {
         "is_package": false,
-        "loc": 465,
+        "loc": 455,
         "module": "easyuse_anima.aio.sampling",
-        "normalized_git_blob_sha1": "4fba4a918bbe345d973f02033a1e5e320c140256",
+        "normalized_git_blob_sha1": "139c6037c7868367923e1c353e871f9ca4e6d7dd",
         "path": "easyuse_anima/aio/sampling.py",
         "top_level": {
           "class_count": 0,
-          "function_count": 13,
-          "global_count": 3
+          "function_count": 14,
+          "global_count": 1
         }
       },
       {
@@ -44511,9 +44856,9 @@
       },
       {
         "is_package": false,
-        "loc": 1182,
+        "loc": 1158,
         "module": "nodes",
-        "normalized_git_blob_sha1": "40f7789cb9de0f3149fa2498ddd127d47067c405",
+        "normalized_git_blob_sha1": "cfe6755171d9ad699ad019c980421cfdaadefbb2",
         "path": "nodes.py",
         "top_level": {
           "class_count": 0,
@@ -46061,7 +46406,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -46070,7 +46415,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:AIO_FIRST_PASS_CACHE_MAX_ENTRIES",
         "kind": "static_from",
-        "line": 573,
+        "line": 570,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46084,7 +46429,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -46093,7 +46438,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_AIO_FIRST_PASS_CACHE",
         "kind": "static_from",
-        "line": 573,
+        "line": 570,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46107,7 +46452,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -46116,7 +46461,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_AIO_FIRST_PASS_CACHE_ORDER",
         "kind": "static_from",
-        "line": 573,
+        "line": 570,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46130,7 +46475,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -46139,7 +46484,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_aio_first_pass_cache_key",
         "kind": "static_from",
-        "line": 573,
+        "line": 570,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46153,7 +46498,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -46162,7 +46507,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_clone_aio_cache_value",
         "kind": "static_from",
-        "line": 573,
+        "line": 570,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46176,7 +46521,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -46185,7 +46530,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_get_aio_first_pass_cache",
         "kind": "static_from",
-        "line": 573,
+        "line": 570,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46199,7 +46544,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -46208,7 +46553,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_put_aio_first_pass_cache",
         "kind": "static_from",
-        "line": 573,
+        "line": 570,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46222,7 +46567,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -46231,7 +46576,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_bind_aio_legacy_generation_runtime",
         "kind": "static_from",
-        "line": 583,
+        "line": 580,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46245,7 +46590,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -46254,7 +46599,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_detailer_stage",
         "kind": "static_from",
-        "line": 583,
+        "line": 580,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46268,7 +46613,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -46277,7 +46622,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_detailer_target",
         "kind": "static_from",
-        "line": 583,
+        "line": 580,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46291,7 +46636,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -46300,7 +46645,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_highres_stage",
         "kind": "static_from",
-        "line": 583,
+        "line": 580,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46314,7 +46659,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -46323,7 +46668,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_legacy_generation",
         "kind": "static_from",
-        "line": 583,
+        "line": 580,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46337,7 +46682,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -46346,7 +46691,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_resshift_upscale_stage",
         "kind": "static_from",
-        "line": 583,
+        "line": 580,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46360,7 +46705,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -46369,7 +46714,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_upscale_stage",
         "kind": "static_from",
-        "line": 583,
+        "line": 580,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46383,7 +46728,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -46392,7 +46737,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_usdu_upscale_stage",
         "kind": "static_from",
-        "line": 583,
+        "line": 580,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46406,7 +46751,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -46415,7 +46760,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_AIO_DETAILER_CUSTOM_RE",
         "kind": "static_from",
-        "line": 593,
+        "line": 590,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46429,7 +46774,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -46438,7 +46783,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_AIO_DETAILER_RESERVED_KEYS",
         "kind": "static_from",
-        "line": 593,
+        "line": 590,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46452,7 +46797,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -46461,7 +46806,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_aio_detailer_has_enabled_targets",
         "kind": "static_from",
-        "line": 593,
+        "line": 590,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46475,7 +46820,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -46484,7 +46829,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_aio_detailer_target_defaults",
         "kind": "static_from",
-        "line": 593,
+        "line": 590,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46498,7 +46843,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -46507,7 +46852,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_aio_detailer_target_order",
         "kind": "static_from",
-        "line": 593,
+        "line": 590,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46521,7 +46866,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -46530,7 +46875,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_is_aio_detailer_target_name",
         "kind": "static_from",
-        "line": 593,
+        "line": 590,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46544,7 +46889,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -46553,7 +46898,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_merge_versioned_settings",
         "kind": "static_from",
-        "line": 593,
+        "line": 590,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46567,7 +46912,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -46576,7 +46921,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_dit_corrections_settings",
         "kind": "static_from",
-        "line": 593,
+        "line": 590,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46590,7 +46935,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -46599,7 +46944,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_generation_settings",
         "kind": "static_from",
-        "line": 593,
+        "line": 590,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46613,7 +46958,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -46622,7 +46967,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_seed",
         "kind": "static_from",
-        "line": 593,
+        "line": 590,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46636,7 +46981,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -46645,7 +46990,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_spectrum_settings",
         "kind": "static_from",
-        "line": 593,
+        "line": 590,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46659,7 +47004,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -46668,7 +47013,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_FINAL_FIT_MODES",
         "kind": "static_from",
-        "line": 606,
+        "line": 603,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46682,7 +47027,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -46691,7 +47036,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_FINAL_UPSCALE_BACKENDS",
         "kind": "static_from",
-        "line": 606,
+        "line": 603,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46705,7 +47050,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -46714,7 +47059,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_GENERATION_DEFAULT_SETTINGS",
         "kind": "static_from",
-        "line": 606,
+        "line": 603,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46728,7 +47073,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -46737,7 +47082,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_GENERATION_SETTINGS_SCHEMA",
         "kind": "static_from",
-        "line": 606,
+        "line": 603,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46751,7 +47096,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -46760,7 +47105,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_GENERATION_SETTINGS_VERSION",
         "kind": "static_from",
-        "line": 606,
+        "line": 603,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46774,7 +47119,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -46783,7 +47128,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_RESHIFT_DTYPES",
         "kind": "static_from",
-        "line": 606,
+        "line": 603,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46797,7 +47142,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -46806,7 +47151,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_RESHIFT_SCALES",
         "kind": "static_from",
-        "line": 606,
+        "line": 603,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46820,7 +47165,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -46829,7 +47174,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_SPECIAL_SEEDS",
         "kind": "static_from",
-        "line": 606,
+        "line": 603,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46843,7 +47188,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -46852,7 +47197,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_SPECIAL_SEED_DECREMENT",
         "kind": "static_from",
-        "line": 606,
+        "line": 603,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46866,7 +47211,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -46875,7 +47220,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_SPECIAL_SEED_INCREMENT",
         "kind": "static_from",
-        "line": 606,
+        "line": 603,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46889,7 +47234,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -46898,7 +47243,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_SPECIAL_SEED_RANDOM",
         "kind": "static_from",
-        "line": 606,
+        "line": 603,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46912,7 +47257,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -46921,7 +47266,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_USDU_MODE_TYPES",
         "kind": "static_from",
-        "line": 606,
+        "line": 603,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46935,7 +47280,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -46944,7 +47289,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_USDU_PROMPT_FULL",
         "kind": "static_from",
-        "line": 606,
+        "line": 603,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46958,7 +47303,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -46967,7 +47312,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_USDU_PROMPT_MODES",
         "kind": "static_from",
-        "line": 606,
+        "line": 603,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46981,7 +47326,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -46990,7 +47335,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_USDU_PROMPT_NO_GENERAL",
         "kind": "static_from",
-        "line": 606,
+        "line": 603,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47004,7 +47349,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -47013,7 +47358,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_USDU_SEAM_FIX_MODES",
         "kind": "static_from",
-        "line": 606,
+        "line": 603,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47027,7 +47372,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -47036,7 +47381,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_settings:round_trip_aio_generation_settings",
         "kind": "static_from",
-        "line": 624,
+        "line": 621,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47050,7 +47395,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -47059,7 +47404,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.input_defaults:AIO_INPUT_DEFAULT_SETTINGS",
         "kind": "static_from",
-        "line": 627,
+        "line": 624,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47073,7 +47418,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -47082,7 +47427,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.input_defaults:ANIMA_CLIP_DEVICES",
         "kind": "static_from",
-        "line": 627,
+        "line": 624,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47096,7 +47441,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -47105,7 +47450,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.input_defaults:ANIMA_CLIP_TYPES",
         "kind": "static_from",
-        "line": 627,
+        "line": 624,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47119,7 +47464,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -47128,7 +47473,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.input_defaults:ANIMA_DEFAULT_CLIP_CANDIDATES",
         "kind": "static_from",
-        "line": 627,
+        "line": 624,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47142,7 +47487,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -47151,7 +47496,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.input_defaults:ANIMA_DEFAULT_DIFFUSION_MODEL_CANDIDATES",
         "kind": "static_from",
-        "line": 627,
+        "line": 624,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47165,7 +47510,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -47174,7 +47519,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.input_defaults:ANIMA_DEFAULT_VAE_CANDIDATES",
         "kind": "static_from",
-        "line": 627,
+        "line": 624,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47188,7 +47533,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -47197,7 +47542,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.input_defaults:ANIMA_UNET_WEIGHT_DTYPES",
         "kind": "static_from",
-        "line": 627,
+        "line": 624,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47211,7 +47556,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -47220,7 +47565,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.input_defaults:EASY_USE_ANIMA_INPUT_SCHEMA",
         "kind": "static_from",
-        "line": 627,
+        "line": 624,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47234,7 +47579,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -47243,7 +47588,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.input_defaults:EASY_USE_ANIMA_INPUT_SETTINGS_VERSION",
         "kind": "static_from",
-        "line": 627,
+        "line": 624,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47257,7 +47602,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -47266,7 +47611,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.usdu:_aio_usdu_auto_tile_dimension",
         "kind": "static_from",
-        "line": 638,
+        "line": 635,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47280,7 +47625,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -47289,7 +47634,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.usdu:_aio_usdu_tile_plan",
         "kind": "static_from",
-        "line": 638,
+        "line": 635,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47303,7 +47648,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -47312,7 +47657,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_aio_final_fit_size",
         "kind": "static_from",
-        "line": 642,
+        "line": 639,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47326,7 +47671,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -47335,7 +47680,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_apply_aio_final_fit",
         "kind": "static_from",
-        "line": 642,
+        "line": 639,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47349,7 +47694,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -47358,7 +47703,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_resize_image_to_size_if_needed",
         "kind": "static_from",
-        "line": 642,
+        "line": 639,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47372,7 +47717,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -47381,7 +47726,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_run_aio_postprocess_stage",
         "kind": "static_from",
-        "line": 642,
+        "line": 639,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47395,7 +47740,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -47404,7 +47749,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_prompt_data_fields_for_usdu",
         "kind": "static_from",
-        "line": 648,
+        "line": 645,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47418,7 +47763,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -47427,7 +47772,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_usdu_conditioning",
         "kind": "static_from",
-        "line": 648,
+        "line": 645,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47441,7 +47786,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -47450,7 +47795,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_usdu_prompt_without_general",
         "kind": "static_from",
-        "line": 648,
+        "line": 645,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47464,30 +47809,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
-            "kind": "try",
-            "line": 8
-          }
-        ],
-        "classification": "compatibility_fallback",
-        "conditional": true,
-        "imported": "easyuse_anima.aio.conditioning:_bind_aio_conditioning_runtime",
-        "kind": "static_from",
-        "line": 648,
-        "optional": false,
-        "role": "compatibility_fallback",
-        "source": "nodes.py",
-        "target": "easyuse_anima/aio/conditioning.py"
-      },
-      {
-        "branch_context": [
-          {
-            "branch": "except",
-            "catches_import_error": true,
-            "exceptions": [
-              "ImportError"
-            ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -47496,7 +47818,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_aio_lora_stack_signature",
         "kind": "static_from",
-        "line": 654,
+        "line": 650,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47510,7 +47832,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -47519,7 +47841,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_anima_dave_patch",
         "kind": "static_from",
-        "line": 654,
+        "line": 650,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47533,7 +47855,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -47542,7 +47864,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_kj_model_patches",
         "kind": "static_from",
-        "line": 654,
+        "line": 650,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47556,7 +47878,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -47565,7 +47887,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_lora_stack",
         "kind": "static_from",
-        "line": 654,
+        "line": 650,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47579,7 +47901,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -47588,7 +47910,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_model_patches",
         "kind": "static_from",
-        "line": 654,
+        "line": 650,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47602,7 +47924,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -47611,7 +47933,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_safe_pag_patch",
         "kind": "static_from",
-        "line": 654,
+        "line": 650,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47625,7 +47947,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -47634,7 +47956,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_correction_patch_for_comfy_sampler",
         "kind": "static_from",
-        "line": 654,
+        "line": 650,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47648,7 +47970,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -47657,7 +47979,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_forecast_patch_for_comfy_sampler",
         "kind": "static_from",
-        "line": 654,
+        "line": 650,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47671,7 +47993,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -47680,7 +48002,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_model_patches_for_comfy_sampler",
         "kind": "static_from",
-        "line": 654,
+        "line": 650,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47694,30 +48016,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
-            "kind": "try",
-            "line": 8
-          }
-        ],
-        "classification": "compatibility_fallback",
-        "conditional": true,
-        "imported": "easyuse_anima.aio.model_preparation:_bind_aio_model_preparation_runtime",
-        "kind": "static_from",
-        "line": 654,
-        "optional": false,
-        "role": "compatibility_fallback",
-        "source": "nodes.py",
-        "target": "easyuse_anima/aio/model_preparation.py"
-      },
-      {
-        "branch_context": [
-          {
-            "branch": "except",
-            "catches_import_error": true,
-            "exceptions": [
-              "ImportError"
-            ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -47726,7 +48025,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_cleanup_aio_ephemeral_model",
         "kind": "static_from",
-        "line": 654,
+        "line": 650,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47740,7 +48039,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -47749,7 +48048,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_normalize_aio_lora_stack",
         "kind": "static_from",
-        "line": 654,
+        "line": 650,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47763,7 +48062,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -47772,7 +48071,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_patch_model_sampling_aura_flow",
         "kind": "static_from",
-        "line": 654,
+        "line": 650,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47786,7 +48085,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -47795,7 +48094,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_aio_highres_effective_backend",
         "kind": "static_from",
-        "line": 669,
+        "line": 664,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47809,7 +48108,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -47818,7 +48117,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_aio_stage_sampler_settings",
         "kind": "static_from",
-        "line": 669,
+        "line": 664,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47832,30 +48131,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
-            "kind": "try",
-            "line": 8
-          }
-        ],
-        "classification": "compatibility_fallback",
-        "conditional": true,
-        "imported": "easyuse_anima.aio.sampling:_bind_aio_sampling_runtime",
-        "kind": "static_from",
-        "line": 669,
-        "optional": false,
-        "role": "compatibility_fallback",
-        "source": "nodes.py",
-        "target": "easyuse_anima/aio/sampling.py"
-      },
-      {
-        "branch_context": [
-          {
-            "branch": "except",
-            "catches_import_error": true,
-            "exceptions": [
-              "ImportError"
-            ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -47864,7 +48140,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_decode_latent_with_comfy",
         "kind": "static_from",
-        "line": 669,
+        "line": 664,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47878,7 +48154,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -47887,7 +48163,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_encode_image_with_comfy_vae",
         "kind": "static_from",
-        "line": 669,
+        "line": 664,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47901,7 +48177,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -47910,7 +48186,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_generate_empty_latent_with_comfy",
         "kind": "static_from",
-        "line": 669,
+        "line": 664,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47924,7 +48200,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -47933,7 +48209,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_new_aio_random_seed",
         "kind": "static_from",
-        "line": 669,
+        "line": 664,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47947,7 +48223,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -47956,7 +48232,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_resolve_aio_runtime_seed",
         "kind": "static_from",
-        "line": 669,
+        "line": 664,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47970,7 +48246,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -47979,7 +48255,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_aio_backend",
         "kind": "static_from",
-        "line": 669,
+        "line": 664,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47993,7 +48269,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -48002,7 +48278,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_comfy",
         "kind": "static_from",
-        "line": 669,
+        "line": 664,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48016,7 +48292,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -48025,7 +48301,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_spectrum_mod_guidance_advanced",
         "kind": "static_from",
-        "line": 669,
+        "line": 664,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48039,7 +48315,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -48048,7 +48324,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_spectrum_spd",
         "kind": "static_from",
-        "line": 669,
+        "line": 664,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48062,7 +48338,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -48071,7 +48347,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_CACHE_FORMAT",
         "kind": "static_from",
-        "line": 683,
+        "line": 677,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48085,7 +48361,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -48094,7 +48370,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_CACHE_QUALITY",
         "kind": "static_from",
-        "line": 683,
+        "line": 677,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48108,7 +48384,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -48117,7 +48393,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_EVENT",
         "kind": "static_from",
-        "line": 683,
+        "line": 677,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48131,7 +48407,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -48140,7 +48416,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_STAGE_LABELS",
         "kind": "static_from",
-        "line": 683,
+        "line": 677,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48154,7 +48430,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -48163,7 +48439,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_aio_preview_base_directory",
         "kind": "static_from",
-        "line": 683,
+        "line": 677,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48177,7 +48453,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -48186,7 +48462,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_aio_preview_file_size_bytes",
         "kind": "static_from",
-        "line": 683,
+        "line": 677,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48200,7 +48476,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -48209,7 +48485,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_save_aio_temp_preview_image",
         "kind": "static_from",
-        "line": 683,
+        "line": 677,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48223,7 +48499,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -48232,7 +48508,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_send_aio_preview_event",
         "kind": "static_from",
-        "line": 683,
+        "line": 677,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48246,7 +48522,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -48255,7 +48531,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_tag_aio_preview_images",
         "kind": "static_from",
-        "line": 683,
+        "line": 677,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48269,7 +48545,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -48278,7 +48554,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_image_saver_additional_hashes",
         "kind": "static_from",
-        "line": 694,
+        "line": 688,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48292,7 +48568,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -48301,7 +48577,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_image_saver_civitai_hash_fetcher_entries",
         "kind": "static_from",
-        "line": 694,
+        "line": 688,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48315,7 +48591,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -48324,7 +48600,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_lora_metadata_name",
         "kind": "static_from",
-        "line": 694,
+        "line": 688,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48338,7 +48614,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -48347,7 +48623,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_prompt_with_lora_metadata",
         "kind": "static_from",
-        "line": 694,
+        "line": 688,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48361,7 +48637,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -48370,7 +48646,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_save_filename_prefix",
         "kind": "static_from",
-        "line": 694,
+        "line": 688,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48384,7 +48660,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -48393,7 +48669,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_save_image_with_comfy",
         "kind": "static_from",
-        "line": 694,
+        "line": 688,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48407,7 +48683,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -48416,7 +48692,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_save_image_with_image_saver",
         "kind": "static_from",
-        "line": 694,
+        "line": 688,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48430,7 +48706,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -48439,7 +48715,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output_settings:_normalize_aio_civitai_hash_fetchers",
         "kind": "static_from",
-        "line": 703,
+        "line": 697,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48453,7 +48729,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -48462,7 +48738,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output_settings:_normalize_aio_hash_bundles",
         "kind": "static_from",
-        "line": 703,
+        "line": 697,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48476,7 +48752,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -48485,7 +48761,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_clip_loader_types",
         "kind": "static_from",
-        "line": 707,
+        "line": 701,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48499,7 +48775,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -48508,7 +48784,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_diffusion_model_names",
         "kind": "static_from",
-        "line": 707,
+        "line": 701,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48522,7 +48798,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -48531,7 +48807,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_text_encoder_names",
         "kind": "static_from",
-        "line": 707,
+        "line": 701,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48545,7 +48821,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -48554,7 +48830,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_vae_names",
         "kind": "static_from",
-        "line": 707,
+        "line": 701,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48568,7 +48844,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -48577,7 +48853,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_aio_resources_from_input_context",
         "kind": "static_from",
-        "line": 707,
+        "line": 701,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48591,7 +48867,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -48600,7 +48876,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_aio_sam3_context",
         "kind": "static_from",
-        "line": 707,
+        "line": 701,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48614,7 +48890,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -48623,7 +48899,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_checkpoint_with_comfy",
         "kind": "static_from",
-        "line": 707,
+        "line": 701,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48637,7 +48913,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -48646,7 +48922,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_clip_with_comfy",
         "kind": "static_from",
-        "line": 707,
+        "line": 701,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48660,7 +48936,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -48669,7 +48945,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_diffusion_model_with_comfy",
         "kind": "static_from",
-        "line": 707,
+        "line": 701,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48683,7 +48959,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -48692,7 +48968,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_upscale_model_with_comfy",
         "kind": "static_from",
-        "line": 707,
+        "line": 701,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48706,7 +48982,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -48715,7 +48991,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_vae_with_comfy",
         "kind": "static_from",
-        "line": 707,
+        "line": 701,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48729,7 +49005,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -48738,7 +49014,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_normalize_aio_input_settings",
         "kind": "static_from",
-        "line": 707,
+        "line": 701,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48752,7 +49028,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -48761,7 +49037,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_checkpoint_default",
         "kind": "static_from",
-        "line": 707,
+        "line": 701,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48775,7 +49051,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -48784,7 +49060,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_clip_type_default",
         "kind": "static_from",
-        "line": 707,
+        "line": 701,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48798,7 +49074,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -48807,7 +49083,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_name_default",
         "kind": "static_from",
-        "line": 707,
+        "line": 701,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48821,7 +49097,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -48830,7 +49106,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_json_clone",
         "kind": "static_from",
-        "line": 724,
+        "line": 718,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48844,7 +49120,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -48853,7 +49129,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_json_object",
         "kind": "static_from",
-        "line": 724,
+        "line": 718,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48867,7 +49143,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -48876,7 +49152,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_stable_change_key",
         "kind": "static_from",
-        "line": 724,
+        "line": 718,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48890,7 +49166,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -48899,7 +49175,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_bool",
         "kind": "static_from",
-        "line": 729,
+        "line": 723,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48913,7 +49189,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -48922,7 +49198,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_float",
         "kind": "static_from",
-        "line": 729,
+        "line": 723,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48936,7 +49212,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -48945,7 +49221,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_int",
         "kind": "static_from",
-        "line": 729,
+        "line": 723,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48959,7 +49235,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -48968,7 +49244,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_choice",
         "kind": "static_from",
-        "line": 729,
+        "line": 723,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48982,7 +49258,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -48991,7 +49267,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_single_value",
         "kind": "static_from",
-        "line": 729,
+        "line": 723,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49005,7 +49281,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -49014,7 +49290,7 @@
         "conditional": true,
         "imported": "easyuse_anima.seed.compatibility:WILDCARD_QUEUE_MAX_SAFE_SEED",
         "kind": "static_from",
-        "line": 736,
+        "line": 730,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49028,7 +49304,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -49037,7 +49313,7 @@
         "conditional": true,
         "imported": "easyuse_anima.seed.compatibility:WILDCARD_RESERVED_NEXT_SEED_INPUT",
         "kind": "static_from",
-        "line": 736,
+        "line": 730,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49051,7 +49327,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -49060,7 +49336,7 @@
         "conditional": true,
         "imported": "easyuse_anima.seed.compatibility:_consume_reserved_wildcard_next_seed",
         "kind": "static_from",
-        "line": 736,
+        "line": 730,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49074,7 +49350,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -49083,7 +49359,7 @@
         "conditional": true,
         "imported": "easyuse_anima.workflow:_get_workflow_node",
         "kind": "static_from",
-        "line": 741,
+        "line": 735,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49097,7 +49373,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -49106,7 +49382,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_prompt_translation_change_key",
         "kind": "static_from",
-        "line": 742,
+        "line": 736,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49120,7 +49396,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -49129,7 +49405,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_split_tag_text",
         "kind": "static_from",
-        "line": 742,
+        "line": 736,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49143,7 +49419,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -49152,7 +49428,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_translate_prompt_text",
         "kind": "static_from",
-        "line": 742,
+        "line": 736,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49166,7 +49442,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -49175,7 +49451,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_HASH_COMMENT_RE",
         "kind": "static_from",
-        "line": 747,
+        "line": 741,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49189,7 +49465,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -49198,7 +49474,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_INLINE_SPACE_RE",
         "kind": "static_from",
-        "line": 747,
+        "line": 741,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49212,7 +49488,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -49221,7 +49497,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_WEIGHTED_TOKEN_RE",
         "kind": "static_from",
-        "line": 747,
+        "line": 741,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49235,7 +49511,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -49244,7 +49520,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_correct_builder_prompt",
         "kind": "static_from",
-        "line": 747,
+        "line": 741,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49258,7 +49534,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -49267,7 +49543,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_filter_metadata_prompt",
         "kind": "static_from",
-        "line": 747,
+        "line": 741,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49281,7 +49557,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -49290,7 +49566,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_join_prompt_tokens",
         "kind": "static_from",
-        "line": 747,
+        "line": 741,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49304,7 +49580,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -49313,7 +49589,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_metadata_filter_key",
         "kind": "static_from",
-        "line": 747,
+        "line": 741,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49327,7 +49603,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -49336,7 +49612,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_metadata_filter_keys",
         "kind": "static_from",
-        "line": 747,
+        "line": 741,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49350,7 +49626,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -49359,7 +49635,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_prompt_tokens",
         "kind": "static_from",
-        "line": 747,
+        "line": 741,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49373,7 +49649,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -49382,7 +49658,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:PROMPT_DATA_TYPE",
         "kind": "static_from",
-        "line": 760,
+        "line": 754,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49396,7 +49672,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -49405,7 +49681,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_advanced_outputs_from_prompt_data",
         "kind": "static_from",
-        "line": 760,
+        "line": 754,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49419,7 +49695,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -49428,7 +49704,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_apply_prompt_data_overrides",
         "kind": "static_from",
-        "line": 760,
+        "line": 754,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49442,7 +49718,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -49451,7 +49727,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_copy_prompt_data_for_update",
         "kind": "static_from",
-        "line": 760,
+        "line": 754,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49465,7 +49741,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -49474,7 +49750,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_normalize_prompt_data",
         "kind": "static_from",
-        "line": 760,
+        "line": 754,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49488,7 +49764,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -49497,7 +49773,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_prompt_data_json_safe",
         "kind": "static_from",
-        "line": 760,
+        "line": 754,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49511,7 +49787,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -49520,7 +49796,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_prompt_data_parameter_snapshot",
         "kind": "static_from",
-        "line": 760,
+        "line": 754,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49534,7 +49810,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -49543,7 +49819,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_artist_field_prompt",
         "kind": "static_from",
-        "line": 778,
+        "line": 772,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49557,7 +49833,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -49566,7 +49842,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_default_fields",
         "kind": "static_from",
-        "line": 778,
+        "line": 772,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49580,7 +49856,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -49589,7 +49865,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_enabled_naia_panes",
         "kind": "static_from",
-        "line": 778,
+        "line": 772,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49603,7 +49879,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -49612,7 +49888,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_enabled_pane_fields",
         "kind": "static_from",
-        "line": 778,
+        "line": 772,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49626,7 +49902,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -49635,7 +49911,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_field_input_values",
         "kind": "static_from",
-        "line": 778,
+        "line": 772,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49649,7 +49925,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -49658,7 +49934,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_field_socket_name",
         "kind": "static_from",
-        "line": 778,
+        "line": 772,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49672,7 +49948,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -49681,7 +49957,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_fields_json",
         "kind": "static_from",
-        "line": 778,
+        "line": 772,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49695,7 +49971,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -49704,7 +49980,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_has_enabled_naia",
         "kind": "static_from",
-        "line": 778,
+        "line": 772,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49718,7 +49994,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -49727,7 +50003,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_prompt_with_artist_override",
         "kind": "static_from",
-        "line": 778,
+        "line": 772,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49741,7 +50017,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -49750,7 +50026,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_uses_naia_resolution",
         "kind": "static_from",
-        "line": 778,
+        "line": 772,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49764,7 +50040,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -49773,7 +50049,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_apply_advanced_field_inputs",
         "kind": "static_from",
-        "line": 778,
+        "line": 772,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49787,7 +50063,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -49796,7 +50072,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_as_advanced_height",
         "kind": "static_from",
-        "line": 778,
+        "line": 772,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49810,7 +50086,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -49819,7 +50095,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_build_advanced_prompt_data",
         "kind": "static_from",
-        "line": 778,
+        "line": 772,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49833,7 +50109,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -49842,7 +50118,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_build_advanced_prompts",
         "kind": "static_from",
-        "line": 778,
+        "line": 772,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49856,7 +50132,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -49865,7 +50141,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_clone_advanced_fields",
         "kind": "static_from",
-        "line": 778,
+        "line": 772,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49879,7 +50155,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -49888,7 +50164,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_correct_advanced_field_sequence",
         "kind": "static_from",
-        "line": 778,
+        "line": 772,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49902,7 +50178,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -49911,7 +50187,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_expand_advanced_wildcard_fields",
         "kind": "static_from",
-        "line": 778,
+        "line": 772,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49925,7 +50201,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -49934,7 +50210,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_normalize_advanced_fields",
         "kind": "static_from",
-        "line": 778,
+        "line": 772,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49948,7 +50224,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -49957,7 +50233,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_normalize_prompt_studio_wildcard_seed_control",
         "kind": "static_from",
-        "line": 778,
+        "line": 772,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49971,7 +50247,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -49980,7 +50256,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_set_naia_field_text",
         "kind": "static_from",
-        "line": 778,
+        "line": 772,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49994,7 +50270,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -50003,7 +50279,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_translate_prompt_fields",
         "kind": "static_from",
-        "line": 778,
+        "line": 772,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50017,7 +50293,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -50026,7 +50302,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_apply_regional_field_inputs",
         "kind": "static_from",
-        "line": 813,
+        "line": 807,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50040,7 +50316,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -50049,7 +50325,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_build_regional_outputs",
         "kind": "static_from",
-        "line": 813,
+        "line": 807,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50063,7 +50339,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -50072,7 +50348,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_clone_regional_fields",
         "kind": "static_from",
-        "line": 813,
+        "line": 807,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50086,7 +50362,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -50095,7 +50371,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_conditioning_set_values",
         "kind": "static_from",
-        "line": 813,
+        "line": 807,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50109,7 +50385,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -50118,7 +50394,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_mask_ids",
         "kind": "static_from",
-        "line": 813,
+        "line": 807,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50132,7 +50408,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -50141,7 +50417,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_regional_config",
         "kind": "static_from",
-        "line": 813,
+        "line": 807,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50155,7 +50431,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -50164,7 +50440,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_regional_fields",
         "kind": "static_from",
-        "line": 813,
+        "line": 807,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50178,7 +50454,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -50187,7 +50463,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_parse_json_object",
         "kind": "static_from",
-        "line": 813,
+        "line": 807,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50201,7 +50477,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -50210,7 +50486,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_config_json",
         "kind": "static_from",
-        "line": 813,
+        "line": 807,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50224,7 +50500,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -50233,7 +50509,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_fields_json",
         "kind": "static_from",
-        "line": 813,
+        "line": 807,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50247,7 +50523,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -50256,7 +50532,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_mask_bounds_area",
         "kind": "static_from",
-        "line": 813,
+        "line": 807,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50270,7 +50546,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -50279,7 +50555,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_payload_canvas",
         "kind": "static_from",
-        "line": 813,
+        "line": 807,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50293,7 +50569,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -50302,7 +50578,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_union_mask_for_ids",
         "kind": "static_from",
-        "line": 813,
+        "line": 807,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50316,7 +50592,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -50325,7 +50601,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
         "kind": "static_from",
-        "line": 840,
+        "line": 834,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50339,7 +50615,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -50348,7 +50624,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODES",
         "kind": "static_from",
-        "line": 840,
+        "line": 834,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50362,7 +50638,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -50371,7 +50647,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 840,
+        "line": 834,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50385,7 +50661,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -50394,7 +50670,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_PROFILE_OFF",
         "kind": "static_from",
-        "line": 840,
+        "line": 834,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50408,7 +50684,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -50417,7 +50693,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_apply_spectrum_anima_mod_guidance",
         "kind": "static_from",
-        "line": 840,
+        "line": 834,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50431,7 +50707,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -50440,7 +50716,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_find_spectrum_anima_mod_guidance_class",
         "kind": "static_from",
-        "line": 840,
+        "line": 834,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50454,7 +50730,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -50463,7 +50739,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_normalize_anima_mod_guidance_profile",
         "kind": "static_from",
-        "line": 840,
+        "line": 834,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50477,7 +50753,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -50486,7 +50762,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_resolve_anima_mod_guidance_enabled",
         "kind": "static_from",
-        "line": 840,
+        "line": 834,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50500,7 +50776,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -50509,7 +50785,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
         "kind": "static_from",
-        "line": 855,
+        "line": 849,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50523,7 +50799,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -50532,7 +50808,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
         "kind": "static_from",
-        "line": 855,
+        "line": 849,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50546,7 +50822,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -50555,7 +50831,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
         "kind": "static_from",
-        "line": 855,
+        "line": 849,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50569,7 +50845,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -50578,7 +50854,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_EXACT_TOP_K",
         "kind": "static_from",
-        "line": 855,
+        "line": 849,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50592,7 +50868,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -50601,7 +50877,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
         "kind": "static_from",
-        "line": 855,
+        "line": 849,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50615,7 +50891,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -50624,7 +50900,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_START_PERCENT",
         "kind": "static_from",
-        "line": 855,
+        "line": 849,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50638,7 +50914,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -50647,7 +50923,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
         "kind": "static_from",
-        "line": 855,
+        "line": 849,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50661,7 +50937,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -50670,7 +50946,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STYLE_GAIN",
         "kind": "static_from",
-        "line": 855,
+        "line": 849,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50684,7 +50960,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -50693,7 +50969,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_INPUT_MODES",
         "kind": "static_from",
-        "line": 855,
+        "line": 849,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50707,7 +50983,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -50716,7 +50992,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 855,
+        "line": 849,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50730,7 +51006,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -50739,7 +51015,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_mix_inline_prompt",
         "kind": "static_from",
-        "line": 855,
+        "line": 849,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50753,7 +51029,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -50762,7 +51038,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_mix_mode_tooltip",
         "kind": "static_from",
-        "line": 855,
+        "line": 849,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50776,7 +51052,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -50785,7 +51061,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_prompt_with_position",
         "kind": "static_from",
-        "line": 855,
+        "line": 849,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50799,7 +51075,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -50808,7 +51084,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_tags_from_prompt",
         "kind": "static_from",
-        "line": 855,
+        "line": 849,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50822,7 +51098,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -50831,7 +51107,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_blend_conditionings",
         "kind": "static_from",
-        "line": 855,
+        "line": 849,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50845,7 +51121,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -50854,7 +51130,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bounded_artist_mix_float",
         "kind": "static_from",
-        "line": 855,
+        "line": 849,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50868,7 +51144,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -50877,7 +51153,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bounded_artist_mix_int",
         "kind": "static_from",
-        "line": 855,
+        "line": 849,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50891,7 +51167,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -50900,7 +51176,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_clustered",
         "kind": "static_from",
-        "line": 855,
+        "line": 849,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50914,7 +51190,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -50923,7 +51199,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_delta_rms",
         "kind": "static_from",
-        "line": 855,
+        "line": 849,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50937,7 +51213,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -50946,7 +51222,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_prompt_data_positive_conditioning",
         "kind": "static_from",
-        "line": 855,
+        "line": 849,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50960,7 +51236,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -50969,7 +51245,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_join_artist_mix_source_prompts",
         "kind": "static_from",
-        "line": 855,
+        "line": 849,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50983,7 +51259,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -50992,7 +51268,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_normalize_artist_mix_mode",
         "kind": "static_from",
-        "line": 855,
+        "line": 849,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51006,7 +51282,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -51015,7 +51291,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_normalize_artist_tag_position",
         "kind": "static_from",
-        "line": 855,
+        "line": 849,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51029,7 +51305,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -51038,7 +51314,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_parse_artist_mix_items",
         "kind": "static_from",
-        "line": 855,
+        "line": 849,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51052,7 +51328,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -51061,7 +51337,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaArtistMixConditioning",
         "kind": "static_from",
-        "line": 934,
+        "line": 928,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51075,7 +51351,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -51084,7 +51360,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataConditioning",
         "kind": "static_from",
-        "line": 934,
+        "line": 928,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51098,7 +51374,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -51107,7 +51383,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataUnpack",
         "kind": "static_from",
-        "line": 934,
+        "line": 928,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51121,7 +51397,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -51130,7 +51406,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_ANY_TYPE",
         "kind": "static_from",
-        "line": 939,
+        "line": 933,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51144,7 +51420,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -51153,7 +51429,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_AnyType",
         "kind": "static_from",
-        "line": 939,
+        "line": 933,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51167,7 +51443,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -51176,7 +51452,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_FlexibleOptionalInputType",
         "kind": "static_from",
-        "line": 939,
+        "line": 933,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51190,7 +51466,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -51199,7 +51475,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvanced",
         "kind": "static_from",
-        "line": 944,
+        "line": 938,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51213,7 +51489,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -51222,7 +51498,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvancedV2",
         "kind": "static_from",
-        "line": 944,
+        "line": 938,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51236,7 +51512,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -51245,7 +51521,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:EasyUseAnimaAIOGenerator",
         "kind": "static_from",
-        "line": 949,
+        "line": 943,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51259,7 +51535,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -51268,7 +51544,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:EasyUseAnimaInput",
         "kind": "static_from",
-        "line": 949,
+        "line": 943,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51282,7 +51558,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -51291,7 +51567,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_aio_generation_settings_json",
         "kind": "static_from",
-        "line": 949,
+        "line": 943,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51305,7 +51581,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -51314,7 +51590,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_aio_input_settings_json",
         "kind": "static_from",
-        "line": 949,
+        "line": 943,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51328,7 +51604,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -51337,7 +51613,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_bind_aio_node_runtime",
         "kind": "static_from",
-        "line": 949,
+        "line": 943,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51351,7 +51627,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -51360,7 +51636,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_easy_use_anima_input_signature",
         "kind": "static_from",
-        "line": 949,
+        "line": 943,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51374,7 +51650,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -51383,7 +51659,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_require_easy_use_anima_input",
         "kind": "static_from",
-        "line": 949,
+        "line": 943,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51397,7 +51673,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -51406,7 +51682,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_align_down",
         "kind": "static_from",
-        "line": 958,
+        "line": 952,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51420,7 +51696,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -51429,7 +51705,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_align_nearest",
         "kind": "static_from",
-        "line": 958,
+        "line": 952,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51443,7 +51719,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -51452,7 +51728,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_image_tensor_size",
         "kind": "static_from",
-        "line": 958,
+        "line": 952,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51466,7 +51742,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -51475,7 +51751,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_context_value",
         "kind": "static_from",
-        "line": 969,
+        "line": 963,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51489,7 +51765,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -51498,7 +51774,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_sam3_context",
         "kind": "static_from",
-        "line": 969,
+        "line": 963,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51512,7 +51788,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -51521,7 +51797,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_segs_has_items",
         "kind": "static_from",
-        "line": 969,
+        "line": 963,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51535,7 +51811,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -51544,7 +51820,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:IMAGE_SCALE_MULTIPLES",
         "kind": "static_from",
-        "line": 981,
+        "line": 975,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51558,7 +51834,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -51567,7 +51843,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:IMAGE_UPSCALE_METHODS",
         "kind": "static_from",
-        "line": 981,
+        "line": 975,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51581,7 +51857,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -51590,7 +51866,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_sampler_names",
         "kind": "static_from",
-        "line": 989,
+        "line": 983,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51604,7 +51880,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -51613,7 +51889,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_scheduler_names",
         "kind": "static_from",
-        "line": 989,
+        "line": 983,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51627,7 +51903,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -51636,7 +51912,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_impact_scheduler_names",
         "kind": "static_from",
-        "line": 989,
+        "line": 983,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51650,7 +51926,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -51659,7 +51935,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_call_with_supported_kwargs",
         "kind": "static_from",
-        "line": 995,
+        "line": 989,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51673,7 +51949,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -51682,7 +51958,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_common_upscale_image",
         "kind": "static_from",
-        "line": 995,
+        "line": 989,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51696,7 +51972,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -51705,7 +51981,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_node_output_tuple",
         "kind": "static_from",
-        "line": 995,
+        "line": 989,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51719,7 +51995,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -51728,7 +52004,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.wiring:resolve_comfy_host_helper",
         "kind": "static_from",
-        "line": 1000,
+        "line": 994,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51742,7 +52018,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -51751,7 +52027,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_clip_loader_types",
         "kind": "static_from",
-        "line": 1003,
+        "line": 997,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51765,7 +52041,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -51774,7 +52050,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_diffusion_model_names",
         "kind": "static_from",
-        "line": 1003,
+        "line": 997,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51788,7 +52064,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -51797,7 +52073,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_text_encoder_names",
         "kind": "static_from",
-        "line": 1003,
+        "line": 997,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51811,7 +52087,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -51820,7 +52096,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_vae_names",
         "kind": "static_from",
-        "line": 1003,
+        "line": 997,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51834,7 +52110,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -51843,7 +52119,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_folder_path_names",
         "kind": "static_from",
-        "line": 1003,
+        "line": 997,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51857,7 +52133,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -51866,7 +52142,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.image_nodes:EasyUseAnimaDetailerAlignHook",
         "kind": "static_from",
-        "line": 1011,
+        "line": 1005,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51880,7 +52156,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -51889,7 +52165,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.image_nodes:EasyUseAnimaImageScaleByMultiple",
         "kind": "static_from",
-        "line": 1011,
+        "line": 1005,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51903,7 +52179,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -51912,7 +52188,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Context",
         "kind": "static_from",
-        "line": 1015,
+        "line": 1009,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51926,7 +52202,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -51935,7 +52211,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Detailer",
         "kind": "static_from",
-        "line": 1015,
+        "line": 1009,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51949,7 +52225,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -51958,7 +52234,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptBuilder",
         "kind": "static_from",
-        "line": 1019,
+        "line": 1013,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51972,7 +52248,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -51981,7 +52257,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrector",
         "kind": "static_from",
-        "line": 1019,
+        "line": 1013,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51995,7 +52271,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -52004,7 +52280,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrectorSimple",
         "kind": "static_from",
-        "line": 1019,
+        "line": 1013,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52018,7 +52294,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -52027,7 +52303,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptStudio",
         "kind": "static_from",
-        "line": 1019,
+        "line": 1013,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52041,7 +52317,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -52050,7 +52326,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:EasyUseAnimaPromptStudioRegional",
         "kind": "static_from",
-        "line": 1025,
+        "line": 1019,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52064,7 +52340,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -52073,7 +52349,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:EasyUseAnimaRegionalConditioning",
         "kind": "static_from",
-        "line": 1025,
+        "line": 1019,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52087,7 +52363,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -52096,7 +52372,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:LATENT_ALIGN",
         "kind": "static_from",
-        "line": 1029,
+        "line": 1023,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52110,7 +52386,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -52119,7 +52395,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_parse_random_response",
         "kind": "static_from",
-        "line": 1029,
+        "line": 1023,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52133,7 +52409,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -52142,7 +52418,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_post_random",
         "kind": "static_from",
-        "line": 1029,
+        "line": 1023,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52156,7 +52432,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -52165,7 +52441,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_advanced_resolution_from_selection",
         "kind": "static_from",
-        "line": 1047,
+        "line": 1041,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52179,7 +52455,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -52188,7 +52464,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_normalize_resolution_bucket",
         "kind": "static_from",
-        "line": 1047,
+        "line": 1041,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52202,7 +52478,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -52211,7 +52487,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_ratio_label",
         "kind": "static_from",
-        "line": 1047,
+        "line": 1041,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52225,7 +52501,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -52234,7 +52510,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolution_label",
         "kind": "static_from",
-        "line": 1047,
+        "line": 1041,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52248,7 +52524,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -52257,7 +52533,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolve_naia_resolution",
         "kind": "static_from",
-        "line": 1047,
+        "line": 1041,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52271,7 +52547,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -52280,7 +52556,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.naia_nodes:EasyUseAnimaNAIARandomPrompt",
         "kind": "static_from",
-        "line": 1070,
+        "line": 1064,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52294,7 +52570,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -52303,7 +52579,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.naia_nodes:_bind_naia_node_runtime",
         "kind": "static_from",
-        "line": 1070,
+        "line": 1064,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52317,7 +52593,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -52326,7 +52602,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.wildcard_nodes:EasyUseAnimaWildcard",
         "kind": "static_from",
-        "line": 1074,
+        "line": 1068,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52340,7 +52616,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -52349,7 +52625,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.wildcard_nodes:_bind_wildcard_node_runtime",
         "kind": "static_from",
-        "line": 1074,
+        "line": 1068,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52363,7 +52639,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -52372,7 +52648,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_apply_lora_syntax_format",
         "kind": "static_from",
-        "line": 1079,
+        "line": 1073,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52386,7 +52662,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -52395,7 +52671,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_dedupe_text_values",
         "kind": "static_from",
-        "line": 1079,
+        "line": 1073,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52409,7 +52685,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -52418,7 +52694,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_fallback_lora_path",
         "kind": "static_from",
-        "line": 1079,
+        "line": 1073,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52432,7 +52708,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -52441,7 +52717,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_get_lora_info",
         "kind": "static_from",
-        "line": 1079,
+        "line": 1073,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52455,7 +52731,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -52464,7 +52740,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_get_lora_manager_trigger_words",
         "kind": "static_from",
-        "line": 1079,
+        "line": 1073,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52478,7 +52754,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -52487,7 +52763,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_load_lora_manager_metadata",
         "kind": "static_from",
-        "line": 1079,
+        "line": 1073,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52501,7 +52777,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -52510,7 +52786,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_combo_values",
         "kind": "static_from",
-        "line": 1079,
+        "line": 1073,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52524,7 +52800,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -52533,7 +52809,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_manager_trigger_words_from_metadata",
         "kind": "static_from",
-        "line": 1079,
+        "line": 1073,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52547,7 +52823,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -52556,7 +52832,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_model_exists",
         "kind": "static_from",
-        "line": 1079,
+        "line": 1073,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52570,7 +52846,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -52579,7 +52855,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_stack_name",
         "kind": "static_from",
-        "line": 1079,
+        "line": 1073,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52593,7 +52869,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -52602,7 +52878,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_metadata_json_paths_for_lora",
         "kind": "static_from",
-        "line": 1079,
+        "line": 1073,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52616,7 +52892,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -52625,7 +52901,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_missing_lora_display_name",
         "kind": "static_from",
-        "line": 1079,
+        "line": 1073,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52639,7 +52915,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -52648,7 +52924,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_raise_missing_loras",
         "kind": "static_from",
-        "line": 1079,
+        "line": 1073,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52662,7 +52938,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -52671,7 +52947,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_trigger_words_from_value",
         "kind": "static_from",
-        "line": 1079,
+        "line": 1073,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52685,7 +52961,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -52694,7 +52970,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_correct_style_prompt",
         "kind": "static_from",
-        "line": 1095,
+        "line": 1089,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52708,7 +52984,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -52717,7 +52993,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_format_strength",
         "kind": "static_from",
-        "line": 1095,
+        "line": 1089,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52731,7 +53007,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -52740,7 +53016,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_get_loras_list",
         "kind": "static_from",
-        "line": 1095,
+        "line": 1089,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52754,7 +53030,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -52763,7 +53039,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_load_profile_data",
         "kind": "static_from",
-        "line": 1095,
+        "line": 1089,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52777,7 +53053,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -52786,7 +53062,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_profile_key",
         "kind": "static_from",
-        "line": 1095,
+        "line": 1089,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52800,7 +53076,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -52809,7 +53085,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_select_profile_values",
         "kind": "static_from",
-        "line": 1095,
+        "line": 1089,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52823,7 +53099,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -52832,7 +53108,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_wrap_profile_index",
         "kind": "static_from",
-        "line": 1095,
+        "line": 1089,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52846,7 +53122,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -52855,7 +53131,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.lora_nodes:EasyUseAnimaLoraPreset",
         "kind": "static_from",
-        "line": 1104,
+        "line": 1098,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52869,7 +53145,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -52878,7 +53154,7 @@
         "conditional": true,
         "imported": "anima_prompt:correct_prompt",
         "kind": "static_from",
-        "line": 1107,
+        "line": 1101,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52892,7 +53168,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -52901,7 +53177,7 @@
         "conditional": true,
         "imported": "anima_prompt:load_knowledge_base",
         "kind": "static_from",
-        "line": 1107,
+        "line": 1101,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52915,7 +53191,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -52924,7 +53200,7 @@
         "conditional": true,
         "imported": "anima_prompt.parser:parse_prompt",
         "kind": "static_from",
-        "line": 1108,
+        "line": 1102,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52938,7 +53214,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -52947,7 +53223,7 @@
         "conditional": true,
         "imported": "settings:resolve_metadata_filter_words",
         "kind": "static_from",
-        "line": 1109,
+        "line": 1103,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52961,7 +53237,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -52970,7 +53246,7 @@
         "conditional": true,
         "imported": "settings:resolve_naia_settings",
         "kind": "static_from",
-        "line": 1109,
+        "line": 1103,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52984,7 +53260,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -52993,7 +53269,7 @@
         "conditional": true,
         "imported": "settings:resolve_prompt_translation_settings",
         "kind": "static_from",
-        "line": 1109,
+        "line": 1103,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53007,7 +53283,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -53016,7 +53292,7 @@
         "conditional": true,
         "imported": "prompt_translation:has_prompt_translation_markers",
         "kind": "static_from",
-        "line": 1114,
+        "line": 1108,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53030,7 +53306,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -53039,7 +53315,7 @@
         "conditional": true,
         "imported": "prompt_translation:translate_prompt_markers",
         "kind": "static_from",
-        "line": 1114,
+        "line": 1108,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53053,7 +53329,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -53062,7 +53338,7 @@
         "conditional": true,
         "imported": "wildcard_engine:MAX_SEED",
         "kind": "static_from",
-        "line": 1115,
+        "line": 1109,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53076,7 +53352,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -53085,7 +53361,7 @@
         "conditional": true,
         "imported": "wildcard_engine:PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "kind": "static_from",
-        "line": 1115,
+        "line": 1109,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53099,7 +53375,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -53108,7 +53384,7 @@
         "conditional": true,
         "imported": "wildcard_engine:PUBLIC_MAX_SEED",
         "kind": "static_from",
-        "line": 1115,
+        "line": 1109,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53122,7 +53398,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -53131,7 +53407,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_DECREMENT",
         "kind": "static_from",
-        "line": 1115,
+        "line": 1109,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53145,7 +53421,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -53154,7 +53430,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_FIXED",
         "kind": "static_from",
-        "line": 1115,
+        "line": 1109,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53168,7 +53444,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -53177,7 +53453,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_INCREMENT",
         "kind": "static_from",
-        "line": 1115,
+        "line": 1109,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53191,7 +53467,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -53200,7 +53476,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_MODES",
         "kind": "static_from",
-        "line": 1115,
+        "line": 1109,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53214,7 +53490,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -53223,7 +53499,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_RANDOMIZE",
         "kind": "static_from",
-        "line": 1115,
+        "line": 1109,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53237,7 +53513,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -53246,7 +53522,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_FIXED",
         "kind": "static_from",
-        "line": 1115,
+        "line": 1109,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53260,7 +53536,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -53269,7 +53545,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_POPULATE",
         "kind": "static_from",
-        "line": 1115,
+        "line": 1109,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53283,7 +53559,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -53292,7 +53568,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_SEQUENTIAL",
         "kind": "static_from",
-        "line": 1115,
+        "line": 1109,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53306,7 +53582,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -53315,7 +53591,7 @@
         "conditional": true,
         "imported": "wildcard_engine:expand_wildcard_texts",
         "kind": "static_from",
-        "line": 1115,
+        "line": 1109,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53329,7 +53605,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -53338,7 +53614,7 @@
         "conditional": true,
         "imported": "wildcard_engine:expand_wildcards",
         "kind": "static_from",
-        "line": 1115,
+        "line": 1109,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53352,7 +53628,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -53361,7 +53637,7 @@
         "conditional": true,
         "imported": "wildcard_engine:has_wildcard_syntax",
         "kind": "static_from",
-        "line": 1115,
+        "line": 1109,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53375,7 +53651,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -53384,7 +53660,7 @@
         "conditional": true,
         "imported": "wildcard_engine:next_seed",
         "kind": "static_from",
-        "line": 1115,
+        "line": 1109,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53398,7 +53674,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -53407,7 +53683,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_prompt_studio_wildcard_mode",
         "kind": "static_from",
-        "line": 1115,
+        "line": 1109,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53421,7 +53697,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -53430,7 +53706,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_seed",
         "kind": "static_from",
-        "line": 1115,
+        "line": 1109,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53444,7 +53720,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -53453,7 +53729,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_wildcard_mode",
         "kind": "static_from",
-        "line": 1115,
+        "line": 1109,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53467,7 +53743,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 569,
             "kind": "try",
             "line": 8
           }
@@ -53476,7 +53752,7 @@
         "conditional": true,
         "imported": "wildcard_engine:wildcard_sources_signature",
         "kind": "static_from",
-        "line": 1115,
+        "line": 1109,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54490,31 +54766,9 @@
         "branch_context": [],
         "classification": "external",
         "conditional": false,
-        "imported": "collections.abc:Callable",
-        "kind": "static_from",
-        "line": 5,
-        "optional": false,
-        "role": "ordinary",
-        "source": "easyuse_anima/aio/conditioning.py"
-      },
-      {
-        "branch_context": [],
-        "classification": "external",
-        "conditional": false,
         "imported": "typing:Any",
         "kind": "static_from",
-        "line": 6,
-        "optional": false,
-        "role": "ordinary",
-        "source": "easyuse_anima/aio/conditioning.py"
-      },
-      {
-        "branch_context": [],
-        "classification": "external",
-        "conditional": false,
-        "imported": "typing:TypeAlias",
-        "kind": "static_from",
-        "line": 6,
+        "line": 5,
         "optional": false,
         "role": "ordinary",
         "source": "easyuse_anima/aio/conditioning.py"
@@ -54930,8 +55184,8 @@
         "branch_context": [],
         "classification": "external",
         "conditional": false,
-        "imported": "collections.abc:Callable",
-        "kind": "static_from",
+        "imported": "logging",
+        "kind": "static_import",
         "line": 6,
         "optional": false,
         "role": "ordinary",
@@ -54949,31 +55203,20 @@
         "source": "easyuse_anima/aio/model_preparation.py"
       },
       {
-        "branch_context": [],
-        "classification": "external",
-        "conditional": false,
-        "imported": "typing:TypeAlias",
-        "kind": "static_from",
-        "line": 7,
-        "optional": false,
-        "role": "ordinary",
-        "source": "easyuse_anima/aio/model_preparation.py"
-      },
-      {
         "branch_context": [
           {
             "branch": "body",
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 309
+            "line": 315
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "comfy.model_management",
         "kind": "static_import",
-        "line": 310,
+        "line": 316,
         "optional": true,
         "role": "optional_dependency",
         "source": "easyuse_anima/aio/model_preparation.py"
@@ -55330,8 +55573,8 @@
         "branch_context": [],
         "classification": "external",
         "conditional": false,
-        "imported": "collections.abc:Callable",
-        "kind": "static_from",
+        "imported": "random",
+        "kind": "static_import",
         "line": 5,
         "optional": false,
         "role": "ordinary",
@@ -55342,17 +55585,6 @@
         "classification": "external",
         "conditional": false,
         "imported": "typing:Any",
-        "kind": "static_from",
-        "line": 6,
-        "optional": false,
-        "role": "ordinary",
-        "source": "easyuse_anima/aio/sampling.py"
-      },
-      {
-        "branch_context": [],
-        "classification": "external",
-        "conditional": false,
-        "imported": "typing:TypeAlias",
         "kind": "static_from",
         "line": 6,
         "optional": false,
@@ -58064,14 +58296,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 309
+            "line": 315
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "comfy.model_management",
         "kind": "static_import",
-        "line": 310,
+        "line": 316,
         "optional": true,
         "role": "optional_dependency",
         "source": "easyuse_anima/aio/model_preparation.py"
@@ -59854,6 +60086,15 @@
         "column": 9,
         "context": "assign:logger",
         "kind": "import_time_call",
+        "line": 17,
+        "module": "easyuse_anima/aio/model_preparation.py",
+        "scope": "<module>"
+      },
+      {
+        "callee": "logging.getLogger",
+        "column": 9,
+        "context": "assign:logger",
+        "kind": "import_time_call",
         "line": 21,
         "module": "easyuse_anima/aio/output.py",
         "scope": "<module>"
@@ -60151,7 +60392,7 @@
         "column": 9,
         "context": "assign:logger",
         "kind": "import_time_call",
-        "line": 1137,
+        "line": 1131,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -60160,34 +60401,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1143,
-        "module": "nodes.py",
-        "scope": "<module>"
-      },
-      {
-        "callee": "_bind_aio_model_preparation_runtime",
-        "column": 0,
-        "context": "expression",
-        "kind": "import_time_call",
-        "line": 1149,
-        "module": "nodes.py",
-        "scope": "<module>"
-      },
-      {
-        "callee": "_bind_aio_sampling_runtime",
-        "column": 0,
-        "context": "expression",
-        "kind": "import_time_call",
-        "line": 1155,
-        "module": "nodes.py",
-        "scope": "<module>"
-      },
-      {
-        "callee": "_bind_aio_conditioning_runtime",
-        "column": 0,
-        "context": "expression",
-        "kind": "import_time_call",
-        "line": 1161,
+        "line": 1137,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -60196,7 +60410,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1167,
+        "line": 1143,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -60205,7 +60419,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1170,
+        "line": 1146,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -60214,7 +60428,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1177,
+        "line": 1153,
         "module": "nodes.py",
         "scope": "<module>"
       },

--- a/tests/fixtures/python_compatibility_surface.v1.json
+++ b/tests/fixtures/python_compatibility_surface.v1.json
@@ -111,14 +111,14 @@
   "expected_counts": {
     "root_entrypoints": 3,
     "excluded_preamble_implementation_bindings": 3,
-    "nodes_canonical_bindings": 296,
+    "nodes_canonical_bindings": 293,
     "nodes_legacy_bindings": 27,
     "mapped_public_classes": 18,
     "unmapped_classes": 2,
     "root_residual_functions": 0,
     "root_residual_classes": 0,
     "root_residual_globals": 3,
-    "runtime_binders": 7,
+    "runtime_binders": 4,
     "direct_nodes_import_test_files": 21
   },
   "mapped_public_classes": [
@@ -152,9 +152,6 @@
   },
   "runtime_binders": [
     "_bind_aio_legacy_generation_runtime",
-    "_bind_aio_model_preparation_runtime",
-    "_bind_aio_sampling_runtime",
-    "_bind_aio_conditioning_runtime",
     "_bind_aio_node_runtime",
     "_bind_wildcard_node_runtime",
     "_bind_naia_node_runtime"
@@ -167,15 +164,10 @@
       "easyuse_anima.nodes.aio_nodes"
     ],
     "AIO_SPECIAL_SEEDS": [
-      "easyuse_anima.aio.sampling",
       "easyuse_anima.nodes.aio_nodes"
     ],
     "AIO_USDU_PROMPT_FULL": [
-      "easyuse_anima.aio.conditioning",
       "easyuse_anima.aio.legacy_generation"
-    ],
-    "AIO_USDU_PROMPT_NO_GENERAL": [
-      "easyuse_anima.aio.conditioning"
     ],
     "ANIMA_DEFAULT_CLIP_CANDIDATES": [
       "easyuse_anima.nodes.aio_nodes"
@@ -186,12 +178,8 @@
     "ANIMA_DEFAULT_VAE_CANDIDATES": [
       "easyuse_anima.nodes.aio_nodes"
     ],
-    "ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE": [
-      "easyuse_anima.aio.sampling"
-    ],
     "ANIMA_MOD_GUIDANCE_PROFILE_OFF": [
-      "easyuse_anima.aio.legacy_generation",
-      "easyuse_anima.aio.sampling"
+      "easyuse_anima.aio.legacy_generation"
     ],
     "EASY_USE_ANIMA_INPUT_SCHEMA": [
       "easyuse_anima.nodes.aio_nodes"
@@ -208,20 +196,8 @@
     "EasyUseAnimaSAM3Detailer": [
       "easyuse_anima.aio.legacy_generation"
     ],
-    "MAX_SEED": [
-      "easyuse_anima.aio.sampling"
-    ],
     "PROMPT_DATA_TYPE": [
       "easyuse_anima.nodes.aio_nodes"
-    ],
-    "SEED_CONTROL_FIXED": [
-      "easyuse_anima.aio.sampling"
-    ],
-    "_advanced_artist_field_prompt": [
-      "easyuse_anima.aio.conditioning"
-    ],
-    "_advanced_enabled_pane_fields": [
-      "easyuse_anima.aio.conditioning"
     ],
     "_advanced_outputs_from_prompt_data": [
       "easyuse_anima.aio.legacy_generation"
@@ -247,9 +223,6 @@
     "_aio_lora_stack_signature": [
       "easyuse_anima.nodes.aio_nodes"
     ],
-    "_aio_prompt_data_fields_for_usdu": [
-      "easyuse_anima.aio.conditioning"
-    ],
     "_aio_save_filename_prefix": [
       "easyuse_anima.aio.legacy_generation"
     ],
@@ -259,32 +232,14 @@
     "_aio_usdu_conditioning": [
       "easyuse_anima.aio.legacy_generation"
     ],
-    "_aio_usdu_prompt_without_general": [
-      "easyuse_anima.aio.conditioning"
-    ],
     "_aio_usdu_tile_plan": [
       "easyuse_anima.aio.legacy_generation"
-    ],
-    "_apply_aio_anima_dave_patch": [
-      "easyuse_anima.aio.model_preparation"
-    ],
-    "_apply_aio_kj_model_patches": [
-      "easyuse_anima.aio.model_preparation"
     ],
     "_apply_aio_lora_stack": [
       "easyuse_anima.aio.legacy_generation"
     ],
     "_apply_aio_model_patches": [
       "easyuse_anima.aio.legacy_generation"
-    ],
-    "_apply_aio_safe_pag_patch": [
-      "easyuse_anima.aio.model_preparation"
-    ],
-    "_apply_aio_spectrum_correction_patch_for_comfy_sampler": [
-      "easyuse_anima.aio.model_preparation"
-    ],
-    "_apply_aio_spectrum_forecast_patch_for_comfy_sampler": [
-      "easyuse_anima.aio.model_preparation"
     ],
     "_apply_aio_spectrum_model_patches_for_comfy_sampler": [
       "easyuse_anima.aio.legacy_generation"
@@ -293,24 +248,13 @@
       "easyuse_anima.aio.legacy_generation"
     ],
     "_as_bool": [
-      "easyuse_anima.aio.conditioning",
-      "easyuse_anima.aio.legacy_generation",
-      "easyuse_anima.aio.model_preparation",
-      "easyuse_anima.aio.sampling"
+      "easyuse_anima.aio.legacy_generation"
     ],
     "_as_float": [
-      "easyuse_anima.aio.legacy_generation",
-      "easyuse_anima.aio.model_preparation",
-      "easyuse_anima.aio.sampling"
+      "easyuse_anima.aio.legacy_generation"
     ],
     "_as_int": [
-      "easyuse_anima.aio.legacy_generation",
-      "easyuse_anima.aio.model_preparation",
-      "easyuse_anima.aio.sampling"
-    ],
-    "_call_with_supported_kwargs": [
-      "easyuse_anima.aio.model_preparation",
-      "easyuse_anima.aio.sampling"
+      "easyuse_anima.aio.legacy_generation"
     ],
     "_cleanup_aio_ephemeral_model": [
       "easyuse_anima.aio.legacy_generation"
@@ -332,9 +276,6 @@
     ],
     "_copy_prompt_data_for_update": [
       "easyuse_anima.nodes.aio_nodes"
-    ],
-    "_correct_advanced_field_sequence": [
-      "easyuse_anima.aio.conditioning"
     ],
     "_decode_latent_with_comfy": [
       "easyuse_anima.aio.legacy_generation"
@@ -358,7 +299,6 @@
       "easyuse_anima.aio.legacy_generation"
     ],
     "_json_clone": [
-      "easyuse_anima.aio.sampling",
       "easyuse_anima.nodes.aio_nodes"
     ],
     "_load_aio_resources_from_input_context": [
@@ -370,19 +310,8 @@
     "_load_upscale_model_with_comfy": [
       "easyuse_anima.aio.legacy_generation"
     ],
-    "_lora_stack_name": [
-      "easyuse_anima.aio.model_preparation"
-    ],
-    "_new_aio_random_seed": [
-      "easyuse_anima.aio.sampling"
-    ],
     "_node_output_tuple": [
-      "easyuse_anima.aio.legacy_generation",
-      "easyuse_anima.aio.model_preparation",
-      "easyuse_anima.aio.sampling"
-    ],
-    "_normalize_advanced_fields": [
-      "easyuse_anima.aio.conditioning"
+      "easyuse_anima.aio.legacy_generation"
     ],
     "_normalize_aio_generation_settings": [
       "easyuse_anima.aio.legacy_generation",
@@ -391,23 +320,12 @@
     "_normalize_aio_input_settings": [
       "easyuse_anima.nodes.aio_nodes"
     ],
-    "_normalize_aio_lora_stack": [
-      "easyuse_anima.aio.model_preparation"
-    ],
-    "_normalize_aio_seed": [
-      "easyuse_anima.aio.sampling"
-    ],
     "_normalize_anima_mod_guidance_profile": [
-      "easyuse_anima.aio.legacy_generation",
-      "easyuse_anima.aio.sampling"
+      "easyuse_anima.aio.legacy_generation"
     ],
     "_normalize_prompt_data": [
-      "easyuse_anima.aio.conditioning",
       "easyuse_anima.aio.legacy_generation",
       "easyuse_anima.nodes.aio_nodes"
-    ],
-    "_patch_model_sampling_aura_flow": [
-      "easyuse_anima.aio.model_preparation"
     ],
     "_preferred_clip_type_default": [
       "easyuse_anima.nodes.aio_nodes"
@@ -430,7 +348,6 @@
     ],
     "_resolve_aio_runtime_seed": [
       "easyuse_anima.aio.legacy_generation",
-      "easyuse_anima.aio.sampling",
       "easyuse_anima.nodes.aio_nodes"
     ],
     "_resolve_anima_mod_guidance_enabled": [
@@ -463,15 +380,6 @@
     "_sample_latent_with_aio_backend": [
       "easyuse_anima.aio.legacy_generation"
     ],
-    "_sample_latent_with_comfy": [
-      "easyuse_anima.aio.sampling"
-    ],
-    "_sample_latent_with_spectrum_mod_guidance_advanced": [
-      "easyuse_anima.aio.sampling"
-    ],
-    "_sample_latent_with_spectrum_spd": [
-      "easyuse_anima.aio.sampling"
-    ],
     "_save_aio_temp_preview_image": [
       "easyuse_anima.aio.legacy_generation"
     ],
@@ -497,35 +405,31 @@
       "easyuse_anima.aio.legacy_generation"
     ],
     "logger": [
-      "easyuse_anima.aio.legacy_generation",
-      "easyuse_anima.aio.model_preparation"
+      "easyuse_anima.aio.legacy_generation"
     ]
   },
   "runtime_binder_audit": {
     "summary": {
-      "binder_count": 7,
+      "binder_count": 4,
       "family_count": 2,
       "mode_counts": {
-        "comfy_provider_then_root": 4,
+        "comfy_provider_then_root": 1,
         "root_globals": 1,
         "explicit_callbacks": 2
       },
-      "unique_resolver_names": 112,
-      "unique_root_resolver_names": 108,
-      "unique_provider_resolver_names": 4,
+      "unique_resolver_names": 86,
+      "unique_root_resolver_names": 84,
+      "unique_provider_resolver_names": 2,
       "unique_direct_root_dependencies": 9,
-      "direct_root_dependency_slots": 13,
-      "provider_consumer_slots": 8,
-      "provider_consumer_modules": 4,
-      "repository_replacement_names": 85,
-      "repository_replacement_files": 8
+      "direct_root_dependency_slots": 10,
+      "provider_consumer_slots": 2,
+      "provider_consumer_modules": 1,
+      "repository_replacement_names": 71,
+      "repository_replacement_files": 5
     },
     "families": {
       "aio": [
         "_bind_aio_legacy_generation_runtime",
-        "_bind_aio_model_preparation_runtime",
-        "_bind_aio_sampling_runtime",
-        "_bind_aio_conditioning_runtime",
         "_bind_aio_node_runtime"
       ],
       "wildcard_naia": [
@@ -545,40 +449,10 @@
       "retired_subgroups": [
         "B-11c30d1_cache_state",
         "B-11c30d2_normalization_planning",
-        "B-11c30d3_io_boundary"
+        "B-11c30d3_io_boundary",
+        "B-11c30d4_execution_services"
       ],
       "subgroups": {
-        "B-11c30d4_execution_services": {
-          "binders": [
-            "_bind_aio_model_preparation_runtime",
-            "_bind_aio_sampling_runtime",
-            "_bind_aio_conditioning_runtime"
-          ],
-          "mode_counts": {
-            "comfy_provider_then_root": 3,
-            "root_globals": 0
-          },
-          "bound_global_slots": 3,
-          "unique_bound_globals": [
-            "_RUNTIME_RESOLVER"
-          ],
-          "root_resolver_slots": 43,
-          "unique_root_resolver_names": 37,
-          "provider_resolver_slots": 6,
-          "unique_provider_resolver_names": 4,
-          "direct_root_dependency_slots": 3,
-          "unique_direct_root_dependencies": 1,
-          "repository_replacement_slots": 23,
-          "unique_repository_replacement_names": 21,
-          "repository_replacement_files": [
-            "tests/test_aio_conditioning.py",
-            "tests/test_aio_legacy_generation.py",
-            "tests/test_aio_model_preparation.py",
-            "tests/test_aio_nodes.py",
-            "tests/test_aio_sampling.py",
-            "tests/test_node_contracts.py"
-          ]
-        },
         "B-11c30d5_legacy_orchestration": {
           "binders": [
             "_bind_aio_legacy_generation_runtime"
@@ -602,7 +476,6 @@
           "repository_replacement_files": [
             "tests/test_aio_legacy_generation.py",
             "tests/test_aio_nodes.py",
-            "tests/test_aio_sampling.py",
             "tests/test_node_contracts.py"
           ]
         },
@@ -629,7 +502,6 @@
           "repository_replacement_files": [
             "tests/test_aio_legacy_generation.py",
             "tests/test_aio_nodes.py",
-            "tests/test_aio_sampling.py",
             "tests/test_node_contracts.py"
           ]
         }
@@ -689,22 +561,16 @@
       "AIO_INPUT_DEFAULT_SETTINGS",
       "AIO_SPECIAL_SEEDS",
       "AIO_USDU_PROMPT_FULL",
-      "AIO_USDU_PROMPT_NO_GENERAL",
       "ANIMA_DEFAULT_CLIP_CANDIDATES",
       "ANIMA_DEFAULT_DIFFUSION_MODEL_CANDIDATES",
       "ANIMA_DEFAULT_VAE_CANDIDATES",
-      "ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
       "ANIMA_MOD_GUIDANCE_PROFILE_OFF",
       "EASY_USE_ANIMA_INPUT_SCHEMA",
       "EASY_USE_ANIMA_INPUT_SETTINGS_VERSION",
       "EASY_USE_ANIMA_INPUT_TYPE",
       "EasyUseAnimaImageScaleByMultiple",
       "EasyUseAnimaSAM3Detailer",
-      "MAX_SEED",
       "PROMPT_DATA_TYPE",
-      "SEED_CONTROL_FIXED",
-      "_advanced_artist_field_prompt",
-      "_advanced_enabled_pane_fields",
       "_advanced_outputs_from_prompt_data",
       "_aio_detailer_has_enabled_targets",
       "_aio_detailer_target_order",
@@ -713,25 +579,17 @@
       "_aio_highres_effective_backend",
       "_aio_input_settings_json",
       "_aio_lora_stack_signature",
-      "_aio_prompt_data_fields_for_usdu",
       "_aio_save_filename_prefix",
       "_aio_stage_sampler_settings",
       "_aio_usdu_conditioning",
-      "_aio_usdu_prompt_without_general",
       "_aio_usdu_tile_plan",
-      "_apply_aio_anima_dave_patch",
-      "_apply_aio_kj_model_patches",
       "_apply_aio_lora_stack",
       "_apply_aio_model_patches",
-      "_apply_aio_safe_pag_patch",
-      "_apply_aio_spectrum_correction_patch_for_comfy_sampler",
-      "_apply_aio_spectrum_forecast_patch_for_comfy_sampler",
       "_apply_aio_spectrum_model_patches_for_comfy_sampler",
       "_apply_spectrum_anima_mod_guidance",
       "_as_bool",
       "_as_float",
       "_as_int",
-      "_call_with_supported_kwargs",
       "_cleanup_aio_ephemeral_model",
       "_comfy_clip_loader_types",
       "_comfy_diffusion_model_names",
@@ -739,7 +597,6 @@
       "_comfy_vae_names",
       "_context_value",
       "_copy_prompt_data_for_update",
-      "_correct_advanced_field_sequence",
       "_decode_latent_with_comfy",
       "_easy_use_anima_input_signature",
       "_encode_image_with_comfy_vae",
@@ -751,17 +608,11 @@
       "_load_aio_resources_from_input_context",
       "_load_aio_sam3_context",
       "_load_upscale_model_with_comfy",
-      "_lora_stack_name",
-      "_new_aio_random_seed",
       "_node_output_tuple",
-      "_normalize_advanced_fields",
       "_normalize_aio_generation_settings",
       "_normalize_aio_input_settings",
-      "_normalize_aio_lora_stack",
-      "_normalize_aio_seed",
       "_normalize_anima_mod_guidance_profile",
       "_normalize_prompt_data",
-      "_patch_model_sampling_aura_flow",
       "_preferred_clip_type_default",
       "_preferred_name_default",
       "_prompt_data_json_safe",
@@ -779,9 +630,6 @@
       "_run_aio_upscale_stage",
       "_run_aio_usdu_upscale_stage",
       "_sample_latent_with_aio_backend",
-      "_sample_latent_with_comfy",
-      "_sample_latent_with_spectrum_mod_guidance_advanced",
-      "_sample_latent_with_spectrum_spd",
       "_save_aio_temp_preview_image",
       "_save_image_with_comfy",
       "_save_image_with_image_saver",
@@ -796,8 +644,6 @@
     ],
     "provider_resolver_names": [
       "_encode_with_comfy_clip",
-      "_find_comfy_node_class",
-      "_require_any_custom_node_class",
       "_require_custom_node_class"
     ],
     "repository_root_replacements": {
@@ -808,8 +654,7 @@
         "tests/test_node_contracts.py"
       ],
       "AIO_SPECIAL_SEEDS": [
-        "tests/test_aio_nodes.py",
-        "tests/test_node_contracts.py"
+        "tests/test_aio_nodes.py"
       ],
       "ANIMA_DEFAULT_CLIP_CANDIDATES": [
         "tests/test_aio_nodes.py"
@@ -822,9 +667,6 @@
       ],
       "EASY_USE_ANIMA_INPUT_TYPE": [
         "tests/test_aio_nodes.py"
-      ],
-      "MAX_SEED": [
-        "tests/test_node_contracts.py"
       ],
       "PROMPT_DATA_TYPE": [
         "tests/test_aio_nodes.py"
@@ -854,17 +696,6 @@
       "_aio_save_filename_prefix": [
         "tests/test_aio_legacy_generation.py"
       ],
-      "_aio_usdu_prompt_without_general": [
-        "tests/test_aio_conditioning.py"
-      ],
-      "_apply_aio_anima_dave_patch": [
-        "tests/test_aio_model_preparation.py",
-        "tests/test_aio_nodes.py"
-      ],
-      "_apply_aio_kj_model_patches": [
-        "tests/test_aio_model_preparation.py",
-        "tests/test_aio_nodes.py"
-      ],
       "_apply_aio_lora_stack": [
         "tests/test_aio_legacy_generation.py",
         "tests/test_aio_nodes.py"
@@ -872,16 +703,6 @@
       "_apply_aio_model_patches": [
         "tests/test_aio_legacy_generation.py",
         "tests/test_aio_nodes.py"
-      ],
-      "_apply_aio_safe_pag_patch": [
-        "tests/test_aio_model_preparation.py",
-        "tests/test_aio_nodes.py"
-      ],
-      "_apply_aio_spectrum_correction_patch_for_comfy_sampler": [
-        "tests/test_aio_model_preparation.py"
-      ],
-      "_apply_aio_spectrum_forecast_patch_for_comfy_sampler": [
-        "tests/test_aio_model_preparation.py"
       ],
       "_apply_aio_spectrum_model_patches_for_comfy_sampler": [
         "tests/test_aio_legacy_generation.py",
@@ -958,9 +779,6 @@
       "_load_upscale_model_with_comfy": [
         "tests/test_aio_nodes.py"
       ],
-      "_new_aio_random_seed": [
-        "tests/test_node_contracts.py"
-      ],
       "_normalize_aio_generation_settings": [
         "tests/test_aio_legacy_generation.py",
         "tests/test_aio_nodes.py"
@@ -968,21 +786,11 @@
       "_normalize_aio_input_settings": [
         "tests/test_aio_nodes.py"
       ],
-      "_normalize_aio_lora_stack": [
-        "tests/test_node_contracts.py"
-      ],
-      "_normalize_aio_seed": [
-        "tests/test_node_contracts.py"
-      ],
       "_normalize_anima_mod_guidance_profile": [
         "tests/test_aio_legacy_generation.py"
       ],
       "_normalize_prompt_data": [
         "tests/test_aio_legacy_generation.py",
-        "tests/test_aio_nodes.py"
-      ],
-      "_patch_model_sampling_aura_flow": [
-        "tests/test_aio_model_preparation.py",
         "tests/test_aio_nodes.py"
       ],
       "_post_random": [
@@ -1010,8 +818,7 @@
       ],
       "_resolve_aio_runtime_seed": [
         "tests/test_aio_legacy_generation.py",
-        "tests/test_aio_nodes.py",
-        "tests/test_aio_sampling.py"
+        "tests/test_aio_nodes.py"
       ],
       "_resolve_anima_mod_guidance_enabled": [
         "tests/test_aio_legacy_generation.py"
@@ -1040,15 +847,6 @@
       ],
       "_sample_latent_with_aio_backend": [
         "tests/test_aio_legacy_generation.py",
-        "tests/test_aio_nodes.py"
-      ],
-      "_sample_latent_with_comfy": [
-        "tests/test_aio_nodes.py"
-      ],
-      "_sample_latent_with_spectrum_mod_guidance_advanced": [
-        "tests/test_aio_nodes.py"
-      ],
-      "_sample_latent_with_spectrum_spd": [
         "tests/test_aio_nodes.py"
       ],
       "_save_aio_temp_preview_image": [
@@ -1081,8 +879,7 @@
         "tests/test_node_contracts.py"
       ],
       "random": [
-        "tests/test_aio_legacy_generation.py",
-        "tests/test_node_contracts.py"
+        "tests/test_aio_legacy_generation.py"
       ],
       "resolve_naia_settings": [
         "tests/test_naia_settings.py",
@@ -1280,199 +1077,6 @@
           "_tag_aio_preview_images",
           "json",
           "random"
-        ]
-      },
-      {
-        "binder": "_bind_aio_model_preparation_runtime",
-        "module": "easyuse_anima.aio.model_preparation",
-        "family": "aio",
-        "mode": "comfy_provider_then_root",
-        "root_observation": "call_time_resolver",
-        "root_keywords": [
-          "resolve_helper"
-        ],
-        "bound_globals": [
-          "_RUNTIME_RESOLVER"
-        ],
-        "direct_root_dependencies": [
-          "_resolve_comfy_host_helper"
-        ],
-        "resolver_names": [
-          "_apply_aio_anima_dave_patch",
-          "_apply_aio_kj_model_patches",
-          "_apply_aio_safe_pag_patch",
-          "_apply_aio_spectrum_correction_patch_for_comfy_sampler",
-          "_apply_aio_spectrum_forecast_patch_for_comfy_sampler",
-          "_as_bool",
-          "_as_float",
-          "_as_int",
-          "_call_with_supported_kwargs",
-          "_find_comfy_node_class",
-          "_lora_stack_name",
-          "_node_output_tuple",
-          "_normalize_aio_lora_stack",
-          "_patch_model_sampling_aura_flow",
-          "_require_any_custom_node_class",
-          "_require_custom_node_class",
-          "logger"
-        ],
-        "root_resolver_names": [
-          "_apply_aio_anima_dave_patch",
-          "_apply_aio_kj_model_patches",
-          "_apply_aio_safe_pag_patch",
-          "_apply_aio_spectrum_correction_patch_for_comfy_sampler",
-          "_apply_aio_spectrum_forecast_patch_for_comfy_sampler",
-          "_as_bool",
-          "_as_float",
-          "_as_int",
-          "_call_with_supported_kwargs",
-          "_lora_stack_name",
-          "_node_output_tuple",
-          "_normalize_aio_lora_stack",
-          "_patch_model_sampling_aura_flow",
-          "logger"
-        ],
-        "provider_resolver_names": [
-          "_find_comfy_node_class",
-          "_require_any_custom_node_class",
-          "_require_custom_node_class"
-        ],
-        "repository_replacement_names": [
-          "_apply_aio_anima_dave_patch",
-          "_apply_aio_kj_model_patches",
-          "_apply_aio_safe_pag_patch",
-          "_apply_aio_spectrum_correction_patch_for_comfy_sampler",
-          "_apply_aio_spectrum_forecast_patch_for_comfy_sampler",
-          "_as_bool",
-          "_normalize_aio_lora_stack",
-          "_patch_model_sampling_aura_flow"
-        ]
-      },
-      {
-        "binder": "_bind_aio_sampling_runtime",
-        "module": "easyuse_anima.aio.sampling",
-        "family": "aio",
-        "mode": "comfy_provider_then_root",
-        "root_observation": "call_time_resolver",
-        "root_keywords": [
-          "resolve_helper"
-        ],
-        "bound_globals": [
-          "_RUNTIME_RESOLVER"
-        ],
-        "direct_root_dependencies": [
-          "_resolve_comfy_host_helper"
-        ],
-        "resolver_names": [
-          "AIO_SPECIAL_SEEDS",
-          "ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
-          "ANIMA_MOD_GUIDANCE_PROFILE_OFF",
-          "MAX_SEED",
-          "SEED_CONTROL_FIXED",
-          "_as_bool",
-          "_as_float",
-          "_as_int",
-          "_call_with_supported_kwargs",
-          "_find_comfy_node_class",
-          "_json_clone",
-          "_new_aio_random_seed",
-          "_node_output_tuple",
-          "_normalize_aio_seed",
-          "_normalize_anima_mod_guidance_profile",
-          "_require_custom_node_class",
-          "_resolve_aio_runtime_seed",
-          "_sample_latent_with_comfy",
-          "_sample_latent_with_spectrum_mod_guidance_advanced",
-          "_sample_latent_with_spectrum_spd",
-          "random"
-        ],
-        "root_resolver_names": [
-          "AIO_SPECIAL_SEEDS",
-          "ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
-          "ANIMA_MOD_GUIDANCE_PROFILE_OFF",
-          "MAX_SEED",
-          "SEED_CONTROL_FIXED",
-          "_as_bool",
-          "_as_float",
-          "_as_int",
-          "_call_with_supported_kwargs",
-          "_json_clone",
-          "_new_aio_random_seed",
-          "_node_output_tuple",
-          "_normalize_aio_seed",
-          "_normalize_anima_mod_guidance_profile",
-          "_resolve_aio_runtime_seed",
-          "_sample_latent_with_comfy",
-          "_sample_latent_with_spectrum_mod_guidance_advanced",
-          "_sample_latent_with_spectrum_spd",
-          "random"
-        ],
-        "provider_resolver_names": [
-          "_find_comfy_node_class",
-          "_require_custom_node_class"
-        ],
-        "repository_replacement_names": [
-          "AIO_SPECIAL_SEEDS",
-          "MAX_SEED",
-          "_as_bool",
-          "_json_clone",
-          "_new_aio_random_seed",
-          "_normalize_aio_seed",
-          "_normalize_anima_mod_guidance_profile",
-          "_resolve_aio_runtime_seed",
-          "_sample_latent_with_comfy",
-          "_sample_latent_with_spectrum_mod_guidance_advanced",
-          "_sample_latent_with_spectrum_spd",
-          "random"
-        ]
-      },
-      {
-        "binder": "_bind_aio_conditioning_runtime",
-        "module": "easyuse_anima.aio.conditioning",
-        "family": "aio",
-        "mode": "comfy_provider_then_root",
-        "root_observation": "call_time_resolver",
-        "root_keywords": [
-          "resolve_helper"
-        ],
-        "bound_globals": [
-          "_RUNTIME_RESOLVER"
-        ],
-        "direct_root_dependencies": [
-          "_resolve_comfy_host_helper"
-        ],
-        "resolver_names": [
-          "AIO_USDU_PROMPT_FULL",
-          "AIO_USDU_PROMPT_NO_GENERAL",
-          "_advanced_artist_field_prompt",
-          "_advanced_enabled_pane_fields",
-          "_aio_prompt_data_fields_for_usdu",
-          "_aio_usdu_prompt_without_general",
-          "_as_bool",
-          "_correct_advanced_field_sequence",
-          "_encode_with_comfy_clip",
-          "_normalize_advanced_fields",
-          "_normalize_prompt_data"
-        ],
-        "root_resolver_names": [
-          "AIO_USDU_PROMPT_FULL",
-          "AIO_USDU_PROMPT_NO_GENERAL",
-          "_advanced_artist_field_prompt",
-          "_advanced_enabled_pane_fields",
-          "_aio_prompt_data_fields_for_usdu",
-          "_aio_usdu_prompt_without_general",
-          "_as_bool",
-          "_correct_advanced_field_sequence",
-          "_normalize_advanced_fields",
-          "_normalize_prompt_data"
-        ],
-        "provider_resolver_names": [
-          "_encode_with_comfy_clip"
-        ],
-        "repository_replacement_names": [
-          "_aio_usdu_prompt_without_general",
-          "_as_bool",
-          "_normalize_prompt_data"
         ]
       },
       {
@@ -2406,10 +2010,7 @@
       "id": "nodes_canonical_bindings:easyuse_anima.aio.conditioning:transitional_private_seam",
       "surface": "nodes_canonical_bindings",
       "symbols": {
-        "_aio_prompt_data_fields_for_usdu": "_aio_prompt_data_fields_for_usdu",
-        "_aio_usdu_conditioning": "_aio_usdu_conditioning",
-        "_aio_usdu_prompt_without_general": "_aio_usdu_prompt_without_general",
-        "_bind_aio_conditioning_runtime": "_bind_aio_conditioning_runtime"
+        "_aio_usdu_conditioning": "_aio_usdu_conditioning"
       },
       "classification": "transitional_private_seam",
       "current_target": "nodes.py",
@@ -2421,13 +2022,9 @@
       "owner": "#184/#188",
       "first_release": null,
       "known_consumers": [
-        "nodes.py residual runtime",
-        "canonical runtime resolver: easyuse_anima.aio.conditioning",
         "canonical runtime resolver: easyuse_anima.aio.legacy_generation"
       ],
       "evidence": [
-        "AST:nodes.py direct runtime load",
-        "AST:easyuse_anima.aio.conditioning string runtime lookup",
         "AST:easyuse_anima.aio.legacy_generation string runtime lookup"
       ],
       "removal_gates": [
@@ -2436,6 +2033,36 @@
         "separate B-10b or B-11 rollback unit"
       ],
       "lifecycle_state": "transitional"
+    },
+    {
+      "id": "nodes_canonical_bindings:easyuse_anima.aio.conditioning:unsupported_test_only",
+      "surface": "nodes_canonical_bindings",
+      "symbols": {
+        "_aio_prompt_data_fields_for_usdu": "_aio_prompt_data_fields_for_usdu",
+        "_aio_usdu_prompt_without_general": "_aio_usdu_prompt_without_general"
+      },
+      "classification": "unsupported_test_only",
+      "current_target": "nodes.py",
+      "canonical_target": "easyuse_anima.aio.conditioning",
+      "target_state": "canonical",
+      "identity_requirement": "not_applicable",
+      "binding_shape": "direct_import",
+      "import_target": "easyuse_anima.aio.conditioning",
+      "owner": "#184/#188",
+      "first_release": null,
+      "known_consumers": [
+        "repository tests may import this root name"
+      ],
+      "evidence": [
+        "AST:no nodes.py runtime load",
+        "test-only consumption is not public support evidence"
+      ],
+      "removal_gates": [
+        "test imports migrate to canonical targets",
+        "no production consumer evidence",
+        "separate B-10b removal review"
+      ],
+      "lifecycle_state": "unsupported"
     },
     {
       "id": "nodes_canonical_bindings:easyuse_anima.aio.first_pass_cache:transitional_private_seam",
@@ -2505,8 +2132,7 @@
       "symbols": {
         "AIO_GENERATION_DEFAULT_SETTINGS": "AIO_GENERATION_DEFAULT_SETTINGS",
         "AIO_SPECIAL_SEEDS": "AIO_SPECIAL_SEEDS",
-        "AIO_USDU_PROMPT_FULL": "AIO_USDU_PROMPT_FULL",
-        "AIO_USDU_PROMPT_NO_GENERAL": "AIO_USDU_PROMPT_NO_GENERAL"
+        "AIO_USDU_PROMPT_FULL": "AIO_USDU_PROMPT_FULL"
       },
       "classification": "transitional_private_seam",
       "current_target": "nodes.py",
@@ -2518,15 +2144,11 @@
       "owner": "#184/#188",
       "first_release": null,
       "known_consumers": [
-        "canonical runtime resolver: easyuse_anima.aio.conditioning",
         "canonical runtime resolver: easyuse_anima.aio.legacy_generation",
-        "canonical runtime resolver: easyuse_anima.aio.sampling",
         "canonical runtime resolver: easyuse_anima.nodes.aio_nodes"
       ],
       "evidence": [
-        "AST:easyuse_anima.aio.conditioning string runtime lookup",
         "AST:easyuse_anima.aio.legacy_generation string runtime lookup",
-        "AST:easyuse_anima.aio.sampling string runtime lookup",
         "AST:easyuse_anima.nodes.aio_nodes string runtime lookup"
       ],
       "removal_gates": [
@@ -2551,6 +2173,7 @@
         "AIO_SPECIAL_SEED_RANDOM": "AIO_SPECIAL_SEED_RANDOM",
         "AIO_USDU_MODE_TYPES": "AIO_USDU_MODE_TYPES",
         "AIO_USDU_PROMPT_MODES": "AIO_USDU_PROMPT_MODES",
+        "AIO_USDU_PROMPT_NO_GENERAL": "AIO_USDU_PROMPT_NO_GENERAL",
         "AIO_USDU_SEAM_FIX_MODES": "AIO_USDU_SEAM_FIX_MODES"
       },
       "classification": "unsupported_test_only",
@@ -2582,8 +2205,7 @@
       "symbols": {
         "_aio_detailer_has_enabled_targets": "_aio_detailer_has_enabled_targets",
         "_aio_detailer_target_order": "_aio_detailer_target_order",
-        "_normalize_aio_generation_settings": "_normalize_aio_generation_settings",
-        "_normalize_aio_seed": "_normalize_aio_seed"
+        "_normalize_aio_generation_settings": "_normalize_aio_generation_settings"
       },
       "classification": "transitional_private_seam",
       "current_target": "nodes.py",
@@ -2596,12 +2218,10 @@
       "first_release": null,
       "known_consumers": [
         "canonical runtime resolver: easyuse_anima.aio.legacy_generation",
-        "canonical runtime resolver: easyuse_anima.aio.sampling",
         "canonical runtime resolver: easyuse_anima.nodes.aio_nodes"
       ],
       "evidence": [
         "AST:easyuse_anima.aio.legacy_generation string runtime lookup",
-        "AST:easyuse_anima.aio.sampling string runtime lookup",
         "AST:easyuse_anima.nodes.aio_nodes string runtime lookup"
       ],
       "removal_gates": [
@@ -2621,6 +2241,7 @@
         "_is_aio_detailer_target_name": "_is_aio_detailer_target_name",
         "_merge_versioned_settings": "_merge_versioned_settings",
         "_normalize_aio_dit_corrections_settings": "_normalize_aio_dit_corrections_settings",
+        "_normalize_aio_seed": "_normalize_aio_seed",
         "_normalize_aio_spectrum_settings": "_normalize_aio_spectrum_settings"
       },
       "classification": "unsupported_test_only",
@@ -2783,18 +2404,10 @@
       "surface": "nodes_canonical_bindings",
       "symbols": {
         "_aio_lora_stack_signature": "_aio_lora_stack_signature",
-        "_apply_aio_anima_dave_patch": "_apply_aio_anima_dave_patch",
-        "_apply_aio_kj_model_patches": "_apply_aio_kj_model_patches",
         "_apply_aio_lora_stack": "_apply_aio_lora_stack",
         "_apply_aio_model_patches": "_apply_aio_model_patches",
-        "_apply_aio_safe_pag_patch": "_apply_aio_safe_pag_patch",
-        "_apply_aio_spectrum_correction_patch_for_comfy_sampler": "_apply_aio_spectrum_correction_patch_for_comfy_sampler",
-        "_apply_aio_spectrum_forecast_patch_for_comfy_sampler": "_apply_aio_spectrum_forecast_patch_for_comfy_sampler",
         "_apply_aio_spectrum_model_patches_for_comfy_sampler": "_apply_aio_spectrum_model_patches_for_comfy_sampler",
-        "_bind_aio_model_preparation_runtime": "_bind_aio_model_preparation_runtime",
-        "_cleanup_aio_ephemeral_model": "_cleanup_aio_ephemeral_model",
-        "_normalize_aio_lora_stack": "_normalize_aio_lora_stack",
-        "_patch_model_sampling_aura_flow": "_patch_model_sampling_aura_flow"
+        "_cleanup_aio_ephemeral_model": "_cleanup_aio_ephemeral_model"
       },
       "classification": "transitional_private_seam",
       "current_target": "nodes.py",
@@ -2806,15 +2419,11 @@
       "owner": "#184/#188",
       "first_release": null,
       "known_consumers": [
-        "nodes.py residual runtime",
         "canonical runtime resolver: easyuse_anima.aio.legacy_generation",
-        "canonical runtime resolver: easyuse_anima.aio.model_preparation",
         "canonical runtime resolver: easyuse_anima.nodes.aio_nodes"
       ],
       "evidence": [
-        "AST:nodes.py direct runtime load",
         "AST:easyuse_anima.aio.legacy_generation string runtime lookup",
-        "AST:easyuse_anima.aio.model_preparation string runtime lookup",
         "AST:easyuse_anima.nodes.aio_nodes string runtime lookup"
       ],
       "removal_gates": [
@@ -2823,6 +2432,41 @@
         "separate B-10b or B-11 rollback unit"
       ],
       "lifecycle_state": "transitional"
+    },
+    {
+      "id": "nodes_canonical_bindings:easyuse_anima.aio.model_preparation:unsupported_test_only",
+      "surface": "nodes_canonical_bindings",
+      "symbols": {
+        "_apply_aio_anima_dave_patch": "_apply_aio_anima_dave_patch",
+        "_apply_aio_kj_model_patches": "_apply_aio_kj_model_patches",
+        "_apply_aio_safe_pag_patch": "_apply_aio_safe_pag_patch",
+        "_apply_aio_spectrum_correction_patch_for_comfy_sampler": "_apply_aio_spectrum_correction_patch_for_comfy_sampler",
+        "_apply_aio_spectrum_forecast_patch_for_comfy_sampler": "_apply_aio_spectrum_forecast_patch_for_comfy_sampler",
+        "_normalize_aio_lora_stack": "_normalize_aio_lora_stack",
+        "_patch_model_sampling_aura_flow": "_patch_model_sampling_aura_flow"
+      },
+      "classification": "unsupported_test_only",
+      "current_target": "nodes.py",
+      "canonical_target": "easyuse_anima.aio.model_preparation",
+      "target_state": "canonical",
+      "identity_requirement": "not_applicable",
+      "binding_shape": "direct_import",
+      "import_target": "easyuse_anima.aio.model_preparation",
+      "owner": "#184/#188",
+      "first_release": null,
+      "known_consumers": [
+        "repository tests may import this root name"
+      ],
+      "evidence": [
+        "AST:no nodes.py runtime load",
+        "test-only consumption is not public support evidence"
+      ],
+      "removal_gates": [
+        "test imports migrate to canonical targets",
+        "no production consumer evidence",
+        "separate B-10b removal review"
+      ],
+      "lifecycle_state": "unsupported"
     },
     {
       "id": "nodes_canonical_bindings:easyuse_anima.aio.output:transitional_private_seam",
@@ -3117,16 +2761,11 @@
       "symbols": {
         "_aio_highres_effective_backend": "_aio_highres_effective_backend",
         "_aio_stage_sampler_settings": "_aio_stage_sampler_settings",
-        "_bind_aio_sampling_runtime": "_bind_aio_sampling_runtime",
         "_decode_latent_with_comfy": "_decode_latent_with_comfy",
         "_encode_image_with_comfy_vae": "_encode_image_with_comfy_vae",
         "_generate_empty_latent_with_comfy": "_generate_empty_latent_with_comfy",
-        "_new_aio_random_seed": "_new_aio_random_seed",
         "_resolve_aio_runtime_seed": "_resolve_aio_runtime_seed",
-        "_sample_latent_with_aio_backend": "_sample_latent_with_aio_backend",
-        "_sample_latent_with_comfy": "_sample_latent_with_comfy",
-        "_sample_latent_with_spectrum_mod_guidance_advanced": "_sample_latent_with_spectrum_mod_guidance_advanced",
-        "_sample_latent_with_spectrum_spd": "_sample_latent_with_spectrum_spd"
+        "_sample_latent_with_aio_backend": "_sample_latent_with_aio_backend"
       },
       "classification": "transitional_private_seam",
       "current_target": "nodes.py",
@@ -3138,15 +2777,11 @@
       "owner": "#184/#188",
       "first_release": null,
       "known_consumers": [
-        "nodes.py residual runtime",
         "canonical runtime resolver: easyuse_anima.aio.legacy_generation",
-        "canonical runtime resolver: easyuse_anima.aio.sampling",
         "canonical runtime resolver: easyuse_anima.nodes.aio_nodes"
       ],
       "evidence": [
-        "AST:nodes.py direct runtime load",
         "AST:easyuse_anima.aio.legacy_generation string runtime lookup",
-        "AST:easyuse_anima.aio.sampling string runtime lookup",
         "AST:easyuse_anima.nodes.aio_nodes string runtime lookup"
       ],
       "removal_gates": [
@@ -3155,6 +2790,38 @@
         "separate B-10b or B-11 rollback unit"
       ],
       "lifecycle_state": "transitional"
+    },
+    {
+      "id": "nodes_canonical_bindings:easyuse_anima.aio.sampling:unsupported_test_only",
+      "surface": "nodes_canonical_bindings",
+      "symbols": {
+        "_new_aio_random_seed": "_new_aio_random_seed",
+        "_sample_latent_with_comfy": "_sample_latent_with_comfy",
+        "_sample_latent_with_spectrum_mod_guidance_advanced": "_sample_latent_with_spectrum_mod_guidance_advanced",
+        "_sample_latent_with_spectrum_spd": "_sample_latent_with_spectrum_spd"
+      },
+      "classification": "unsupported_test_only",
+      "current_target": "nodes.py",
+      "canonical_target": "easyuse_anima.aio.sampling",
+      "target_state": "canonical",
+      "identity_requirement": "not_applicable",
+      "binding_shape": "direct_import",
+      "import_target": "easyuse_anima.aio.sampling",
+      "owner": "#184/#188",
+      "first_release": null,
+      "known_consumers": [
+        "repository tests may import this root name"
+      ],
+      "evidence": [
+        "AST:no nodes.py runtime load",
+        "test-only consumption is not public support evidence"
+      ],
+      "removal_gates": [
+        "test imports migrate to canonical targets",
+        "no production consumer evidence",
+        "separate B-10b removal review"
+      ],
+      "lifecycle_state": "unsupported"
     },
     {
       "id": "nodes_canonical_bindings:easyuse_anima.aio.usdu:transitional_private_seam",
@@ -3230,11 +2897,9 @@
       "owner": "#184/#188",
       "first_release": null,
       "known_consumers": [
-        "canonical runtime resolver: easyuse_anima.aio.sampling",
         "canonical runtime resolver: easyuse_anima.nodes.aio_nodes"
       ],
       "evidence": [
-        "AST:easyuse_anima.aio.sampling string runtime lookup",
         "AST:easyuse_anima.nodes.aio_nodes string runtime lookup"
       ],
       "removal_gates": [
@@ -3292,16 +2957,10 @@
       "owner": "#184/#188",
       "first_release": null,
       "known_consumers": [
-        "canonical runtime resolver: easyuse_anima.aio.conditioning",
-        "canonical runtime resolver: easyuse_anima.aio.legacy_generation",
-        "canonical runtime resolver: easyuse_anima.aio.model_preparation",
-        "canonical runtime resolver: easyuse_anima.aio.sampling"
+        "canonical runtime resolver: easyuse_anima.aio.legacy_generation"
       ],
       "evidence": [
-        "AST:easyuse_anima.aio.conditioning string runtime lookup",
-        "AST:easyuse_anima.aio.legacy_generation string runtime lookup",
-        "AST:easyuse_anima.aio.model_preparation string runtime lookup",
-        "AST:easyuse_anima.aio.sampling string runtime lookup"
+        "AST:easyuse_anima.aio.legacy_generation string runtime lookup"
       ],
       "removal_gates": [
         "canonical production consumer migration",
@@ -3520,7 +3179,6 @@
       "id": "nodes_canonical_bindings:easyuse_anima.infrastructure.comfy.invocation:transitional_private_seam",
       "surface": "nodes_canonical_bindings",
       "symbols": {
-        "_call_with_supported_kwargs": "_call_with_supported_kwargs",
         "_node_output_tuple": "_node_output_tuple"
       },
       "classification": "transitional_private_seam",
@@ -3533,14 +3191,10 @@
       "owner": "#184/#188",
       "first_release": null,
       "known_consumers": [
-        "canonical runtime resolver: easyuse_anima.aio.legacy_generation",
-        "canonical runtime resolver: easyuse_anima.aio.model_preparation",
-        "canonical runtime resolver: easyuse_anima.aio.sampling"
+        "canonical runtime resolver: easyuse_anima.aio.legacy_generation"
       ],
       "evidence": [
-        "AST:easyuse_anima.aio.legacy_generation string runtime lookup",
-        "AST:easyuse_anima.aio.model_preparation string runtime lookup",
-        "AST:easyuse_anima.aio.sampling string runtime lookup"
+        "AST:easyuse_anima.aio.legacy_generation string runtime lookup"
       ],
       "removal_gates": [
         "canonical production consumer migration",
@@ -3553,6 +3207,7 @@
       "id": "nodes_canonical_bindings:easyuse_anima.infrastructure.comfy.invocation:unsupported_test_only",
       "surface": "nodes_canonical_bindings",
       "symbols": {
+        "_call_with_supported_kwargs": "_call_with_supported_kwargs",
         "_common_upscale_image": "_common_upscale_image"
       },
       "classification": "unsupported_test_only",
@@ -3640,34 +3295,6 @@
       "lifecycle_state": "transitional"
     },
     {
-      "id": "nodes_canonical_bindings:easyuse_anima.lora.metadata:transitional_private_seam",
-      "surface": "nodes_canonical_bindings",
-      "symbols": {
-        "_lora_stack_name": "_lora_stack_name"
-      },
-      "classification": "transitional_private_seam",
-      "current_target": "nodes.py",
-      "canonical_target": "easyuse_anima.lora.metadata",
-      "target_state": "canonical",
-      "identity_requirement": "required",
-      "binding_shape": "direct_import",
-      "import_target": "easyuse_anima.lora.metadata",
-      "owner": "#184/#188",
-      "first_release": null,
-      "known_consumers": [
-        "canonical runtime resolver: easyuse_anima.aio.model_preparation"
-      ],
-      "evidence": [
-        "AST:easyuse_anima.aio.model_preparation string runtime lookup"
-      ],
-      "removal_gates": [
-        "canonical production consumer migration",
-        "focused monkeypatch and identity contract review",
-        "separate B-10b or B-11 rollback unit"
-      ],
-      "lifecycle_state": "transitional"
-    },
-    {
       "id": "nodes_canonical_bindings:easyuse_anima.lora.metadata:unsupported_test_only",
       "surface": "nodes_canonical_bindings",
       "symbols": {
@@ -3680,6 +3307,7 @@
         "_lora_combo_values": "_lora_combo_values",
         "_lora_manager_trigger_words_from_metadata": "_lora_manager_trigger_words_from_metadata",
         "_lora_model_exists": "_lora_model_exists",
+        "_lora_stack_name": "_lora_stack_name",
         "_metadata_json_paths_for_lora": "_metadata_json_paths_for_lora",
         "_missing_lora_display_name": "_missing_lora_display_name",
         "_raise_missing_loras": "_raise_missing_loras",
@@ -4268,42 +3896,13 @@
       "lifecycle_state": "transitional"
     },
     {
-      "id": "nodes_canonical_bindings:easyuse_anima.prompt.advanced:transitional_private_seam",
-      "surface": "nodes_canonical_bindings",
-      "symbols": {
-        "_advanced_artist_field_prompt": "_advanced_artist_field_prompt",
-        "_advanced_enabled_pane_fields": "_advanced_enabled_pane_fields",
-        "_correct_advanced_field_sequence": "_correct_advanced_field_sequence",
-        "_normalize_advanced_fields": "_normalize_advanced_fields"
-      },
-      "classification": "transitional_private_seam",
-      "current_target": "nodes.py",
-      "canonical_target": "easyuse_anima.prompt.advanced",
-      "target_state": "canonical",
-      "identity_requirement": "required",
-      "binding_shape": "direct_import",
-      "import_target": "easyuse_anima.prompt.advanced",
-      "owner": "#184/#188",
-      "first_release": null,
-      "known_consumers": [
-        "canonical runtime resolver: easyuse_anima.aio.conditioning"
-      ],
-      "evidence": [
-        "AST:easyuse_anima.aio.conditioning string runtime lookup"
-      ],
-      "removal_gates": [
-        "canonical production consumer migration",
-        "focused monkeypatch and identity contract review",
-        "separate B-10b or B-11 rollback unit"
-      ],
-      "lifecycle_state": "transitional"
-    },
-    {
       "id": "nodes_canonical_bindings:easyuse_anima.prompt.advanced:unsupported_test_only",
       "surface": "nodes_canonical_bindings",
       "symbols": {
+        "_advanced_artist_field_prompt": "_advanced_artist_field_prompt",
         "_advanced_default_fields": "_advanced_default_fields",
         "_advanced_enabled_naia_panes": "_advanced_enabled_naia_panes",
+        "_advanced_enabled_pane_fields": "_advanced_enabled_pane_fields",
         "_advanced_field_input_values": "_advanced_field_input_values",
         "_advanced_field_socket_name": "_advanced_field_socket_name",
         "_advanced_fields_json": "_advanced_fields_json",
@@ -4315,7 +3914,9 @@
         "_build_advanced_prompt_data": "_build_advanced_prompt_data",
         "_build_advanced_prompts": "_build_advanced_prompts",
         "_clone_advanced_fields": "_clone_advanced_fields",
+        "_correct_advanced_field_sequence": "_correct_advanced_field_sequence",
         "_expand_advanced_wildcard_fields": "_expand_advanced_wildcard_fields",
+        "_normalize_advanced_fields": "_normalize_advanced_fields",
         "_normalize_prompt_studio_wildcard_seed_control": "_normalize_prompt_studio_wildcard_seed_control",
         "_set_naia_field_text": "_set_naia_field_text",
         "_translate_prompt_fields": "_translate_prompt_fields"
@@ -4426,7 +4027,6 @@
       "id": "nodes_canonical_bindings:easyuse_anima.prompt.conditioning:transitional_private_seam",
       "surface": "nodes_canonical_bindings",
       "symbols": {
-        "ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE": "ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
         "ANIMA_MOD_GUIDANCE_PROFILE_OFF": "ANIMA_MOD_GUIDANCE_PROFILE_OFF",
         "_apply_spectrum_anima_mod_guidance": "_apply_spectrum_anima_mod_guidance",
         "_normalize_anima_mod_guidance_profile": "_normalize_anima_mod_guidance_profile",
@@ -4442,12 +4042,10 @@
       "owner": "#184/#188",
       "first_release": null,
       "known_consumers": [
-        "canonical runtime resolver: easyuse_anima.aio.legacy_generation",
-        "canonical runtime resolver: easyuse_anima.aio.sampling"
+        "canonical runtime resolver: easyuse_anima.aio.legacy_generation"
       ],
       "evidence": [
-        "AST:easyuse_anima.aio.legacy_generation string runtime lookup",
-        "AST:easyuse_anima.aio.sampling string runtime lookup"
+        "AST:easyuse_anima.aio.legacy_generation string runtime lookup"
       ],
       "removal_gates": [
         "canonical production consumer migration",
@@ -4460,6 +4058,7 @@
       "id": "nodes_canonical_bindings:easyuse_anima.prompt.conditioning:unsupported_test_only",
       "surface": "nodes_canonical_bindings",
       "symbols": {
+        "ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE": "ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
         "ANIMA_MOD_GUIDANCE_MODES": "ANIMA_MOD_GUIDANCE_MODES",
         "ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA": "ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
         "_find_spectrum_anima_mod_guidance_class": "_find_spectrum_anima_mod_guidance_class"
@@ -4538,12 +4137,10 @@
       "owner": "#184/#188",
       "first_release": null,
       "known_consumers": [
-        "canonical runtime resolver: easyuse_anima.aio.conditioning",
         "canonical runtime resolver: easyuse_anima.aio.legacy_generation",
         "canonical runtime resolver: easyuse_anima.nodes.aio_nodes"
       ],
       "evidence": [
-        "AST:easyuse_anima.aio.conditioning string runtime lookup",
         "AST:easyuse_anima.aio.legacy_generation string runtime lookup",
         "AST:easyuse_anima.nodes.aio_nodes string runtime lookup"
       ],
@@ -4872,8 +4469,6 @@
       "id": "nodes_legacy_bindings:wildcard_engine:transitional_private_seam",
       "surface": "nodes_legacy_bindings",
       "symbols": {
-        "MAX_SEED": "MAX_SEED",
-        "SEED_CONTROL_FIXED": "SEED_CONTROL_FIXED",
         "expand_wildcards": "expand_wildcards",
         "normalize_seed": "normalize_seed",
         "normalize_wildcard_mode": "normalize_wildcard_mode",
@@ -4889,12 +4484,10 @@
       "owner": "#184/#186",
       "first_release": null,
       "known_consumers": [
-        "nodes.py residual runtime",
-        "canonical runtime resolver: easyuse_anima.aio.sampling"
+        "nodes.py residual runtime"
       ],
       "evidence": [
-        "AST:nodes.py direct runtime load",
-        "AST:easyuse_anima.aio.sampling string runtime lookup"
+        "AST:nodes.py direct runtime load"
       ],
       "removal_gates": [
         "canonical production consumer migration",
@@ -4907,9 +4500,11 @@
       "id": "nodes_legacy_bindings:wildcard_engine:unsupported_test_only",
       "surface": "nodes_legacy_bindings",
       "symbols": {
+        "MAX_SEED": "MAX_SEED",
         "PROMPT_STUDIO_WILDCARD_MODE_LABELS": "PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "PUBLIC_MAX_SEED": "PUBLIC_MAX_SEED",
         "SEED_CONTROL_DECREMENT": "SEED_CONTROL_DECREMENT",
+        "SEED_CONTROL_FIXED": "SEED_CONTROL_FIXED",
         "SEED_CONTROL_INCREMENT": "SEED_CONTROL_INCREMENT",
         "SEED_CONTROL_MODES": "SEED_CONTROL_MODES",
         "SEED_CONTROL_RANDOMIZE": "SEED_CONTROL_RANDOMIZE",

--- a/tests/test_aio_conditioning.py
+++ b/tests/test_aio_conditioning.py
@@ -113,7 +113,11 @@ class AIOConditioningMoveTests(unittest.TestCase):
             return f"first:{text}"
 
         with (
-            patch.object(nodes, "_aio_usdu_prompt_without_general", return_value=("", False)),
+            patch.object(
+                conditioning,
+                "_aio_usdu_prompt_without_general",
+                return_value=("", False),
+            ),
             patch_comfy_helper(
                 nodes,
                 "_encode_with_comfy_clip",

--- a/tests/test_aio_model_preparation.py
+++ b/tests/test_aio_model_preparation.py
@@ -76,7 +76,7 @@ class AIOModelPreparationMoveTests(unittest.TestCase):
         self.assertIs(result_clip, original_clip)
         self.assertEqual(applied, [])
 
-    def test_model_patch_aggregate_re_resolves_each_root_subcall_in_order(self):
+    def test_model_patch_aggregate_uses_canonical_subcalls_in_order(self):
         trace: list[tuple[str, object]] = []
         replacement_dave = Mock(
             side_effect=lambda model, _settings: trace.append(("dave", model)) or "dave"
@@ -84,7 +84,7 @@ class AIOModelPreparationMoveTests(unittest.TestCase):
 
         def apply_aura(model, _settings):
             trace.append(("aura", model))
-            nodes._apply_aio_anima_dave_patch = replacement_dave
+            model_preparation._apply_aio_anima_dave_patch = replacement_dave
             return "aura"
 
         stale_dave = Mock(return_value="stale")
@@ -98,10 +98,26 @@ class AIOModelPreparationMoveTests(unittest.TestCase):
             return "kj"
 
         with (
-            patch.object(nodes, "_patch_model_sampling_aura_flow", side_effect=apply_aura),
-            patch.object(nodes, "_apply_aio_anima_dave_patch", stale_dave),
-            patch.object(nodes, "_apply_aio_safe_pag_patch", side_effect=apply_safe_pag),
-            patch.object(nodes, "_apply_aio_kj_model_patches", side_effect=apply_kj),
+            patch.object(
+                model_preparation,
+                "_patch_model_sampling_aura_flow",
+                side_effect=apply_aura,
+            ),
+            patch.object(
+                model_preparation,
+                "_apply_aio_anima_dave_patch",
+                stale_dave,
+            ),
+            patch.object(
+                model_preparation,
+                "_apply_aio_safe_pag_patch",
+                side_effect=apply_safe_pag,
+            ),
+            patch.object(
+                model_preparation,
+                "_apply_aio_kj_model_patches",
+                side_effect=apply_kj,
+            ),
         ):
             result = model_preparation._apply_aio_model_patches(
                 "base",
@@ -220,7 +236,7 @@ class AIOModelPreparationMoveTests(unittest.TestCase):
                 sys.modules,
                 {"comfy": comfy, "comfy.model_management": model_management},
             ),
-            patch.object(nodes.logger, "debug") as debug,
+            patch.object(model_preparation.logger, "debug") as debug,
         ):
             model_preparation._cleanup_aio_ephemeral_model(None, base_model)
             model_preparation._cleanup_aio_ephemeral_model(base_model, base_model)
@@ -246,14 +262,14 @@ class AIOModelPreparationMoveTests(unittest.TestCase):
                 sys.modules,
                 {"comfy": comfy, "comfy.model_management": model_management},
             ),
-            patch.object(nodes.logger, "debug") as debug,
+            patch.object(model_preparation.logger, "debug") as debug,
         ):
             model_preparation._cleanup_aio_ephemeral_model(model)
 
         debug.assert_called_once()
         self.assertIn("failed to unload ephemeral AiO model clone", debug.call_args.args[0])
 
-    def test_spectrum_aggregate_re_resolves_root_subcalls_in_order(self):
+    def test_spectrum_aggregate_uses_canonical_subcalls_in_order(self):
         trace: list[tuple[str, object]] = []
         replacement_forecast = Mock(
             side_effect=lambda model, _settings: trace.append(("forecast", model))
@@ -262,7 +278,7 @@ class AIOModelPreparationMoveTests(unittest.TestCase):
 
         def apply_correction(model, _clip, _positive, _settings):
             trace.append(("correction", model))
-            nodes._apply_aio_spectrum_forecast_patch_for_comfy_sampler = (
+            model_preparation._apply_aio_spectrum_forecast_patch_for_comfy_sampler = (
                 replacement_forecast
             )
             return "corrected"
@@ -270,12 +286,12 @@ class AIOModelPreparationMoveTests(unittest.TestCase):
         stale_forecast = Mock(return_value="stale")
         with (
             patch.object(
-                nodes,
+                model_preparation,
                 "_apply_aio_spectrum_correction_patch_for_comfy_sampler",
                 side_effect=apply_correction,
             ),
             patch.object(
-                nodes,
+                model_preparation,
                 "_apply_aio_spectrum_forecast_patch_for_comfy_sampler",
                 stale_forecast,
             ),

--- a/tests/test_aio_nodes.py
+++ b/tests/test_aio_nodes.py
@@ -6,7 +6,13 @@ import unittest
 from unittest.mock import patch
 
 import nodes
-from easyuse_anima.aio import first_pass_cache, generation_normalization, postprocess
+from easyuse_anima.aio import (
+    first_pass_cache,
+    generation_normalization,
+    model_preparation,
+    postprocess,
+    sampling,
+)
 from easyuse_anima.nodes import aio_nodes
 from tests.comfy_host_fakes import (
     FakeComfyHostProvider,
@@ -1416,9 +1422,9 @@ class AIOSamplerDependencyTests(unittest.TestCase):
                 calls = []
 
                 with (
-                    patch.object(nodes, "_sample_latent_with_comfy", side_effect=lambda *args: calls.append("comfy") or f"{backend}_latent"),
-                    patch.object(nodes, "_sample_latent_with_spectrum_spd", side_effect=lambda *args: calls.append("spd") or f"{backend}_latent"),
-                    patch.object(nodes, "_sample_latent_with_spectrum_mod_guidance_advanced", side_effect=lambda *args: calls.append("advanced") or f"{backend}_latent"),
+                    patch.object(sampling, "_sample_latent_with_comfy", side_effect=lambda *args: calls.append("comfy") or f"{backend}_latent"),
+                    patch.object(sampling, "_sample_latent_with_spectrum_spd", side_effect=lambda *args: calls.append("spd") or f"{backend}_latent"),
+                    patch.object(sampling, "_sample_latent_with_spectrum_mod_guidance_advanced", side_effect=lambda *args: calls.append("advanced") or f"{backend}_latent"),
                 ):
                     result = nodes._sample_latent_with_aio_backend(
                         model="model",
@@ -1630,10 +1636,10 @@ class AIOSamplerDependencyTests(unittest.TestCase):
         }))
 
         with (
-            patch.object(nodes, "_patch_model_sampling_aura_flow", return_value="aura_model") as aura,
-            patch.object(nodes, "_apply_aio_anima_dave_patch", return_value="dave_model") as dave,
-            patch.object(nodes, "_apply_aio_safe_pag_patch", return_value="safe_pag_model") as safe_pag,
-            patch.object(nodes, "_apply_aio_kj_model_patches", return_value="kj_model") as kj,
+            patch.object(model_preparation, "_patch_model_sampling_aura_flow", return_value="aura_model") as aura,
+            patch.object(model_preparation, "_apply_aio_anima_dave_patch", return_value="dave_model") as dave,
+            patch.object(model_preparation, "_apply_aio_safe_pag_patch", return_value="safe_pag_model") as safe_pag,
+            patch.object(model_preparation, "_apply_aio_kj_model_patches", return_value="kj_model") as kj,
         ):
             result = nodes._apply_aio_model_patches("base_model", settings)
 
@@ -1655,10 +1661,10 @@ class AIOSamplerDependencyTests(unittest.TestCase):
         }))
 
         with (
-            patch.object(nodes, "_patch_model_sampling_aura_flow", return_value="aura_model") as aura,
-            patch.object(nodes, "_apply_aio_anima_dave_patch", return_value="dave_model") as dave,
-            patch.object(nodes, "_apply_aio_safe_pag_patch", return_value="safe_pag_model") as safe_pag,
-            patch.object(nodes, "_apply_aio_kj_model_patches", return_value="kj_model") as kj,
+            patch.object(model_preparation, "_patch_model_sampling_aura_flow", return_value="aura_model") as aura,
+            patch.object(model_preparation, "_apply_aio_anima_dave_patch", return_value="dave_model") as dave,
+            patch.object(model_preparation, "_apply_aio_safe_pag_patch", return_value="safe_pag_model") as safe_pag,
+            patch.object(model_preparation, "_apply_aio_kj_model_patches", return_value="kj_model") as kj,
         ):
             result = nodes._apply_aio_model_patches("base_model", settings)
 

--- a/tests/test_aio_sampling.py
+++ b/tests/test_aio_sampling.py
@@ -11,6 +11,8 @@ from tests.comfy_host_fakes import patch_comfy_helper
 class AIOSamplingMoveTests(unittest.TestCase):
     def test_root_symbols_are_direct_canonical_aliases(self):
         for name in (
+            "_new_aio_random_seed",
+            "_resolve_aio_runtime_seed",
             "_generate_empty_latent_with_comfy",
             "_sample_latent_with_comfy",
             "_sample_latent_with_spectrum_mod_guidance_advanced",
@@ -24,7 +26,7 @@ class AIOSamplingMoveTests(unittest.TestCase):
             with self.subTest(name=name):
                 self.assertIs(getattr(nodes, name), getattr(sampling, name))
 
-    def test_backend_dispatch_re_resolves_selected_root_helper_at_call_time(self):
+    def test_backend_dispatch_uses_selected_canonical_helper_at_call_time(self):
         settings = {
             "seed": 1,
             "steps": 2,
@@ -44,7 +46,7 @@ class AIOSamplingMoveTests(unittest.TestCase):
         for backend, helper_name in cases:
             with self.subTest(backend=backend):
                 replacement = Mock(return_value=f"{backend}-latent")
-                with patch.object(nodes, helper_name, replacement):
+                with patch.object(sampling, helper_name, replacement):
                     result = sampling._sample_latent_with_aio_backend(
                         "model",
                         "clip",
@@ -95,7 +97,7 @@ class AIOSamplingMoveTests(unittest.TestCase):
                 "_find_comfy_node_class",
                 side_effect=classes.get,
             ),
-            patch.object(nodes, "_resolve_aio_runtime_seed", return_value=987),
+            patch.object(sampling, "_resolve_aio_runtime_seed", return_value=987),
         ):
             empty = sampling._generate_empty_latent_with_comfy(8, 20)
             sampled = sampling._sample_latent_with_comfy(
@@ -198,7 +200,7 @@ class AIOSamplingMoveTests(unittest.TestCase):
                 "_require_custom_node_class",
                 return_value=SpectrumKSamplerAdvanced,
             ),
-            patch.object(nodes, "_resolve_aio_runtime_seed", return_value=4242),
+            patch.object(sampling, "_resolve_aio_runtime_seed", return_value=4242),
         ):
             result = sampling._sample_latent_with_spectrum_mod_guidance_advanced(
                 "model",
@@ -238,7 +240,7 @@ class AIOSamplingMoveTests(unittest.TestCase):
                 "_require_custom_node_class",
                 return_value=SpectrumSPDKSampler,
             ),
-            patch.object(nodes, "_resolve_aio_runtime_seed", return_value=55),
+            patch.object(sampling, "_resolve_aio_runtime_seed", return_value=55),
         ):
             result = sampling._sample_latent_with_spectrum_spd(
                 "model",
@@ -274,7 +276,7 @@ class AIOSamplingMoveTests(unittest.TestCase):
         spectrum = {"enabled": True}
         corrections = {"enabled": True}
         spd = {"scale": 0.5}
-        with patch.object(nodes, "_resolve_aio_runtime_seed", return_value=77):
+        with patch.object(sampling, "_resolve_aio_runtime_seed", return_value=77):
             result = sampling._aio_stage_sampler_settings(
                 base,
                 {
@@ -290,7 +292,7 @@ class AIOSamplingMoveTests(unittest.TestCase):
 
         self.assertEqual(result["backend"], "comfy_ksampler")
         self.assertEqual(result["seed"], 77)
-        self.assertEqual(result["seed_after_generate"], nodes.SEED_CONTROL_FIXED)
+        self.assertEqual(result["seed_after_generate"], sampling.SEED_CONTROL_FIXED)
         self.assertEqual(result["sampler_name"], "euler")
         self.assertEqual(result["scheduler"], "beta")
         self.assertEqual(result["steps"], 30)

--- a/tests/test_node_contracts.py
+++ b/tests/test_node_contracts.py
@@ -640,14 +640,14 @@ class AioLoraSignatureMoveContractTests(unittest.TestCase):
         }
     ]
 
-    def test_root_alias_and_call_time_normalizer_rebind(self):
+    def test_root_alias_and_canonical_normalizer_rebind(self):
         self.assertIs(
             nodes._aio_lora_stack_signature,
             aio_model_preparation._aio_lora_stack_signature,
         )
         normalized = [("styles/test.safetensors", 0.8, 0.6)]
         with patch.object(
-            nodes,
+            aio_model_preparation,
             "_normalize_aio_lora_stack",
             return_value=normalized,
         ) as normalize:
@@ -657,7 +657,7 @@ class AioLoraSignatureMoveContractTests(unittest.TestCase):
             )
         normalize.assert_called_once_with("raw")
 
-    def test_package_alias_and_call_time_normalizer_rebind(self):
+    def test_package_alias_and_canonical_normalizer_rebind(self):
         with _loaded_package_entrypoint() as (_, package_nodes):
             package_name = package_nodes.__package__
             package_model_preparation = sys.modules[
@@ -669,7 +669,7 @@ class AioLoraSignatureMoveContractTests(unittest.TestCase):
             )
             normalized = [("styles/test.safetensors", 0.8, 0.6)]
             with patch.object(
-                package_nodes,
+                package_model_preparation,
                 "_normalize_aio_lora_stack",
                 return_value=normalized,
             ) as normalize:
@@ -1863,21 +1863,25 @@ class AioRuntimeSeedMoveContractTests(unittest.TestCase):
             randint=lambda lower, upper: randint_calls.append((lower, upper)) or 7
         )
         with (
-            patch.object(root_module, "random", random_module),
-            patch.object(root_module, "MAX_SEED", 12),
+            patch.object(canonical_module, "random", random_module),
+            patch.object(canonical_module, "MAX_SEED", 12),
         ):
             self.assertEqual(canonical_module._new_aio_random_seed(), 7)
         self.assertEqual(randint_calls, [(0, 12)])
 
         with (
             patch.object(
-                root_module,
+                canonical_module,
                 "_normalize_aio_seed",
                 side_effect=(-1, 99, -99),
             ) as normalize_seed,
-            patch.object(root_module, "AIO_SPECIAL_SEEDS", {-1}),
-            patch.object(root_module, "_new_aio_random_seed", return_value=777) as new_seed,
-            patch.object(root_module, "MAX_SEED", 12),
+            patch.object(canonical_module, "AIO_SPECIAL_SEEDS", {-1}),
+            patch.object(
+                canonical_module,
+                "_new_aio_random_seed",
+                return_value=777,
+            ) as new_seed,
+            patch.object(canonical_module, "MAX_SEED", 12),
         ):
             self.assertEqual(canonical_module._resolve_aio_runtime_seed("special"), 777)
             self.assertEqual(canonical_module._resolve_aio_runtime_seed("high"), 12)
@@ -1889,10 +1893,10 @@ class AioRuntimeSeedMoveContractTests(unittest.TestCase):
         )
         new_seed.assert_called_once_with()
 
-    def test_root_aliases_and_runtime_helper_replacements(self):
+    def test_root_aliases_and_canonical_replacements(self):
         self._assert_contract(nodes, aio_sampling)
 
-    def test_package_aliases_and_runtime_helper_replacements(self):
+    def test_package_aliases_and_canonical_replacements(self):
         with _loaded_package_entrypoint() as (_, package_nodes):
             package_name = package_nodes.__package__
             package_sampling = sys.modules[f"{package_name}.easyuse_anima.aio.sampling"]

--- a/tests/test_nodes_module_analyzer.py
+++ b/tests/test_nodes_module_analyzer.py
@@ -73,12 +73,12 @@ def load_dynamic():
     def test_current_nodes_module_shape_matches_recorded_baseline(self):
         report = analyzer.analyze_path(ROOT / "nodes.py")
 
-        self.assertEqual(report["git_blob_sha1"], "40f7789cb9de0f3149fa2498ddd127d47067c405")
+        self.assertEqual(report["git_blob_sha1"], "cfe6755171d9ad699ad019c980421cfdaadefbb2")
         # B-11c30d3 moves declarative input defaults and retires three
         # I/O-boundary binders without changing the public class surface.
         self.assertEqual(report["top_level"]["function_count"], 0)
         self.assertEqual(report["top_level"]["class_count"], 0)
-        self.assertEqual(report["line_count"], 1_182)
+        self.assertEqual(report["line_count"], 1_158)
         class_names = {item["name"] for item in report["top_level"]["classes"]}
         self.assertNotIn("EasyUseAnimaAIOGenerator", class_names)
         self.assertNotIn("EasyUseAnimaInput", class_names)

--- a/tests/test_python_compatibility_surface.py
+++ b/tests/test_python_compatibility_surface.py
@@ -98,9 +98,6 @@ PROMPT_NODE_ADAPTER_RETIRED_RUNTIME_BINDERS = (
 RUNTIME_BINDER_FAMILIES = {
     "aio": (
         "_bind_aio_legacy_generation_runtime",
-        "_bind_aio_model_preparation_runtime",
-        "_bind_aio_sampling_runtime",
-        "_bind_aio_conditioning_runtime",
         "_bind_aio_node_runtime",
     ),
     "wildcard_naia": (
@@ -138,6 +135,7 @@ AIO_RUNTIME_RETIRED_SUBGROUPS = (
     "B-11c30d1_cache_state",
     "B-11c30d2_normalization_planning",
     "B-11c30d3_io_boundary",
+    "B-11c30d4_execution_services",
 )
 AIO_RUNTIME_PREREQUISITE_MOVES = (
     {
@@ -2325,14 +2323,14 @@ def _build_document() -> dict[str, Any]:
         "expected_counts": {
             "root_entrypoints": 3,
             "excluded_preamble_implementation_bindings": 3,
-            "nodes_canonical_bindings": 296,
+            "nodes_canonical_bindings": 293,
             "nodes_legacy_bindings": 27,
             "mapped_public_classes": 18,
             "unmapped_classes": 2,
             "root_residual_functions": 0,
             "root_residual_classes": 0,
             "root_residual_globals": 3,
-            "runtime_binders": 7,
+            "runtime_binders": 4,
             "direct_nodes_import_test_files": 21,
         },
         "mapped_public_classes": sorted(mapped_classes),
@@ -2564,7 +2562,7 @@ class PythonCompatibilitySurfaceTests(unittest.TestCase):
             len(self.document["direct_nodes_import_test_files"]),
             counts["direct_nodes_import_test_files"],
         )
-        self.assertEqual(len(set(self.document["runtime_binders"])), 7)
+        self.assertEqual(len(set(self.document["runtime_binders"])), 4)
         self.assertEqual(len(set(self.document["direct_nodes_import_test_files"])), 21)
 
     def test_runtime_binder_audit_covers_provider_and_root_names(self):
@@ -2572,34 +2570,30 @@ class PythonCompatibilitySurfaceTests(unittest.TestCase):
         self.assertEqual(
             audit["summary"],
             {
-                "binder_count": 7,
+                "binder_count": 4,
                 "family_count": 2,
                 "mode_counts": {
-                    "comfy_provider_then_root": 4,
+                    "comfy_provider_then_root": 1,
                     "root_globals": 1,
                     "explicit_callbacks": 2,
                 },
-                "unique_resolver_names": 112,
-                "unique_root_resolver_names": 108,
-                "unique_provider_resolver_names": 4,
+                "unique_resolver_names": 86,
+                "unique_root_resolver_names": 84,
+                "unique_provider_resolver_names": 2,
                 "unique_direct_root_dependencies": 9,
-                "direct_root_dependency_slots": 13,
-                "provider_consumer_slots": 8,
-                "provider_consumer_modules": 4,
-                "repository_replacement_names": 85,
-                "repository_replacement_files": 8,
+                "direct_root_dependency_slots": 10,
+                "provider_consumer_slots": 2,
+                "provider_consumer_modules": 1,
+                "repository_replacement_names": 71,
+                "repository_replacement_files": 5,
             },
         )
         self.assertEqual(
             audit["provider_resolver_names"],
-            sorted(
-                set(COMFY_HOST_WRAPPERS)
-                - {
-                    "_comfy_max_resolution",
-                    "_find_comfy_node_mapping_class",
-                    "_find_loaded_node_class",
-                }
-            ),
+            [
+                "_encode_with_comfy_clip",
+                "_require_custom_node_class",
+            ],
         )
         self.assertEqual(
             set(audit["root_resolver_names"])
@@ -2692,14 +2686,6 @@ class PythonCompatibilitySurfaceTests(unittest.TestCase):
         self.assertEqual(
             summaries,
             {
-                "B-11c30d4_execution_services": {
-                    "root_resolver_slots": 43,
-                    "unique_root_resolver_names": 37,
-                    "provider_resolver_slots": 6,
-                    "direct_root_dependency_slots": 3,
-                    "repository_replacement_slots": 23,
-                    "unique_repository_replacement_names": 21,
-                },
                 "B-11c30d5_legacy_orchestration": {
                     "root_resolver_slots": 59,
                     "unique_root_resolver_names": 59,


### PR DESCRIPTION
## 변경 요약

B-11c30d4 frozen subgroup의 model-preparation, sampling, conditioning runtime binder 세 개만 퇴역시키는 **Move 전용 PR**입니다.

- `_bind_aio_model_preparation_runtime`, `_bind_aio_sampling_runtime`, `_bind_aio_conditioning_runtime`과 각 `_RUNTIME_RESOLVER`/`_runtime_helper`를 제거했습니다.
- 세 canonical module은 기존 common, Prompt, LoRA, seed, generation, Comfy invocation owner를 직접 사용합니다.
- `_find_comfy_node_class`, `_require_custom_node_class`, `_require_any_custom_node_class`, `_encode_with_comfy_clip`은 기존 E-07 call-time provider를 유지합니다.
- root의 canonical execution function 26개는 package/flat mode에서 exact alias identity를 유지합니다.
- d4 owner test의 same-module patch만 canonical owner로 이동했습니다. d5/d6를 구동하는 root replacements는 유지했습니다.

## 사전 symbol/caller/alias/global-state inventory

- binders: 3개
  - `_bind_aio_model_preparation_runtime`
  - `_bind_aio_sampling_runtime`
  - `_bind_aio_conditioning_runtime`
- global state: 각 canonical module의 `_RUNTIME_RESOLVER` 1개, 총 3개
- frozen cost: root resolver 43 slots / 37 unique names, provider 6 slots / 4 names, direct E-07 bridge 3 slots, repository replacement 23 slots / 21 names / 6 files
- canonical symbols/root aliases:
  - model preparation 12개
  - sampling 11개
  - conditioning 3개
- production caller: `easyuse_anima.aio.legacy_generation`의 still-active d5 resolver

## 변경 결과

- 전체 runtime binder: 7개 → 4개
  - AiO d5 legacy orchestrator 1개
  - AiO d6 node adapter 1개
  - Wildcard/NAIA callback 2개
- canonical root bindings: 296개 → 293개
- root residual globals: 3개 유지
- shipped/reachable Python modules: 92개 유지
- `nodes.py`: 1,158 lines
- Phase A 12,663-line baseline 대비 11,505 lines, 약 90.9% 제거

## 주요 파일

Production:
- `nodes.py`
- `easyuse_anima/aio/model_preparation.py`
- `easyuse_anima/aio/sampling.py`
- `easyuse_anima/aio/conditioning.py`

Supporting:
- d4 owner/caller tests
- Comfy-host 및 Python compatibility gate/fixture
- nodes/backend analyzer gate/fixture
- backend architecture 문서 3개

## 검증

- Final focused unittest: 274 tests, 13.260s, 통과
- Canonical production owner targeted Ruff 0.15.22: 통과
- Official full (`tools/check_project.ps1 -Profile full`): 통과
  - Python compile: 통과
  - Ruff G-01 report-only: 기존 78 findings, blocking failure 없음
  - Pyright baseline ratchet: 통과 (75 files, 14 baseline errors, 신규 증가 없음)
  - Python import boundary: 6 completed groups, 0 violations
  - Python unittest: 983 tests, 29.934s, 통과
  - Frontend: 114 JavaScript files, TypeScript 6.0.3, 통과
  - `git diff --check`: 통과
- ComfyUI Codex test surface: repository full validation
- Live ComfyUI smoke: 미실행 (순수 Python Move, behavior/schema/workflow 변경 없음)

## 유지한 경계와 남은 위험

patch order/kwargs, LoRA normalization/application, cleanup timing, seed/random semantics, backend selection, sampler/Spectrum/VAE invocation, SPD Euler normalization, stage sampler settings, Prompt Data selection, quality fallback, CLIP text, provider lookup, errors/logs, schemas/workflows, cache, stage order는 변경하지 않았습니다.

`nodes.py`의 남은 정적 Ruff unused 항목은 d5/d6 및 Wildcard/NAIA compatibility alias와 기존 G-01 부채입니다. 후속 retirement 경계에서만 제거합니다.

Owner: #184
Behavior boundaries: #168, #169