### PR TITLE
B-11c30d5: retire AiO legacy-orchestration binder

### DIFF
--- a/docs/architecture/comfy-host-provider-bridge.md
+++ b/docs/architecture/comfy-host-provider-bridge.md
@@ -2190,6 +2190,144 @@ Result:
   package-closure, and analyzer gates preserve signature shape, JSON-safe
   conversion, validation/error behavior, object identity, and import closure.
 
+### B-11c30d5 — AiO legacy-orchestration binder Move
+
+- **State:** IN PROGRESS
+- **Owner:** #184
+- **Behavior boundary:** #168 and #169
+- **Type:** Move
+- **Base:** `dev@4409c17e87a8d7a06157c85ce38b72b8e3de5c39`
+
+Pre-edit inventory:
+
+- the frozen d5 subgroup contains exactly
+  `_bind_aio_legacy_generation_runtime`;
+- the binder owns one `_RUNTIME_RESOLVER` global and one `_runtime_helper`
+  dispatcher. After d0b it accounts for 58 root-resolver slots over 58 unique
+  names, two provider slots (`_encode_with_comfy_clip` and
+  `_require_custom_node_class`), one direct `_resolve_comfy_host_helper`
+  dependency, and 42 repository replacement slots over 42 names in
+  `tests/test_aio_legacy_generation.py`, `tests/test_aio_nodes.py`, and
+  `tests/test_node_contracts.py`;
+- root imports the binder plus seven execution functions as exact package/flat
+  aliases, then invokes the binder once during module initialization;
+- `easyuse_anima.nodes.aio_nodes` is the sole production consumer of
+  `_run_aio_legacy_generation` through the still-active d6 resolver. The other
+  six stage functions are same-module orchestration calls and root
+  compatibility aliases;
+- direct canonical owners already exist for all 55 non-provider dependencies.
+  They span common values and invocation, Prompt Data/conditioning/Artist Mix,
+  AiO settings/cache/resources/model/sampling/conditioning/planning/preview/
+  output/postprocess, image geometry/SAM3, and the two existing node adapters;
+- `json`, `logger`, and `random` are currently root-resolved even though the
+  canonical module can own the same standard-library/module-local objects;
+  no process-global state or new service contract is required; and
+- the legacy execution trace fixture freezes base generation and optional
+  stage order, cache/cleanup timing, preview/save behavior, and returned
+  metadata. Existing tests also freeze short circuits, exact errors,
+  call-time provider observation, and package/flat root alias identity.
+
+Exact root-resolver ownership:
+
+```text
+stdlib/module-local:
+  json, logger, random
+common/invocation:
+  _as_bool, _as_float, _as_int, _single_value, _node_output_tuple
+prompt:
+  ANIMA_MOD_GUIDANCE_PROFILE_OFF
+  _advanced_outputs_from_prompt_data
+  _apply_spectrum_anima_mod_guidance
+  _encode_prompt_data_positive_conditioning
+  _normalize_anima_mod_guidance_profile
+  _normalize_prompt_data
+  _prompt_data_json_safe
+  _resolve_anima_mod_guidance_enabled
+aio generation/cache:
+  AIO_USDU_PROMPT_FULL
+  _aio_detailer_has_enabled_targets
+  _aio_detailer_target_order
+  _aio_first_pass_cache_key
+  _get_aio_first_pass_cache
+  _normalize_aio_generation_settings
+  _put_aio_first_pass_cache
+aio model/sampling/conditioning/planning:
+  _aio_highres_effective_backend
+  _aio_stage_sampler_settings
+  _aio_usdu_conditioning
+  _aio_usdu_tile_plan
+  _apply_aio_lora_stack
+  _apply_aio_model_patches
+  _apply_aio_spectrum_model_patches_for_comfy_sampler
+  _cleanup_aio_ephemeral_model
+  _decode_latent_with_comfy
+  _encode_image_with_comfy_vae
+  _generate_empty_latent_with_comfy
+  _resolve_aio_runtime_seed
+  _sample_latent_with_aio_backend
+aio resources/output/preview/postprocess:
+  _aio_save_filename_prefix
+  _load_aio_resources_from_input_context
+  _load_aio_sam3_context
+  _load_upscale_model_with_comfy
+  _resize_image_to_size_if_needed
+  _run_aio_postprocess_stage
+  _save_aio_temp_preview_image
+  _save_image_with_comfy
+  _save_image_with_image_saver
+  _send_aio_preview_event
+  _tag_aio_preview_images
+image/node adapters:
+  EasyUseAnimaImageScaleByMultiple
+  EasyUseAnimaSAM3Detailer
+  _context_value
+  _image_tensor_size
+  _segs_has_items
+same-module:
+  _run_aio_detailer_stage
+  _run_aio_detailer_target
+  _run_aio_highres_stage
+  _run_aio_resshift_upscale_stage
+  _run_aio_upscale_stage
+  _run_aio_usdu_upscale_stage
+```
+
+Allowed production files:
+
+```text
+nodes.py
+easyuse_anima/aio/legacy_generation.py
+```
+
+Allowed supporting files are the three d5 replacement-owner tests, Comfy-host
+and Python compatibility gates/fixtures, nodes/backend analyzer gates/fixture,
+the frozen legacy execution trace assertion, and the three architecture
+documents.
+
+Exit:
+
+- the d5 binder definition, root imports/call, `_RUNTIME_RESOLVER`, and
+  `_runtime_helper` are absent;
+- legacy orchestration imports existing canonical stateless owners directly,
+  uses direct same-module calls, and owns standard-library logger/random/JSON
+  access;
+- the two E-07 host seams remain call-time provider-resolved;
+- all seven root execution aliases retain exact identity;
+- only d5 replacement ownership moves from root/binder injection to the
+  canonical consumer module; and
+- d6 and Wildcard/NAIA remain active while stage/cache/seed/provider/error/
+  schema/workflow behavior and the execution trace remain unchanged.
+
+Forbidden:
+
+- retiring or otherwise changing the d6 or Wildcard/NAIA binders;
+- changing stage order, cache keys/state/eviction, cleanup timing, preview/save
+  order, seed/random semantics, sampler/model/conditioning behavior, provider
+  lookup, optional dependency timing, errors/logs, metadata, schemas, or
+  workflows;
+- beginning #168/#169 Behavior, d6, or final root-shim work; and
+- combining Contract, performance, dependency, or broad formatting cleanup.
+
 ### B-11d — Final root shim
 
 - **State:** BLOCKED by the remaining AiO and Wildcard/NAIA binder families
@@ -2242,7 +2380,7 @@ COMPLETE: B-11c30d2 normalization/planning binder Move / PR #349
 COMPLETE: B-11c30d3 I/O-boundary binder Move / PR #350
 COMPLETE: B-11c30d4 execution-service Move / PR #351
 COMPLETE: B-11c30d0b input-context owner Move / PR #352
-READY:    B-11c30d5 legacy-orchestration Move
+IN PROGRESS: B-11c30d5 legacy-orchestration Move
 PLANNED:  B-11c30d6 node-adapter Move
 BLOCKED:  B-11d final root shim
 

--- a/docs/architecture/comfy-host-provider-bridge.md
+++ b/docs/architecture/comfy-host-provider-bridge.md
@@ -2192,7 +2192,7 @@ Result:
 
 ### B-11c30d5 — AiO legacy-orchestration binder Move
 
-- **State:** IN PROGRESS
+- **State:** COMPLETE IN PR #353
 - **Owner:** #184
 - **Behavior boundary:** #168 and #169
 - **Type:** Move
@@ -2318,6 +2318,25 @@ Exit:
 - d6 and Wildcard/NAIA remain active while stage/cache/seed/provider/error/
   schema/workflow behavior and the execution trace remain unchanged.
 
+Implementation result:
+
+- the binder, resolver global/helper, root imports, and root initialization call
+  are absent; all seven root execution aliases retain exact identity;
+- the canonical orchestrator imports its existing stateless owners directly,
+  uses direct same-module stage calls, and keeps both E-07 host seams
+  call-time provider-resolved;
+- d5 test replacements now target the canonical consumer, so tests no longer
+  install or restore process-global resolver state;
+- the active audit contains only d6 plus the Wildcard/NAIA callbacks: three
+  binders, 29 unique resolver/root names, no provider-resolver slot, and 32
+  replacement names across five files;
+- the compatibility surface contains 291 canonical root bindings, three
+  residual globals, 93 shipped/reachable Python modules, and a 1,147-line
+  `nodes.py`; and
+- the consolidated focused checkpoint ran 239 tests in 13.401 seconds. Its 237
+  behavior/contract passes were retained; the two deterministic fixture/SHA
+  gate drifts were updated and their exact closure tests pass.
+
 Forbidden:
 
 - retiring or otherwise changing the d6 or Wildcard/NAIA binders;
@@ -2380,7 +2399,7 @@ COMPLETE: B-11c30d2 normalization/planning binder Move / PR #349
 COMPLETE: B-11c30d3 I/O-boundary binder Move / PR #350
 COMPLETE: B-11c30d4 execution-service Move / PR #351
 COMPLETE: B-11c30d0b input-context owner Move / PR #352
-IN PROGRESS: B-11c30d5 legacy-orchestration Move
+COMPLETE: B-11c30d5 legacy-orchestration Move / PR #353
 PLANNED:  B-11c30d6 node-adapter Move
 BLOCKED:  B-11d final root shim
 

--- a/docs/architecture/python-backend-execution-roadmap.md
+++ b/docs/architecture/python-backend-execution-roadmap.md
@@ -5,7 +5,7 @@
 - Status: operational execution runbook
 - Snapshot date: 2026-07-24
 - Snapshot branch: `dev`
-- Integrated `dev` snapshot commit: `7c5cd5c41a9a2b777c4acb9c5307b5ad1920692b`
+- Integrated `dev` snapshot commit: `4409c17e87a8d7a06157c85ce38b72b8e3de5c39`
 - Scope: Python backend only
 - Target architecture: [`python-backend.md`](python-backend.md)
 - Architecture decisions: [ADR-001](adr-001-modular-monolith.md) and
@@ -31,7 +31,7 @@ merged PR, the owning issue's evidence record, and every stated exit gate.
 | Phase | Integrated snapshot / open implementation state | Remaining exit work |
 | --- | --- | --- |
 | A - baseline | Complete; #191 is closed | Keep fixtures and analyzers current during later moves |
-| B - `nodes.py` extraction | Integrated through B-11c30d4 / PR #351; B-11c30d0b completes in PR #352 | Execute d5, d6, Wildcard/NAIA, and the final root shim as separate rollback units |
+| B - `nodes.py` extraction | Integrated through B-11c30d0b / PR #352; B-11c30d5 completes in PR #353 | Execute d6, Wildcard/NAIA, and the final root shim as separate rollback units |
 | C - feature contracts/behavior | Partially complete through S167-01a / PR #344 | Continue #167 and #169 in separate Contract/Move/Behavior PRs |
 | D - root consolidation | Not started | Execute #186 feature by feature after the corresponding behavior contracts are stable |
 | E - runtime ownership | Partial: E-02a and E-07a/E-07b integrated | Continue #187 only where canonical feature owners and explicit contracts exist |
@@ -42,9 +42,9 @@ merged PR, the owning issue's evidence record, and every stated exit gate.
 ### Measured Phase B progress
 
 - The Phase A baseline recorded root `nodes.py` at 12,663 lines.
-- In B-11c30d0b / PR #352, the analyzer measures root `nodes.py` at 1,162 lines.
-- The mechanical extraction has removed 11,501
-  lines, approximately 90.8% of the Phase A baseline, while preserving the root
+- In B-11c30d5 / PR #353, the analyzer measures root `nodes.py` at 1,147 lines.
+- The mechanical extraction has removed 11,516
+  lines, approximately 90.9% of the Phase A baseline, while preserving the root
   compatibility surface.
 - B-01 through B-09b2 are integrated. The latest completed implementation slice
   is the AiO generator adapter Move in PR #270.
@@ -146,7 +146,11 @@ merged PR, the owning issue's evidence record, and every stated exit gate.
   binders. B-11c30d0b / PR #352 then moves the two input-context helpers to
   the pure `easyuse_anima.aio.input_context` owner. The d5 and d6 root-resolver
   sets each lose one cycle-forming name without retiring either binder or
-  changing input validation or signature behavior.
+  changing input validation or signature behavior. B-11c30d5 / PR #353 then
+  retires only the legacy-orchestration binder. Its canonical owner imports the
+  existing stateless owners directly, keeps the two E-07 host seams call-time
+  provider-resolved, and preserves all seven root execution aliases. Three
+  binders remain: d6 and the two Wildcard/NAIA callbacks.
 
 ### Current quality baseline
 
@@ -390,7 +394,7 @@ mechanical retirement series.
 | 11 | B-09b2 AiO generator adapter move | COMPLETE on `dev` | Move | #184 | PR #270 / `57d40b4` |
 | 12 | B-10a machine-readable compatibility audit | COMPLETE on `dev` | Contract/gate | #184/#188 | PR #271 / `3c7b857` |
 | 13 | B-10b private alias reduction | COMPLETE on `dev` through PR #291 / `c6b4680` | Contract/cleanup, split PRs | #184/#188 | Audited alias surface integrated |
-| 14 | B-11 registration/bootstrap/root shim | IN PROGRESS through B-11c30d0b PR #352; d5 and d6 are next as separate Moves | Move/Contract, split PRs | #184 | Frozen AiO split gate; S167-01 contract |
+| 14 | B-11 registration/bootstrap/root shim | IN PROGRESS through B-11c30d5 PR #353; d6 is the next separate Move | Move/Contract, split PRs | #184 | Frozen AiO split gate; S167-01 contract |
 | 15 | S167 backend seed reservation series | S167-01 Contract COMPLETE in PR #343 and S167-01a consumer Move COMPLETE in PR #344; Behavior and Adapter remain | Contract then Move then Behavior | #167 | Canonical AiO/node seams |
 | 16 | A169 stage pipeline series | BLOCKED by #168 and B exit | Contract then Behavior | #169 | Typed config and mechanical AiO move |
 | 17 | A169 first-pass cache policy | BLOCKED by stage/cache ownership seam | Behavior | #169 | Mechanical cache move and benchmark harness |
@@ -1114,7 +1118,14 @@ unchanged. The separate legacy Wildcard unsupported alias remains for D-12.
     `easyuse_anima.aio.input_context` owner in PR #352. Legacy generation and
     the node adapter consume the owner directly, root aliases retain identity,
     and d5/d6 remain separate active binders. The audited package grows to 93
-    shipped and reachable modules; B-11c30d5 is the next READY Move.
+    shipped and reachable modules.
+  - B-11c30d5 retires only `_bind_aio_legacy_generation_runtime` in PR #353.
+    The legacy orchestrator imports its 55 stateless dependencies directly,
+    owns JSON/logger/random locally, and keeps CLIP encoding plus optional-node
+    requirements behind the existing E-07 call-time provider. Root retains all
+    seven execution aliases, the frozen legacy execution trace is unchanged,
+    and d6 plus Wildcard/NAIA remain separate. The root shim falls to 1,147
+    lines; B-11c30d6 is the next READY Move.
   - The final B-11c cutover removes remaining root execution ownership and
     leaves the explicit supported `nodes.py` compatibility shim.
 - Add `easyuse_anima/registration.py` as pure mapping composition. It performs no

--- a/docs/architecture/python-compatibility-shims.md
+++ b/docs/architecture/python-compatibility-shims.md
@@ -1001,6 +1001,32 @@ convenience-node compatibility; it remains unmapped and is not public support.
 - B-11c30d5 legacy orchestration is the next separate Move; d6, Wildcard/NAIA,
   #168/#169 Behavior, and final root-shim work remain outside PR #352.
 
+### B-11c30d5 AiO legacy-orchestration binder retirement
+
+- PR #353 retires exactly `_bind_aio_legacy_generation_runtime`, its single
+  `_RUNTIME_RESOLVER`, and `_runtime_helper`.
+- `easyuse_anima.aio.legacy_generation` imports the existing common, Prompt,
+  AiO, image, invocation, and node-adapter owners directly. Same-module stage
+  calls are direct, and JSON, logging, and random access are module-owned.
+- CLIP encoding and optional custom-node requirements still resolve through
+  the existing E-07 provider at call time. Their lookup order, lazy failure,
+  and exact feature errors are unchanged.
+- All seven legacy execution functions remain exact package/flat root aliases.
+  The d6 adapter remains the sole production consumer of
+  `_run_aio_legacy_generation` through its separate active resolver.
+- Tests patch the canonical consumer rather than installing and restoring a
+  process-global resolver. This removes cross-test resolver state while
+  preserving short circuits, cleanup order, metadata order, provider timing,
+  and the frozen legacy execution trace.
+- Three binders remain: d6 and the two Wildcard/NAIA callbacks. The audit now
+  contains 29 unique resolver/root names, no provider-resolver slot, and 32
+  repository replacement names across five files.
+- The compatibility inventory contains 291 canonical root bindings and three
+  residual root globals. The package remains at 93 shipped and reachable
+  Python modules, and the root shim is 1,147 lines.
+- B-11c30d6 is the next separate Move; Wildcard/NAIA, #168/#169 Behavior, and
+  final root-shim work remain outside PR #353.
+
 ### `nodes.py` public node-class surface
 
 The confirmed 0.5.2 mapped classes are:

--- a/easyuse_anima/aio/legacy_generation.py
+++ b/easyuse_anima/aio/legacy_generation.py
@@ -1,26 +1,105 @@
 from __future__ import annotations
 
-from collections.abc import Callable
+import json
+import logging
+import random
 from typing import Any
 
+from ..common.values import _as_bool, _as_float, _as_int, _single_value
+from ..image.geometry import _image_tensor_size
+from ..image.sam3 import _context_value, _segs_has_items
+from ..infrastructure.comfy.invocation import _node_output_tuple
+from ..infrastructure.comfy.wiring import resolve_comfy_host_helper
+from ..nodes.image_nodes import EasyUseAnimaImageScaleByMultiple
+from ..nodes.sam3_nodes import EasyUseAnimaSAM3Detailer
+from ..prompt.artist_mix import _encode_prompt_data_positive_conditioning
+from ..prompt.conditioning import (
+    ANIMA_MOD_GUIDANCE_PROFILE_OFF,
+    _apply_spectrum_anima_mod_guidance,
+    _normalize_anima_mod_guidance_profile,
+    _resolve_anima_mod_guidance_enabled,
+)
+from ..prompt.data import (
+    _advanced_outputs_from_prompt_data,
+    _normalize_prompt_data,
+    _prompt_data_json_safe,
+)
+from .conditioning import _aio_usdu_conditioning
+from .first_pass_cache import (
+    _aio_first_pass_cache_key,
+    _get_aio_first_pass_cache,
+    _put_aio_first_pass_cache,
+)
+from .generation_defaults import AIO_USDU_PROMPT_FULL
+from .generation_normalization import (
+    _aio_detailer_has_enabled_targets,
+    _aio_detailer_target_order,
+    _normalize_aio_generation_settings,
+)
 from .input_context import _require_easy_use_anima_input
+from .model_preparation import (
+    _apply_aio_lora_stack,
+    _apply_aio_model_patches,
+    _apply_aio_spectrum_model_patches_for_comfy_sampler,
+    _cleanup_aio_ephemeral_model,
+)
+from .output import (
+    _aio_save_filename_prefix,
+    _save_image_with_comfy,
+    _save_image_with_image_saver,
+)
+from .postprocess import (
+    _resize_image_to_size_if_needed,
+    _run_aio_postprocess_stage,
+)
+from .preview import (
+    _save_aio_temp_preview_image,
+    _send_aio_preview_event,
+    _tag_aio_preview_images,
+)
+from .resources import (
+    _load_aio_resources_from_input_context,
+    _load_aio_sam3_context,
+    _load_upscale_model_with_comfy,
+)
+from .sampling import (
+    _aio_highres_effective_backend,
+    _aio_stage_sampler_settings,
+    _decode_latent_with_comfy,
+    _encode_image_with_comfy_vae,
+    _generate_empty_latent_with_comfy,
+    _resolve_aio_runtime_seed,
+    _sample_latent_with_aio_backend,
+)
+from .usdu import _aio_usdu_tile_plan
 
-_RuntimeResolver = Callable[[str], Any]
-
-_RUNTIME_RESOLVER: _RuntimeResolver | None = None
+logger = logging.getLogger("ComfyUI-EasyUseAnima")
 
 
-def _bind_aio_legacy_generation_runtime(*, resolve_helper: _RuntimeResolver) -> None:
-    global _RUNTIME_RESOLVER
+def _missing_host_helper(name: str):
+    raise RuntimeError(
+        f"[EasyUseAnima] AiO legacy generation Comfy host helper is unavailable: {name}"
+    )
 
-    _RUNTIME_RESOLVER = resolve_helper
+
+def _encode_with_comfy_clip(clip, text: str):
+    helper = resolve_comfy_host_helper(
+        "_encode_with_comfy_clip",
+        _missing_host_helper,
+    )
+    return helper(clip, text)
 
 
-def _runtime_helper(name: str) -> Any:
-    resolver = _RUNTIME_RESOLVER
-    if resolver is None:
-        raise RuntimeError("AiO legacy generation runtime is not bound.")
-    return resolver(name)
+def _require_custom_node_class(
+    node_id: str,
+    node_pack: str,
+    install_hint: str,
+):
+    helper = resolve_comfy_host_helper(
+        "_require_custom_node_class",
+        _missing_host_helper,
+    )
+    return helper(node_id, node_pack, install_hint)
 
 
 def _run_aio_highres_stage(
@@ -40,41 +119,33 @@ def _run_aio_highres_stage(
     quality_tags: str = "",
     quality_neg: str = "",
 ) -> tuple[Any, Any, int, int, dict[str, Any]]:
-    if not _runtime_helper("_as_bool")(
-        highres_settings.get("enabled"), False
-    ):
+    if not _as_bool(highres_settings.get("enabled"), False):
         return base_latent, image, int(base_width), int(base_height), {"enabled": False}
 
-    stage_sampler = _runtime_helper("_aio_stage_sampler_settings")(
+    stage_sampler = _aio_stage_sampler_settings(
         sampler_settings,
         highres_settings,
         scheduler_default="simple",
         inherit_backend=True,
     )
-    scaled_image, width, height, applied_scale = _runtime_helper(
-        "EasyUseAnimaImageScaleByMultiple"
-    )().upscale(
+    scaled_image, width, height, applied_scale = EasyUseAnimaImageScaleByMultiple().upscale(
         image,
         highres_settings.get("scale_by", 1.25),
         highres_settings.get("upscale_method", "bicubic"),
         highres_settings.get("multiple", "32"),
         highres_settings.get("max_long_edge", 2560),
     )
-    latent_image = _runtime_helper("_encode_image_with_comfy_vae")(
-        vae, scaled_image
-    )
+    latent_image = _encode_image_with_comfy_vae(vae, scaled_image)
     stage_model = model
     if stage_sampler.get("backend") == "comfy_ksampler":
-        stage_model = _runtime_helper(
-            "_apply_aio_spectrum_model_patches_for_comfy_sampler"
-        )(
+        stage_model = _apply_aio_spectrum_model_patches_for_comfy_sampler(
             model,
             clip,
             positive,
             stage_sampler,
         )
     try:
-        latent = _runtime_helper("_sample_latent_with_aio_backend")(
+        latent = _sample_latent_with_aio_backend(
             stage_model,
             clip,
             positive,
@@ -87,22 +158,22 @@ def _run_aio_highres_stage(
             quality_neg,
         )
     finally:
-        _runtime_helper("_cleanup_aio_ephemeral_model")(stage_model, model)
-    decoded = _runtime_helper("_decode_latent_with_comfy")(vae, latent)
-    decoded, resized = _runtime_helper("_resize_image_to_size_if_needed")(
+        _cleanup_aio_ephemeral_model(stage_model, model)
+    decoded = _decode_latent_with_comfy(vae, latent)
+    decoded, resized = _resize_image_to_size_if_needed(
         decoded,
         width,
         height,
         highres_settings.get("upscale_method", "bicubic"),
     )
     if resized:
-        latent = _runtime_helper("_encode_image_with_comfy_vae")(vae, decoded)
+        latent = _encode_image_with_comfy_vae(vae, decoded)
     return latent, decoded, int(width), int(height), {
         "enabled": True,
         "width": int(width),
         "height": int(height),
         "applied_scale": float(applied_scale),
-        "sampler": _runtime_helper("_prompt_data_json_safe")(stage_sampler),
+        "sampler": _prompt_data_json_safe(stage_sampler),
     }
 
 
@@ -117,31 +188,25 @@ def _run_aio_detailer_stage(
     detailer_settings: dict[str, Any],
     preview_callback=None,
 ) -> tuple[Any, dict[str, Any]]:
-    if not _runtime_helper("_as_bool")(
-        detailer_settings.get("enabled"), False
-    ):
+    if not _as_bool(detailer_settings.get("enabled"), False):
         return image, {"enabled": False}
-    target_order = _runtime_helper("_aio_detailer_target_order")(detailer_settings)
+    target_order = _aio_detailer_target_order(detailer_settings)
     enabled_targets = [
         name
         for name in target_order
         if isinstance(detailer_settings.get(name), dict)
-        and _runtime_helper("_as_bool")(
-            detailer_settings[name].get("enabled"), False
-        )
+        and _as_bool(detailer_settings[name].get("enabled"), False)
     ]
     if not enabled_targets:
         return image, {"enabled": False, "reason": "no target enabled"}
 
-    sam3_context = _runtime_helper("_load_aio_sam3_context")(detailer_settings)
+    sam3_context = _load_aio_sam3_context(detailer_settings)
     output = image
     target_results: dict[str, Any] = {}
     for target_name in target_order:
         if target_name not in enabled_targets:
             continue
-        output, target_results[target_name] = _runtime_helper(
-            "_run_aio_detailer_target"
-        )(
+        output, target_results[target_name] = _run_aio_detailer_target(
             target_name,
             detailer_settings[target_name],
             output,
@@ -157,9 +222,7 @@ def _run_aio_detailer_stage(
             preview_callback(f"detailer_{target_name}", output)
     return output, {
         "enabled": True,
-        "sam3_checkpoint": _runtime_helper("_context_value")(
-            sam3_context, "ckpt_name"
-        ),
+        "sam3_checkpoint": _context_value(sam3_context, "ckpt_name"),
         "order": target_order,
         "targets": target_results,
     }
@@ -177,67 +240,63 @@ def _run_aio_detailer_target(
     sampler_settings: dict[str, Any],
     sam3_context: dict[str, Any],
 ) -> tuple[Any, dict[str, Any]]:
-    if not _runtime_helper("_as_bool")(
-        target_settings.get("enabled"), False
-    ):
+    if not _as_bool(target_settings.get("enabled"), False):
         return image, {"enabled": False}
 
-    stage_sampler = _runtime_helper("_aio_stage_sampler_settings")(
+    stage_sampler = _aio_stage_sampler_settings(
         sampler_settings,
         target_settings,
         scheduler_default="sgm_uniform",
     )
-    stage_model = _runtime_helper(
-        "_apply_aio_spectrum_model_patches_for_comfy_sampler"
-    )(
+    stage_model = _apply_aio_spectrum_model_patches_for_comfy_sampler(
         model,
         clip,
         positive,
         stage_sampler,
     )
     try:
-        result = _runtime_helper("EasyUseAnimaSAM3Detailer")().doit(
+        result = EasyUseAnimaSAM3Detailer().doit(
             enabled=True,
             image=image,
             ctx_SAM3=sam3_context,
             detect_prompt=target_settings.get("detect_prompt", target_name),
-            detect_count=_runtime_helper("_as_int")(
+            detect_count=_as_int(
                 target_settings.get("detect_count"), 1
             ),
-            threshold=_runtime_helper("_as_float")(
+            threshold=_as_float(
                 target_settings.get("threshold"), 0.5
             ),
-            refine_iterations=_runtime_helper("_as_int")(
+            refine_iterations=_as_int(
                 target_settings.get("refine_iterations"), 2
             ),
-            individual_masks=_runtime_helper("_as_bool")(
+            individual_masks=_as_bool(
                 target_settings.get("individual_masks"), True
             ),
-            combined=_runtime_helper("_as_bool")(
+            combined=_as_bool(
                 target_settings.get("combined"), False
             ),
-            crop_factor=_runtime_helper("_as_float")(
+            crop_factor=_as_float(
                 target_settings.get("crop_factor"), 4.0
             ),
-            bbox_fill=_runtime_helper("_as_bool")(
+            bbox_fill=_as_bool(
                 target_settings.get("bbox_fill"), False
             ),
-            drop_size=_runtime_helper("_as_int")(
+            drop_size=_as_int(
                 target_settings.get("drop_size"), 100
             ),
-            contour_fill=_runtime_helper("_as_bool")(
+            contour_fill=_as_bool(
                 target_settings.get("contour_fill"), True
             ),
             model=stage_model,
             clip=clip,
             vae=vae,
-            guide_size=_runtime_helper("_as_int")(
+            guide_size=_as_int(
                 target_settings.get("guide_size"), 1024
             ),
-            guide_size_for=_runtime_helper("_as_bool")(
+            guide_size_for=_as_bool(
                 target_settings.get("guide_size_for"), False
             ),
-            max_size=_runtime_helper("_as_int")(
+            max_size=_as_int(
                 target_settings.get("max_size"), 2048
             ),
             seed=stage_sampler["seed"],
@@ -248,46 +307,46 @@ def _run_aio_detailer_target(
             positive=positive,
             negative=negative,
             denoise=stage_sampler["denoise"],
-            feather=_runtime_helper("_as_int")(
+            feather=_as_int(
                 target_settings.get("feather"), 5
             ),
-            noise_mask=_runtime_helper("_as_bool")(
+            noise_mask=_as_bool(
                 target_settings.get("noise_mask"), True
             ),
-            force_inpaint=_runtime_helper("_as_bool")(
+            force_inpaint=_as_bool(
                 target_settings.get("force_inpaint"), True
             ),
             wildcard=str(target_settings.get("wildcard") or ""),
-            cycle=_runtime_helper("_as_int")(
+            cycle=_as_int(
                 target_settings.get("cycle"), 1
             ),
             alignment=str(target_settings.get("alignment") or "32"),
             preserve_conditioning_metadata=True,
             fail_on_unsupported_opt=False,
             detailer_hook=None,
-            inpaint_model=_runtime_helper("_as_bool")(
+            inpaint_model=_as_bool(
                 target_settings.get("inpaint_model"), False
             ),
-            noise_mask_feather=_runtime_helper("_as_int")(
+            noise_mask_feather=_as_int(
                 target_settings.get("noise_mask_feather"), 0
             ),
             scheduler_func_opt=None,
-            tiled_encode=_runtime_helper("_as_bool")(
+            tiled_encode=_as_bool(
                 target_settings.get("tiled_encode"), False
             ),
-            tiled_decode=_runtime_helper("_as_bool")(
+            tiled_decode=_as_bool(
                 target_settings.get("tiled_decode"), False
             ),
         )
     finally:
-        _runtime_helper("_cleanup_aio_ephemeral_model")(stage_model, model)
+        _cleanup_aio_ephemeral_model(stage_model, model)
 
     detailed_image = result[0]
     segs = result[1] if len(result) > 1 else None
     return detailed_image, {
         "enabled": True,
-        "detected": _runtime_helper("_segs_has_items")(segs),
-        "sampler": _runtime_helper("_prompt_data_json_safe")(stage_sampler),
+        "detected": _segs_has_items(segs),
+        "sampler": _prompt_data_json_safe(stage_sampler),
     }
 
 
@@ -309,29 +368,25 @@ def _run_aio_usdu_upscale_stage(
     usdu_settings = upscale_settings.get("usdu", {})
     if not isinstance(usdu_settings, dict):
         usdu_settings = {}
-    usdu_cls = _runtime_helper("_require_custom_node_class")(
+    usdu_cls = _require_custom_node_class(
         "UltimateSDUpscale",
         "ComfyUI_UltimateSDUpscale",
         "Required for AiO Generator final Upscale > USDU.",
     )
-    upscale_model = _runtime_helper("_load_upscale_model_with_comfy")(
+    upscale_model = _load_upscale_model_with_comfy(
         str(usdu_settings.get("upscale_model_name") or "")
     )
-    stage_sampler = _runtime_helper("_aio_stage_sampler_settings")(
+    stage_sampler = _aio_stage_sampler_settings(
         sampler_settings,
         upscale_settings,
         scheduler_default="simple",
     )
-    scale_by = _runtime_helper("_as_float")(
-        upscale_settings.get("scale_by"), 2.0
-    )
-    tile_plan = _runtime_helper("_aio_usdu_tile_plan")(
-        image, scale_by, usdu_settings
-    )
+    scale_by = _as_float(upscale_settings.get("scale_by"), 2.0)
+    tile_plan = _aio_usdu_tile_plan(image, scale_by, usdu_settings)
     tile_width = int(tile_plan["tile_width"])
     tile_height = int(tile_plan["tile_height"])
     if tile_plan.get("auto"):
-        _runtime_helper("logger").info(
+        logger.info(
             "[EasyUseAnima][AiO] USDU auto tile: input=%sx%s scale_by=%.3g expected=%sx%s target/min/max=%s/%s/%s resolved_tile=%sx%s",
             tile_plan.get("input_width"),
             tile_plan.get("input_height"),
@@ -345,7 +400,7 @@ def _run_aio_usdu_upscale_stage(
             tile_height,
         )
     else:
-        _runtime_helper("logger").info(
+        logger.info(
             "[EasyUseAnima][AiO] USDU manual tile: input=%sx%s scale_by=%.3g expected=%sx%s tile=%sx%s",
             tile_plan.get("input_width"),
             tile_plan.get("input_height"),
@@ -355,15 +410,15 @@ def _run_aio_usdu_upscale_stage(
             tile_width,
             tile_height,
         )
-    _runtime_helper("logger").info(
+    logger.info(
         "[EasyUseAnima][AiO] USDU sampler: steps=%s denoise=%.3f cfg=%.3g sampler=%s scheduler=%s",
-        _runtime_helper("_as_int")(stage_sampler.get("steps"), 20),
-        _runtime_helper("_as_float")(stage_sampler.get("denoise"), 0.2),
-        _runtime_helper("_as_float")(stage_sampler.get("cfg"), 8.0),
+        _as_int(stage_sampler.get("steps"), 20),
+        _as_float(stage_sampler.get("denoise"), 0.2),
+        _as_float(stage_sampler.get("cfg"), 8.0),
         str(stage_sampler.get("sampler_name") or "euler"),
         str(stage_sampler.get("scheduler") or "simple"),
     )
-    usdu_positive, usdu_negative = _runtime_helper("_aio_usdu_conditioning")(
+    usdu_positive, usdu_negative = _aio_usdu_conditioning(
         clip,
         positive,
         negative,
@@ -374,9 +429,7 @@ def _run_aio_usdu_upscale_stage(
         exclude_positive_quality,
         exclude_negative_quality,
     )
-    stage_model = _runtime_helper(
-        "_apply_aio_spectrum_model_patches_for_comfy_sampler"
-    )(
+    stage_model = _apply_aio_spectrum_model_patches_for_comfy_sampler(
         model,
         clip,
         usdu_positive,
@@ -390,56 +443,48 @@ def _run_aio_usdu_upscale_stage(
             negative=usdu_negative,
             vae=vae,
             upscale_by=scale_by,
-            seed=_runtime_helper("_resolve_aio_runtime_seed")(
-                stage_sampler.get("seed")
-            ),
-            steps=_runtime_helper("_as_int")(stage_sampler.get("steps"), 20),
-            cfg=_runtime_helper("_as_float")(stage_sampler.get("cfg"), 8.0),
+            seed=_resolve_aio_runtime_seed(stage_sampler.get("seed")),
+            steps=_as_int(stage_sampler.get("steps"), 20),
+            cfg=_as_float(stage_sampler.get("cfg"), 8.0),
             sampler_name=str(stage_sampler.get("sampler_name") or "euler"),
             scheduler=str(stage_sampler.get("scheduler") or "simple"),
-            denoise=_runtime_helper("_as_float")(
-                stage_sampler.get("denoise"), 0.2
-            ),
+            denoise=_as_float(stage_sampler.get("denoise"), 0.2),
             upscale_model=upscale_model,
             mode_type=str(usdu_settings.get("mode_type") or "Linear"),
             tile_width=tile_width,
             tile_height=tile_height,
-            mask_blur=_runtime_helper("_as_int")(
-                usdu_settings.get("mask_blur"), 8
-            ),
-            tile_padding=_runtime_helper("_as_int")(
-                usdu_settings.get("tile_padding"), 32
-            ),
+            mask_blur=_as_int(usdu_settings.get("mask_blur"), 8),
+            tile_padding=_as_int(usdu_settings.get("tile_padding"), 32),
             seam_fix_mode=str(usdu_settings.get("seam_fix_mode") or "None"),
-            seam_fix_denoise=_runtime_helper("_as_float")(
+            seam_fix_denoise=_as_float(
                 usdu_settings.get("seam_fix_denoise"), 1.0
             ),
-            seam_fix_mask_blur=_runtime_helper("_as_int")(
+            seam_fix_mask_blur=_as_int(
                 usdu_settings.get("seam_fix_mask_blur"), 8
             ),
-            seam_fix_width=_runtime_helper("_as_int")(
+            seam_fix_width=_as_int(
                 usdu_settings.get("seam_fix_width"), 64
             ),
-            seam_fix_padding=_runtime_helper("_as_int")(
+            seam_fix_padding=_as_int(
                 usdu_settings.get("seam_fix_padding"), 16
             ),
-            force_uniform_tiles=_runtime_helper("_as_bool")(
+            force_uniform_tiles=_as_bool(
                 usdu_settings.get("force_uniform_tiles"), True
             ),
-            tiled_decode=_runtime_helper("_as_bool")(
+            tiled_decode=_as_bool(
                 usdu_settings.get("tiled_decode"), False
             ),
-            batch_size=_runtime_helper("_as_int")(
+            batch_size=_as_int(
                 usdu_settings.get("batch_size"), 1
             ),
         )
     finally:
-        _runtime_helper("_cleanup_aio_ephemeral_model")(stage_model, model)
-    values = _runtime_helper("_node_output_tuple")(result)
+        _cleanup_aio_ephemeral_model(stage_model, model)
+    values = _node_output_tuple(result)
     if not values:
         raise RuntimeError("[EasyUseAnima] UltimateSDUpscale returned no IMAGE.")
     output = values[0]
-    width, height = _runtime_helper("_image_tensor_size")(output, 0, 0)
+    width, height = _image_tensor_size(output, 0, 0)
     return output, {
         "enabled": True,
         "backend": "usdu",
@@ -453,9 +498,9 @@ def _run_aio_usdu_upscale_stage(
         "tile_target_height": int(tile_plan.get("target_height") or 0),
         "prompt_mode": str(
             usdu_settings.get("prompt_mode")
-            or _runtime_helper("AIO_USDU_PROMPT_FULL")
+            or AIO_USDU_PROMPT_FULL
         ),
-        "sampler": _runtime_helper("_prompt_data_json_safe")(stage_sampler),
+        "sampler": _prompt_data_json_safe(stage_sampler),
     }
 
 
@@ -472,12 +517,12 @@ def _run_aio_resshift_upscale_stage(
     resshift_settings = upscale_settings.get("resshift", {})
     if not isinstance(resshift_settings, dict):
         resshift_settings = {}
-    loader_cls = _runtime_helper("_require_custom_node_class")(
+    loader_cls = _require_custom_node_class(
         "ResShiftLoader",
         "ComfyUI-Distilled-ResShift",
         "Required for AiO Generator final Upscale > ResShift.",
     )
-    upscale_cls = _runtime_helper("_require_custom_node_class")(
+    upscale_cls = _require_custom_node_class(
         "ResShiftUpscale",
         "ComfyUI-Distilled-ResShift",
         "Required for AiO Generator final Upscale > ResShift.",
@@ -486,7 +531,7 @@ def _run_aio_resshift_upscale_stage(
     load = getattr(loader, "load", None)
     if load is None:
         raise RuntimeError("[EasyUseAnima] ResShiftLoader does not expose load().")
-    model_values = _runtime_helper("_node_output_tuple")(
+    model_values = _node_output_tuple(
         load(
             str(resshift_settings.get("scale") or "x2"),
             str(resshift_settings.get("student_name") or "(auto-download)"),
@@ -499,20 +544,20 @@ def _run_aio_resshift_upscale_stage(
     upscale = getattr(upscaler, "upscale", None)
     if upscale is None:
         raise RuntimeError("[EasyUseAnima] ResShiftUpscale does not expose upscale().")
-    values = _runtime_helper("_node_output_tuple")(
+    values = _node_output_tuple(
         upscale(
             model_values[0],
             image,
-            _runtime_helper("_resolve_aio_runtime_seed")(sampler_settings.get("seed")),
-            _runtime_helper("_as_int")(resshift_settings.get("chop"), 512),
-            _runtime_helper("_as_int")(resshift_settings.get("overlap"), 64),
-            _runtime_helper("_as_int")(resshift_settings.get("tile_batch"), 4),
+            _resolve_aio_runtime_seed(sampler_settings.get("seed")),
+            _as_int(resshift_settings.get("chop"), 512),
+            _as_int(resshift_settings.get("overlap"), 64),
+            _as_int(resshift_settings.get("tile_batch"), 4),
         )
     )
     if not values:
         raise RuntimeError("[EasyUseAnima] ResShiftUpscale returned no IMAGE.")
     output = values[0]
-    width, height = _runtime_helper("_image_tensor_size")(output, 0, 0)
+    width, height = _image_tensor_size(output, 0, 0)
     return output, {
         "enabled": True,
         "backend": "resshift",
@@ -537,13 +582,11 @@ def _run_aio_upscale_stage(
     exclude_positive_quality: bool = False,
     exclude_negative_quality: bool = False,
 ) -> tuple[Any, dict[str, Any]]:
-    if not _runtime_helper("_as_bool")(
-        upscale_settings.get("enabled"), False
-    ):
+    if not _as_bool(upscale_settings.get("enabled"), False):
         return image, {"enabled": False}
     backend = str(upscale_settings.get("backend") or "usdu")
     if backend == "usdu":
-        output, metadata = _runtime_helper("_run_aio_usdu_upscale_stage")(
+        output, metadata = _run_aio_usdu_upscale_stage(
             model,
             clip,
             vae,
@@ -559,7 +602,7 @@ def _run_aio_upscale_stage(
             exclude_negative_quality,
         )
     elif backend == "resshift":
-        output, metadata = _runtime_helper("_run_aio_resshift_upscale_stage")(
+        output, metadata = _run_aio_resshift_upscale_stage(
             image,
             sampler_settings,
             upscale_settings,
@@ -586,23 +629,21 @@ def _run_aio_legacy_generation(
     unique_id=None,
 ):
     context = _require_easy_use_anima_input(easy_use_anima_input)
-    settings = _runtime_helper("_normalize_aio_generation_settings")(generation_settings)
-    settings["sampler"]["seed"] = _runtime_helper("_resolve_aio_runtime_seed")(
+    settings = _normalize_aio_generation_settings(generation_settings)
+    settings["sampler"]["seed"] = _resolve_aio_runtime_seed(
         settings["sampler"].get("seed")
     )
     if settings["mode"] != "txt2img":
         raise RuntimeError("[EasyUseAnima] AiO Generator draft currently supports txt2img only.")
 
-    base_model, base_clip, vae = _runtime_helper(
-        "_load_aio_resources_from_input_context"
-    )(context)
-    model_with_lora, clip, applied_loras = _runtime_helper("_apply_aio_lora_stack")(
+    base_model, base_clip, vae = _load_aio_resources_from_input_context(context)
+    model_with_lora, clip, applied_loras = _apply_aio_lora_stack(
         base_model,
         base_clip,
         lora_stack,
     )
-    model = _runtime_helper("_apply_aio_model_patches")(model_with_lora, settings)
-    prompt_data = _runtime_helper("_normalize_prompt_data")(context["prompt_data"])
+    model = _apply_aio_model_patches(model_with_lora, settings)
+    prompt_data = _normalize_prompt_data(context["prompt_data"])
     (
         positive_prompt,
         negative_prompt,
@@ -614,12 +655,12 @@ def _run_aio_legacy_generation(
         metadata_negative_prompt,
         width,
         height,
-    ) = _runtime_helper("_advanced_outputs_from_prompt_data")(prompt_data)
+    ) = _advanced_outputs_from_prompt_data(prompt_data)
     image_saver_positive_prompt = metadata_prompt or positive_prompt
     image_saver_negative_prompt = metadata_negative_prompt or negative_prompt
 
     artist_mix = settings["artist_mix"]
-    positive = _runtime_helper("_encode_prompt_data_positive_conditioning")(
+    positive = _encode_prompt_data_positive_conditioning(
         clip,
         prompt_data,
         positive_prompt,
@@ -633,44 +674,36 @@ def _run_aio_legacy_generation(
         artist_mix_dominant_isolation=artist_mix["dominant_isolation"],
         artist_mix_dominant_threshold=artist_mix["dominant_threshold"],
     )
-    negative = _runtime_helper("_encode_with_comfy_clip")(clip, negative_prompt)
+    negative = _encode_with_comfy_clip(clip, negative_prompt)
 
     sampler = settings["sampler"]
     mod_guidance = settings["mod_guidance"]
-    will_run_highres = _runtime_helper("_as_bool")(
-        settings["highres"].get("enabled"), False
-    )
-    will_run_detailer = _runtime_helper("_aio_detailer_has_enabled_targets")(
-        settings["detailer"]
-    )
-    will_run_upscale = _runtime_helper("_as_bool")(
-        settings["upscale"].get("enabled"), False
-    )
-    will_run_postprocess = _runtime_helper("_as_bool")(
-        settings["postprocess"].get("enabled"), False
-    )
-    profile = _runtime_helper("_normalize_anima_mod_guidance_profile")(
+    will_run_highres = _as_bool(settings["highres"].get("enabled"), False)
+    will_run_detailer = _aio_detailer_has_enabled_targets(settings["detailer"])
+    will_run_upscale = _as_bool(settings["upscale"].get("enabled"), False)
+    will_run_postprocess = _as_bool(settings["postprocess"].get("enabled"), False)
+    profile = _normalize_anima_mod_guidance_profile(
         mod_guidance["profile"]
     )
-    use_mod_guidance = _runtime_helper("_resolve_anima_mod_guidance_enabled")(
+    use_mod_guidance = _resolve_anima_mod_guidance_enabled(
         use_anima_mod_guidance,
         mod_guidance["mode"],
     )
     sampler_backend = str(sampler.get("backend") or "comfy_ksampler")
-    highres_backend = _runtime_helper("_aio_highres_effective_backend")(
+    highres_backend = _aio_highres_effective_backend(
         sampler, settings["highres"]
     )
     mod_guidance_model = model
     can_apply_standalone_mod_guidance = (
         use_mod_guidance
-        and profile != _runtime_helper("ANIMA_MOD_GUIDANCE_PROFILE_OFF")
+        and profile != ANIMA_MOD_GUIDANCE_PROFILE_OFF
     )
 
     def ensure_standalone_mod_guidance_model():
         nonlocal mod_guidance_model
         if not can_apply_standalone_mod_guidance or mod_guidance_model is not model:
             return mod_guidance_model
-        mod_guidance_model = _runtime_helper("_apply_spectrum_anima_mod_guidance")(
+        mod_guidance_model = _apply_spectrum_anima_mod_guidance(
             model,
             clip,
             positive,
@@ -692,9 +725,7 @@ def _run_aio_legacy_generation(
         sampler_backend
     )
     if sampler_backend == "comfy_ksampler":
-        base_sample_model = _runtime_helper(
-            "_apply_aio_spectrum_model_patches_for_comfy_sampler"
-        )(
+        base_sample_model = _apply_aio_spectrum_model_patches_for_comfy_sampler(
             base_sample_model,
             clip,
             positive,
@@ -704,12 +735,12 @@ def _run_aio_legacy_generation(
     stage_metadata: dict[str, Any] = {}
     preview_settings = settings["preview"]
     preview_images: list[dict[str, Any]] = []
-    preview_node_id = _runtime_helper("_single_value")(unique_id)
+    preview_node_id = _single_value(unique_id)
     preview_run_id = (
         f"{preview_node_id or 'aio'}:"
-        f"{_runtime_helper('random').getrandbits(64):016x}"
+        f"{random.getrandbits(64):016x}"
     )
-    first_pass_cache_key = _runtime_helper("_aio_first_pass_cache_key")(
+    first_pass_cache_key = _aio_first_pass_cache_key(
         cache_scope=str(unique_id or id(generator)),
         context=context,
         prompt_data=prompt_data,
@@ -727,7 +758,7 @@ def _run_aio_legacy_generation(
     first_pass_cache_hit = False
 
     def add_preview(stage: str, stage_image):
-        images = _runtime_helper("_save_aio_temp_preview_image")(
+        images = _save_aio_temp_preview_image(
             stage_image,
             stage,
             workflow_prompt=workflow_prompt,
@@ -735,22 +766,22 @@ def _run_aio_legacy_generation(
         )
         if images:
             preview_images.extend(images)
-            _runtime_helper("_send_aio_preview_event")(
+            _send_aio_preview_event(
                 preview_node_id, preview_run_id, stage, images
             )
 
     try:
-        cached_first_pass = _runtime_helper("_get_aio_first_pass_cache")(
+        cached_first_pass = _get_aio_first_pass_cache(
             first_pass_cache_key
         )
         if cached_first_pass is not None:
             latent, image = cached_first_pass
             first_pass_cache_hit = True
         else:
-            latent_image = _runtime_helper("_generate_empty_latent_with_comfy")(
+            latent_image = _generate_empty_latent_with_comfy(
                 width, height
             )
-            latent = _runtime_helper("_sample_latent_with_aio_backend")(
+            latent = _sample_latent_with_aio_backend(
                 base_sample_model,
                 clip,
                 positive,
@@ -762,24 +793,20 @@ def _run_aio_legacy_generation(
                 quality_tags,
                 quality_neg if use_negative_anima_mod_guidance else "",
             )
-            image = _runtime_helper("_decode_latent_with_comfy")(vae, latent)
-        image, first_pass_resized = _runtime_helper(
-            "_resize_image_to_size_if_needed"
-        )(
+            image = _decode_latent_with_comfy(vae, latent)
+        image, first_pass_resized = _resize_image_to_size_if_needed(
             image,
             width,
             height,
             "bicubic",
         )
         if first_pass_resized:
-            latent = _runtime_helper("_encode_image_with_comfy_vae")(vae, image)
+            latent = _encode_image_with_comfy_vae(vae, image)
         if not first_pass_cache_hit or first_pass_resized:
             try:
-                _runtime_helper("_put_aio_first_pass_cache")(
-                    first_pass_cache_key, latent, image
-                )
+                _put_aio_first_pass_cache(first_pass_cache_key, latent, image)
             except Exception as exc:
-                _runtime_helper("logger").debug(
+                logger.debug(
                     "[EasyUseAnima] failed to store AiO first-pass cache: %s", exc
                 )
         stage_metadata["first_pass"] = {"cache_hit": first_pass_cache_hit}
@@ -790,9 +817,7 @@ def _run_aio_legacy_generation(
             if will_run_highres
             else (model, False)
         )
-        latent, image, width, height, highres_metadata = _runtime_helper(
-            "_run_aio_highres_stage"
-        )(
+        latent, image, width, height, highres_metadata = _run_aio_highres_stage(
             highres_model,
             clip,
             vae,
@@ -815,7 +840,7 @@ def _run_aio_legacy_generation(
         ):
             if preview_settings["intermediate_images"] and will_run_detailer:
                 add_preview("highres", image)
-        image, detailer_metadata = _runtime_helper("_run_aio_detailer_stage")(
+        image, detailer_metadata = _run_aio_detailer_stage(
             ensure_standalone_mod_guidance_model()
             if will_run_detailer
             else mod_guidance_model,
@@ -830,8 +855,8 @@ def _run_aio_legacy_generation(
         )
         stage_metadata["detailer"] = detailer_metadata
         if detailer_metadata.get("enabled"):
-            width, height = _runtime_helper("_image_tensor_size")(image, width, height)
-        image, upscale_metadata = _runtime_helper("_run_aio_upscale_stage")(
+            width, height = _image_tensor_size(image, width, height)
+        image, upscale_metadata = _run_aio_upscale_stage(
             ensure_standalone_mod_guidance_model()
             if will_run_upscale
             else mod_guidance_model,
@@ -852,23 +877,23 @@ def _run_aio_legacy_generation(
         )
         stage_metadata["upscale"] = upscale_metadata
         if upscale_metadata.get("enabled"):
-            width, height = _runtime_helper("_image_tensor_size")(image, width, height)
-            latent = _runtime_helper("_encode_image_with_comfy_vae")(vae, image)
+            width, height = _image_tensor_size(image, width, height)
+            latent = _encode_image_with_comfy_vae(vae, image)
             if preview_settings["intermediate_images"]:
                 add_preview("upscale", image)
-        image, postprocess_metadata = _runtime_helper("_run_aio_postprocess_stage")(
+        image, postprocess_metadata = _run_aio_postprocess_stage(
             image,
             settings["postprocess"],
         )
         stage_metadata["postprocess"] = postprocess_metadata
         if postprocess_metadata.get("enabled"):
-            width, height = _runtime_helper("_image_tensor_size")(image, width, height)
-            postprocess_changed = _runtime_helper("_as_bool")(
+            width, height = _image_tensor_size(image, width, height)
+            postprocess_changed = _as_bool(
                 (postprocess_metadata.get("fit") or {}).get("applied"),
                 False,
             )
             if postprocess_changed:
-                latent = _runtime_helper("_encode_image_with_comfy_vae")(vae, image)
+                latent = _encode_image_with_comfy_vae(vae, image)
             if (
                 preview_settings["intermediate_images"]
                 and postprocess_changed
@@ -889,15 +914,13 @@ def _run_aio_legacy_generation(
             if key in seen_model_ids:
                 continue
             seen_model_ids.add(key)
-            _runtime_helper("_cleanup_aio_ephemeral_model")(
-                ephemeral_model, base_model
-            )
+            _cleanup_aio_ephemeral_model(ephemeral_model, base_model)
 
     save_settings = settings["save"]
     save_ui = {}
     if save_settings.get("enabled"):
         if save_settings.get("backend") == "image_saver":
-            save_result = _runtime_helper("_save_image_with_image_saver")(
+            save_result = _save_image_with_image_saver(
                 image,
                 save_settings,
                 positive_prompt=image_saver_positive_prompt,
@@ -911,19 +934,19 @@ def _run_aio_legacy_generation(
                 extra_pnginfo=extra_pnginfo,
             )
         else:
-            save_result = _runtime_helper("_save_image_with_comfy")(
+            save_result = _save_image_with_comfy(
                 image,
-                _runtime_helper("_aio_save_filename_prefix")(save_settings),
+                _aio_save_filename_prefix(save_settings),
                 workflow_prompt=workflow_prompt,
                 extra_pnginfo=extra_pnginfo,
             )
         if isinstance(save_result, dict) and isinstance(save_result.get("ui"), dict):
             save_ui = save_result["ui"]
-    final_preview = _runtime_helper("_tag_aio_preview_images")(
+    final_preview = _tag_aio_preview_images(
         save_ui.get("images", []), "final", width=width, height=height
     )
     if not final_preview:
-        final_preview = _runtime_helper("_save_aio_temp_preview_image")(
+        final_preview = _save_aio_temp_preview_image(
             image,
             "final",
             workflow_prompt=workflow_prompt,
@@ -942,20 +965,14 @@ def _run_aio_legacy_generation(
         "version": 1,
         "width": int(width),
         "height": int(height),
-        "resource_info": _runtime_helper("_prompt_data_json_safe")(
-            context.get("resource_info", {})
-        ),
-        "input_settings": _runtime_helper("_prompt_data_json_safe")(
-            context.get("input_settings", {})
-        ),
-        "lora_stack": _runtime_helper("_prompt_data_json_safe")(applied_loras),
-        "generation_settings": _runtime_helper("_prompt_data_json_safe")(settings),
-        "stages": _runtime_helper("_prompt_data_json_safe")(stage_metadata),
-        "prompt_data": _runtime_helper("_prompt_data_json_safe")(prompt_data),
+        "resource_info": _prompt_data_json_safe(context.get("resource_info", {})),
+        "input_settings": _prompt_data_json_safe(context.get("input_settings", {})),
+        "lora_stack": _prompt_data_json_safe(applied_loras),
+        "generation_settings": _prompt_data_json_safe(settings),
+        "stages": _prompt_data_json_safe(stage_metadata),
+        "prompt_data": _prompt_data_json_safe(prompt_data),
     }
-    metadata_json = _runtime_helper("json").dumps(
-        metadata, ensure_ascii=False, sort_keys=True
-    )
+    metadata_json = json.dumps(metadata, ensure_ascii=False, sort_keys=True)
     ui = {
         "status": ["generated"],
         "width": [int(width)],

--- a/nodes.py
+++ b/nodes.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 
 import json
 import logging
-import random
 
 try:
     from .easyuse_anima.aio.first_pass_cache import (
@@ -17,7 +16,6 @@ try:
         _put_aio_first_pass_cache as _put_aio_first_pass_cache,
     )
     from .easyuse_anima.aio.legacy_generation import (
-        _bind_aio_legacy_generation_runtime as _bind_aio_legacy_generation_runtime,
         _run_aio_detailer_stage as _run_aio_detailer_stage,
         _run_aio_detailer_target as _run_aio_detailer_target,
         _run_aio_highres_stage as _run_aio_highres_stage,
@@ -432,9 +430,6 @@ try:
         _common_upscale_image as _common_upscale_image,
         _node_output_tuple as _node_output_tuple,
     )
-    from .easyuse_anima.infrastructure.comfy.wiring import (
-        resolve_comfy_host_helper as _resolve_comfy_host_helper,
-    )
     from .easyuse_anima.infrastructure.comfy.resources import (
         # B-10b1 deliberately omits the retired root _comfy_checkpoint_names alias.
         _comfy_clip_loader_types as _adapter_comfy_clip_loader_types,
@@ -580,7 +575,6 @@ except ImportError:  # allows simple local import tests outside ComfyUI's packag
         _put_aio_first_pass_cache as _put_aio_first_pass_cache,
     )
     from easyuse_anima.aio.legacy_generation import (
-        _bind_aio_legacy_generation_runtime as _bind_aio_legacy_generation_runtime,
         _run_aio_detailer_stage as _run_aio_detailer_stage,
         _run_aio_detailer_target as _run_aio_detailer_target,
         _run_aio_highres_stage as _run_aio_highres_stage,
@@ -995,9 +989,6 @@ except ImportError:  # allows simple local import tests outside ComfyUI's packag
         _common_upscale_image as _common_upscale_image,
         _node_output_tuple as _node_output_tuple,
     )
-    from easyuse_anima.infrastructure.comfy.wiring import (
-        resolve_comfy_host_helper as _resolve_comfy_host_helper,
-    )
     from easyuse_anima.infrastructure.comfy.resources import (
         # B-10b1 deliberately omits the retired root _comfy_checkpoint_names alias.
         _comfy_clip_loader_types as _adapter_comfy_clip_loader_types,
@@ -1138,12 +1129,6 @@ EASY_USE_ANIMA_INPUT_TYPE = "EASY_USE_ANIMA_INPUT"
 _TRIGGER_WORD_KEYS = ("trainedWords", "trained_words", "trigger_words", "activation_text")
 
 
-_bind_aio_legacy_generation_runtime(
-    resolve_helper=lambda name: _resolve_comfy_host_helper(
-        name,
-        lambda fallback_name: globals()[fallback_name],
-    ),
-)
 _bind_aio_node_runtime(
     resolve_helper=lambda name: globals()[name],
 )

--- a/tests/fixtures/comfy_host_compatibility.v1.json
+++ b/tests/fixtures/comfy_host_compatibility.v1.json
@@ -17,7 +17,7 @@
     "production_consumer_slots": 22,
     "unique_production_modules": 15,
     "root_monkeypatch_test_files": 0,
-    "canonical_monkeypatch_test_files": 2
+    "canonical_monkeypatch_test_files": 3
   },
   "external_evidence": {
     "github_public_code_search_2026_07_23": {
@@ -108,7 +108,7 @@
         },
         {
           "module": "easyuse_anima.aio.legacy_generation",
-          "binder": "_bind_aio_legacy_generation_runtime",
+          "binder": null,
           "root_observation": "call_time"
         },
         {
@@ -368,7 +368,7 @@
       "production_consumers": [
         {
           "module": "easyuse_anima.aio.legacy_generation",
-          "binder": "_bind_aio_legacy_generation_runtime",
+          "binder": null,
           "root_observation": "call_time"
         },
         {
@@ -389,7 +389,9 @@
       ],
       "repository_monkeypatch_consumers": {
         "root": [],
-        "canonical": []
+        "canonical": [
+          "tests/test_aio_legacy_generation.py"
+        ]
       },
       "confirmed_external_consumers": [],
       "external_evidence_ref": "github_public_code_search_2026_07_23",

--- a/tests/fixtures/python_backend_baseline.json
+++ b/tests/fixtures/python_backend_baseline.json
@@ -7540,17 +7540,51 @@
       },
       {
         "alias": null,
-        "bound_name": "Callable",
+        "bound_name": "json",
         "branch_context": [],
         "classification": "external",
         "column": 0,
         "conditional": false,
-        "imported": "collections.abc:Callable",
-        "kind": "static_from",
+        "imported": "json",
+        "kind": "static_import",
         "line": 3,
-        "name": "Callable",
+        "name": null,
         "optional": false,
-        "requested": "collections.abc",
+        "requested": "json",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/aio/legacy_generation.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "logging",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "logging",
+        "kind": "static_import",
+        "line": 4,
+        "name": null,
+        "optional": false,
+        "requested": "logging",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/aio/legacy_generation.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "random",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "random",
+        "kind": "static_import",
+        "line": 5,
+        "name": null,
+        "optional": false,
+        "requested": "random",
         "role": "ordinary",
         "scope": "<module>",
         "source": "easyuse_anima/aio/legacy_generation.py"
@@ -7564,13 +7598,499 @@
         "conditional": false,
         "imported": "typing:Any",
         "kind": "static_from",
-        "line": 4,
+        "line": 6,
         "name": "Any",
         "optional": false,
         "requested": "typing",
         "role": "ordinary",
         "scope": "<module>",
         "source": "easyuse_anima/aio/legacy_generation.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_as_bool",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": "..common.values:_as_bool",
+        "kind": "static_from",
+        "line": 8,
+        "name": "_as_bool",
+        "optional": false,
+        "requested": "..common.values",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/aio/legacy_generation.py",
+        "target": "easyuse_anima/common/values.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_as_float",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": "..common.values:_as_float",
+        "kind": "static_from",
+        "line": 8,
+        "name": "_as_float",
+        "optional": false,
+        "requested": "..common.values",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/aio/legacy_generation.py",
+        "target": "easyuse_anima/common/values.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_as_int",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": "..common.values:_as_int",
+        "kind": "static_from",
+        "line": 8,
+        "name": "_as_int",
+        "optional": false,
+        "requested": "..common.values",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/aio/legacy_generation.py",
+        "target": "easyuse_anima/common/values.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_single_value",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": "..common.values:_single_value",
+        "kind": "static_from",
+        "line": 8,
+        "name": "_single_value",
+        "optional": false,
+        "requested": "..common.values",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/aio/legacy_generation.py",
+        "target": "easyuse_anima/common/values.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_image_tensor_size",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": "..image.geometry:_image_tensor_size",
+        "kind": "static_from",
+        "line": 9,
+        "name": "_image_tensor_size",
+        "optional": false,
+        "requested": "..image.geometry",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/aio/legacy_generation.py",
+        "target": "easyuse_anima/image/geometry.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_context_value",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": "..image.sam3:_context_value",
+        "kind": "static_from",
+        "line": 10,
+        "name": "_context_value",
+        "optional": false,
+        "requested": "..image.sam3",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/aio/legacy_generation.py",
+        "target": "easyuse_anima/image/sam3.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_segs_has_items",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": "..image.sam3:_segs_has_items",
+        "kind": "static_from",
+        "line": 10,
+        "name": "_segs_has_items",
+        "optional": false,
+        "requested": "..image.sam3",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/aio/legacy_generation.py",
+        "target": "easyuse_anima/image/sam3.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_node_output_tuple",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": "..infrastructure.comfy.invocation:_node_output_tuple",
+        "kind": "static_from",
+        "line": 11,
+        "name": "_node_output_tuple",
+        "optional": false,
+        "requested": "..infrastructure.comfy.invocation",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/aio/legacy_generation.py",
+        "target": "easyuse_anima/infrastructure/comfy/invocation.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "resolve_comfy_host_helper",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": "..infrastructure.comfy.wiring:resolve_comfy_host_helper",
+        "kind": "static_from",
+        "line": 12,
+        "name": "resolve_comfy_host_helper",
+        "optional": false,
+        "requested": "..infrastructure.comfy.wiring",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/aio/legacy_generation.py",
+        "target": "easyuse_anima/infrastructure/comfy/wiring.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "EasyUseAnimaImageScaleByMultiple",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": "..nodes.image_nodes:EasyUseAnimaImageScaleByMultiple",
+        "kind": "static_from",
+        "line": 13,
+        "name": "EasyUseAnimaImageScaleByMultiple",
+        "optional": false,
+        "requested": "..nodes.image_nodes",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/aio/legacy_generation.py",
+        "target": "easyuse_anima/nodes/image_nodes.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "EasyUseAnimaSAM3Detailer",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": "..nodes.sam3_nodes:EasyUseAnimaSAM3Detailer",
+        "kind": "static_from",
+        "line": 14,
+        "name": "EasyUseAnimaSAM3Detailer",
+        "optional": false,
+        "requested": "..nodes.sam3_nodes",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/aio/legacy_generation.py",
+        "target": "easyuse_anima/nodes/sam3_nodes.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_encode_prompt_data_positive_conditioning",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": "..prompt.artist_mix:_encode_prompt_data_positive_conditioning",
+        "kind": "static_from",
+        "line": 15,
+        "name": "_encode_prompt_data_positive_conditioning",
+        "optional": false,
+        "requested": "..prompt.artist_mix",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/aio/legacy_generation.py",
+        "target": "easyuse_anima/prompt/artist_mix.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "ANIMA_MOD_GUIDANCE_PROFILE_OFF",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": "..prompt.conditioning:ANIMA_MOD_GUIDANCE_PROFILE_OFF",
+        "kind": "static_from",
+        "line": 16,
+        "name": "ANIMA_MOD_GUIDANCE_PROFILE_OFF",
+        "optional": false,
+        "requested": "..prompt.conditioning",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/aio/legacy_generation.py",
+        "target": "easyuse_anima/prompt/conditioning.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_apply_spectrum_anima_mod_guidance",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": "..prompt.conditioning:_apply_spectrum_anima_mod_guidance",
+        "kind": "static_from",
+        "line": 16,
+        "name": "_apply_spectrum_anima_mod_guidance",
+        "optional": false,
+        "requested": "..prompt.conditioning",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/aio/legacy_generation.py",
+        "target": "easyuse_anima/prompt/conditioning.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_normalize_anima_mod_guidance_profile",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": "..prompt.conditioning:_normalize_anima_mod_guidance_profile",
+        "kind": "static_from",
+        "line": 16,
+        "name": "_normalize_anima_mod_guidance_profile",
+        "optional": false,
+        "requested": "..prompt.conditioning",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/aio/legacy_generation.py",
+        "target": "easyuse_anima/prompt/conditioning.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_resolve_anima_mod_guidance_enabled",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": "..prompt.conditioning:_resolve_anima_mod_guidance_enabled",
+        "kind": "static_from",
+        "line": 16,
+        "name": "_resolve_anima_mod_guidance_enabled",
+        "optional": false,
+        "requested": "..prompt.conditioning",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/aio/legacy_generation.py",
+        "target": "easyuse_anima/prompt/conditioning.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_advanced_outputs_from_prompt_data",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": "..prompt.data:_advanced_outputs_from_prompt_data",
+        "kind": "static_from",
+        "line": 22,
+        "name": "_advanced_outputs_from_prompt_data",
+        "optional": false,
+        "requested": "..prompt.data",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/aio/legacy_generation.py",
+        "target": "easyuse_anima/prompt/data.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_normalize_prompt_data",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": "..prompt.data:_normalize_prompt_data",
+        "kind": "static_from",
+        "line": 22,
+        "name": "_normalize_prompt_data",
+        "optional": false,
+        "requested": "..prompt.data",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/aio/legacy_generation.py",
+        "target": "easyuse_anima/prompt/data.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_prompt_data_json_safe",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": "..prompt.data:_prompt_data_json_safe",
+        "kind": "static_from",
+        "line": 22,
+        "name": "_prompt_data_json_safe",
+        "optional": false,
+        "requested": "..prompt.data",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/aio/legacy_generation.py",
+        "target": "easyuse_anima/prompt/data.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_aio_usdu_conditioning",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".conditioning:_aio_usdu_conditioning",
+        "kind": "static_from",
+        "line": 27,
+        "name": "_aio_usdu_conditioning",
+        "optional": false,
+        "requested": ".conditioning",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/aio/legacy_generation.py",
+        "target": "easyuse_anima/aio/conditioning.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_aio_first_pass_cache_key",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".first_pass_cache:_aio_first_pass_cache_key",
+        "kind": "static_from",
+        "line": 28,
+        "name": "_aio_first_pass_cache_key",
+        "optional": false,
+        "requested": ".first_pass_cache",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/aio/legacy_generation.py",
+        "target": "easyuse_anima/aio/first_pass_cache.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_get_aio_first_pass_cache",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".first_pass_cache:_get_aio_first_pass_cache",
+        "kind": "static_from",
+        "line": 28,
+        "name": "_get_aio_first_pass_cache",
+        "optional": false,
+        "requested": ".first_pass_cache",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/aio/legacy_generation.py",
+        "target": "easyuse_anima/aio/first_pass_cache.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_put_aio_first_pass_cache",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".first_pass_cache:_put_aio_first_pass_cache",
+        "kind": "static_from",
+        "line": 28,
+        "name": "_put_aio_first_pass_cache",
+        "optional": false,
+        "requested": ".first_pass_cache",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/aio/legacy_generation.py",
+        "target": "easyuse_anima/aio/first_pass_cache.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "AIO_USDU_PROMPT_FULL",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".generation_defaults:AIO_USDU_PROMPT_FULL",
+        "kind": "static_from",
+        "line": 33,
+        "name": "AIO_USDU_PROMPT_FULL",
+        "optional": false,
+        "requested": ".generation_defaults",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/aio/legacy_generation.py",
+        "target": "easyuse_anima/aio/generation_defaults.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_aio_detailer_has_enabled_targets",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".generation_normalization:_aio_detailer_has_enabled_targets",
+        "kind": "static_from",
+        "line": 34,
+        "name": "_aio_detailer_has_enabled_targets",
+        "optional": false,
+        "requested": ".generation_normalization",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/aio/legacy_generation.py",
+        "target": "easyuse_anima/aio/generation_normalization.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_aio_detailer_target_order",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".generation_normalization:_aio_detailer_target_order",
+        "kind": "static_from",
+        "line": 34,
+        "name": "_aio_detailer_target_order",
+        "optional": false,
+        "requested": ".generation_normalization",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/aio/legacy_generation.py",
+        "target": "easyuse_anima/aio/generation_normalization.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_normalize_aio_generation_settings",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".generation_normalization:_normalize_aio_generation_settings",
+        "kind": "static_from",
+        "line": 34,
+        "name": "_normalize_aio_generation_settings",
+        "optional": false,
+        "requested": ".generation_normalization",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/aio/legacy_generation.py",
+        "target": "easyuse_anima/aio/generation_normalization.py"
       },
       {
         "alias": null,
@@ -7581,7 +8101,7 @@
         "conditional": false,
         "imported": ".input_context:_require_easy_use_anima_input",
         "kind": "static_from",
-        "line": 6,
+        "line": 39,
         "name": "_require_easy_use_anima_input",
         "optional": false,
         "requested": ".input_context",
@@ -7589,6 +8109,420 @@
         "scope": "<module>",
         "source": "easyuse_anima/aio/legacy_generation.py",
         "target": "easyuse_anima/aio/input_context.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_apply_aio_lora_stack",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".model_preparation:_apply_aio_lora_stack",
+        "kind": "static_from",
+        "line": 40,
+        "name": "_apply_aio_lora_stack",
+        "optional": false,
+        "requested": ".model_preparation",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/aio/legacy_generation.py",
+        "target": "easyuse_anima/aio/model_preparation.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_apply_aio_model_patches",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".model_preparation:_apply_aio_model_patches",
+        "kind": "static_from",
+        "line": 40,
+        "name": "_apply_aio_model_patches",
+        "optional": false,
+        "requested": ".model_preparation",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/aio/legacy_generation.py",
+        "target": "easyuse_anima/aio/model_preparation.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_apply_aio_spectrum_model_patches_for_comfy_sampler",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".model_preparation:_apply_aio_spectrum_model_patches_for_comfy_sampler",
+        "kind": "static_from",
+        "line": 40,
+        "name": "_apply_aio_spectrum_model_patches_for_comfy_sampler",
+        "optional": false,
+        "requested": ".model_preparation",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/aio/legacy_generation.py",
+        "target": "easyuse_anima/aio/model_preparation.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_cleanup_aio_ephemeral_model",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".model_preparation:_cleanup_aio_ephemeral_model",
+        "kind": "static_from",
+        "line": 40,
+        "name": "_cleanup_aio_ephemeral_model",
+        "optional": false,
+        "requested": ".model_preparation",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/aio/legacy_generation.py",
+        "target": "easyuse_anima/aio/model_preparation.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_aio_save_filename_prefix",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".output:_aio_save_filename_prefix",
+        "kind": "static_from",
+        "line": 46,
+        "name": "_aio_save_filename_prefix",
+        "optional": false,
+        "requested": ".output",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/aio/legacy_generation.py",
+        "target": "easyuse_anima/aio/output.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_save_image_with_comfy",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".output:_save_image_with_comfy",
+        "kind": "static_from",
+        "line": 46,
+        "name": "_save_image_with_comfy",
+        "optional": false,
+        "requested": ".output",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/aio/legacy_generation.py",
+        "target": "easyuse_anima/aio/output.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_save_image_with_image_saver",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".output:_save_image_with_image_saver",
+        "kind": "static_from",
+        "line": 46,
+        "name": "_save_image_with_image_saver",
+        "optional": false,
+        "requested": ".output",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/aio/legacy_generation.py",
+        "target": "easyuse_anima/aio/output.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_resize_image_to_size_if_needed",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".postprocess:_resize_image_to_size_if_needed",
+        "kind": "static_from",
+        "line": 51,
+        "name": "_resize_image_to_size_if_needed",
+        "optional": false,
+        "requested": ".postprocess",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/aio/legacy_generation.py",
+        "target": "easyuse_anima/aio/postprocess.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_run_aio_postprocess_stage",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".postprocess:_run_aio_postprocess_stage",
+        "kind": "static_from",
+        "line": 51,
+        "name": "_run_aio_postprocess_stage",
+        "optional": false,
+        "requested": ".postprocess",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/aio/legacy_generation.py",
+        "target": "easyuse_anima/aio/postprocess.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_save_aio_temp_preview_image",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".preview:_save_aio_temp_preview_image",
+        "kind": "static_from",
+        "line": 55,
+        "name": "_save_aio_temp_preview_image",
+        "optional": false,
+        "requested": ".preview",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/aio/legacy_generation.py",
+        "target": "easyuse_anima/aio/preview.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_send_aio_preview_event",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".preview:_send_aio_preview_event",
+        "kind": "static_from",
+        "line": 55,
+        "name": "_send_aio_preview_event",
+        "optional": false,
+        "requested": ".preview",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/aio/legacy_generation.py",
+        "target": "easyuse_anima/aio/preview.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_tag_aio_preview_images",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".preview:_tag_aio_preview_images",
+        "kind": "static_from",
+        "line": 55,
+        "name": "_tag_aio_preview_images",
+        "optional": false,
+        "requested": ".preview",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/aio/legacy_generation.py",
+        "target": "easyuse_anima/aio/preview.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_load_aio_resources_from_input_context",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".resources:_load_aio_resources_from_input_context",
+        "kind": "static_from",
+        "line": 60,
+        "name": "_load_aio_resources_from_input_context",
+        "optional": false,
+        "requested": ".resources",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/aio/legacy_generation.py",
+        "target": "easyuse_anima/aio/resources.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_load_aio_sam3_context",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".resources:_load_aio_sam3_context",
+        "kind": "static_from",
+        "line": 60,
+        "name": "_load_aio_sam3_context",
+        "optional": false,
+        "requested": ".resources",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/aio/legacy_generation.py",
+        "target": "easyuse_anima/aio/resources.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_load_upscale_model_with_comfy",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".resources:_load_upscale_model_with_comfy",
+        "kind": "static_from",
+        "line": 60,
+        "name": "_load_upscale_model_with_comfy",
+        "optional": false,
+        "requested": ".resources",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/aio/legacy_generation.py",
+        "target": "easyuse_anima/aio/resources.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_aio_highres_effective_backend",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".sampling:_aio_highres_effective_backend",
+        "kind": "static_from",
+        "line": 65,
+        "name": "_aio_highres_effective_backend",
+        "optional": false,
+        "requested": ".sampling",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/aio/legacy_generation.py",
+        "target": "easyuse_anima/aio/sampling.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_aio_stage_sampler_settings",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".sampling:_aio_stage_sampler_settings",
+        "kind": "static_from",
+        "line": 65,
+        "name": "_aio_stage_sampler_settings",
+        "optional": false,
+        "requested": ".sampling",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/aio/legacy_generation.py",
+        "target": "easyuse_anima/aio/sampling.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_decode_latent_with_comfy",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".sampling:_decode_latent_with_comfy",
+        "kind": "static_from",
+        "line": 65,
+        "name": "_decode_latent_with_comfy",
+        "optional": false,
+        "requested": ".sampling",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/aio/legacy_generation.py",
+        "target": "easyuse_anima/aio/sampling.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_encode_image_with_comfy_vae",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".sampling:_encode_image_with_comfy_vae",
+        "kind": "static_from",
+        "line": 65,
+        "name": "_encode_image_with_comfy_vae",
+        "optional": false,
+        "requested": ".sampling",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/aio/legacy_generation.py",
+        "target": "easyuse_anima/aio/sampling.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_generate_empty_latent_with_comfy",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".sampling:_generate_empty_latent_with_comfy",
+        "kind": "static_from",
+        "line": 65,
+        "name": "_generate_empty_latent_with_comfy",
+        "optional": false,
+        "requested": ".sampling",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/aio/legacy_generation.py",
+        "target": "easyuse_anima/aio/sampling.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_resolve_aio_runtime_seed",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".sampling:_resolve_aio_runtime_seed",
+        "kind": "static_from",
+        "line": 65,
+        "name": "_resolve_aio_runtime_seed",
+        "optional": false,
+        "requested": ".sampling",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/aio/legacy_generation.py",
+        "target": "easyuse_anima/aio/sampling.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_sample_latent_with_aio_backend",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".sampling:_sample_latent_with_aio_backend",
+        "kind": "static_from",
+        "line": 65,
+        "name": "_sample_latent_with_aio_backend",
+        "optional": false,
+        "requested": ".sampling",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/aio/legacy_generation.py",
+        "target": "easyuse_anima/aio/sampling.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_aio_usdu_tile_plan",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".usdu:_aio_usdu_tile_plan",
+        "kind": "static_from",
+        "line": 74,
+        "name": "_aio_usdu_tile_plan",
+        "optional": false,
+        "requested": ".usdu",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/aio/legacy_generation.py",
+        "target": "easyuse_anima/aio/usdu.py"
       },
       {
         "alias": null,
@@ -19905,23 +20839,6 @@
         "source": "nodes.py"
       },
       {
-        "alias": null,
-        "bound_name": "random",
-        "branch_context": [],
-        "classification": "external",
-        "column": 0,
-        "conditional": false,
-        "imported": "random",
-        "kind": "static_import",
-        "line": 6,
-        "name": null,
-        "optional": false,
-        "requested": "random",
-        "role": "ordinary",
-        "scope": "<module>",
-        "source": "nodes.py"
-      },
-      {
         "alias": "AIO_FIRST_PASS_CACHE_MAX_ENTRIES",
         "bound_name": "AIO_FIRST_PASS_CACHE_MAX_ENTRIES",
         "branch_context": [
@@ -19930,7 +20847,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -19938,12 +20855,12 @@
         "compatibility_pair": {
           "bound_name": "AIO_FIRST_PASS_CACHE_MAX_ENTRIES",
           "target": "easyuse_anima/aio/first_pass_cache.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.first_pass_cache:AIO_FIRST_PASS_CACHE_MAX_ENTRIES",
         "kind": "static_from",
-        "line": 9,
+        "line": 8,
         "name": "AIO_FIRST_PASS_CACHE_MAX_ENTRIES",
         "optional": false,
         "requested": ".easyuse_anima.aio.first_pass_cache",
@@ -19961,7 +20878,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -19969,12 +20886,12 @@
         "compatibility_pair": {
           "bound_name": "_AIO_FIRST_PASS_CACHE",
           "target": "easyuse_anima/aio/first_pass_cache.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.first_pass_cache:_AIO_FIRST_PASS_CACHE",
         "kind": "static_from",
-        "line": 9,
+        "line": 8,
         "name": "_AIO_FIRST_PASS_CACHE",
         "optional": false,
         "requested": ".easyuse_anima.aio.first_pass_cache",
@@ -19992,7 +20909,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -20000,12 +20917,12 @@
         "compatibility_pair": {
           "bound_name": "_AIO_FIRST_PASS_CACHE_ORDER",
           "target": "easyuse_anima/aio/first_pass_cache.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.first_pass_cache:_AIO_FIRST_PASS_CACHE_ORDER",
         "kind": "static_from",
-        "line": 9,
+        "line": 8,
         "name": "_AIO_FIRST_PASS_CACHE_ORDER",
         "optional": false,
         "requested": ".easyuse_anima.aio.first_pass_cache",
@@ -20023,7 +20940,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -20031,12 +20948,12 @@
         "compatibility_pair": {
           "bound_name": "_aio_first_pass_cache_key",
           "target": "easyuse_anima/aio/first_pass_cache.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.first_pass_cache:_aio_first_pass_cache_key",
         "kind": "static_from",
-        "line": 9,
+        "line": 8,
         "name": "_aio_first_pass_cache_key",
         "optional": false,
         "requested": ".easyuse_anima.aio.first_pass_cache",
@@ -20054,7 +20971,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -20062,12 +20979,12 @@
         "compatibility_pair": {
           "bound_name": "_clone_aio_cache_value",
           "target": "easyuse_anima/aio/first_pass_cache.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.first_pass_cache:_clone_aio_cache_value",
         "kind": "static_from",
-        "line": 9,
+        "line": 8,
         "name": "_clone_aio_cache_value",
         "optional": false,
         "requested": ".easyuse_anima.aio.first_pass_cache",
@@ -20085,7 +21002,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -20093,12 +21010,12 @@
         "compatibility_pair": {
           "bound_name": "_get_aio_first_pass_cache",
           "target": "easyuse_anima/aio/first_pass_cache.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.first_pass_cache:_get_aio_first_pass_cache",
         "kind": "static_from",
-        "line": 9,
+        "line": 8,
         "name": "_get_aio_first_pass_cache",
         "optional": false,
         "requested": ".easyuse_anima.aio.first_pass_cache",
@@ -20116,7 +21033,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -20124,12 +21041,12 @@
         "compatibility_pair": {
           "bound_name": "_put_aio_first_pass_cache",
           "target": "easyuse_anima/aio/first_pass_cache.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.first_pass_cache:_put_aio_first_pass_cache",
         "kind": "static_from",
-        "line": 9,
+        "line": 8,
         "name": "_put_aio_first_pass_cache",
         "optional": false,
         "requested": ".easyuse_anima.aio.first_pass_cache",
@@ -20137,37 +21054,6 @@
         "scope": "<module>",
         "source": "nodes.py",
         "target": "easyuse_anima/aio/first_pass_cache.py"
-      },
-      {
-        "alias": "_bind_aio_legacy_generation_runtime",
-        "bound_name": "_bind_aio_legacy_generation_runtime",
-        "branch_context": [
-          {
-            "branch": "body",
-            "handles_import_failure": true,
-            "has_import_fallback_handler": true,
-            "kind": "try",
-            "line": 8
-          }
-        ],
-        "classification": "internal",
-        "column": 4,
-        "compatibility_pair": {
-          "bound_name": "_bind_aio_legacy_generation_runtime",
-          "target": "easyuse_anima/aio/legacy_generation.py",
-          "try_line": 8
-        },
-        "conditional": true,
-        "imported": ".easyuse_anima.aio.legacy_generation:_bind_aio_legacy_generation_runtime",
-        "kind": "static_from",
-        "line": 19,
-        "name": "_bind_aio_legacy_generation_runtime",
-        "optional": false,
-        "requested": ".easyuse_anima.aio.legacy_generation",
-        "role": "compatibility_primary",
-        "scope": "<module>",
-        "source": "nodes.py",
-        "target": "easyuse_anima/aio/legacy_generation.py"
       },
       {
         "alias": "_run_aio_detailer_stage",
@@ -20178,7 +21064,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -20186,12 +21072,12 @@
         "compatibility_pair": {
           "bound_name": "_run_aio_detailer_stage",
           "target": "easyuse_anima/aio/legacy_generation.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.legacy_generation:_run_aio_detailer_stage",
         "kind": "static_from",
-        "line": 19,
+        "line": 18,
         "name": "_run_aio_detailer_stage",
         "optional": false,
         "requested": ".easyuse_anima.aio.legacy_generation",
@@ -20209,7 +21095,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -20217,12 +21103,12 @@
         "compatibility_pair": {
           "bound_name": "_run_aio_detailer_target",
           "target": "easyuse_anima/aio/legacy_generation.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.legacy_generation:_run_aio_detailer_target",
         "kind": "static_from",
-        "line": 19,
+        "line": 18,
         "name": "_run_aio_detailer_target",
         "optional": false,
         "requested": ".easyuse_anima.aio.legacy_generation",
@@ -20240,7 +21126,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -20248,12 +21134,12 @@
         "compatibility_pair": {
           "bound_name": "_run_aio_highres_stage",
           "target": "easyuse_anima/aio/legacy_generation.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.legacy_generation:_run_aio_highres_stage",
         "kind": "static_from",
-        "line": 19,
+        "line": 18,
         "name": "_run_aio_highres_stage",
         "optional": false,
         "requested": ".easyuse_anima.aio.legacy_generation",
@@ -20271,7 +21157,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -20279,12 +21165,12 @@
         "compatibility_pair": {
           "bound_name": "_run_aio_legacy_generation",
           "target": "easyuse_anima/aio/legacy_generation.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.legacy_generation:_run_aio_legacy_generation",
         "kind": "static_from",
-        "line": 19,
+        "line": 18,
         "name": "_run_aio_legacy_generation",
         "optional": false,
         "requested": ".easyuse_anima.aio.legacy_generation",
@@ -20302,7 +21188,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -20310,12 +21196,12 @@
         "compatibility_pair": {
           "bound_name": "_run_aio_resshift_upscale_stage",
           "target": "easyuse_anima/aio/legacy_generation.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.legacy_generation:_run_aio_resshift_upscale_stage",
         "kind": "static_from",
-        "line": 19,
+        "line": 18,
         "name": "_run_aio_resshift_upscale_stage",
         "optional": false,
         "requested": ".easyuse_anima.aio.legacy_generation",
@@ -20333,7 +21219,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -20341,12 +21227,12 @@
         "compatibility_pair": {
           "bound_name": "_run_aio_upscale_stage",
           "target": "easyuse_anima/aio/legacy_generation.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.legacy_generation:_run_aio_upscale_stage",
         "kind": "static_from",
-        "line": 19,
+        "line": 18,
         "name": "_run_aio_upscale_stage",
         "optional": false,
         "requested": ".easyuse_anima.aio.legacy_generation",
@@ -20364,7 +21250,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -20372,12 +21258,12 @@
         "compatibility_pair": {
           "bound_name": "_run_aio_usdu_upscale_stage",
           "target": "easyuse_anima/aio/legacy_generation.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.legacy_generation:_run_aio_usdu_upscale_stage",
         "kind": "static_from",
-        "line": 19,
+        "line": 18,
         "name": "_run_aio_usdu_upscale_stage",
         "optional": false,
         "requested": ".easyuse_anima.aio.legacy_generation",
@@ -20395,7 +21281,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -20403,12 +21289,12 @@
         "compatibility_pair": {
           "bound_name": "_AIO_DETAILER_CUSTOM_RE",
           "target": "easyuse_anima/aio/generation_normalization.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.generation_normalization:_AIO_DETAILER_CUSTOM_RE",
         "kind": "static_from",
-        "line": 29,
+        "line": 27,
         "name": "_AIO_DETAILER_CUSTOM_RE",
         "optional": false,
         "requested": ".easyuse_anima.aio.generation_normalization",
@@ -20426,7 +21312,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -20434,12 +21320,12 @@
         "compatibility_pair": {
           "bound_name": "_AIO_DETAILER_RESERVED_KEYS",
           "target": "easyuse_anima/aio/generation_normalization.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.generation_normalization:_AIO_DETAILER_RESERVED_KEYS",
         "kind": "static_from",
-        "line": 29,
+        "line": 27,
         "name": "_AIO_DETAILER_RESERVED_KEYS",
         "optional": false,
         "requested": ".easyuse_anima.aio.generation_normalization",
@@ -20457,7 +21343,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -20465,12 +21351,12 @@
         "compatibility_pair": {
           "bound_name": "_aio_detailer_has_enabled_targets",
           "target": "easyuse_anima/aio/generation_normalization.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.generation_normalization:_aio_detailer_has_enabled_targets",
         "kind": "static_from",
-        "line": 29,
+        "line": 27,
         "name": "_aio_detailer_has_enabled_targets",
         "optional": false,
         "requested": ".easyuse_anima.aio.generation_normalization",
@@ -20488,7 +21374,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -20496,12 +21382,12 @@
         "compatibility_pair": {
           "bound_name": "_aio_detailer_target_defaults",
           "target": "easyuse_anima/aio/generation_normalization.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.generation_normalization:_aio_detailer_target_defaults",
         "kind": "static_from",
-        "line": 29,
+        "line": 27,
         "name": "_aio_detailer_target_defaults",
         "optional": false,
         "requested": ".easyuse_anima.aio.generation_normalization",
@@ -20519,7 +21405,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -20527,12 +21413,12 @@
         "compatibility_pair": {
           "bound_name": "_aio_detailer_target_order",
           "target": "easyuse_anima/aio/generation_normalization.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.generation_normalization:_aio_detailer_target_order",
         "kind": "static_from",
-        "line": 29,
+        "line": 27,
         "name": "_aio_detailer_target_order",
         "optional": false,
         "requested": ".easyuse_anima.aio.generation_normalization",
@@ -20550,7 +21436,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -20558,12 +21444,12 @@
         "compatibility_pair": {
           "bound_name": "_is_aio_detailer_target_name",
           "target": "easyuse_anima/aio/generation_normalization.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.generation_normalization:_is_aio_detailer_target_name",
         "kind": "static_from",
-        "line": 29,
+        "line": 27,
         "name": "_is_aio_detailer_target_name",
         "optional": false,
         "requested": ".easyuse_anima.aio.generation_normalization",
@@ -20581,7 +21467,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -20589,12 +21475,12 @@
         "compatibility_pair": {
           "bound_name": "_merge_versioned_settings",
           "target": "easyuse_anima/aio/generation_normalization.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.generation_normalization:_merge_versioned_settings",
         "kind": "static_from",
-        "line": 29,
+        "line": 27,
         "name": "_merge_versioned_settings",
         "optional": false,
         "requested": ".easyuse_anima.aio.generation_normalization",
@@ -20612,7 +21498,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -20620,12 +21506,12 @@
         "compatibility_pair": {
           "bound_name": "_normalize_aio_dit_corrections_settings",
           "target": "easyuse_anima/aio/generation_normalization.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.generation_normalization:_normalize_aio_dit_corrections_settings",
         "kind": "static_from",
-        "line": 29,
+        "line": 27,
         "name": "_normalize_aio_dit_corrections_settings",
         "optional": false,
         "requested": ".easyuse_anima.aio.generation_normalization",
@@ -20643,7 +21529,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -20651,12 +21537,12 @@
         "compatibility_pair": {
           "bound_name": "_normalize_aio_generation_settings",
           "target": "easyuse_anima/aio/generation_normalization.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.generation_normalization:_normalize_aio_generation_settings",
         "kind": "static_from",
-        "line": 29,
+        "line": 27,
         "name": "_normalize_aio_generation_settings",
         "optional": false,
         "requested": ".easyuse_anima.aio.generation_normalization",
@@ -20674,7 +21560,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -20682,12 +21568,12 @@
         "compatibility_pair": {
           "bound_name": "_normalize_aio_seed",
           "target": "easyuse_anima/aio/generation_normalization.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.generation_normalization:_normalize_aio_seed",
         "kind": "static_from",
-        "line": 29,
+        "line": 27,
         "name": "_normalize_aio_seed",
         "optional": false,
         "requested": ".easyuse_anima.aio.generation_normalization",
@@ -20705,7 +21591,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -20713,12 +21599,12 @@
         "compatibility_pair": {
           "bound_name": "_normalize_aio_spectrum_settings",
           "target": "easyuse_anima/aio/generation_normalization.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.generation_normalization:_normalize_aio_spectrum_settings",
         "kind": "static_from",
-        "line": 29,
+        "line": 27,
         "name": "_normalize_aio_spectrum_settings",
         "optional": false,
         "requested": ".easyuse_anima.aio.generation_normalization",
@@ -20736,7 +21622,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -20744,12 +21630,12 @@
         "compatibility_pair": {
           "bound_name": "AIO_FINAL_FIT_MODES",
           "target": "easyuse_anima/aio/generation_defaults.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.generation_defaults:AIO_FINAL_FIT_MODES",
         "kind": "static_from",
-        "line": 42,
+        "line": 40,
         "name": "AIO_FINAL_FIT_MODES",
         "optional": false,
         "requested": ".easyuse_anima.aio.generation_defaults",
@@ -20767,7 +21653,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -20775,12 +21661,12 @@
         "compatibility_pair": {
           "bound_name": "AIO_FINAL_UPSCALE_BACKENDS",
           "target": "easyuse_anima/aio/generation_defaults.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.generation_defaults:AIO_FINAL_UPSCALE_BACKENDS",
         "kind": "static_from",
-        "line": 42,
+        "line": 40,
         "name": "AIO_FINAL_UPSCALE_BACKENDS",
         "optional": false,
         "requested": ".easyuse_anima.aio.generation_defaults",
@@ -20798,7 +21684,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -20806,12 +21692,12 @@
         "compatibility_pair": {
           "bound_name": "AIO_GENERATION_DEFAULT_SETTINGS",
           "target": "easyuse_anima/aio/generation_defaults.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.generation_defaults:AIO_GENERATION_DEFAULT_SETTINGS",
         "kind": "static_from",
-        "line": 42,
+        "line": 40,
         "name": "AIO_GENERATION_DEFAULT_SETTINGS",
         "optional": false,
         "requested": ".easyuse_anima.aio.generation_defaults",
@@ -20829,7 +21715,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -20837,12 +21723,12 @@
         "compatibility_pair": {
           "bound_name": "AIO_GENERATION_SETTINGS_SCHEMA",
           "target": "easyuse_anima/aio/generation_defaults.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.generation_defaults:AIO_GENERATION_SETTINGS_SCHEMA",
         "kind": "static_from",
-        "line": 42,
+        "line": 40,
         "name": "AIO_GENERATION_SETTINGS_SCHEMA",
         "optional": false,
         "requested": ".easyuse_anima.aio.generation_defaults",
@@ -20860,7 +21746,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -20868,12 +21754,12 @@
         "compatibility_pair": {
           "bound_name": "AIO_GENERATION_SETTINGS_VERSION",
           "target": "easyuse_anima/aio/generation_defaults.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.generation_defaults:AIO_GENERATION_SETTINGS_VERSION",
         "kind": "static_from",
-        "line": 42,
+        "line": 40,
         "name": "AIO_GENERATION_SETTINGS_VERSION",
         "optional": false,
         "requested": ".easyuse_anima.aio.generation_defaults",
@@ -20891,7 +21777,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -20899,12 +21785,12 @@
         "compatibility_pair": {
           "bound_name": "AIO_RESHIFT_DTYPES",
           "target": "easyuse_anima/aio/generation_defaults.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.generation_defaults:AIO_RESHIFT_DTYPES",
         "kind": "static_from",
-        "line": 42,
+        "line": 40,
         "name": "AIO_RESHIFT_DTYPES",
         "optional": false,
         "requested": ".easyuse_anima.aio.generation_defaults",
@@ -20922,7 +21808,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -20930,12 +21816,12 @@
         "compatibility_pair": {
           "bound_name": "AIO_RESHIFT_SCALES",
           "target": "easyuse_anima/aio/generation_defaults.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.generation_defaults:AIO_RESHIFT_SCALES",
         "kind": "static_from",
-        "line": 42,
+        "line": 40,
         "name": "AIO_RESHIFT_SCALES",
         "optional": false,
         "requested": ".easyuse_anima.aio.generation_defaults",
@@ -20953,7 +21839,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -20961,12 +21847,12 @@
         "compatibility_pair": {
           "bound_name": "AIO_SPECIAL_SEEDS",
           "target": "easyuse_anima/aio/generation_defaults.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.generation_defaults:AIO_SPECIAL_SEEDS",
         "kind": "static_from",
-        "line": 42,
+        "line": 40,
         "name": "AIO_SPECIAL_SEEDS",
         "optional": false,
         "requested": ".easyuse_anima.aio.generation_defaults",
@@ -20984,7 +21870,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -20992,12 +21878,12 @@
         "compatibility_pair": {
           "bound_name": "AIO_SPECIAL_SEED_DECREMENT",
           "target": "easyuse_anima/aio/generation_defaults.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.generation_defaults:AIO_SPECIAL_SEED_DECREMENT",
         "kind": "static_from",
-        "line": 42,
+        "line": 40,
         "name": "AIO_SPECIAL_SEED_DECREMENT",
         "optional": false,
         "requested": ".easyuse_anima.aio.generation_defaults",
@@ -21015,7 +21901,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -21023,12 +21909,12 @@
         "compatibility_pair": {
           "bound_name": "AIO_SPECIAL_SEED_INCREMENT",
           "target": "easyuse_anima/aio/generation_defaults.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.generation_defaults:AIO_SPECIAL_SEED_INCREMENT",
         "kind": "static_from",
-        "line": 42,
+        "line": 40,
         "name": "AIO_SPECIAL_SEED_INCREMENT",
         "optional": false,
         "requested": ".easyuse_anima.aio.generation_defaults",
@@ -21046,7 +21932,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -21054,12 +21940,12 @@
         "compatibility_pair": {
           "bound_name": "AIO_SPECIAL_SEED_RANDOM",
           "target": "easyuse_anima/aio/generation_defaults.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.generation_defaults:AIO_SPECIAL_SEED_RANDOM",
         "kind": "static_from",
-        "line": 42,
+        "line": 40,
         "name": "AIO_SPECIAL_SEED_RANDOM",
         "optional": false,
         "requested": ".easyuse_anima.aio.generation_defaults",
@@ -21077,7 +21963,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -21085,12 +21971,12 @@
         "compatibility_pair": {
           "bound_name": "AIO_USDU_MODE_TYPES",
           "target": "easyuse_anima/aio/generation_defaults.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.generation_defaults:AIO_USDU_MODE_TYPES",
         "kind": "static_from",
-        "line": 42,
+        "line": 40,
         "name": "AIO_USDU_MODE_TYPES",
         "optional": false,
         "requested": ".easyuse_anima.aio.generation_defaults",
@@ -21108,7 +21994,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -21116,12 +22002,12 @@
         "compatibility_pair": {
           "bound_name": "AIO_USDU_PROMPT_FULL",
           "target": "easyuse_anima/aio/generation_defaults.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.generation_defaults:AIO_USDU_PROMPT_FULL",
         "kind": "static_from",
-        "line": 42,
+        "line": 40,
         "name": "AIO_USDU_PROMPT_FULL",
         "optional": false,
         "requested": ".easyuse_anima.aio.generation_defaults",
@@ -21139,7 +22025,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -21147,12 +22033,12 @@
         "compatibility_pair": {
           "bound_name": "AIO_USDU_PROMPT_MODES",
           "target": "easyuse_anima/aio/generation_defaults.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.generation_defaults:AIO_USDU_PROMPT_MODES",
         "kind": "static_from",
-        "line": 42,
+        "line": 40,
         "name": "AIO_USDU_PROMPT_MODES",
         "optional": false,
         "requested": ".easyuse_anima.aio.generation_defaults",
@@ -21170,7 +22056,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -21178,12 +22064,12 @@
         "compatibility_pair": {
           "bound_name": "AIO_USDU_PROMPT_NO_GENERAL",
           "target": "easyuse_anima/aio/generation_defaults.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.generation_defaults:AIO_USDU_PROMPT_NO_GENERAL",
         "kind": "static_from",
-        "line": 42,
+        "line": 40,
         "name": "AIO_USDU_PROMPT_NO_GENERAL",
         "optional": false,
         "requested": ".easyuse_anima.aio.generation_defaults",
@@ -21201,7 +22087,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -21209,12 +22095,12 @@
         "compatibility_pair": {
           "bound_name": "AIO_USDU_SEAM_FIX_MODES",
           "target": "easyuse_anima/aio/generation_defaults.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.generation_defaults:AIO_USDU_SEAM_FIX_MODES",
         "kind": "static_from",
-        "line": 42,
+        "line": 40,
         "name": "AIO_USDU_SEAM_FIX_MODES",
         "optional": false,
         "requested": ".easyuse_anima.aio.generation_defaults",
@@ -21232,7 +22118,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -21240,12 +22126,12 @@
         "compatibility_pair": {
           "bound_name": "_round_trip_aio_generation_settings",
           "target": "easyuse_anima/aio/generation_settings.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.generation_settings:round_trip_aio_generation_settings",
         "kind": "static_from",
-        "line": 60,
+        "line": 58,
         "name": "round_trip_aio_generation_settings",
         "optional": false,
         "requested": ".easyuse_anima.aio.generation_settings",
@@ -21263,7 +22149,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -21271,12 +22157,12 @@
         "compatibility_pair": {
           "bound_name": "AIO_INPUT_DEFAULT_SETTINGS",
           "target": "easyuse_anima/aio/input_defaults.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.input_defaults:AIO_INPUT_DEFAULT_SETTINGS",
         "kind": "static_from",
-        "line": 63,
+        "line": 61,
         "name": "AIO_INPUT_DEFAULT_SETTINGS",
         "optional": false,
         "requested": ".easyuse_anima.aio.input_defaults",
@@ -21294,7 +22180,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -21302,12 +22188,12 @@
         "compatibility_pair": {
           "bound_name": "ANIMA_CLIP_DEVICES",
           "target": "easyuse_anima/aio/input_defaults.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.input_defaults:ANIMA_CLIP_DEVICES",
         "kind": "static_from",
-        "line": 63,
+        "line": 61,
         "name": "ANIMA_CLIP_DEVICES",
         "optional": false,
         "requested": ".easyuse_anima.aio.input_defaults",
@@ -21325,7 +22211,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -21333,12 +22219,12 @@
         "compatibility_pair": {
           "bound_name": "ANIMA_CLIP_TYPES",
           "target": "easyuse_anima/aio/input_defaults.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.input_defaults:ANIMA_CLIP_TYPES",
         "kind": "static_from",
-        "line": 63,
+        "line": 61,
         "name": "ANIMA_CLIP_TYPES",
         "optional": false,
         "requested": ".easyuse_anima.aio.input_defaults",
@@ -21356,7 +22242,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -21364,12 +22250,12 @@
         "compatibility_pair": {
           "bound_name": "ANIMA_DEFAULT_CLIP_CANDIDATES",
           "target": "easyuse_anima/aio/input_defaults.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.input_defaults:ANIMA_DEFAULT_CLIP_CANDIDATES",
         "kind": "static_from",
-        "line": 63,
+        "line": 61,
         "name": "ANIMA_DEFAULT_CLIP_CANDIDATES",
         "optional": false,
         "requested": ".easyuse_anima.aio.input_defaults",
@@ -21387,7 +22273,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -21395,12 +22281,12 @@
         "compatibility_pair": {
           "bound_name": "ANIMA_DEFAULT_DIFFUSION_MODEL_CANDIDATES",
           "target": "easyuse_anima/aio/input_defaults.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.input_defaults:ANIMA_DEFAULT_DIFFUSION_MODEL_CANDIDATES",
         "kind": "static_from",
-        "line": 63,
+        "line": 61,
         "name": "ANIMA_DEFAULT_DIFFUSION_MODEL_CANDIDATES",
         "optional": false,
         "requested": ".easyuse_anima.aio.input_defaults",
@@ -21418,7 +22304,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -21426,12 +22312,12 @@
         "compatibility_pair": {
           "bound_name": "ANIMA_DEFAULT_VAE_CANDIDATES",
           "target": "easyuse_anima/aio/input_defaults.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.input_defaults:ANIMA_DEFAULT_VAE_CANDIDATES",
         "kind": "static_from",
-        "line": 63,
+        "line": 61,
         "name": "ANIMA_DEFAULT_VAE_CANDIDATES",
         "optional": false,
         "requested": ".easyuse_anima.aio.input_defaults",
@@ -21449,7 +22335,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -21457,12 +22343,12 @@
         "compatibility_pair": {
           "bound_name": "ANIMA_UNET_WEIGHT_DTYPES",
           "target": "easyuse_anima/aio/input_defaults.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.input_defaults:ANIMA_UNET_WEIGHT_DTYPES",
         "kind": "static_from",
-        "line": 63,
+        "line": 61,
         "name": "ANIMA_UNET_WEIGHT_DTYPES",
         "optional": false,
         "requested": ".easyuse_anima.aio.input_defaults",
@@ -21480,7 +22366,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -21488,12 +22374,12 @@
         "compatibility_pair": {
           "bound_name": "EASY_USE_ANIMA_INPUT_SCHEMA",
           "target": "easyuse_anima/aio/input_defaults.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.input_defaults:EASY_USE_ANIMA_INPUT_SCHEMA",
         "kind": "static_from",
-        "line": 63,
+        "line": 61,
         "name": "EASY_USE_ANIMA_INPUT_SCHEMA",
         "optional": false,
         "requested": ".easyuse_anima.aio.input_defaults",
@@ -21511,7 +22397,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -21519,12 +22405,12 @@
         "compatibility_pair": {
           "bound_name": "EASY_USE_ANIMA_INPUT_SETTINGS_VERSION",
           "target": "easyuse_anima/aio/input_defaults.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.input_defaults:EASY_USE_ANIMA_INPUT_SETTINGS_VERSION",
         "kind": "static_from",
-        "line": 63,
+        "line": 61,
         "name": "EASY_USE_ANIMA_INPUT_SETTINGS_VERSION",
         "optional": false,
         "requested": ".easyuse_anima.aio.input_defaults",
@@ -21542,7 +22428,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -21550,12 +22436,12 @@
         "compatibility_pair": {
           "bound_name": "_easy_use_anima_input_signature",
           "target": "easyuse_anima/aio/input_context.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.input_context:_easy_use_anima_input_signature",
         "kind": "static_from",
-        "line": 74,
+        "line": 72,
         "name": "_easy_use_anima_input_signature",
         "optional": false,
         "requested": ".easyuse_anima.aio.input_context",
@@ -21573,7 +22459,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -21581,12 +22467,12 @@
         "compatibility_pair": {
           "bound_name": "_require_easy_use_anima_input",
           "target": "easyuse_anima/aio/input_context.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.input_context:_require_easy_use_anima_input",
         "kind": "static_from",
-        "line": 74,
+        "line": 72,
         "name": "_require_easy_use_anima_input",
         "optional": false,
         "requested": ".easyuse_anima.aio.input_context",
@@ -21604,7 +22490,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -21612,12 +22498,12 @@
         "compatibility_pair": {
           "bound_name": "_aio_usdu_auto_tile_dimension",
           "target": "easyuse_anima/aio/usdu.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.usdu:_aio_usdu_auto_tile_dimension",
         "kind": "static_from",
-        "line": 78,
+        "line": 76,
         "name": "_aio_usdu_auto_tile_dimension",
         "optional": false,
         "requested": ".easyuse_anima.aio.usdu",
@@ -21635,7 +22521,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -21643,12 +22529,12 @@
         "compatibility_pair": {
           "bound_name": "_aio_usdu_tile_plan",
           "target": "easyuse_anima/aio/usdu.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.usdu:_aio_usdu_tile_plan",
         "kind": "static_from",
-        "line": 78,
+        "line": 76,
         "name": "_aio_usdu_tile_plan",
         "optional": false,
         "requested": ".easyuse_anima.aio.usdu",
@@ -21666,7 +22552,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -21674,12 +22560,12 @@
         "compatibility_pair": {
           "bound_name": "_aio_final_fit_size",
           "target": "easyuse_anima/aio/postprocess.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.postprocess:_aio_final_fit_size",
         "kind": "static_from",
-        "line": 82,
+        "line": 80,
         "name": "_aio_final_fit_size",
         "optional": false,
         "requested": ".easyuse_anima.aio.postprocess",
@@ -21697,7 +22583,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -21705,12 +22591,12 @@
         "compatibility_pair": {
           "bound_name": "_apply_aio_final_fit",
           "target": "easyuse_anima/aio/postprocess.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.postprocess:_apply_aio_final_fit",
         "kind": "static_from",
-        "line": 82,
+        "line": 80,
         "name": "_apply_aio_final_fit",
         "optional": false,
         "requested": ".easyuse_anima.aio.postprocess",
@@ -21728,7 +22614,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -21736,12 +22622,12 @@
         "compatibility_pair": {
           "bound_name": "_resize_image_to_size_if_needed",
           "target": "easyuse_anima/aio/postprocess.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.postprocess:_resize_image_to_size_if_needed",
         "kind": "static_from",
-        "line": 82,
+        "line": 80,
         "name": "_resize_image_to_size_if_needed",
         "optional": false,
         "requested": ".easyuse_anima.aio.postprocess",
@@ -21759,7 +22645,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -21767,12 +22653,12 @@
         "compatibility_pair": {
           "bound_name": "_run_aio_postprocess_stage",
           "target": "easyuse_anima/aio/postprocess.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.postprocess:_run_aio_postprocess_stage",
         "kind": "static_from",
-        "line": 82,
+        "line": 80,
         "name": "_run_aio_postprocess_stage",
         "optional": false,
         "requested": ".easyuse_anima.aio.postprocess",
@@ -21790,7 +22676,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -21798,12 +22684,12 @@
         "compatibility_pair": {
           "bound_name": "_aio_prompt_data_fields_for_usdu",
           "target": "easyuse_anima/aio/conditioning.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.conditioning:_aio_prompt_data_fields_for_usdu",
         "kind": "static_from",
-        "line": 88,
+        "line": 86,
         "name": "_aio_prompt_data_fields_for_usdu",
         "optional": false,
         "requested": ".easyuse_anima.aio.conditioning",
@@ -21821,7 +22707,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -21829,12 +22715,12 @@
         "compatibility_pair": {
           "bound_name": "_aio_usdu_conditioning",
           "target": "easyuse_anima/aio/conditioning.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.conditioning:_aio_usdu_conditioning",
         "kind": "static_from",
-        "line": 88,
+        "line": 86,
         "name": "_aio_usdu_conditioning",
         "optional": false,
         "requested": ".easyuse_anima.aio.conditioning",
@@ -21852,7 +22738,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -21860,12 +22746,12 @@
         "compatibility_pair": {
           "bound_name": "_aio_usdu_prompt_without_general",
           "target": "easyuse_anima/aio/conditioning.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.conditioning:_aio_usdu_prompt_without_general",
         "kind": "static_from",
-        "line": 88,
+        "line": 86,
         "name": "_aio_usdu_prompt_without_general",
         "optional": false,
         "requested": ".easyuse_anima.aio.conditioning",
@@ -21883,7 +22769,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -21891,12 +22777,12 @@
         "compatibility_pair": {
           "bound_name": "_aio_lora_stack_signature",
           "target": "easyuse_anima/aio/model_preparation.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_aio_lora_stack_signature",
         "kind": "static_from",
-        "line": 93,
+        "line": 91,
         "name": "_aio_lora_stack_signature",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -21914,7 +22800,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -21922,12 +22808,12 @@
         "compatibility_pair": {
           "bound_name": "_apply_aio_anima_dave_patch",
           "target": "easyuse_anima/aio/model_preparation.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_apply_aio_anima_dave_patch",
         "kind": "static_from",
-        "line": 93,
+        "line": 91,
         "name": "_apply_aio_anima_dave_patch",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -21945,7 +22831,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -21953,12 +22839,12 @@
         "compatibility_pair": {
           "bound_name": "_apply_aio_kj_model_patches",
           "target": "easyuse_anima/aio/model_preparation.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_apply_aio_kj_model_patches",
         "kind": "static_from",
-        "line": 93,
+        "line": 91,
         "name": "_apply_aio_kj_model_patches",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -21976,7 +22862,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -21984,12 +22870,12 @@
         "compatibility_pair": {
           "bound_name": "_apply_aio_lora_stack",
           "target": "easyuse_anima/aio/model_preparation.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_apply_aio_lora_stack",
         "kind": "static_from",
-        "line": 93,
+        "line": 91,
         "name": "_apply_aio_lora_stack",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -22007,7 +22893,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -22015,12 +22901,12 @@
         "compatibility_pair": {
           "bound_name": "_apply_aio_model_patches",
           "target": "easyuse_anima/aio/model_preparation.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_apply_aio_model_patches",
         "kind": "static_from",
-        "line": 93,
+        "line": 91,
         "name": "_apply_aio_model_patches",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -22038,7 +22924,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -22046,12 +22932,12 @@
         "compatibility_pair": {
           "bound_name": "_apply_aio_safe_pag_patch",
           "target": "easyuse_anima/aio/model_preparation.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_apply_aio_safe_pag_patch",
         "kind": "static_from",
-        "line": 93,
+        "line": 91,
         "name": "_apply_aio_safe_pag_patch",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -22069,7 +22955,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -22077,12 +22963,12 @@
         "compatibility_pair": {
           "bound_name": "_apply_aio_spectrum_correction_patch_for_comfy_sampler",
           "target": "easyuse_anima/aio/model_preparation.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_apply_aio_spectrum_correction_patch_for_comfy_sampler",
         "kind": "static_from",
-        "line": 93,
+        "line": 91,
         "name": "_apply_aio_spectrum_correction_patch_for_comfy_sampler",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -22100,7 +22986,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -22108,12 +22994,12 @@
         "compatibility_pair": {
           "bound_name": "_apply_aio_spectrum_forecast_patch_for_comfy_sampler",
           "target": "easyuse_anima/aio/model_preparation.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_apply_aio_spectrum_forecast_patch_for_comfy_sampler",
         "kind": "static_from",
-        "line": 93,
+        "line": 91,
         "name": "_apply_aio_spectrum_forecast_patch_for_comfy_sampler",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -22131,7 +23017,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -22139,12 +23025,12 @@
         "compatibility_pair": {
           "bound_name": "_apply_aio_spectrum_model_patches_for_comfy_sampler",
           "target": "easyuse_anima/aio/model_preparation.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_apply_aio_spectrum_model_patches_for_comfy_sampler",
         "kind": "static_from",
-        "line": 93,
+        "line": 91,
         "name": "_apply_aio_spectrum_model_patches_for_comfy_sampler",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -22162,7 +23048,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -22170,12 +23056,12 @@
         "compatibility_pair": {
           "bound_name": "_cleanup_aio_ephemeral_model",
           "target": "easyuse_anima/aio/model_preparation.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_cleanup_aio_ephemeral_model",
         "kind": "static_from",
-        "line": 93,
+        "line": 91,
         "name": "_cleanup_aio_ephemeral_model",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -22193,7 +23079,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -22201,12 +23087,12 @@
         "compatibility_pair": {
           "bound_name": "_normalize_aio_lora_stack",
           "target": "easyuse_anima/aio/model_preparation.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_normalize_aio_lora_stack",
         "kind": "static_from",
-        "line": 93,
+        "line": 91,
         "name": "_normalize_aio_lora_stack",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -22224,7 +23110,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -22232,12 +23118,12 @@
         "compatibility_pair": {
           "bound_name": "_patch_model_sampling_aura_flow",
           "target": "easyuse_anima/aio/model_preparation.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_patch_model_sampling_aura_flow",
         "kind": "static_from",
-        "line": 93,
+        "line": 91,
         "name": "_patch_model_sampling_aura_flow",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -22255,7 +23141,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -22263,12 +23149,12 @@
         "compatibility_pair": {
           "bound_name": "_aio_highres_effective_backend",
           "target": "easyuse_anima/aio/sampling.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_aio_highres_effective_backend",
         "kind": "static_from",
-        "line": 107,
+        "line": 105,
         "name": "_aio_highres_effective_backend",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -22286,7 +23172,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -22294,12 +23180,12 @@
         "compatibility_pair": {
           "bound_name": "_aio_stage_sampler_settings",
           "target": "easyuse_anima/aio/sampling.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_aio_stage_sampler_settings",
         "kind": "static_from",
-        "line": 107,
+        "line": 105,
         "name": "_aio_stage_sampler_settings",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -22317,7 +23203,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -22325,12 +23211,12 @@
         "compatibility_pair": {
           "bound_name": "_decode_latent_with_comfy",
           "target": "easyuse_anima/aio/sampling.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_decode_latent_with_comfy",
         "kind": "static_from",
-        "line": 107,
+        "line": 105,
         "name": "_decode_latent_with_comfy",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -22348,7 +23234,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -22356,12 +23242,12 @@
         "compatibility_pair": {
           "bound_name": "_encode_image_with_comfy_vae",
           "target": "easyuse_anima/aio/sampling.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_encode_image_with_comfy_vae",
         "kind": "static_from",
-        "line": 107,
+        "line": 105,
         "name": "_encode_image_with_comfy_vae",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -22379,7 +23265,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -22387,12 +23273,12 @@
         "compatibility_pair": {
           "bound_name": "_generate_empty_latent_with_comfy",
           "target": "easyuse_anima/aio/sampling.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_generate_empty_latent_with_comfy",
         "kind": "static_from",
-        "line": 107,
+        "line": 105,
         "name": "_generate_empty_latent_with_comfy",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -22410,7 +23296,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -22418,12 +23304,12 @@
         "compatibility_pair": {
           "bound_name": "_new_aio_random_seed",
           "target": "easyuse_anima/aio/sampling.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_new_aio_random_seed",
         "kind": "static_from",
-        "line": 107,
+        "line": 105,
         "name": "_new_aio_random_seed",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -22441,7 +23327,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -22449,12 +23335,12 @@
         "compatibility_pair": {
           "bound_name": "_resolve_aio_runtime_seed",
           "target": "easyuse_anima/aio/sampling.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_resolve_aio_runtime_seed",
         "kind": "static_from",
-        "line": 107,
+        "line": 105,
         "name": "_resolve_aio_runtime_seed",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -22472,7 +23358,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -22480,12 +23366,12 @@
         "compatibility_pair": {
           "bound_name": "_sample_latent_with_aio_backend",
           "target": "easyuse_anima/aio/sampling.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_sample_latent_with_aio_backend",
         "kind": "static_from",
-        "line": 107,
+        "line": 105,
         "name": "_sample_latent_with_aio_backend",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -22503,7 +23389,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -22511,12 +23397,12 @@
         "compatibility_pair": {
           "bound_name": "_sample_latent_with_comfy",
           "target": "easyuse_anima/aio/sampling.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_sample_latent_with_comfy",
         "kind": "static_from",
-        "line": 107,
+        "line": 105,
         "name": "_sample_latent_with_comfy",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -22534,7 +23420,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -22542,12 +23428,12 @@
         "compatibility_pair": {
           "bound_name": "_sample_latent_with_spectrum_mod_guidance_advanced",
           "target": "easyuse_anima/aio/sampling.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_sample_latent_with_spectrum_mod_guidance_advanced",
         "kind": "static_from",
-        "line": 107,
+        "line": 105,
         "name": "_sample_latent_with_spectrum_mod_guidance_advanced",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -22565,7 +23451,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -22573,12 +23459,12 @@
         "compatibility_pair": {
           "bound_name": "_sample_latent_with_spectrum_spd",
           "target": "easyuse_anima/aio/sampling.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_sample_latent_with_spectrum_spd",
         "kind": "static_from",
-        "line": 107,
+        "line": 105,
         "name": "_sample_latent_with_spectrum_spd",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -22596,7 +23482,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -22604,12 +23490,12 @@
         "compatibility_pair": {
           "bound_name": "AIO_PREVIEW_CACHE_FORMAT",
           "target": "easyuse_anima/aio/preview.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.preview:AIO_PREVIEW_CACHE_FORMAT",
         "kind": "static_from",
-        "line": 120,
+        "line": 118,
         "name": "AIO_PREVIEW_CACHE_FORMAT",
         "optional": false,
         "requested": ".easyuse_anima.aio.preview",
@@ -22627,7 +23513,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -22635,12 +23521,12 @@
         "compatibility_pair": {
           "bound_name": "AIO_PREVIEW_CACHE_QUALITY",
           "target": "easyuse_anima/aio/preview.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.preview:AIO_PREVIEW_CACHE_QUALITY",
         "kind": "static_from",
-        "line": 120,
+        "line": 118,
         "name": "AIO_PREVIEW_CACHE_QUALITY",
         "optional": false,
         "requested": ".easyuse_anima.aio.preview",
@@ -22658,7 +23544,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -22666,12 +23552,12 @@
         "compatibility_pair": {
           "bound_name": "AIO_PREVIEW_EVENT",
           "target": "easyuse_anima/aio/preview.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.preview:AIO_PREVIEW_EVENT",
         "kind": "static_from",
-        "line": 120,
+        "line": 118,
         "name": "AIO_PREVIEW_EVENT",
         "optional": false,
         "requested": ".easyuse_anima.aio.preview",
@@ -22689,7 +23575,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -22697,12 +23583,12 @@
         "compatibility_pair": {
           "bound_name": "AIO_PREVIEW_STAGE_LABELS",
           "target": "easyuse_anima/aio/preview.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.preview:AIO_PREVIEW_STAGE_LABELS",
         "kind": "static_from",
-        "line": 120,
+        "line": 118,
         "name": "AIO_PREVIEW_STAGE_LABELS",
         "optional": false,
         "requested": ".easyuse_anima.aio.preview",
@@ -22720,7 +23606,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -22728,12 +23614,12 @@
         "compatibility_pair": {
           "bound_name": "_aio_preview_base_directory",
           "target": "easyuse_anima/aio/preview.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.preview:_aio_preview_base_directory",
         "kind": "static_from",
-        "line": 120,
+        "line": 118,
         "name": "_aio_preview_base_directory",
         "optional": false,
         "requested": ".easyuse_anima.aio.preview",
@@ -22751,7 +23637,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -22759,12 +23645,12 @@
         "compatibility_pair": {
           "bound_name": "_aio_preview_file_size_bytes",
           "target": "easyuse_anima/aio/preview.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.preview:_aio_preview_file_size_bytes",
         "kind": "static_from",
-        "line": 120,
+        "line": 118,
         "name": "_aio_preview_file_size_bytes",
         "optional": false,
         "requested": ".easyuse_anima.aio.preview",
@@ -22782,7 +23668,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -22790,12 +23676,12 @@
         "compatibility_pair": {
           "bound_name": "_save_aio_temp_preview_image",
           "target": "easyuse_anima/aio/preview.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.preview:_save_aio_temp_preview_image",
         "kind": "static_from",
-        "line": 120,
+        "line": 118,
         "name": "_save_aio_temp_preview_image",
         "optional": false,
         "requested": ".easyuse_anima.aio.preview",
@@ -22813,7 +23699,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -22821,12 +23707,12 @@
         "compatibility_pair": {
           "bound_name": "_send_aio_preview_event",
           "target": "easyuse_anima/aio/preview.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.preview:_send_aio_preview_event",
         "kind": "static_from",
-        "line": 120,
+        "line": 118,
         "name": "_send_aio_preview_event",
         "optional": false,
         "requested": ".easyuse_anima.aio.preview",
@@ -22844,7 +23730,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -22852,12 +23738,12 @@
         "compatibility_pair": {
           "bound_name": "_tag_aio_preview_images",
           "target": "easyuse_anima/aio/preview.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.preview:_tag_aio_preview_images",
         "kind": "static_from",
-        "line": 120,
+        "line": 118,
         "name": "_tag_aio_preview_images",
         "optional": false,
         "requested": ".easyuse_anima.aio.preview",
@@ -22875,7 +23761,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -22883,12 +23769,12 @@
         "compatibility_pair": {
           "bound_name": "_aio_image_saver_additional_hashes",
           "target": "easyuse_anima/aio/output.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.output:_aio_image_saver_additional_hashes",
         "kind": "static_from",
-        "line": 131,
+        "line": 129,
         "name": "_aio_image_saver_additional_hashes",
         "optional": false,
         "requested": ".easyuse_anima.aio.output",
@@ -22906,7 +23792,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -22914,12 +23800,12 @@
         "compatibility_pair": {
           "bound_name": "_aio_image_saver_civitai_hash_fetcher_entries",
           "target": "easyuse_anima/aio/output.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.output:_aio_image_saver_civitai_hash_fetcher_entries",
         "kind": "static_from",
-        "line": 131,
+        "line": 129,
         "name": "_aio_image_saver_civitai_hash_fetcher_entries",
         "optional": false,
         "requested": ".easyuse_anima.aio.output",
@@ -22937,7 +23823,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -22945,12 +23831,12 @@
         "compatibility_pair": {
           "bound_name": "_aio_lora_metadata_name",
           "target": "easyuse_anima/aio/output.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.output:_aio_lora_metadata_name",
         "kind": "static_from",
-        "line": 131,
+        "line": 129,
         "name": "_aio_lora_metadata_name",
         "optional": false,
         "requested": ".easyuse_anima.aio.output",
@@ -22968,7 +23854,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -22976,12 +23862,12 @@
         "compatibility_pair": {
           "bound_name": "_aio_prompt_with_lora_metadata",
           "target": "easyuse_anima/aio/output.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.output:_aio_prompt_with_lora_metadata",
         "kind": "static_from",
-        "line": 131,
+        "line": 129,
         "name": "_aio_prompt_with_lora_metadata",
         "optional": false,
         "requested": ".easyuse_anima.aio.output",
@@ -22999,7 +23885,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -23007,12 +23893,12 @@
         "compatibility_pair": {
           "bound_name": "_aio_save_filename_prefix",
           "target": "easyuse_anima/aio/output.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.output:_aio_save_filename_prefix",
         "kind": "static_from",
-        "line": 131,
+        "line": 129,
         "name": "_aio_save_filename_prefix",
         "optional": false,
         "requested": ".easyuse_anima.aio.output",
@@ -23030,7 +23916,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -23038,12 +23924,12 @@
         "compatibility_pair": {
           "bound_name": "_save_image_with_comfy",
           "target": "easyuse_anima/aio/output.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.output:_save_image_with_comfy",
         "kind": "static_from",
-        "line": 131,
+        "line": 129,
         "name": "_save_image_with_comfy",
         "optional": false,
         "requested": ".easyuse_anima.aio.output",
@@ -23061,7 +23947,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -23069,12 +23955,12 @@
         "compatibility_pair": {
           "bound_name": "_save_image_with_image_saver",
           "target": "easyuse_anima/aio/output.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.output:_save_image_with_image_saver",
         "kind": "static_from",
-        "line": 131,
+        "line": 129,
         "name": "_save_image_with_image_saver",
         "optional": false,
         "requested": ".easyuse_anima.aio.output",
@@ -23092,7 +23978,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -23100,12 +23986,12 @@
         "compatibility_pair": {
           "bound_name": "_normalize_aio_civitai_hash_fetchers",
           "target": "easyuse_anima/aio/output_settings.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.output_settings:_normalize_aio_civitai_hash_fetchers",
         "kind": "static_from",
-        "line": 140,
+        "line": 138,
         "name": "_normalize_aio_civitai_hash_fetchers",
         "optional": false,
         "requested": ".easyuse_anima.aio.output_settings",
@@ -23123,7 +24009,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -23131,12 +24017,12 @@
         "compatibility_pair": {
           "bound_name": "_normalize_aio_hash_bundles",
           "target": "easyuse_anima/aio/output_settings.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.output_settings:_normalize_aio_hash_bundles",
         "kind": "static_from",
-        "line": 140,
+        "line": 138,
         "name": "_normalize_aio_hash_bundles",
         "optional": false,
         "requested": ".easyuse_anima.aio.output_settings",
@@ -23154,7 +24040,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -23162,12 +24048,12 @@
         "compatibility_pair": {
           "bound_name": "_comfy_clip_loader_types",
           "target": "easyuse_anima/aio/resources.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_comfy_clip_loader_types",
         "kind": "static_from",
-        "line": 144,
+        "line": 142,
         "name": "_comfy_clip_loader_types",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -23185,7 +24071,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -23193,12 +24079,12 @@
         "compatibility_pair": {
           "bound_name": "_comfy_diffusion_model_names",
           "target": "easyuse_anima/aio/resources.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_comfy_diffusion_model_names",
         "kind": "static_from",
-        "line": 144,
+        "line": 142,
         "name": "_comfy_diffusion_model_names",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -23216,7 +24102,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -23224,12 +24110,12 @@
         "compatibility_pair": {
           "bound_name": "_comfy_text_encoder_names",
           "target": "easyuse_anima/aio/resources.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_comfy_text_encoder_names",
         "kind": "static_from",
-        "line": 144,
+        "line": 142,
         "name": "_comfy_text_encoder_names",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -23247,7 +24133,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -23255,12 +24141,12 @@
         "compatibility_pair": {
           "bound_name": "_comfy_vae_names",
           "target": "easyuse_anima/aio/resources.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_comfy_vae_names",
         "kind": "static_from",
-        "line": 144,
+        "line": 142,
         "name": "_comfy_vae_names",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -23278,7 +24164,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -23286,12 +24172,12 @@
         "compatibility_pair": {
           "bound_name": "_load_aio_resources_from_input_context",
           "target": "easyuse_anima/aio/resources.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_load_aio_resources_from_input_context",
         "kind": "static_from",
-        "line": 144,
+        "line": 142,
         "name": "_load_aio_resources_from_input_context",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -23309,7 +24195,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -23317,12 +24203,12 @@
         "compatibility_pair": {
           "bound_name": "_load_aio_sam3_context",
           "target": "easyuse_anima/aio/resources.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_load_aio_sam3_context",
         "kind": "static_from",
-        "line": 144,
+        "line": 142,
         "name": "_load_aio_sam3_context",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -23340,7 +24226,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -23348,12 +24234,12 @@
         "compatibility_pair": {
           "bound_name": "_load_checkpoint_with_comfy",
           "target": "easyuse_anima/aio/resources.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_load_checkpoint_with_comfy",
         "kind": "static_from",
-        "line": 144,
+        "line": 142,
         "name": "_load_checkpoint_with_comfy",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -23371,7 +24257,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -23379,12 +24265,12 @@
         "compatibility_pair": {
           "bound_name": "_load_clip_with_comfy",
           "target": "easyuse_anima/aio/resources.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_load_clip_with_comfy",
         "kind": "static_from",
-        "line": 144,
+        "line": 142,
         "name": "_load_clip_with_comfy",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -23402,7 +24288,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -23410,12 +24296,12 @@
         "compatibility_pair": {
           "bound_name": "_load_diffusion_model_with_comfy",
           "target": "easyuse_anima/aio/resources.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_load_diffusion_model_with_comfy",
         "kind": "static_from",
-        "line": 144,
+        "line": 142,
         "name": "_load_diffusion_model_with_comfy",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -23433,7 +24319,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -23441,12 +24327,12 @@
         "compatibility_pair": {
           "bound_name": "_load_upscale_model_with_comfy",
           "target": "easyuse_anima/aio/resources.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_load_upscale_model_with_comfy",
         "kind": "static_from",
-        "line": 144,
+        "line": 142,
         "name": "_load_upscale_model_with_comfy",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -23464,7 +24350,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -23472,12 +24358,12 @@
         "compatibility_pair": {
           "bound_name": "_load_vae_with_comfy",
           "target": "easyuse_anima/aio/resources.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_load_vae_with_comfy",
         "kind": "static_from",
-        "line": 144,
+        "line": 142,
         "name": "_load_vae_with_comfy",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -23495,7 +24381,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -23503,12 +24389,12 @@
         "compatibility_pair": {
           "bound_name": "_normalize_aio_input_settings",
           "target": "easyuse_anima/aio/resources.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_normalize_aio_input_settings",
         "kind": "static_from",
-        "line": 144,
+        "line": 142,
         "name": "_normalize_aio_input_settings",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -23526,7 +24412,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -23534,12 +24420,12 @@
         "compatibility_pair": {
           "bound_name": "_preferred_checkpoint_default",
           "target": "easyuse_anima/aio/resources.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_preferred_checkpoint_default",
         "kind": "static_from",
-        "line": 144,
+        "line": 142,
         "name": "_preferred_checkpoint_default",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -23557,7 +24443,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -23565,12 +24451,12 @@
         "compatibility_pair": {
           "bound_name": "_preferred_clip_type_default",
           "target": "easyuse_anima/aio/resources.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_preferred_clip_type_default",
         "kind": "static_from",
-        "line": 144,
+        "line": 142,
         "name": "_preferred_clip_type_default",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -23588,7 +24474,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -23596,12 +24482,12 @@
         "compatibility_pair": {
           "bound_name": "_preferred_name_default",
           "target": "easyuse_anima/aio/resources.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_preferred_name_default",
         "kind": "static_from",
-        "line": 144,
+        "line": 142,
         "name": "_preferred_name_default",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -23619,7 +24505,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -23627,12 +24513,12 @@
         "compatibility_pair": {
           "bound_name": "_json_clone",
           "target": "easyuse_anima/common/serialization.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.common.serialization:_json_clone",
         "kind": "static_from",
-        "line": 161,
+        "line": 159,
         "name": "_json_clone",
         "optional": false,
         "requested": ".easyuse_anima.common.serialization",
@@ -23650,7 +24536,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -23658,12 +24544,12 @@
         "compatibility_pair": {
           "bound_name": "_json_object",
           "target": "easyuse_anima/common/serialization.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.common.serialization:_json_object",
         "kind": "static_from",
-        "line": 161,
+        "line": 159,
         "name": "_json_object",
         "optional": false,
         "requested": ".easyuse_anima.common.serialization",
@@ -23681,7 +24567,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -23689,12 +24575,12 @@
         "compatibility_pair": {
           "bound_name": "_stable_change_key",
           "target": "easyuse_anima/common/serialization.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.common.serialization:_stable_change_key",
         "kind": "static_from",
-        "line": 161,
+        "line": 159,
         "name": "_stable_change_key",
         "optional": false,
         "requested": ".easyuse_anima.common.serialization",
@@ -23712,7 +24598,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -23720,12 +24606,12 @@
         "compatibility_pair": {
           "bound_name": "_as_bool",
           "target": "easyuse_anima/common/values.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.common.values:_as_bool",
         "kind": "static_from",
-        "line": 166,
+        "line": 164,
         "name": "_as_bool",
         "optional": false,
         "requested": ".easyuse_anima.common.values",
@@ -23743,7 +24629,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -23751,12 +24637,12 @@
         "compatibility_pair": {
           "bound_name": "_as_float",
           "target": "easyuse_anima/common/values.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.common.values:_as_float",
         "kind": "static_from",
-        "line": 166,
+        "line": 164,
         "name": "_as_float",
         "optional": false,
         "requested": ".easyuse_anima.common.values",
@@ -23774,7 +24660,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -23782,12 +24668,12 @@
         "compatibility_pair": {
           "bound_name": "_as_int",
           "target": "easyuse_anima/common/values.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.common.values:_as_int",
         "kind": "static_from",
-        "line": 166,
+        "line": 164,
         "name": "_as_int",
         "optional": false,
         "requested": ".easyuse_anima.common.values",
@@ -23805,7 +24691,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -23813,12 +24699,12 @@
         "compatibility_pair": {
           "bound_name": "_choice",
           "target": "easyuse_anima/common/values.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.common.values:_choice",
         "kind": "static_from",
-        "line": 166,
+        "line": 164,
         "name": "_choice",
         "optional": false,
         "requested": ".easyuse_anima.common.values",
@@ -23836,7 +24722,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -23844,12 +24730,12 @@
         "compatibility_pair": {
           "bound_name": "_single_value",
           "target": "easyuse_anima/common/values.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.common.values:_single_value",
         "kind": "static_from",
-        "line": 166,
+        "line": 164,
         "name": "_single_value",
         "optional": false,
         "requested": ".easyuse_anima.common.values",
@@ -23867,7 +24753,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -23875,12 +24761,12 @@
         "compatibility_pair": {
           "bound_name": "WILDCARD_QUEUE_MAX_SAFE_SEED",
           "target": "easyuse_anima/seed/compatibility.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.seed.compatibility:WILDCARD_QUEUE_MAX_SAFE_SEED",
         "kind": "static_from",
-        "line": 173,
+        "line": 171,
         "name": "WILDCARD_QUEUE_MAX_SAFE_SEED",
         "optional": false,
         "requested": ".easyuse_anima.seed.compatibility",
@@ -23898,7 +24784,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -23906,12 +24792,12 @@
         "compatibility_pair": {
           "bound_name": "WILDCARD_RESERVED_NEXT_SEED_INPUT",
           "target": "easyuse_anima/seed/compatibility.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.seed.compatibility:WILDCARD_RESERVED_NEXT_SEED_INPUT",
         "kind": "static_from",
-        "line": 173,
+        "line": 171,
         "name": "WILDCARD_RESERVED_NEXT_SEED_INPUT",
         "optional": false,
         "requested": ".easyuse_anima.seed.compatibility",
@@ -23929,7 +24815,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -23937,12 +24823,12 @@
         "compatibility_pair": {
           "bound_name": "_consume_reserved_wildcard_next_seed",
           "target": "easyuse_anima/seed/compatibility.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.seed.compatibility:_consume_reserved_wildcard_next_seed",
         "kind": "static_from",
-        "line": 173,
+        "line": 171,
         "name": "_consume_reserved_wildcard_next_seed",
         "optional": false,
         "requested": ".easyuse_anima.seed.compatibility",
@@ -23960,7 +24846,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -23968,12 +24854,12 @@
         "compatibility_pair": {
           "bound_name": "_get_workflow_node",
           "target": "easyuse_anima/workflow.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.workflow:_get_workflow_node",
         "kind": "static_from",
-        "line": 178,
+        "line": 176,
         "name": "_get_workflow_node",
         "optional": false,
         "requested": ".easyuse_anima.workflow",
@@ -23991,7 +24877,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -23999,12 +24885,12 @@
         "compatibility_pair": {
           "bound_name": "_prompt_translation_change_key",
           "target": "easyuse_anima/prompt/correction.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.correction:_prompt_translation_change_key",
         "kind": "static_from",
-        "line": 179,
+        "line": 177,
         "name": "_prompt_translation_change_key",
         "optional": false,
         "requested": ".easyuse_anima.prompt.correction",
@@ -24022,7 +24908,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -24030,12 +24916,12 @@
         "compatibility_pair": {
           "bound_name": "_split_tag_text",
           "target": "easyuse_anima/prompt/correction.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.correction:_split_tag_text",
         "kind": "static_from",
-        "line": 179,
+        "line": 177,
         "name": "_split_tag_text",
         "optional": false,
         "requested": ".easyuse_anima.prompt.correction",
@@ -24053,7 +24939,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -24061,12 +24947,12 @@
         "compatibility_pair": {
           "bound_name": "_translate_prompt_text",
           "target": "easyuse_anima/prompt/correction.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.correction:_translate_prompt_text",
         "kind": "static_from",
-        "line": 179,
+        "line": 177,
         "name": "_translate_prompt_text",
         "optional": false,
         "requested": ".easyuse_anima.prompt.correction",
@@ -24084,7 +24970,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -24092,12 +24978,12 @@
         "compatibility_pair": {
           "bound_name": "_HASH_COMMENT_RE",
           "target": "easyuse_anima/prompt/fields.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_HASH_COMMENT_RE",
         "kind": "static_from",
-        "line": 184,
+        "line": 182,
         "name": "_HASH_COMMENT_RE",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -24115,7 +25001,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -24123,12 +25009,12 @@
         "compatibility_pair": {
           "bound_name": "_INLINE_SPACE_RE",
           "target": "easyuse_anima/prompt/fields.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_INLINE_SPACE_RE",
         "kind": "static_from",
-        "line": 184,
+        "line": 182,
         "name": "_INLINE_SPACE_RE",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -24146,7 +25032,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -24154,12 +25040,12 @@
         "compatibility_pair": {
           "bound_name": "_WEIGHTED_TOKEN_RE",
           "target": "easyuse_anima/prompt/fields.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_WEIGHTED_TOKEN_RE",
         "kind": "static_from",
-        "line": 184,
+        "line": 182,
         "name": "_WEIGHTED_TOKEN_RE",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -24177,7 +25063,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -24185,12 +25071,12 @@
         "compatibility_pair": {
           "bound_name": "_correct_builder_prompt",
           "target": "easyuse_anima/prompt/fields.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_correct_builder_prompt",
         "kind": "static_from",
-        "line": 184,
+        "line": 182,
         "name": "_correct_builder_prompt",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -24208,7 +25094,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -24216,12 +25102,12 @@
         "compatibility_pair": {
           "bound_name": "_filter_metadata_prompt",
           "target": "easyuse_anima/prompt/fields.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_filter_metadata_prompt",
         "kind": "static_from",
-        "line": 184,
+        "line": 182,
         "name": "_filter_metadata_prompt",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -24239,7 +25125,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -24247,12 +25133,12 @@
         "compatibility_pair": {
           "bound_name": "_join_prompt_tokens",
           "target": "easyuse_anima/prompt/fields.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_join_prompt_tokens",
         "kind": "static_from",
-        "line": 184,
+        "line": 182,
         "name": "_join_prompt_tokens",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -24270,7 +25156,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -24278,12 +25164,12 @@
         "compatibility_pair": {
           "bound_name": "_metadata_filter_key",
           "target": "easyuse_anima/prompt/fields.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_metadata_filter_key",
         "kind": "static_from",
-        "line": 184,
+        "line": 182,
         "name": "_metadata_filter_key",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -24301,7 +25187,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -24309,12 +25195,12 @@
         "compatibility_pair": {
           "bound_name": "_metadata_filter_keys",
           "target": "easyuse_anima/prompt/fields.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_metadata_filter_keys",
         "kind": "static_from",
-        "line": 184,
+        "line": 182,
         "name": "_metadata_filter_keys",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -24332,7 +25218,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -24340,12 +25226,12 @@
         "compatibility_pair": {
           "bound_name": "_prompt_tokens",
           "target": "easyuse_anima/prompt/fields.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_prompt_tokens",
         "kind": "static_from",
-        "line": 184,
+        "line": 182,
         "name": "_prompt_tokens",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -24363,7 +25249,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -24371,12 +25257,12 @@
         "compatibility_pair": {
           "bound_name": "PROMPT_DATA_TYPE",
           "target": "easyuse_anima/prompt/data.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:PROMPT_DATA_TYPE",
         "kind": "static_from",
-        "line": 197,
+        "line": 195,
         "name": "PROMPT_DATA_TYPE",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -24394,7 +25280,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -24402,12 +25288,12 @@
         "compatibility_pair": {
           "bound_name": "_advanced_outputs_from_prompt_data",
           "target": "easyuse_anima/prompt/data.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:_advanced_outputs_from_prompt_data",
         "kind": "static_from",
-        "line": 197,
+        "line": 195,
         "name": "_advanced_outputs_from_prompt_data",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -24425,7 +25311,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -24433,12 +25319,12 @@
         "compatibility_pair": {
           "bound_name": "_apply_prompt_data_overrides",
           "target": "easyuse_anima/prompt/data.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:_apply_prompt_data_overrides",
         "kind": "static_from",
-        "line": 197,
+        "line": 195,
         "name": "_apply_prompt_data_overrides",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -24456,7 +25342,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -24464,12 +25350,12 @@
         "compatibility_pair": {
           "bound_name": "_copy_prompt_data_for_update",
           "target": "easyuse_anima/prompt/data.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:_copy_prompt_data_for_update",
         "kind": "static_from",
-        "line": 197,
+        "line": 195,
         "name": "_copy_prompt_data_for_update",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -24487,7 +25373,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -24495,12 +25381,12 @@
         "compatibility_pair": {
           "bound_name": "_normalize_prompt_data",
           "target": "easyuse_anima/prompt/data.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:_normalize_prompt_data",
         "kind": "static_from",
-        "line": 197,
+        "line": 195,
         "name": "_normalize_prompt_data",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -24518,7 +25404,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -24526,12 +25412,12 @@
         "compatibility_pair": {
           "bound_name": "_prompt_data_json_safe",
           "target": "easyuse_anima/prompt/data.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:_prompt_data_json_safe",
         "kind": "static_from",
-        "line": 197,
+        "line": 195,
         "name": "_prompt_data_json_safe",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -24549,7 +25435,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -24557,12 +25443,12 @@
         "compatibility_pair": {
           "bound_name": "_prompt_data_parameter_snapshot",
           "target": "easyuse_anima/prompt/data.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:_prompt_data_parameter_snapshot",
         "kind": "static_from",
-        "line": 197,
+        "line": 195,
         "name": "_prompt_data_parameter_snapshot",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -24580,7 +25466,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -24588,12 +25474,12 @@
         "compatibility_pair": {
           "bound_name": "_advanced_artist_field_prompt",
           "target": "easyuse_anima/prompt/advanced.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_artist_field_prompt",
         "kind": "static_from",
-        "line": 215,
+        "line": 213,
         "name": "_advanced_artist_field_prompt",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -24611,7 +25497,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -24619,12 +25505,12 @@
         "compatibility_pair": {
           "bound_name": "_advanced_default_fields",
           "target": "easyuse_anima/prompt/advanced.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_default_fields",
         "kind": "static_from",
-        "line": 215,
+        "line": 213,
         "name": "_advanced_default_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -24642,7 +25528,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -24650,12 +25536,12 @@
         "compatibility_pair": {
           "bound_name": "_advanced_enabled_naia_panes",
           "target": "easyuse_anima/prompt/advanced.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_enabled_naia_panes",
         "kind": "static_from",
-        "line": 215,
+        "line": 213,
         "name": "_advanced_enabled_naia_panes",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -24673,7 +25559,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -24681,12 +25567,12 @@
         "compatibility_pair": {
           "bound_name": "_advanced_enabled_pane_fields",
           "target": "easyuse_anima/prompt/advanced.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_enabled_pane_fields",
         "kind": "static_from",
-        "line": 215,
+        "line": 213,
         "name": "_advanced_enabled_pane_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -24704,7 +25590,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -24712,12 +25598,12 @@
         "compatibility_pair": {
           "bound_name": "_advanced_field_input_values",
           "target": "easyuse_anima/prompt/advanced.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_field_input_values",
         "kind": "static_from",
-        "line": 215,
+        "line": 213,
         "name": "_advanced_field_input_values",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -24735,7 +25621,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -24743,12 +25629,12 @@
         "compatibility_pair": {
           "bound_name": "_advanced_field_socket_name",
           "target": "easyuse_anima/prompt/advanced.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_field_socket_name",
         "kind": "static_from",
-        "line": 215,
+        "line": 213,
         "name": "_advanced_field_socket_name",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -24766,7 +25652,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -24774,12 +25660,12 @@
         "compatibility_pair": {
           "bound_name": "_advanced_fields_json",
           "target": "easyuse_anima/prompt/advanced.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_fields_json",
         "kind": "static_from",
-        "line": 215,
+        "line": 213,
         "name": "_advanced_fields_json",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -24797,7 +25683,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -24805,12 +25691,12 @@
         "compatibility_pair": {
           "bound_name": "_advanced_has_enabled_naia",
           "target": "easyuse_anima/prompt/advanced.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_has_enabled_naia",
         "kind": "static_from",
-        "line": 215,
+        "line": 213,
         "name": "_advanced_has_enabled_naia",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -24828,7 +25714,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -24836,12 +25722,12 @@
         "compatibility_pair": {
           "bound_name": "_advanced_prompt_with_artist_override",
           "target": "easyuse_anima/prompt/advanced.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_prompt_with_artist_override",
         "kind": "static_from",
-        "line": 215,
+        "line": 213,
         "name": "_advanced_prompt_with_artist_override",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -24859,7 +25745,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -24867,12 +25753,12 @@
         "compatibility_pair": {
           "bound_name": "_advanced_uses_naia_resolution",
           "target": "easyuse_anima/prompt/advanced.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_uses_naia_resolution",
         "kind": "static_from",
-        "line": 215,
+        "line": 213,
         "name": "_advanced_uses_naia_resolution",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -24890,7 +25776,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -24898,12 +25784,12 @@
         "compatibility_pair": {
           "bound_name": "_apply_advanced_field_inputs",
           "target": "easyuse_anima/prompt/advanced.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_apply_advanced_field_inputs",
         "kind": "static_from",
-        "line": 215,
+        "line": 213,
         "name": "_apply_advanced_field_inputs",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -24921,7 +25807,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -24929,12 +25815,12 @@
         "compatibility_pair": {
           "bound_name": "_as_advanced_height",
           "target": "easyuse_anima/prompt/advanced.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_as_advanced_height",
         "kind": "static_from",
-        "line": 215,
+        "line": 213,
         "name": "_as_advanced_height",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -24952,7 +25838,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -24960,12 +25846,12 @@
         "compatibility_pair": {
           "bound_name": "_build_advanced_prompt_data",
           "target": "easyuse_anima/prompt/advanced.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_build_advanced_prompt_data",
         "kind": "static_from",
-        "line": 215,
+        "line": 213,
         "name": "_build_advanced_prompt_data",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -24983,7 +25869,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -24991,12 +25877,12 @@
         "compatibility_pair": {
           "bound_name": "_build_advanced_prompts",
           "target": "easyuse_anima/prompt/advanced.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_build_advanced_prompts",
         "kind": "static_from",
-        "line": 215,
+        "line": 213,
         "name": "_build_advanced_prompts",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -25014,7 +25900,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -25022,12 +25908,12 @@
         "compatibility_pair": {
           "bound_name": "_clone_advanced_fields",
           "target": "easyuse_anima/prompt/advanced.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_clone_advanced_fields",
         "kind": "static_from",
-        "line": 215,
+        "line": 213,
         "name": "_clone_advanced_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -25045,7 +25931,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -25053,12 +25939,12 @@
         "compatibility_pair": {
           "bound_name": "_correct_advanced_field_sequence",
           "target": "easyuse_anima/prompt/advanced.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_correct_advanced_field_sequence",
         "kind": "static_from",
-        "line": 215,
+        "line": 213,
         "name": "_correct_advanced_field_sequence",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -25076,7 +25962,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -25084,12 +25970,12 @@
         "compatibility_pair": {
           "bound_name": "_expand_advanced_wildcard_fields",
           "target": "easyuse_anima/prompt/advanced.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_expand_advanced_wildcard_fields",
         "kind": "static_from",
-        "line": 215,
+        "line": 213,
         "name": "_expand_advanced_wildcard_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -25107,7 +25993,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -25115,12 +26001,12 @@
         "compatibility_pair": {
           "bound_name": "_normalize_advanced_fields",
           "target": "easyuse_anima/prompt/advanced.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_normalize_advanced_fields",
         "kind": "static_from",
-        "line": 215,
+        "line": 213,
         "name": "_normalize_advanced_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -25138,7 +26024,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -25146,12 +26032,12 @@
         "compatibility_pair": {
           "bound_name": "_normalize_prompt_studio_wildcard_seed_control",
           "target": "easyuse_anima/prompt/advanced.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_normalize_prompt_studio_wildcard_seed_control",
         "kind": "static_from",
-        "line": 215,
+        "line": 213,
         "name": "_normalize_prompt_studio_wildcard_seed_control",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -25169,7 +26055,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -25177,12 +26063,12 @@
         "compatibility_pair": {
           "bound_name": "_set_naia_field_text",
           "target": "easyuse_anima/prompt/advanced.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_set_naia_field_text",
         "kind": "static_from",
-        "line": 215,
+        "line": 213,
         "name": "_set_naia_field_text",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -25200,7 +26086,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -25208,12 +26094,12 @@
         "compatibility_pair": {
           "bound_name": "_translate_prompt_fields",
           "target": "easyuse_anima/prompt/advanced.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_translate_prompt_fields",
         "kind": "static_from",
-        "line": 215,
+        "line": 213,
         "name": "_translate_prompt_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -25231,7 +26117,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -25239,12 +26125,12 @@
         "compatibility_pair": {
           "bound_name": "_apply_regional_field_inputs",
           "target": "easyuse_anima/prompt/regional.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_apply_regional_field_inputs",
         "kind": "static_from",
-        "line": 250,
+        "line": 248,
         "name": "_apply_regional_field_inputs",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -25262,7 +26148,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -25270,12 +26156,12 @@
         "compatibility_pair": {
           "bound_name": "_build_regional_outputs",
           "target": "easyuse_anima/prompt/regional.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_build_regional_outputs",
         "kind": "static_from",
-        "line": 250,
+        "line": 248,
         "name": "_build_regional_outputs",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -25293,7 +26179,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -25301,12 +26187,12 @@
         "compatibility_pair": {
           "bound_name": "_clone_regional_fields",
           "target": "easyuse_anima/prompt/regional.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_clone_regional_fields",
         "kind": "static_from",
-        "line": 250,
+        "line": 248,
         "name": "_clone_regional_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -25324,7 +26210,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -25332,12 +26218,12 @@
         "compatibility_pair": {
           "bound_name": "_conditioning_set_values",
           "target": "easyuse_anima/prompt/regional.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_conditioning_set_values",
         "kind": "static_from",
-        "line": 250,
+        "line": 248,
         "name": "_conditioning_set_values",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -25355,7 +26241,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -25363,12 +26249,12 @@
         "compatibility_pair": {
           "bound_name": "_normalize_mask_ids",
           "target": "easyuse_anima/prompt/regional.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_normalize_mask_ids",
         "kind": "static_from",
-        "line": 250,
+        "line": 248,
         "name": "_normalize_mask_ids",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -25386,7 +26272,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -25394,12 +26280,12 @@
         "compatibility_pair": {
           "bound_name": "_normalize_regional_config",
           "target": "easyuse_anima/prompt/regional.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_normalize_regional_config",
         "kind": "static_from",
-        "line": 250,
+        "line": 248,
         "name": "_normalize_regional_config",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -25417,7 +26303,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -25425,12 +26311,12 @@
         "compatibility_pair": {
           "bound_name": "_normalize_regional_fields",
           "target": "easyuse_anima/prompt/regional.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_normalize_regional_fields",
         "kind": "static_from",
-        "line": 250,
+        "line": 248,
         "name": "_normalize_regional_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -25448,7 +26334,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -25456,12 +26342,12 @@
         "compatibility_pair": {
           "bound_name": "_parse_json_object",
           "target": "easyuse_anima/prompt/regional.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_parse_json_object",
         "kind": "static_from",
-        "line": 250,
+        "line": 248,
         "name": "_parse_json_object",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -25479,7 +26365,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -25487,12 +26373,12 @@
         "compatibility_pair": {
           "bound_name": "_regional_config_json",
           "target": "easyuse_anima/prompt/regional.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_regional_config_json",
         "kind": "static_from",
-        "line": 250,
+        "line": 248,
         "name": "_regional_config_json",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -25510,7 +26396,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -25518,12 +26404,12 @@
         "compatibility_pair": {
           "bound_name": "_regional_fields_json",
           "target": "easyuse_anima/prompt/regional.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_regional_fields_json",
         "kind": "static_from",
-        "line": 250,
+        "line": 248,
         "name": "_regional_fields_json",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -25541,7 +26427,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -25549,12 +26435,12 @@
         "compatibility_pair": {
           "bound_name": "_regional_mask_bounds_area",
           "target": "easyuse_anima/prompt/regional.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_regional_mask_bounds_area",
         "kind": "static_from",
-        "line": 250,
+        "line": 248,
         "name": "_regional_mask_bounds_area",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -25572,7 +26458,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -25580,12 +26466,12 @@
         "compatibility_pair": {
           "bound_name": "_regional_payload_canvas",
           "target": "easyuse_anima/prompt/regional.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_regional_payload_canvas",
         "kind": "static_from",
-        "line": 250,
+        "line": 248,
         "name": "_regional_payload_canvas",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -25603,7 +26489,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -25611,12 +26497,12 @@
         "compatibility_pair": {
           "bound_name": "_regional_union_mask_for_ids",
           "target": "easyuse_anima/prompt/regional.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_regional_union_mask_for_ids",
         "kind": "static_from",
-        "line": 250,
+        "line": 248,
         "name": "_regional_union_mask_for_ids",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -25634,7 +26520,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -25642,12 +26528,12 @@
         "compatibility_pair": {
           "bound_name": "ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
           "target": "easyuse_anima/prompt/conditioning.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
         "kind": "static_from",
-        "line": 277,
+        "line": 275,
         "name": "ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -25665,7 +26551,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -25673,12 +26559,12 @@
         "compatibility_pair": {
           "bound_name": "ANIMA_MOD_GUIDANCE_MODES",
           "target": "easyuse_anima/prompt/conditioning.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODES",
         "kind": "static_from",
-        "line": 277,
+        "line": 275,
         "name": "ANIMA_MOD_GUIDANCE_MODES",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -25696,7 +26582,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -25704,12 +26590,12 @@
         "compatibility_pair": {
           "bound_name": "ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
           "target": "easyuse_anima/prompt/conditioning.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 277,
+        "line": 275,
         "name": "ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -25727,7 +26613,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -25735,12 +26621,12 @@
         "compatibility_pair": {
           "bound_name": "ANIMA_MOD_GUIDANCE_PROFILE_OFF",
           "target": "easyuse_anima/prompt/conditioning.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_PROFILE_OFF",
         "kind": "static_from",
-        "line": 277,
+        "line": 275,
         "name": "ANIMA_MOD_GUIDANCE_PROFILE_OFF",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -25758,7 +26644,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -25766,12 +26652,12 @@
         "compatibility_pair": {
           "bound_name": "_apply_spectrum_anima_mod_guidance",
           "target": "easyuse_anima/prompt/conditioning.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:_apply_spectrum_anima_mod_guidance",
         "kind": "static_from",
-        "line": 277,
+        "line": 275,
         "name": "_apply_spectrum_anima_mod_guidance",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -25789,7 +26675,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -25797,12 +26683,12 @@
         "compatibility_pair": {
           "bound_name": "_find_spectrum_anima_mod_guidance_class",
           "target": "easyuse_anima/prompt/conditioning.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:_find_spectrum_anima_mod_guidance_class",
         "kind": "static_from",
-        "line": 277,
+        "line": 275,
         "name": "_find_spectrum_anima_mod_guidance_class",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -25820,7 +26706,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -25828,12 +26714,12 @@
         "compatibility_pair": {
           "bound_name": "_normalize_anima_mod_guidance_profile",
           "target": "easyuse_anima/prompt/conditioning.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:_normalize_anima_mod_guidance_profile",
         "kind": "static_from",
-        "line": 277,
+        "line": 275,
         "name": "_normalize_anima_mod_guidance_profile",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -25851,7 +26737,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -25859,12 +26745,12 @@
         "compatibility_pair": {
           "bound_name": "_resolve_anima_mod_guidance_enabled",
           "target": "easyuse_anima/prompt/conditioning.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:_resolve_anima_mod_guidance_enabled",
         "kind": "static_from",
-        "line": 277,
+        "line": 275,
         "name": "_resolve_anima_mod_guidance_enabled",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -25882,7 +26768,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -25890,12 +26776,12 @@
         "compatibility_pair": {
           "bound_name": "ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
           "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
         "kind": "static_from",
-        "line": 292,
+        "line": 290,
         "name": "ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -25913,7 +26799,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -25921,12 +26807,12 @@
         "compatibility_pair": {
           "bound_name": "ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
           "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
         "kind": "static_from",
-        "line": 292,
+        "line": 290,
         "name": "ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -25944,7 +26830,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -25952,12 +26838,12 @@
         "compatibility_pair": {
           "bound_name": "ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
           "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
         "kind": "static_from",
-        "line": 292,
+        "line": 290,
         "name": "ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -25975,7 +26861,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -25983,12 +26869,12 @@
         "compatibility_pair": {
           "bound_name": "ARTIST_MIX_DEFAULT_EXACT_TOP_K",
           "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_EXACT_TOP_K",
         "kind": "static_from",
-        "line": 292,
+        "line": 290,
         "name": "ARTIST_MIX_DEFAULT_EXACT_TOP_K",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -26006,7 +26892,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -26014,12 +26900,12 @@
         "compatibility_pair": {
           "bound_name": "ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
           "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
         "kind": "static_from",
-        "line": 292,
+        "line": 290,
         "name": "ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -26037,7 +26923,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -26045,12 +26931,12 @@
         "compatibility_pair": {
           "bound_name": "ARTIST_MIX_DEFAULT_START_PERCENT",
           "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_START_PERCENT",
         "kind": "static_from",
-        "line": 292,
+        "line": 290,
         "name": "ARTIST_MIX_DEFAULT_START_PERCENT",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -26068,7 +26954,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -26076,12 +26962,12 @@
         "compatibility_pair": {
           "bound_name": "ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
           "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
         "kind": "static_from",
-        "line": 292,
+        "line": 290,
         "name": "ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -26099,7 +26985,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -26107,12 +26993,12 @@
         "compatibility_pair": {
           "bound_name": "ARTIST_MIX_DEFAULT_STYLE_GAIN",
           "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STYLE_GAIN",
         "kind": "static_from",
-        "line": 292,
+        "line": 290,
         "name": "ARTIST_MIX_DEFAULT_STYLE_GAIN",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -26130,7 +27016,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -26138,12 +27024,12 @@
         "compatibility_pair": {
           "bound_name": "ARTIST_MIX_INPUT_MODES",
           "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_INPUT_MODES",
         "kind": "static_from",
-        "line": 292,
+        "line": 290,
         "name": "ARTIST_MIX_INPUT_MODES",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -26161,7 +27047,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -26169,12 +27055,12 @@
         "compatibility_pair": {
           "bound_name": "ARTIST_MIX_MODE_FROM_PROMPT_DATA",
           "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 292,
+        "line": 290,
         "name": "ARTIST_MIX_MODE_FROM_PROMPT_DATA",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -26192,7 +27078,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -26200,12 +27086,12 @@
         "compatibility_pair": {
           "bound_name": "_artist_mix_inline_prompt",
           "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_artist_mix_inline_prompt",
         "kind": "static_from",
-        "line": 292,
+        "line": 290,
         "name": "_artist_mix_inline_prompt",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -26223,7 +27109,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -26231,12 +27117,12 @@
         "compatibility_pair": {
           "bound_name": "_artist_mix_mode_tooltip",
           "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_artist_mix_mode_tooltip",
         "kind": "static_from",
-        "line": 292,
+        "line": 290,
         "name": "_artist_mix_mode_tooltip",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -26254,7 +27140,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -26262,12 +27148,12 @@
         "compatibility_pair": {
           "bound_name": "_artist_prompt_with_position",
           "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_artist_prompt_with_position",
         "kind": "static_from",
-        "line": 292,
+        "line": 290,
         "name": "_artist_prompt_with_position",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -26285,7 +27171,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -26293,12 +27179,12 @@
         "compatibility_pair": {
           "bound_name": "_artist_tags_from_prompt",
           "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_artist_tags_from_prompt",
         "kind": "static_from",
-        "line": 292,
+        "line": 290,
         "name": "_artist_tags_from_prompt",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -26316,7 +27202,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -26324,12 +27210,12 @@
         "compatibility_pair": {
           "bound_name": "_blend_conditionings",
           "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_blend_conditionings",
         "kind": "static_from",
-        "line": 292,
+        "line": 290,
         "name": "_blend_conditionings",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -26347,7 +27233,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -26355,12 +27241,12 @@
         "compatibility_pair": {
           "bound_name": "_bounded_artist_mix_float",
           "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_bounded_artist_mix_float",
         "kind": "static_from",
-        "line": 292,
+        "line": 290,
         "name": "_bounded_artist_mix_float",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -26378,7 +27264,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -26386,12 +27272,12 @@
         "compatibility_pair": {
           "bound_name": "_bounded_artist_mix_int",
           "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_bounded_artist_mix_int",
         "kind": "static_from",
-        "line": 292,
+        "line": 290,
         "name": "_bounded_artist_mix_int",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -26409,7 +27295,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -26417,12 +27303,12 @@
         "compatibility_pair": {
           "bound_name": "_encode_artist_clustered",
           "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_encode_artist_clustered",
         "kind": "static_from",
-        "line": 292,
+        "line": 290,
         "name": "_encode_artist_clustered",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -26440,7 +27326,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -26448,12 +27334,12 @@
         "compatibility_pair": {
           "bound_name": "_encode_artist_delta_rms",
           "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_encode_artist_delta_rms",
         "kind": "static_from",
-        "line": 292,
+        "line": 290,
         "name": "_encode_artist_delta_rms",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -26471,7 +27357,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -26479,12 +27365,12 @@
         "compatibility_pair": {
           "bound_name": "_encode_prompt_data_positive_conditioning",
           "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_encode_prompt_data_positive_conditioning",
         "kind": "static_from",
-        "line": 292,
+        "line": 290,
         "name": "_encode_prompt_data_positive_conditioning",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -26502,7 +27388,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -26510,12 +27396,12 @@
         "compatibility_pair": {
           "bound_name": "_join_artist_mix_source_prompts",
           "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_join_artist_mix_source_prompts",
         "kind": "static_from",
-        "line": 292,
+        "line": 290,
         "name": "_join_artist_mix_source_prompts",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -26533,7 +27419,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -26541,12 +27427,12 @@
         "compatibility_pair": {
           "bound_name": "_normalize_artist_mix_mode",
           "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_normalize_artist_mix_mode",
         "kind": "static_from",
-        "line": 292,
+        "line": 290,
         "name": "_normalize_artist_mix_mode",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -26564,7 +27450,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -26572,12 +27458,12 @@
         "compatibility_pair": {
           "bound_name": "_normalize_artist_tag_position",
           "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_normalize_artist_tag_position",
         "kind": "static_from",
-        "line": 292,
+        "line": 290,
         "name": "_normalize_artist_tag_position",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -26595,7 +27481,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -26603,12 +27489,12 @@
         "compatibility_pair": {
           "bound_name": "_parse_artist_mix_items",
           "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_parse_artist_mix_items",
         "kind": "static_from",
-        "line": 292,
+        "line": 290,
         "name": "_parse_artist_mix_items",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -26626,7 +27512,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -26634,12 +27520,12 @@
         "compatibility_pair": {
           "bound_name": "EasyUseAnimaArtistMixConditioning",
           "target": "easyuse_anima/nodes/prompt_data_nodes.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaArtistMixConditioning",
         "kind": "static_from",
-        "line": 371,
+        "line": 369,
         "name": "EasyUseAnimaArtistMixConditioning",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_data_nodes",
@@ -26657,7 +27543,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -26665,12 +27551,12 @@
         "compatibility_pair": {
           "bound_name": "EasyUseAnimaPromptDataConditioning",
           "target": "easyuse_anima/nodes/prompt_data_nodes.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataConditioning",
         "kind": "static_from",
-        "line": 371,
+        "line": 369,
         "name": "EasyUseAnimaPromptDataConditioning",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_data_nodes",
@@ -26688,7 +27574,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -26696,12 +27582,12 @@
         "compatibility_pair": {
           "bound_name": "EasyUseAnimaPromptDataUnpack",
           "target": "easyuse_anima/nodes/prompt_data_nodes.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataUnpack",
         "kind": "static_from",
-        "line": 371,
+        "line": 369,
         "name": "EasyUseAnimaPromptDataUnpack",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_data_nodes",
@@ -26719,7 +27605,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -26727,12 +27613,12 @@
         "compatibility_pair": {
           "bound_name": "_ANY_TYPE",
           "target": "easyuse_anima/nodes/input_types.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.nodes.input_types:_ANY_TYPE",
         "kind": "static_from",
-        "line": 376,
+        "line": 374,
         "name": "_ANY_TYPE",
         "optional": false,
         "requested": ".easyuse_anima.nodes.input_types",
@@ -26750,7 +27636,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -26758,12 +27644,12 @@
         "compatibility_pair": {
           "bound_name": "_AnyType",
           "target": "easyuse_anima/nodes/input_types.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.nodes.input_types:_AnyType",
         "kind": "static_from",
-        "line": 376,
+        "line": 374,
         "name": "_AnyType",
         "optional": false,
         "requested": ".easyuse_anima.nodes.input_types",
@@ -26781,7 +27667,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -26789,12 +27675,12 @@
         "compatibility_pair": {
           "bound_name": "_FlexibleOptionalInputType",
           "target": "easyuse_anima/nodes/input_types.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.nodes.input_types:_FlexibleOptionalInputType",
         "kind": "static_from",
-        "line": 376,
+        "line": 374,
         "name": "_FlexibleOptionalInputType",
         "optional": false,
         "requested": ".easyuse_anima.nodes.input_types",
@@ -26812,7 +27698,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -26820,12 +27706,12 @@
         "compatibility_pair": {
           "bound_name": "EasyUseAnimaPromptStudioAdvanced",
           "target": "easyuse_anima/nodes/prompt_advanced_nodes.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvanced",
         "kind": "static_from",
-        "line": 381,
+        "line": 379,
         "name": "EasyUseAnimaPromptStudioAdvanced",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_advanced_nodes",
@@ -26843,7 +27729,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -26851,12 +27737,12 @@
         "compatibility_pair": {
           "bound_name": "EasyUseAnimaPromptStudioAdvancedV2",
           "target": "easyuse_anima/nodes/prompt_advanced_nodes.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvancedV2",
         "kind": "static_from",
-        "line": 381,
+        "line": 379,
         "name": "EasyUseAnimaPromptStudioAdvancedV2",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_advanced_nodes",
@@ -26874,7 +27760,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -26882,12 +27768,12 @@
         "compatibility_pair": {
           "bound_name": "EasyUseAnimaAIOGenerator",
           "target": "easyuse_anima/nodes/aio_nodes.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.nodes.aio_nodes:EasyUseAnimaAIOGenerator",
         "kind": "static_from",
-        "line": 386,
+        "line": 384,
         "name": "EasyUseAnimaAIOGenerator",
         "optional": false,
         "requested": ".easyuse_anima.nodes.aio_nodes",
@@ -26905,7 +27791,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -26913,12 +27799,12 @@
         "compatibility_pair": {
           "bound_name": "EasyUseAnimaInput",
           "target": "easyuse_anima/nodes/aio_nodes.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.nodes.aio_nodes:EasyUseAnimaInput",
         "kind": "static_from",
-        "line": 386,
+        "line": 384,
         "name": "EasyUseAnimaInput",
         "optional": false,
         "requested": ".easyuse_anima.nodes.aio_nodes",
@@ -26936,7 +27822,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -26944,12 +27830,12 @@
         "compatibility_pair": {
           "bound_name": "_aio_generation_settings_json",
           "target": "easyuse_anima/nodes/aio_nodes.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.nodes.aio_nodes:_aio_generation_settings_json",
         "kind": "static_from",
-        "line": 386,
+        "line": 384,
         "name": "_aio_generation_settings_json",
         "optional": false,
         "requested": ".easyuse_anima.nodes.aio_nodes",
@@ -26967,7 +27853,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -26975,12 +27861,12 @@
         "compatibility_pair": {
           "bound_name": "_aio_input_settings_json",
           "target": "easyuse_anima/nodes/aio_nodes.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.nodes.aio_nodes:_aio_input_settings_json",
         "kind": "static_from",
-        "line": 386,
+        "line": 384,
         "name": "_aio_input_settings_json",
         "optional": false,
         "requested": ".easyuse_anima.nodes.aio_nodes",
@@ -26998,7 +27884,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -27006,12 +27892,12 @@
         "compatibility_pair": {
           "bound_name": "_bind_aio_node_runtime",
           "target": "easyuse_anima/nodes/aio_nodes.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.nodes.aio_nodes:_bind_aio_node_runtime",
         "kind": "static_from",
-        "line": 386,
+        "line": 384,
         "name": "_bind_aio_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.aio_nodes",
@@ -27029,7 +27915,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -27037,12 +27923,12 @@
         "compatibility_pair": {
           "bound_name": "_align_down",
           "target": "easyuse_anima/image/geometry.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.image.geometry:_align_down",
         "kind": "static_from",
-        "line": 393,
+        "line": 391,
         "name": "_align_down",
         "optional": false,
         "requested": ".easyuse_anima.image.geometry",
@@ -27060,7 +27946,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -27068,12 +27954,12 @@
         "compatibility_pair": {
           "bound_name": "_align_nearest",
           "target": "easyuse_anima/image/geometry.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.image.geometry:_align_nearest",
         "kind": "static_from",
-        "line": 393,
+        "line": 391,
         "name": "_align_nearest",
         "optional": false,
         "requested": ".easyuse_anima.image.geometry",
@@ -27091,7 +27977,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -27099,12 +27985,12 @@
         "compatibility_pair": {
           "bound_name": "_image_tensor_size",
           "target": "easyuse_anima/image/geometry.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.image.geometry:_image_tensor_size",
         "kind": "static_from",
-        "line": 393,
+        "line": 391,
         "name": "_image_tensor_size",
         "optional": false,
         "requested": ".easyuse_anima.image.geometry",
@@ -27122,7 +28008,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -27130,12 +28016,12 @@
         "compatibility_pair": {
           "bound_name": "_context_value",
           "target": "easyuse_anima/image/sam3.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.image.sam3:_context_value",
         "kind": "static_from",
-        "line": 404,
+        "line": 402,
         "name": "_context_value",
         "optional": false,
         "requested": ".easyuse_anima.image.sam3",
@@ -27153,7 +28039,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -27161,12 +28047,12 @@
         "compatibility_pair": {
           "bound_name": "_sam3_context",
           "target": "easyuse_anima/image/sam3.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.image.sam3:_sam3_context",
         "kind": "static_from",
-        "line": 404,
+        "line": 402,
         "name": "_sam3_context",
         "optional": false,
         "requested": ".easyuse_anima.image.sam3",
@@ -27184,7 +28070,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -27192,12 +28078,12 @@
         "compatibility_pair": {
           "bound_name": "_segs_has_items",
           "target": "easyuse_anima/image/sam3.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.image.sam3:_segs_has_items",
         "kind": "static_from",
-        "line": 404,
+        "line": 402,
         "name": "_segs_has_items",
         "optional": false,
         "requested": ".easyuse_anima.image.sam3",
@@ -27215,7 +28101,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -27223,12 +28109,12 @@
         "compatibility_pair": {
           "bound_name": "IMAGE_SCALE_MULTIPLES",
           "target": "easyuse_anima/image/scaling.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.image.scaling:IMAGE_SCALE_MULTIPLES",
         "kind": "static_from",
-        "line": 416,
+        "line": 414,
         "name": "IMAGE_SCALE_MULTIPLES",
         "optional": false,
         "requested": ".easyuse_anima.image.scaling",
@@ -27246,7 +28132,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -27254,12 +28140,12 @@
         "compatibility_pair": {
           "bound_name": "IMAGE_UPSCALE_METHODS",
           "target": "easyuse_anima/image/scaling.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.image.scaling:IMAGE_UPSCALE_METHODS",
         "kind": "static_from",
-        "line": 416,
+        "line": 414,
         "name": "IMAGE_UPSCALE_METHODS",
         "optional": false,
         "requested": ".easyuse_anima.image.scaling",
@@ -27277,7 +28163,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -27285,12 +28171,12 @@
         "compatibility_pair": {
           "bound_name": "_comfy_sampler_names",
           "target": "easyuse_anima/infrastructure/comfy/capabilities.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_comfy_sampler_names",
         "kind": "static_from",
-        "line": 424,
+        "line": 422,
         "name": "_comfy_sampler_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -27308,7 +28194,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -27316,12 +28202,12 @@
         "compatibility_pair": {
           "bound_name": "_comfy_scheduler_names",
           "target": "easyuse_anima/infrastructure/comfy/capabilities.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_comfy_scheduler_names",
         "kind": "static_from",
-        "line": 424,
+        "line": 422,
         "name": "_comfy_scheduler_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -27339,7 +28225,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -27347,12 +28233,12 @@
         "compatibility_pair": {
           "bound_name": "_impact_scheduler_names",
           "target": "easyuse_anima/infrastructure/comfy/capabilities.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_impact_scheduler_names",
         "kind": "static_from",
-        "line": 424,
+        "line": 422,
         "name": "_impact_scheduler_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -27370,7 +28256,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -27378,12 +28264,12 @@
         "compatibility_pair": {
           "bound_name": "_call_with_supported_kwargs",
           "target": "easyuse_anima/infrastructure/comfy/invocation.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.invocation:_call_with_supported_kwargs",
         "kind": "static_from",
-        "line": 430,
+        "line": 428,
         "name": "_call_with_supported_kwargs",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.invocation",
@@ -27401,7 +28287,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -27409,12 +28295,12 @@
         "compatibility_pair": {
           "bound_name": "_common_upscale_image",
           "target": "easyuse_anima/infrastructure/comfy/invocation.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.invocation:_common_upscale_image",
         "kind": "static_from",
-        "line": 430,
+        "line": 428,
         "name": "_common_upscale_image",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.invocation",
@@ -27432,7 +28318,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -27440,12 +28326,12 @@
         "compatibility_pair": {
           "bound_name": "_node_output_tuple",
           "target": "easyuse_anima/infrastructure/comfy/invocation.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.invocation:_node_output_tuple",
         "kind": "static_from",
-        "line": 430,
+        "line": 428,
         "name": "_node_output_tuple",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.invocation",
@@ -27453,37 +28339,6 @@
         "scope": "<module>",
         "source": "nodes.py",
         "target": "easyuse_anima/infrastructure/comfy/invocation.py"
-      },
-      {
-        "alias": "_resolve_comfy_host_helper",
-        "bound_name": "_resolve_comfy_host_helper",
-        "branch_context": [
-          {
-            "branch": "body",
-            "handles_import_failure": true,
-            "has_import_fallback_handler": true,
-            "kind": "try",
-            "line": 8
-          }
-        ],
-        "classification": "internal",
-        "column": 4,
-        "compatibility_pair": {
-          "bound_name": "_resolve_comfy_host_helper",
-          "target": "easyuse_anima/infrastructure/comfy/wiring.py",
-          "try_line": 8
-        },
-        "conditional": true,
-        "imported": ".easyuse_anima.infrastructure.comfy.wiring:resolve_comfy_host_helper",
-        "kind": "static_from",
-        "line": 435,
-        "name": "resolve_comfy_host_helper",
-        "optional": false,
-        "requested": ".easyuse_anima.infrastructure.comfy.wiring",
-        "role": "compatibility_primary",
-        "scope": "<module>",
-        "source": "nodes.py",
-        "target": "easyuse_anima/infrastructure/comfy/wiring.py"
       },
       {
         "alias": "_adapter_comfy_clip_loader_types",
@@ -27494,7 +28349,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -27502,12 +28357,12 @@
         "compatibility_pair": {
           "bound_name": "_adapter_comfy_clip_loader_types",
           "target": "easyuse_anima/infrastructure/comfy/resources.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_comfy_clip_loader_types",
         "kind": "static_from",
-        "line": 438,
+        "line": 433,
         "name": "_comfy_clip_loader_types",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -27525,7 +28380,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -27533,12 +28388,12 @@
         "compatibility_pair": {
           "bound_name": "_adapter_comfy_diffusion_model_names",
           "target": "easyuse_anima/infrastructure/comfy/resources.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_comfy_diffusion_model_names",
         "kind": "static_from",
-        "line": 438,
+        "line": 433,
         "name": "_comfy_diffusion_model_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -27556,7 +28411,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -27564,12 +28419,12 @@
         "compatibility_pair": {
           "bound_name": "_adapter_comfy_text_encoder_names",
           "target": "easyuse_anima/infrastructure/comfy/resources.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_comfy_text_encoder_names",
         "kind": "static_from",
-        "line": 438,
+        "line": 433,
         "name": "_comfy_text_encoder_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -27587,7 +28442,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -27595,12 +28450,12 @@
         "compatibility_pair": {
           "bound_name": "_adapter_comfy_vae_names",
           "target": "easyuse_anima/infrastructure/comfy/resources.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_comfy_vae_names",
         "kind": "static_from",
-        "line": 438,
+        "line": 433,
         "name": "_comfy_vae_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -27618,7 +28473,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -27626,12 +28481,12 @@
         "compatibility_pair": {
           "bound_name": "_folder_path_names",
           "target": "easyuse_anima/infrastructure/comfy/resources.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_folder_path_names",
         "kind": "static_from",
-        "line": 438,
+        "line": 433,
         "name": "_folder_path_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -27649,7 +28504,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -27657,12 +28512,12 @@
         "compatibility_pair": {
           "bound_name": "EasyUseAnimaDetailerAlignHook",
           "target": "easyuse_anima/nodes/image_nodes.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.nodes.image_nodes:EasyUseAnimaDetailerAlignHook",
         "kind": "static_from",
-        "line": 446,
+        "line": 441,
         "name": "EasyUseAnimaDetailerAlignHook",
         "optional": false,
         "requested": ".easyuse_anima.nodes.image_nodes",
@@ -27680,7 +28535,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -27688,12 +28543,12 @@
         "compatibility_pair": {
           "bound_name": "EasyUseAnimaImageScaleByMultiple",
           "target": "easyuse_anima/nodes/image_nodes.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.nodes.image_nodes:EasyUseAnimaImageScaleByMultiple",
         "kind": "static_from",
-        "line": 446,
+        "line": 441,
         "name": "EasyUseAnimaImageScaleByMultiple",
         "optional": false,
         "requested": ".easyuse_anima.nodes.image_nodes",
@@ -27711,7 +28566,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -27719,12 +28574,12 @@
         "compatibility_pair": {
           "bound_name": "EasyUseAnimaSAM3Context",
           "target": "easyuse_anima/nodes/sam3_nodes.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Context",
         "kind": "static_from",
-        "line": 450,
+        "line": 445,
         "name": "EasyUseAnimaSAM3Context",
         "optional": false,
         "requested": ".easyuse_anima.nodes.sam3_nodes",
@@ -27742,7 +28597,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -27750,12 +28605,12 @@
         "compatibility_pair": {
           "bound_name": "EasyUseAnimaSAM3Detailer",
           "target": "easyuse_anima/nodes/sam3_nodes.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Detailer",
         "kind": "static_from",
-        "line": 450,
+        "line": 445,
         "name": "EasyUseAnimaSAM3Detailer",
         "optional": false,
         "requested": ".easyuse_anima.nodes.sam3_nodes",
@@ -27773,7 +28628,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -27781,12 +28636,12 @@
         "compatibility_pair": {
           "bound_name": "EasyUseAnimaPromptBuilder",
           "target": "easyuse_anima/nodes/prompt_nodes.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptBuilder",
         "kind": "static_from",
-        "line": 454,
+        "line": 449,
         "name": "EasyUseAnimaPromptBuilder",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_nodes",
@@ -27804,7 +28659,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -27812,12 +28667,12 @@
         "compatibility_pair": {
           "bound_name": "EasyUseAnimaPromptCorrector",
           "target": "easyuse_anima/nodes/prompt_nodes.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrector",
         "kind": "static_from",
-        "line": 454,
+        "line": 449,
         "name": "EasyUseAnimaPromptCorrector",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_nodes",
@@ -27835,7 +28690,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -27843,12 +28698,12 @@
         "compatibility_pair": {
           "bound_name": "EasyUseAnimaPromptCorrectorSimple",
           "target": "easyuse_anima/nodes/prompt_nodes.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrectorSimple",
         "kind": "static_from",
-        "line": 454,
+        "line": 449,
         "name": "EasyUseAnimaPromptCorrectorSimple",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_nodes",
@@ -27866,7 +28721,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -27874,12 +28729,12 @@
         "compatibility_pair": {
           "bound_name": "EasyUseAnimaPromptStudio",
           "target": "easyuse_anima/nodes/prompt_nodes.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptStudio",
         "kind": "static_from",
-        "line": 454,
+        "line": 449,
         "name": "EasyUseAnimaPromptStudio",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_nodes",
@@ -27897,7 +28752,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -27905,12 +28760,12 @@
         "compatibility_pair": {
           "bound_name": "EasyUseAnimaPromptStudioRegional",
           "target": "easyuse_anima/nodes/regional_nodes.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.nodes.regional_nodes:EasyUseAnimaPromptStudioRegional",
         "kind": "static_from",
-        "line": 460,
+        "line": 455,
         "name": "EasyUseAnimaPromptStudioRegional",
         "optional": false,
         "requested": ".easyuse_anima.nodes.regional_nodes",
@@ -27928,7 +28783,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -27936,12 +28791,12 @@
         "compatibility_pair": {
           "bound_name": "EasyUseAnimaRegionalConditioning",
           "target": "easyuse_anima/nodes/regional_nodes.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.nodes.regional_nodes:EasyUseAnimaRegionalConditioning",
         "kind": "static_from",
-        "line": 460,
+        "line": 455,
         "name": "EasyUseAnimaRegionalConditioning",
         "optional": false,
         "requested": ".easyuse_anima.nodes.regional_nodes",
@@ -27959,7 +28814,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -27967,12 +28822,12 @@
         "compatibility_pair": {
           "bound_name": "LATENT_ALIGN",
           "target": "easyuse_anima/naia/client.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.naia.client:LATENT_ALIGN",
         "kind": "static_from",
-        "line": 464,
+        "line": 459,
         "name": "LATENT_ALIGN",
         "optional": false,
         "requested": ".easyuse_anima.naia.client",
@@ -27990,7 +28845,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -27998,12 +28853,12 @@
         "compatibility_pair": {
           "bound_name": "_parse_random_response",
           "target": "easyuse_anima/naia/client.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.naia.client:_parse_random_response",
         "kind": "static_from",
-        "line": 464,
+        "line": 459,
         "name": "_parse_random_response",
         "optional": false,
         "requested": ".easyuse_anima.naia.client",
@@ -28021,7 +28876,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -28029,12 +28884,12 @@
         "compatibility_pair": {
           "bound_name": "_post_random",
           "target": "easyuse_anima/naia/client.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.naia.client:_post_random",
         "kind": "static_from",
-        "line": 464,
+        "line": 459,
         "name": "_post_random",
         "optional": false,
         "requested": ".easyuse_anima.naia.client",
@@ -28052,7 +28907,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -28060,12 +28915,12 @@
         "compatibility_pair": {
           "bound_name": "_advanced_resolution_from_selection",
           "target": "easyuse_anima/naia/resolution.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_advanced_resolution_from_selection",
         "kind": "static_from",
-        "line": 482,
+        "line": 477,
         "name": "_advanced_resolution_from_selection",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -28083,7 +28938,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -28091,12 +28946,12 @@
         "compatibility_pair": {
           "bound_name": "_normalize_resolution_bucket",
           "target": "easyuse_anima/naia/resolution.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_normalize_resolution_bucket",
         "kind": "static_from",
-        "line": 482,
+        "line": 477,
         "name": "_normalize_resolution_bucket",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -28114,7 +28969,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -28122,12 +28977,12 @@
         "compatibility_pair": {
           "bound_name": "_ratio_label",
           "target": "easyuse_anima/naia/resolution.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_ratio_label",
         "kind": "static_from",
-        "line": 482,
+        "line": 477,
         "name": "_ratio_label",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -28145,7 +29000,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -28153,12 +29008,12 @@
         "compatibility_pair": {
           "bound_name": "_resolution_label",
           "target": "easyuse_anima/naia/resolution.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_resolution_label",
         "kind": "static_from",
-        "line": 482,
+        "line": 477,
         "name": "_resolution_label",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -28176,7 +29031,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -28184,12 +29039,12 @@
         "compatibility_pair": {
           "bound_name": "_resolve_naia_resolution",
           "target": "easyuse_anima/naia/resolution.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_resolve_naia_resolution",
         "kind": "static_from",
-        "line": 482,
+        "line": 477,
         "name": "_resolve_naia_resolution",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -28207,7 +29062,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -28215,12 +29070,12 @@
         "compatibility_pair": {
           "bound_name": "EasyUseAnimaNAIARandomPrompt",
           "target": "easyuse_anima/nodes/naia_nodes.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.nodes.naia_nodes:EasyUseAnimaNAIARandomPrompt",
         "kind": "static_from",
-        "line": 505,
+        "line": 500,
         "name": "EasyUseAnimaNAIARandomPrompt",
         "optional": false,
         "requested": ".easyuse_anima.nodes.naia_nodes",
@@ -28238,7 +29093,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -28246,12 +29101,12 @@
         "compatibility_pair": {
           "bound_name": "_bind_naia_node_runtime",
           "target": "easyuse_anima/nodes/naia_nodes.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.nodes.naia_nodes:_bind_naia_node_runtime",
         "kind": "static_from",
-        "line": 505,
+        "line": 500,
         "name": "_bind_naia_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.naia_nodes",
@@ -28269,7 +29124,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -28277,12 +29132,12 @@
         "compatibility_pair": {
           "bound_name": "EasyUseAnimaWildcard",
           "target": "easyuse_anima/nodes/wildcard_nodes.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.nodes.wildcard_nodes:EasyUseAnimaWildcard",
         "kind": "static_from",
-        "line": 509,
+        "line": 504,
         "name": "EasyUseAnimaWildcard",
         "optional": false,
         "requested": ".easyuse_anima.nodes.wildcard_nodes",
@@ -28300,7 +29155,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -28308,12 +29163,12 @@
         "compatibility_pair": {
           "bound_name": "_bind_wildcard_node_runtime",
           "target": "easyuse_anima/nodes/wildcard_nodes.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.nodes.wildcard_nodes:_bind_wildcard_node_runtime",
         "kind": "static_from",
-        "line": 509,
+        "line": 504,
         "name": "_bind_wildcard_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.wildcard_nodes",
@@ -28331,7 +29186,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -28339,12 +29194,12 @@
         "compatibility_pair": {
           "bound_name": "_apply_lora_syntax_format",
           "target": "easyuse_anima/lora/metadata.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_apply_lora_syntax_format",
         "kind": "static_from",
-        "line": 514,
+        "line": 509,
         "name": "_apply_lora_syntax_format",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -28362,7 +29217,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -28370,12 +29225,12 @@
         "compatibility_pair": {
           "bound_name": "_dedupe_text_values",
           "target": "easyuse_anima/lora/metadata.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_dedupe_text_values",
         "kind": "static_from",
-        "line": 514,
+        "line": 509,
         "name": "_dedupe_text_values",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -28393,7 +29248,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -28401,12 +29256,12 @@
         "compatibility_pair": {
           "bound_name": "_fallback_lora_path",
           "target": "easyuse_anima/lora/metadata.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_fallback_lora_path",
         "kind": "static_from",
-        "line": 514,
+        "line": 509,
         "name": "_fallback_lora_path",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -28424,7 +29279,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -28432,12 +29287,12 @@
         "compatibility_pair": {
           "bound_name": "_get_lora_info",
           "target": "easyuse_anima/lora/metadata.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_get_lora_info",
         "kind": "static_from",
-        "line": 514,
+        "line": 509,
         "name": "_get_lora_info",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -28455,7 +29310,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -28463,12 +29318,12 @@
         "compatibility_pair": {
           "bound_name": "_get_lora_manager_trigger_words",
           "target": "easyuse_anima/lora/metadata.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_get_lora_manager_trigger_words",
         "kind": "static_from",
-        "line": 514,
+        "line": 509,
         "name": "_get_lora_manager_trigger_words",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -28486,7 +29341,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -28494,12 +29349,12 @@
         "compatibility_pair": {
           "bound_name": "_load_lora_manager_metadata",
           "target": "easyuse_anima/lora/metadata.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_load_lora_manager_metadata",
         "kind": "static_from",
-        "line": 514,
+        "line": 509,
         "name": "_load_lora_manager_metadata",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -28517,7 +29372,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -28525,12 +29380,12 @@
         "compatibility_pair": {
           "bound_name": "_lora_combo_values",
           "target": "easyuse_anima/lora/metadata.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_lora_combo_values",
         "kind": "static_from",
-        "line": 514,
+        "line": 509,
         "name": "_lora_combo_values",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -28548,7 +29403,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -28556,12 +29411,12 @@
         "compatibility_pair": {
           "bound_name": "_lora_manager_trigger_words_from_metadata",
           "target": "easyuse_anima/lora/metadata.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_lora_manager_trigger_words_from_metadata",
         "kind": "static_from",
-        "line": 514,
+        "line": 509,
         "name": "_lora_manager_trigger_words_from_metadata",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -28579,7 +29434,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -28587,12 +29442,12 @@
         "compatibility_pair": {
           "bound_name": "_lora_model_exists",
           "target": "easyuse_anima/lora/metadata.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_lora_model_exists",
         "kind": "static_from",
-        "line": 514,
+        "line": 509,
         "name": "_lora_model_exists",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -28610,7 +29465,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -28618,12 +29473,12 @@
         "compatibility_pair": {
           "bound_name": "_lora_stack_name",
           "target": "easyuse_anima/lora/metadata.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_lora_stack_name",
         "kind": "static_from",
-        "line": 514,
+        "line": 509,
         "name": "_lora_stack_name",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -28641,7 +29496,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -28649,12 +29504,12 @@
         "compatibility_pair": {
           "bound_name": "_metadata_json_paths_for_lora",
           "target": "easyuse_anima/lora/metadata.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_metadata_json_paths_for_lora",
         "kind": "static_from",
-        "line": 514,
+        "line": 509,
         "name": "_metadata_json_paths_for_lora",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -28672,7 +29527,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -28680,12 +29535,12 @@
         "compatibility_pair": {
           "bound_name": "_missing_lora_display_name",
           "target": "easyuse_anima/lora/metadata.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_missing_lora_display_name",
         "kind": "static_from",
-        "line": 514,
+        "line": 509,
         "name": "_missing_lora_display_name",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -28703,7 +29558,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -28711,12 +29566,12 @@
         "compatibility_pair": {
           "bound_name": "_raise_missing_loras",
           "target": "easyuse_anima/lora/metadata.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_raise_missing_loras",
         "kind": "static_from",
-        "line": 514,
+        "line": 509,
         "name": "_raise_missing_loras",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -28734,7 +29589,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -28742,12 +29597,12 @@
         "compatibility_pair": {
           "bound_name": "_trigger_words_from_value",
           "target": "easyuse_anima/lora/metadata.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_trigger_words_from_value",
         "kind": "static_from",
-        "line": 514,
+        "line": 509,
         "name": "_trigger_words_from_value",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -28765,7 +29620,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -28773,12 +29628,12 @@
         "compatibility_pair": {
           "bound_name": "_correct_style_prompt",
           "target": "easyuse_anima/lora/preset.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_correct_style_prompt",
         "kind": "static_from",
-        "line": 530,
+        "line": 525,
         "name": "_correct_style_prompt",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -28796,7 +29651,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -28804,12 +29659,12 @@
         "compatibility_pair": {
           "bound_name": "_format_strength",
           "target": "easyuse_anima/lora/preset.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_format_strength",
         "kind": "static_from",
-        "line": 530,
+        "line": 525,
         "name": "_format_strength",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -28827,7 +29682,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -28835,12 +29690,12 @@
         "compatibility_pair": {
           "bound_name": "_get_loras_list",
           "target": "easyuse_anima/lora/preset.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_get_loras_list",
         "kind": "static_from",
-        "line": 530,
+        "line": 525,
         "name": "_get_loras_list",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -28858,7 +29713,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -28866,12 +29721,12 @@
         "compatibility_pair": {
           "bound_name": "_load_profile_data",
           "target": "easyuse_anima/lora/preset.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_load_profile_data",
         "kind": "static_from",
-        "line": 530,
+        "line": 525,
         "name": "_load_profile_data",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -28889,7 +29744,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -28897,12 +29752,12 @@
         "compatibility_pair": {
           "bound_name": "_profile_key",
           "target": "easyuse_anima/lora/preset.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_profile_key",
         "kind": "static_from",
-        "line": 530,
+        "line": 525,
         "name": "_profile_key",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -28920,7 +29775,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -28928,12 +29783,12 @@
         "compatibility_pair": {
           "bound_name": "_select_profile_values",
           "target": "easyuse_anima/lora/preset.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_select_profile_values",
         "kind": "static_from",
-        "line": 530,
+        "line": 525,
         "name": "_select_profile_values",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -28951,7 +29806,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -28959,12 +29814,12 @@
         "compatibility_pair": {
           "bound_name": "_wrap_profile_index",
           "target": "easyuse_anima/lora/preset.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_wrap_profile_index",
         "kind": "static_from",
-        "line": 530,
+        "line": 525,
         "name": "_wrap_profile_index",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -28982,7 +29837,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -28990,12 +29845,12 @@
         "compatibility_pair": {
           "bound_name": "EasyUseAnimaLoraPreset",
           "target": "easyuse_anima/nodes/lora_nodes.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".easyuse_anima.nodes.lora_nodes:EasyUseAnimaLoraPreset",
         "kind": "static_from",
-        "line": 539,
+        "line": 534,
         "name": "EasyUseAnimaLoraPreset",
         "optional": false,
         "requested": ".easyuse_anima.nodes.lora_nodes",
@@ -29013,7 +29868,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -29021,12 +29876,12 @@
         "compatibility_pair": {
           "bound_name": "correct_prompt",
           "target": "anima_prompt/__init__.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".anima_prompt:correct_prompt",
         "kind": "static_from",
-        "line": 542,
+        "line": 537,
         "name": "correct_prompt",
         "optional": false,
         "requested": ".anima_prompt",
@@ -29044,7 +29899,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -29052,12 +29907,12 @@
         "compatibility_pair": {
           "bound_name": "load_knowledge_base",
           "target": "anima_prompt/__init__.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".anima_prompt:load_knowledge_base",
         "kind": "static_from",
-        "line": 542,
+        "line": 537,
         "name": "load_knowledge_base",
         "optional": false,
         "requested": ".anima_prompt",
@@ -29075,7 +29930,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -29083,12 +29938,12 @@
         "compatibility_pair": {
           "bound_name": "parse_prompt",
           "target": "anima_prompt/parser.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".anima_prompt.parser:parse_prompt",
         "kind": "static_from",
-        "line": 543,
+        "line": 538,
         "name": "parse_prompt",
         "optional": false,
         "requested": ".anima_prompt.parser",
@@ -29106,7 +29961,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -29114,12 +29969,12 @@
         "compatibility_pair": {
           "bound_name": "resolve_metadata_filter_words",
           "target": "settings.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".settings:resolve_metadata_filter_words",
         "kind": "static_from",
-        "line": 544,
+        "line": 539,
         "name": "resolve_metadata_filter_words",
         "optional": false,
         "requested": ".settings",
@@ -29137,7 +29992,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -29145,12 +30000,12 @@
         "compatibility_pair": {
           "bound_name": "resolve_naia_settings",
           "target": "settings.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".settings:resolve_naia_settings",
         "kind": "static_from",
-        "line": 544,
+        "line": 539,
         "name": "resolve_naia_settings",
         "optional": false,
         "requested": ".settings",
@@ -29168,7 +30023,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -29176,12 +30031,12 @@
         "compatibility_pair": {
           "bound_name": "resolve_prompt_translation_settings",
           "target": "settings.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".settings:resolve_prompt_translation_settings",
         "kind": "static_from",
-        "line": 544,
+        "line": 539,
         "name": "resolve_prompt_translation_settings",
         "optional": false,
         "requested": ".settings",
@@ -29199,7 +30054,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -29207,12 +30062,12 @@
         "compatibility_pair": {
           "bound_name": "has_prompt_translation_markers",
           "target": "prompt_translation.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".prompt_translation:has_prompt_translation_markers",
         "kind": "static_from",
-        "line": 549,
+        "line": 544,
         "name": "has_prompt_translation_markers",
         "optional": false,
         "requested": ".prompt_translation",
@@ -29230,7 +30085,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -29238,12 +30093,12 @@
         "compatibility_pair": {
           "bound_name": "translate_prompt_markers",
           "target": "prompt_translation.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".prompt_translation:translate_prompt_markers",
         "kind": "static_from",
-        "line": 549,
+        "line": 544,
         "name": "translate_prompt_markers",
         "optional": false,
         "requested": ".prompt_translation",
@@ -29261,7 +30116,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -29269,12 +30124,12 @@
         "compatibility_pair": {
           "bound_name": "MAX_SEED",
           "target": "wildcard_engine.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".wildcard_engine:MAX_SEED",
         "kind": "static_from",
-        "line": 550,
+        "line": 545,
         "name": "MAX_SEED",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -29292,7 +30147,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -29300,12 +30155,12 @@
         "compatibility_pair": {
           "bound_name": "PROMPT_STUDIO_WILDCARD_MODE_LABELS",
           "target": "wildcard_engine.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".wildcard_engine:PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "kind": "static_from",
-        "line": 550,
+        "line": 545,
         "name": "PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -29323,7 +30178,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -29331,12 +30186,12 @@
         "compatibility_pair": {
           "bound_name": "PUBLIC_MAX_SEED",
           "target": "wildcard_engine.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".wildcard_engine:PUBLIC_MAX_SEED",
         "kind": "static_from",
-        "line": 550,
+        "line": 545,
         "name": "PUBLIC_MAX_SEED",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -29354,7 +30209,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -29362,12 +30217,12 @@
         "compatibility_pair": {
           "bound_name": "SEED_CONTROL_DECREMENT",
           "target": "wildcard_engine.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_DECREMENT",
         "kind": "static_from",
-        "line": 550,
+        "line": 545,
         "name": "SEED_CONTROL_DECREMENT",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -29385,7 +30240,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -29393,12 +30248,12 @@
         "compatibility_pair": {
           "bound_name": "SEED_CONTROL_FIXED",
           "target": "wildcard_engine.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_FIXED",
         "kind": "static_from",
-        "line": 550,
+        "line": 545,
         "name": "SEED_CONTROL_FIXED",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -29416,7 +30271,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -29424,12 +30279,12 @@
         "compatibility_pair": {
           "bound_name": "SEED_CONTROL_INCREMENT",
           "target": "wildcard_engine.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_INCREMENT",
         "kind": "static_from",
-        "line": 550,
+        "line": 545,
         "name": "SEED_CONTROL_INCREMENT",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -29447,7 +30302,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -29455,12 +30310,12 @@
         "compatibility_pair": {
           "bound_name": "SEED_CONTROL_MODES",
           "target": "wildcard_engine.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_MODES",
         "kind": "static_from",
-        "line": 550,
+        "line": 545,
         "name": "SEED_CONTROL_MODES",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -29478,7 +30333,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -29486,12 +30341,12 @@
         "compatibility_pair": {
           "bound_name": "SEED_CONTROL_RANDOMIZE",
           "target": "wildcard_engine.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_RANDOMIZE",
         "kind": "static_from",
-        "line": 550,
+        "line": 545,
         "name": "SEED_CONTROL_RANDOMIZE",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -29509,7 +30364,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -29517,12 +30372,12 @@
         "compatibility_pair": {
           "bound_name": "WILDCARD_MODE_FIXED",
           "target": "wildcard_engine.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".wildcard_engine:WILDCARD_MODE_FIXED",
         "kind": "static_from",
-        "line": 550,
+        "line": 545,
         "name": "WILDCARD_MODE_FIXED",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -29540,7 +30395,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -29548,12 +30403,12 @@
         "compatibility_pair": {
           "bound_name": "WILDCARD_MODE_POPULATE",
           "target": "wildcard_engine.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".wildcard_engine:WILDCARD_MODE_POPULATE",
         "kind": "static_from",
-        "line": 550,
+        "line": 545,
         "name": "WILDCARD_MODE_POPULATE",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -29571,7 +30426,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -29579,12 +30434,12 @@
         "compatibility_pair": {
           "bound_name": "WILDCARD_MODE_SEQUENTIAL",
           "target": "wildcard_engine.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".wildcard_engine:WILDCARD_MODE_SEQUENTIAL",
         "kind": "static_from",
-        "line": 550,
+        "line": 545,
         "name": "WILDCARD_MODE_SEQUENTIAL",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -29602,7 +30457,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -29610,12 +30465,12 @@
         "compatibility_pair": {
           "bound_name": "expand_wildcard_texts",
           "target": "wildcard_engine.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".wildcard_engine:expand_wildcard_texts",
         "kind": "static_from",
-        "line": 550,
+        "line": 545,
         "name": "expand_wildcard_texts",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -29633,7 +30488,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -29641,12 +30496,12 @@
         "compatibility_pair": {
           "bound_name": "expand_wildcards",
           "target": "wildcard_engine.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".wildcard_engine:expand_wildcards",
         "kind": "static_from",
-        "line": 550,
+        "line": 545,
         "name": "expand_wildcards",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -29664,7 +30519,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -29672,12 +30527,12 @@
         "compatibility_pair": {
           "bound_name": "has_wildcard_syntax",
           "target": "wildcard_engine.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".wildcard_engine:has_wildcard_syntax",
         "kind": "static_from",
-        "line": 550,
+        "line": 545,
         "name": "has_wildcard_syntax",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -29695,7 +30550,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -29703,12 +30558,12 @@
         "compatibility_pair": {
           "bound_name": "next_seed",
           "target": "wildcard_engine.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".wildcard_engine:next_seed",
         "kind": "static_from",
-        "line": 550,
+        "line": 545,
         "name": "next_seed",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -29726,7 +30581,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -29734,12 +30589,12 @@
         "compatibility_pair": {
           "bound_name": "normalize_prompt_studio_wildcard_mode",
           "target": "wildcard_engine.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".wildcard_engine:normalize_prompt_studio_wildcard_mode",
         "kind": "static_from",
-        "line": 550,
+        "line": 545,
         "name": "normalize_prompt_studio_wildcard_mode",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -29757,7 +30612,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -29765,12 +30620,12 @@
         "compatibility_pair": {
           "bound_name": "normalize_seed",
           "target": "wildcard_engine.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".wildcard_engine:normalize_seed",
         "kind": "static_from",
-        "line": 550,
+        "line": 545,
         "name": "normalize_seed",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -29788,7 +30643,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -29796,12 +30651,12 @@
         "compatibility_pair": {
           "bound_name": "normalize_wildcard_mode",
           "target": "wildcard_engine.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".wildcard_engine:normalize_wildcard_mode",
         "kind": "static_from",
-        "line": 550,
+        "line": 545,
         "name": "normalize_wildcard_mode",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -29819,7 +30674,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "internal",
@@ -29827,12 +30682,12 @@
         "compatibility_pair": {
           "bound_name": "wildcard_sources_signature",
           "target": "wildcard_engine.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": ".wildcard_engine:wildcard_sources_signature",
         "kind": "static_from",
-        "line": 550,
+        "line": 545,
         "name": "wildcard_sources_signature",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -29851,9 +30706,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -29861,12 +30716,12 @@
         "compatibility_pair": {
           "bound_name": "AIO_FIRST_PASS_CACHE_MAX_ENTRIES",
           "target": "easyuse_anima/aio/first_pass_cache.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:AIO_FIRST_PASS_CACHE_MAX_ENTRIES",
         "kind": "static_from",
-        "line": 572,
+        "line": 567,
         "name": "AIO_FIRST_PASS_CACHE_MAX_ENTRIES",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -29885,9 +30740,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -29895,12 +30750,12 @@
         "compatibility_pair": {
           "bound_name": "_AIO_FIRST_PASS_CACHE",
           "target": "easyuse_anima/aio/first_pass_cache.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_AIO_FIRST_PASS_CACHE",
         "kind": "static_from",
-        "line": 572,
+        "line": 567,
         "name": "_AIO_FIRST_PASS_CACHE",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -29919,9 +30774,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -29929,12 +30784,12 @@
         "compatibility_pair": {
           "bound_name": "_AIO_FIRST_PASS_CACHE_ORDER",
           "target": "easyuse_anima/aio/first_pass_cache.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_AIO_FIRST_PASS_CACHE_ORDER",
         "kind": "static_from",
-        "line": 572,
+        "line": 567,
         "name": "_AIO_FIRST_PASS_CACHE_ORDER",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -29953,9 +30808,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -29963,12 +30818,12 @@
         "compatibility_pair": {
           "bound_name": "_aio_first_pass_cache_key",
           "target": "easyuse_anima/aio/first_pass_cache.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_aio_first_pass_cache_key",
         "kind": "static_from",
-        "line": 572,
+        "line": 567,
         "name": "_aio_first_pass_cache_key",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -29987,9 +30842,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -29997,12 +30852,12 @@
         "compatibility_pair": {
           "bound_name": "_clone_aio_cache_value",
           "target": "easyuse_anima/aio/first_pass_cache.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_clone_aio_cache_value",
         "kind": "static_from",
-        "line": 572,
+        "line": 567,
         "name": "_clone_aio_cache_value",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -30021,9 +30876,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -30031,12 +30886,12 @@
         "compatibility_pair": {
           "bound_name": "_get_aio_first_pass_cache",
           "target": "easyuse_anima/aio/first_pass_cache.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_get_aio_first_pass_cache",
         "kind": "static_from",
-        "line": 572,
+        "line": 567,
         "name": "_get_aio_first_pass_cache",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -30055,9 +30910,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -30065,12 +30920,12 @@
         "compatibility_pair": {
           "bound_name": "_put_aio_first_pass_cache",
           "target": "easyuse_anima/aio/first_pass_cache.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_put_aio_first_pass_cache",
         "kind": "static_from",
-        "line": 572,
+        "line": 567,
         "name": "_put_aio_first_pass_cache",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -30078,40 +30933,6 @@
         "scope": "<module>",
         "source": "nodes.py",
         "target": "easyuse_anima/aio/first_pass_cache.py"
-      },
-      {
-        "alias": "_bind_aio_legacy_generation_runtime",
-        "bound_name": "_bind_aio_legacy_generation_runtime",
-        "branch_context": [
-          {
-            "branch": "except",
-            "catches_import_error": true,
-            "exceptions": [
-              "ImportError"
-            ],
-            "handler_line": 571,
-            "kind": "try",
-            "line": 8
-          }
-        ],
-        "classification": "compatibility_fallback",
-        "column": 4,
-        "compatibility_pair": {
-          "bound_name": "_bind_aio_legacy_generation_runtime",
-          "target": "easyuse_anima/aio/legacy_generation.py",
-          "try_line": 8
-        },
-        "conditional": true,
-        "imported": "easyuse_anima.aio.legacy_generation:_bind_aio_legacy_generation_runtime",
-        "kind": "static_from",
-        "line": 582,
-        "name": "_bind_aio_legacy_generation_runtime",
-        "optional": false,
-        "requested": "easyuse_anima.aio.legacy_generation",
-        "role": "compatibility_fallback",
-        "scope": "<module>",
-        "source": "nodes.py",
-        "target": "easyuse_anima/aio/legacy_generation.py"
       },
       {
         "alias": "_run_aio_detailer_stage",
@@ -30123,9 +30944,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -30133,12 +30954,12 @@
         "compatibility_pair": {
           "bound_name": "_run_aio_detailer_stage",
           "target": "easyuse_anima/aio/legacy_generation.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_detailer_stage",
         "kind": "static_from",
-        "line": 582,
+        "line": 577,
         "name": "_run_aio_detailer_stage",
         "optional": false,
         "requested": "easyuse_anima.aio.legacy_generation",
@@ -30157,9 +30978,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -30167,12 +30988,12 @@
         "compatibility_pair": {
           "bound_name": "_run_aio_detailer_target",
           "target": "easyuse_anima/aio/legacy_generation.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_detailer_target",
         "kind": "static_from",
-        "line": 582,
+        "line": 577,
         "name": "_run_aio_detailer_target",
         "optional": false,
         "requested": "easyuse_anima.aio.legacy_generation",
@@ -30191,9 +31012,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -30201,12 +31022,12 @@
         "compatibility_pair": {
           "bound_name": "_run_aio_highres_stage",
           "target": "easyuse_anima/aio/legacy_generation.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_highres_stage",
         "kind": "static_from",
-        "line": 582,
+        "line": 577,
         "name": "_run_aio_highres_stage",
         "optional": false,
         "requested": "easyuse_anima.aio.legacy_generation",
@@ -30225,9 +31046,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -30235,12 +31056,12 @@
         "compatibility_pair": {
           "bound_name": "_run_aio_legacy_generation",
           "target": "easyuse_anima/aio/legacy_generation.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_legacy_generation",
         "kind": "static_from",
-        "line": 582,
+        "line": 577,
         "name": "_run_aio_legacy_generation",
         "optional": false,
         "requested": "easyuse_anima.aio.legacy_generation",
@@ -30259,9 +31080,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -30269,12 +31090,12 @@
         "compatibility_pair": {
           "bound_name": "_run_aio_resshift_upscale_stage",
           "target": "easyuse_anima/aio/legacy_generation.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_resshift_upscale_stage",
         "kind": "static_from",
-        "line": 582,
+        "line": 577,
         "name": "_run_aio_resshift_upscale_stage",
         "optional": false,
         "requested": "easyuse_anima.aio.legacy_generation",
@@ -30293,9 +31114,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -30303,12 +31124,12 @@
         "compatibility_pair": {
           "bound_name": "_run_aio_upscale_stage",
           "target": "easyuse_anima/aio/legacy_generation.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_upscale_stage",
         "kind": "static_from",
-        "line": 582,
+        "line": 577,
         "name": "_run_aio_upscale_stage",
         "optional": false,
         "requested": "easyuse_anima.aio.legacy_generation",
@@ -30327,9 +31148,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -30337,12 +31158,12 @@
         "compatibility_pair": {
           "bound_name": "_run_aio_usdu_upscale_stage",
           "target": "easyuse_anima/aio/legacy_generation.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_usdu_upscale_stage",
         "kind": "static_from",
-        "line": 582,
+        "line": 577,
         "name": "_run_aio_usdu_upscale_stage",
         "optional": false,
         "requested": "easyuse_anima.aio.legacy_generation",
@@ -30361,9 +31182,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -30371,12 +31192,12 @@
         "compatibility_pair": {
           "bound_name": "_AIO_DETAILER_CUSTOM_RE",
           "target": "easyuse_anima/aio/generation_normalization.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_AIO_DETAILER_CUSTOM_RE",
         "kind": "static_from",
-        "line": 592,
+        "line": 586,
         "name": "_AIO_DETAILER_CUSTOM_RE",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -30395,9 +31216,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -30405,12 +31226,12 @@
         "compatibility_pair": {
           "bound_name": "_AIO_DETAILER_RESERVED_KEYS",
           "target": "easyuse_anima/aio/generation_normalization.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_AIO_DETAILER_RESERVED_KEYS",
         "kind": "static_from",
-        "line": 592,
+        "line": 586,
         "name": "_AIO_DETAILER_RESERVED_KEYS",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -30429,9 +31250,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -30439,12 +31260,12 @@
         "compatibility_pair": {
           "bound_name": "_aio_detailer_has_enabled_targets",
           "target": "easyuse_anima/aio/generation_normalization.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_aio_detailer_has_enabled_targets",
         "kind": "static_from",
-        "line": 592,
+        "line": 586,
         "name": "_aio_detailer_has_enabled_targets",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -30463,9 +31284,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -30473,12 +31294,12 @@
         "compatibility_pair": {
           "bound_name": "_aio_detailer_target_defaults",
           "target": "easyuse_anima/aio/generation_normalization.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_aio_detailer_target_defaults",
         "kind": "static_from",
-        "line": 592,
+        "line": 586,
         "name": "_aio_detailer_target_defaults",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -30497,9 +31318,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -30507,12 +31328,12 @@
         "compatibility_pair": {
           "bound_name": "_aio_detailer_target_order",
           "target": "easyuse_anima/aio/generation_normalization.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_aio_detailer_target_order",
         "kind": "static_from",
-        "line": 592,
+        "line": 586,
         "name": "_aio_detailer_target_order",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -30531,9 +31352,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -30541,12 +31362,12 @@
         "compatibility_pair": {
           "bound_name": "_is_aio_detailer_target_name",
           "target": "easyuse_anima/aio/generation_normalization.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_is_aio_detailer_target_name",
         "kind": "static_from",
-        "line": 592,
+        "line": 586,
         "name": "_is_aio_detailer_target_name",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -30565,9 +31386,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -30575,12 +31396,12 @@
         "compatibility_pair": {
           "bound_name": "_merge_versioned_settings",
           "target": "easyuse_anima/aio/generation_normalization.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_merge_versioned_settings",
         "kind": "static_from",
-        "line": 592,
+        "line": 586,
         "name": "_merge_versioned_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -30599,9 +31420,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -30609,12 +31430,12 @@
         "compatibility_pair": {
           "bound_name": "_normalize_aio_dit_corrections_settings",
           "target": "easyuse_anima/aio/generation_normalization.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_dit_corrections_settings",
         "kind": "static_from",
-        "line": 592,
+        "line": 586,
         "name": "_normalize_aio_dit_corrections_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -30633,9 +31454,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -30643,12 +31464,12 @@
         "compatibility_pair": {
           "bound_name": "_normalize_aio_generation_settings",
           "target": "easyuse_anima/aio/generation_normalization.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_generation_settings",
         "kind": "static_from",
-        "line": 592,
+        "line": 586,
         "name": "_normalize_aio_generation_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -30667,9 +31488,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -30677,12 +31498,12 @@
         "compatibility_pair": {
           "bound_name": "_normalize_aio_seed",
           "target": "easyuse_anima/aio/generation_normalization.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_seed",
         "kind": "static_from",
-        "line": 592,
+        "line": 586,
         "name": "_normalize_aio_seed",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -30701,9 +31522,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -30711,12 +31532,12 @@
         "compatibility_pair": {
           "bound_name": "_normalize_aio_spectrum_settings",
           "target": "easyuse_anima/aio/generation_normalization.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_spectrum_settings",
         "kind": "static_from",
-        "line": 592,
+        "line": 586,
         "name": "_normalize_aio_spectrum_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -30735,9 +31556,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -30745,12 +31566,12 @@
         "compatibility_pair": {
           "bound_name": "AIO_FINAL_FIT_MODES",
           "target": "easyuse_anima/aio/generation_defaults.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_FINAL_FIT_MODES",
         "kind": "static_from",
-        "line": 605,
+        "line": 599,
         "name": "AIO_FINAL_FIT_MODES",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_defaults",
@@ -30769,9 +31590,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -30779,12 +31600,12 @@
         "compatibility_pair": {
           "bound_name": "AIO_FINAL_UPSCALE_BACKENDS",
           "target": "easyuse_anima/aio/generation_defaults.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_FINAL_UPSCALE_BACKENDS",
         "kind": "static_from",
-        "line": 605,
+        "line": 599,
         "name": "AIO_FINAL_UPSCALE_BACKENDS",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_defaults",
@@ -30803,9 +31624,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -30813,12 +31634,12 @@
         "compatibility_pair": {
           "bound_name": "AIO_GENERATION_DEFAULT_SETTINGS",
           "target": "easyuse_anima/aio/generation_defaults.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_GENERATION_DEFAULT_SETTINGS",
         "kind": "static_from",
-        "line": 605,
+        "line": 599,
         "name": "AIO_GENERATION_DEFAULT_SETTINGS",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_defaults",
@@ -30837,9 +31658,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -30847,12 +31668,12 @@
         "compatibility_pair": {
           "bound_name": "AIO_GENERATION_SETTINGS_SCHEMA",
           "target": "easyuse_anima/aio/generation_defaults.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_GENERATION_SETTINGS_SCHEMA",
         "kind": "static_from",
-        "line": 605,
+        "line": 599,
         "name": "AIO_GENERATION_SETTINGS_SCHEMA",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_defaults",
@@ -30871,9 +31692,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -30881,12 +31702,12 @@
         "compatibility_pair": {
           "bound_name": "AIO_GENERATION_SETTINGS_VERSION",
           "target": "easyuse_anima/aio/generation_defaults.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_GENERATION_SETTINGS_VERSION",
         "kind": "static_from",
-        "line": 605,
+        "line": 599,
         "name": "AIO_GENERATION_SETTINGS_VERSION",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_defaults",
@@ -30905,9 +31726,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -30915,12 +31736,12 @@
         "compatibility_pair": {
           "bound_name": "AIO_RESHIFT_DTYPES",
           "target": "easyuse_anima/aio/generation_defaults.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_RESHIFT_DTYPES",
         "kind": "static_from",
-        "line": 605,
+        "line": 599,
         "name": "AIO_RESHIFT_DTYPES",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_defaults",
@@ -30939,9 +31760,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -30949,12 +31770,12 @@
         "compatibility_pair": {
           "bound_name": "AIO_RESHIFT_SCALES",
           "target": "easyuse_anima/aio/generation_defaults.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_RESHIFT_SCALES",
         "kind": "static_from",
-        "line": 605,
+        "line": 599,
         "name": "AIO_RESHIFT_SCALES",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_defaults",
@@ -30973,9 +31794,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -30983,12 +31804,12 @@
         "compatibility_pair": {
           "bound_name": "AIO_SPECIAL_SEEDS",
           "target": "easyuse_anima/aio/generation_defaults.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_SPECIAL_SEEDS",
         "kind": "static_from",
-        "line": 605,
+        "line": 599,
         "name": "AIO_SPECIAL_SEEDS",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_defaults",
@@ -31007,9 +31828,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -31017,12 +31838,12 @@
         "compatibility_pair": {
           "bound_name": "AIO_SPECIAL_SEED_DECREMENT",
           "target": "easyuse_anima/aio/generation_defaults.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_SPECIAL_SEED_DECREMENT",
         "kind": "static_from",
-        "line": 605,
+        "line": 599,
         "name": "AIO_SPECIAL_SEED_DECREMENT",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_defaults",
@@ -31041,9 +31862,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -31051,12 +31872,12 @@
         "compatibility_pair": {
           "bound_name": "AIO_SPECIAL_SEED_INCREMENT",
           "target": "easyuse_anima/aio/generation_defaults.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_SPECIAL_SEED_INCREMENT",
         "kind": "static_from",
-        "line": 605,
+        "line": 599,
         "name": "AIO_SPECIAL_SEED_INCREMENT",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_defaults",
@@ -31075,9 +31896,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -31085,12 +31906,12 @@
         "compatibility_pair": {
           "bound_name": "AIO_SPECIAL_SEED_RANDOM",
           "target": "easyuse_anima/aio/generation_defaults.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_SPECIAL_SEED_RANDOM",
         "kind": "static_from",
-        "line": 605,
+        "line": 599,
         "name": "AIO_SPECIAL_SEED_RANDOM",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_defaults",
@@ -31109,9 +31930,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -31119,12 +31940,12 @@
         "compatibility_pair": {
           "bound_name": "AIO_USDU_MODE_TYPES",
           "target": "easyuse_anima/aio/generation_defaults.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_USDU_MODE_TYPES",
         "kind": "static_from",
-        "line": 605,
+        "line": 599,
         "name": "AIO_USDU_MODE_TYPES",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_defaults",
@@ -31143,9 +31964,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -31153,12 +31974,12 @@
         "compatibility_pair": {
           "bound_name": "AIO_USDU_PROMPT_FULL",
           "target": "easyuse_anima/aio/generation_defaults.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_USDU_PROMPT_FULL",
         "kind": "static_from",
-        "line": 605,
+        "line": 599,
         "name": "AIO_USDU_PROMPT_FULL",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_defaults",
@@ -31177,9 +31998,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -31187,12 +32008,12 @@
         "compatibility_pair": {
           "bound_name": "AIO_USDU_PROMPT_MODES",
           "target": "easyuse_anima/aio/generation_defaults.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_USDU_PROMPT_MODES",
         "kind": "static_from",
-        "line": 605,
+        "line": 599,
         "name": "AIO_USDU_PROMPT_MODES",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_defaults",
@@ -31211,9 +32032,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -31221,12 +32042,12 @@
         "compatibility_pair": {
           "bound_name": "AIO_USDU_PROMPT_NO_GENERAL",
           "target": "easyuse_anima/aio/generation_defaults.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_USDU_PROMPT_NO_GENERAL",
         "kind": "static_from",
-        "line": 605,
+        "line": 599,
         "name": "AIO_USDU_PROMPT_NO_GENERAL",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_defaults",
@@ -31245,9 +32066,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -31255,12 +32076,12 @@
         "compatibility_pair": {
           "bound_name": "AIO_USDU_SEAM_FIX_MODES",
           "target": "easyuse_anima/aio/generation_defaults.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_USDU_SEAM_FIX_MODES",
         "kind": "static_from",
-        "line": 605,
+        "line": 599,
         "name": "AIO_USDU_SEAM_FIX_MODES",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_defaults",
@@ -31279,9 +32100,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -31289,12 +32110,12 @@
         "compatibility_pair": {
           "bound_name": "_round_trip_aio_generation_settings",
           "target": "easyuse_anima/aio/generation_settings.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_settings:round_trip_aio_generation_settings",
         "kind": "static_from",
-        "line": 623,
+        "line": 617,
         "name": "round_trip_aio_generation_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_settings",
@@ -31313,9 +32134,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -31323,12 +32144,12 @@
         "compatibility_pair": {
           "bound_name": "AIO_INPUT_DEFAULT_SETTINGS",
           "target": "easyuse_anima/aio/input_defaults.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.input_defaults:AIO_INPUT_DEFAULT_SETTINGS",
         "kind": "static_from",
-        "line": 626,
+        "line": 620,
         "name": "AIO_INPUT_DEFAULT_SETTINGS",
         "optional": false,
         "requested": "easyuse_anima.aio.input_defaults",
@@ -31347,9 +32168,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -31357,12 +32178,12 @@
         "compatibility_pair": {
           "bound_name": "ANIMA_CLIP_DEVICES",
           "target": "easyuse_anima/aio/input_defaults.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.input_defaults:ANIMA_CLIP_DEVICES",
         "kind": "static_from",
-        "line": 626,
+        "line": 620,
         "name": "ANIMA_CLIP_DEVICES",
         "optional": false,
         "requested": "easyuse_anima.aio.input_defaults",
@@ -31381,9 +32202,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -31391,12 +32212,12 @@
         "compatibility_pair": {
           "bound_name": "ANIMA_CLIP_TYPES",
           "target": "easyuse_anima/aio/input_defaults.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.input_defaults:ANIMA_CLIP_TYPES",
         "kind": "static_from",
-        "line": 626,
+        "line": 620,
         "name": "ANIMA_CLIP_TYPES",
         "optional": false,
         "requested": "easyuse_anima.aio.input_defaults",
@@ -31415,9 +32236,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -31425,12 +32246,12 @@
         "compatibility_pair": {
           "bound_name": "ANIMA_DEFAULT_CLIP_CANDIDATES",
           "target": "easyuse_anima/aio/input_defaults.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.input_defaults:ANIMA_DEFAULT_CLIP_CANDIDATES",
         "kind": "static_from",
-        "line": 626,
+        "line": 620,
         "name": "ANIMA_DEFAULT_CLIP_CANDIDATES",
         "optional": false,
         "requested": "easyuse_anima.aio.input_defaults",
@@ -31449,9 +32270,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -31459,12 +32280,12 @@
         "compatibility_pair": {
           "bound_name": "ANIMA_DEFAULT_DIFFUSION_MODEL_CANDIDATES",
           "target": "easyuse_anima/aio/input_defaults.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.input_defaults:ANIMA_DEFAULT_DIFFUSION_MODEL_CANDIDATES",
         "kind": "static_from",
-        "line": 626,
+        "line": 620,
         "name": "ANIMA_DEFAULT_DIFFUSION_MODEL_CANDIDATES",
         "optional": false,
         "requested": "easyuse_anima.aio.input_defaults",
@@ -31483,9 +32304,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -31493,12 +32314,12 @@
         "compatibility_pair": {
           "bound_name": "ANIMA_DEFAULT_VAE_CANDIDATES",
           "target": "easyuse_anima/aio/input_defaults.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.input_defaults:ANIMA_DEFAULT_VAE_CANDIDATES",
         "kind": "static_from",
-        "line": 626,
+        "line": 620,
         "name": "ANIMA_DEFAULT_VAE_CANDIDATES",
         "optional": false,
         "requested": "easyuse_anima.aio.input_defaults",
@@ -31517,9 +32338,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -31527,12 +32348,12 @@
         "compatibility_pair": {
           "bound_name": "ANIMA_UNET_WEIGHT_DTYPES",
           "target": "easyuse_anima/aio/input_defaults.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.input_defaults:ANIMA_UNET_WEIGHT_DTYPES",
         "kind": "static_from",
-        "line": 626,
+        "line": 620,
         "name": "ANIMA_UNET_WEIGHT_DTYPES",
         "optional": false,
         "requested": "easyuse_anima.aio.input_defaults",
@@ -31551,9 +32372,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -31561,12 +32382,12 @@
         "compatibility_pair": {
           "bound_name": "EASY_USE_ANIMA_INPUT_SCHEMA",
           "target": "easyuse_anima/aio/input_defaults.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.input_defaults:EASY_USE_ANIMA_INPUT_SCHEMA",
         "kind": "static_from",
-        "line": 626,
+        "line": 620,
         "name": "EASY_USE_ANIMA_INPUT_SCHEMA",
         "optional": false,
         "requested": "easyuse_anima.aio.input_defaults",
@@ -31585,9 +32406,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -31595,12 +32416,12 @@
         "compatibility_pair": {
           "bound_name": "EASY_USE_ANIMA_INPUT_SETTINGS_VERSION",
           "target": "easyuse_anima/aio/input_defaults.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.input_defaults:EASY_USE_ANIMA_INPUT_SETTINGS_VERSION",
         "kind": "static_from",
-        "line": 626,
+        "line": 620,
         "name": "EASY_USE_ANIMA_INPUT_SETTINGS_VERSION",
         "optional": false,
         "requested": "easyuse_anima.aio.input_defaults",
@@ -31619,9 +32440,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -31629,12 +32450,12 @@
         "compatibility_pair": {
           "bound_name": "_easy_use_anima_input_signature",
           "target": "easyuse_anima/aio/input_context.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.input_context:_easy_use_anima_input_signature",
         "kind": "static_from",
-        "line": 637,
+        "line": 631,
         "name": "_easy_use_anima_input_signature",
         "optional": false,
         "requested": "easyuse_anima.aio.input_context",
@@ -31653,9 +32474,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -31663,12 +32484,12 @@
         "compatibility_pair": {
           "bound_name": "_require_easy_use_anima_input",
           "target": "easyuse_anima/aio/input_context.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.input_context:_require_easy_use_anima_input",
         "kind": "static_from",
-        "line": 637,
+        "line": 631,
         "name": "_require_easy_use_anima_input",
         "optional": false,
         "requested": "easyuse_anima.aio.input_context",
@@ -31687,9 +32508,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -31697,12 +32518,12 @@
         "compatibility_pair": {
           "bound_name": "_aio_usdu_auto_tile_dimension",
           "target": "easyuse_anima/aio/usdu.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.usdu:_aio_usdu_auto_tile_dimension",
         "kind": "static_from",
-        "line": 641,
+        "line": 635,
         "name": "_aio_usdu_auto_tile_dimension",
         "optional": false,
         "requested": "easyuse_anima.aio.usdu",
@@ -31721,9 +32542,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -31731,12 +32552,12 @@
         "compatibility_pair": {
           "bound_name": "_aio_usdu_tile_plan",
           "target": "easyuse_anima/aio/usdu.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.usdu:_aio_usdu_tile_plan",
         "kind": "static_from",
-        "line": 641,
+        "line": 635,
         "name": "_aio_usdu_tile_plan",
         "optional": false,
         "requested": "easyuse_anima.aio.usdu",
@@ -31755,9 +32576,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -31765,12 +32586,12 @@
         "compatibility_pair": {
           "bound_name": "_aio_final_fit_size",
           "target": "easyuse_anima/aio/postprocess.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_aio_final_fit_size",
         "kind": "static_from",
-        "line": 645,
+        "line": 639,
         "name": "_aio_final_fit_size",
         "optional": false,
         "requested": "easyuse_anima.aio.postprocess",
@@ -31789,9 +32610,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -31799,12 +32620,12 @@
         "compatibility_pair": {
           "bound_name": "_apply_aio_final_fit",
           "target": "easyuse_anima/aio/postprocess.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_apply_aio_final_fit",
         "kind": "static_from",
-        "line": 645,
+        "line": 639,
         "name": "_apply_aio_final_fit",
         "optional": false,
         "requested": "easyuse_anima.aio.postprocess",
@@ -31823,9 +32644,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -31833,12 +32654,12 @@
         "compatibility_pair": {
           "bound_name": "_resize_image_to_size_if_needed",
           "target": "easyuse_anima/aio/postprocess.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_resize_image_to_size_if_needed",
         "kind": "static_from",
-        "line": 645,
+        "line": 639,
         "name": "_resize_image_to_size_if_needed",
         "optional": false,
         "requested": "easyuse_anima.aio.postprocess",
@@ -31857,9 +32678,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -31867,12 +32688,12 @@
         "compatibility_pair": {
           "bound_name": "_run_aio_postprocess_stage",
           "target": "easyuse_anima/aio/postprocess.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_run_aio_postprocess_stage",
         "kind": "static_from",
-        "line": 645,
+        "line": 639,
         "name": "_run_aio_postprocess_stage",
         "optional": false,
         "requested": "easyuse_anima.aio.postprocess",
@@ -31891,9 +32712,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -31901,12 +32722,12 @@
         "compatibility_pair": {
           "bound_name": "_aio_prompt_data_fields_for_usdu",
           "target": "easyuse_anima/aio/conditioning.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_prompt_data_fields_for_usdu",
         "kind": "static_from",
-        "line": 651,
+        "line": 645,
         "name": "_aio_prompt_data_fields_for_usdu",
         "optional": false,
         "requested": "easyuse_anima.aio.conditioning",
@@ -31925,9 +32746,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -31935,12 +32756,12 @@
         "compatibility_pair": {
           "bound_name": "_aio_usdu_conditioning",
           "target": "easyuse_anima/aio/conditioning.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_usdu_conditioning",
         "kind": "static_from",
-        "line": 651,
+        "line": 645,
         "name": "_aio_usdu_conditioning",
         "optional": false,
         "requested": "easyuse_anima.aio.conditioning",
@@ -31959,9 +32780,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -31969,12 +32790,12 @@
         "compatibility_pair": {
           "bound_name": "_aio_usdu_prompt_without_general",
           "target": "easyuse_anima/aio/conditioning.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_usdu_prompt_without_general",
         "kind": "static_from",
-        "line": 651,
+        "line": 645,
         "name": "_aio_usdu_prompt_without_general",
         "optional": false,
         "requested": "easyuse_anima.aio.conditioning",
@@ -31993,9 +32814,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -32003,12 +32824,12 @@
         "compatibility_pair": {
           "bound_name": "_aio_lora_stack_signature",
           "target": "easyuse_anima/aio/model_preparation.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_aio_lora_stack_signature",
         "kind": "static_from",
-        "line": 656,
+        "line": 650,
         "name": "_aio_lora_stack_signature",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -32027,9 +32848,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -32037,12 +32858,12 @@
         "compatibility_pair": {
           "bound_name": "_apply_aio_anima_dave_patch",
           "target": "easyuse_anima/aio/model_preparation.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_anima_dave_patch",
         "kind": "static_from",
-        "line": 656,
+        "line": 650,
         "name": "_apply_aio_anima_dave_patch",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -32061,9 +32882,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -32071,12 +32892,12 @@
         "compatibility_pair": {
           "bound_name": "_apply_aio_kj_model_patches",
           "target": "easyuse_anima/aio/model_preparation.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_kj_model_patches",
         "kind": "static_from",
-        "line": 656,
+        "line": 650,
         "name": "_apply_aio_kj_model_patches",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -32095,9 +32916,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -32105,12 +32926,12 @@
         "compatibility_pair": {
           "bound_name": "_apply_aio_lora_stack",
           "target": "easyuse_anima/aio/model_preparation.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_lora_stack",
         "kind": "static_from",
-        "line": 656,
+        "line": 650,
         "name": "_apply_aio_lora_stack",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -32129,9 +32950,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -32139,12 +32960,12 @@
         "compatibility_pair": {
           "bound_name": "_apply_aio_model_patches",
           "target": "easyuse_anima/aio/model_preparation.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_model_patches",
         "kind": "static_from",
-        "line": 656,
+        "line": 650,
         "name": "_apply_aio_model_patches",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -32163,9 +32984,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -32173,12 +32994,12 @@
         "compatibility_pair": {
           "bound_name": "_apply_aio_safe_pag_patch",
           "target": "easyuse_anima/aio/model_preparation.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_safe_pag_patch",
         "kind": "static_from",
-        "line": 656,
+        "line": 650,
         "name": "_apply_aio_safe_pag_patch",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -32197,9 +33018,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -32207,12 +33028,12 @@
         "compatibility_pair": {
           "bound_name": "_apply_aio_spectrum_correction_patch_for_comfy_sampler",
           "target": "easyuse_anima/aio/model_preparation.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_correction_patch_for_comfy_sampler",
         "kind": "static_from",
-        "line": 656,
+        "line": 650,
         "name": "_apply_aio_spectrum_correction_patch_for_comfy_sampler",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -32231,9 +33052,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -32241,12 +33062,12 @@
         "compatibility_pair": {
           "bound_name": "_apply_aio_spectrum_forecast_patch_for_comfy_sampler",
           "target": "easyuse_anima/aio/model_preparation.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_forecast_patch_for_comfy_sampler",
         "kind": "static_from",
-        "line": 656,
+        "line": 650,
         "name": "_apply_aio_spectrum_forecast_patch_for_comfy_sampler",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -32265,9 +33086,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -32275,12 +33096,12 @@
         "compatibility_pair": {
           "bound_name": "_apply_aio_spectrum_model_patches_for_comfy_sampler",
           "target": "easyuse_anima/aio/model_preparation.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_model_patches_for_comfy_sampler",
         "kind": "static_from",
-        "line": 656,
+        "line": 650,
         "name": "_apply_aio_spectrum_model_patches_for_comfy_sampler",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -32299,9 +33120,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -32309,12 +33130,12 @@
         "compatibility_pair": {
           "bound_name": "_cleanup_aio_ephemeral_model",
           "target": "easyuse_anima/aio/model_preparation.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_cleanup_aio_ephemeral_model",
         "kind": "static_from",
-        "line": 656,
+        "line": 650,
         "name": "_cleanup_aio_ephemeral_model",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -32333,9 +33154,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -32343,12 +33164,12 @@
         "compatibility_pair": {
           "bound_name": "_normalize_aio_lora_stack",
           "target": "easyuse_anima/aio/model_preparation.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_normalize_aio_lora_stack",
         "kind": "static_from",
-        "line": 656,
+        "line": 650,
         "name": "_normalize_aio_lora_stack",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -32367,9 +33188,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -32377,12 +33198,12 @@
         "compatibility_pair": {
           "bound_name": "_patch_model_sampling_aura_flow",
           "target": "easyuse_anima/aio/model_preparation.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_patch_model_sampling_aura_flow",
         "kind": "static_from",
-        "line": 656,
+        "line": 650,
         "name": "_patch_model_sampling_aura_flow",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -32401,9 +33222,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -32411,12 +33232,12 @@
         "compatibility_pair": {
           "bound_name": "_aio_highres_effective_backend",
           "target": "easyuse_anima/aio/sampling.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_aio_highres_effective_backend",
         "kind": "static_from",
-        "line": 670,
+        "line": 664,
         "name": "_aio_highres_effective_backend",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -32435,9 +33256,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -32445,12 +33266,12 @@
         "compatibility_pair": {
           "bound_name": "_aio_stage_sampler_settings",
           "target": "easyuse_anima/aio/sampling.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_aio_stage_sampler_settings",
         "kind": "static_from",
-        "line": 670,
+        "line": 664,
         "name": "_aio_stage_sampler_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -32469,9 +33290,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -32479,12 +33300,12 @@
         "compatibility_pair": {
           "bound_name": "_decode_latent_with_comfy",
           "target": "easyuse_anima/aio/sampling.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_decode_latent_with_comfy",
         "kind": "static_from",
-        "line": 670,
+        "line": 664,
         "name": "_decode_latent_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -32503,9 +33324,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -32513,12 +33334,12 @@
         "compatibility_pair": {
           "bound_name": "_encode_image_with_comfy_vae",
           "target": "easyuse_anima/aio/sampling.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_encode_image_with_comfy_vae",
         "kind": "static_from",
-        "line": 670,
+        "line": 664,
         "name": "_encode_image_with_comfy_vae",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -32537,9 +33358,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -32547,12 +33368,12 @@
         "compatibility_pair": {
           "bound_name": "_generate_empty_latent_with_comfy",
           "target": "easyuse_anima/aio/sampling.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_generate_empty_latent_with_comfy",
         "kind": "static_from",
-        "line": 670,
+        "line": 664,
         "name": "_generate_empty_latent_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -32571,9 +33392,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -32581,12 +33402,12 @@
         "compatibility_pair": {
           "bound_name": "_new_aio_random_seed",
           "target": "easyuse_anima/aio/sampling.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_new_aio_random_seed",
         "kind": "static_from",
-        "line": 670,
+        "line": 664,
         "name": "_new_aio_random_seed",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -32605,9 +33426,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -32615,12 +33436,12 @@
         "compatibility_pair": {
           "bound_name": "_resolve_aio_runtime_seed",
           "target": "easyuse_anima/aio/sampling.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_resolve_aio_runtime_seed",
         "kind": "static_from",
-        "line": 670,
+        "line": 664,
         "name": "_resolve_aio_runtime_seed",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -32639,9 +33460,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -32649,12 +33470,12 @@
         "compatibility_pair": {
           "bound_name": "_sample_latent_with_aio_backend",
           "target": "easyuse_anima/aio/sampling.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_aio_backend",
         "kind": "static_from",
-        "line": 670,
+        "line": 664,
         "name": "_sample_latent_with_aio_backend",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -32673,9 +33494,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -32683,12 +33504,12 @@
         "compatibility_pair": {
           "bound_name": "_sample_latent_with_comfy",
           "target": "easyuse_anima/aio/sampling.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_comfy",
         "kind": "static_from",
-        "line": 670,
+        "line": 664,
         "name": "_sample_latent_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -32707,9 +33528,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -32717,12 +33538,12 @@
         "compatibility_pair": {
           "bound_name": "_sample_latent_with_spectrum_mod_guidance_advanced",
           "target": "easyuse_anima/aio/sampling.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_spectrum_mod_guidance_advanced",
         "kind": "static_from",
-        "line": 670,
+        "line": 664,
         "name": "_sample_latent_with_spectrum_mod_guidance_advanced",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -32741,9 +33562,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -32751,12 +33572,12 @@
         "compatibility_pair": {
           "bound_name": "_sample_latent_with_spectrum_spd",
           "target": "easyuse_anima/aio/sampling.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_spectrum_spd",
         "kind": "static_from",
-        "line": 670,
+        "line": 664,
         "name": "_sample_latent_with_spectrum_spd",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -32775,9 +33596,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -32785,12 +33606,12 @@
         "compatibility_pair": {
           "bound_name": "AIO_PREVIEW_CACHE_FORMAT",
           "target": "easyuse_anima/aio/preview.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_CACHE_FORMAT",
         "kind": "static_from",
-        "line": 683,
+        "line": 677,
         "name": "AIO_PREVIEW_CACHE_FORMAT",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -32809,9 +33630,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -32819,12 +33640,12 @@
         "compatibility_pair": {
           "bound_name": "AIO_PREVIEW_CACHE_QUALITY",
           "target": "easyuse_anima/aio/preview.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_CACHE_QUALITY",
         "kind": "static_from",
-        "line": 683,
+        "line": 677,
         "name": "AIO_PREVIEW_CACHE_QUALITY",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -32843,9 +33664,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -32853,12 +33674,12 @@
         "compatibility_pair": {
           "bound_name": "AIO_PREVIEW_EVENT",
           "target": "easyuse_anima/aio/preview.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_EVENT",
         "kind": "static_from",
-        "line": 683,
+        "line": 677,
         "name": "AIO_PREVIEW_EVENT",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -32877,9 +33698,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -32887,12 +33708,12 @@
         "compatibility_pair": {
           "bound_name": "AIO_PREVIEW_STAGE_LABELS",
           "target": "easyuse_anima/aio/preview.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_STAGE_LABELS",
         "kind": "static_from",
-        "line": 683,
+        "line": 677,
         "name": "AIO_PREVIEW_STAGE_LABELS",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -32911,9 +33732,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -32921,12 +33742,12 @@
         "compatibility_pair": {
           "bound_name": "_aio_preview_base_directory",
           "target": "easyuse_anima/aio/preview.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_aio_preview_base_directory",
         "kind": "static_from",
-        "line": 683,
+        "line": 677,
         "name": "_aio_preview_base_directory",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -32945,9 +33766,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -32955,12 +33776,12 @@
         "compatibility_pair": {
           "bound_name": "_aio_preview_file_size_bytes",
           "target": "easyuse_anima/aio/preview.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_aio_preview_file_size_bytes",
         "kind": "static_from",
-        "line": 683,
+        "line": 677,
         "name": "_aio_preview_file_size_bytes",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -32979,9 +33800,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -32989,12 +33810,12 @@
         "compatibility_pair": {
           "bound_name": "_save_aio_temp_preview_image",
           "target": "easyuse_anima/aio/preview.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_save_aio_temp_preview_image",
         "kind": "static_from",
-        "line": 683,
+        "line": 677,
         "name": "_save_aio_temp_preview_image",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -33013,9 +33834,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -33023,12 +33844,12 @@
         "compatibility_pair": {
           "bound_name": "_send_aio_preview_event",
           "target": "easyuse_anima/aio/preview.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_send_aio_preview_event",
         "kind": "static_from",
-        "line": 683,
+        "line": 677,
         "name": "_send_aio_preview_event",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -33047,9 +33868,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -33057,12 +33878,12 @@
         "compatibility_pair": {
           "bound_name": "_tag_aio_preview_images",
           "target": "easyuse_anima/aio/preview.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_tag_aio_preview_images",
         "kind": "static_from",
-        "line": 683,
+        "line": 677,
         "name": "_tag_aio_preview_images",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -33081,9 +33902,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -33091,12 +33912,12 @@
         "compatibility_pair": {
           "bound_name": "_aio_image_saver_additional_hashes",
           "target": "easyuse_anima/aio/output.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_image_saver_additional_hashes",
         "kind": "static_from",
-        "line": 694,
+        "line": 688,
         "name": "_aio_image_saver_additional_hashes",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -33115,9 +33936,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -33125,12 +33946,12 @@
         "compatibility_pair": {
           "bound_name": "_aio_image_saver_civitai_hash_fetcher_entries",
           "target": "easyuse_anima/aio/output.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_image_saver_civitai_hash_fetcher_entries",
         "kind": "static_from",
-        "line": 694,
+        "line": 688,
         "name": "_aio_image_saver_civitai_hash_fetcher_entries",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -33149,9 +33970,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -33159,12 +33980,12 @@
         "compatibility_pair": {
           "bound_name": "_aio_lora_metadata_name",
           "target": "easyuse_anima/aio/output.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_lora_metadata_name",
         "kind": "static_from",
-        "line": 694,
+        "line": 688,
         "name": "_aio_lora_metadata_name",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -33183,9 +34004,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -33193,12 +34014,12 @@
         "compatibility_pair": {
           "bound_name": "_aio_prompt_with_lora_metadata",
           "target": "easyuse_anima/aio/output.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_prompt_with_lora_metadata",
         "kind": "static_from",
-        "line": 694,
+        "line": 688,
         "name": "_aio_prompt_with_lora_metadata",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -33217,9 +34038,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -33227,12 +34048,12 @@
         "compatibility_pair": {
           "bound_name": "_aio_save_filename_prefix",
           "target": "easyuse_anima/aio/output.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_save_filename_prefix",
         "kind": "static_from",
-        "line": 694,
+        "line": 688,
         "name": "_aio_save_filename_prefix",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -33251,9 +34072,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -33261,12 +34082,12 @@
         "compatibility_pair": {
           "bound_name": "_save_image_with_comfy",
           "target": "easyuse_anima/aio/output.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_save_image_with_comfy",
         "kind": "static_from",
-        "line": 694,
+        "line": 688,
         "name": "_save_image_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -33285,9 +34106,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -33295,12 +34116,12 @@
         "compatibility_pair": {
           "bound_name": "_save_image_with_image_saver",
           "target": "easyuse_anima/aio/output.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_save_image_with_image_saver",
         "kind": "static_from",
-        "line": 694,
+        "line": 688,
         "name": "_save_image_with_image_saver",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -33319,9 +34140,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -33329,12 +34150,12 @@
         "compatibility_pair": {
           "bound_name": "_normalize_aio_civitai_hash_fetchers",
           "target": "easyuse_anima/aio/output_settings.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.output_settings:_normalize_aio_civitai_hash_fetchers",
         "kind": "static_from",
-        "line": 703,
+        "line": 697,
         "name": "_normalize_aio_civitai_hash_fetchers",
         "optional": false,
         "requested": "easyuse_anima.aio.output_settings",
@@ -33353,9 +34174,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -33363,12 +34184,12 @@
         "compatibility_pair": {
           "bound_name": "_normalize_aio_hash_bundles",
           "target": "easyuse_anima/aio/output_settings.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.output_settings:_normalize_aio_hash_bundles",
         "kind": "static_from",
-        "line": 703,
+        "line": 697,
         "name": "_normalize_aio_hash_bundles",
         "optional": false,
         "requested": "easyuse_anima.aio.output_settings",
@@ -33387,9 +34208,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -33397,12 +34218,12 @@
         "compatibility_pair": {
           "bound_name": "_comfy_clip_loader_types",
           "target": "easyuse_anima/aio/resources.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_clip_loader_types",
         "kind": "static_from",
-        "line": 707,
+        "line": 701,
         "name": "_comfy_clip_loader_types",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -33421,9 +34242,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -33431,12 +34252,12 @@
         "compatibility_pair": {
           "bound_name": "_comfy_diffusion_model_names",
           "target": "easyuse_anima/aio/resources.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_diffusion_model_names",
         "kind": "static_from",
-        "line": 707,
+        "line": 701,
         "name": "_comfy_diffusion_model_names",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -33455,9 +34276,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -33465,12 +34286,12 @@
         "compatibility_pair": {
           "bound_name": "_comfy_text_encoder_names",
           "target": "easyuse_anima/aio/resources.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_text_encoder_names",
         "kind": "static_from",
-        "line": 707,
+        "line": 701,
         "name": "_comfy_text_encoder_names",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -33489,9 +34310,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -33499,12 +34320,12 @@
         "compatibility_pair": {
           "bound_name": "_comfy_vae_names",
           "target": "easyuse_anima/aio/resources.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_vae_names",
         "kind": "static_from",
-        "line": 707,
+        "line": 701,
         "name": "_comfy_vae_names",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -33523,9 +34344,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -33533,12 +34354,12 @@
         "compatibility_pair": {
           "bound_name": "_load_aio_resources_from_input_context",
           "target": "easyuse_anima/aio/resources.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_aio_resources_from_input_context",
         "kind": "static_from",
-        "line": 707,
+        "line": 701,
         "name": "_load_aio_resources_from_input_context",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -33557,9 +34378,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -33567,12 +34388,12 @@
         "compatibility_pair": {
           "bound_name": "_load_aio_sam3_context",
           "target": "easyuse_anima/aio/resources.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_aio_sam3_context",
         "kind": "static_from",
-        "line": 707,
+        "line": 701,
         "name": "_load_aio_sam3_context",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -33591,9 +34412,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -33601,12 +34422,12 @@
         "compatibility_pair": {
           "bound_name": "_load_checkpoint_with_comfy",
           "target": "easyuse_anima/aio/resources.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_checkpoint_with_comfy",
         "kind": "static_from",
-        "line": 707,
+        "line": 701,
         "name": "_load_checkpoint_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -33625,9 +34446,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -33635,12 +34456,12 @@
         "compatibility_pair": {
           "bound_name": "_load_clip_with_comfy",
           "target": "easyuse_anima/aio/resources.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_clip_with_comfy",
         "kind": "static_from",
-        "line": 707,
+        "line": 701,
         "name": "_load_clip_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -33659,9 +34480,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -33669,12 +34490,12 @@
         "compatibility_pair": {
           "bound_name": "_load_diffusion_model_with_comfy",
           "target": "easyuse_anima/aio/resources.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_diffusion_model_with_comfy",
         "kind": "static_from",
-        "line": 707,
+        "line": 701,
         "name": "_load_diffusion_model_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -33693,9 +34514,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -33703,12 +34524,12 @@
         "compatibility_pair": {
           "bound_name": "_load_upscale_model_with_comfy",
           "target": "easyuse_anima/aio/resources.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_upscale_model_with_comfy",
         "kind": "static_from",
-        "line": 707,
+        "line": 701,
         "name": "_load_upscale_model_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -33727,9 +34548,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -33737,12 +34558,12 @@
         "compatibility_pair": {
           "bound_name": "_load_vae_with_comfy",
           "target": "easyuse_anima/aio/resources.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_vae_with_comfy",
         "kind": "static_from",
-        "line": 707,
+        "line": 701,
         "name": "_load_vae_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -33761,9 +34582,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -33771,12 +34592,12 @@
         "compatibility_pair": {
           "bound_name": "_normalize_aio_input_settings",
           "target": "easyuse_anima/aio/resources.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_normalize_aio_input_settings",
         "kind": "static_from",
-        "line": 707,
+        "line": 701,
         "name": "_normalize_aio_input_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -33795,9 +34616,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -33805,12 +34626,12 @@
         "compatibility_pair": {
           "bound_name": "_preferred_checkpoint_default",
           "target": "easyuse_anima/aio/resources.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_checkpoint_default",
         "kind": "static_from",
-        "line": 707,
+        "line": 701,
         "name": "_preferred_checkpoint_default",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -33829,9 +34650,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -33839,12 +34660,12 @@
         "compatibility_pair": {
           "bound_name": "_preferred_clip_type_default",
           "target": "easyuse_anima/aio/resources.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_clip_type_default",
         "kind": "static_from",
-        "line": 707,
+        "line": 701,
         "name": "_preferred_clip_type_default",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -33863,9 +34684,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -33873,12 +34694,12 @@
         "compatibility_pair": {
           "bound_name": "_preferred_name_default",
           "target": "easyuse_anima/aio/resources.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_name_default",
         "kind": "static_from",
-        "line": 707,
+        "line": 701,
         "name": "_preferred_name_default",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -33897,9 +34718,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -33907,12 +34728,12 @@
         "compatibility_pair": {
           "bound_name": "_json_clone",
           "target": "easyuse_anima/common/serialization.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_json_clone",
         "kind": "static_from",
-        "line": 724,
+        "line": 718,
         "name": "_json_clone",
         "optional": false,
         "requested": "easyuse_anima.common.serialization",
@@ -33931,9 +34752,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -33941,12 +34762,12 @@
         "compatibility_pair": {
           "bound_name": "_json_object",
           "target": "easyuse_anima/common/serialization.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_json_object",
         "kind": "static_from",
-        "line": 724,
+        "line": 718,
         "name": "_json_object",
         "optional": false,
         "requested": "easyuse_anima.common.serialization",
@@ -33965,9 +34786,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -33975,12 +34796,12 @@
         "compatibility_pair": {
           "bound_name": "_stable_change_key",
           "target": "easyuse_anima/common/serialization.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_stable_change_key",
         "kind": "static_from",
-        "line": 724,
+        "line": 718,
         "name": "_stable_change_key",
         "optional": false,
         "requested": "easyuse_anima.common.serialization",
@@ -33999,9 +34820,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -34009,12 +34830,12 @@
         "compatibility_pair": {
           "bound_name": "_as_bool",
           "target": "easyuse_anima/common/values.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_bool",
         "kind": "static_from",
-        "line": 729,
+        "line": 723,
         "name": "_as_bool",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -34033,9 +34854,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -34043,12 +34864,12 @@
         "compatibility_pair": {
           "bound_name": "_as_float",
           "target": "easyuse_anima/common/values.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_float",
         "kind": "static_from",
-        "line": 729,
+        "line": 723,
         "name": "_as_float",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -34067,9 +34888,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -34077,12 +34898,12 @@
         "compatibility_pair": {
           "bound_name": "_as_int",
           "target": "easyuse_anima/common/values.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_int",
         "kind": "static_from",
-        "line": 729,
+        "line": 723,
         "name": "_as_int",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -34101,9 +34922,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -34111,12 +34932,12 @@
         "compatibility_pair": {
           "bound_name": "_choice",
           "target": "easyuse_anima/common/values.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.common.values:_choice",
         "kind": "static_from",
-        "line": 729,
+        "line": 723,
         "name": "_choice",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -34135,9 +34956,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -34145,12 +34966,12 @@
         "compatibility_pair": {
           "bound_name": "_single_value",
           "target": "easyuse_anima/common/values.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.common.values:_single_value",
         "kind": "static_from",
-        "line": 729,
+        "line": 723,
         "name": "_single_value",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -34169,9 +34990,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -34179,12 +35000,12 @@
         "compatibility_pair": {
           "bound_name": "WILDCARD_QUEUE_MAX_SAFE_SEED",
           "target": "easyuse_anima/seed/compatibility.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.seed.compatibility:WILDCARD_QUEUE_MAX_SAFE_SEED",
         "kind": "static_from",
-        "line": 736,
+        "line": 730,
         "name": "WILDCARD_QUEUE_MAX_SAFE_SEED",
         "optional": false,
         "requested": "easyuse_anima.seed.compatibility",
@@ -34203,9 +35024,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -34213,12 +35034,12 @@
         "compatibility_pair": {
           "bound_name": "WILDCARD_RESERVED_NEXT_SEED_INPUT",
           "target": "easyuse_anima/seed/compatibility.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.seed.compatibility:WILDCARD_RESERVED_NEXT_SEED_INPUT",
         "kind": "static_from",
-        "line": 736,
+        "line": 730,
         "name": "WILDCARD_RESERVED_NEXT_SEED_INPUT",
         "optional": false,
         "requested": "easyuse_anima.seed.compatibility",
@@ -34237,9 +35058,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -34247,12 +35068,12 @@
         "compatibility_pair": {
           "bound_name": "_consume_reserved_wildcard_next_seed",
           "target": "easyuse_anima/seed/compatibility.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.seed.compatibility:_consume_reserved_wildcard_next_seed",
         "kind": "static_from",
-        "line": 736,
+        "line": 730,
         "name": "_consume_reserved_wildcard_next_seed",
         "optional": false,
         "requested": "easyuse_anima.seed.compatibility",
@@ -34271,9 +35092,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -34281,12 +35102,12 @@
         "compatibility_pair": {
           "bound_name": "_get_workflow_node",
           "target": "easyuse_anima/workflow.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.workflow:_get_workflow_node",
         "kind": "static_from",
-        "line": 741,
+        "line": 735,
         "name": "_get_workflow_node",
         "optional": false,
         "requested": "easyuse_anima.workflow",
@@ -34305,9 +35126,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -34315,12 +35136,12 @@
         "compatibility_pair": {
           "bound_name": "_prompt_translation_change_key",
           "target": "easyuse_anima/prompt/correction.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_prompt_translation_change_key",
         "kind": "static_from",
-        "line": 742,
+        "line": 736,
         "name": "_prompt_translation_change_key",
         "optional": false,
         "requested": "easyuse_anima.prompt.correction",
@@ -34339,9 +35160,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -34349,12 +35170,12 @@
         "compatibility_pair": {
           "bound_name": "_split_tag_text",
           "target": "easyuse_anima/prompt/correction.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_split_tag_text",
         "kind": "static_from",
-        "line": 742,
+        "line": 736,
         "name": "_split_tag_text",
         "optional": false,
         "requested": "easyuse_anima.prompt.correction",
@@ -34373,9 +35194,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -34383,12 +35204,12 @@
         "compatibility_pair": {
           "bound_name": "_translate_prompt_text",
           "target": "easyuse_anima/prompt/correction.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_translate_prompt_text",
         "kind": "static_from",
-        "line": 742,
+        "line": 736,
         "name": "_translate_prompt_text",
         "optional": false,
         "requested": "easyuse_anima.prompt.correction",
@@ -34407,9 +35228,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -34417,12 +35238,12 @@
         "compatibility_pair": {
           "bound_name": "_HASH_COMMENT_RE",
           "target": "easyuse_anima/prompt/fields.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_HASH_COMMENT_RE",
         "kind": "static_from",
-        "line": 747,
+        "line": 741,
         "name": "_HASH_COMMENT_RE",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -34441,9 +35262,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -34451,12 +35272,12 @@
         "compatibility_pair": {
           "bound_name": "_INLINE_SPACE_RE",
           "target": "easyuse_anima/prompt/fields.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_INLINE_SPACE_RE",
         "kind": "static_from",
-        "line": 747,
+        "line": 741,
         "name": "_INLINE_SPACE_RE",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -34475,9 +35296,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -34485,12 +35306,12 @@
         "compatibility_pair": {
           "bound_name": "_WEIGHTED_TOKEN_RE",
           "target": "easyuse_anima/prompt/fields.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_WEIGHTED_TOKEN_RE",
         "kind": "static_from",
-        "line": 747,
+        "line": 741,
         "name": "_WEIGHTED_TOKEN_RE",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -34509,9 +35330,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -34519,12 +35340,12 @@
         "compatibility_pair": {
           "bound_name": "_correct_builder_prompt",
           "target": "easyuse_anima/prompt/fields.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_correct_builder_prompt",
         "kind": "static_from",
-        "line": 747,
+        "line": 741,
         "name": "_correct_builder_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -34543,9 +35364,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -34553,12 +35374,12 @@
         "compatibility_pair": {
           "bound_name": "_filter_metadata_prompt",
           "target": "easyuse_anima/prompt/fields.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_filter_metadata_prompt",
         "kind": "static_from",
-        "line": 747,
+        "line": 741,
         "name": "_filter_metadata_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -34577,9 +35398,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -34587,12 +35408,12 @@
         "compatibility_pair": {
           "bound_name": "_join_prompt_tokens",
           "target": "easyuse_anima/prompt/fields.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_join_prompt_tokens",
         "kind": "static_from",
-        "line": 747,
+        "line": 741,
         "name": "_join_prompt_tokens",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -34611,9 +35432,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -34621,12 +35442,12 @@
         "compatibility_pair": {
           "bound_name": "_metadata_filter_key",
           "target": "easyuse_anima/prompt/fields.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_metadata_filter_key",
         "kind": "static_from",
-        "line": 747,
+        "line": 741,
         "name": "_metadata_filter_key",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -34645,9 +35466,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -34655,12 +35476,12 @@
         "compatibility_pair": {
           "bound_name": "_metadata_filter_keys",
           "target": "easyuse_anima/prompt/fields.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_metadata_filter_keys",
         "kind": "static_from",
-        "line": 747,
+        "line": 741,
         "name": "_metadata_filter_keys",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -34679,9 +35500,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -34689,12 +35510,12 @@
         "compatibility_pair": {
           "bound_name": "_prompt_tokens",
           "target": "easyuse_anima/prompt/fields.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_prompt_tokens",
         "kind": "static_from",
-        "line": 747,
+        "line": 741,
         "name": "_prompt_tokens",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -34713,9 +35534,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -34723,12 +35544,12 @@
         "compatibility_pair": {
           "bound_name": "PROMPT_DATA_TYPE",
           "target": "easyuse_anima/prompt/data.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:PROMPT_DATA_TYPE",
         "kind": "static_from",
-        "line": 760,
+        "line": 754,
         "name": "PROMPT_DATA_TYPE",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -34747,9 +35568,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -34757,12 +35578,12 @@
         "compatibility_pair": {
           "bound_name": "_advanced_outputs_from_prompt_data",
           "target": "easyuse_anima/prompt/data.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_advanced_outputs_from_prompt_data",
         "kind": "static_from",
-        "line": 760,
+        "line": 754,
         "name": "_advanced_outputs_from_prompt_data",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -34781,9 +35602,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -34791,12 +35612,12 @@
         "compatibility_pair": {
           "bound_name": "_apply_prompt_data_overrides",
           "target": "easyuse_anima/prompt/data.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_apply_prompt_data_overrides",
         "kind": "static_from",
-        "line": 760,
+        "line": 754,
         "name": "_apply_prompt_data_overrides",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -34815,9 +35636,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -34825,12 +35646,12 @@
         "compatibility_pair": {
           "bound_name": "_copy_prompt_data_for_update",
           "target": "easyuse_anima/prompt/data.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_copy_prompt_data_for_update",
         "kind": "static_from",
-        "line": 760,
+        "line": 754,
         "name": "_copy_prompt_data_for_update",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -34849,9 +35670,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -34859,12 +35680,12 @@
         "compatibility_pair": {
           "bound_name": "_normalize_prompt_data",
           "target": "easyuse_anima/prompt/data.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_normalize_prompt_data",
         "kind": "static_from",
-        "line": 760,
+        "line": 754,
         "name": "_normalize_prompt_data",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -34883,9 +35704,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -34893,12 +35714,12 @@
         "compatibility_pair": {
           "bound_name": "_prompt_data_json_safe",
           "target": "easyuse_anima/prompt/data.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_prompt_data_json_safe",
         "kind": "static_from",
-        "line": 760,
+        "line": 754,
         "name": "_prompt_data_json_safe",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -34917,9 +35738,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -34927,12 +35748,12 @@
         "compatibility_pair": {
           "bound_name": "_prompt_data_parameter_snapshot",
           "target": "easyuse_anima/prompt/data.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_prompt_data_parameter_snapshot",
         "kind": "static_from",
-        "line": 760,
+        "line": 754,
         "name": "_prompt_data_parameter_snapshot",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -34951,9 +35772,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -34961,12 +35782,12 @@
         "compatibility_pair": {
           "bound_name": "_advanced_artist_field_prompt",
           "target": "easyuse_anima/prompt/advanced.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_artist_field_prompt",
         "kind": "static_from",
-        "line": 778,
+        "line": 772,
         "name": "_advanced_artist_field_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -34985,9 +35806,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -34995,12 +35816,12 @@
         "compatibility_pair": {
           "bound_name": "_advanced_default_fields",
           "target": "easyuse_anima/prompt/advanced.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_default_fields",
         "kind": "static_from",
-        "line": 778,
+        "line": 772,
         "name": "_advanced_default_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -35019,9 +35840,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -35029,12 +35850,12 @@
         "compatibility_pair": {
           "bound_name": "_advanced_enabled_naia_panes",
           "target": "easyuse_anima/prompt/advanced.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_enabled_naia_panes",
         "kind": "static_from",
-        "line": 778,
+        "line": 772,
         "name": "_advanced_enabled_naia_panes",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -35053,9 +35874,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -35063,12 +35884,12 @@
         "compatibility_pair": {
           "bound_name": "_advanced_enabled_pane_fields",
           "target": "easyuse_anima/prompt/advanced.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_enabled_pane_fields",
         "kind": "static_from",
-        "line": 778,
+        "line": 772,
         "name": "_advanced_enabled_pane_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -35087,9 +35908,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -35097,12 +35918,12 @@
         "compatibility_pair": {
           "bound_name": "_advanced_field_input_values",
           "target": "easyuse_anima/prompt/advanced.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_field_input_values",
         "kind": "static_from",
-        "line": 778,
+        "line": 772,
         "name": "_advanced_field_input_values",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -35121,9 +35942,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -35131,12 +35952,12 @@
         "compatibility_pair": {
           "bound_name": "_advanced_field_socket_name",
           "target": "easyuse_anima/prompt/advanced.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_field_socket_name",
         "kind": "static_from",
-        "line": 778,
+        "line": 772,
         "name": "_advanced_field_socket_name",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -35155,9 +35976,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -35165,12 +35986,12 @@
         "compatibility_pair": {
           "bound_name": "_advanced_fields_json",
           "target": "easyuse_anima/prompt/advanced.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_fields_json",
         "kind": "static_from",
-        "line": 778,
+        "line": 772,
         "name": "_advanced_fields_json",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -35189,9 +36010,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -35199,12 +36020,12 @@
         "compatibility_pair": {
           "bound_name": "_advanced_has_enabled_naia",
           "target": "easyuse_anima/prompt/advanced.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_has_enabled_naia",
         "kind": "static_from",
-        "line": 778,
+        "line": 772,
         "name": "_advanced_has_enabled_naia",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -35223,9 +36044,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -35233,12 +36054,12 @@
         "compatibility_pair": {
           "bound_name": "_advanced_prompt_with_artist_override",
           "target": "easyuse_anima/prompt/advanced.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_prompt_with_artist_override",
         "kind": "static_from",
-        "line": 778,
+        "line": 772,
         "name": "_advanced_prompt_with_artist_override",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -35257,9 +36078,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -35267,12 +36088,12 @@
         "compatibility_pair": {
           "bound_name": "_advanced_uses_naia_resolution",
           "target": "easyuse_anima/prompt/advanced.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_uses_naia_resolution",
         "kind": "static_from",
-        "line": 778,
+        "line": 772,
         "name": "_advanced_uses_naia_resolution",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -35291,9 +36112,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -35301,12 +36122,12 @@
         "compatibility_pair": {
           "bound_name": "_apply_advanced_field_inputs",
           "target": "easyuse_anima/prompt/advanced.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_apply_advanced_field_inputs",
         "kind": "static_from",
-        "line": 778,
+        "line": 772,
         "name": "_apply_advanced_field_inputs",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -35325,9 +36146,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -35335,12 +36156,12 @@
         "compatibility_pair": {
           "bound_name": "_as_advanced_height",
           "target": "easyuse_anima/prompt/advanced.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_as_advanced_height",
         "kind": "static_from",
-        "line": 778,
+        "line": 772,
         "name": "_as_advanced_height",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -35359,9 +36180,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -35369,12 +36190,12 @@
         "compatibility_pair": {
           "bound_name": "_build_advanced_prompt_data",
           "target": "easyuse_anima/prompt/advanced.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_build_advanced_prompt_data",
         "kind": "static_from",
-        "line": 778,
+        "line": 772,
         "name": "_build_advanced_prompt_data",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -35393,9 +36214,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -35403,12 +36224,12 @@
         "compatibility_pair": {
           "bound_name": "_build_advanced_prompts",
           "target": "easyuse_anima/prompt/advanced.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_build_advanced_prompts",
         "kind": "static_from",
-        "line": 778,
+        "line": 772,
         "name": "_build_advanced_prompts",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -35427,9 +36248,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -35437,12 +36258,12 @@
         "compatibility_pair": {
           "bound_name": "_clone_advanced_fields",
           "target": "easyuse_anima/prompt/advanced.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_clone_advanced_fields",
         "kind": "static_from",
-        "line": 778,
+        "line": 772,
         "name": "_clone_advanced_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -35461,9 +36282,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -35471,12 +36292,12 @@
         "compatibility_pair": {
           "bound_name": "_correct_advanced_field_sequence",
           "target": "easyuse_anima/prompt/advanced.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_correct_advanced_field_sequence",
         "kind": "static_from",
-        "line": 778,
+        "line": 772,
         "name": "_correct_advanced_field_sequence",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -35495,9 +36316,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -35505,12 +36326,12 @@
         "compatibility_pair": {
           "bound_name": "_expand_advanced_wildcard_fields",
           "target": "easyuse_anima/prompt/advanced.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_expand_advanced_wildcard_fields",
         "kind": "static_from",
-        "line": 778,
+        "line": 772,
         "name": "_expand_advanced_wildcard_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -35529,9 +36350,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -35539,12 +36360,12 @@
         "compatibility_pair": {
           "bound_name": "_normalize_advanced_fields",
           "target": "easyuse_anima/prompt/advanced.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_normalize_advanced_fields",
         "kind": "static_from",
-        "line": 778,
+        "line": 772,
         "name": "_normalize_advanced_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -35563,9 +36384,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -35573,12 +36394,12 @@
         "compatibility_pair": {
           "bound_name": "_normalize_prompt_studio_wildcard_seed_control",
           "target": "easyuse_anima/prompt/advanced.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_normalize_prompt_studio_wildcard_seed_control",
         "kind": "static_from",
-        "line": 778,
+        "line": 772,
         "name": "_normalize_prompt_studio_wildcard_seed_control",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -35597,9 +36418,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -35607,12 +36428,12 @@
         "compatibility_pair": {
           "bound_name": "_set_naia_field_text",
           "target": "easyuse_anima/prompt/advanced.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_set_naia_field_text",
         "kind": "static_from",
-        "line": 778,
+        "line": 772,
         "name": "_set_naia_field_text",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -35631,9 +36452,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -35641,12 +36462,12 @@
         "compatibility_pair": {
           "bound_name": "_translate_prompt_fields",
           "target": "easyuse_anima/prompt/advanced.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_translate_prompt_fields",
         "kind": "static_from",
-        "line": 778,
+        "line": 772,
         "name": "_translate_prompt_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -35665,9 +36486,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -35675,12 +36496,12 @@
         "compatibility_pair": {
           "bound_name": "_apply_regional_field_inputs",
           "target": "easyuse_anima/prompt/regional.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_apply_regional_field_inputs",
         "kind": "static_from",
-        "line": 813,
+        "line": 807,
         "name": "_apply_regional_field_inputs",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -35699,9 +36520,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -35709,12 +36530,12 @@
         "compatibility_pair": {
           "bound_name": "_build_regional_outputs",
           "target": "easyuse_anima/prompt/regional.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_build_regional_outputs",
         "kind": "static_from",
-        "line": 813,
+        "line": 807,
         "name": "_build_regional_outputs",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -35733,9 +36554,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -35743,12 +36564,12 @@
         "compatibility_pair": {
           "bound_name": "_clone_regional_fields",
           "target": "easyuse_anima/prompt/regional.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_clone_regional_fields",
         "kind": "static_from",
-        "line": 813,
+        "line": 807,
         "name": "_clone_regional_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -35767,9 +36588,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -35777,12 +36598,12 @@
         "compatibility_pair": {
           "bound_name": "_conditioning_set_values",
           "target": "easyuse_anima/prompt/regional.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_conditioning_set_values",
         "kind": "static_from",
-        "line": 813,
+        "line": 807,
         "name": "_conditioning_set_values",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -35801,9 +36622,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -35811,12 +36632,12 @@
         "compatibility_pair": {
           "bound_name": "_normalize_mask_ids",
           "target": "easyuse_anima/prompt/regional.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_mask_ids",
         "kind": "static_from",
-        "line": 813,
+        "line": 807,
         "name": "_normalize_mask_ids",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -35835,9 +36656,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -35845,12 +36666,12 @@
         "compatibility_pair": {
           "bound_name": "_normalize_regional_config",
           "target": "easyuse_anima/prompt/regional.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_regional_config",
         "kind": "static_from",
-        "line": 813,
+        "line": 807,
         "name": "_normalize_regional_config",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -35869,9 +36690,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -35879,12 +36700,12 @@
         "compatibility_pair": {
           "bound_name": "_normalize_regional_fields",
           "target": "easyuse_anima/prompt/regional.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_regional_fields",
         "kind": "static_from",
-        "line": 813,
+        "line": 807,
         "name": "_normalize_regional_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -35903,9 +36724,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -35913,12 +36734,12 @@
         "compatibility_pair": {
           "bound_name": "_parse_json_object",
           "target": "easyuse_anima/prompt/regional.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_parse_json_object",
         "kind": "static_from",
-        "line": 813,
+        "line": 807,
         "name": "_parse_json_object",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -35937,9 +36758,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -35947,12 +36768,12 @@
         "compatibility_pair": {
           "bound_name": "_regional_config_json",
           "target": "easyuse_anima/prompt/regional.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_config_json",
         "kind": "static_from",
-        "line": 813,
+        "line": 807,
         "name": "_regional_config_json",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -35971,9 +36792,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -35981,12 +36802,12 @@
         "compatibility_pair": {
           "bound_name": "_regional_fields_json",
           "target": "easyuse_anima/prompt/regional.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_fields_json",
         "kind": "static_from",
-        "line": 813,
+        "line": 807,
         "name": "_regional_fields_json",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -36005,9 +36826,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -36015,12 +36836,12 @@
         "compatibility_pair": {
           "bound_name": "_regional_mask_bounds_area",
           "target": "easyuse_anima/prompt/regional.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_mask_bounds_area",
         "kind": "static_from",
-        "line": 813,
+        "line": 807,
         "name": "_regional_mask_bounds_area",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -36039,9 +36860,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -36049,12 +36870,12 @@
         "compatibility_pair": {
           "bound_name": "_regional_payload_canvas",
           "target": "easyuse_anima/prompt/regional.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_payload_canvas",
         "kind": "static_from",
-        "line": 813,
+        "line": 807,
         "name": "_regional_payload_canvas",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -36073,9 +36894,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -36083,12 +36904,12 @@
         "compatibility_pair": {
           "bound_name": "_regional_union_mask_for_ids",
           "target": "easyuse_anima/prompt/regional.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_union_mask_for_ids",
         "kind": "static_from",
-        "line": 813,
+        "line": 807,
         "name": "_regional_union_mask_for_ids",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -36107,9 +36928,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -36117,12 +36938,12 @@
         "compatibility_pair": {
           "bound_name": "ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
           "target": "easyuse_anima/prompt/conditioning.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
         "kind": "static_from",
-        "line": 840,
+        "line": 834,
         "name": "ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -36141,9 +36962,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -36151,12 +36972,12 @@
         "compatibility_pair": {
           "bound_name": "ANIMA_MOD_GUIDANCE_MODES",
           "target": "easyuse_anima/prompt/conditioning.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODES",
         "kind": "static_from",
-        "line": 840,
+        "line": 834,
         "name": "ANIMA_MOD_GUIDANCE_MODES",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -36175,9 +36996,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -36185,12 +37006,12 @@
         "compatibility_pair": {
           "bound_name": "ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
           "target": "easyuse_anima/prompt/conditioning.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 840,
+        "line": 834,
         "name": "ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -36209,9 +37030,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -36219,12 +37040,12 @@
         "compatibility_pair": {
           "bound_name": "ANIMA_MOD_GUIDANCE_PROFILE_OFF",
           "target": "easyuse_anima/prompt/conditioning.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_PROFILE_OFF",
         "kind": "static_from",
-        "line": 840,
+        "line": 834,
         "name": "ANIMA_MOD_GUIDANCE_PROFILE_OFF",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -36243,9 +37064,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -36253,12 +37074,12 @@
         "compatibility_pair": {
           "bound_name": "_apply_spectrum_anima_mod_guidance",
           "target": "easyuse_anima/prompt/conditioning.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_apply_spectrum_anima_mod_guidance",
         "kind": "static_from",
-        "line": 840,
+        "line": 834,
         "name": "_apply_spectrum_anima_mod_guidance",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -36277,9 +37098,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -36287,12 +37108,12 @@
         "compatibility_pair": {
           "bound_name": "_find_spectrum_anima_mod_guidance_class",
           "target": "easyuse_anima/prompt/conditioning.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_find_spectrum_anima_mod_guidance_class",
         "kind": "static_from",
-        "line": 840,
+        "line": 834,
         "name": "_find_spectrum_anima_mod_guidance_class",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -36311,9 +37132,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -36321,12 +37142,12 @@
         "compatibility_pair": {
           "bound_name": "_normalize_anima_mod_guidance_profile",
           "target": "easyuse_anima/prompt/conditioning.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_normalize_anima_mod_guidance_profile",
         "kind": "static_from",
-        "line": 840,
+        "line": 834,
         "name": "_normalize_anima_mod_guidance_profile",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -36345,9 +37166,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -36355,12 +37176,12 @@
         "compatibility_pair": {
           "bound_name": "_resolve_anima_mod_guidance_enabled",
           "target": "easyuse_anima/prompt/conditioning.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_resolve_anima_mod_guidance_enabled",
         "kind": "static_from",
-        "line": 840,
+        "line": 834,
         "name": "_resolve_anima_mod_guidance_enabled",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -36379,9 +37200,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -36389,12 +37210,12 @@
         "compatibility_pair": {
           "bound_name": "ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
           "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
         "kind": "static_from",
-        "line": 855,
+        "line": 849,
         "name": "ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -36413,9 +37234,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -36423,12 +37244,12 @@
         "compatibility_pair": {
           "bound_name": "ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
           "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
         "kind": "static_from",
-        "line": 855,
+        "line": 849,
         "name": "ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -36447,9 +37268,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -36457,12 +37278,12 @@
         "compatibility_pair": {
           "bound_name": "ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
           "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
         "kind": "static_from",
-        "line": 855,
+        "line": 849,
         "name": "ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -36481,9 +37302,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -36491,12 +37312,12 @@
         "compatibility_pair": {
           "bound_name": "ARTIST_MIX_DEFAULT_EXACT_TOP_K",
           "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_EXACT_TOP_K",
         "kind": "static_from",
-        "line": 855,
+        "line": 849,
         "name": "ARTIST_MIX_DEFAULT_EXACT_TOP_K",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -36515,9 +37336,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -36525,12 +37346,12 @@
         "compatibility_pair": {
           "bound_name": "ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
           "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
         "kind": "static_from",
-        "line": 855,
+        "line": 849,
         "name": "ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -36549,9 +37370,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -36559,12 +37380,12 @@
         "compatibility_pair": {
           "bound_name": "ARTIST_MIX_DEFAULT_START_PERCENT",
           "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_START_PERCENT",
         "kind": "static_from",
-        "line": 855,
+        "line": 849,
         "name": "ARTIST_MIX_DEFAULT_START_PERCENT",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -36583,9 +37404,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -36593,12 +37414,12 @@
         "compatibility_pair": {
           "bound_name": "ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
           "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
         "kind": "static_from",
-        "line": 855,
+        "line": 849,
         "name": "ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -36617,9 +37438,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -36627,12 +37448,12 @@
         "compatibility_pair": {
           "bound_name": "ARTIST_MIX_DEFAULT_STYLE_GAIN",
           "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STYLE_GAIN",
         "kind": "static_from",
-        "line": 855,
+        "line": 849,
         "name": "ARTIST_MIX_DEFAULT_STYLE_GAIN",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -36651,9 +37472,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -36661,12 +37482,12 @@
         "compatibility_pair": {
           "bound_name": "ARTIST_MIX_INPUT_MODES",
           "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_INPUT_MODES",
         "kind": "static_from",
-        "line": 855,
+        "line": 849,
         "name": "ARTIST_MIX_INPUT_MODES",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -36685,9 +37506,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -36695,12 +37516,12 @@
         "compatibility_pair": {
           "bound_name": "ARTIST_MIX_MODE_FROM_PROMPT_DATA",
           "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 855,
+        "line": 849,
         "name": "ARTIST_MIX_MODE_FROM_PROMPT_DATA",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -36719,9 +37540,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -36729,12 +37550,12 @@
         "compatibility_pair": {
           "bound_name": "_artist_mix_inline_prompt",
           "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_mix_inline_prompt",
         "kind": "static_from",
-        "line": 855,
+        "line": 849,
         "name": "_artist_mix_inline_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -36753,9 +37574,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -36763,12 +37584,12 @@
         "compatibility_pair": {
           "bound_name": "_artist_mix_mode_tooltip",
           "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_mix_mode_tooltip",
         "kind": "static_from",
-        "line": 855,
+        "line": 849,
         "name": "_artist_mix_mode_tooltip",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -36787,9 +37608,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -36797,12 +37618,12 @@
         "compatibility_pair": {
           "bound_name": "_artist_prompt_with_position",
           "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_prompt_with_position",
         "kind": "static_from",
-        "line": 855,
+        "line": 849,
         "name": "_artist_prompt_with_position",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -36821,9 +37642,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -36831,12 +37652,12 @@
         "compatibility_pair": {
           "bound_name": "_artist_tags_from_prompt",
           "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_tags_from_prompt",
         "kind": "static_from",
-        "line": 855,
+        "line": 849,
         "name": "_artist_tags_from_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -36855,9 +37676,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -36865,12 +37686,12 @@
         "compatibility_pair": {
           "bound_name": "_blend_conditionings",
           "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_blend_conditionings",
         "kind": "static_from",
-        "line": 855,
+        "line": 849,
         "name": "_blend_conditionings",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -36889,9 +37710,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -36899,12 +37720,12 @@
         "compatibility_pair": {
           "bound_name": "_bounded_artist_mix_float",
           "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bounded_artist_mix_float",
         "kind": "static_from",
-        "line": 855,
+        "line": 849,
         "name": "_bounded_artist_mix_float",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -36923,9 +37744,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -36933,12 +37754,12 @@
         "compatibility_pair": {
           "bound_name": "_bounded_artist_mix_int",
           "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bounded_artist_mix_int",
         "kind": "static_from",
-        "line": 855,
+        "line": 849,
         "name": "_bounded_artist_mix_int",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -36957,9 +37778,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -36967,12 +37788,12 @@
         "compatibility_pair": {
           "bound_name": "_encode_artist_clustered",
           "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_clustered",
         "kind": "static_from",
-        "line": 855,
+        "line": 849,
         "name": "_encode_artist_clustered",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -36991,9 +37812,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -37001,12 +37822,12 @@
         "compatibility_pair": {
           "bound_name": "_encode_artist_delta_rms",
           "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_delta_rms",
         "kind": "static_from",
-        "line": 855,
+        "line": 849,
         "name": "_encode_artist_delta_rms",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -37025,9 +37846,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -37035,12 +37856,12 @@
         "compatibility_pair": {
           "bound_name": "_encode_prompt_data_positive_conditioning",
           "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_prompt_data_positive_conditioning",
         "kind": "static_from",
-        "line": 855,
+        "line": 849,
         "name": "_encode_prompt_data_positive_conditioning",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -37059,9 +37880,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -37069,12 +37890,12 @@
         "compatibility_pair": {
           "bound_name": "_join_artist_mix_source_prompts",
           "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_join_artist_mix_source_prompts",
         "kind": "static_from",
-        "line": 855,
+        "line": 849,
         "name": "_join_artist_mix_source_prompts",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -37093,9 +37914,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -37103,12 +37924,12 @@
         "compatibility_pair": {
           "bound_name": "_normalize_artist_mix_mode",
           "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_normalize_artist_mix_mode",
         "kind": "static_from",
-        "line": 855,
+        "line": 849,
         "name": "_normalize_artist_mix_mode",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -37127,9 +37948,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -37137,12 +37958,12 @@
         "compatibility_pair": {
           "bound_name": "_normalize_artist_tag_position",
           "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_normalize_artist_tag_position",
         "kind": "static_from",
-        "line": 855,
+        "line": 849,
         "name": "_normalize_artist_tag_position",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -37161,9 +37982,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -37171,12 +37992,12 @@
         "compatibility_pair": {
           "bound_name": "_parse_artist_mix_items",
           "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_parse_artist_mix_items",
         "kind": "static_from",
-        "line": 855,
+        "line": 849,
         "name": "_parse_artist_mix_items",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -37195,9 +38016,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -37205,12 +38026,12 @@
         "compatibility_pair": {
           "bound_name": "EasyUseAnimaArtistMixConditioning",
           "target": "easyuse_anima/nodes/prompt_data_nodes.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaArtistMixConditioning",
         "kind": "static_from",
-        "line": 934,
+        "line": 928,
         "name": "EasyUseAnimaArtistMixConditioning",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_data_nodes",
@@ -37229,9 +38050,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -37239,12 +38060,12 @@
         "compatibility_pair": {
           "bound_name": "EasyUseAnimaPromptDataConditioning",
           "target": "easyuse_anima/nodes/prompt_data_nodes.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataConditioning",
         "kind": "static_from",
-        "line": 934,
+        "line": 928,
         "name": "EasyUseAnimaPromptDataConditioning",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_data_nodes",
@@ -37263,9 +38084,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -37273,12 +38094,12 @@
         "compatibility_pair": {
           "bound_name": "EasyUseAnimaPromptDataUnpack",
           "target": "easyuse_anima/nodes/prompt_data_nodes.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataUnpack",
         "kind": "static_from",
-        "line": 934,
+        "line": 928,
         "name": "EasyUseAnimaPromptDataUnpack",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_data_nodes",
@@ -37297,9 +38118,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -37307,12 +38128,12 @@
         "compatibility_pair": {
           "bound_name": "_ANY_TYPE",
           "target": "easyuse_anima/nodes/input_types.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_ANY_TYPE",
         "kind": "static_from",
-        "line": 939,
+        "line": 933,
         "name": "_ANY_TYPE",
         "optional": false,
         "requested": "easyuse_anima.nodes.input_types",
@@ -37331,9 +38152,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -37341,12 +38162,12 @@
         "compatibility_pair": {
           "bound_name": "_AnyType",
           "target": "easyuse_anima/nodes/input_types.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_AnyType",
         "kind": "static_from",
-        "line": 939,
+        "line": 933,
         "name": "_AnyType",
         "optional": false,
         "requested": "easyuse_anima.nodes.input_types",
@@ -37365,9 +38186,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -37375,12 +38196,12 @@
         "compatibility_pair": {
           "bound_name": "_FlexibleOptionalInputType",
           "target": "easyuse_anima/nodes/input_types.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_FlexibleOptionalInputType",
         "kind": "static_from",
-        "line": 939,
+        "line": 933,
         "name": "_FlexibleOptionalInputType",
         "optional": false,
         "requested": "easyuse_anima.nodes.input_types",
@@ -37399,9 +38220,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -37409,12 +38230,12 @@
         "compatibility_pair": {
           "bound_name": "EasyUseAnimaPromptStudioAdvanced",
           "target": "easyuse_anima/nodes/prompt_advanced_nodes.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvanced",
         "kind": "static_from",
-        "line": 944,
+        "line": 938,
         "name": "EasyUseAnimaPromptStudioAdvanced",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_advanced_nodes",
@@ -37433,9 +38254,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -37443,12 +38264,12 @@
         "compatibility_pair": {
           "bound_name": "EasyUseAnimaPromptStudioAdvancedV2",
           "target": "easyuse_anima/nodes/prompt_advanced_nodes.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvancedV2",
         "kind": "static_from",
-        "line": 944,
+        "line": 938,
         "name": "EasyUseAnimaPromptStudioAdvancedV2",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_advanced_nodes",
@@ -37467,9 +38288,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -37477,12 +38298,12 @@
         "compatibility_pair": {
           "bound_name": "EasyUseAnimaAIOGenerator",
           "target": "easyuse_anima/nodes/aio_nodes.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:EasyUseAnimaAIOGenerator",
         "kind": "static_from",
-        "line": 949,
+        "line": 943,
         "name": "EasyUseAnimaAIOGenerator",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -37501,9 +38322,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -37511,12 +38332,12 @@
         "compatibility_pair": {
           "bound_name": "EasyUseAnimaInput",
           "target": "easyuse_anima/nodes/aio_nodes.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:EasyUseAnimaInput",
         "kind": "static_from",
-        "line": 949,
+        "line": 943,
         "name": "EasyUseAnimaInput",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -37535,9 +38356,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -37545,12 +38366,12 @@
         "compatibility_pair": {
           "bound_name": "_aio_generation_settings_json",
           "target": "easyuse_anima/nodes/aio_nodes.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_aio_generation_settings_json",
         "kind": "static_from",
-        "line": 949,
+        "line": 943,
         "name": "_aio_generation_settings_json",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -37569,9 +38390,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -37579,12 +38400,12 @@
         "compatibility_pair": {
           "bound_name": "_aio_input_settings_json",
           "target": "easyuse_anima/nodes/aio_nodes.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_aio_input_settings_json",
         "kind": "static_from",
-        "line": 949,
+        "line": 943,
         "name": "_aio_input_settings_json",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -37603,9 +38424,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -37613,12 +38434,12 @@
         "compatibility_pair": {
           "bound_name": "_bind_aio_node_runtime",
           "target": "easyuse_anima/nodes/aio_nodes.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_bind_aio_node_runtime",
         "kind": "static_from",
-        "line": 949,
+        "line": 943,
         "name": "_bind_aio_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -37637,9 +38458,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -37647,12 +38468,12 @@
         "compatibility_pair": {
           "bound_name": "_align_down",
           "target": "easyuse_anima/image/geometry.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_align_down",
         "kind": "static_from",
-        "line": 956,
+        "line": 950,
         "name": "_align_down",
         "optional": false,
         "requested": "easyuse_anima.image.geometry",
@@ -37671,9 +38492,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -37681,12 +38502,12 @@
         "compatibility_pair": {
           "bound_name": "_align_nearest",
           "target": "easyuse_anima/image/geometry.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_align_nearest",
         "kind": "static_from",
-        "line": 956,
+        "line": 950,
         "name": "_align_nearest",
         "optional": false,
         "requested": "easyuse_anima.image.geometry",
@@ -37705,9 +38526,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -37715,12 +38536,12 @@
         "compatibility_pair": {
           "bound_name": "_image_tensor_size",
           "target": "easyuse_anima/image/geometry.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_image_tensor_size",
         "kind": "static_from",
-        "line": 956,
+        "line": 950,
         "name": "_image_tensor_size",
         "optional": false,
         "requested": "easyuse_anima.image.geometry",
@@ -37739,9 +38560,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -37749,12 +38570,12 @@
         "compatibility_pair": {
           "bound_name": "_context_value",
           "target": "easyuse_anima/image/sam3.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_context_value",
         "kind": "static_from",
-        "line": 967,
+        "line": 961,
         "name": "_context_value",
         "optional": false,
         "requested": "easyuse_anima.image.sam3",
@@ -37773,9 +38594,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -37783,12 +38604,12 @@
         "compatibility_pair": {
           "bound_name": "_sam3_context",
           "target": "easyuse_anima/image/sam3.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_sam3_context",
         "kind": "static_from",
-        "line": 967,
+        "line": 961,
         "name": "_sam3_context",
         "optional": false,
         "requested": "easyuse_anima.image.sam3",
@@ -37807,9 +38628,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -37817,12 +38638,12 @@
         "compatibility_pair": {
           "bound_name": "_segs_has_items",
           "target": "easyuse_anima/image/sam3.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_segs_has_items",
         "kind": "static_from",
-        "line": 967,
+        "line": 961,
         "name": "_segs_has_items",
         "optional": false,
         "requested": "easyuse_anima.image.sam3",
@@ -37841,9 +38662,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -37851,12 +38672,12 @@
         "compatibility_pair": {
           "bound_name": "IMAGE_SCALE_MULTIPLES",
           "target": "easyuse_anima/image/scaling.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:IMAGE_SCALE_MULTIPLES",
         "kind": "static_from",
-        "line": 979,
+        "line": 973,
         "name": "IMAGE_SCALE_MULTIPLES",
         "optional": false,
         "requested": "easyuse_anima.image.scaling",
@@ -37875,9 +38696,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -37885,12 +38706,12 @@
         "compatibility_pair": {
           "bound_name": "IMAGE_UPSCALE_METHODS",
           "target": "easyuse_anima/image/scaling.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:IMAGE_UPSCALE_METHODS",
         "kind": "static_from",
-        "line": 979,
+        "line": 973,
         "name": "IMAGE_UPSCALE_METHODS",
         "optional": false,
         "requested": "easyuse_anima.image.scaling",
@@ -37909,9 +38730,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -37919,12 +38740,12 @@
         "compatibility_pair": {
           "bound_name": "_comfy_sampler_names",
           "target": "easyuse_anima/infrastructure/comfy/capabilities.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_sampler_names",
         "kind": "static_from",
-        "line": 987,
+        "line": 981,
         "name": "_comfy_sampler_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -37943,9 +38764,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -37953,12 +38774,12 @@
         "compatibility_pair": {
           "bound_name": "_comfy_scheduler_names",
           "target": "easyuse_anima/infrastructure/comfy/capabilities.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_scheduler_names",
         "kind": "static_from",
-        "line": 987,
+        "line": 981,
         "name": "_comfy_scheduler_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -37977,9 +38798,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -37987,12 +38808,12 @@
         "compatibility_pair": {
           "bound_name": "_impact_scheduler_names",
           "target": "easyuse_anima/infrastructure/comfy/capabilities.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_impact_scheduler_names",
         "kind": "static_from",
-        "line": 987,
+        "line": 981,
         "name": "_impact_scheduler_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -38011,9 +38832,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -38021,12 +38842,12 @@
         "compatibility_pair": {
           "bound_name": "_call_with_supported_kwargs",
           "target": "easyuse_anima/infrastructure/comfy/invocation.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_call_with_supported_kwargs",
         "kind": "static_from",
-        "line": 993,
+        "line": 987,
         "name": "_call_with_supported_kwargs",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.invocation",
@@ -38045,9 +38866,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -38055,12 +38876,12 @@
         "compatibility_pair": {
           "bound_name": "_common_upscale_image",
           "target": "easyuse_anima/infrastructure/comfy/invocation.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_common_upscale_image",
         "kind": "static_from",
-        "line": 993,
+        "line": 987,
         "name": "_common_upscale_image",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.invocation",
@@ -38079,9 +38900,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -38089,12 +38910,12 @@
         "compatibility_pair": {
           "bound_name": "_node_output_tuple",
           "target": "easyuse_anima/infrastructure/comfy/invocation.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_node_output_tuple",
         "kind": "static_from",
-        "line": 993,
+        "line": 987,
         "name": "_node_output_tuple",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.invocation",
@@ -38102,40 +38923,6 @@
         "scope": "<module>",
         "source": "nodes.py",
         "target": "easyuse_anima/infrastructure/comfy/invocation.py"
-      },
-      {
-        "alias": "_resolve_comfy_host_helper",
-        "bound_name": "_resolve_comfy_host_helper",
-        "branch_context": [
-          {
-            "branch": "except",
-            "catches_import_error": true,
-            "exceptions": [
-              "ImportError"
-            ],
-            "handler_line": 571,
-            "kind": "try",
-            "line": 8
-          }
-        ],
-        "classification": "compatibility_fallback",
-        "column": 4,
-        "compatibility_pair": {
-          "bound_name": "_resolve_comfy_host_helper",
-          "target": "easyuse_anima/infrastructure/comfy/wiring.py",
-          "try_line": 8
-        },
-        "conditional": true,
-        "imported": "easyuse_anima.infrastructure.comfy.wiring:resolve_comfy_host_helper",
-        "kind": "static_from",
-        "line": 998,
-        "name": "resolve_comfy_host_helper",
-        "optional": false,
-        "requested": "easyuse_anima.infrastructure.comfy.wiring",
-        "role": "compatibility_fallback",
-        "scope": "<module>",
-        "source": "nodes.py",
-        "target": "easyuse_anima/infrastructure/comfy/wiring.py"
       },
       {
         "alias": "_adapter_comfy_clip_loader_types",
@@ -38147,9 +38934,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -38157,12 +38944,12 @@
         "compatibility_pair": {
           "bound_name": "_adapter_comfy_clip_loader_types",
           "target": "easyuse_anima/infrastructure/comfy/resources.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_clip_loader_types",
         "kind": "static_from",
-        "line": 1001,
+        "line": 992,
         "name": "_comfy_clip_loader_types",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -38181,9 +38968,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -38191,12 +38978,12 @@
         "compatibility_pair": {
           "bound_name": "_adapter_comfy_diffusion_model_names",
           "target": "easyuse_anima/infrastructure/comfy/resources.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_diffusion_model_names",
         "kind": "static_from",
-        "line": 1001,
+        "line": 992,
         "name": "_comfy_diffusion_model_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -38215,9 +39002,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -38225,12 +39012,12 @@
         "compatibility_pair": {
           "bound_name": "_adapter_comfy_text_encoder_names",
           "target": "easyuse_anima/infrastructure/comfy/resources.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_text_encoder_names",
         "kind": "static_from",
-        "line": 1001,
+        "line": 992,
         "name": "_comfy_text_encoder_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -38249,9 +39036,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -38259,12 +39046,12 @@
         "compatibility_pair": {
           "bound_name": "_adapter_comfy_vae_names",
           "target": "easyuse_anima/infrastructure/comfy/resources.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_vae_names",
         "kind": "static_from",
-        "line": 1001,
+        "line": 992,
         "name": "_comfy_vae_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -38283,9 +39070,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -38293,12 +39080,12 @@
         "compatibility_pair": {
           "bound_name": "_folder_path_names",
           "target": "easyuse_anima/infrastructure/comfy/resources.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_folder_path_names",
         "kind": "static_from",
-        "line": 1001,
+        "line": 992,
         "name": "_folder_path_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -38317,9 +39104,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -38327,12 +39114,12 @@
         "compatibility_pair": {
           "bound_name": "EasyUseAnimaDetailerAlignHook",
           "target": "easyuse_anima/nodes/image_nodes.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.nodes.image_nodes:EasyUseAnimaDetailerAlignHook",
         "kind": "static_from",
-        "line": 1009,
+        "line": 1000,
         "name": "EasyUseAnimaDetailerAlignHook",
         "optional": false,
         "requested": "easyuse_anima.nodes.image_nodes",
@@ -38351,9 +39138,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -38361,12 +39148,12 @@
         "compatibility_pair": {
           "bound_name": "EasyUseAnimaImageScaleByMultiple",
           "target": "easyuse_anima/nodes/image_nodes.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.nodes.image_nodes:EasyUseAnimaImageScaleByMultiple",
         "kind": "static_from",
-        "line": 1009,
+        "line": 1000,
         "name": "EasyUseAnimaImageScaleByMultiple",
         "optional": false,
         "requested": "easyuse_anima.nodes.image_nodes",
@@ -38385,9 +39172,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -38395,12 +39182,12 @@
         "compatibility_pair": {
           "bound_name": "EasyUseAnimaSAM3Context",
           "target": "easyuse_anima/nodes/sam3_nodes.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Context",
         "kind": "static_from",
-        "line": 1013,
+        "line": 1004,
         "name": "EasyUseAnimaSAM3Context",
         "optional": false,
         "requested": "easyuse_anima.nodes.sam3_nodes",
@@ -38419,9 +39206,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -38429,12 +39216,12 @@
         "compatibility_pair": {
           "bound_name": "EasyUseAnimaSAM3Detailer",
           "target": "easyuse_anima/nodes/sam3_nodes.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Detailer",
         "kind": "static_from",
-        "line": 1013,
+        "line": 1004,
         "name": "EasyUseAnimaSAM3Detailer",
         "optional": false,
         "requested": "easyuse_anima.nodes.sam3_nodes",
@@ -38453,9 +39240,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -38463,12 +39250,12 @@
         "compatibility_pair": {
           "bound_name": "EasyUseAnimaPromptBuilder",
           "target": "easyuse_anima/nodes/prompt_nodes.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptBuilder",
         "kind": "static_from",
-        "line": 1017,
+        "line": 1008,
         "name": "EasyUseAnimaPromptBuilder",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -38487,9 +39274,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -38497,12 +39284,12 @@
         "compatibility_pair": {
           "bound_name": "EasyUseAnimaPromptCorrector",
           "target": "easyuse_anima/nodes/prompt_nodes.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrector",
         "kind": "static_from",
-        "line": 1017,
+        "line": 1008,
         "name": "EasyUseAnimaPromptCorrector",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -38521,9 +39308,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -38531,12 +39318,12 @@
         "compatibility_pair": {
           "bound_name": "EasyUseAnimaPromptCorrectorSimple",
           "target": "easyuse_anima/nodes/prompt_nodes.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrectorSimple",
         "kind": "static_from",
-        "line": 1017,
+        "line": 1008,
         "name": "EasyUseAnimaPromptCorrectorSimple",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -38555,9 +39342,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -38565,12 +39352,12 @@
         "compatibility_pair": {
           "bound_name": "EasyUseAnimaPromptStudio",
           "target": "easyuse_anima/nodes/prompt_nodes.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptStudio",
         "kind": "static_from",
-        "line": 1017,
+        "line": 1008,
         "name": "EasyUseAnimaPromptStudio",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -38589,9 +39376,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -38599,12 +39386,12 @@
         "compatibility_pair": {
           "bound_name": "EasyUseAnimaPromptStudioRegional",
           "target": "easyuse_anima/nodes/regional_nodes.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:EasyUseAnimaPromptStudioRegional",
         "kind": "static_from",
-        "line": 1023,
+        "line": 1014,
         "name": "EasyUseAnimaPromptStudioRegional",
         "optional": false,
         "requested": "easyuse_anima.nodes.regional_nodes",
@@ -38623,9 +39410,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -38633,12 +39420,12 @@
         "compatibility_pair": {
           "bound_name": "EasyUseAnimaRegionalConditioning",
           "target": "easyuse_anima/nodes/regional_nodes.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:EasyUseAnimaRegionalConditioning",
         "kind": "static_from",
-        "line": 1023,
+        "line": 1014,
         "name": "EasyUseAnimaRegionalConditioning",
         "optional": false,
         "requested": "easyuse_anima.nodes.regional_nodes",
@@ -38657,9 +39444,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -38667,12 +39454,12 @@
         "compatibility_pair": {
           "bound_name": "LATENT_ALIGN",
           "target": "easyuse_anima/naia/client.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.naia.client:LATENT_ALIGN",
         "kind": "static_from",
-        "line": 1027,
+        "line": 1018,
         "name": "LATENT_ALIGN",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -38691,9 +39478,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -38701,12 +39488,12 @@
         "compatibility_pair": {
           "bound_name": "_parse_random_response",
           "target": "easyuse_anima/naia/client.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_parse_random_response",
         "kind": "static_from",
-        "line": 1027,
+        "line": 1018,
         "name": "_parse_random_response",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -38725,9 +39512,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -38735,12 +39522,12 @@
         "compatibility_pair": {
           "bound_name": "_post_random",
           "target": "easyuse_anima/naia/client.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_post_random",
         "kind": "static_from",
-        "line": 1027,
+        "line": 1018,
         "name": "_post_random",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -38759,9 +39546,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -38769,12 +39556,12 @@
         "compatibility_pair": {
           "bound_name": "_advanced_resolution_from_selection",
           "target": "easyuse_anima/naia/resolution.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_advanced_resolution_from_selection",
         "kind": "static_from",
-        "line": 1045,
+        "line": 1036,
         "name": "_advanced_resolution_from_selection",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -38793,9 +39580,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -38803,12 +39590,12 @@
         "compatibility_pair": {
           "bound_name": "_normalize_resolution_bucket",
           "target": "easyuse_anima/naia/resolution.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_normalize_resolution_bucket",
         "kind": "static_from",
-        "line": 1045,
+        "line": 1036,
         "name": "_normalize_resolution_bucket",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -38827,9 +39614,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -38837,12 +39624,12 @@
         "compatibility_pair": {
           "bound_name": "_ratio_label",
           "target": "easyuse_anima/naia/resolution.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_ratio_label",
         "kind": "static_from",
-        "line": 1045,
+        "line": 1036,
         "name": "_ratio_label",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -38861,9 +39648,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -38871,12 +39658,12 @@
         "compatibility_pair": {
           "bound_name": "_resolution_label",
           "target": "easyuse_anima/naia/resolution.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolution_label",
         "kind": "static_from",
-        "line": 1045,
+        "line": 1036,
         "name": "_resolution_label",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -38895,9 +39682,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -38905,12 +39692,12 @@
         "compatibility_pair": {
           "bound_name": "_resolve_naia_resolution",
           "target": "easyuse_anima/naia/resolution.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolve_naia_resolution",
         "kind": "static_from",
-        "line": 1045,
+        "line": 1036,
         "name": "_resolve_naia_resolution",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -38929,9 +39716,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -38939,12 +39726,12 @@
         "compatibility_pair": {
           "bound_name": "EasyUseAnimaNAIARandomPrompt",
           "target": "easyuse_anima/nodes/naia_nodes.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.nodes.naia_nodes:EasyUseAnimaNAIARandomPrompt",
         "kind": "static_from",
-        "line": 1068,
+        "line": 1059,
         "name": "EasyUseAnimaNAIARandomPrompt",
         "optional": false,
         "requested": "easyuse_anima.nodes.naia_nodes",
@@ -38963,9 +39750,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -38973,12 +39760,12 @@
         "compatibility_pair": {
           "bound_name": "_bind_naia_node_runtime",
           "target": "easyuse_anima/nodes/naia_nodes.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.nodes.naia_nodes:_bind_naia_node_runtime",
         "kind": "static_from",
-        "line": 1068,
+        "line": 1059,
         "name": "_bind_naia_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.naia_nodes",
@@ -38997,9 +39784,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -39007,12 +39794,12 @@
         "compatibility_pair": {
           "bound_name": "EasyUseAnimaWildcard",
           "target": "easyuse_anima/nodes/wildcard_nodes.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.nodes.wildcard_nodes:EasyUseAnimaWildcard",
         "kind": "static_from",
-        "line": 1072,
+        "line": 1063,
         "name": "EasyUseAnimaWildcard",
         "optional": false,
         "requested": "easyuse_anima.nodes.wildcard_nodes",
@@ -39031,9 +39818,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -39041,12 +39828,12 @@
         "compatibility_pair": {
           "bound_name": "_bind_wildcard_node_runtime",
           "target": "easyuse_anima/nodes/wildcard_nodes.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.nodes.wildcard_nodes:_bind_wildcard_node_runtime",
         "kind": "static_from",
-        "line": 1072,
+        "line": 1063,
         "name": "_bind_wildcard_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.wildcard_nodes",
@@ -39065,9 +39852,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -39075,12 +39862,12 @@
         "compatibility_pair": {
           "bound_name": "_apply_lora_syntax_format",
           "target": "easyuse_anima/lora/metadata.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_apply_lora_syntax_format",
         "kind": "static_from",
-        "line": 1077,
+        "line": 1068,
         "name": "_apply_lora_syntax_format",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -39099,9 +39886,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -39109,12 +39896,12 @@
         "compatibility_pair": {
           "bound_name": "_dedupe_text_values",
           "target": "easyuse_anima/lora/metadata.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_dedupe_text_values",
         "kind": "static_from",
-        "line": 1077,
+        "line": 1068,
         "name": "_dedupe_text_values",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -39133,9 +39920,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -39143,12 +39930,12 @@
         "compatibility_pair": {
           "bound_name": "_fallback_lora_path",
           "target": "easyuse_anima/lora/metadata.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_fallback_lora_path",
         "kind": "static_from",
-        "line": 1077,
+        "line": 1068,
         "name": "_fallback_lora_path",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -39167,9 +39954,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -39177,12 +39964,12 @@
         "compatibility_pair": {
           "bound_name": "_get_lora_info",
           "target": "easyuse_anima/lora/metadata.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_get_lora_info",
         "kind": "static_from",
-        "line": 1077,
+        "line": 1068,
         "name": "_get_lora_info",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -39201,9 +39988,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -39211,12 +39998,12 @@
         "compatibility_pair": {
           "bound_name": "_get_lora_manager_trigger_words",
           "target": "easyuse_anima/lora/metadata.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_get_lora_manager_trigger_words",
         "kind": "static_from",
-        "line": 1077,
+        "line": 1068,
         "name": "_get_lora_manager_trigger_words",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -39235,9 +40022,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -39245,12 +40032,12 @@
         "compatibility_pair": {
           "bound_name": "_load_lora_manager_metadata",
           "target": "easyuse_anima/lora/metadata.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_load_lora_manager_metadata",
         "kind": "static_from",
-        "line": 1077,
+        "line": 1068,
         "name": "_load_lora_manager_metadata",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -39269,9 +40056,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -39279,12 +40066,12 @@
         "compatibility_pair": {
           "bound_name": "_lora_combo_values",
           "target": "easyuse_anima/lora/metadata.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_combo_values",
         "kind": "static_from",
-        "line": 1077,
+        "line": 1068,
         "name": "_lora_combo_values",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -39303,9 +40090,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -39313,12 +40100,12 @@
         "compatibility_pair": {
           "bound_name": "_lora_manager_trigger_words_from_metadata",
           "target": "easyuse_anima/lora/metadata.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_manager_trigger_words_from_metadata",
         "kind": "static_from",
-        "line": 1077,
+        "line": 1068,
         "name": "_lora_manager_trigger_words_from_metadata",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -39337,9 +40124,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -39347,12 +40134,12 @@
         "compatibility_pair": {
           "bound_name": "_lora_model_exists",
           "target": "easyuse_anima/lora/metadata.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_model_exists",
         "kind": "static_from",
-        "line": 1077,
+        "line": 1068,
         "name": "_lora_model_exists",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -39371,9 +40158,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -39381,12 +40168,12 @@
         "compatibility_pair": {
           "bound_name": "_lora_stack_name",
           "target": "easyuse_anima/lora/metadata.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_stack_name",
         "kind": "static_from",
-        "line": 1077,
+        "line": 1068,
         "name": "_lora_stack_name",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -39405,9 +40192,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -39415,12 +40202,12 @@
         "compatibility_pair": {
           "bound_name": "_metadata_json_paths_for_lora",
           "target": "easyuse_anima/lora/metadata.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_metadata_json_paths_for_lora",
         "kind": "static_from",
-        "line": 1077,
+        "line": 1068,
         "name": "_metadata_json_paths_for_lora",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -39439,9 +40226,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -39449,12 +40236,12 @@
         "compatibility_pair": {
           "bound_name": "_missing_lora_display_name",
           "target": "easyuse_anima/lora/metadata.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_missing_lora_display_name",
         "kind": "static_from",
-        "line": 1077,
+        "line": 1068,
         "name": "_missing_lora_display_name",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -39473,9 +40260,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -39483,12 +40270,12 @@
         "compatibility_pair": {
           "bound_name": "_raise_missing_loras",
           "target": "easyuse_anima/lora/metadata.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_raise_missing_loras",
         "kind": "static_from",
-        "line": 1077,
+        "line": 1068,
         "name": "_raise_missing_loras",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -39507,9 +40294,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -39517,12 +40304,12 @@
         "compatibility_pair": {
           "bound_name": "_trigger_words_from_value",
           "target": "easyuse_anima/lora/metadata.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_trigger_words_from_value",
         "kind": "static_from",
-        "line": 1077,
+        "line": 1068,
         "name": "_trigger_words_from_value",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -39541,9 +40328,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -39551,12 +40338,12 @@
         "compatibility_pair": {
           "bound_name": "_correct_style_prompt",
           "target": "easyuse_anima/lora/preset.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_correct_style_prompt",
         "kind": "static_from",
-        "line": 1093,
+        "line": 1084,
         "name": "_correct_style_prompt",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -39575,9 +40362,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -39585,12 +40372,12 @@
         "compatibility_pair": {
           "bound_name": "_format_strength",
           "target": "easyuse_anima/lora/preset.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_format_strength",
         "kind": "static_from",
-        "line": 1093,
+        "line": 1084,
         "name": "_format_strength",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -39609,9 +40396,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -39619,12 +40406,12 @@
         "compatibility_pair": {
           "bound_name": "_get_loras_list",
           "target": "easyuse_anima/lora/preset.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_get_loras_list",
         "kind": "static_from",
-        "line": 1093,
+        "line": 1084,
         "name": "_get_loras_list",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -39643,9 +40430,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -39653,12 +40440,12 @@
         "compatibility_pair": {
           "bound_name": "_load_profile_data",
           "target": "easyuse_anima/lora/preset.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_load_profile_data",
         "kind": "static_from",
-        "line": 1093,
+        "line": 1084,
         "name": "_load_profile_data",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -39677,9 +40464,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -39687,12 +40474,12 @@
         "compatibility_pair": {
           "bound_name": "_profile_key",
           "target": "easyuse_anima/lora/preset.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_profile_key",
         "kind": "static_from",
-        "line": 1093,
+        "line": 1084,
         "name": "_profile_key",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -39711,9 +40498,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -39721,12 +40508,12 @@
         "compatibility_pair": {
           "bound_name": "_select_profile_values",
           "target": "easyuse_anima/lora/preset.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_select_profile_values",
         "kind": "static_from",
-        "line": 1093,
+        "line": 1084,
         "name": "_select_profile_values",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -39745,9 +40532,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -39755,12 +40542,12 @@
         "compatibility_pair": {
           "bound_name": "_wrap_profile_index",
           "target": "easyuse_anima/lora/preset.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_wrap_profile_index",
         "kind": "static_from",
-        "line": 1093,
+        "line": 1084,
         "name": "_wrap_profile_index",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -39779,9 +40566,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -39789,12 +40576,12 @@
         "compatibility_pair": {
           "bound_name": "EasyUseAnimaLoraPreset",
           "target": "easyuse_anima/nodes/lora_nodes.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "easyuse_anima.nodes.lora_nodes:EasyUseAnimaLoraPreset",
         "kind": "static_from",
-        "line": 1102,
+        "line": 1093,
         "name": "EasyUseAnimaLoraPreset",
         "optional": false,
         "requested": "easyuse_anima.nodes.lora_nodes",
@@ -39813,9 +40600,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -39823,12 +40610,12 @@
         "compatibility_pair": {
           "bound_name": "correct_prompt",
           "target": "anima_prompt/__init__.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "anima_prompt:correct_prompt",
         "kind": "static_from",
-        "line": 1105,
+        "line": 1096,
         "name": "correct_prompt",
         "optional": false,
         "requested": "anima_prompt",
@@ -39847,9 +40634,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -39857,12 +40644,12 @@
         "compatibility_pair": {
           "bound_name": "load_knowledge_base",
           "target": "anima_prompt/__init__.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "anima_prompt:load_knowledge_base",
         "kind": "static_from",
-        "line": 1105,
+        "line": 1096,
         "name": "load_knowledge_base",
         "optional": false,
         "requested": "anima_prompt",
@@ -39881,9 +40668,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -39891,12 +40678,12 @@
         "compatibility_pair": {
           "bound_name": "parse_prompt",
           "target": "anima_prompt/parser.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "anima_prompt.parser:parse_prompt",
         "kind": "static_from",
-        "line": 1106,
+        "line": 1097,
         "name": "parse_prompt",
         "optional": false,
         "requested": "anima_prompt.parser",
@@ -39915,9 +40702,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -39925,12 +40712,12 @@
         "compatibility_pair": {
           "bound_name": "resolve_metadata_filter_words",
           "target": "settings.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "settings:resolve_metadata_filter_words",
         "kind": "static_from",
-        "line": 1107,
+        "line": 1098,
         "name": "resolve_metadata_filter_words",
         "optional": false,
         "requested": "settings",
@@ -39949,9 +40736,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -39959,12 +40746,12 @@
         "compatibility_pair": {
           "bound_name": "resolve_naia_settings",
           "target": "settings.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "settings:resolve_naia_settings",
         "kind": "static_from",
-        "line": 1107,
+        "line": 1098,
         "name": "resolve_naia_settings",
         "optional": false,
         "requested": "settings",
@@ -39983,9 +40770,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -39993,12 +40780,12 @@
         "compatibility_pair": {
           "bound_name": "resolve_prompt_translation_settings",
           "target": "settings.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "settings:resolve_prompt_translation_settings",
         "kind": "static_from",
-        "line": 1107,
+        "line": 1098,
         "name": "resolve_prompt_translation_settings",
         "optional": false,
         "requested": "settings",
@@ -40017,9 +40804,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -40027,12 +40814,12 @@
         "compatibility_pair": {
           "bound_name": "has_prompt_translation_markers",
           "target": "prompt_translation.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "prompt_translation:has_prompt_translation_markers",
         "kind": "static_from",
-        "line": 1112,
+        "line": 1103,
         "name": "has_prompt_translation_markers",
         "optional": false,
         "requested": "prompt_translation",
@@ -40051,9 +40838,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -40061,12 +40848,12 @@
         "compatibility_pair": {
           "bound_name": "translate_prompt_markers",
           "target": "prompt_translation.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "prompt_translation:translate_prompt_markers",
         "kind": "static_from",
-        "line": 1112,
+        "line": 1103,
         "name": "translate_prompt_markers",
         "optional": false,
         "requested": "prompt_translation",
@@ -40085,9 +40872,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -40095,12 +40882,12 @@
         "compatibility_pair": {
           "bound_name": "MAX_SEED",
           "target": "wildcard_engine.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "wildcard_engine:MAX_SEED",
         "kind": "static_from",
-        "line": 1113,
+        "line": 1104,
         "name": "MAX_SEED",
         "optional": false,
         "requested": "wildcard_engine",
@@ -40119,9 +40906,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -40129,12 +40916,12 @@
         "compatibility_pair": {
           "bound_name": "PROMPT_STUDIO_WILDCARD_MODE_LABELS",
           "target": "wildcard_engine.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "wildcard_engine:PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "kind": "static_from",
-        "line": 1113,
+        "line": 1104,
         "name": "PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "optional": false,
         "requested": "wildcard_engine",
@@ -40153,9 +40940,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -40163,12 +40950,12 @@
         "compatibility_pair": {
           "bound_name": "PUBLIC_MAX_SEED",
           "target": "wildcard_engine.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "wildcard_engine:PUBLIC_MAX_SEED",
         "kind": "static_from",
-        "line": 1113,
+        "line": 1104,
         "name": "PUBLIC_MAX_SEED",
         "optional": false,
         "requested": "wildcard_engine",
@@ -40187,9 +40974,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -40197,12 +40984,12 @@
         "compatibility_pair": {
           "bound_name": "SEED_CONTROL_DECREMENT",
           "target": "wildcard_engine.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_DECREMENT",
         "kind": "static_from",
-        "line": 1113,
+        "line": 1104,
         "name": "SEED_CONTROL_DECREMENT",
         "optional": false,
         "requested": "wildcard_engine",
@@ -40221,9 +41008,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -40231,12 +41018,12 @@
         "compatibility_pair": {
           "bound_name": "SEED_CONTROL_FIXED",
           "target": "wildcard_engine.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_FIXED",
         "kind": "static_from",
-        "line": 1113,
+        "line": 1104,
         "name": "SEED_CONTROL_FIXED",
         "optional": false,
         "requested": "wildcard_engine",
@@ -40255,9 +41042,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -40265,12 +41052,12 @@
         "compatibility_pair": {
           "bound_name": "SEED_CONTROL_INCREMENT",
           "target": "wildcard_engine.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_INCREMENT",
         "kind": "static_from",
-        "line": 1113,
+        "line": 1104,
         "name": "SEED_CONTROL_INCREMENT",
         "optional": false,
         "requested": "wildcard_engine",
@@ -40289,9 +41076,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -40299,12 +41086,12 @@
         "compatibility_pair": {
           "bound_name": "SEED_CONTROL_MODES",
           "target": "wildcard_engine.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_MODES",
         "kind": "static_from",
-        "line": 1113,
+        "line": 1104,
         "name": "SEED_CONTROL_MODES",
         "optional": false,
         "requested": "wildcard_engine",
@@ -40323,9 +41110,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -40333,12 +41120,12 @@
         "compatibility_pair": {
           "bound_name": "SEED_CONTROL_RANDOMIZE",
           "target": "wildcard_engine.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_RANDOMIZE",
         "kind": "static_from",
-        "line": 1113,
+        "line": 1104,
         "name": "SEED_CONTROL_RANDOMIZE",
         "optional": false,
         "requested": "wildcard_engine",
@@ -40357,9 +41144,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -40367,12 +41154,12 @@
         "compatibility_pair": {
           "bound_name": "WILDCARD_MODE_FIXED",
           "target": "wildcard_engine.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_FIXED",
         "kind": "static_from",
-        "line": 1113,
+        "line": 1104,
         "name": "WILDCARD_MODE_FIXED",
         "optional": false,
         "requested": "wildcard_engine",
@@ -40391,9 +41178,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -40401,12 +41188,12 @@
         "compatibility_pair": {
           "bound_name": "WILDCARD_MODE_POPULATE",
           "target": "wildcard_engine.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_POPULATE",
         "kind": "static_from",
-        "line": 1113,
+        "line": 1104,
         "name": "WILDCARD_MODE_POPULATE",
         "optional": false,
         "requested": "wildcard_engine",
@@ -40425,9 +41212,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -40435,12 +41222,12 @@
         "compatibility_pair": {
           "bound_name": "WILDCARD_MODE_SEQUENTIAL",
           "target": "wildcard_engine.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_SEQUENTIAL",
         "kind": "static_from",
-        "line": 1113,
+        "line": 1104,
         "name": "WILDCARD_MODE_SEQUENTIAL",
         "optional": false,
         "requested": "wildcard_engine",
@@ -40459,9 +41246,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -40469,12 +41256,12 @@
         "compatibility_pair": {
           "bound_name": "expand_wildcard_texts",
           "target": "wildcard_engine.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "wildcard_engine:expand_wildcard_texts",
         "kind": "static_from",
-        "line": 1113,
+        "line": 1104,
         "name": "expand_wildcard_texts",
         "optional": false,
         "requested": "wildcard_engine",
@@ -40493,9 +41280,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -40503,12 +41290,12 @@
         "compatibility_pair": {
           "bound_name": "expand_wildcards",
           "target": "wildcard_engine.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "wildcard_engine:expand_wildcards",
         "kind": "static_from",
-        "line": 1113,
+        "line": 1104,
         "name": "expand_wildcards",
         "optional": false,
         "requested": "wildcard_engine",
@@ -40527,9 +41314,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -40537,12 +41324,12 @@
         "compatibility_pair": {
           "bound_name": "has_wildcard_syntax",
           "target": "wildcard_engine.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "wildcard_engine:has_wildcard_syntax",
         "kind": "static_from",
-        "line": 1113,
+        "line": 1104,
         "name": "has_wildcard_syntax",
         "optional": false,
         "requested": "wildcard_engine",
@@ -40561,9 +41348,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -40571,12 +41358,12 @@
         "compatibility_pair": {
           "bound_name": "next_seed",
           "target": "wildcard_engine.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "wildcard_engine:next_seed",
         "kind": "static_from",
-        "line": 1113,
+        "line": 1104,
         "name": "next_seed",
         "optional": false,
         "requested": "wildcard_engine",
@@ -40595,9 +41382,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -40605,12 +41392,12 @@
         "compatibility_pair": {
           "bound_name": "normalize_prompt_studio_wildcard_mode",
           "target": "wildcard_engine.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "wildcard_engine:normalize_prompt_studio_wildcard_mode",
         "kind": "static_from",
-        "line": 1113,
+        "line": 1104,
         "name": "normalize_prompt_studio_wildcard_mode",
         "optional": false,
         "requested": "wildcard_engine",
@@ -40629,9 +41416,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -40639,12 +41426,12 @@
         "compatibility_pair": {
           "bound_name": "normalize_seed",
           "target": "wildcard_engine.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "wildcard_engine:normalize_seed",
         "kind": "static_from",
-        "line": 1113,
+        "line": 1104,
         "name": "normalize_seed",
         "optional": false,
         "requested": "wildcard_engine",
@@ -40663,9 +41450,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -40673,12 +41460,12 @@
         "compatibility_pair": {
           "bound_name": "normalize_wildcard_mode",
           "target": "wildcard_engine.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "wildcard_engine:normalize_wildcard_mode",
         "kind": "static_from",
-        "line": 1113,
+        "line": 1104,
         "name": "normalize_wildcard_mode",
         "optional": false,
         "requested": "wildcard_engine",
@@ -40697,9 +41484,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
@@ -40707,12 +41494,12 @@
         "compatibility_pair": {
           "bound_name": "wildcard_sources_signature",
           "target": "wildcard_engine.py",
-          "try_line": 8
+          "try_line": 7
         },
         "conditional": true,
         "imported": "wildcard_engine:wildcard_sources_signature",
         "kind": "static_from",
-        "line": 1113,
+        "line": 1104,
         "name": "wildcard_sources_signature",
         "optional": false,
         "requested": "wildcard_engine",
@@ -42484,7 +43271,91 @@
       },
       {
         "from": "easyuse_anima/aio/legacy_generation.py",
+        "to": "easyuse_anima/aio/conditioning.py"
+      },
+      {
+        "from": "easyuse_anima/aio/legacy_generation.py",
+        "to": "easyuse_anima/aio/first_pass_cache.py"
+      },
+      {
+        "from": "easyuse_anima/aio/legacy_generation.py",
+        "to": "easyuse_anima/aio/generation_defaults.py"
+      },
+      {
+        "from": "easyuse_anima/aio/legacy_generation.py",
+        "to": "easyuse_anima/aio/generation_normalization.py"
+      },
+      {
+        "from": "easyuse_anima/aio/legacy_generation.py",
         "to": "easyuse_anima/aio/input_context.py"
+      },
+      {
+        "from": "easyuse_anima/aio/legacy_generation.py",
+        "to": "easyuse_anima/aio/model_preparation.py"
+      },
+      {
+        "from": "easyuse_anima/aio/legacy_generation.py",
+        "to": "easyuse_anima/aio/output.py"
+      },
+      {
+        "from": "easyuse_anima/aio/legacy_generation.py",
+        "to": "easyuse_anima/aio/postprocess.py"
+      },
+      {
+        "from": "easyuse_anima/aio/legacy_generation.py",
+        "to": "easyuse_anima/aio/preview.py"
+      },
+      {
+        "from": "easyuse_anima/aio/legacy_generation.py",
+        "to": "easyuse_anima/aio/resources.py"
+      },
+      {
+        "from": "easyuse_anima/aio/legacy_generation.py",
+        "to": "easyuse_anima/aio/sampling.py"
+      },
+      {
+        "from": "easyuse_anima/aio/legacy_generation.py",
+        "to": "easyuse_anima/aio/usdu.py"
+      },
+      {
+        "from": "easyuse_anima/aio/legacy_generation.py",
+        "to": "easyuse_anima/common/values.py"
+      },
+      {
+        "from": "easyuse_anima/aio/legacy_generation.py",
+        "to": "easyuse_anima/image/geometry.py"
+      },
+      {
+        "from": "easyuse_anima/aio/legacy_generation.py",
+        "to": "easyuse_anima/image/sam3.py"
+      },
+      {
+        "from": "easyuse_anima/aio/legacy_generation.py",
+        "to": "easyuse_anima/infrastructure/comfy/invocation.py"
+      },
+      {
+        "from": "easyuse_anima/aio/legacy_generation.py",
+        "to": "easyuse_anima/infrastructure/comfy/wiring.py"
+      },
+      {
+        "from": "easyuse_anima/aio/legacy_generation.py",
+        "to": "easyuse_anima/nodes/image_nodes.py"
+      },
+      {
+        "from": "easyuse_anima/aio/legacy_generation.py",
+        "to": "easyuse_anima/nodes/sam3_nodes.py"
+      },
+      {
+        "from": "easyuse_anima/aio/legacy_generation.py",
+        "to": "easyuse_anima/prompt/artist_mix.py"
+      },
+      {
+        "from": "easyuse_anima/aio/legacy_generation.py",
+        "to": "easyuse_anima/prompt/conditioning.py"
+      },
+      {
+        "from": "easyuse_anima/aio/legacy_generation.py",
+        "to": "easyuse_anima/prompt/data.py"
       },
       {
         "from": "easyuse_anima/aio/model_preparation.py",
@@ -43233,10 +44104,6 @@
       {
         "from": "nodes.py",
         "to": "easyuse_anima/infrastructure/comfy/resources.py"
-      },
-      {
-        "from": "nodes.py",
-        "to": "easyuse_anima/infrastructure/comfy/wiring.py"
       },
       {
         "from": "nodes.py",
@@ -44264,14 +45131,14 @@
       },
       {
         "is_package": false,
-        "loc": 978,
+        "loc": 995,
         "module": "easyuse_anima.aio.legacy_generation",
-        "normalized_git_blob_sha1": "810ad3a9ba260feb721389fc47e1b5a4e76f5a9f",
+        "normalized_git_blob_sha1": "0785521ebb29768c62f0defd2f4675f71dd6d417",
         "path": "easyuse_anima/aio/legacy_generation.py",
         "top_level": {
           "class_count": 0,
-          "function_count": 9,
-          "global_count": 3
+          "function_count": 10,
+          "global_count": 2
         }
       },
       {
@@ -44996,9 +45863,9 @@
       },
       {
         "is_package": false,
-        "loc": 1162,
+        "loc": 1147,
         "module": "nodes",
-        "normalized_git_blob_sha1": "878eec7e07e2230600ad9e62fc61e6fbe2038399",
+        "normalized_git_blob_sha1": "735f1fcd3249adb58b2e64eb35d78ca264a7ec1d",
         "path": "nodes.py",
         "top_level": {
           "class_count": 0,
@@ -46546,16 +47413,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:AIO_FIRST_PASS_CACHE_MAX_ENTRIES",
         "kind": "static_from",
-        "line": 572,
+        "line": 567,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46569,16 +47436,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_AIO_FIRST_PASS_CACHE",
         "kind": "static_from",
-        "line": 572,
+        "line": 567,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46592,16 +47459,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_AIO_FIRST_PASS_CACHE_ORDER",
         "kind": "static_from",
-        "line": 572,
+        "line": 567,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46615,16 +47482,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_aio_first_pass_cache_key",
         "kind": "static_from",
-        "line": 572,
+        "line": 567,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46638,16 +47505,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_clone_aio_cache_value",
         "kind": "static_from",
-        "line": 572,
+        "line": 567,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46661,16 +47528,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_get_aio_first_pass_cache",
         "kind": "static_from",
-        "line": 572,
+        "line": 567,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46684,16 +47551,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_put_aio_first_pass_cache",
         "kind": "static_from",
-        "line": 572,
+        "line": 567,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46707,39 +47574,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
-          }
-        ],
-        "classification": "compatibility_fallback",
-        "conditional": true,
-        "imported": "easyuse_anima.aio.legacy_generation:_bind_aio_legacy_generation_runtime",
-        "kind": "static_from",
-        "line": 582,
-        "optional": false,
-        "role": "compatibility_fallback",
-        "source": "nodes.py",
-        "target": "easyuse_anima/aio/legacy_generation.py"
-      },
-      {
-        "branch_context": [
-          {
-            "branch": "except",
-            "catches_import_error": true,
-            "exceptions": [
-              "ImportError"
-            ],
-            "handler_line": 571,
-            "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_detailer_stage",
         "kind": "static_from",
-        "line": 582,
+        "line": 577,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46753,16 +47597,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_detailer_target",
         "kind": "static_from",
-        "line": 582,
+        "line": 577,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46776,16 +47620,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_highres_stage",
         "kind": "static_from",
-        "line": 582,
+        "line": 577,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46799,16 +47643,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_legacy_generation",
         "kind": "static_from",
-        "line": 582,
+        "line": 577,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46822,16 +47666,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_resshift_upscale_stage",
         "kind": "static_from",
-        "line": 582,
+        "line": 577,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46845,16 +47689,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_upscale_stage",
         "kind": "static_from",
-        "line": 582,
+        "line": 577,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46868,16 +47712,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_usdu_upscale_stage",
         "kind": "static_from",
-        "line": 582,
+        "line": 577,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46891,16 +47735,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_AIO_DETAILER_CUSTOM_RE",
         "kind": "static_from",
-        "line": 592,
+        "line": 586,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46914,16 +47758,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_AIO_DETAILER_RESERVED_KEYS",
         "kind": "static_from",
-        "line": 592,
+        "line": 586,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46937,16 +47781,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_aio_detailer_has_enabled_targets",
         "kind": "static_from",
-        "line": 592,
+        "line": 586,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46960,16 +47804,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_aio_detailer_target_defaults",
         "kind": "static_from",
-        "line": 592,
+        "line": 586,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46983,16 +47827,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_aio_detailer_target_order",
         "kind": "static_from",
-        "line": 592,
+        "line": 586,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47006,16 +47850,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_is_aio_detailer_target_name",
         "kind": "static_from",
-        "line": 592,
+        "line": 586,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47029,16 +47873,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_merge_versioned_settings",
         "kind": "static_from",
-        "line": 592,
+        "line": 586,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47052,16 +47896,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_dit_corrections_settings",
         "kind": "static_from",
-        "line": 592,
+        "line": 586,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47075,16 +47919,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_generation_settings",
         "kind": "static_from",
-        "line": 592,
+        "line": 586,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47098,16 +47942,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_seed",
         "kind": "static_from",
-        "line": 592,
+        "line": 586,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47121,16 +47965,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_spectrum_settings",
         "kind": "static_from",
-        "line": 592,
+        "line": 586,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47144,16 +47988,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_FINAL_FIT_MODES",
         "kind": "static_from",
-        "line": 605,
+        "line": 599,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47167,16 +48011,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_FINAL_UPSCALE_BACKENDS",
         "kind": "static_from",
-        "line": 605,
+        "line": 599,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47190,16 +48034,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_GENERATION_DEFAULT_SETTINGS",
         "kind": "static_from",
-        "line": 605,
+        "line": 599,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47213,16 +48057,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_GENERATION_SETTINGS_SCHEMA",
         "kind": "static_from",
-        "line": 605,
+        "line": 599,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47236,16 +48080,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_GENERATION_SETTINGS_VERSION",
         "kind": "static_from",
-        "line": 605,
+        "line": 599,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47259,16 +48103,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_RESHIFT_DTYPES",
         "kind": "static_from",
-        "line": 605,
+        "line": 599,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47282,16 +48126,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_RESHIFT_SCALES",
         "kind": "static_from",
-        "line": 605,
+        "line": 599,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47305,16 +48149,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_SPECIAL_SEEDS",
         "kind": "static_from",
-        "line": 605,
+        "line": 599,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47328,16 +48172,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_SPECIAL_SEED_DECREMENT",
         "kind": "static_from",
-        "line": 605,
+        "line": 599,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47351,16 +48195,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_SPECIAL_SEED_INCREMENT",
         "kind": "static_from",
-        "line": 605,
+        "line": 599,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47374,16 +48218,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_SPECIAL_SEED_RANDOM",
         "kind": "static_from",
-        "line": 605,
+        "line": 599,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47397,16 +48241,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_USDU_MODE_TYPES",
         "kind": "static_from",
-        "line": 605,
+        "line": 599,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47420,16 +48264,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_USDU_PROMPT_FULL",
         "kind": "static_from",
-        "line": 605,
+        "line": 599,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47443,16 +48287,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_USDU_PROMPT_MODES",
         "kind": "static_from",
-        "line": 605,
+        "line": 599,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47466,16 +48310,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_USDU_PROMPT_NO_GENERAL",
         "kind": "static_from",
-        "line": 605,
+        "line": 599,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47489,16 +48333,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_USDU_SEAM_FIX_MODES",
         "kind": "static_from",
-        "line": 605,
+        "line": 599,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47512,16 +48356,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_settings:round_trip_aio_generation_settings",
         "kind": "static_from",
-        "line": 623,
+        "line": 617,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47535,16 +48379,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.input_defaults:AIO_INPUT_DEFAULT_SETTINGS",
         "kind": "static_from",
-        "line": 626,
+        "line": 620,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47558,16 +48402,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.input_defaults:ANIMA_CLIP_DEVICES",
         "kind": "static_from",
-        "line": 626,
+        "line": 620,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47581,16 +48425,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.input_defaults:ANIMA_CLIP_TYPES",
         "kind": "static_from",
-        "line": 626,
+        "line": 620,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47604,16 +48448,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.input_defaults:ANIMA_DEFAULT_CLIP_CANDIDATES",
         "kind": "static_from",
-        "line": 626,
+        "line": 620,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47627,16 +48471,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.input_defaults:ANIMA_DEFAULT_DIFFUSION_MODEL_CANDIDATES",
         "kind": "static_from",
-        "line": 626,
+        "line": 620,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47650,16 +48494,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.input_defaults:ANIMA_DEFAULT_VAE_CANDIDATES",
         "kind": "static_from",
-        "line": 626,
+        "line": 620,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47673,16 +48517,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.input_defaults:ANIMA_UNET_WEIGHT_DTYPES",
         "kind": "static_from",
-        "line": 626,
+        "line": 620,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47696,16 +48540,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.input_defaults:EASY_USE_ANIMA_INPUT_SCHEMA",
         "kind": "static_from",
-        "line": 626,
+        "line": 620,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47719,16 +48563,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.input_defaults:EASY_USE_ANIMA_INPUT_SETTINGS_VERSION",
         "kind": "static_from",
-        "line": 626,
+        "line": 620,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47742,16 +48586,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.input_context:_easy_use_anima_input_signature",
         "kind": "static_from",
-        "line": 637,
+        "line": 631,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47765,16 +48609,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.input_context:_require_easy_use_anima_input",
         "kind": "static_from",
-        "line": 637,
+        "line": 631,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47788,16 +48632,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.usdu:_aio_usdu_auto_tile_dimension",
         "kind": "static_from",
-        "line": 641,
+        "line": 635,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47811,16 +48655,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.usdu:_aio_usdu_tile_plan",
         "kind": "static_from",
-        "line": 641,
+        "line": 635,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47834,16 +48678,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_aio_final_fit_size",
         "kind": "static_from",
-        "line": 645,
+        "line": 639,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47857,16 +48701,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_apply_aio_final_fit",
         "kind": "static_from",
-        "line": 645,
+        "line": 639,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47880,16 +48724,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_resize_image_to_size_if_needed",
         "kind": "static_from",
-        "line": 645,
+        "line": 639,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47903,16 +48747,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_run_aio_postprocess_stage",
         "kind": "static_from",
-        "line": 645,
+        "line": 639,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47926,16 +48770,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_prompt_data_fields_for_usdu",
         "kind": "static_from",
-        "line": 651,
+        "line": 645,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47949,16 +48793,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_usdu_conditioning",
         "kind": "static_from",
-        "line": 651,
+        "line": 645,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47972,16 +48816,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_usdu_prompt_without_general",
         "kind": "static_from",
-        "line": 651,
+        "line": 645,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47995,16 +48839,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_aio_lora_stack_signature",
         "kind": "static_from",
-        "line": 656,
+        "line": 650,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48018,16 +48862,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_anima_dave_patch",
         "kind": "static_from",
-        "line": 656,
+        "line": 650,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48041,16 +48885,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_kj_model_patches",
         "kind": "static_from",
-        "line": 656,
+        "line": 650,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48064,16 +48908,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_lora_stack",
         "kind": "static_from",
-        "line": 656,
+        "line": 650,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48087,16 +48931,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_model_patches",
         "kind": "static_from",
-        "line": 656,
+        "line": 650,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48110,16 +48954,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_safe_pag_patch",
         "kind": "static_from",
-        "line": 656,
+        "line": 650,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48133,16 +48977,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_correction_patch_for_comfy_sampler",
         "kind": "static_from",
-        "line": 656,
+        "line": 650,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48156,16 +49000,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_forecast_patch_for_comfy_sampler",
         "kind": "static_from",
-        "line": 656,
+        "line": 650,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48179,16 +49023,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_model_patches_for_comfy_sampler",
         "kind": "static_from",
-        "line": 656,
+        "line": 650,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48202,16 +49046,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_cleanup_aio_ephemeral_model",
         "kind": "static_from",
-        "line": 656,
+        "line": 650,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48225,16 +49069,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_normalize_aio_lora_stack",
         "kind": "static_from",
-        "line": 656,
+        "line": 650,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48248,16 +49092,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_patch_model_sampling_aura_flow",
         "kind": "static_from",
-        "line": 656,
+        "line": 650,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48271,16 +49115,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_aio_highres_effective_backend",
         "kind": "static_from",
-        "line": 670,
+        "line": 664,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48294,16 +49138,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_aio_stage_sampler_settings",
         "kind": "static_from",
-        "line": 670,
+        "line": 664,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48317,16 +49161,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_decode_latent_with_comfy",
         "kind": "static_from",
-        "line": 670,
+        "line": 664,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48340,16 +49184,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_encode_image_with_comfy_vae",
         "kind": "static_from",
-        "line": 670,
+        "line": 664,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48363,16 +49207,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_generate_empty_latent_with_comfy",
         "kind": "static_from",
-        "line": 670,
+        "line": 664,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48386,16 +49230,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_new_aio_random_seed",
         "kind": "static_from",
-        "line": 670,
+        "line": 664,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48409,16 +49253,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_resolve_aio_runtime_seed",
         "kind": "static_from",
-        "line": 670,
+        "line": 664,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48432,16 +49276,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_aio_backend",
         "kind": "static_from",
-        "line": 670,
+        "line": 664,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48455,16 +49299,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_comfy",
         "kind": "static_from",
-        "line": 670,
+        "line": 664,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48478,16 +49322,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_spectrum_mod_guidance_advanced",
         "kind": "static_from",
-        "line": 670,
+        "line": 664,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48501,16 +49345,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_spectrum_spd",
         "kind": "static_from",
-        "line": 670,
+        "line": 664,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48524,16 +49368,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_CACHE_FORMAT",
         "kind": "static_from",
-        "line": 683,
+        "line": 677,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48547,16 +49391,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_CACHE_QUALITY",
         "kind": "static_from",
-        "line": 683,
+        "line": 677,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48570,16 +49414,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_EVENT",
         "kind": "static_from",
-        "line": 683,
+        "line": 677,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48593,16 +49437,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_STAGE_LABELS",
         "kind": "static_from",
-        "line": 683,
+        "line": 677,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48616,16 +49460,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_aio_preview_base_directory",
         "kind": "static_from",
-        "line": 683,
+        "line": 677,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48639,16 +49483,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_aio_preview_file_size_bytes",
         "kind": "static_from",
-        "line": 683,
+        "line": 677,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48662,16 +49506,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_save_aio_temp_preview_image",
         "kind": "static_from",
-        "line": 683,
+        "line": 677,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48685,16 +49529,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_send_aio_preview_event",
         "kind": "static_from",
-        "line": 683,
+        "line": 677,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48708,16 +49552,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_tag_aio_preview_images",
         "kind": "static_from",
-        "line": 683,
+        "line": 677,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48731,16 +49575,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_image_saver_additional_hashes",
         "kind": "static_from",
-        "line": 694,
+        "line": 688,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48754,16 +49598,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_image_saver_civitai_hash_fetcher_entries",
         "kind": "static_from",
-        "line": 694,
+        "line": 688,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48777,16 +49621,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_lora_metadata_name",
         "kind": "static_from",
-        "line": 694,
+        "line": 688,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48800,16 +49644,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_prompt_with_lora_metadata",
         "kind": "static_from",
-        "line": 694,
+        "line": 688,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48823,16 +49667,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_save_filename_prefix",
         "kind": "static_from",
-        "line": 694,
+        "line": 688,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48846,16 +49690,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_save_image_with_comfy",
         "kind": "static_from",
-        "line": 694,
+        "line": 688,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48869,16 +49713,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_save_image_with_image_saver",
         "kind": "static_from",
-        "line": 694,
+        "line": 688,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48892,16 +49736,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.output_settings:_normalize_aio_civitai_hash_fetchers",
         "kind": "static_from",
-        "line": 703,
+        "line": 697,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48915,16 +49759,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.output_settings:_normalize_aio_hash_bundles",
         "kind": "static_from",
-        "line": 703,
+        "line": 697,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48938,16 +49782,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_clip_loader_types",
         "kind": "static_from",
-        "line": 707,
+        "line": 701,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48961,16 +49805,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_diffusion_model_names",
         "kind": "static_from",
-        "line": 707,
+        "line": 701,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48984,16 +49828,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_text_encoder_names",
         "kind": "static_from",
-        "line": 707,
+        "line": 701,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49007,16 +49851,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_vae_names",
         "kind": "static_from",
-        "line": 707,
+        "line": 701,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49030,16 +49874,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_aio_resources_from_input_context",
         "kind": "static_from",
-        "line": 707,
+        "line": 701,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49053,16 +49897,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_aio_sam3_context",
         "kind": "static_from",
-        "line": 707,
+        "line": 701,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49076,16 +49920,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_checkpoint_with_comfy",
         "kind": "static_from",
-        "line": 707,
+        "line": 701,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49099,16 +49943,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_clip_with_comfy",
         "kind": "static_from",
-        "line": 707,
+        "line": 701,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49122,16 +49966,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_diffusion_model_with_comfy",
         "kind": "static_from",
-        "line": 707,
+        "line": 701,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49145,16 +49989,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_upscale_model_with_comfy",
         "kind": "static_from",
-        "line": 707,
+        "line": 701,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49168,16 +50012,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_vae_with_comfy",
         "kind": "static_from",
-        "line": 707,
+        "line": 701,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49191,16 +50035,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_normalize_aio_input_settings",
         "kind": "static_from",
-        "line": 707,
+        "line": 701,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49214,16 +50058,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_checkpoint_default",
         "kind": "static_from",
-        "line": 707,
+        "line": 701,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49237,16 +50081,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_clip_type_default",
         "kind": "static_from",
-        "line": 707,
+        "line": 701,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49260,16 +50104,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_name_default",
         "kind": "static_from",
-        "line": 707,
+        "line": 701,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49283,16 +50127,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_json_clone",
         "kind": "static_from",
-        "line": 724,
+        "line": 718,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49306,16 +50150,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_json_object",
         "kind": "static_from",
-        "line": 724,
+        "line": 718,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49329,16 +50173,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_stable_change_key",
         "kind": "static_from",
-        "line": 724,
+        "line": 718,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49352,16 +50196,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_bool",
         "kind": "static_from",
-        "line": 729,
+        "line": 723,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49375,16 +50219,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_float",
         "kind": "static_from",
-        "line": 729,
+        "line": 723,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49398,16 +50242,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_int",
         "kind": "static_from",
-        "line": 729,
+        "line": 723,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49421,16 +50265,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.common.values:_choice",
         "kind": "static_from",
-        "line": 729,
+        "line": 723,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49444,16 +50288,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.common.values:_single_value",
         "kind": "static_from",
-        "line": 729,
+        "line": 723,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49467,16 +50311,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.seed.compatibility:WILDCARD_QUEUE_MAX_SAFE_SEED",
         "kind": "static_from",
-        "line": 736,
+        "line": 730,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49490,16 +50334,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.seed.compatibility:WILDCARD_RESERVED_NEXT_SEED_INPUT",
         "kind": "static_from",
-        "line": 736,
+        "line": 730,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49513,16 +50357,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.seed.compatibility:_consume_reserved_wildcard_next_seed",
         "kind": "static_from",
-        "line": 736,
+        "line": 730,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49536,16 +50380,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.workflow:_get_workflow_node",
         "kind": "static_from",
-        "line": 741,
+        "line": 735,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49559,16 +50403,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_prompt_translation_change_key",
         "kind": "static_from",
-        "line": 742,
+        "line": 736,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49582,16 +50426,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_split_tag_text",
         "kind": "static_from",
-        "line": 742,
+        "line": 736,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49605,16 +50449,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_translate_prompt_text",
         "kind": "static_from",
-        "line": 742,
+        "line": 736,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49628,16 +50472,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_HASH_COMMENT_RE",
         "kind": "static_from",
-        "line": 747,
+        "line": 741,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49651,16 +50495,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_INLINE_SPACE_RE",
         "kind": "static_from",
-        "line": 747,
+        "line": 741,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49674,16 +50518,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_WEIGHTED_TOKEN_RE",
         "kind": "static_from",
-        "line": 747,
+        "line": 741,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49697,16 +50541,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_correct_builder_prompt",
         "kind": "static_from",
-        "line": 747,
+        "line": 741,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49720,16 +50564,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_filter_metadata_prompt",
         "kind": "static_from",
-        "line": 747,
+        "line": 741,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49743,16 +50587,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_join_prompt_tokens",
         "kind": "static_from",
-        "line": 747,
+        "line": 741,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49766,16 +50610,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_metadata_filter_key",
         "kind": "static_from",
-        "line": 747,
+        "line": 741,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49789,16 +50633,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_metadata_filter_keys",
         "kind": "static_from",
-        "line": 747,
+        "line": 741,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49812,16 +50656,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_prompt_tokens",
         "kind": "static_from",
-        "line": 747,
+        "line": 741,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49835,16 +50679,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:PROMPT_DATA_TYPE",
         "kind": "static_from",
-        "line": 760,
+        "line": 754,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49858,16 +50702,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_advanced_outputs_from_prompt_data",
         "kind": "static_from",
-        "line": 760,
+        "line": 754,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49881,16 +50725,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_apply_prompt_data_overrides",
         "kind": "static_from",
-        "line": 760,
+        "line": 754,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49904,16 +50748,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_copy_prompt_data_for_update",
         "kind": "static_from",
-        "line": 760,
+        "line": 754,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49927,16 +50771,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_normalize_prompt_data",
         "kind": "static_from",
-        "line": 760,
+        "line": 754,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49950,16 +50794,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_prompt_data_json_safe",
         "kind": "static_from",
-        "line": 760,
+        "line": 754,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49973,16 +50817,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_prompt_data_parameter_snapshot",
         "kind": "static_from",
-        "line": 760,
+        "line": 754,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49996,16 +50840,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_artist_field_prompt",
         "kind": "static_from",
-        "line": 778,
+        "line": 772,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50019,16 +50863,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_default_fields",
         "kind": "static_from",
-        "line": 778,
+        "line": 772,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50042,16 +50886,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_enabled_naia_panes",
         "kind": "static_from",
-        "line": 778,
+        "line": 772,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50065,16 +50909,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_enabled_pane_fields",
         "kind": "static_from",
-        "line": 778,
+        "line": 772,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50088,16 +50932,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_field_input_values",
         "kind": "static_from",
-        "line": 778,
+        "line": 772,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50111,16 +50955,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_field_socket_name",
         "kind": "static_from",
-        "line": 778,
+        "line": 772,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50134,16 +50978,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_fields_json",
         "kind": "static_from",
-        "line": 778,
+        "line": 772,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50157,16 +51001,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_has_enabled_naia",
         "kind": "static_from",
-        "line": 778,
+        "line": 772,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50180,16 +51024,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_prompt_with_artist_override",
         "kind": "static_from",
-        "line": 778,
+        "line": 772,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50203,16 +51047,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_uses_naia_resolution",
         "kind": "static_from",
-        "line": 778,
+        "line": 772,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50226,16 +51070,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_apply_advanced_field_inputs",
         "kind": "static_from",
-        "line": 778,
+        "line": 772,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50249,16 +51093,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_as_advanced_height",
         "kind": "static_from",
-        "line": 778,
+        "line": 772,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50272,16 +51116,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_build_advanced_prompt_data",
         "kind": "static_from",
-        "line": 778,
+        "line": 772,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50295,16 +51139,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_build_advanced_prompts",
         "kind": "static_from",
-        "line": 778,
+        "line": 772,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50318,16 +51162,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_clone_advanced_fields",
         "kind": "static_from",
-        "line": 778,
+        "line": 772,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50341,16 +51185,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_correct_advanced_field_sequence",
         "kind": "static_from",
-        "line": 778,
+        "line": 772,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50364,16 +51208,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_expand_advanced_wildcard_fields",
         "kind": "static_from",
-        "line": 778,
+        "line": 772,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50387,16 +51231,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_normalize_advanced_fields",
         "kind": "static_from",
-        "line": 778,
+        "line": 772,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50410,16 +51254,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_normalize_prompt_studio_wildcard_seed_control",
         "kind": "static_from",
-        "line": 778,
+        "line": 772,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50433,16 +51277,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_set_naia_field_text",
         "kind": "static_from",
-        "line": 778,
+        "line": 772,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50456,16 +51300,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_translate_prompt_fields",
         "kind": "static_from",
-        "line": 778,
+        "line": 772,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50479,16 +51323,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_apply_regional_field_inputs",
         "kind": "static_from",
-        "line": 813,
+        "line": 807,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50502,16 +51346,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_build_regional_outputs",
         "kind": "static_from",
-        "line": 813,
+        "line": 807,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50525,16 +51369,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_clone_regional_fields",
         "kind": "static_from",
-        "line": 813,
+        "line": 807,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50548,16 +51392,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_conditioning_set_values",
         "kind": "static_from",
-        "line": 813,
+        "line": 807,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50571,16 +51415,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_mask_ids",
         "kind": "static_from",
-        "line": 813,
+        "line": 807,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50594,16 +51438,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_regional_config",
         "kind": "static_from",
-        "line": 813,
+        "line": 807,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50617,16 +51461,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_regional_fields",
         "kind": "static_from",
-        "line": 813,
+        "line": 807,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50640,16 +51484,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_parse_json_object",
         "kind": "static_from",
-        "line": 813,
+        "line": 807,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50663,16 +51507,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_config_json",
         "kind": "static_from",
-        "line": 813,
+        "line": 807,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50686,16 +51530,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_fields_json",
         "kind": "static_from",
-        "line": 813,
+        "line": 807,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50709,16 +51553,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_mask_bounds_area",
         "kind": "static_from",
-        "line": 813,
+        "line": 807,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50732,16 +51576,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_payload_canvas",
         "kind": "static_from",
-        "line": 813,
+        "line": 807,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50755,16 +51599,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_union_mask_for_ids",
         "kind": "static_from",
-        "line": 813,
+        "line": 807,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50778,16 +51622,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
         "kind": "static_from",
-        "line": 840,
+        "line": 834,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50801,16 +51645,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODES",
         "kind": "static_from",
-        "line": 840,
+        "line": 834,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50824,16 +51668,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 840,
+        "line": 834,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50847,16 +51691,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_PROFILE_OFF",
         "kind": "static_from",
-        "line": 840,
+        "line": 834,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50870,16 +51714,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_apply_spectrum_anima_mod_guidance",
         "kind": "static_from",
-        "line": 840,
+        "line": 834,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50893,16 +51737,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_find_spectrum_anima_mod_guidance_class",
         "kind": "static_from",
-        "line": 840,
+        "line": 834,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50916,16 +51760,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_normalize_anima_mod_guidance_profile",
         "kind": "static_from",
-        "line": 840,
+        "line": 834,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50939,16 +51783,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_resolve_anima_mod_guidance_enabled",
         "kind": "static_from",
-        "line": 840,
+        "line": 834,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50962,16 +51806,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
         "kind": "static_from",
-        "line": 855,
+        "line": 849,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50985,16 +51829,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
         "kind": "static_from",
-        "line": 855,
+        "line": 849,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51008,16 +51852,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
         "kind": "static_from",
-        "line": 855,
+        "line": 849,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51031,16 +51875,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_EXACT_TOP_K",
         "kind": "static_from",
-        "line": 855,
+        "line": 849,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51054,16 +51898,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
         "kind": "static_from",
-        "line": 855,
+        "line": 849,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51077,16 +51921,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_START_PERCENT",
         "kind": "static_from",
-        "line": 855,
+        "line": 849,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51100,16 +51944,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
         "kind": "static_from",
-        "line": 855,
+        "line": 849,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51123,16 +51967,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STYLE_GAIN",
         "kind": "static_from",
-        "line": 855,
+        "line": 849,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51146,16 +51990,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_INPUT_MODES",
         "kind": "static_from",
-        "line": 855,
+        "line": 849,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51169,16 +52013,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 855,
+        "line": 849,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51192,16 +52036,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_mix_inline_prompt",
         "kind": "static_from",
-        "line": 855,
+        "line": 849,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51215,16 +52059,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_mix_mode_tooltip",
         "kind": "static_from",
-        "line": 855,
+        "line": 849,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51238,16 +52082,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_prompt_with_position",
         "kind": "static_from",
-        "line": 855,
+        "line": 849,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51261,16 +52105,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_tags_from_prompt",
         "kind": "static_from",
-        "line": 855,
+        "line": 849,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51284,16 +52128,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_blend_conditionings",
         "kind": "static_from",
-        "line": 855,
+        "line": 849,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51307,16 +52151,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bounded_artist_mix_float",
         "kind": "static_from",
-        "line": 855,
+        "line": 849,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51330,16 +52174,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bounded_artist_mix_int",
         "kind": "static_from",
-        "line": 855,
+        "line": 849,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51353,16 +52197,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_clustered",
         "kind": "static_from",
-        "line": 855,
+        "line": 849,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51376,16 +52220,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_delta_rms",
         "kind": "static_from",
-        "line": 855,
+        "line": 849,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51399,16 +52243,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_prompt_data_positive_conditioning",
         "kind": "static_from",
-        "line": 855,
+        "line": 849,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51422,16 +52266,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_join_artist_mix_source_prompts",
         "kind": "static_from",
-        "line": 855,
+        "line": 849,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51445,16 +52289,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_normalize_artist_mix_mode",
         "kind": "static_from",
-        "line": 855,
+        "line": 849,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51468,16 +52312,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_normalize_artist_tag_position",
         "kind": "static_from",
-        "line": 855,
+        "line": 849,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51491,16 +52335,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_parse_artist_mix_items",
         "kind": "static_from",
-        "line": 855,
+        "line": 849,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51514,16 +52358,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaArtistMixConditioning",
         "kind": "static_from",
-        "line": 934,
+        "line": 928,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51537,16 +52381,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataConditioning",
         "kind": "static_from",
-        "line": 934,
+        "line": 928,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51560,16 +52404,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataUnpack",
         "kind": "static_from",
-        "line": 934,
+        "line": 928,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51583,16 +52427,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_ANY_TYPE",
         "kind": "static_from",
-        "line": 939,
+        "line": 933,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51606,16 +52450,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_AnyType",
         "kind": "static_from",
-        "line": 939,
+        "line": 933,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51629,16 +52473,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_FlexibleOptionalInputType",
         "kind": "static_from",
-        "line": 939,
+        "line": 933,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51652,16 +52496,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvanced",
         "kind": "static_from",
-        "line": 944,
+        "line": 938,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51675,16 +52519,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvancedV2",
         "kind": "static_from",
-        "line": 944,
+        "line": 938,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51698,16 +52542,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:EasyUseAnimaAIOGenerator",
         "kind": "static_from",
-        "line": 949,
+        "line": 943,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51721,16 +52565,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:EasyUseAnimaInput",
         "kind": "static_from",
-        "line": 949,
+        "line": 943,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51744,16 +52588,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_aio_generation_settings_json",
         "kind": "static_from",
-        "line": 949,
+        "line": 943,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51767,16 +52611,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_aio_input_settings_json",
         "kind": "static_from",
-        "line": 949,
+        "line": 943,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51790,16 +52634,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_bind_aio_node_runtime",
         "kind": "static_from",
-        "line": 949,
+        "line": 943,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51813,16 +52657,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_align_down",
         "kind": "static_from",
-        "line": 956,
+        "line": 950,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51836,16 +52680,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_align_nearest",
         "kind": "static_from",
-        "line": 956,
+        "line": 950,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51859,16 +52703,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_image_tensor_size",
         "kind": "static_from",
-        "line": 956,
+        "line": 950,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51882,16 +52726,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_context_value",
         "kind": "static_from",
-        "line": 967,
+        "line": 961,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51905,16 +52749,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_sam3_context",
         "kind": "static_from",
-        "line": 967,
+        "line": 961,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51928,16 +52772,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_segs_has_items",
         "kind": "static_from",
-        "line": 967,
+        "line": 961,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51951,16 +52795,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:IMAGE_SCALE_MULTIPLES",
         "kind": "static_from",
-        "line": 979,
+        "line": 973,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51974,16 +52818,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:IMAGE_UPSCALE_METHODS",
         "kind": "static_from",
-        "line": 979,
+        "line": 973,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51997,16 +52841,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_sampler_names",
         "kind": "static_from",
-        "line": 987,
+        "line": 981,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52020,16 +52864,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_scheduler_names",
         "kind": "static_from",
-        "line": 987,
+        "line": 981,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52043,16 +52887,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_impact_scheduler_names",
         "kind": "static_from",
-        "line": 987,
+        "line": 981,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52066,16 +52910,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_call_with_supported_kwargs",
         "kind": "static_from",
-        "line": 993,
+        "line": 987,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52089,16 +52933,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_common_upscale_image",
         "kind": "static_from",
-        "line": 993,
+        "line": 987,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52112,16 +52956,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_node_output_tuple",
         "kind": "static_from",
-        "line": 993,
+        "line": 987,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52135,39 +52979,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
-          }
-        ],
-        "classification": "compatibility_fallback",
-        "conditional": true,
-        "imported": "easyuse_anima.infrastructure.comfy.wiring:resolve_comfy_host_helper",
-        "kind": "static_from",
-        "line": 998,
-        "optional": false,
-        "role": "compatibility_fallback",
-        "source": "nodes.py",
-        "target": "easyuse_anima/infrastructure/comfy/wiring.py"
-      },
-      {
-        "branch_context": [
-          {
-            "branch": "except",
-            "catches_import_error": true,
-            "exceptions": [
-              "ImportError"
-            ],
-            "handler_line": 571,
-            "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_clip_loader_types",
         "kind": "static_from",
-        "line": 1001,
+        "line": 992,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52181,16 +53002,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_diffusion_model_names",
         "kind": "static_from",
-        "line": 1001,
+        "line": 992,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52204,16 +53025,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_text_encoder_names",
         "kind": "static_from",
-        "line": 1001,
+        "line": 992,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52227,16 +53048,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_vae_names",
         "kind": "static_from",
-        "line": 1001,
+        "line": 992,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52250,16 +53071,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_folder_path_names",
         "kind": "static_from",
-        "line": 1001,
+        "line": 992,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52273,16 +53094,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.nodes.image_nodes:EasyUseAnimaDetailerAlignHook",
         "kind": "static_from",
-        "line": 1009,
+        "line": 1000,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52296,16 +53117,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.nodes.image_nodes:EasyUseAnimaImageScaleByMultiple",
         "kind": "static_from",
-        "line": 1009,
+        "line": 1000,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52319,16 +53140,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Context",
         "kind": "static_from",
-        "line": 1013,
+        "line": 1004,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52342,16 +53163,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Detailer",
         "kind": "static_from",
-        "line": 1013,
+        "line": 1004,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52365,16 +53186,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptBuilder",
         "kind": "static_from",
-        "line": 1017,
+        "line": 1008,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52388,16 +53209,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrector",
         "kind": "static_from",
-        "line": 1017,
+        "line": 1008,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52411,16 +53232,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrectorSimple",
         "kind": "static_from",
-        "line": 1017,
+        "line": 1008,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52434,16 +53255,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptStudio",
         "kind": "static_from",
-        "line": 1017,
+        "line": 1008,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52457,16 +53278,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:EasyUseAnimaPromptStudioRegional",
         "kind": "static_from",
-        "line": 1023,
+        "line": 1014,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52480,16 +53301,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:EasyUseAnimaRegionalConditioning",
         "kind": "static_from",
-        "line": 1023,
+        "line": 1014,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52503,16 +53324,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.naia.client:LATENT_ALIGN",
         "kind": "static_from",
-        "line": 1027,
+        "line": 1018,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52526,16 +53347,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_parse_random_response",
         "kind": "static_from",
-        "line": 1027,
+        "line": 1018,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52549,16 +53370,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_post_random",
         "kind": "static_from",
-        "line": 1027,
+        "line": 1018,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52572,16 +53393,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_advanced_resolution_from_selection",
         "kind": "static_from",
-        "line": 1045,
+        "line": 1036,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52595,16 +53416,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_normalize_resolution_bucket",
         "kind": "static_from",
-        "line": 1045,
+        "line": 1036,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52618,16 +53439,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_ratio_label",
         "kind": "static_from",
-        "line": 1045,
+        "line": 1036,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52641,16 +53462,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolution_label",
         "kind": "static_from",
-        "line": 1045,
+        "line": 1036,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52664,16 +53485,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolve_naia_resolution",
         "kind": "static_from",
-        "line": 1045,
+        "line": 1036,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52687,16 +53508,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.nodes.naia_nodes:EasyUseAnimaNAIARandomPrompt",
         "kind": "static_from",
-        "line": 1068,
+        "line": 1059,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52710,16 +53531,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.nodes.naia_nodes:_bind_naia_node_runtime",
         "kind": "static_from",
-        "line": 1068,
+        "line": 1059,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52733,16 +53554,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.nodes.wildcard_nodes:EasyUseAnimaWildcard",
         "kind": "static_from",
-        "line": 1072,
+        "line": 1063,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52756,16 +53577,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.nodes.wildcard_nodes:_bind_wildcard_node_runtime",
         "kind": "static_from",
-        "line": 1072,
+        "line": 1063,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52779,16 +53600,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_apply_lora_syntax_format",
         "kind": "static_from",
-        "line": 1077,
+        "line": 1068,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52802,16 +53623,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_dedupe_text_values",
         "kind": "static_from",
-        "line": 1077,
+        "line": 1068,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52825,16 +53646,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_fallback_lora_path",
         "kind": "static_from",
-        "line": 1077,
+        "line": 1068,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52848,16 +53669,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_get_lora_info",
         "kind": "static_from",
-        "line": 1077,
+        "line": 1068,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52871,16 +53692,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_get_lora_manager_trigger_words",
         "kind": "static_from",
-        "line": 1077,
+        "line": 1068,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52894,16 +53715,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_load_lora_manager_metadata",
         "kind": "static_from",
-        "line": 1077,
+        "line": 1068,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52917,16 +53738,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_combo_values",
         "kind": "static_from",
-        "line": 1077,
+        "line": 1068,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52940,16 +53761,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_manager_trigger_words_from_metadata",
         "kind": "static_from",
-        "line": 1077,
+        "line": 1068,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52963,16 +53784,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_model_exists",
         "kind": "static_from",
-        "line": 1077,
+        "line": 1068,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52986,16 +53807,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_stack_name",
         "kind": "static_from",
-        "line": 1077,
+        "line": 1068,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53009,16 +53830,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_metadata_json_paths_for_lora",
         "kind": "static_from",
-        "line": 1077,
+        "line": 1068,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53032,16 +53853,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_missing_lora_display_name",
         "kind": "static_from",
-        "line": 1077,
+        "line": 1068,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53055,16 +53876,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_raise_missing_loras",
         "kind": "static_from",
-        "line": 1077,
+        "line": 1068,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53078,16 +53899,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_trigger_words_from_value",
         "kind": "static_from",
-        "line": 1077,
+        "line": 1068,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53101,16 +53922,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_correct_style_prompt",
         "kind": "static_from",
-        "line": 1093,
+        "line": 1084,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53124,16 +53945,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_format_strength",
         "kind": "static_from",
-        "line": 1093,
+        "line": 1084,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53147,16 +53968,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_get_loras_list",
         "kind": "static_from",
-        "line": 1093,
+        "line": 1084,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53170,16 +53991,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_load_profile_data",
         "kind": "static_from",
-        "line": 1093,
+        "line": 1084,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53193,16 +54014,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_profile_key",
         "kind": "static_from",
-        "line": 1093,
+        "line": 1084,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53216,16 +54037,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_select_profile_values",
         "kind": "static_from",
-        "line": 1093,
+        "line": 1084,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53239,16 +54060,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_wrap_profile_index",
         "kind": "static_from",
-        "line": 1093,
+        "line": 1084,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53262,16 +54083,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.nodes.lora_nodes:EasyUseAnimaLoraPreset",
         "kind": "static_from",
-        "line": 1102,
+        "line": 1093,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53285,16 +54106,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "anima_prompt:correct_prompt",
         "kind": "static_from",
-        "line": 1105,
+        "line": 1096,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53308,16 +54129,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "anima_prompt:load_knowledge_base",
         "kind": "static_from",
-        "line": 1105,
+        "line": 1096,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53331,16 +54152,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "anima_prompt.parser:parse_prompt",
         "kind": "static_from",
-        "line": 1106,
+        "line": 1097,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53354,16 +54175,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "settings:resolve_metadata_filter_words",
         "kind": "static_from",
-        "line": 1107,
+        "line": 1098,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53377,16 +54198,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "settings:resolve_naia_settings",
         "kind": "static_from",
-        "line": 1107,
+        "line": 1098,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53400,16 +54221,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "settings:resolve_prompt_translation_settings",
         "kind": "static_from",
-        "line": 1107,
+        "line": 1098,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53423,16 +54244,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "prompt_translation:has_prompt_translation_markers",
         "kind": "static_from",
-        "line": 1112,
+        "line": 1103,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53446,16 +54267,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "prompt_translation:translate_prompt_markers",
         "kind": "static_from",
-        "line": 1112,
+        "line": 1103,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53469,16 +54290,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "wildcard_engine:MAX_SEED",
         "kind": "static_from",
-        "line": 1113,
+        "line": 1104,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53492,16 +54313,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "wildcard_engine:PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "kind": "static_from",
-        "line": 1113,
+        "line": 1104,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53515,16 +54336,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "wildcard_engine:PUBLIC_MAX_SEED",
         "kind": "static_from",
-        "line": 1113,
+        "line": 1104,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53538,16 +54359,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_DECREMENT",
         "kind": "static_from",
-        "line": 1113,
+        "line": 1104,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53561,16 +54382,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_FIXED",
         "kind": "static_from",
-        "line": 1113,
+        "line": 1104,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53584,16 +54405,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_INCREMENT",
         "kind": "static_from",
-        "line": 1113,
+        "line": 1104,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53607,16 +54428,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_MODES",
         "kind": "static_from",
-        "line": 1113,
+        "line": 1104,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53630,16 +54451,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_RANDOMIZE",
         "kind": "static_from",
-        "line": 1113,
+        "line": 1104,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53653,16 +54474,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_FIXED",
         "kind": "static_from",
-        "line": 1113,
+        "line": 1104,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53676,16 +54497,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_POPULATE",
         "kind": "static_from",
-        "line": 1113,
+        "line": 1104,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53699,16 +54520,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_SEQUENTIAL",
         "kind": "static_from",
-        "line": 1113,
+        "line": 1104,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53722,16 +54543,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "wildcard_engine:expand_wildcard_texts",
         "kind": "static_from",
-        "line": 1113,
+        "line": 1104,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53745,16 +54566,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "wildcard_engine:expand_wildcards",
         "kind": "static_from",
-        "line": 1113,
+        "line": 1104,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53768,16 +54589,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "wildcard_engine:has_wildcard_syntax",
         "kind": "static_from",
-        "line": 1113,
+        "line": 1104,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53791,16 +54612,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "wildcard_engine:next_seed",
         "kind": "static_from",
-        "line": 1113,
+        "line": 1104,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53814,16 +54635,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "wildcard_engine:normalize_prompt_studio_wildcard_mode",
         "kind": "static_from",
-        "line": 1113,
+        "line": 1104,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53837,16 +54658,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "wildcard_engine:normalize_seed",
         "kind": "static_from",
-        "line": 1113,
+        "line": 1104,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53860,16 +54681,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "wildcard_engine:normalize_wildcard_mode",
         "kind": "static_from",
-        "line": 1113,
+        "line": 1104,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53883,16 +54704,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 566,
             "kind": "try",
-            "line": 8
+            "line": 7
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "wildcard_engine:wildcard_sources_signature",
         "kind": "static_from",
-        "line": 1113,
+        "line": 1104,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -55302,9 +56123,31 @@
         "branch_context": [],
         "classification": "external",
         "conditional": false,
-        "imported": "collections.abc:Callable",
-        "kind": "static_from",
+        "imported": "json",
+        "kind": "static_import",
         "line": 3,
+        "optional": false,
+        "role": "ordinary",
+        "source": "easyuse_anima/aio/legacy_generation.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "logging",
+        "kind": "static_import",
+        "line": 4,
+        "optional": false,
+        "role": "ordinary",
+        "source": "easyuse_anima/aio/legacy_generation.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "random",
+        "kind": "static_import",
+        "line": 5,
         "optional": false,
         "role": "ordinary",
         "source": "easyuse_anima/aio/legacy_generation.py"
@@ -55315,7 +56158,7 @@
         "conditional": false,
         "imported": "typing:Any",
         "kind": "static_from",
-        "line": 4,
+        "line": 6,
         "optional": false,
         "role": "ordinary",
         "source": "easyuse_anima/aio/legacy_generation.py"
@@ -57790,17 +58633,6 @@
         "branch_context": [],
         "classification": "external",
         "conditional": false,
-        "imported": "random",
-        "kind": "static_import",
-        "line": 6,
-        "optional": false,
-        "role": "ordinary",
-        "source": "nodes.py"
-      },
-      {
-        "branch_context": [],
-        "classification": "external",
-        "conditional": false,
         "imported": "__future__:annotations",
         "kind": "static_from",
         "line": 1,
@@ -60250,6 +61082,15 @@
         "column": 9,
         "context": "assign:logger",
         "kind": "import_time_call",
+        "line": 76,
+        "module": "easyuse_anima/aio/legacy_generation.py",
+        "scope": "<module>"
+      },
+      {
+        "callee": "logging.getLogger",
+        "column": 9,
+        "context": "assign:logger",
+        "kind": "import_time_call",
         "line": 17,
         "module": "easyuse_anima/aio/model_preparation.py",
         "scope": "<module>"
@@ -60556,16 +61397,7 @@
         "column": 9,
         "context": "assign:logger",
         "kind": "import_time_call",
-        "line": 1135,
-        "module": "nodes.py",
-        "scope": "<module>"
-      },
-      {
-        "callee": "_bind_aio_legacy_generation_runtime",
-        "column": 0,
-        "context": "expression",
-        "kind": "import_time_call",
-        "line": 1141,
+        "line": 1126,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -60574,7 +61406,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1147,
+        "line": 1132,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -60583,7 +61415,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1150,
+        "line": 1135,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -60592,7 +61424,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1157,
+        "line": 1142,
         "module": "nodes.py",
         "scope": "<module>"
       },

--- a/tests/fixtures/python_compatibility_surface.v1.json
+++ b/tests/fixtures/python_compatibility_surface.v1.json
@@ -79,7 +79,8 @@
       "B-11c30d2",
       "B-11c30d3",
       "B-11c30d4",
-      "B-11c30d0b"
+      "B-11c30d0b",
+      "B-11c30d5"
     ]
   },
   "enums": {
@@ -113,15 +114,15 @@
   },
   "expected_counts": {
     "root_entrypoints": 3,
-    "excluded_preamble_implementation_bindings": 3,
-    "nodes_canonical_bindings": 293,
+    "excluded_preamble_implementation_bindings": 2,
+    "nodes_canonical_bindings": 291,
     "nodes_legacy_bindings": 27,
     "mapped_public_classes": 18,
     "unmapped_classes": 2,
     "root_residual_functions": 0,
     "root_residual_classes": 0,
     "root_residual_globals": 3,
-    "runtime_binders": 4,
+    "runtime_binders": 3,
     "direct_nodes_import_test_files": 21
   },
   "mapped_public_classes": [
@@ -150,11 +151,9 @@
   ],
   "excluded_preamble_implementation_bindings": {
     "json": "json:json",
-    "logging": "logging:logging",
-    "random": "random:random"
+    "logging": "logging:logging"
   },
   "runtime_binders": [
-    "_bind_aio_legacy_generation_runtime",
     "_bind_aio_node_runtime",
     "_bind_wildcard_node_runtime",
     "_bind_naia_node_runtime"
@@ -169,9 +168,6 @@
     "AIO_SPECIAL_SEEDS": [
       "easyuse_anima.nodes.aio_nodes"
     ],
-    "AIO_USDU_PROMPT_FULL": [
-      "easyuse_anima.aio.legacy_generation"
-    ],
     "ANIMA_DEFAULT_CLIP_CANDIDATES": [
       "easyuse_anima.nodes.aio_nodes"
     ],
@@ -180,9 +176,6 @@
     ],
     "ANIMA_DEFAULT_VAE_CANDIDATES": [
       "easyuse_anima.nodes.aio_nodes"
-    ],
-    "ANIMA_MOD_GUIDANCE_PROFILE_OFF": [
-      "easyuse_anima.aio.legacy_generation"
     ],
     "EASY_USE_ANIMA_INPUT_SCHEMA": [
       "easyuse_anima.nodes.aio_nodes"
@@ -193,74 +186,17 @@
     "EASY_USE_ANIMA_INPUT_TYPE": [
       "easyuse_anima.nodes.aio_nodes"
     ],
-    "EasyUseAnimaImageScaleByMultiple": [
-      "easyuse_anima.aio.legacy_generation"
-    ],
-    "EasyUseAnimaSAM3Detailer": [
-      "easyuse_anima.aio.legacy_generation"
-    ],
     "PROMPT_DATA_TYPE": [
       "easyuse_anima.nodes.aio_nodes"
     ],
-    "_advanced_outputs_from_prompt_data": [
-      "easyuse_anima.aio.legacy_generation"
-    ],
-    "_aio_detailer_has_enabled_targets": [
-      "easyuse_anima.aio.legacy_generation"
-    ],
-    "_aio_detailer_target_order": [
-      "easyuse_anima.aio.legacy_generation"
-    ],
-    "_aio_first_pass_cache_key": [
-      "easyuse_anima.aio.legacy_generation"
-    ],
     "_aio_generation_settings_json": [
       "easyuse_anima.nodes.aio_nodes"
-    ],
-    "_aio_highres_effective_backend": [
-      "easyuse_anima.aio.legacy_generation"
     ],
     "_aio_input_settings_json": [
       "easyuse_anima.nodes.aio_nodes"
     ],
     "_aio_lora_stack_signature": [
       "easyuse_anima.nodes.aio_nodes"
-    ],
-    "_aio_save_filename_prefix": [
-      "easyuse_anima.aio.legacy_generation"
-    ],
-    "_aio_stage_sampler_settings": [
-      "easyuse_anima.aio.legacy_generation"
-    ],
-    "_aio_usdu_conditioning": [
-      "easyuse_anima.aio.legacy_generation"
-    ],
-    "_aio_usdu_tile_plan": [
-      "easyuse_anima.aio.legacy_generation"
-    ],
-    "_apply_aio_lora_stack": [
-      "easyuse_anima.aio.legacy_generation"
-    ],
-    "_apply_aio_model_patches": [
-      "easyuse_anima.aio.legacy_generation"
-    ],
-    "_apply_aio_spectrum_model_patches_for_comfy_sampler": [
-      "easyuse_anima.aio.legacy_generation"
-    ],
-    "_apply_spectrum_anima_mod_guidance": [
-      "easyuse_anima.aio.legacy_generation"
-    ],
-    "_as_bool": [
-      "easyuse_anima.aio.legacy_generation"
-    ],
-    "_as_float": [
-      "easyuse_anima.aio.legacy_generation"
-    ],
-    "_as_int": [
-      "easyuse_anima.aio.legacy_generation"
-    ],
-    "_cleanup_aio_ephemeral_model": [
-      "easyuse_anima.aio.legacy_generation"
     ],
     "_comfy_clip_loader_types": [
       "easyuse_anima.nodes.aio_nodes"
@@ -274,57 +210,19 @@
     "_comfy_vae_names": [
       "easyuse_anima.nodes.aio_nodes"
     ],
-    "_context_value": [
-      "easyuse_anima.aio.legacy_generation"
-    ],
     "_copy_prompt_data_for_update": [
       "easyuse_anima.nodes.aio_nodes"
-    ],
-    "_decode_latent_with_comfy": [
-      "easyuse_anima.aio.legacy_generation"
-    ],
-    "_encode_image_with_comfy_vae": [
-      "easyuse_anima.aio.legacy_generation"
-    ],
-    "_encode_prompt_data_positive_conditioning": [
-      "easyuse_anima.aio.legacy_generation"
-    ],
-    "_generate_empty_latent_with_comfy": [
-      "easyuse_anima.aio.legacy_generation"
-    ],
-    "_get_aio_first_pass_cache": [
-      "easyuse_anima.aio.legacy_generation"
-    ],
-    "_image_tensor_size": [
-      "easyuse_anima.aio.legacy_generation"
     ],
     "_json_clone": [
       "easyuse_anima.nodes.aio_nodes"
     ],
-    "_load_aio_resources_from_input_context": [
-      "easyuse_anima.aio.legacy_generation"
-    ],
-    "_load_aio_sam3_context": [
-      "easyuse_anima.aio.legacy_generation"
-    ],
-    "_load_upscale_model_with_comfy": [
-      "easyuse_anima.aio.legacy_generation"
-    ],
-    "_node_output_tuple": [
-      "easyuse_anima.aio.legacy_generation"
-    ],
     "_normalize_aio_generation_settings": [
-      "easyuse_anima.aio.legacy_generation",
       "easyuse_anima.nodes.aio_nodes"
     ],
     "_normalize_aio_input_settings": [
       "easyuse_anima.nodes.aio_nodes"
     ],
-    "_normalize_anima_mod_guidance_profile": [
-      "easyuse_anima.aio.legacy_generation"
-    ],
     "_normalize_prompt_data": [
-      "easyuse_anima.aio.legacy_generation",
       "easyuse_anima.nodes.aio_nodes"
     ],
     "_preferred_clip_type_default": [
@@ -334,99 +232,39 @@
       "easyuse_anima.nodes.aio_nodes"
     ],
     "_prompt_data_json_safe": [
-      "easyuse_anima.aio.legacy_generation",
       "easyuse_anima.nodes.aio_nodes"
-    ],
-    "_put_aio_first_pass_cache": [
-      "easyuse_anima.aio.legacy_generation"
-    ],
-    "_resize_image_to_size_if_needed": [
-      "easyuse_anima.aio.legacy_generation"
     ],
     "_resolve_aio_runtime_seed": [
-      "easyuse_anima.aio.legacy_generation",
       "easyuse_anima.nodes.aio_nodes"
-    ],
-    "_resolve_anima_mod_guidance_enabled": [
-      "easyuse_anima.aio.legacy_generation"
-    ],
-    "_run_aio_detailer_stage": [
-      "easyuse_anima.aio.legacy_generation"
-    ],
-    "_run_aio_detailer_target": [
-      "easyuse_anima.aio.legacy_generation"
-    ],
-    "_run_aio_highres_stage": [
-      "easyuse_anima.aio.legacy_generation"
     ],
     "_run_aio_legacy_generation": [
       "easyuse_anima.nodes.aio_nodes"
     ],
-    "_run_aio_postprocess_stage": [
-      "easyuse_anima.aio.legacy_generation"
-    ],
-    "_run_aio_resshift_upscale_stage": [
-      "easyuse_anima.aio.legacy_generation"
-    ],
-    "_run_aio_upscale_stage": [
-      "easyuse_anima.aio.legacy_generation"
-    ],
-    "_run_aio_usdu_upscale_stage": [
-      "easyuse_anima.aio.legacy_generation"
-    ],
-    "_sample_latent_with_aio_backend": [
-      "easyuse_anima.aio.legacy_generation"
-    ],
-    "_save_aio_temp_preview_image": [
-      "easyuse_anima.aio.legacy_generation"
-    ],
-    "_save_image_with_comfy": [
-      "easyuse_anima.aio.legacy_generation"
-    ],
-    "_save_image_with_image_saver": [
-      "easyuse_anima.aio.legacy_generation"
-    ],
-    "_segs_has_items": [
-      "easyuse_anima.aio.legacy_generation"
-    ],
-    "_send_aio_preview_event": [
-      "easyuse_anima.aio.legacy_generation"
-    ],
-    "_single_value": [
-      "easyuse_anima.aio.legacy_generation"
-    ],
     "_stable_change_key": [
       "easyuse_anima.nodes.aio_nodes"
-    ],
-    "_tag_aio_preview_images": [
-      "easyuse_anima.aio.legacy_generation"
-    ],
-    "logger": [
-      "easyuse_anima.aio.legacy_generation"
     ]
   },
   "runtime_binder_audit": {
     "summary": {
-      "binder_count": 4,
+      "binder_count": 3,
       "family_count": 2,
       "mode_counts": {
-        "comfy_provider_then_root": 1,
+        "comfy_provider_then_root": 0,
         "root_globals": 1,
         "explicit_callbacks": 2
       },
-      "unique_resolver_names": 84,
-      "unique_root_resolver_names": 82,
-      "unique_provider_resolver_names": 2,
-      "unique_direct_root_dependencies": 9,
-      "direct_root_dependency_slots": 10,
-      "provider_consumer_slots": 2,
-      "provider_consumer_modules": 1,
-      "repository_replacement_names": 69,
+      "unique_resolver_names": 29,
+      "unique_root_resolver_names": 29,
+      "unique_provider_resolver_names": 0,
+      "unique_direct_root_dependencies": 8,
+      "direct_root_dependency_slots": 9,
+      "provider_consumer_slots": 0,
+      "provider_consumer_modules": 0,
+      "repository_replacement_names": 32,
       "repository_replacement_files": 5
     },
     "families": {
       "aio": [
-        "_bind_aio_legacy_generation_runtime",
         "_bind_aio_node_runtime"
       ],
       "wildcard_naia": [
@@ -447,35 +285,10 @@
         "B-11c30d1_cache_state",
         "B-11c30d2_normalization_planning",
         "B-11c30d3_io_boundary",
-        "B-11c30d4_execution_services"
+        "B-11c30d4_execution_services",
+        "B-11c30d5_legacy_orchestration"
       ],
       "subgroups": {
-        "B-11c30d5_legacy_orchestration": {
-          "binders": [
-            "_bind_aio_legacy_generation_runtime"
-          ],
-          "mode_counts": {
-            "comfy_provider_then_root": 1,
-            "root_globals": 0
-          },
-          "bound_global_slots": 1,
-          "unique_bound_globals": [
-            "_RUNTIME_RESOLVER"
-          ],
-          "root_resolver_slots": 58,
-          "unique_root_resolver_names": 58,
-          "provider_resolver_slots": 2,
-          "unique_provider_resolver_names": 2,
-          "direct_root_dependency_slots": 1,
-          "unique_direct_root_dependencies": 1,
-          "repository_replacement_slots": 42,
-          "unique_repository_replacement_names": 42,
-          "repository_replacement_files": [
-            "tests/test_aio_legacy_generation.py",
-            "tests/test_aio_nodes.py",
-            "tests/test_node_contracts.py"
-          ]
-        },
         "B-11c30d6_node_adapter": {
           "binders": [
             "_bind_aio_node_runtime"
@@ -557,90 +370,34 @@
       "AIO_GENERATION_DEFAULT_SETTINGS",
       "AIO_INPUT_DEFAULT_SETTINGS",
       "AIO_SPECIAL_SEEDS",
-      "AIO_USDU_PROMPT_FULL",
       "ANIMA_DEFAULT_CLIP_CANDIDATES",
       "ANIMA_DEFAULT_DIFFUSION_MODEL_CANDIDATES",
       "ANIMA_DEFAULT_VAE_CANDIDATES",
-      "ANIMA_MOD_GUIDANCE_PROFILE_OFF",
       "EASY_USE_ANIMA_INPUT_SCHEMA",
       "EASY_USE_ANIMA_INPUT_SETTINGS_VERSION",
       "EASY_USE_ANIMA_INPUT_TYPE",
-      "EasyUseAnimaImageScaleByMultiple",
-      "EasyUseAnimaSAM3Detailer",
       "PROMPT_DATA_TYPE",
-      "_advanced_outputs_from_prompt_data",
-      "_aio_detailer_has_enabled_targets",
-      "_aio_detailer_target_order",
-      "_aio_first_pass_cache_key",
       "_aio_generation_settings_json",
-      "_aio_highres_effective_backend",
       "_aio_input_settings_json",
       "_aio_lora_stack_signature",
-      "_aio_save_filename_prefix",
-      "_aio_stage_sampler_settings",
-      "_aio_usdu_conditioning",
-      "_aio_usdu_tile_plan",
-      "_apply_aio_lora_stack",
-      "_apply_aio_model_patches",
-      "_apply_aio_spectrum_model_patches_for_comfy_sampler",
-      "_apply_spectrum_anima_mod_guidance",
-      "_as_bool",
-      "_as_float",
-      "_as_int",
-      "_cleanup_aio_ephemeral_model",
       "_comfy_clip_loader_types",
       "_comfy_diffusion_model_names",
       "_comfy_text_encoder_names",
       "_comfy_vae_names",
-      "_context_value",
       "_copy_prompt_data_for_update",
-      "_decode_latent_with_comfy",
-      "_encode_image_with_comfy_vae",
-      "_encode_prompt_data_positive_conditioning",
-      "_generate_empty_latent_with_comfy",
-      "_get_aio_first_pass_cache",
-      "_image_tensor_size",
       "_json_clone",
-      "_load_aio_resources_from_input_context",
-      "_load_aio_sam3_context",
-      "_load_upscale_model_with_comfy",
-      "_node_output_tuple",
       "_normalize_aio_generation_settings",
       "_normalize_aio_input_settings",
-      "_normalize_anima_mod_guidance_profile",
       "_normalize_prompt_data",
       "_preferred_clip_type_default",
       "_preferred_name_default",
       "_prompt_data_json_safe",
-      "_put_aio_first_pass_cache",
-      "_resize_image_to_size_if_needed",
       "_resolve_aio_runtime_seed",
-      "_resolve_anima_mod_guidance_enabled",
-      "_run_aio_detailer_stage",
-      "_run_aio_detailer_target",
-      "_run_aio_highres_stage",
       "_run_aio_legacy_generation",
-      "_run_aio_postprocess_stage",
-      "_run_aio_resshift_upscale_stage",
-      "_run_aio_upscale_stage",
-      "_run_aio_usdu_upscale_stage",
-      "_sample_latent_with_aio_backend",
-      "_save_aio_temp_preview_image",
-      "_save_image_with_comfy",
-      "_save_image_with_image_saver",
-      "_segs_has_items",
-      "_send_aio_preview_event",
-      "_single_value",
       "_stable_change_key",
-      "_tag_aio_preview_images",
-      "json",
-      "logger",
-      "random"
+      "json"
     ],
-    "provider_resolver_names": [
-      "_encode_with_comfy_clip",
-      "_require_custom_node_class"
-    ],
+    "provider_resolver_names": [],
     "repository_root_replacements": {
       "AIO_GENERATION_DEFAULT_SETTINGS": [
         "tests/test_node_contracts.py"
@@ -666,52 +423,13 @@
       "PROMPT_DATA_TYPE": [
         "tests/test_aio_nodes.py"
       ],
-      "_advanced_outputs_from_prompt_data": [
-        "tests/test_aio_legacy_generation.py",
-        "tests/test_aio_nodes.py"
-      ],
-      "_aio_detailer_has_enabled_targets": [
-        "tests/test_aio_legacy_generation.py"
-      ],
-      "_aio_first_pass_cache_key": [
-        "tests/test_aio_legacy_generation.py"
-      ],
       "_aio_generation_settings_json": [
         "tests/test_aio_nodes.py"
-      ],
-      "_aio_highres_effective_backend": [
-        "tests/test_aio_legacy_generation.py"
       ],
       "_aio_input_settings_json": [
         "tests/test_aio_nodes.py"
       ],
       "_aio_lora_stack_signature": [
-        "tests/test_aio_nodes.py"
-      ],
-      "_aio_save_filename_prefix": [
-        "tests/test_aio_legacy_generation.py"
-      ],
-      "_apply_aio_lora_stack": [
-        "tests/test_aio_legacy_generation.py",
-        "tests/test_aio_nodes.py"
-      ],
-      "_apply_aio_model_patches": [
-        "tests/test_aio_legacy_generation.py",
-        "tests/test_aio_nodes.py"
-      ],
-      "_apply_aio_spectrum_model_patches_for_comfy_sampler": [
-        "tests/test_aio_legacy_generation.py",
-        "tests/test_aio_nodes.py"
-      ],
-      "_apply_spectrum_anima_mod_guidance": [
-        "tests/test_aio_legacy_generation.py",
-        "tests/test_aio_nodes.py"
-      ],
-      "_as_bool": [
-        "tests/test_aio_legacy_generation.py"
-      ],
-      "_cleanup_aio_ephemeral_model": [
-        "tests/test_aio_legacy_generation.py",
         "tests/test_aio_nodes.py"
       ],
       "_comfy_clip_loader_types": [
@@ -733,56 +451,19 @@
       "_copy_prompt_data_for_update": [
         "tests/test_aio_nodes.py"
       ],
-      "_decode_latent_with_comfy": [
-        "tests/test_aio_legacy_generation.py",
-        "tests/test_aio_nodes.py"
-      ],
-      "_encode_image_with_comfy_vae": [
-        "tests/test_aio_legacy_generation.py",
-        "tests/test_aio_nodes.py"
-      ],
-      "_encode_prompt_data_positive_conditioning": [
-        "tests/test_aio_legacy_generation.py",
-        "tests/test_aio_nodes.py"
-      ],
-      "_generate_empty_latent_with_comfy": [
-        "tests/test_aio_legacy_generation.py",
-        "tests/test_aio_nodes.py"
-      ],
-      "_get_aio_first_pass_cache": [
-        "tests/test_aio_legacy_generation.py"
-      ],
       "_get_workflow_node": [
         "tests/test_node_contracts.py"
-      ],
-      "_image_tensor_size": [
-        "tests/test_aio_legacy_generation.py"
       ],
       "_json_clone": [
         "tests/test_aio_nodes.py"
       ],
-      "_load_aio_resources_from_input_context": [
-        "tests/test_aio_legacy_generation.py",
-        "tests/test_aio_nodes.py"
-      ],
-      "_load_aio_sam3_context": [
-        "tests/test_aio_nodes.py"
-      ],
-      "_load_upscale_model_with_comfy": [
-        "tests/test_aio_nodes.py"
-      ],
       "_normalize_aio_generation_settings": [
-        "tests/test_aio_legacy_generation.py",
         "tests/test_aio_nodes.py"
       ],
       "_normalize_aio_input_settings": [
         "tests/test_aio_nodes.py"
       ],
-      "_normalize_anima_mod_guidance_profile": [
-        "tests/test_aio_legacy_generation.py"
-      ],
       "_normalize_prompt_data": [
-        "tests/test_aio_legacy_generation.py",
         "tests/test_aio_nodes.py"
       ],
       "_post_random": [
@@ -795,80 +476,22 @@
         "tests/test_aio_nodes.py"
       ],
       "_prompt_data_json_safe": [
-        "tests/test_aio_legacy_generation.py",
-        "tests/test_aio_nodes.py"
-      ],
-      "_put_aio_first_pass_cache": [
-        "tests/test_aio_legacy_generation.py"
-      ],
-      "_resize_image_to_size_if_needed": [
-        "tests/test_aio_legacy_generation.py",
         "tests/test_aio_nodes.py"
       ],
       "_resolve_aio_runtime_seed": [
-        "tests/test_aio_legacy_generation.py",
-        "tests/test_aio_nodes.py"
-      ],
-      "_resolve_anima_mod_guidance_enabled": [
-        "tests/test_aio_legacy_generation.py"
-      ],
-      "_run_aio_detailer_stage": [
-        "tests/test_aio_legacy_generation.py",
-        "tests/test_aio_nodes.py"
-      ],
-      "_run_aio_detailer_target": [
-        "tests/test_aio_nodes.py"
-      ],
-      "_run_aio_highres_stage": [
-        "tests/test_aio_legacy_generation.py",
         "tests/test_aio_nodes.py"
       ],
       "_run_aio_legacy_generation": [
         "tests/test_aio_legacy_generation.py"
       ],
-      "_run_aio_postprocess_stage": [
-        "tests/test_aio_legacy_generation.py",
-        "tests/test_aio_nodes.py"
-      ],
-      "_run_aio_upscale_stage": [
-        "tests/test_aio_legacy_generation.py",
-        "tests/test_aio_nodes.py"
-      ],
-      "_sample_latent_with_aio_backend": [
-        "tests/test_aio_legacy_generation.py",
-        "tests/test_aio_nodes.py"
-      ],
-      "_save_aio_temp_preview_image": [
-        "tests/test_aio_legacy_generation.py",
-        "tests/test_aio_nodes.py"
-      ],
-      "_save_image_with_comfy": [
-        "tests/test_aio_legacy_generation.py"
-      ],
-      "_save_image_with_image_saver": [
-        "tests/test_aio_nodes.py"
-      ],
-      "_send_aio_preview_event": [
-        "tests/test_aio_legacy_generation.py",
-        "tests/test_aio_nodes.py"
-      ],
-      "_single_value": [
-        "tests/test_aio_legacy_generation.py"
-      ],
       "_stable_change_key": [
         "tests/test_aio_nodes.py"
-      ],
-      "_tag_aio_preview_images": [
-        "tests/test_aio_legacy_generation.py"
       ],
       "expand_wildcards": [
         "tests/test_wildcards.py"
       ],
       "json": [
         "tests/test_node_contracts.py"
-      ],
-      "random": [
-        "tests/test_aio_legacy_generation.py"
       ],
       "resolve_naia_settings": [
         "tests/test_naia_settings.py",
@@ -879,192 +502,6 @@
       ]
     },
     "entries": [
-      {
-        "binder": "_bind_aio_legacy_generation_runtime",
-        "module": "easyuse_anima.aio.legacy_generation",
-        "family": "aio",
-        "mode": "comfy_provider_then_root",
-        "root_observation": "call_time_resolver",
-        "root_keywords": [
-          "resolve_helper"
-        ],
-        "bound_globals": [
-          "_RUNTIME_RESOLVER"
-        ],
-        "direct_root_dependencies": [
-          "_resolve_comfy_host_helper"
-        ],
-        "resolver_names": [
-          "AIO_USDU_PROMPT_FULL",
-          "ANIMA_MOD_GUIDANCE_PROFILE_OFF",
-          "EasyUseAnimaImageScaleByMultiple",
-          "EasyUseAnimaSAM3Detailer",
-          "_advanced_outputs_from_prompt_data",
-          "_aio_detailer_has_enabled_targets",
-          "_aio_detailer_target_order",
-          "_aio_first_pass_cache_key",
-          "_aio_highres_effective_backend",
-          "_aio_save_filename_prefix",
-          "_aio_stage_sampler_settings",
-          "_aio_usdu_conditioning",
-          "_aio_usdu_tile_plan",
-          "_apply_aio_lora_stack",
-          "_apply_aio_model_patches",
-          "_apply_aio_spectrum_model_patches_for_comfy_sampler",
-          "_apply_spectrum_anima_mod_guidance",
-          "_as_bool",
-          "_as_float",
-          "_as_int",
-          "_cleanup_aio_ephemeral_model",
-          "_context_value",
-          "_decode_latent_with_comfy",
-          "_encode_image_with_comfy_vae",
-          "_encode_prompt_data_positive_conditioning",
-          "_encode_with_comfy_clip",
-          "_generate_empty_latent_with_comfy",
-          "_get_aio_first_pass_cache",
-          "_image_tensor_size",
-          "_load_aio_resources_from_input_context",
-          "_load_aio_sam3_context",
-          "_load_upscale_model_with_comfy",
-          "_node_output_tuple",
-          "_normalize_aio_generation_settings",
-          "_normalize_anima_mod_guidance_profile",
-          "_normalize_prompt_data",
-          "_prompt_data_json_safe",
-          "_put_aio_first_pass_cache",
-          "_require_custom_node_class",
-          "_resize_image_to_size_if_needed",
-          "_resolve_aio_runtime_seed",
-          "_resolve_anima_mod_guidance_enabled",
-          "_run_aio_detailer_stage",
-          "_run_aio_detailer_target",
-          "_run_aio_highres_stage",
-          "_run_aio_postprocess_stage",
-          "_run_aio_resshift_upscale_stage",
-          "_run_aio_upscale_stage",
-          "_run_aio_usdu_upscale_stage",
-          "_sample_latent_with_aio_backend",
-          "_save_aio_temp_preview_image",
-          "_save_image_with_comfy",
-          "_save_image_with_image_saver",
-          "_segs_has_items",
-          "_send_aio_preview_event",
-          "_single_value",
-          "_tag_aio_preview_images",
-          "json",
-          "logger",
-          "random"
-        ],
-        "root_resolver_names": [
-          "AIO_USDU_PROMPT_FULL",
-          "ANIMA_MOD_GUIDANCE_PROFILE_OFF",
-          "EasyUseAnimaImageScaleByMultiple",
-          "EasyUseAnimaSAM3Detailer",
-          "_advanced_outputs_from_prompt_data",
-          "_aio_detailer_has_enabled_targets",
-          "_aio_detailer_target_order",
-          "_aio_first_pass_cache_key",
-          "_aio_highres_effective_backend",
-          "_aio_save_filename_prefix",
-          "_aio_stage_sampler_settings",
-          "_aio_usdu_conditioning",
-          "_aio_usdu_tile_plan",
-          "_apply_aio_lora_stack",
-          "_apply_aio_model_patches",
-          "_apply_aio_spectrum_model_patches_for_comfy_sampler",
-          "_apply_spectrum_anima_mod_guidance",
-          "_as_bool",
-          "_as_float",
-          "_as_int",
-          "_cleanup_aio_ephemeral_model",
-          "_context_value",
-          "_decode_latent_with_comfy",
-          "_encode_image_with_comfy_vae",
-          "_encode_prompt_data_positive_conditioning",
-          "_generate_empty_latent_with_comfy",
-          "_get_aio_first_pass_cache",
-          "_image_tensor_size",
-          "_load_aio_resources_from_input_context",
-          "_load_aio_sam3_context",
-          "_load_upscale_model_with_comfy",
-          "_node_output_tuple",
-          "_normalize_aio_generation_settings",
-          "_normalize_anima_mod_guidance_profile",
-          "_normalize_prompt_data",
-          "_prompt_data_json_safe",
-          "_put_aio_first_pass_cache",
-          "_resize_image_to_size_if_needed",
-          "_resolve_aio_runtime_seed",
-          "_resolve_anima_mod_guidance_enabled",
-          "_run_aio_detailer_stage",
-          "_run_aio_detailer_target",
-          "_run_aio_highres_stage",
-          "_run_aio_postprocess_stage",
-          "_run_aio_resshift_upscale_stage",
-          "_run_aio_upscale_stage",
-          "_run_aio_usdu_upscale_stage",
-          "_sample_latent_with_aio_backend",
-          "_save_aio_temp_preview_image",
-          "_save_image_with_comfy",
-          "_save_image_with_image_saver",
-          "_segs_has_items",
-          "_send_aio_preview_event",
-          "_single_value",
-          "_tag_aio_preview_images",
-          "json",
-          "logger",
-          "random"
-        ],
-        "provider_resolver_names": [
-          "_encode_with_comfy_clip",
-          "_require_custom_node_class"
-        ],
-        "repository_replacement_names": [
-          "_advanced_outputs_from_prompt_data",
-          "_aio_detailer_has_enabled_targets",
-          "_aio_first_pass_cache_key",
-          "_aio_highres_effective_backend",
-          "_aio_save_filename_prefix",
-          "_apply_aio_lora_stack",
-          "_apply_aio_model_patches",
-          "_apply_aio_spectrum_model_patches_for_comfy_sampler",
-          "_apply_spectrum_anima_mod_guidance",
-          "_as_bool",
-          "_cleanup_aio_ephemeral_model",
-          "_decode_latent_with_comfy",
-          "_encode_image_with_comfy_vae",
-          "_encode_prompt_data_positive_conditioning",
-          "_generate_empty_latent_with_comfy",
-          "_get_aio_first_pass_cache",
-          "_image_tensor_size",
-          "_load_aio_resources_from_input_context",
-          "_load_aio_sam3_context",
-          "_load_upscale_model_with_comfy",
-          "_normalize_aio_generation_settings",
-          "_normalize_anima_mod_guidance_profile",
-          "_normalize_prompt_data",
-          "_prompt_data_json_safe",
-          "_put_aio_first_pass_cache",
-          "_resize_image_to_size_if_needed",
-          "_resolve_aio_runtime_seed",
-          "_resolve_anima_mod_guidance_enabled",
-          "_run_aio_detailer_stage",
-          "_run_aio_detailer_target",
-          "_run_aio_highres_stage",
-          "_run_aio_postprocess_stage",
-          "_run_aio_upscale_stage",
-          "_sample_latent_with_aio_backend",
-          "_save_aio_temp_preview_image",
-          "_save_image_with_comfy",
-          "_save_image_with_image_saver",
-          "_send_aio_preview_event",
-          "_single_value",
-          "_tag_aio_preview_images",
-          "json",
-          "random"
-        ]
-      },
       {
         "binder": "_bind_aio_node_runtime",
         "module": "easyuse_anima.nodes.aio_nodes",
@@ -1990,38 +1427,11 @@
   ],
   "groups": [
     {
-      "id": "nodes_canonical_bindings:easyuse_anima.aio.conditioning:transitional_private_seam",
-      "surface": "nodes_canonical_bindings",
-      "symbols": {
-        "_aio_usdu_conditioning": "_aio_usdu_conditioning"
-      },
-      "classification": "transitional_private_seam",
-      "current_target": "nodes.py",
-      "canonical_target": "easyuse_anima.aio.conditioning",
-      "target_state": "canonical",
-      "identity_requirement": "required",
-      "binding_shape": "direct_import",
-      "import_target": "easyuse_anima.aio.conditioning",
-      "owner": "#184/#188",
-      "first_release": null,
-      "known_consumers": [
-        "canonical runtime resolver: easyuse_anima.aio.legacy_generation"
-      ],
-      "evidence": [
-        "AST:easyuse_anima.aio.legacy_generation string runtime lookup"
-      ],
-      "removal_gates": [
-        "canonical production consumer migration",
-        "focused monkeypatch and identity contract review",
-        "separate B-10b or B-11 rollback unit"
-      ],
-      "lifecycle_state": "transitional"
-    },
-    {
       "id": "nodes_canonical_bindings:easyuse_anima.aio.conditioning:unsupported_test_only",
       "surface": "nodes_canonical_bindings",
       "symbols": {
         "_aio_prompt_data_fields_for_usdu": "_aio_prompt_data_fields_for_usdu",
+        "_aio_usdu_conditioning": "_aio_usdu_conditioning",
         "_aio_usdu_prompt_without_general": "_aio_usdu_prompt_without_general"
       },
       "classification": "unsupported_test_only",
@@ -2048,43 +1458,16 @@
       "lifecycle_state": "unsupported"
     },
     {
-      "id": "nodes_canonical_bindings:easyuse_anima.aio.first_pass_cache:transitional_private_seam",
-      "surface": "nodes_canonical_bindings",
-      "symbols": {
-        "_aio_first_pass_cache_key": "_aio_first_pass_cache_key",
-        "_get_aio_first_pass_cache": "_get_aio_first_pass_cache",
-        "_put_aio_first_pass_cache": "_put_aio_first_pass_cache"
-      },
-      "classification": "transitional_private_seam",
-      "current_target": "nodes.py",
-      "canonical_target": "easyuse_anima.aio.first_pass_cache",
-      "target_state": "canonical",
-      "identity_requirement": "required",
-      "binding_shape": "direct_import",
-      "import_target": "easyuse_anima.aio.first_pass_cache",
-      "owner": "#184/#188",
-      "first_release": null,
-      "known_consumers": [
-        "canonical runtime resolver: easyuse_anima.aio.legacy_generation"
-      ],
-      "evidence": [
-        "AST:easyuse_anima.aio.legacy_generation string runtime lookup"
-      ],
-      "removal_gates": [
-        "canonical production consumer migration",
-        "focused monkeypatch and identity contract review",
-        "separate B-10b or B-11 rollback unit"
-      ],
-      "lifecycle_state": "transitional"
-    },
-    {
       "id": "nodes_canonical_bindings:easyuse_anima.aio.first_pass_cache:unsupported_test_only",
       "surface": "nodes_canonical_bindings",
       "symbols": {
         "AIO_FIRST_PASS_CACHE_MAX_ENTRIES": "AIO_FIRST_PASS_CACHE_MAX_ENTRIES",
         "_AIO_FIRST_PASS_CACHE": "_AIO_FIRST_PASS_CACHE",
         "_AIO_FIRST_PASS_CACHE_ORDER": "_AIO_FIRST_PASS_CACHE_ORDER",
-        "_clone_aio_cache_value": "_clone_aio_cache_value"
+        "_aio_first_pass_cache_key": "_aio_first_pass_cache_key",
+        "_clone_aio_cache_value": "_clone_aio_cache_value",
+        "_get_aio_first_pass_cache": "_get_aio_first_pass_cache",
+        "_put_aio_first_pass_cache": "_put_aio_first_pass_cache"
       },
       "classification": "unsupported_test_only",
       "current_target": "nodes.py",
@@ -2114,8 +1497,7 @@
       "surface": "nodes_canonical_bindings",
       "symbols": {
         "AIO_GENERATION_DEFAULT_SETTINGS": "AIO_GENERATION_DEFAULT_SETTINGS",
-        "AIO_SPECIAL_SEEDS": "AIO_SPECIAL_SEEDS",
-        "AIO_USDU_PROMPT_FULL": "AIO_USDU_PROMPT_FULL"
+        "AIO_SPECIAL_SEEDS": "AIO_SPECIAL_SEEDS"
       },
       "classification": "transitional_private_seam",
       "current_target": "nodes.py",
@@ -2127,11 +1509,9 @@
       "owner": "#184/#188",
       "first_release": null,
       "known_consumers": [
-        "canonical runtime resolver: easyuse_anima.aio.legacy_generation",
         "canonical runtime resolver: easyuse_anima.nodes.aio_nodes"
       ],
       "evidence": [
-        "AST:easyuse_anima.aio.legacy_generation string runtime lookup",
         "AST:easyuse_anima.nodes.aio_nodes string runtime lookup"
       ],
       "removal_gates": [
@@ -2155,6 +1535,7 @@
         "AIO_SPECIAL_SEED_INCREMENT": "AIO_SPECIAL_SEED_INCREMENT",
         "AIO_SPECIAL_SEED_RANDOM": "AIO_SPECIAL_SEED_RANDOM",
         "AIO_USDU_MODE_TYPES": "AIO_USDU_MODE_TYPES",
+        "AIO_USDU_PROMPT_FULL": "AIO_USDU_PROMPT_FULL",
         "AIO_USDU_PROMPT_MODES": "AIO_USDU_PROMPT_MODES",
         "AIO_USDU_PROMPT_NO_GENERAL": "AIO_USDU_PROMPT_NO_GENERAL",
         "AIO_USDU_SEAM_FIX_MODES": "AIO_USDU_SEAM_FIX_MODES"
@@ -2186,8 +1567,6 @@
       "id": "nodes_canonical_bindings:easyuse_anima.aio.generation_normalization:transitional_private_seam",
       "surface": "nodes_canonical_bindings",
       "symbols": {
-        "_aio_detailer_has_enabled_targets": "_aio_detailer_has_enabled_targets",
-        "_aio_detailer_target_order": "_aio_detailer_target_order",
         "_normalize_aio_generation_settings": "_normalize_aio_generation_settings"
       },
       "classification": "transitional_private_seam",
@@ -2200,11 +1579,9 @@
       "owner": "#184/#188",
       "first_release": null,
       "known_consumers": [
-        "canonical runtime resolver: easyuse_anima.aio.legacy_generation",
         "canonical runtime resolver: easyuse_anima.nodes.aio_nodes"
       ],
       "evidence": [
-        "AST:easyuse_anima.aio.legacy_generation string runtime lookup",
         "AST:easyuse_anima.nodes.aio_nodes string runtime lookup"
       ],
       "removal_gates": [
@@ -2220,7 +1597,9 @@
       "symbols": {
         "_AIO_DETAILER_CUSTOM_RE": "_AIO_DETAILER_CUSTOM_RE",
         "_AIO_DETAILER_RESERVED_KEYS": "_AIO_DETAILER_RESERVED_KEYS",
+        "_aio_detailer_has_enabled_targets": "_aio_detailer_has_enabled_targets",
         "_aio_detailer_target_defaults": "_aio_detailer_target_defaults",
+        "_aio_detailer_target_order": "_aio_detailer_target_order",
         "_is_aio_detailer_target_name": "_is_aio_detailer_target_name",
         "_merge_versioned_settings": "_merge_versioned_settings",
         "_normalize_aio_dit_corrections_settings": "_normalize_aio_dit_corrections_settings",
@@ -2377,14 +1756,7 @@
       "id": "nodes_canonical_bindings:easyuse_anima.aio.legacy_generation:transitional_private_seam",
       "surface": "nodes_canonical_bindings",
       "symbols": {
-        "_bind_aio_legacy_generation_runtime": "_bind_aio_legacy_generation_runtime",
-        "_run_aio_detailer_stage": "_run_aio_detailer_stage",
-        "_run_aio_detailer_target": "_run_aio_detailer_target",
-        "_run_aio_highres_stage": "_run_aio_highres_stage",
-        "_run_aio_legacy_generation": "_run_aio_legacy_generation",
-        "_run_aio_resshift_upscale_stage": "_run_aio_resshift_upscale_stage",
-        "_run_aio_upscale_stage": "_run_aio_upscale_stage",
-        "_run_aio_usdu_upscale_stage": "_run_aio_usdu_upscale_stage"
+        "_run_aio_legacy_generation": "_run_aio_legacy_generation"
       },
       "classification": "transitional_private_seam",
       "current_target": "nodes.py",
@@ -2396,13 +1768,9 @@
       "owner": "#184/#188",
       "first_release": null,
       "known_consumers": [
-        "nodes.py residual runtime",
-        "canonical runtime resolver: easyuse_anima.aio.legacy_generation",
         "canonical runtime resolver: easyuse_anima.nodes.aio_nodes"
       ],
       "evidence": [
-        "AST:nodes.py direct runtime load",
-        "AST:easyuse_anima.aio.legacy_generation string runtime lookup",
         "AST:easyuse_anima.nodes.aio_nodes string runtime lookup"
       ],
       "removal_gates": [
@@ -2413,14 +1781,44 @@
       "lifecycle_state": "transitional"
     },
     {
+      "id": "nodes_canonical_bindings:easyuse_anima.aio.legacy_generation:unsupported_test_only",
+      "surface": "nodes_canonical_bindings",
+      "symbols": {
+        "_run_aio_detailer_stage": "_run_aio_detailer_stage",
+        "_run_aio_detailer_target": "_run_aio_detailer_target",
+        "_run_aio_highres_stage": "_run_aio_highres_stage",
+        "_run_aio_resshift_upscale_stage": "_run_aio_resshift_upscale_stage",
+        "_run_aio_upscale_stage": "_run_aio_upscale_stage",
+        "_run_aio_usdu_upscale_stage": "_run_aio_usdu_upscale_stage"
+      },
+      "classification": "unsupported_test_only",
+      "current_target": "nodes.py",
+      "canonical_target": "easyuse_anima.aio.legacy_generation",
+      "target_state": "canonical",
+      "identity_requirement": "not_applicable",
+      "binding_shape": "direct_import",
+      "import_target": "easyuse_anima.aio.legacy_generation",
+      "owner": "#184/#188",
+      "first_release": null,
+      "known_consumers": [
+        "repository tests may import this root name"
+      ],
+      "evidence": [
+        "AST:no nodes.py runtime load",
+        "test-only consumption is not public support evidence"
+      ],
+      "removal_gates": [
+        "test imports migrate to canonical targets",
+        "no production consumer evidence",
+        "separate B-10b removal review"
+      ],
+      "lifecycle_state": "unsupported"
+    },
+    {
       "id": "nodes_canonical_bindings:easyuse_anima.aio.model_preparation:transitional_private_seam",
       "surface": "nodes_canonical_bindings",
       "symbols": {
-        "_aio_lora_stack_signature": "_aio_lora_stack_signature",
-        "_apply_aio_lora_stack": "_apply_aio_lora_stack",
-        "_apply_aio_model_patches": "_apply_aio_model_patches",
-        "_apply_aio_spectrum_model_patches_for_comfy_sampler": "_apply_aio_spectrum_model_patches_for_comfy_sampler",
-        "_cleanup_aio_ephemeral_model": "_cleanup_aio_ephemeral_model"
+        "_aio_lora_stack_signature": "_aio_lora_stack_signature"
       },
       "classification": "transitional_private_seam",
       "current_target": "nodes.py",
@@ -2432,11 +1830,9 @@
       "owner": "#184/#188",
       "first_release": null,
       "known_consumers": [
-        "canonical runtime resolver: easyuse_anima.aio.legacy_generation",
         "canonical runtime resolver: easyuse_anima.nodes.aio_nodes"
       ],
       "evidence": [
-        "AST:easyuse_anima.aio.legacy_generation string runtime lookup",
         "AST:easyuse_anima.nodes.aio_nodes string runtime lookup"
       ],
       "removal_gates": [
@@ -2452,9 +1848,13 @@
       "symbols": {
         "_apply_aio_anima_dave_patch": "_apply_aio_anima_dave_patch",
         "_apply_aio_kj_model_patches": "_apply_aio_kj_model_patches",
+        "_apply_aio_lora_stack": "_apply_aio_lora_stack",
+        "_apply_aio_model_patches": "_apply_aio_model_patches",
         "_apply_aio_safe_pag_patch": "_apply_aio_safe_pag_patch",
         "_apply_aio_spectrum_correction_patch_for_comfy_sampler": "_apply_aio_spectrum_correction_patch_for_comfy_sampler",
         "_apply_aio_spectrum_forecast_patch_for_comfy_sampler": "_apply_aio_spectrum_forecast_patch_for_comfy_sampler",
+        "_apply_aio_spectrum_model_patches_for_comfy_sampler": "_apply_aio_spectrum_model_patches_for_comfy_sampler",
+        "_cleanup_aio_ephemeral_model": "_cleanup_aio_ephemeral_model",
         "_normalize_aio_lora_stack": "_normalize_aio_lora_stack",
         "_patch_model_sampling_aura_flow": "_patch_model_sampling_aura_flow"
       },
@@ -2482,43 +1882,16 @@
       "lifecycle_state": "unsupported"
     },
     {
-      "id": "nodes_canonical_bindings:easyuse_anima.aio.output:transitional_private_seam",
-      "surface": "nodes_canonical_bindings",
-      "symbols": {
-        "_aio_save_filename_prefix": "_aio_save_filename_prefix",
-        "_save_image_with_comfy": "_save_image_with_comfy",
-        "_save_image_with_image_saver": "_save_image_with_image_saver"
-      },
-      "classification": "transitional_private_seam",
-      "current_target": "nodes.py",
-      "canonical_target": "easyuse_anima.aio.output",
-      "target_state": "canonical",
-      "identity_requirement": "required",
-      "binding_shape": "direct_import",
-      "import_target": "easyuse_anima.aio.output",
-      "owner": "#184/#188",
-      "first_release": null,
-      "known_consumers": [
-        "canonical runtime resolver: easyuse_anima.aio.legacy_generation"
-      ],
-      "evidence": [
-        "AST:easyuse_anima.aio.legacy_generation string runtime lookup"
-      ],
-      "removal_gates": [
-        "canonical production consumer migration",
-        "focused monkeypatch and identity contract review",
-        "separate B-10b or B-11 rollback unit"
-      ],
-      "lifecycle_state": "transitional"
-    },
-    {
       "id": "nodes_canonical_bindings:easyuse_anima.aio.output:unsupported_test_only",
       "surface": "nodes_canonical_bindings",
       "symbols": {
         "_aio_image_saver_additional_hashes": "_aio_image_saver_additional_hashes",
         "_aio_image_saver_civitai_hash_fetcher_entries": "_aio_image_saver_civitai_hash_fetcher_entries",
         "_aio_lora_metadata_name": "_aio_lora_metadata_name",
-        "_aio_prompt_with_lora_metadata": "_aio_prompt_with_lora_metadata"
+        "_aio_prompt_with_lora_metadata": "_aio_prompt_with_lora_metadata",
+        "_aio_save_filename_prefix": "_aio_save_filename_prefix",
+        "_save_image_with_comfy": "_save_image_with_comfy",
+        "_save_image_with_image_saver": "_save_image_with_image_saver"
       },
       "classification": "unsupported_test_only",
       "current_target": "nodes.py",
@@ -2574,40 +1947,13 @@
       "lifecycle_state": "unsupported"
     },
     {
-      "id": "nodes_canonical_bindings:easyuse_anima.aio.postprocess:transitional_private_seam",
-      "surface": "nodes_canonical_bindings",
-      "symbols": {
-        "_resize_image_to_size_if_needed": "_resize_image_to_size_if_needed",
-        "_run_aio_postprocess_stage": "_run_aio_postprocess_stage"
-      },
-      "classification": "transitional_private_seam",
-      "current_target": "nodes.py",
-      "canonical_target": "easyuse_anima.aio.postprocess",
-      "target_state": "canonical",
-      "identity_requirement": "required",
-      "binding_shape": "direct_import",
-      "import_target": "easyuse_anima.aio.postprocess",
-      "owner": "#184/#188",
-      "first_release": null,
-      "known_consumers": [
-        "canonical runtime resolver: easyuse_anima.aio.legacy_generation"
-      ],
-      "evidence": [
-        "AST:easyuse_anima.aio.legacy_generation string runtime lookup"
-      ],
-      "removal_gates": [
-        "canonical production consumer migration",
-        "focused monkeypatch and identity contract review",
-        "separate B-10b or B-11 rollback unit"
-      ],
-      "lifecycle_state": "transitional"
-    },
-    {
       "id": "nodes_canonical_bindings:easyuse_anima.aio.postprocess:unsupported_test_only",
       "surface": "nodes_canonical_bindings",
       "symbols": {
         "_aio_final_fit_size": "_aio_final_fit_size",
-        "_apply_aio_final_fit": "_apply_aio_final_fit"
+        "_apply_aio_final_fit": "_apply_aio_final_fit",
+        "_resize_image_to_size_if_needed": "_resize_image_to_size_if_needed",
+        "_run_aio_postprocess_stage": "_run_aio_postprocess_stage"
       },
       "classification": "unsupported_test_only",
       "current_target": "nodes.py",
@@ -2633,36 +1979,6 @@
       "lifecycle_state": "unsupported"
     },
     {
-      "id": "nodes_canonical_bindings:easyuse_anima.aio.preview:transitional_private_seam",
-      "surface": "nodes_canonical_bindings",
-      "symbols": {
-        "_save_aio_temp_preview_image": "_save_aio_temp_preview_image",
-        "_send_aio_preview_event": "_send_aio_preview_event",
-        "_tag_aio_preview_images": "_tag_aio_preview_images"
-      },
-      "classification": "transitional_private_seam",
-      "current_target": "nodes.py",
-      "canonical_target": "easyuse_anima.aio.preview",
-      "target_state": "canonical",
-      "identity_requirement": "required",
-      "binding_shape": "direct_import",
-      "import_target": "easyuse_anima.aio.preview",
-      "owner": "#184/#188",
-      "first_release": null,
-      "known_consumers": [
-        "canonical runtime resolver: easyuse_anima.aio.legacy_generation"
-      ],
-      "evidence": [
-        "AST:easyuse_anima.aio.legacy_generation string runtime lookup"
-      ],
-      "removal_gates": [
-        "canonical production consumer migration",
-        "focused monkeypatch and identity contract review",
-        "separate B-10b or B-11 rollback unit"
-      ],
-      "lifecycle_state": "transitional"
-    },
-    {
       "id": "nodes_canonical_bindings:easyuse_anima.aio.preview:unsupported_test_only",
       "surface": "nodes_canonical_bindings",
       "symbols": {
@@ -2671,7 +1987,10 @@
         "AIO_PREVIEW_EVENT": "AIO_PREVIEW_EVENT",
         "AIO_PREVIEW_STAGE_LABELS": "AIO_PREVIEW_STAGE_LABELS",
         "_aio_preview_base_directory": "_aio_preview_base_directory",
-        "_aio_preview_file_size_bytes": "_aio_preview_file_size_bytes"
+        "_aio_preview_file_size_bytes": "_aio_preview_file_size_bytes",
+        "_save_aio_temp_preview_image": "_save_aio_temp_preview_image",
+        "_send_aio_preview_event": "_send_aio_preview_event",
+        "_tag_aio_preview_images": "_tag_aio_preview_images"
       },
       "classification": "unsupported_test_only",
       "current_target": "nodes.py",
@@ -2704,9 +2023,6 @@
         "_comfy_diffusion_model_names": "_comfy_diffusion_model_names",
         "_comfy_text_encoder_names": "_comfy_text_encoder_names",
         "_comfy_vae_names": "_comfy_vae_names",
-        "_load_aio_resources_from_input_context": "_load_aio_resources_from_input_context",
-        "_load_aio_sam3_context": "_load_aio_sam3_context",
-        "_load_upscale_model_with_comfy": "_load_upscale_model_with_comfy",
         "_normalize_aio_input_settings": "_normalize_aio_input_settings",
         "_preferred_clip_type_default": "_preferred_clip_type_default",
         "_preferred_name_default": "_preferred_name_default"
@@ -2721,11 +2037,9 @@
       "owner": "#184/#188",
       "first_release": null,
       "known_consumers": [
-        "canonical runtime resolver: easyuse_anima.aio.legacy_generation",
         "canonical runtime resolver: easyuse_anima.nodes.aio_nodes"
       ],
       "evidence": [
-        "AST:easyuse_anima.aio.legacy_generation string runtime lookup",
         "AST:easyuse_anima.nodes.aio_nodes string runtime lookup"
       ],
       "removal_gates": [
@@ -2739,9 +2053,12 @@
       "id": "nodes_canonical_bindings:easyuse_anima.aio.resources:unsupported_test_only",
       "surface": "nodes_canonical_bindings",
       "symbols": {
+        "_load_aio_resources_from_input_context": "_load_aio_resources_from_input_context",
+        "_load_aio_sam3_context": "_load_aio_sam3_context",
         "_load_checkpoint_with_comfy": "_load_checkpoint_with_comfy",
         "_load_clip_with_comfy": "_load_clip_with_comfy",
         "_load_diffusion_model_with_comfy": "_load_diffusion_model_with_comfy",
+        "_load_upscale_model_with_comfy": "_load_upscale_model_with_comfy",
         "_load_vae_with_comfy": "_load_vae_with_comfy",
         "_preferred_checkpoint_default": "_preferred_checkpoint_default"
       },
@@ -2772,13 +2089,7 @@
       "id": "nodes_canonical_bindings:easyuse_anima.aio.sampling:transitional_private_seam",
       "surface": "nodes_canonical_bindings",
       "symbols": {
-        "_aio_highres_effective_backend": "_aio_highres_effective_backend",
-        "_aio_stage_sampler_settings": "_aio_stage_sampler_settings",
-        "_decode_latent_with_comfy": "_decode_latent_with_comfy",
-        "_encode_image_with_comfy_vae": "_encode_image_with_comfy_vae",
-        "_generate_empty_latent_with_comfy": "_generate_empty_latent_with_comfy",
-        "_resolve_aio_runtime_seed": "_resolve_aio_runtime_seed",
-        "_sample_latent_with_aio_backend": "_sample_latent_with_aio_backend"
+        "_resolve_aio_runtime_seed": "_resolve_aio_runtime_seed"
       },
       "classification": "transitional_private_seam",
       "current_target": "nodes.py",
@@ -2790,11 +2101,9 @@
       "owner": "#184/#188",
       "first_release": null,
       "known_consumers": [
-        "canonical runtime resolver: easyuse_anima.aio.legacy_generation",
         "canonical runtime resolver: easyuse_anima.nodes.aio_nodes"
       ],
       "evidence": [
-        "AST:easyuse_anima.aio.legacy_generation string runtime lookup",
         "AST:easyuse_anima.nodes.aio_nodes string runtime lookup"
       ],
       "removal_gates": [
@@ -2808,7 +2117,13 @@
       "id": "nodes_canonical_bindings:easyuse_anima.aio.sampling:unsupported_test_only",
       "surface": "nodes_canonical_bindings",
       "symbols": {
+        "_aio_highres_effective_backend": "_aio_highres_effective_backend",
+        "_aio_stage_sampler_settings": "_aio_stage_sampler_settings",
+        "_decode_latent_with_comfy": "_decode_latent_with_comfy",
+        "_encode_image_with_comfy_vae": "_encode_image_with_comfy_vae",
+        "_generate_empty_latent_with_comfy": "_generate_empty_latent_with_comfy",
         "_new_aio_random_seed": "_new_aio_random_seed",
+        "_sample_latent_with_aio_backend": "_sample_latent_with_aio_backend",
         "_sample_latent_with_comfy": "_sample_latent_with_comfy",
         "_sample_latent_with_spectrum_mod_guidance_advanced": "_sample_latent_with_spectrum_mod_guidance_advanced",
         "_sample_latent_with_spectrum_spd": "_sample_latent_with_spectrum_spd"
@@ -2837,38 +2152,11 @@
       "lifecycle_state": "unsupported"
     },
     {
-      "id": "nodes_canonical_bindings:easyuse_anima.aio.usdu:transitional_private_seam",
-      "surface": "nodes_canonical_bindings",
-      "symbols": {
-        "_aio_usdu_tile_plan": "_aio_usdu_tile_plan"
-      },
-      "classification": "transitional_private_seam",
-      "current_target": "nodes.py",
-      "canonical_target": "easyuse_anima.aio.usdu",
-      "target_state": "canonical",
-      "identity_requirement": "required",
-      "binding_shape": "direct_import",
-      "import_target": "easyuse_anima.aio.usdu",
-      "owner": "#184/#188",
-      "first_release": null,
-      "known_consumers": [
-        "canonical runtime resolver: easyuse_anima.aio.legacy_generation"
-      ],
-      "evidence": [
-        "AST:easyuse_anima.aio.legacy_generation string runtime lookup"
-      ],
-      "removal_gates": [
-        "canonical production consumer migration",
-        "focused monkeypatch and identity contract review",
-        "separate B-10b or B-11 rollback unit"
-      ],
-      "lifecycle_state": "transitional"
-    },
-    {
       "id": "nodes_canonical_bindings:easyuse_anima.aio.usdu:unsupported_test_only",
       "surface": "nodes_canonical_bindings",
       "symbols": {
-        "_aio_usdu_auto_tile_dimension": "_aio_usdu_auto_tile_dimension"
+        "_aio_usdu_auto_tile_dimension": "_aio_usdu_auto_tile_dimension",
+        "_aio_usdu_tile_plan": "_aio_usdu_tile_plan"
       },
       "classification": "unsupported_test_only",
       "current_target": "nodes.py",
@@ -2952,41 +2240,14 @@
       "lifecycle_state": "unsupported"
     },
     {
-      "id": "nodes_canonical_bindings:easyuse_anima.common.values:transitional_private_seam",
+      "id": "nodes_canonical_bindings:easyuse_anima.common.values:unsupported_test_only",
       "surface": "nodes_canonical_bindings",
       "symbols": {
         "_as_bool": "_as_bool",
         "_as_float": "_as_float",
         "_as_int": "_as_int",
+        "_choice": "_choice",
         "_single_value": "_single_value"
-      },
-      "classification": "transitional_private_seam",
-      "current_target": "nodes.py",
-      "canonical_target": "easyuse_anima.common.values",
-      "target_state": "canonical",
-      "identity_requirement": "required",
-      "binding_shape": "direct_import",
-      "import_target": "easyuse_anima.common.values",
-      "owner": "#184/#188",
-      "first_release": null,
-      "known_consumers": [
-        "canonical runtime resolver: easyuse_anima.aio.legacy_generation"
-      ],
-      "evidence": [
-        "AST:easyuse_anima.aio.legacy_generation string runtime lookup"
-      ],
-      "removal_gates": [
-        "canonical production consumer migration",
-        "focused monkeypatch and identity contract review",
-        "separate B-10b or B-11 rollback unit"
-      ],
-      "lifecycle_state": "transitional"
-    },
-    {
-      "id": "nodes_canonical_bindings:easyuse_anima.common.values:unsupported_test_only",
-      "surface": "nodes_canonical_bindings",
-      "symbols": {
-        "_choice": "_choice"
       },
       "classification": "unsupported_test_only",
       "current_target": "nodes.py",
@@ -3010,41 +2271,14 @@
         "separate B-10b removal review"
       ],
       "lifecycle_state": "unsupported"
-    },
-    {
-      "id": "nodes_canonical_bindings:easyuse_anima.image.geometry:transitional_private_seam",
-      "surface": "nodes_canonical_bindings",
-      "symbols": {
-        "_image_tensor_size": "_image_tensor_size"
-      },
-      "classification": "transitional_private_seam",
-      "current_target": "nodes.py",
-      "canonical_target": "easyuse_anima.image.geometry",
-      "target_state": "canonical",
-      "identity_requirement": "required",
-      "binding_shape": "direct_import",
-      "import_target": "easyuse_anima.image.geometry",
-      "owner": "#184/#188",
-      "first_release": null,
-      "known_consumers": [
-        "canonical runtime resolver: easyuse_anima.aio.legacy_generation"
-      ],
-      "evidence": [
-        "AST:easyuse_anima.aio.legacy_generation string runtime lookup"
-      ],
-      "removal_gates": [
-        "canonical production consumer migration",
-        "focused monkeypatch and identity contract review",
-        "separate B-10b or B-11 rollback unit"
-      ],
-      "lifecycle_state": "transitional"
     },
     {
       "id": "nodes_canonical_bindings:easyuse_anima.image.geometry:unsupported_test_only",
       "surface": "nodes_canonical_bindings",
       "symbols": {
         "_align_down": "_align_down",
-        "_align_nearest": "_align_nearest"
+        "_align_nearest": "_align_nearest",
+        "_image_tensor_size": "_image_tensor_size"
       },
       "classification": "unsupported_test_only",
       "current_target": "nodes.py",
@@ -3070,39 +2304,12 @@
       "lifecycle_state": "unsupported"
     },
     {
-      "id": "nodes_canonical_bindings:easyuse_anima.image.sam3:transitional_private_seam",
-      "surface": "nodes_canonical_bindings",
-      "symbols": {
-        "_context_value": "_context_value",
-        "_segs_has_items": "_segs_has_items"
-      },
-      "classification": "transitional_private_seam",
-      "current_target": "nodes.py",
-      "canonical_target": "easyuse_anima.image.sam3",
-      "target_state": "canonical",
-      "identity_requirement": "required",
-      "binding_shape": "direct_import",
-      "import_target": "easyuse_anima.image.sam3",
-      "owner": "#184/#188",
-      "first_release": null,
-      "known_consumers": [
-        "canonical runtime resolver: easyuse_anima.aio.legacy_generation"
-      ],
-      "evidence": [
-        "AST:easyuse_anima.aio.legacy_generation string runtime lookup"
-      ],
-      "removal_gates": [
-        "canonical production consumer migration",
-        "focused monkeypatch and identity contract review",
-        "separate B-10b or B-11 rollback unit"
-      ],
-      "lifecycle_state": "transitional"
-    },
-    {
       "id": "nodes_canonical_bindings:easyuse_anima.image.sam3:unsupported_test_only",
       "surface": "nodes_canonical_bindings",
       "symbols": {
-        "_sam3_context": "_sam3_context"
+        "_context_value": "_context_value",
+        "_sam3_context": "_sam3_context",
+        "_segs_has_items": "_segs_has_items"
       },
       "classification": "unsupported_test_only",
       "current_target": "nodes.py",
@@ -3189,39 +2396,12 @@
       "lifecycle_state": "unsupported"
     },
     {
-      "id": "nodes_canonical_bindings:easyuse_anima.infrastructure.comfy.invocation:transitional_private_seam",
-      "surface": "nodes_canonical_bindings",
-      "symbols": {
-        "_node_output_tuple": "_node_output_tuple"
-      },
-      "classification": "transitional_private_seam",
-      "current_target": "nodes.py",
-      "canonical_target": "easyuse_anima.infrastructure.comfy.invocation",
-      "target_state": "canonical",
-      "identity_requirement": "required",
-      "binding_shape": "direct_import",
-      "import_target": "easyuse_anima.infrastructure.comfy.invocation",
-      "owner": "#184/#188",
-      "first_release": null,
-      "known_consumers": [
-        "canonical runtime resolver: easyuse_anima.aio.legacy_generation"
-      ],
-      "evidence": [
-        "AST:easyuse_anima.aio.legacy_generation string runtime lookup"
-      ],
-      "removal_gates": [
-        "canonical production consumer migration",
-        "focused monkeypatch and identity contract review",
-        "separate B-10b or B-11 rollback unit"
-      ],
-      "lifecycle_state": "transitional"
-    },
-    {
       "id": "nodes_canonical_bindings:easyuse_anima.infrastructure.comfy.invocation:unsupported_test_only",
       "surface": "nodes_canonical_bindings",
       "symbols": {
         "_call_with_supported_kwargs": "_call_with_supported_kwargs",
-        "_common_upscale_image": "_common_upscale_image"
+        "_common_upscale_image": "_common_upscale_image",
+        "_node_output_tuple": "_node_output_tuple"
       },
       "classification": "unsupported_test_only",
       "current_target": "nodes.py",
@@ -3278,34 +2458,6 @@
         "separate B-10b removal review"
       ],
       "lifecycle_state": "unsupported"
-    },
-    {
-      "id": "nodes_canonical_bindings:easyuse_anima.infrastructure.comfy.wiring:transitional_private_seam",
-      "surface": "nodes_canonical_bindings",
-      "symbols": {
-        "_resolve_comfy_host_helper": "resolve_comfy_host_helper"
-      },
-      "classification": "transitional_private_seam",
-      "current_target": "nodes.py",
-      "canonical_target": "easyuse_anima.infrastructure.comfy.wiring",
-      "target_state": "canonical",
-      "identity_requirement": "required",
-      "binding_shape": "direct_import",
-      "import_target": "easyuse_anima.infrastructure.comfy.wiring",
-      "owner": "#184/#188",
-      "first_release": null,
-      "known_consumers": [
-        "nodes.py residual runtime"
-      ],
-      "evidence": [
-        "AST:nodes.py direct runtime load"
-      ],
-      "removal_gates": [
-        "canonical production consumer migration",
-        "focused monkeypatch and identity contract review",
-        "separate B-10b or B-11 rollback unit"
-      ],
-      "lifecycle_state": "transitional"
     },
     {
       "id": "nodes_canonical_bindings:easyuse_anima.lora.metadata:unsupported_test_only",
@@ -3819,8 +2971,7 @@
       "id": "nodes_canonical_bindings:easyuse_anima.nodes.sam3_nodes:transitional_private_seam",
       "surface": "nodes_canonical_bindings",
       "symbols": {
-        "EasyUseAnimaSAM3Context": "EasyUseAnimaSAM3Context",
-        "EasyUseAnimaSAM3Detailer": "EasyUseAnimaSAM3Detailer"
+        "EasyUseAnimaSAM3Context": "EasyUseAnimaSAM3Context"
       },
       "classification": "transitional_private_seam",
       "current_target": "nodes.py",
@@ -3832,11 +2983,9 @@
       "owner": "#184/#188",
       "first_release": null,
       "known_consumers": [
-        "canonical runtime resolver: easyuse_anima.aio.legacy_generation",
         "historical SAM3 convenience-node compatibility"
       ],
       "evidence": [
-        "AST:easyuse_anima.aio.legacy_generation string runtime lookup",
         "docs/version-plans/0.1.6-Detailer.md"
       ],
       "removal_gates": [
@@ -3845,6 +2994,35 @@
         "separate B-10b or B-11 rollback unit"
       ],
       "lifecycle_state": "transitional"
+    },
+    {
+      "id": "nodes_canonical_bindings:easyuse_anima.nodes.sam3_nodes:unsupported_test_only",
+      "surface": "nodes_canonical_bindings",
+      "symbols": {
+        "EasyUseAnimaSAM3Detailer": "EasyUseAnimaSAM3Detailer"
+      },
+      "classification": "unsupported_test_only",
+      "current_target": "nodes.py",
+      "canonical_target": "easyuse_anima.nodes.sam3_nodes",
+      "target_state": "canonical",
+      "identity_requirement": "not_applicable",
+      "binding_shape": "direct_import",
+      "import_target": "easyuse_anima.nodes.sam3_nodes",
+      "owner": "#184/#188",
+      "first_release": null,
+      "known_consumers": [
+        "repository tests may import this root name"
+      ],
+      "evidence": [
+        "AST:no nodes.py runtime load",
+        "test-only consumption is not public support evidence"
+      ],
+      "removal_gates": [
+        "test imports migrate to canonical targets",
+        "no production consumer evidence",
+        "separate B-10b removal review"
+      ],
+      "lifecycle_state": "unsupported"
     },
     {
       "id": "nodes_canonical_bindings:easyuse_anima.nodes.wildcard_nodes:supported_public_reexport",
@@ -3954,34 +3132,6 @@
       "lifecycle_state": "unsupported"
     },
     {
-      "id": "nodes_canonical_bindings:easyuse_anima.prompt.artist_mix:transitional_private_seam",
-      "surface": "nodes_canonical_bindings",
-      "symbols": {
-        "_encode_prompt_data_positive_conditioning": "_encode_prompt_data_positive_conditioning"
-      },
-      "classification": "transitional_private_seam",
-      "current_target": "nodes.py",
-      "canonical_target": "easyuse_anima.prompt.artist_mix",
-      "target_state": "canonical",
-      "identity_requirement": "required",
-      "binding_shape": "direct_import",
-      "import_target": "easyuse_anima.prompt.artist_mix",
-      "owner": "#184/#188",
-      "first_release": null,
-      "known_consumers": [
-        "canonical runtime resolver: easyuse_anima.aio.legacy_generation"
-      ],
-      "evidence": [
-        "AST:easyuse_anima.aio.legacy_generation string runtime lookup"
-      ],
-      "removal_gates": [
-        "canonical production consumer migration",
-        "focused monkeypatch and identity contract review",
-        "separate B-10b or B-11 rollback unit"
-      ],
-      "lifecycle_state": "transitional"
-    },
-    {
       "id": "nodes_canonical_bindings:easyuse_anima.prompt.artist_mix:unsupported_test_only",
       "surface": "nodes_canonical_bindings",
       "symbols": {
@@ -4004,6 +3154,7 @@
         "_bounded_artist_mix_int": "_bounded_artist_mix_int",
         "_encode_artist_clustered": "_encode_artist_clustered",
         "_encode_artist_delta_rms": "_encode_artist_delta_rms",
+        "_encode_prompt_data_positive_conditioning": "_encode_prompt_data_positive_conditioning",
         "_join_artist_mix_source_prompts": "_join_artist_mix_source_prompts",
         "_normalize_artist_mix_mode": "_normalize_artist_mix_mode",
         "_normalize_artist_tag_position": "_normalize_artist_tag_position",
@@ -4033,44 +3184,17 @@
       "lifecycle_state": "unsupported"
     },
     {
-      "id": "nodes_canonical_bindings:easyuse_anima.prompt.conditioning:transitional_private_seam",
-      "surface": "nodes_canonical_bindings",
-      "symbols": {
-        "ANIMA_MOD_GUIDANCE_PROFILE_OFF": "ANIMA_MOD_GUIDANCE_PROFILE_OFF",
-        "_apply_spectrum_anima_mod_guidance": "_apply_spectrum_anima_mod_guidance",
-        "_normalize_anima_mod_guidance_profile": "_normalize_anima_mod_guidance_profile",
-        "_resolve_anima_mod_guidance_enabled": "_resolve_anima_mod_guidance_enabled"
-      },
-      "classification": "transitional_private_seam",
-      "current_target": "nodes.py",
-      "canonical_target": "easyuse_anima.prompt.conditioning",
-      "target_state": "canonical",
-      "identity_requirement": "required",
-      "binding_shape": "direct_import",
-      "import_target": "easyuse_anima.prompt.conditioning",
-      "owner": "#184/#188",
-      "first_release": null,
-      "known_consumers": [
-        "canonical runtime resolver: easyuse_anima.aio.legacy_generation"
-      ],
-      "evidence": [
-        "AST:easyuse_anima.aio.legacy_generation string runtime lookup"
-      ],
-      "removal_gates": [
-        "canonical production consumer migration",
-        "focused monkeypatch and identity contract review",
-        "separate B-10b or B-11 rollback unit"
-      ],
-      "lifecycle_state": "transitional"
-    },
-    {
       "id": "nodes_canonical_bindings:easyuse_anima.prompt.conditioning:unsupported_test_only",
       "surface": "nodes_canonical_bindings",
       "symbols": {
         "ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE": "ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
         "ANIMA_MOD_GUIDANCE_MODES": "ANIMA_MOD_GUIDANCE_MODES",
         "ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA": "ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
-        "_find_spectrum_anima_mod_guidance_class": "_find_spectrum_anima_mod_guidance_class"
+        "ANIMA_MOD_GUIDANCE_PROFILE_OFF": "ANIMA_MOD_GUIDANCE_PROFILE_OFF",
+        "_apply_spectrum_anima_mod_guidance": "_apply_spectrum_anima_mod_guidance",
+        "_find_spectrum_anima_mod_guidance_class": "_find_spectrum_anima_mod_guidance_class",
+        "_normalize_anima_mod_guidance_profile": "_normalize_anima_mod_guidance_profile",
+        "_resolve_anima_mod_guidance_enabled": "_resolve_anima_mod_guidance_enabled"
       },
       "classification": "unsupported_test_only",
       "current_target": "nodes.py",
@@ -4131,7 +3255,6 @@
       "surface": "nodes_canonical_bindings",
       "symbols": {
         "PROMPT_DATA_TYPE": "PROMPT_DATA_TYPE",
-        "_advanced_outputs_from_prompt_data": "_advanced_outputs_from_prompt_data",
         "_copy_prompt_data_for_update": "_copy_prompt_data_for_update",
         "_normalize_prompt_data": "_normalize_prompt_data",
         "_prompt_data_json_safe": "_prompt_data_json_safe"
@@ -4146,11 +3269,9 @@
       "owner": "#184/#188",
       "first_release": null,
       "known_consumers": [
-        "canonical runtime resolver: easyuse_anima.aio.legacy_generation",
         "canonical runtime resolver: easyuse_anima.nodes.aio_nodes"
       ],
       "evidence": [
-        "AST:easyuse_anima.aio.legacy_generation string runtime lookup",
         "AST:easyuse_anima.nodes.aio_nodes string runtime lookup"
       ],
       "removal_gates": [
@@ -4164,6 +3285,7 @@
       "id": "nodes_canonical_bindings:easyuse_anima.prompt.data:unsupported_test_only",
       "surface": "nodes_canonical_bindings",
       "symbols": {
+        "_advanced_outputs_from_prompt_data": "_advanced_outputs_from_prompt_data",
         "_apply_prompt_data_overrides": "_apply_prompt_data_overrides",
         "_prompt_data_parameter_snapshot": "_prompt_data_parameter_snapshot"
       },

--- a/tests/test_aio_legacy_generation.py
+++ b/tests/test_aio_legacy_generation.py
@@ -17,13 +17,6 @@ ROOT = Path(__file__).resolve().parents[1]
 TRACE_FIXTURE_PATH = ROOT / "tests" / "fixtures" / "aio_legacy_execution_trace.v1.json"
 
 
-def _production_resolver(name):
-    return nodes._resolve_comfy_host_helper(
-        name,
-        lambda fallback_name: getattr(nodes, fallback_name),
-    )
-
-
 class _Token:
     def __init__(self, name: str):
         self.name = name
@@ -32,10 +25,6 @@ class _Token:
 class AIOGeneratorLegacyMoveTests(unittest.TestCase):
     def test_private_implementation_aliases_are_canonical_in_both_import_modes(self):
         self.assertEqual(legacy_generation.__all__, ())
-        self.assertIs(
-            nodes._bind_aio_legacy_generation_runtime,
-            legacy_generation._bind_aio_legacy_generation_runtime,
-        )
         self.assertIs(
             nodes._run_aio_legacy_generation,
             legacy_generation._run_aio_legacy_generation,
@@ -70,10 +59,6 @@ class AIOGeneratorLegacyMoveTests(unittest.TestCase):
                 f"{package_entrypoint.__name__}.easyuse_anima.aio.legacy_generation"
             ]
             self.assertIs(
-                package_nodes._bind_aio_legacy_generation_runtime,
-                canonical_module._bind_aio_legacy_generation_runtime,
-            )
-            self.assertIs(
                 package_nodes._run_aio_legacy_generation,
                 canonical_module._run_aio_legacy_generation,
             )
@@ -107,14 +92,11 @@ class AIOGeneratorLegacyMoveTests(unittest.TestCase):
         image = object()
         base_latent = object()
 
-        def resolve(name):
-            trace.append(f"resolve:{name}")
-            if name == "_as_bool":
-                return lambda value, default: trace.append("as_bool") or False
-            self.fail(f"disabled highres stage resolved unexpected helper: {name}")
-
-        legacy_generation._bind_aio_legacy_generation_runtime(resolve_helper=resolve)
-        try:
+        with patch.object(
+            legacy_generation,
+            "_as_bool",
+            side_effect=lambda value, default: trace.append("as_bool") or False,
+        ):
             result = nodes._run_aio_highres_stage(
                 object(),
                 object(),
@@ -128,15 +110,11 @@ class AIOGeneratorLegacyMoveTests(unittest.TestCase):
                 {},
                 {"enabled": False},
             )
-        finally:
-            legacy_generation._bind_aio_legacy_generation_runtime(
-                resolve_helper=_production_resolver
-            )
 
         self.assertIs(result[0], base_latent)
         self.assertIs(result[1], image)
         self.assertEqual(result[2:], (64, 96, {"enabled": False}))
-        self.assertEqual(trace, ["resolve:_as_bool", "as_bool"])
+        self.assertEqual(trace, ["as_bool"])
 
     def test_highres_stage_preserves_dependency_and_metadata_order(self):
         trace: list[str] = []
@@ -250,12 +228,7 @@ class AIOGeneratorLegacyMoveTests(unittest.TestCase):
             "_prompt_data_json_safe": json_safe,
         }
 
-        def resolve(name):
-            trace.append(f"resolve:{name}")
-            return helpers[name]
-
-        legacy_generation._bind_aio_legacy_generation_runtime(resolve_helper=resolve)
-        try:
+        with patch.multiple(legacy_generation, **helpers):
             result = nodes._run_aio_highres_stage(
                 model,
                 clip,
@@ -279,10 +252,6 @@ class AIOGeneratorLegacyMoveTests(unittest.TestCase):
                 "quality",
                 "quality-neg",
             )
-        finally:
-            legacy_generation._bind_aio_legacy_generation_runtime(
-                resolve_helper=_production_resolver
-            )
 
         self.assertEqual(
             result,
@@ -303,28 +272,17 @@ class AIOGeneratorLegacyMoveTests(unittest.TestCase):
         self.assertEqual(
             trace,
             [
-                "resolve:_as_bool",
                 "call:_as_bool",
-                "resolve:_aio_stage_sampler_settings",
                 "call:_aio_stage_sampler_settings",
-                "resolve:EasyUseAnimaImageScaleByMultiple",
                 "construct:scaler",
                 "call:upscale",
-                "resolve:_encode_image_with_comfy_vae",
                 "call:encode:scaled_image",
-                "resolve:_apply_aio_spectrum_model_patches_for_comfy_sampler",
                 "call:patch",
-                "resolve:_sample_latent_with_aio_backend",
                 "call:sample",
-                "resolve:_cleanup_aio_ephemeral_model",
                 "call:cleanup",
-                "resolve:_decode_latent_with_comfy",
                 "call:decode",
-                "resolve:_resize_image_to_size_if_needed",
                 "call:resize",
-                "resolve:_encode_image_with_comfy_vae",
                 "call:encode:resized_image",
-                "resolve:_prompt_data_json_safe",
                 "call:json_safe",
             ],
         )
@@ -357,14 +315,7 @@ class AIOGeneratorLegacyMoveTests(unittest.TestCase):
             "_cleanup_aio_ephemeral_model": cleanup,
         }
 
-        def resolve(name):
-            trace.append(f"resolve:{name}")
-            if name not in helpers:
-                self.fail(f"sampling failure resolved unexpected helper: {name}")
-            return helpers[name]
-
-        legacy_generation._bind_aio_legacy_generation_runtime(resolve_helper=resolve)
-        try:
+        with patch.multiple(legacy_generation, **helpers):
             with self.assertRaisesRegex(RuntimeError, "sample failed"):
                 nodes._run_aio_highres_stage(
                     model,
@@ -379,17 +330,11 @@ class AIOGeneratorLegacyMoveTests(unittest.TestCase):
                     {},
                     {"enabled": True},
                 )
-        finally:
-            legacy_generation._bind_aio_legacy_generation_runtime(
-                resolve_helper=_production_resolver
-            )
 
         self.assertEqual(
-            trace[-4:],
+            trace[-2:],
             [
-                "resolve:_sample_latent_with_aio_backend",
                 "sample",
-                "resolve:_cleanup_aio_ephemeral_model",
                 "cleanup",
             ],
         )
@@ -412,16 +357,7 @@ class AIOGeneratorLegacyMoveTests(unittest.TestCase):
                 ),
             }
 
-            def resolve(name):
-                trace.append(("resolve", name))
-                if name not in helpers:
-                    self.fail(f"short-circuit resolved unexpected helper: {name}")
-                return helpers[name]
-
-            legacy_generation._bind_aio_legacy_generation_runtime(
-                resolve_helper=resolve
-            )
-            try:
+            with patch.multiple(legacy_generation, **helpers):
                 result = nodes._run_aio_detailer_stage(
                     object(),
                     object(),
@@ -432,10 +368,6 @@ class AIOGeneratorLegacyMoveTests(unittest.TestCase):
                     {},
                     detailer_settings,
                 )
-            finally:
-                legacy_generation._bind_aio_legacy_generation_runtime(
-                    resolve_helper=_production_resolver
-                )
             return result, trace
 
         disabled_result, disabled_trace = execute({"enabled": False}, [])
@@ -444,7 +376,6 @@ class AIOGeneratorLegacyMoveTests(unittest.TestCase):
         self.assertEqual(
             disabled_trace,
             [
-                ("resolve", "_as_bool"),
                 ("call", "_as_bool", False, False),
             ],
         )
@@ -465,11 +396,8 @@ class AIOGeneratorLegacyMoveTests(unittest.TestCase):
         self.assertEqual(
             no_target_trace,
             [
-                ("resolve", "_as_bool"),
                 ("call", "_as_bool", True, False),
-                ("resolve", "_aio_detailer_target_order"),
                 ("call", "_aio_detailer_target_order"),
-                ("resolve", "_as_bool"),
                 ("call", "_as_bool", False, False),
             ],
         )
@@ -547,15 +475,10 @@ class AIOGeneratorLegacyMoveTests(unittest.TestCase):
             "_context_value": context_value,
         }
 
-        def resolve(name):
-            trace.append(("resolve", name))
-            return helpers[name]
-
         def preview(stage, output):
             trace.append(("callback", stage, output.name))
 
-        legacy_generation._bind_aio_legacy_generation_runtime(resolve_helper=resolve)
-        try:
+        with patch.multiple(legacy_generation, **helpers):
             result = nodes._run_aio_detailer_stage(
                 model,
                 clip,
@@ -566,10 +489,6 @@ class AIOGeneratorLegacyMoveTests(unittest.TestCase):
                 sampler_settings,
                 detailer_settings,
                 preview,
-            )
-        finally:
-            legacy_generation._bind_aio_legacy_generation_runtime(
-                resolve_helper=_production_resolver
             )
 
         self.assertIs(result[0], face_image)
@@ -588,25 +507,16 @@ class AIOGeneratorLegacyMoveTests(unittest.TestCase):
         self.assertEqual(
             trace,
             [
-                ("resolve", "_as_bool"),
                 ("call", "_as_bool", True, False),
-                ("resolve", "_aio_detailer_target_order"),
                 ("call", "_aio_detailer_target_order"),
-                ("resolve", "_as_bool"),
                 ("call", "_as_bool", True, False),
-                ("resolve", "_as_bool"),
                 ("call", "_as_bool", False, False),
-                ("resolve", "_as_bool"),
                 ("call", "_as_bool", True, False),
-                ("resolve", "_load_aio_sam3_context"),
                 ("call", "_load_aio_sam3_context"),
-                ("resolve", "_run_aio_detailer_target"),
                 ("call", "_run_aio_detailer_target", "eye"),
                 ("callback", "detailer_eye", "eye_image"),
-                ("resolve", "_run_aio_detailer_target"),
                 ("call", "_run_aio_detailer_target", "face"),
                 ("callback", "detailer_face", "face_image"),
-                ("resolve", "_context_value"),
                 ("call", "_context_value", "ckpt_name"),
             ],
         )
@@ -627,14 +537,7 @@ class AIOGeneratorLegacyMoveTests(unittest.TestCase):
                 "_context_value": lambda context, key: trace.append("context_value"),
             }
 
-            def resolve(name):
-                trace.append(f"resolve:{name}")
-                return helpers[name]
-
-            legacy_generation._bind_aio_legacy_generation_runtime(
-                resolve_helper=resolve
-            )
-            try:
+            with patch.multiple(legacy_generation, **helpers):
                 nodes._run_aio_detailer_stage(
                     object(),
                     object(),
@@ -645,10 +548,6 @@ class AIOGeneratorLegacyMoveTests(unittest.TestCase):
                     {},
                     detailer_settings,
                     preview_callback(trace),
-                )
-            finally:
-                legacy_generation._bind_aio_legacy_generation_runtime(
-                    resolve_helper=_production_resolver
                 )
             return trace
 
@@ -667,8 +566,8 @@ class AIOGeneratorLegacyMoveTests(unittest.TestCase):
                 target_trace,
             )
         self.assertEqual(
-            target_trace[-2:],
-            ["resolve:_run_aio_detailer_target", "target:eye"],
+            target_trace[-1:],
+            ["target:eye"],
         )
         self.assertNotIn("preview", target_trace)
         self.assertNotIn("target:face", target_trace)
@@ -689,8 +588,8 @@ class AIOGeneratorLegacyMoveTests(unittest.TestCase):
                 unpack_trace,
             )
         self.assertEqual(
-            unpack_trace[-2:],
-            ["resolve:_run_aio_detailer_target", "target:eye"],
+            unpack_trace[-1:],
+            ["target:eye"],
         )
         self.assertNotIn("preview", unpack_trace)
         self.assertNotIn("target:face", unpack_trace)
@@ -716,7 +615,6 @@ class AIOGeneratorLegacyMoveTests(unittest.TestCase):
         self.assertEqual(
             callback_trace[-3:],
             [
-                "resolve:_run_aio_detailer_target",
                 "target:eye",
                 "preview:eye",
             ],
@@ -728,14 +626,11 @@ class AIOGeneratorLegacyMoveTests(unittest.TestCase):
         trace: list[str] = []
         image = object()
 
-        def resolve(name):
-            trace.append(f"resolve:{name}")
-            if name == "_as_bool":
-                return lambda value, default: trace.append("call:_as_bool") or False
-            self.fail(f"disabled Detailer target resolved unexpected helper: {name}")
-
-        legacy_generation._bind_aio_legacy_generation_runtime(resolve_helper=resolve)
-        try:
+        with patch.object(
+            legacy_generation,
+            "_as_bool",
+            side_effect=lambda value, default: trace.append("call:_as_bool") or False,
+        ):
             result = nodes._run_aio_detailer_target(
                 "face",
                 {"enabled": False},
@@ -748,14 +643,10 @@ class AIOGeneratorLegacyMoveTests(unittest.TestCase):
                 {},
                 {},
             )
-        finally:
-            legacy_generation._bind_aio_legacy_generation_runtime(
-                resolve_helper=_production_resolver
-            )
 
         self.assertIs(result[0], image)
         self.assertEqual(result[1], {"enabled": False})
-        self.assertEqual(trace, ["resolve:_as_bool", "call:_as_bool"])
+        self.assertEqual(trace, ["call:_as_bool"])
 
     def test_detailer_target_preserves_kwargs_cleanup_and_metadata_order(self):
         trace: list[str] = []
@@ -870,12 +761,7 @@ class AIOGeneratorLegacyMoveTests(unittest.TestCase):
             "_prompt_data_json_safe": json_safe,
         }
 
-        def resolve(name):
-            trace.append(f"resolve:{name}")
-            return helpers[name]
-
-        legacy_generation._bind_aio_legacy_generation_runtime(resolve_helper=resolve)
-        try:
+        with patch.multiple(legacy_generation, **helpers):
             result = nodes._run_aio_detailer_target(
                 "face",
                 target_settings,
@@ -887,10 +773,6 @@ class AIOGeneratorLegacyMoveTests(unittest.TestCase):
                 negative,
                 sampler_settings,
                 sam3_context,
-            )
-        finally:
-            legacy_generation._bind_aio_legacy_generation_runtime(
-                resolve_helper=_production_resolver
             )
 
         self.assertIs(result[0], detailed_image)
@@ -961,27 +843,6 @@ class AIOGeneratorLegacyMoveTests(unittest.TestCase):
                 "tiled_decode": False,
             },
         )
-        resolved_helpers = [
-            item.removeprefix("resolve:")
-            for item in trace
-            if isinstance(item, str) and item.startswith("resolve:")
-        ]
-        self.assertEqual(
-            resolved_helpers,
-            [
-                "_as_bool",
-                "_aio_stage_sampler_settings",
-                "_apply_aio_spectrum_model_patches_for_comfy_sampler",
-                "EasyUseAnimaSAM3Detailer",
-                "_as_int", "_as_float", "_as_int", "_as_bool", "_as_bool",
-                "_as_float", "_as_bool", "_as_int", "_as_bool", "_as_int",
-                "_as_bool", "_as_int", "_as_int", "_as_bool", "_as_bool",
-                "_as_int", "_as_bool", "_as_int", "_as_bool", "_as_bool",
-                "_cleanup_aio_ephemeral_model",
-                "_segs_has_items",
-                "_prompt_data_json_safe",
-            ],
-        )
         self.assertLess(trace.index("call:cleanup"), trace.index("call:_segs_has_items"))
         self.assertLess(
             trace.index("call:_segs_has_items"),
@@ -1024,14 +885,7 @@ class AIOGeneratorLegacyMoveTests(unittest.TestCase):
                 **overrides,
             }
 
-            def resolve(name):
-                trace.append(f"resolve:{name}")
-                return helpers[name]
-
-            legacy_generation._bind_aio_legacy_generation_runtime(
-                resolve_helper=resolve
-            )
-            try:
+            with patch.multiple(legacy_generation, **helpers):
                 return nodes._run_aio_detailer_target(
                     "face",
                     {"enabled": True},
@@ -1044,10 +898,6 @@ class AIOGeneratorLegacyMoveTests(unittest.TestCase):
                     {},
                     {},
                 )
-            finally:
-                legacy_generation._bind_aio_legacy_generation_runtime(
-                    resolve_helper=_production_resolver
-                )
 
         planner_trace = []
 
@@ -1058,9 +908,6 @@ class AIOGeneratorLegacyMoveTests(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "planner failed"):
             execute({"_aio_stage_sampler_settings": fail_planner}, planner_trace)
         self.assertNotIn("cleanup", planner_trace)
-        self.assertFalse(
-            any(item == "resolve:_cleanup_aio_ephemeral_model" for item in planner_trace)
-        )
 
         class_trace = []
 
@@ -1070,7 +917,7 @@ class AIOGeneratorLegacyMoveTests(unittest.TestCase):
 
         with self.assertRaisesRegex(LookupError, "class failed"):
             execute({"EasyUseAnimaSAM3Detailer": fail_class}, class_trace)
-        self.assertEqual(class_trace[-2:], ["resolve:_cleanup_aio_ephemeral_model", "cleanup"])
+        self.assertEqual(class_trace[-1:], ["cleanup"])
 
         cleanup_trace = []
 
@@ -1091,7 +938,7 @@ class AIOGeneratorLegacyMoveTests(unittest.TestCase):
                 },
                 cleanup_trace,
             )
-        self.assertEqual(cleanup_trace[-3:], ["doit", "resolve:_cleanup_aio_ephemeral_model", "cleanup"])
+        self.assertEqual(cleanup_trace[-2:], ["doit", "cleanup"])
 
         metadata_trace = []
 
@@ -1102,10 +949,7 @@ class AIOGeneratorLegacyMoveTests(unittest.TestCase):
         with self.assertRaisesRegex(ArithmeticError, "segs failed"):
             execute({"_segs_has_items": fail_segs}, metadata_trace)
         self.assertIn("cleanup", metadata_trace)
-        self.assertEqual(metadata_trace[-2:], ["resolve:_segs_has_items", "segs"])
-        self.assertFalse(
-            any(item == "resolve:_prompt_data_json_safe" for item in metadata_trace)
-        )
+        self.assertEqual(metadata_trace[-1:], ["segs"])
 
     def test_usdu_stage_preserves_dependencies_kwargs_cleanup_and_metadata_order(self):
         trace = []
@@ -1282,14 +1126,7 @@ class AIOGeneratorLegacyMoveTests(unittest.TestCase):
             "_prompt_data_json_safe": json_safe,
         }
 
-        def resolve(name):
-            trace.append(f"resolve:{name}")
-            if name == "AIO_USDU_PROMPT_FULL":
-                self.fail("explicit prompt mode must not resolve the default constant")
-            return helpers[name]
-
-        legacy_generation._bind_aio_legacy_generation_runtime(resolve_helper=resolve)
-        try:
+        with patch.multiple(legacy_generation, **helpers):
             result = nodes._run_aio_usdu_upscale_stage(
                 model,
                 clip,
@@ -1304,10 +1141,6 @@ class AIOGeneratorLegacyMoveTests(unittest.TestCase):
                 {"fields": []},
                 True,
                 False,
-            )
-        finally:
-            legacy_generation._bind_aio_legacy_generation_runtime(
-                resolve_helper=_production_resolver
             )
 
         self.assertIs(result[0], output)
@@ -1382,33 +1215,6 @@ class AIOGeneratorLegacyMoveTests(unittest.TestCase):
         self.assertEqual(len(log_calls), 2)
         self.assertIn("USDU auto tile", log_calls[0][2][0])
         self.assertIn("USDU sampler", log_calls[1][2][0])
-        resolved_helpers = [
-            item.removeprefix("resolve:")
-            for item in trace
-            if isinstance(item, str) and item.startswith("resolve:")
-        ]
-        self.assertEqual(
-            resolved_helpers,
-            [
-                "_require_custom_node_class",
-                "_load_upscale_model_with_comfy",
-                "_aio_stage_sampler_settings",
-                "_as_float",
-                "_aio_usdu_tile_plan",
-                "logger",
-                "logger",
-                "_as_int", "_as_float", "_as_float",
-                "_aio_usdu_conditioning",
-                "_apply_aio_spectrum_model_patches_for_comfy_sampler",
-                "_resolve_aio_runtime_seed", "_as_int", "_as_float", "_as_float",
-                "_as_int", "_as_int", "_as_float", "_as_int", "_as_int",
-                "_as_int", "_as_bool", "_as_bool", "_as_int",
-                "_cleanup_aio_ephemeral_model",
-                "_node_output_tuple",
-                "_image_tensor_size",
-                "_prompt_data_json_safe",
-            ],
-        )
         self.assertLess(trace.index("call:cleanup"), trace.index("call:_node_output_tuple"))
 
     def test_usdu_stage_preserves_cleanup_output_and_lazy_default_boundaries(self):
@@ -1461,14 +1267,7 @@ class AIOGeneratorLegacyMoveTests(unittest.TestCase):
                 **overrides,
             }
 
-            def resolve(name):
-                trace.append(f"resolve:{name}")
-                return helpers[name]
-
-            legacy_generation._bind_aio_legacy_generation_runtime(
-                resolve_helper=resolve
-            )
-            try:
+            with patch.multiple(legacy_generation, **helpers):
                 return nodes._run_aio_usdu_upscale_stage(
                     model,
                     object(),
@@ -1478,10 +1277,6 @@ class AIOGeneratorLegacyMoveTests(unittest.TestCase):
                     object(),
                     {},
                     {"usdu": {}},
-                )
-            finally:
-                legacy_generation._bind_aio_legacy_generation_runtime(
-                    resolve_helper=_production_resolver
                 )
 
         patch_trace = []
@@ -1495,7 +1290,6 @@ class AIOGeneratorLegacyMoveTests(unittest.TestCase):
                 patch_trace,
             )
         self.assertNotIn("cleanup", patch_trace)
-        self.assertNotIn("resolve:_cleanup_aio_ephemeral_model", patch_trace)
 
         construct_trace = []
 
@@ -1509,10 +1303,7 @@ class AIOGeneratorLegacyMoveTests(unittest.TestCase):
                 {"_require_custom_node_class": lambda *args: FailingConstructor},
                 construct_trace,
             )
-        self.assertEqual(
-            construct_trace[-2:],
-            ["resolve:_cleanup_aio_ephemeral_model", "cleanup"],
-        )
+        self.assertEqual(construct_trace[-1:], ["cleanup"])
 
         cleanup_trace = []
 
@@ -1533,10 +1324,7 @@ class AIOGeneratorLegacyMoveTests(unittest.TestCase):
                 },
                 cleanup_trace,
             )
-        self.assertEqual(
-            cleanup_trace[-3:],
-            ["upscale", "resolve:_cleanup_aio_ephemeral_model", "cleanup"],
-        )
+        self.assertEqual(cleanup_trace[-2:], ["upscale", "cleanup"])
 
         empty_trace = []
         with self.assertRaisesRegex(
@@ -1545,18 +1333,11 @@ class AIOGeneratorLegacyMoveTests(unittest.TestCase):
         ):
             execute({"_node_output_tuple": lambda value: ()}, empty_trace)
         self.assertIn("cleanup", empty_trace)
-        self.assertIn("resolve:_node_output_tuple", empty_trace)
-        self.assertNotIn("resolve:_image_tensor_size", empty_trace)
-        self.assertNotIn("resolve:AIO_USDU_PROMPT_FULL", empty_trace)
 
         default_trace = []
         result = execute({}, default_trace)
         self.assertIs(result[0], output)
         self.assertEqual(result[1]["prompt_mode"], "full")
-        self.assertLess(
-            default_trace.index("resolve:AIO_USDU_PROMPT_FULL"),
-            default_trace.index("resolve:_prompt_data_json_safe"),
-        )
 
     def test_resshift_stage_preserves_provider_argument_and_metadata_order(self):
         trace = []
@@ -1628,12 +1409,7 @@ class AIOGeneratorLegacyMoveTests(unittest.TestCase):
             "_image_tensor_size": image_size,
         }
 
-        def resolve(name):
-            trace.append(("resolve", name))
-            return helpers[name]
-
-        legacy_generation._bind_aio_legacy_generation_runtime(resolve_helper=resolve)
-        try:
+        with patch.multiple(legacy_generation, **helpers):
             result = nodes._run_aio_resshift_upscale_stage(
                 image,
                 sampler_settings,
@@ -1643,10 +1419,6 @@ class AIOGeneratorLegacyMoveTests(unittest.TestCase):
                 {"unused": True},
                 True,
                 True,
-            )
-        finally:
-            legacy_generation._bind_aio_legacy_generation_runtime(
-                resolve_helper=_production_resolver
             )
 
         self.assertIs(result[0], output)
@@ -1667,12 +1439,9 @@ class AIOGeneratorLegacyMoveTests(unittest.TestCase):
         self.assertEqual(
             trace,
             [
-                ("resolve", "_require_custom_node_class"),
                 ("call", "_require_custom_node_class", "ResShiftLoader"),
-                ("resolve", "_require_custom_node_class"),
                 ("call", "_require_custom_node_class", "ResShiftUpscale"),
                 "construct:loader",
-                ("resolve", "_node_output_tuple"),
                 (
                     "call",
                     "load",
@@ -1680,14 +1449,9 @@ class AIOGeneratorLegacyMoveTests(unittest.TestCase):
                 ),
                 ("call", "_node_output_tuple", "loader-result"),
                 "construct:upscaler",
-                ("resolve", "_node_output_tuple"),
-                ("resolve", "_resolve_aio_runtime_seed"),
                 ("call", "_resolve_aio_runtime_seed", "seed-input"),
-                ("resolve", "_as_int"),
                 ("call", "_as_int", "1024", 512),
-                ("resolve", "_as_int"),
                 ("call", "_as_int", "96", 64),
-                ("resolve", "_as_int"),
                 ("call", "_as_int", "2", 4),
                 (
                     "call",
@@ -1695,7 +1459,6 @@ class AIOGeneratorLegacyMoveTests(unittest.TestCase):
                     (model, image, 321, 1024, 96, 2),
                 ),
                 ("call", "_node_output_tuple", "upscale-result"),
-                ("resolve", "_image_tensor_size"),
                 ("call", "_image_tensor_size"),
             ],
         )
@@ -1704,24 +1467,11 @@ class AIOGeneratorLegacyMoveTests(unittest.TestCase):
         image = _Token("image")
 
         def execute(helpers, trace):
-            def resolve(name):
-                trace.append(f"resolve:{name}")
-                if name not in helpers:
-                    self.fail(f"failure case resolved unexpected helper: {name}")
-                return helpers[name]
-
-            legacy_generation._bind_aio_legacy_generation_runtime(
-                resolve_helper=resolve
-            )
-            try:
+            with patch.multiple(legacy_generation, **helpers):
                 return nodes._run_aio_resshift_upscale_stage(
                     image,
                     {"seed": 7},
                     {"resshift": {}},
-                )
-            finally:
-                legacy_generation._bind_aio_legacy_generation_runtime(
-                    resolve_helper=_production_resolver
                 )
 
         first_provider_trace = []
@@ -1737,7 +1487,7 @@ class AIOGeneratorLegacyMoveTests(unittest.TestCase):
             )
         self.assertEqual(
             first_provider_trace,
-            ["resolve:_require_custom_node_class", "require:loader"],
+            ["require:loader"],
         )
 
         missing_load_trace = []
@@ -1765,9 +1515,7 @@ class AIOGeneratorLegacyMoveTests(unittest.TestCase):
         self.assertEqual(
             missing_load_trace,
             [
-                "resolve:_require_custom_node_class",
                 "require:ResShiftLoader",
-                "resolve:_require_custom_node_class",
                 "require:ResShiftUpscale",
                 "construct:loader",
             ],
@@ -1843,11 +1591,10 @@ class AIOGeneratorLegacyMoveTests(unittest.TestCase):
             )
         self.assertIn("construct:upscaler", seed_failure_trace)
         self.assertEqual(
-            seed_failure_trace[-2:],
-            ["resolve:_resolve_aio_runtime_seed", "seed"],
+            seed_failure_trace[-1:],
+            ["seed"],
         )
         self.assertNotIn("upscale", seed_failure_trace)
-        self.assertFalse(any(item == "resolve:_as_int" for item in seed_failure_trace))
 
     def test_upscale_dispatcher_preserves_lazy_branch_and_exception_contract(self):
         model = _Token("model")
@@ -1868,14 +1615,7 @@ class AIOGeneratorLegacyMoveTests(unittest.TestCase):
 
             helpers = {"_as_bool": as_bool, **leaf_helpers}
 
-            def resolve(name):
-                trace.append(("resolve", name))
-                return helpers[name]
-
-            legacy_generation._bind_aio_legacy_generation_runtime(
-                resolve_helper=resolve
-            )
-            try:
+            with patch.multiple(legacy_generation, **helpers):
                 return nodes._run_aio_upscale_stage(
                     model,
                     clip,
@@ -1891,10 +1631,6 @@ class AIOGeneratorLegacyMoveTests(unittest.TestCase):
                     True,
                     False,
                 )
-            finally:
-                legacy_generation._bind_aio_legacy_generation_runtime(
-                    resolve_helper=_production_resolver
-                )
 
         disabled_trace = []
         disabled_result = execute({"enabled": False}, {}, disabled_trace)
@@ -1903,7 +1639,6 @@ class AIOGeneratorLegacyMoveTests(unittest.TestCase):
         self.assertEqual(
             disabled_trace,
             [
-                ("resolve", "_as_bool"),
                 ("call", "_as_bool", False, False),
             ],
         )
@@ -1946,9 +1681,7 @@ class AIOGeneratorLegacyMoveTests(unittest.TestCase):
         self.assertEqual(
             usdu_trace,
             [
-                ("resolve", "_as_bool"),
                 ("call", "_as_bool", True, False),
-                ("resolve", "_run_aio_usdu_upscale_stage"),
                 ("call", "usdu"),
             ],
         )
@@ -1989,9 +1722,7 @@ class AIOGeneratorLegacyMoveTests(unittest.TestCase):
         self.assertEqual(
             resshift_trace,
             [
-                ("resolve", "_as_bool"),
                 ("call", "_as_bool", True, False),
-                ("resolve", "_run_aio_resshift_upscale_stage"),
                 ("call", "resshift"),
             ],
         )
@@ -2009,7 +1740,6 @@ class AIOGeneratorLegacyMoveTests(unittest.TestCase):
         self.assertEqual(
             unsupported_trace,
             [
-                ("resolve", "_as_bool"),
                 ("call", "_as_bool", True, False),
             ],
         )
@@ -2029,9 +1759,7 @@ class AIOGeneratorLegacyMoveTests(unittest.TestCase):
         self.assertEqual(
             failure_trace,
             [
-                ("resolve", "_as_bool"),
                 ("call", "_as_bool", True, False),
-                ("resolve", "_run_aio_usdu_upscale_stage"),
                 ("call", "usdu"),
             ],
         )
@@ -2317,7 +2045,7 @@ class AIOGeneratorLegacyMoveTests(unittest.TestCase):
 
         with (
             patch.multiple(
-                nodes,
+                legacy_generation,
                 _normalize_aio_generation_settings=normalize_settings,
                 _resolve_aio_runtime_seed=resolve_seed,
                 _load_aio_resources_from_input_context=load_resources,

--- a/tests/test_aio_nodes.py
+++ b/tests/test_aio_nodes.py
@@ -10,6 +10,7 @@ from easyuse_anima.aio import (
     first_pass_cache,
     generation_normalization,
     input_context,
+    legacy_generation,
     model_preparation,
     postprocess,
     sampling,
@@ -893,7 +894,7 @@ class AIOSettingsStorageTests(unittest.TestCase):
         self.assertEqual(settings["sampler"]["seed"], nodes.AIO_SPECIAL_SEED_DECREMENT)
 
     def test_runtime_special_seed_resolves_to_concrete_seed(self):
-        with patch.object(nodes.random, "randint", return_value=123456):
+        with patch.object(sampling.random, "randint", return_value=123456):
             self.assertEqual(
                 nodes._resolve_aio_runtime_seed(nodes.AIO_SPECIAL_SEED_RANDOM),
                 123456,
@@ -1721,11 +1722,11 @@ class AIOHighresDetailerStageTests(unittest.TestCase):
 
         with (
             patch.object(nodes.EasyUseAnimaImageScaleByMultiple, "upscale", return_value=("scaled_image", 640, 960, 1.25)),
-            patch.object(nodes, "_encode_image_with_comfy_vae", return_value="high_latent_image"),
-            patch.object(nodes, "_apply_aio_spectrum_model_patches_for_comfy_sampler", return_value="stage_model"),
-            patch.object(nodes, "_sample_latent_with_aio_backend", side_effect=fake_sample),
-            patch.object(nodes, "_decode_latent_with_comfy", return_value="high_image"),
-            patch.object(nodes, "_cleanup_aio_ephemeral_model"),
+            patch.object(legacy_generation, "_encode_image_with_comfy_vae", return_value="high_latent_image"),
+            patch.object(legacy_generation, "_apply_aio_spectrum_model_patches_for_comfy_sampler", return_value="stage_model"),
+            patch.object(legacy_generation, "_sample_latent_with_aio_backend", side_effect=fake_sample),
+            patch.object(legacy_generation, "_decode_latent_with_comfy", return_value="high_image"),
+            patch.object(legacy_generation, "_cleanup_aio_ephemeral_model"),
         ):
             latent, image, width, height, metadata = nodes._run_aio_highres_stage(
                 "model",
@@ -1776,11 +1777,11 @@ class AIOHighresDetailerStageTests(unittest.TestCase):
 
         with (
             patch.object(nodes.EasyUseAnimaImageScaleByMultiple, "upscale", return_value=("scaled_image", 640, 960, 1.25)),
-            patch.object(nodes, "_encode_image_with_comfy_vae", return_value="high_latent_image"),
-            patch.object(nodes, "_apply_aio_spectrum_model_patches_for_comfy_sampler", return_value="stage_model"),
-            patch.object(nodes, "_sample_latent_with_aio_backend", side_effect=fake_sample),
-            patch.object(nodes, "_decode_latent_with_comfy", return_value="high_image"),
-            patch.object(nodes, "_cleanup_aio_ephemeral_model"),
+            patch.object(legacy_generation, "_encode_image_with_comfy_vae", return_value="high_latent_image"),
+            patch.object(legacy_generation, "_apply_aio_spectrum_model_patches_for_comfy_sampler", return_value="stage_model"),
+            patch.object(legacy_generation, "_sample_latent_with_aio_backend", side_effect=fake_sample),
+            patch.object(legacy_generation, "_decode_latent_with_comfy", return_value="high_image"),
+            patch.object(legacy_generation, "_cleanup_aio_ephemeral_model"),
         ):
             nodes._run_aio_highres_stage(
                 "model",
@@ -1824,11 +1825,11 @@ class AIOHighresDetailerStageTests(unittest.TestCase):
 
         with (
             patch.object(nodes.EasyUseAnimaImageScaleByMultiple, "upscale", return_value=("scaled_image", 640, 960, 1.25)),
-            patch.object(nodes, "_encode_image_with_comfy_vae", return_value="high_latent_image"),
-            patch.object(nodes, "_apply_aio_spectrum_model_patches_for_comfy_sampler") as comfy_patch,
-            patch.object(nodes, "_sample_latent_with_aio_backend", return_value="high_latent") as sample,
-            patch.object(nodes, "_decode_latent_with_comfy", return_value="high_image"),
-            patch.object(nodes, "_cleanup_aio_ephemeral_model"),
+            patch.object(legacy_generation, "_encode_image_with_comfy_vae", return_value="high_latent_image"),
+            patch.object(legacy_generation, "_apply_aio_spectrum_model_patches_for_comfy_sampler") as comfy_patch,
+            patch.object(legacy_generation, "_sample_latent_with_aio_backend", return_value="high_latent") as sample,
+            patch.object(legacy_generation, "_decode_latent_with_comfy", return_value="high_image"),
+            patch.object(legacy_generation, "_cleanup_aio_ephemeral_model"),
         ):
             nodes._run_aio_highres_stage(
                 "model",
@@ -1886,11 +1887,11 @@ class AIOHighresDetailerStageTests(unittest.TestCase):
 
         with (
             patch.object(nodes.EasyUseAnimaImageScaleByMultiple, "upscale", return_value=("scaled_image", 640, 960, 1.25)),
-            patch.object(nodes, "_encode_image_with_comfy_vae", return_value="high_latent_image"),
-            patch.object(nodes, "_apply_aio_spectrum_model_patches_for_comfy_sampler", return_value="stage_model") as comfy_patch,
-            patch.object(nodes, "_sample_latent_with_aio_backend", return_value="high_latent"),
-            patch.object(nodes, "_decode_latent_with_comfy", return_value="high_image"),
-            patch.object(nodes, "_cleanup_aio_ephemeral_model"),
+            patch.object(legacy_generation, "_encode_image_with_comfy_vae", return_value="high_latent_image"),
+            patch.object(legacy_generation, "_apply_aio_spectrum_model_patches_for_comfy_sampler", return_value="stage_model") as comfy_patch,
+            patch.object(legacy_generation, "_sample_latent_with_aio_backend", return_value="high_latent"),
+            patch.object(legacy_generation, "_decode_latent_with_comfy", return_value="high_image"),
+            patch.object(legacy_generation, "_cleanup_aio_ephemeral_model"),
         ):
             nodes._run_aio_highres_stage(
                 "model",
@@ -1928,11 +1929,11 @@ class AIOHighresDetailerStageTests(unittest.TestCase):
 
         with (
             patch.object(nodes.EasyUseAnimaImageScaleByMultiple, "upscale", return_value=("scaled_image", 640, 960, 1.25)),
-            patch.object(nodes, "_encode_image_with_comfy_vae", return_value="high_latent_image"),
-            patch.object(nodes, "_apply_aio_spectrum_model_patches_for_comfy_sampler", return_value="stage_model"),
-            patch.object(nodes, "_sample_latent_with_aio_backend", return_value="high_latent") as sample,
-            patch.object(nodes, "_decode_latent_with_comfy", return_value="high_image"),
-            patch.object(nodes, "_cleanup_aio_ephemeral_model"),
+            patch.object(legacy_generation, "_encode_image_with_comfy_vae", return_value="high_latent_image"),
+            patch.object(legacy_generation, "_apply_aio_spectrum_model_patches_for_comfy_sampler", return_value="stage_model"),
+            patch.object(legacy_generation, "_sample_latent_with_aio_backend", return_value="high_latent") as sample,
+            patch.object(legacy_generation, "_decode_latent_with_comfy", return_value="high_image"),
+            patch.object(legacy_generation, "_cleanup_aio_ephemeral_model"),
         ):
             nodes._run_aio_highres_stage(
                 "model",
@@ -1965,12 +1966,12 @@ class AIOHighresDetailerStageTests(unittest.TestCase):
 
         with (
             patch.object(nodes.EasyUseAnimaImageScaleByMultiple, "upscale", return_value=("scaled_image", 640, 960, 1.25)),
-            patch.object(nodes, "_encode_image_with_comfy_vae", side_effect=["high_latent_image", "corrected_latent"]) as encode,
-            patch.object(nodes, "_apply_aio_spectrum_model_patches_for_comfy_sampler", return_value="stage_model"),
-            patch.object(nodes, "_sample_latent_with_aio_backend", return_value="high_latent"),
-            patch.object(nodes, "_decode_latent_with_comfy", return_value="undersized_image"),
-            patch.object(nodes, "_resize_image_to_size_if_needed", return_value=("corrected_image", True)) as resize,
-            patch.object(nodes, "_cleanup_aio_ephemeral_model"),
+            patch.object(legacy_generation, "_encode_image_with_comfy_vae", side_effect=["high_latent_image", "corrected_latent"]) as encode,
+            patch.object(legacy_generation, "_apply_aio_spectrum_model_patches_for_comfy_sampler", return_value="stage_model"),
+            patch.object(legacy_generation, "_sample_latent_with_aio_backend", return_value="high_latent"),
+            patch.object(legacy_generation, "_decode_latent_with_comfy", return_value="undersized_image"),
+            patch.object(legacy_generation, "_resize_image_to_size_if_needed", return_value=("corrected_image", True)) as resize,
+            patch.object(legacy_generation, "_cleanup_aio_ephemeral_model"),
         ):
             latent, image, width, height, metadata = nodes._run_aio_highres_stage(
                 "model",
@@ -2018,9 +2019,9 @@ class AIOHighresDetailerStageTests(unittest.TestCase):
         }))
 
         with (
-            patch.object(nodes, "_apply_aio_spectrum_model_patches_for_comfy_sampler", return_value="detail_model") as comfy_patch,
+            patch.object(legacy_generation, "_apply_aio_spectrum_model_patches_for_comfy_sampler", return_value="detail_model") as comfy_patch,
             patch.object(nodes.EasyUseAnimaSAM3Detailer, "doit", return_value=("detailed_image", ((1, 1), ["seg"]), "mask", "raw_image")) as detailer,
-            patch.object(nodes, "_cleanup_aio_ephemeral_model"),
+            patch.object(legacy_generation, "_cleanup_aio_ephemeral_model"),
         ):
             image, metadata = nodes._run_aio_detailer_target(
                 "face",
@@ -2067,8 +2068,8 @@ class AIOHighresDetailerStageTests(unittest.TestCase):
             return f"{target_name}_image", {"enabled": True}
 
         with (
-            patch.object(nodes, "_load_aio_sam3_context", return_value={"ckpt_name": "sam3"}),
-            patch.object(nodes, "_run_aio_detailer_target", side_effect=fake_detailer_target),
+            patch.object(legacy_generation, "_load_aio_sam3_context", return_value={"ckpt_name": "sam3"}),
+            patch.object(legacy_generation, "_run_aio_detailer_target", side_effect=fake_detailer_target),
         ):
             image, metadata = nodes._run_aio_detailer_stage(
                 "model",
@@ -2111,8 +2112,8 @@ class AIOHighresDetailerStageTests(unittest.TestCase):
             return f"{target_name}_image", {"enabled": True}
 
         with (
-            patch.object(nodes, "_load_aio_sam3_context", return_value={"ckpt_name": "sam3"}),
-            patch.object(nodes, "_run_aio_detailer_target", side_effect=fake_detailer_target),
+            patch.object(legacy_generation, "_load_aio_sam3_context", return_value={"ckpt_name": "sam3"}),
+            patch.object(legacy_generation, "_run_aio_detailer_target", side_effect=fake_detailer_target),
         ):
             image, metadata = nodes._run_aio_detailer_stage(
                 "model",
@@ -2291,14 +2292,14 @@ class AIOFinalUpscaleStageTests(unittest.TestCase):
                 "_require_custom_node_class",
                 return_value=FakeUSDU,
             ) as require,
-            patch.object(nodes, "_load_upscale_model_with_comfy", return_value="upscale_model") as load_upscale,
+            patch.object(legacy_generation, "_load_upscale_model_with_comfy", return_value="upscale_model") as load_upscale,
             patch_comfy_helper(
                 nodes,
                 "_encode_with_comfy_clip",
                 side_effect=lambda clip, prompt: f"encoded:{prompt}",
             ) as encode,
-            patch.object(nodes, "_apply_aio_spectrum_model_patches_for_comfy_sampler", return_value="stage_model") as patch_stage,
-            patch.object(nodes, "_cleanup_aio_ephemeral_model") as cleanup,
+            patch.object(legacy_generation, "_apply_aio_spectrum_model_patches_for_comfy_sampler", return_value="stage_model") as patch_stage,
+            patch.object(legacy_generation, "_cleanup_aio_ephemeral_model") as cleanup,
             self.assertLogs("ComfyUI-EasyUseAnima", level="INFO") as logs,
         ):
             image, metadata = nodes._run_aio_upscale_stage(
@@ -2389,8 +2390,8 @@ class AIOFinalUpscaleStageTests(unittest.TestCase):
                 "_require_custom_node_class",
                 side_effect=fake_require,
             ) as require,
-            patch.object(nodes, "_load_upscale_model_with_comfy") as load_upscale,
-            patch.object(nodes, "_apply_aio_spectrum_model_patches_for_comfy_sampler") as patch_stage,
+            patch.object(legacy_generation, "_load_upscale_model_with_comfy") as load_upscale,
+            patch.object(legacy_generation, "_apply_aio_spectrum_model_patches_for_comfy_sampler") as patch_stage,
         ):
             image, metadata = nodes._run_aio_upscale_stage(
                 "model",
@@ -2435,17 +2436,17 @@ class AIOGeneratorRuntimeTests(unittest.TestCase):
         context = self._context()
 
         with (
-            patch.object(nodes, "_load_aio_resources_from_input_context", return_value=("base_model", "base_clip", "vae")),
-            patch.object(nodes, "_apply_aio_lora_stack", return_value=("lora_model", "lora_clip", [{"name": "a"}])),
-            patch.object(nodes, "_apply_aio_model_patches", return_value="patched_model"),
-            patch.object(nodes, "_advanced_outputs_from_prompt_data", return_value=("p", "n", "q", "qn", False, False, "", "", 512, 768)),
-            patch.object(nodes, "_encode_prompt_data_positive_conditioning", return_value="positive"),
+            patch.object(legacy_generation, "_load_aio_resources_from_input_context", return_value=("base_model", "base_clip", "vae")),
+            patch.object(legacy_generation, "_apply_aio_lora_stack", return_value=("lora_model", "lora_clip", [{"name": "a"}])),
+            patch.object(legacy_generation, "_apply_aio_model_patches", return_value="patched_model"),
+            patch.object(legacy_generation, "_advanced_outputs_from_prompt_data", return_value=("p", "n", "q", "qn", False, False, "", "", 512, 768)),
+            patch.object(legacy_generation, "_encode_prompt_data_positive_conditioning", return_value="positive"),
             patch_comfy_helper(nodes, "_encode_with_comfy_clip", return_value="negative"),
-            patch.object(nodes, "_generate_empty_latent_with_comfy", return_value="latent_image"),
-            patch.object(nodes, "_sample_latent_with_aio_backend", return_value="latent"),
-            patch.object(nodes, "_decode_latent_with_comfy", return_value="image"),
-            patch.object(nodes, "_save_image_with_image_saver", return_value={"ui": {"images": [{"filename": "preview.webp"}]}}),
-            patch.object(nodes, "_cleanup_aio_ephemeral_model"),
+            patch.object(legacy_generation, "_generate_empty_latent_with_comfy", return_value="latent_image"),
+            patch.object(legacy_generation, "_sample_latent_with_aio_backend", return_value="latent"),
+            patch.object(legacy_generation, "_decode_latent_with_comfy", return_value="image"),
+            patch.object(legacy_generation, "_save_image_with_image_saver", return_value={"ui": {"images": [{"filename": "preview.webp"}]}}),
+            patch.object(legacy_generation, "_cleanup_aio_ephemeral_model"),
         ):
             result = nodes.EasyUseAnimaAIOGenerator().generate(
                 context,
@@ -2462,20 +2463,20 @@ class AIOGeneratorRuntimeTests(unittest.TestCase):
         context = self._context()
 
         with (
-            patch.object(nodes, "_load_aio_resources_from_input_context", return_value=("base_model", "base_clip", "vae")),
-            patch.object(nodes, "_apply_aio_lora_stack", return_value=("lora_model", "lora_clip", [])),
-            patch.object(nodes, "_apply_aio_model_patches", return_value="patched_model"),
-            patch.object(nodes, "_advanced_outputs_from_prompt_data", return_value=("p", "n", "q", "qn", False, False, "", "", 512, 768)),
-            patch.object(nodes, "_encode_prompt_data_positive_conditioning", return_value="positive"),
+            patch.object(legacy_generation, "_load_aio_resources_from_input_context", return_value=("base_model", "base_clip", "vae")),
+            patch.object(legacy_generation, "_apply_aio_lora_stack", return_value=("lora_model", "lora_clip", [])),
+            patch.object(legacy_generation, "_apply_aio_model_patches", return_value="patched_model"),
+            patch.object(legacy_generation, "_advanced_outputs_from_prompt_data", return_value=("p", "n", "q", "qn", False, False, "", "", 512, 768)),
+            patch.object(legacy_generation, "_encode_prompt_data_positive_conditioning", return_value="positive"),
             patch_comfy_helper(nodes, "_encode_with_comfy_clip", return_value="negative"),
-            patch.object(nodes, "_generate_empty_latent_with_comfy", return_value="latent_image"),
-            patch.object(nodes, "_sample_latent_with_aio_backend", return_value="latent"),
-            patch.object(nodes, "_decode_latent_with_comfy", return_value="undersized_image"),
-            patch.object(nodes, "_resize_image_to_size_if_needed", return_value=("corrected_image", True)) as resize,
-            patch.object(nodes, "_encode_image_with_comfy_vae", return_value="corrected_latent") as encode,
-            patch.object(nodes, "_run_aio_highres_stage", return_value=("corrected_latent", "corrected_image", 512, 768, {"enabled": False})),
-            patch.object(nodes, "_save_image_with_image_saver", return_value={"ui": {"images": [{"filename": "final.webp"}]}}),
-            patch.object(nodes, "_cleanup_aio_ephemeral_model"),
+            patch.object(legacy_generation, "_generate_empty_latent_with_comfy", return_value="latent_image"),
+            patch.object(legacy_generation, "_sample_latent_with_aio_backend", return_value="latent"),
+            patch.object(legacy_generation, "_decode_latent_with_comfy", return_value="undersized_image"),
+            patch.object(legacy_generation, "_resize_image_to_size_if_needed", return_value=("corrected_image", True)) as resize,
+            patch.object(legacy_generation, "_encode_image_with_comfy_vae", return_value="corrected_latent") as encode,
+            patch.object(legacy_generation, "_run_aio_highres_stage", return_value=("corrected_latent", "corrected_image", 512, 768, {"enabled": False})),
+            patch.object(legacy_generation, "_save_image_with_image_saver", return_value={"ui": {"images": [{"filename": "final.webp"}]}}),
+            patch.object(legacy_generation, "_cleanup_aio_ephemeral_model"),
         ):
             result = nodes.EasyUseAnimaAIOGenerator().generate(
                 context,
@@ -2505,19 +2506,19 @@ class AIOGeneratorRuntimeTests(unittest.TestCase):
                 context = self._context()
 
                 with (
-                    patch.object(nodes, "_load_aio_resources_from_input_context", return_value=("base_model", "base_clip", "vae")),
-                    patch.object(nodes, "_apply_aio_lora_stack", return_value=("lora_model", "lora_clip", [])),
-                    patch.object(nodes, "_apply_aio_model_patches", return_value="patched_model"),
-                    patch.object(nodes, "_advanced_outputs_from_prompt_data", return_value=("p", "n", "q", "qn", True, False, "", "", 512, 768)),
-                    patch.object(nodes, "_encode_prompt_data_positive_conditioning", return_value="positive"),
+                    patch.object(legacy_generation, "_load_aio_resources_from_input_context", return_value=("base_model", "base_clip", "vae")),
+                    patch.object(legacy_generation, "_apply_aio_lora_stack", return_value=("lora_model", "lora_clip", [])),
+                    patch.object(legacy_generation, "_apply_aio_model_patches", return_value="patched_model"),
+                    patch.object(legacy_generation, "_advanced_outputs_from_prompt_data", return_value=("p", "n", "q", "qn", True, False, "", "", 512, 768)),
+                    patch.object(legacy_generation, "_encode_prompt_data_positive_conditioning", return_value="positive"),
                     patch_comfy_helper(nodes, "_encode_with_comfy_clip", return_value="negative"),
-                    patch.object(nodes, "_generate_empty_latent_with_comfy", return_value="latent_image"),
-                    patch.object(nodes, "_apply_spectrum_anima_mod_guidance", return_value="mod_guidance_model") as standalone_mod,
-                    patch.object(nodes, "_apply_aio_spectrum_model_patches_for_comfy_sampler", return_value="sampler_patch_model") as comfy_patch,
-                    patch.object(nodes, "_sample_latent_with_aio_backend", return_value="latent") as sample,
-                    patch.object(nodes, "_decode_latent_with_comfy", return_value="image"),
-                    patch.object(nodes, "_save_image_with_image_saver", return_value={"ui": {"images": [{"filename": "final.webp"}]}}),
-                    patch.object(nodes, "_cleanup_aio_ephemeral_model"),
+                    patch.object(legacy_generation, "_generate_empty_latent_with_comfy", return_value="latent_image"),
+                    patch.object(legacy_generation, "_apply_spectrum_anima_mod_guidance", return_value="mod_guidance_model") as standalone_mod,
+                    patch.object(legacy_generation, "_apply_aio_spectrum_model_patches_for_comfy_sampler", return_value="sampler_patch_model") as comfy_patch,
+                    patch.object(legacy_generation, "_sample_latent_with_aio_backend", return_value="latent") as sample,
+                    patch.object(legacy_generation, "_decode_latent_with_comfy", return_value="image"),
+                    patch.object(legacy_generation, "_save_image_with_image_saver", return_value={"ui": {"images": [{"filename": "final.webp"}]}}),
+                    patch.object(legacy_generation, "_cleanup_aio_ephemeral_model"),
                 ):
                     result = nodes.EasyUseAnimaAIOGenerator().generate(
                         context,
@@ -2552,20 +2553,20 @@ class AIOGeneratorRuntimeTests(unittest.TestCase):
         stage_sampler = nodes._normalize_aio_generation_settings("{}")["sampler"]
 
         with (
-            patch.object(nodes, "_load_aio_resources_from_input_context", return_value=("base_model", "base_clip", "vae")),
-            patch.object(nodes, "_apply_aio_lora_stack", return_value=("lora_model", "lora_clip", [])),
-            patch.object(nodes, "_apply_aio_model_patches", return_value="patched_model"),
-            patch.object(nodes, "_advanced_outputs_from_prompt_data", return_value=("p", "n", "q", "qn", True, False, "", "", 512, 768)),
-            patch.object(nodes, "_encode_prompt_data_positive_conditioning", return_value="positive"),
+            patch.object(legacy_generation, "_load_aio_resources_from_input_context", return_value=("base_model", "base_clip", "vae")),
+            patch.object(legacy_generation, "_apply_aio_lora_stack", return_value=("lora_model", "lora_clip", [])),
+            patch.object(legacy_generation, "_apply_aio_model_patches", return_value="patched_model"),
+            patch.object(legacy_generation, "_advanced_outputs_from_prompt_data", return_value=("p", "n", "q", "qn", True, False, "", "", 512, 768)),
+            patch.object(legacy_generation, "_encode_prompt_data_positive_conditioning", return_value="positive"),
             patch_comfy_helper(nodes, "_encode_with_comfy_clip", return_value="negative"),
-            patch.object(nodes, "_generate_empty_latent_with_comfy", return_value="latent_image"),
-            patch.object(nodes, "_apply_spectrum_anima_mod_guidance", return_value="mod_guidance_model") as standalone_mod,
-            patch.object(nodes, "_apply_aio_spectrum_model_patches_for_comfy_sampler") as comfy_patch,
-            patch.object(nodes, "_sample_latent_with_aio_backend", return_value="latent") as sample,
-            patch.object(nodes, "_decode_latent_with_comfy", return_value="image"),
-            patch.object(nodes, "_run_aio_highres_stage", return_value=("high_latent", "high_image", 640, 960, {"enabled": True, "sampler": stage_sampler})) as highres,
-            patch.object(nodes, "_save_image_with_image_saver", return_value={"ui": {"images": [{"filename": "final.webp"}]}}),
-            patch.object(nodes, "_cleanup_aio_ephemeral_model"),
+            patch.object(legacy_generation, "_generate_empty_latent_with_comfy", return_value="latent_image"),
+            patch.object(legacy_generation, "_apply_spectrum_anima_mod_guidance", return_value="mod_guidance_model") as standalone_mod,
+            patch.object(legacy_generation, "_apply_aio_spectrum_model_patches_for_comfy_sampler") as comfy_patch,
+            patch.object(legacy_generation, "_sample_latent_with_aio_backend", return_value="latent") as sample,
+            patch.object(legacy_generation, "_decode_latent_with_comfy", return_value="image"),
+            patch.object(legacy_generation, "_run_aio_highres_stage", return_value=("high_latent", "high_image", 640, 960, {"enabled": True, "sampler": stage_sampler})) as highres,
+            patch.object(legacy_generation, "_save_image_with_image_saver", return_value={"ui": {"images": [{"filename": "final.webp"}]}}),
+            patch.object(legacy_generation, "_cleanup_aio_ephemeral_model"),
         ):
             nodes.EasyUseAnimaAIOGenerator().generate(
                 context,
@@ -2593,21 +2594,21 @@ class AIOGeneratorRuntimeTests(unittest.TestCase):
         context = self._context()
 
         with (
-            patch.object(nodes, "_load_aio_resources_from_input_context", return_value=("base_model", "base_clip", "vae")),
-            patch.object(nodes, "_apply_aio_lora_stack", return_value=("lora_model", "lora_clip", [])),
-            patch.object(nodes, "_apply_aio_model_patches", return_value="patched_model"),
-            patch.object(nodes, "_advanced_outputs_from_prompt_data", return_value=("p", "n", "q", "qn", True, False, "", "", 512, 768)),
-            patch.object(nodes, "_encode_prompt_data_positive_conditioning", return_value="positive"),
+            patch.object(legacy_generation, "_load_aio_resources_from_input_context", return_value=("base_model", "base_clip", "vae")),
+            patch.object(legacy_generation, "_apply_aio_lora_stack", return_value=("lora_model", "lora_clip", [])),
+            patch.object(legacy_generation, "_apply_aio_model_patches", return_value="patched_model"),
+            patch.object(legacy_generation, "_advanced_outputs_from_prompt_data", return_value=("p", "n", "q", "qn", True, False, "", "", 512, 768)),
+            patch.object(legacy_generation, "_encode_prompt_data_positive_conditioning", return_value="positive"),
             patch_comfy_helper(nodes, "_encode_with_comfy_clip", return_value="negative"),
-            patch.object(nodes, "_generate_empty_latent_with_comfy", return_value="latent_image"),
-            patch.object(nodes, "_apply_spectrum_anima_mod_guidance", return_value="mod_guidance_model") as standalone_mod,
-            patch.object(nodes, "_apply_aio_spectrum_model_patches_for_comfy_sampler") as comfy_patch,
-            patch.object(nodes, "_sample_latent_with_aio_backend", return_value="latent") as sample,
-            patch.object(nodes, "_decode_latent_with_comfy", return_value="image"),
-            patch.object(nodes, "_run_aio_highres_stage", return_value=("latent", "image", 512, 768, {"enabled": False})),
-            patch.object(nodes, "_run_aio_detailer_stage", return_value=("detail_image", {"enabled": True})) as detailer,
-            patch.object(nodes, "_save_image_with_image_saver", return_value={"ui": {"images": [{"filename": "final.webp"}]}}),
-            patch.object(nodes, "_cleanup_aio_ephemeral_model"),
+            patch.object(legacy_generation, "_generate_empty_latent_with_comfy", return_value="latent_image"),
+            patch.object(legacy_generation, "_apply_spectrum_anima_mod_guidance", return_value="mod_guidance_model") as standalone_mod,
+            patch.object(legacy_generation, "_apply_aio_spectrum_model_patches_for_comfy_sampler") as comfy_patch,
+            patch.object(legacy_generation, "_sample_latent_with_aio_backend", return_value="latent") as sample,
+            patch.object(legacy_generation, "_decode_latent_with_comfy", return_value="image"),
+            patch.object(legacy_generation, "_run_aio_highres_stage", return_value=("latent", "image", 512, 768, {"enabled": False})),
+            patch.object(legacy_generation, "_run_aio_detailer_stage", return_value=("detail_image", {"enabled": True})) as detailer,
+            patch.object(legacy_generation, "_save_image_with_image_saver", return_value={"ui": {"images": [{"filename": "final.webp"}]}}),
+            patch.object(legacy_generation, "_cleanup_aio_ephemeral_model"),
         ):
             nodes.EasyUseAnimaAIOGenerator().generate(
                 context,
@@ -2662,22 +2663,22 @@ class AIOGeneratorRuntimeTests(unittest.TestCase):
             return {"ui": {"images": [{"filename": "final.webp"}]}}
 
         with (
-            patch.object(nodes, "_load_aio_resources_from_input_context", return_value=("base_model", "base_clip", "vae")),
-            patch.object(nodes, "_apply_aio_lora_stack", return_value=("lora_model", "lora_clip", [])),
-            patch.object(nodes, "_apply_aio_model_patches", return_value="patched_model"),
-            patch.object(nodes, "_advanced_outputs_from_prompt_data", return_value=("p", "n", "q", "qn", False, False, "", "", 512, 768)),
-            patch.object(nodes, "_encode_prompt_data_positive_conditioning", return_value="positive"),
+            patch.object(legacy_generation, "_load_aio_resources_from_input_context", return_value=("base_model", "base_clip", "vae")),
+            patch.object(legacy_generation, "_apply_aio_lora_stack", return_value=("lora_model", "lora_clip", [])),
+            patch.object(legacy_generation, "_apply_aio_model_patches", return_value="patched_model"),
+            patch.object(legacy_generation, "_advanced_outputs_from_prompt_data", return_value=("p", "n", "q", "qn", False, False, "", "", 512, 768)),
+            patch.object(legacy_generation, "_encode_prompt_data_positive_conditioning", return_value="positive"),
             patch_comfy_helper(nodes, "_encode_with_comfy_clip", return_value="negative"),
-            patch.object(nodes, "_generate_empty_latent_with_comfy", return_value="latent_image"),
-            patch.object(nodes, "_sample_latent_with_aio_backend", return_value="latent"),
-            patch.object(nodes, "_decode_latent_with_comfy", return_value="first_image"),
-            patch.object(nodes, "_run_aio_highres_stage", return_value=("latent", "first_image", 512, 768, {"enabled": False})),
-            patch.object(nodes, "_run_aio_detailer_stage", side_effect=fake_detailer),
-            patch.object(nodes, "_run_aio_upscale_stage", side_effect=fake_upscale) as upscale,
-            patch.object(nodes, "_run_aio_postprocess_stage", side_effect=fake_postprocess) as postprocess,
-            patch.object(nodes, "_encode_image_with_comfy_vae", side_effect=["upscaled_latent", "postprocess_latent"]) as encode,
-            patch.object(nodes, "_save_image_with_image_saver", side_effect=fake_save) as save,
-            patch.object(nodes, "_cleanup_aio_ephemeral_model"),
+            patch.object(legacy_generation, "_generate_empty_latent_with_comfy", return_value="latent_image"),
+            patch.object(legacy_generation, "_sample_latent_with_aio_backend", return_value="latent"),
+            patch.object(legacy_generation, "_decode_latent_with_comfy", return_value="first_image"),
+            patch.object(legacy_generation, "_run_aio_highres_stage", return_value=("latent", "first_image", 512, 768, {"enabled": False})),
+            patch.object(legacy_generation, "_run_aio_detailer_stage", side_effect=fake_detailer),
+            patch.object(legacy_generation, "_run_aio_upscale_stage", side_effect=fake_upscale) as upscale,
+            patch.object(legacy_generation, "_run_aio_postprocess_stage", side_effect=fake_postprocess) as postprocess,
+            patch.object(legacy_generation, "_encode_image_with_comfy_vae", side_effect=["upscaled_latent", "postprocess_latent"]) as encode,
+            patch.object(legacy_generation, "_save_image_with_image_saver", side_effect=fake_save) as save,
+            patch.object(legacy_generation, "_cleanup_aio_ephemeral_model"),
         ):
             result = nodes.EasyUseAnimaAIOGenerator().generate(
                 context,
@@ -2730,18 +2731,18 @@ class AIOGeneratorRuntimeTests(unittest.TestCase):
             return {"ui": {"images": [{"filename": "final.webp"}]}}
 
         with (
-            patch.object(nodes, "_load_aio_resources_from_input_context", return_value=("base_model", "base_clip", "vae")),
-            patch.object(nodes, "_apply_aio_lora_stack", return_value=("lora_model", "lora_clip", [{"name": "style/foo.safetensors", "strength_model": 0.8}])),
-            patch.object(nodes, "_apply_aio_model_patches", return_value="patched_model"),
-            patch.object(nodes, "_advanced_outputs_from_prompt_data", return_value=("p", "n", "q", "qn", False, False, "", "", 512, 768)),
-            patch.object(nodes, "_encode_prompt_data_positive_conditioning", return_value="positive"),
+            patch.object(legacy_generation, "_load_aio_resources_from_input_context", return_value=("base_model", "base_clip", "vae")),
+            patch.object(legacy_generation, "_apply_aio_lora_stack", return_value=("lora_model", "lora_clip", [{"name": "style/foo.safetensors", "strength_model": 0.8}])),
+            patch.object(legacy_generation, "_apply_aio_model_patches", return_value="patched_model"),
+            patch.object(legacy_generation, "_advanced_outputs_from_prompt_data", return_value=("p", "n", "q", "qn", False, False, "", "", 512, 768)),
+            patch.object(legacy_generation, "_encode_prompt_data_positive_conditioning", return_value="positive"),
             patch_comfy_helper(nodes, "_encode_with_comfy_clip", return_value="negative"),
-            patch.object(nodes, "_generate_empty_latent_with_comfy", return_value="latent_image"),
-            patch.object(nodes, "_sample_latent_with_aio_backend", return_value="latent"),
-            patch.object(nodes, "_decode_latent_with_comfy", return_value="image"),
-            patch.object(nodes, "_run_aio_highres_stage", return_value=("high_latent", "high_image", 1024, 1536, {"enabled": True, "sampler": highres_sampler})),
-            patch.object(nodes, "_save_image_with_image_saver", side_effect=fake_save),
-            patch.object(nodes, "_cleanup_aio_ephemeral_model"),
+            patch.object(legacy_generation, "_generate_empty_latent_with_comfy", return_value="latent_image"),
+            patch.object(legacy_generation, "_sample_latent_with_aio_backend", return_value="latent"),
+            patch.object(legacy_generation, "_decode_latent_with_comfy", return_value="image"),
+            patch.object(legacy_generation, "_run_aio_highres_stage", return_value=("high_latent", "high_image", 1024, 1536, {"enabled": True, "sampler": highres_sampler})),
+            patch.object(legacy_generation, "_save_image_with_image_saver", side_effect=fake_save),
+            patch.object(legacy_generation, "_cleanup_aio_ephemeral_model"),
         ):
             nodes.EasyUseAnimaAIOGenerator().generate(
                 context,
@@ -2783,11 +2784,11 @@ class AIOGeneratorRuntimeTests(unittest.TestCase):
             return {"ui": {"images": [{"filename": "final.webp"}]}}
 
         with (
-            patch.object(nodes, "_load_aio_resources_from_input_context", return_value=("base_model", "base_clip", "vae")),
-            patch.object(nodes, "_apply_aio_lora_stack", return_value=("lora_model", "lora_clip", [])),
-            patch.object(nodes, "_apply_aio_model_patches", return_value="patched_model"),
+            patch.object(legacy_generation, "_load_aio_resources_from_input_context", return_value=("base_model", "base_clip", "vae")),
+            patch.object(legacy_generation, "_apply_aio_lora_stack", return_value=("lora_model", "lora_clip", [])),
+            patch.object(legacy_generation, "_apply_aio_model_patches", return_value="patched_model"),
             patch.object(
-                nodes,
+                legacy_generation,
                 "_advanced_outputs_from_prompt_data",
                 return_value=(
                     "generation positive",
@@ -2802,20 +2803,20 @@ class AIOGeneratorRuntimeTests(unittest.TestCase):
                     768,
                 ),
             ),
-            patch.object(nodes, "_encode_prompt_data_positive_conditioning", return_value="positive") as encode_positive,
+            patch.object(legacy_generation, "_encode_prompt_data_positive_conditioning", return_value="positive") as encode_positive,
             patch_comfy_helper(
                 nodes,
                 "_encode_with_comfy_clip",
                 return_value="negative",
             ) as encode_negative,
-            patch.object(nodes, "_generate_empty_latent_with_comfy", return_value="latent_image"),
-            patch.object(nodes, "_apply_spectrum_anima_mod_guidance", return_value="mod_guidance_model"),
-            patch.object(nodes, "_apply_aio_spectrum_model_patches_for_comfy_sampler", return_value="sampler_patch_model"),
-            patch.object(nodes, "_sample_latent_with_aio_backend", return_value="latent") as sample,
-            patch.object(nodes, "_decode_latent_with_comfy", return_value="image"),
-            patch.object(nodes, "_run_aio_highres_stage", return_value=("latent", "image", 512, 768, {"enabled": False})),
-            patch.object(nodes, "_save_image_with_image_saver", side_effect=fake_save),
-            patch.object(nodes, "_cleanup_aio_ephemeral_model"),
+            patch.object(legacy_generation, "_generate_empty_latent_with_comfy", return_value="latent_image"),
+            patch.object(legacy_generation, "_apply_spectrum_anima_mod_guidance", return_value="mod_guidance_model"),
+            patch.object(legacy_generation, "_apply_aio_spectrum_model_patches_for_comfy_sampler", return_value="sampler_patch_model"),
+            patch.object(legacy_generation, "_sample_latent_with_aio_backend", return_value="latent") as sample,
+            patch.object(legacy_generation, "_decode_latent_with_comfy", return_value="image"),
+            patch.object(legacy_generation, "_run_aio_highres_stage", return_value=("latent", "image", 512, 768, {"enabled": False})),
+            patch.object(legacy_generation, "_save_image_with_image_saver", side_effect=fake_save),
+            patch.object(legacy_generation, "_cleanup_aio_ephemeral_model"),
         ):
             nodes.EasyUseAnimaAIOGenerator().generate(
                 context,
@@ -2847,21 +2848,21 @@ class AIOGeneratorRuntimeTests(unittest.TestCase):
         }
 
         with (
-            patch.object(nodes, "_load_aio_resources_from_input_context", return_value=("base_model", "base_clip", "vae")),
-            patch.object(nodes, "_apply_aio_lora_stack", return_value=("lora_model", "lora_clip", [])),
-            patch.object(nodes, "_apply_aio_model_patches", return_value="patched_model"),
-            patch.object(nodes, "_advanced_outputs_from_prompt_data", return_value=("p", "n", "q", "qn", False, False, "", "", 512, 768)),
-            patch.object(nodes, "_encode_prompt_data_positive_conditioning", return_value="positive"),
+            patch.object(legacy_generation, "_load_aio_resources_from_input_context", return_value=("base_model", "base_clip", "vae")),
+            patch.object(legacy_generation, "_apply_aio_lora_stack", return_value=("lora_model", "lora_clip", [])),
+            patch.object(legacy_generation, "_apply_aio_model_patches", return_value="patched_model"),
+            patch.object(legacy_generation, "_advanced_outputs_from_prompt_data", return_value=("p", "n", "q", "qn", False, False, "", "", 512, 768)),
+            patch.object(legacy_generation, "_encode_prompt_data_positive_conditioning", return_value="positive"),
             patch_comfy_helper(nodes, "_encode_with_comfy_clip", return_value="negative"),
-            patch.object(nodes, "_generate_empty_latent_with_comfy", return_value="latent_image") as empty_latent,
-            patch.object(nodes, "_sample_latent_with_aio_backend", return_value="latent") as sample,
-            patch.object(nodes, "_decode_latent_with_comfy", return_value="image") as decode,
-            patch.object(nodes, "_run_aio_highres_stage", side_effect=[
+            patch.object(legacy_generation, "_generate_empty_latent_with_comfy", return_value="latent_image") as empty_latent,
+            patch.object(legacy_generation, "_sample_latent_with_aio_backend", return_value="latent") as sample,
+            patch.object(legacy_generation, "_decode_latent_with_comfy", return_value="image") as decode,
+            patch.object(legacy_generation, "_run_aio_highres_stage", side_effect=[
                 ("high_latent_1", "high_image_1", 640, 960, {"enabled": True, "sampler": nodes._normalize_aio_generation_settings("{}")["sampler"]}),
                 ("high_latent_2", "high_image_2", 768, 1152, {"enabled": True, "sampler": nodes._normalize_aio_generation_settings("{}")["sampler"]}),
             ]) as highres,
-            patch.object(nodes, "_save_image_with_image_saver", return_value={"ui": {"images": [{"filename": "final.webp"}]}}),
-            patch.object(nodes, "_cleanup_aio_ephemeral_model"),
+            patch.object(legacy_generation, "_save_image_with_image_saver", return_value={"ui": {"images": [{"filename": "final.webp"}]}}),
+            patch.object(legacy_generation, "_cleanup_aio_ephemeral_model"),
         ):
             generator = nodes.EasyUseAnimaAIOGenerator()
             for scale in (1.25, 1.5):
@@ -2902,16 +2903,16 @@ class AIOGeneratorRuntimeTests(unittest.TestCase):
             return [{"filename": f"{stage}.png", "type": "temp", "stage": stage, "label": stage}]
 
         with (
-            patch.object(nodes, "_load_aio_resources_from_input_context", return_value=("base_model", "base_clip", "vae")),
-            patch.object(nodes, "_apply_aio_lora_stack", return_value=("lora_model", "lora_clip", [])),
-            patch.object(nodes, "_apply_aio_model_patches", return_value="patched_model"),
-            patch.object(nodes, "_advanced_outputs_from_prompt_data", return_value=("p", "n", "q", "qn", False, False, "", "", 512, 768)),
-            patch.object(nodes, "_encode_prompt_data_positive_conditioning", return_value="positive"),
+            patch.object(legacy_generation, "_load_aio_resources_from_input_context", return_value=("base_model", "base_clip", "vae")),
+            patch.object(legacy_generation, "_apply_aio_lora_stack", return_value=("lora_model", "lora_clip", [])),
+            patch.object(legacy_generation, "_apply_aio_model_patches", return_value="patched_model"),
+            patch.object(legacy_generation, "_advanced_outputs_from_prompt_data", return_value=("p", "n", "q", "qn", False, False, "", "", 512, 768)),
+            patch.object(legacy_generation, "_encode_prompt_data_positive_conditioning", return_value="positive"),
             patch_comfy_helper(nodes, "_encode_with_comfy_clip", return_value="negative"),
-            patch.object(nodes, "_generate_empty_latent_with_comfy", return_value="latent_image"),
-            patch.object(nodes, "_sample_latent_with_aio_backend", return_value="latent"),
-            patch.object(nodes, "_decode_latent_with_comfy", return_value="image"),
-            patch.object(nodes, "_run_aio_highres_stage", return_value=(
+            patch.object(legacy_generation, "_generate_empty_latent_with_comfy", return_value="latent_image"),
+            patch.object(legacy_generation, "_sample_latent_with_aio_backend", return_value="latent"),
+            patch.object(legacy_generation, "_decode_latent_with_comfy", return_value="image"),
+            patch.object(legacy_generation, "_run_aio_highres_stage", return_value=(
                 "highres_latent",
                 "highres_image",
                 768,
@@ -2921,9 +2922,9 @@ class AIOGeneratorRuntimeTests(unittest.TestCase):
                     "sampler": nodes._normalize_aio_generation_settings("{}")["sampler"],
                 },
             )),
-            patch.object(nodes, "_save_image_with_image_saver", return_value={"ui": {"images": [{"filename": "final.webp"}]}}),
-            patch.object(nodes, "_save_aio_temp_preview_image", side_effect=fake_preview),
-            patch.object(nodes, "_cleanup_aio_ephemeral_model"),
+            patch.object(legacy_generation, "_save_image_with_image_saver", return_value={"ui": {"images": [{"filename": "final.webp"}]}}),
+            patch.object(legacy_generation, "_save_aio_temp_preview_image", side_effect=fake_preview),
+            patch.object(legacy_generation, "_cleanup_aio_ephemeral_model"),
         ):
             result = nodes.EasyUseAnimaAIOGenerator().generate(
                 context,
@@ -2967,19 +2968,19 @@ class AIOGeneratorRuntimeTests(unittest.TestCase):
             return [{"filename": f"{stage}.webp", "type": "temp", "stage": stage, "label": stage}]
 
         with (
-            patch.object(nodes, "_load_aio_resources_from_input_context", return_value=("base_model", "base_clip", "vae")),
-            patch.object(nodes, "_apply_aio_lora_stack", return_value=("lora_model", "lora_clip", [])),
-            patch.object(nodes, "_apply_aio_model_patches", return_value="patched_model"),
-            patch.object(nodes, "_advanced_outputs_from_prompt_data", return_value=("p", "n", "q", "qn", False, False, "", "", 512, 768)),
-            patch.object(nodes, "_encode_prompt_data_positive_conditioning", return_value="positive"),
+            patch.object(legacy_generation, "_load_aio_resources_from_input_context", return_value=("base_model", "base_clip", "vae")),
+            patch.object(legacy_generation, "_apply_aio_lora_stack", return_value=("lora_model", "lora_clip", [])),
+            patch.object(legacy_generation, "_apply_aio_model_patches", return_value="patched_model"),
+            patch.object(legacy_generation, "_advanced_outputs_from_prompt_data", return_value=("p", "n", "q", "qn", False, False, "", "", 512, 768)),
+            patch.object(legacy_generation, "_encode_prompt_data_positive_conditioning", return_value="positive"),
             patch_comfy_helper(nodes, "_encode_with_comfy_clip", return_value="negative"),
-            patch.object(nodes, "_generate_empty_latent_with_comfy", return_value="latent_image"),
-            patch.object(nodes, "_sample_latent_with_aio_backend", return_value="latent"),
-            patch.object(nodes, "_decode_latent_with_comfy", return_value="image"),
-            patch.object(nodes, "_save_image_with_image_saver", return_value={"ui": {"images": [{"filename": "final.webp"}]}}),
-            patch.object(nodes, "_save_aio_temp_preview_image", side_effect=fake_preview),
-            patch.object(nodes, "_send_aio_preview_event") as send_preview_event,
-            patch.object(nodes, "_cleanup_aio_ephemeral_model"),
+            patch.object(legacy_generation, "_generate_empty_latent_with_comfy", return_value="latent_image"),
+            patch.object(legacy_generation, "_sample_latent_with_aio_backend", return_value="latent"),
+            patch.object(legacy_generation, "_decode_latent_with_comfy", return_value="image"),
+            patch.object(legacy_generation, "_save_image_with_image_saver", return_value={"ui": {"images": [{"filename": "final.webp"}]}}),
+            patch.object(legacy_generation, "_save_aio_temp_preview_image", side_effect=fake_preview),
+            patch.object(legacy_generation, "_send_aio_preview_event") as send_preview_event,
+            patch.object(legacy_generation, "_cleanup_aio_ephemeral_model"),
         ):
             result = nodes.EasyUseAnimaAIOGenerator().generate(
                 context,

--- a/tests/test_nodes_module_analyzer.py
+++ b/tests/test_nodes_module_analyzer.py
@@ -73,12 +73,12 @@ def load_dynamic():
     def test_current_nodes_module_shape_matches_recorded_baseline(self):
         report = analyzer.analyze_path(ROOT / "nodes.py")
 
-        self.assertEqual(report["git_blob_sha1"], "878eec7e07e2230600ad9e62fc61e6fbe2038399")
-        # B-11c30d0b redirects two root aliases to the pure input-context
-        # owner without changing the public class surface.
+        self.assertEqual(report["git_blob_sha1"], "735f1fcd3249adb58b2e64eb35d78ca264a7ec1d")
+        # B-11c30d5 removes the legacy-orchestration binder import and
+        # initialization without changing the public class surface.
         self.assertEqual(report["top_level"]["function_count"], 0)
         self.assertEqual(report["top_level"]["class_count"], 0)
-        self.assertEqual(report["line_count"], 1_162)
+        self.assertEqual(report["line_count"], 1_147)
         class_names = {item["name"] for item in report["top_level"]["classes"]}
         self.assertNotIn("EasyUseAnimaAIOGenerator", class_names)
         self.assertNotIn("EasyUseAnimaInput", class_names)

--- a/tests/test_python_compatibility_surface.py
+++ b/tests/test_python_compatibility_surface.py
@@ -79,7 +79,6 @@ RUNTIME_LOOKUP_CALLS = {
 PREAMBLE_IMPLEMENTATION_BINDINGS = {
     "json": "json:json",
     "logging": "logging:logging",
-    "random": "random:random",
 }
 PROMPT_SERVICE_RUNTIME_BINDERS = (
     "_bind_regional_runtime",
@@ -97,7 +96,6 @@ PROMPT_NODE_ADAPTER_RETIRED_RUNTIME_BINDERS = (
 )
 RUNTIME_BINDER_FAMILIES = {
     "aio": (
-        "_bind_aio_legacy_generation_runtime",
         "_bind_aio_node_runtime",
     ),
     "wildcard_naia": (
@@ -136,6 +134,7 @@ AIO_RUNTIME_RETIRED_SUBGROUPS = (
     "B-11c30d2_normalization_planning",
     "B-11c30d3_io_boundary",
     "B-11c30d4_execution_services",
+    "B-11c30d5_legacy_orchestration",
 )
 AIO_RUNTIME_PREREQUISITE_MOVES = (
     {
@@ -2314,6 +2313,7 @@ def _build_document() -> dict[str, Any]:
                 "B-11c30d3",
                 "B-11c30d4",
                 "B-11c30d0b",
+                "B-11c30d5",
             ],
         },
         "enums": {
@@ -2325,15 +2325,15 @@ def _build_document() -> dict[str, Any]:
         },
         "expected_counts": {
             "root_entrypoints": 3,
-            "excluded_preamble_implementation_bindings": 3,
-            "nodes_canonical_bindings": 293,
+            "excluded_preamble_implementation_bindings": 2,
+            "nodes_canonical_bindings": 291,
             "nodes_legacy_bindings": 27,
             "mapped_public_classes": 18,
             "unmapped_classes": 2,
             "root_residual_functions": 0,
             "root_residual_classes": 0,
             "root_residual_globals": 3,
-            "runtime_binders": 4,
+            "runtime_binders": 3,
             "direct_nodes_import_test_files": 21,
         },
         "mapped_public_classes": sorted(mapped_classes),
@@ -2565,7 +2565,7 @@ class PythonCompatibilitySurfaceTests(unittest.TestCase):
             len(self.document["direct_nodes_import_test_files"]),
             counts["direct_nodes_import_test_files"],
         )
-        self.assertEqual(len(set(self.document["runtime_binders"])), 4)
+        self.assertEqual(len(set(self.document["runtime_binders"])), 3)
         self.assertEqual(len(set(self.document["direct_nodes_import_test_files"])), 21)
 
     def test_runtime_binder_audit_covers_provider_and_root_names(self):
@@ -2573,35 +2573,29 @@ class PythonCompatibilitySurfaceTests(unittest.TestCase):
         self.assertEqual(
             audit["summary"],
             {
-                "binder_count": 4,
+                "binder_count": 3,
                 "family_count": 2,
                 "mode_counts": {
-                    "comfy_provider_then_root": 1,
+                    "comfy_provider_then_root": 0,
                     "root_globals": 1,
                     "explicit_callbacks": 2,
                 },
-                "unique_resolver_names": 84,
-                "unique_root_resolver_names": 82,
-                "unique_provider_resolver_names": 2,
-                "unique_direct_root_dependencies": 9,
-                "direct_root_dependency_slots": 10,
-                "provider_consumer_slots": 2,
-                "provider_consumer_modules": 1,
-                "repository_replacement_names": 69,
+                "unique_resolver_names": 29,
+                "unique_root_resolver_names": 29,
+                "unique_provider_resolver_names": 0,
+                "unique_direct_root_dependencies": 8,
+                "direct_root_dependency_slots": 9,
+                "provider_consumer_slots": 0,
+                "provider_consumer_modules": 0,
+                "repository_replacement_names": 32,
                 "repository_replacement_files": 5,
             },
         )
-        self.assertEqual(
-            audit["provider_resolver_names"],
-            [
-                "_encode_with_comfy_clip",
-                "_require_custom_node_class",
-            ],
-        )
+        self.assertEqual(audit["provider_resolver_names"], [])
         self.assertEqual(
             set(audit["root_resolver_names"])
             - set(self.document["runtime_resolver_consumers"]),
-            {"json", "random"},
+            {"json"},
         )
         self.assertTrue(
             set(self.document["runtime_resolver_consumers"]).issubset(
@@ -2689,14 +2683,6 @@ class PythonCompatibilitySurfaceTests(unittest.TestCase):
         self.assertEqual(
             summaries,
             {
-                "B-11c30d5_legacy_orchestration": {
-                    "root_resolver_slots": 58,
-                    "unique_root_resolver_names": 58,
-                    "provider_resolver_slots": 2,
-                    "direct_root_dependency_slots": 1,
-                    "repository_replacement_slots": 42,
-                    "unique_repository_replacement_names": 42,
-                },
                 "B-11c30d6_node_adapter": {
                     "root_resolver_slots": 29,
                     "unique_root_resolver_names": 29,
@@ -2784,6 +2770,9 @@ class PythonCompatibilitySurfaceTests(unittest.TestCase):
             "_bind_aio_first_pass_cache_runtime": (
                 "easyuse_anima.aio.first_pass_cache"
             ),
+            "_bind_aio_legacy_generation_runtime": (
+                "easyuse_anima.aio.legacy_generation"
+            ),
         }
         for binder, module in retired_modules.items():
             functions = {
@@ -2824,14 +2813,33 @@ class PythonCompatibilitySurfaceTests(unittest.TestCase):
             }.isdisjoint(self.document["runtime_resolver_consumers"])
         )
 
+    def test_aio_legacy_generation_runtime_resolver_is_retired(self):
+        tree = _read_tree(_module_path("easyuse_anima.aio.legacy_generation"))
+        top_level_names = {
+            target.id
+            for node in tree.body
+            if isinstance(node, (ast.Assign, ast.AnnAssign))
+            for target in (
+                node.targets
+                if isinstance(node, ast.Assign)
+                else [node.target]
+            )
+            if isinstance(target, ast.Name)
+        }
+        functions = {
+            node.name
+            for node in tree.body
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+        }
+        self.assertNotIn("_RUNTIME_RESOLVER", top_level_names)
+        self.assertNotIn("_runtime_helper", functions)
+        self.assertNotIn("_bind_aio_legacy_generation_runtime", functions)
+
     def test_string_runtime_resolvers_keep_production_seams_transitional(self):
         representative = {
             "_run_aio_legacy_generation",
-            "_aio_first_pass_cache_key",
-            "_get_aio_first_pass_cache",
-            "_load_aio_resources_from_input_context",
-            "_sample_latent_with_aio_backend",
             "_aio_generation_settings_json",
+            "_resolve_aio_runtime_seed",
         }
         consumers = self.document["runtime_resolver_consumers"]
         classifications = {


### PR DESCRIPTION
## 변경 요약

B-11c30d5 frozen subgroup의 legacy-orchestration runtime binder 한 개만 퇴역시키는 **Move 전용 PR**입니다.

- `easyuse_anima.aio.legacy_generation`이 기존 canonical owner 55개와 JSON/logger/random을 직접 사용합니다.
- `_bind_aio_legacy_generation_runtime`, `_RUNTIME_RESOLVER`, `_runtime_helper`, root binder import/초기화를 제거했습니다.
- `_encode_with_comfy_clip`, `_require_custom_node_class`는 기존 E-07 provider를 call-time에 계속 관찰합니다.
- 7개 root execution alias와 d6/Wildcard/NAIA binder는 그대로 유지합니다.
- 테스트는 process-global resolver 설치/복원 대신 canonical consumer를 직접 patch합니다.

## 사전 symbol/caller/alias/global-state inventory

- binder: `_bind_aio_legacy_generation_runtime`
- owner: `easyuse_anima.aio.legacy_generation`
- mutable global: `_RUNTIME_RESOLVER` 1개
- dispatcher: `_runtime_helper` 1개
- frozen cost after d0b:
  - root resolver: 58 slots / 58 unique names
  - E-07 provider: 2 slots / `_encode_with_comfy_clip`, `_require_custom_node_class`
  - direct bridge: `_resolve_comfy_host_helper` 1 slot
  - repository replacement: 42 slots / 42 names / 3 files
- root exact aliases:
  - `_run_aio_legacy_generation`
  - `_run_aio_highres_stage`
  - `_run_aio_detailer_stage`
  - `_run_aio_detailer_target`
  - `_run_aio_usdu_upscale_stage`
  - `_run_aio_resshift_upscale_stage`
  - `_run_aio_upscale_stage`
- production caller:
  - d6 node adapter가 `_run_aio_legacy_generation`을 아직 root resolver로 관찰
  - 나머지 6개 stage 함수는 same-module orchestration call과 root compatibility alias
- canonical dependency groups:
  - common value/invocation
  - Prompt Data/conditioning/Artist Mix
  - AiO settings/cache/resources/model/sampling/conditioning/planning/preview/output/postprocess
  - image geometry/SAM3와 기존 image/SAM3 node adapter
  - standard-library `json`, module-local `logger`, `random`
- frozen behavior evidence:
  - `aio_legacy_execution_trace.v1.json`
  - short circuit, exact errors, cleanup/cache/preview/save order, provider timing, package/flat alias tests

## 주요 변경 파일

- production
  - `easyuse_anima/aio/legacy_generation.py`
  - `nodes.py`
- tests/gates
  - `tests/test_aio_legacy_generation.py`
  - `tests/test_aio_nodes.py`
  - `tests/test_python_compatibility_surface.py`
  - `tests/test_nodes_module_analyzer.py`
  - compatibility/backend fixtures
- architecture
  - `docs/architecture/comfy-host-provider-bridge.md`
  - `docs/architecture/python-backend-execution-roadmap.md`
  - `docs/architecture/python-compatibility-shims.md`

## 검증

- focused legacy/AiO: 94개 중 93개 통과, canonical patch 누락 1개 확인 후 해당 테스트 1개 통과
- consolidated execution/contract/compatibility/analyzer/import/package: 239개 중 237개 통과, 예상된 ledger/SHA gate drift 2개 갱신 후 해당 closure 2개 통과
- post-cleanup compatibility/analyzer: 28개 통과
- targeted Ruff 0.15.22 (`easyuse_anima/aio/legacy_generation.py`): 통과
- official full은 정책대로 정확히 1회 실행:
  - compile: 통과
  - Ruff report-only: 77개 기존 부채 보고, 실행 성공
  - Pyright baseline: 76 files / 기존 14 errors / ratchet 통과
  - import boundary: 6 groups / 0 violations
  - Python unittest: 984개 중 983개 통과, 남은 `nodes.random` 테스트 소유권 1개 확인
  - exact closure: 해당 테스트와 backend analyzer 19개 통과
  - full은 반복하지 않았으며, Python 단계 뒤의 변경 없는 frontend 표면은 PR #352의 직전 official full 증거를 재사용
- `git diff --check`: 통과

## 결과와 경계

- active binder: d6 + Wildcard/NAIA, 총 3개
- runtime audit: 29 unique resolver/root names, provider-resolver slot 0
- compatibility: 291 canonical root bindings, residual globals 3개
- package: shipped/reachable Python module 93개
- `nodes.py`: 1,147 lines
- frozen legacy execution trace는 변경하지 않았습니다.
- #168/#169 Behavior, d6, Wildcard/NAIA, final root shim은 이 PR에 포함하지 않습니다.

Owner: #184
Behavior boundaries: #168, #169
