### PR TITLE
B-11c30d6: retire AiO node-adapter binder

### DIFF
--- a/docs/architecture/comfy-host-provider-bridge.md
+++ b/docs/architecture/comfy-host-provider-bridge.md
@@ -2349,7 +2349,7 @@ Forbidden:
 
 ### B-11c30d6 — AiO node-adapter binder Move
 
-- **State:** IN PROGRESS
+- **State:** COMPLETE IN PR #354
 - **Owner:** #184
 - **Behavior boundary:** #167
 - **Type:** Move
@@ -2445,6 +2445,25 @@ Exit:
   callback binders. Node inputs, change keys, seed reservation, context,
   generation, mappings, errors, schemas, and workflows remain unchanged.
 
+Implementation result:
+
+- `easyuse_anima.nodes.aio_nodes` imports the existing common, Prompt Data, AiO
+  defaults/normalization/resources/model/sampling/input-context/orchestration
+  owners directly and owns its existing JSON serialization locally;
+- `EASY_USE_ANIMA_INPUT_TYPE` moves from the residual root assignment to the
+  canonical node adapter, while root keeps an exact package/flat alias;
+- d6 tests patch the canonical consumer instead of installing a process-global
+  string resolver. The two mapped classes, hidden serializer aliases, input
+  context, generation forwarding, and workflow contracts remain unchanged;
+- `_bind_aio_node_runtime`, `_RUNTIME_RESOLVER`, and `_runtime_helper` are
+  absent. All six AiO subgroups are retired, leaving only the two explicit
+  Wildcard/NAIA callback binders in one active family;
+- the active audit has zero string-resolver names, eight unique direct callback
+  dependencies, and five repository replacement names across three files; and
+- the compatibility inventory contains 291 canonical root bindings, two
+  residual root globals, one root implementation import, 93 shipped/reachable
+  Python modules, and a 1,142-line root shim.
+
 Forbidden:
 
 - retiring or otherwise changing the Wildcard/NAIA binders;
@@ -2456,7 +2475,7 @@ Forbidden:
 
 ### B-11d — Final root shim
 
-- **State:** BLOCKED by the remaining AiO and Wildcard/NAIA binder families
+- **State:** BLOCKED by the remaining Wildcard/NAIA binder family
 - **Owner:** #184
 - **Type:** Move
 
@@ -2507,7 +2526,8 @@ COMPLETE: B-11c30d3 I/O-boundary binder Move / PR #350
 COMPLETE: B-11c30d4 execution-service Move / PR #351
 COMPLETE: B-11c30d0b input-context owner Move / PR #352
 COMPLETE: B-11c30d5 legacy-orchestration Move / PR #353
-PLANNED:  B-11c30d6 node-adapter Move
+COMPLETE: B-11c30d6 node-adapter Move / PR #354
+PLANNED:  B-11c30e Wildcard/NAIA callback binder Move
 BLOCKED:  B-11d final root shim
 
 LATER:    #167 seed reservation

--- a/docs/architecture/comfy-host-provider-bridge.md
+++ b/docs/architecture/comfy-host-provider-bridge.md
@@ -2347,6 +2347,113 @@ Forbidden:
 - beginning #168/#169 Behavior, d6, or final root-shim work; and
 - combining Contract, performance, dependency, or broad formatting cleanup.
 
+### B-11c30d6 — AiO node-adapter binder Move
+
+- **State:** IN PROGRESS
+- **Owner:** #184
+- **Behavior boundary:** #167
+- **Type:** Move
+- **Base:** `dev@cf772f1d8c0fe47999deb2af1a25621587717939`
+
+Pre-edit inventory:
+
+- the final active AiO subgroup contains exactly `_bind_aio_node_runtime`;
+- the binder owns one `_RUNTIME_RESOLVER` global and one `_runtime_helper`
+  dispatcher. After d5 it accounts for 29 root-resolver slots over 29 unique
+  names, no provider or direct-root dependency, and 27 repository replacement
+  slots over 27 names in `tests/test_aio_legacy_generation.py`,
+  `tests/test_aio_nodes.py`, and `tests/test_node_contracts.py`;
+- root imports the binder, both mapped classes (`EasyUseAnimaInput` and
+  `EasyUseAnimaAIOGenerator`), and the two hidden-widget serializers
+  (`_aio_input_settings_json` and `_aio_generation_settings_json`) as exact
+  package/flat aliases, then invokes the binder once during module
+  initialization;
+- `easyuse_anima.registration` consumes the two mapped classes directly.
+  ComfyUI calls their class methods, and `EasyUseAnimaAIOGenerator.generate`
+  is the sole node-adapter caller of the canonical legacy orchestrator;
+- the module also re-exports the two input-context helpers from their existing
+  pure owner. Root already imports those helpers directly from input context,
+  so their identity and ownership do not move here;
+- all 29 resolver names already have canonical owners under common
+  serialization, Prompt Data, AiO defaults/normalization/resources/model/
+  sampling/input-context/legacy orchestration, or the Python `json` module;
+  no provider, process-global state, service, or new contract is required; and
+- existing tests freeze `INPUT_TYPES`, hidden JSON defaults, `IS_CHANGED`
+  special-seed order, input context construction/copy boundaries, generation
+  forwarding/signature, package/flat aliases, mapping identity, workflow
+  serialization, and exact errors.
+
+Exact root-resolver ownership:
+
+```text
+module/defaults/types:
+  json
+  AIO_GENERATION_DEFAULT_SETTINGS
+  AIO_INPUT_DEFAULT_SETTINGS
+  AIO_SPECIAL_SEEDS
+  ANIMA_DEFAULT_CLIP_CANDIDATES
+  ANIMA_DEFAULT_DIFFUSION_MODEL_CANDIDATES
+  ANIMA_DEFAULT_VAE_CANDIDATES
+  EASY_USE_ANIMA_INPUT_SCHEMA
+  EASY_USE_ANIMA_INPUT_SETTINGS_VERSION
+  EASY_USE_ANIMA_INPUT_TYPE
+  PROMPT_DATA_TYPE
+serialization/signature:
+  _aio_generation_settings_json
+  _aio_input_settings_json
+  _aio_lora_stack_signature
+  _copy_prompt_data_for_update
+  _json_clone
+  _stable_change_key
+prompt/settings/resources:
+  _normalize_prompt_data
+  _prompt_data_json_safe
+  _normalize_aio_generation_settings
+  _normalize_aio_input_settings
+  _comfy_clip_loader_types
+  _comfy_diffusion_model_names
+  _comfy_text_encoder_names
+  _comfy_vae_names
+  _preferred_clip_type_default
+  _preferred_name_default
+execution:
+  _resolve_aio_runtime_seed
+  _run_aio_legacy_generation
+```
+
+Allowed production files:
+
+```text
+nodes.py
+easyuse_anima/nodes/aio_nodes.py
+```
+
+Allowed supporting files are the three d6 replacement-owner tests, Python
+compatibility and backend/nodes analyzer gates/fixtures, workflow/package
+contract coverage, and the three architecture documents.
+
+Exit:
+
+- the d6 binder definition, root imports/call, `_RUNTIME_RESOLVER`, and
+  `_runtime_helper` are absent;
+- the adapter imports existing canonical owners directly and owns JSON access;
+- both mapped classes and the two serializer root aliases retain exact
+  identity in package and flat-import modes;
+- only d6 replacement ownership moves from root/binder injection to the
+  canonical consumer module; and
+- the AiO binder family is empty while Wildcard/NAIA remain the only active
+  callback binders. Node inputs, change keys, seed reservation, context,
+  generation, mappings, errors, schemas, and workflows remain unchanged.
+
+Forbidden:
+
+- retiring or otherwise changing the Wildcard/NAIA binders;
+- changing hidden JSON shape/order/options, input/resource defaults, mutable
+  settings or special-seed semantics, `IS_CHANGED`, context copies, generation
+  forwarding, node signatures/IDs/mappings, errors, schemas, or workflows;
+- beginning #167 Behavior, Wildcard/NAIA, final root-shim, Contract,
+  performance, dependency, or broad formatting work.
+
 ### B-11d — Final root shim
 
 - **State:** BLOCKED by the remaining AiO and Wildcard/NAIA binder families

--- a/docs/architecture/python-backend-execution-roadmap.md
+++ b/docs/architecture/python-backend-execution-roadmap.md
@@ -5,7 +5,7 @@
 - Status: operational execution runbook
 - Snapshot date: 2026-07-24
 - Snapshot branch: `dev`
-- Integrated `dev` snapshot commit: `4409c17e87a8d7a06157c85ce38b72b8e3de5c39`
+- Integrated `dev` snapshot commit: `cf772f1d8c0fe47999deb2af1a25621587717939`
 - Scope: Python backend only
 - Target architecture: [`python-backend.md`](python-backend.md)
 - Architecture decisions: [ADR-001](adr-001-modular-monolith.md) and
@@ -31,7 +31,7 @@ merged PR, the owning issue's evidence record, and every stated exit gate.
 | Phase | Integrated snapshot / open implementation state | Remaining exit work |
 | --- | --- | --- |
 | A - baseline | Complete; #191 is closed | Keep fixtures and analyzers current during later moves |
-| B - `nodes.py` extraction | Integrated through B-11c30d0b / PR #352; B-11c30d5 completes in PR #353 | Execute d6, Wildcard/NAIA, and the final root shim as separate rollback units |
+| B - `nodes.py` extraction | Integrated through B-11c30d5 / PR #353; B-11c30d6 completes in PR #354 | Execute Wildcard/NAIA and the final root shim as separate rollback units |
 | C - feature contracts/behavior | Partially complete through S167-01a / PR #344 | Continue #167 and #169 in separate Contract/Move/Behavior PRs |
 | D - root consolidation | Not started | Execute #186 feature by feature after the corresponding behavior contracts are stable |
 | E - runtime ownership | Partial: E-02a and E-07a/E-07b integrated | Continue #187 only where canonical feature owners and explicit contracts exist |
@@ -42,9 +42,9 @@ merged PR, the owning issue's evidence record, and every stated exit gate.
 ### Measured Phase B progress
 
 - The Phase A baseline recorded root `nodes.py` at 12,663 lines.
-- In B-11c30d5 / PR #353, the analyzer measures root `nodes.py` at 1,147 lines.
-- The mechanical extraction has removed 11,516
-  lines, approximately 90.9% of the Phase A baseline, while preserving the root
+- In B-11c30d6 / PR #354, the analyzer measures root `nodes.py` at 1,142 lines.
+- The mechanical extraction has removed 11,521
+  lines, approximately 91.0% of the Phase A baseline, while preserving the root
   compatibility surface.
 - B-01 through B-09b2 are integrated. The latest completed implementation slice
   is the AiO generator adapter Move in PR #270.
@@ -151,6 +151,11 @@ merged PR, the owning issue's evidence record, and every stated exit gate.
   existing stateless owners directly, keeps the two E-07 host seams call-time
   provider-resolved, and preserves all seven root execution aliases. Three
   binders remain: d6 and the two Wildcard/NAIA callbacks.
+  B-11c30d6 / PR #354 then retires only the final AiO node-adapter binder. The
+  adapter imports existing canonical owners directly, moves its input-type
+  constant to the canonical module, and preserves exact root aliases, node
+  signatures, widget defaults, change keys, seed behavior, context copies, and
+  generation forwarding. Two explicit Wildcard/NAIA callback binders remain.
 
 ### Current quality baseline
 
@@ -394,7 +399,7 @@ mechanical retirement series.
 | 11 | B-09b2 AiO generator adapter move | COMPLETE on `dev` | Move | #184 | PR #270 / `57d40b4` |
 | 12 | B-10a machine-readable compatibility audit | COMPLETE on `dev` | Contract/gate | #184/#188 | PR #271 / `3c7b857` |
 | 13 | B-10b private alias reduction | COMPLETE on `dev` through PR #291 / `c6b4680` | Contract/cleanup, split PRs | #184/#188 | Audited alias surface integrated |
-| 14 | B-11 registration/bootstrap/root shim | IN PROGRESS through B-11c30d5 PR #353; d6 is the next separate Move | Move/Contract, split PRs | #184 | Frozen AiO split gate; S167-01 contract |
+| 14 | B-11 registration/bootstrap/root shim | IN PROGRESS through B-11c30d6 PR #354; Wildcard/NAIA is the next separate Move | Move/Contract, split PRs | #184 | Frozen AiO split gate; S167-01 contract |
 | 15 | S167 backend seed reservation series | S167-01 Contract COMPLETE in PR #343 and S167-01a consumer Move COMPLETE in PR #344; Behavior and Adapter remain | Contract then Move then Behavior | #167 | Canonical AiO/node seams |
 | 16 | A169 stage pipeline series | BLOCKED by #168 and B exit | Contract then Behavior | #169 | Typed config and mechanical AiO move |
 | 17 | A169 first-pass cache policy | BLOCKED by stage/cache ownership seam | Behavior | #169 | Mechanical cache move and benchmark harness |
@@ -1125,7 +1130,13 @@ unchanged. The separate legacy Wildcard unsupported alias remains for D-12.
     requirements behind the existing E-07 call-time provider. Root retains all
     seven execution aliases, the frozen legacy execution trace is unchanged,
     and d6 plus Wildcard/NAIA remain separate. The root shim falls to 1,147
-    lines; B-11c30d6 is the next READY Move.
+    lines.
+  - B-11c30d6 retires only `_bind_aio_node_runtime` in PR #354. The canonical
+    adapter imports existing owners directly, owns JSON access and its input
+    type constant, and preserves class/helper alias identity, node contracts,
+    hidden widget serialization, change keys, seed handling, context copies,
+    and generation forwarding. The root shim falls to 1,142 lines. Only the two
+    Wildcard/NAIA callback binders remain before the final root shim.
   - The final B-11c cutover removes remaining root execution ownership and
     leaves the explicit supported `nodes.py` compatibility shim.
 - Add `easyuse_anima/registration.py` as pure mapping composition. It performs no

--- a/docs/architecture/python-compatibility-shims.md
+++ b/docs/architecture/python-compatibility-shims.md
@@ -8,12 +8,11 @@
 - Policy: [ADR-002](adr-002-compatibility-shims.md)
 - Machine-readable audit:
   [`python_compatibility_surface.v1.json`](../../tests/fixtures/python_compatibility_surface.v1.json)
-- Current state: B-11a through B-11c30d4 / PR #351 are integrated in the
-  reviewed sequence, and B-11c30d0b / PR #352 moves only the two AiO
-  input-context helpers to a pure owner. S167-01a / PR #344 supplies the
-  canonical reserved-seed compatibility consumer while retaining its root
-  aliases. Four AiO and Wildcard/NAIA binders remain before the final root
-  shim.
+- Current state: B-11a through B-11c30d5 / PR #353 are integrated in the
+  reviewed sequence, and B-11c30d6 / PR #354 retires the final AiO
+  node-adapter resolver. S167-01a / PR #344 supplies the canonical
+  reserved-seed compatibility consumer while retaining its root aliases. Only
+  the two Wildcard/NAIA callback binders remain before the final root shim.
 
 This is an actionable registry, not a removal schedule. `N` means the first
 published Registry release containing both a canonical target and its root
@@ -75,11 +74,11 @@ The versioned fixture records the exact post-B-09b2 surface rather than
 inferring public support from spelling or test imports:
 
 - root `__init__.py` permanent entrypoints: 3;
-- `nodes.py` preamble implementation imports: 3 (`json`, `logging`, and
-  `random`), excluded from compatibility classification
+- `nodes.py` preamble implementation imports: 1 (`logging`), excluded from
+  compatibility classification
   by an exact AST allowlist and drift gate;
-- `nodes.py` bindings with an `easyuse_anima` canonical target: 290 in
-  B-11c30d2 (258 at the integrated B-10b20 baseline), with exact
+- `nodes.py` bindings with an `easyuse_anima` canonical target: 291 in
+  B-11c30d6 (258 at the integrated B-10b20 baseline), with exact
   relative-package/flat-fallback parity;
 - bindings still owned by `anima_prompt`, `settings`, `prompt_translation`, or
   `wildcard_engine`: 27, with the same fallback parity;
@@ -87,11 +86,11 @@ inferring public support from spelling or test imports:
 - unmapped root classes: `EasyUseAnimaSAM3Context` and
   `EasyUseAnimaSAM3Detailer`; the canonical legacy Extend class remains in its
   owner module without a root alias or backend mapping;
-- root-owned residual implementation: 0 functions, 0 classes, and 12 assigned
-  globals in B-11c30d2 (41/2/33 at the integrated B-10b20 baseline).
-- import-time runtime binders: 10 exact top-level `_bind_*_runtime` calls;
-- root names reached by those canonical runtime resolvers: 136, including
-  literal lookups and binder-owned helper-name/default collections;
+- root-owned residual implementation: 0 functions, 0 classes, and 2 assigned
+  globals in B-11c30d6 (41/2/33 at the integrated B-10b20 baseline).
+- import-time runtime binders: 2 exact top-level `_bind_*_runtime` calls;
+- no string runtime resolver remains. The two explicit Wildcard/NAIA callback
+  binders reach eight unique direct root dependencies across nine slots;
 - retired private bindings: `_comfy_checkpoint_names`,
   `_EasyUseAnimaAlignedDetailerHook`, and
   `_EasyUseAnimaImpactDetailerDelegate`, plus `_impact_core_module`,
@@ -121,7 +120,7 @@ mapped-public classification drift, and silent promotion of residual root
 implementation. A repository test import can justify migration work, but never
 supported-public classification by itself.
 
-The five preamble imports are implementation dependencies of the remaining
+The single preamble import is an implementation dependency of the remaining
 root body, not compatibility aliases or supported exports. Any addition,
 removal, or retargeting fails the fixture build until it is deliberately
 classified; B-10b must not treat these imports as private-alias cleanup.
@@ -1026,6 +1025,28 @@ convenience-node compatibility; it remains unmapped and is not public support.
   Python modules, and the root shim is 1,147 lines.
 - B-11c30d6 is the next separate Move; Wildcard/NAIA, #168/#169 Behavior, and
   final root-shim work remain outside PR #353.
+
+### B-11c30d6 AiO node-adapter binder retirement
+
+- PR #354 retires exactly `_bind_aio_node_runtime`, its single
+  `_RUNTIME_RESOLVER`, and `_runtime_helper`.
+- `easyuse_anima.nodes.aio_nodes` imports existing common, Prompt Data, AiO
+  defaults/normalization/resources/model/sampling/input-context/orchestration
+  owners directly and owns the existing JSON serializers locally.
+- `EASY_USE_ANIMA_INPUT_TYPE` moves from the residual root assignment to the
+  canonical adapter, while root retains exact package/flat identity.
+- Tests patch the canonical consumer rather than process-global resolver state.
+  Node signatures, hidden widget serialization, change keys, seed handling,
+  input context/copy behavior, generation forwarding, mappings, schemas,
+  workflows, and exact errors remain unchanged.
+- The AiO family and all string runtime resolvers are now absent. Two explicit
+  Wildcard/NAIA callback binders remain in one family, with eight unique direct
+  callback dependencies and five repository replacement names in three files.
+- The compatibility inventory contains 291 canonical root bindings, two
+  residual root globals, one preamble implementation import, 93 shipped and
+  reachable Python modules, and a 1,142-line root shim.
+- B-11c30e Wildcard/NAIA is the next separate Move; #168/#169 Behavior and the
+  final root shim remain outside PR #354.
 
 ### `nodes.py` public node-class surface
 

--- a/easyuse_anima/nodes/aio_nodes.py
+++ b/easyuse_anima/nodes/aio_nodes.py
@@ -2,49 +2,61 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable
-from typing import Any, TypeAlias
+import json
 
+from ..aio.generation_defaults import (
+    AIO_GENERATION_DEFAULT_SETTINGS,
+    AIO_SPECIAL_SEEDS,
+)
+from ..aio.generation_normalization import _normalize_aio_generation_settings
 from ..aio.input_context import (
     _easy_use_anima_input_signature as _easy_use_anima_input_signature,
 )
 from ..aio.input_context import (
     _require_easy_use_anima_input as _require_easy_use_anima_input,
 )
+from ..aio.input_defaults import (
+    AIO_INPUT_DEFAULT_SETTINGS,
+    ANIMA_DEFAULT_CLIP_CANDIDATES,
+    ANIMA_DEFAULT_DIFFUSION_MODEL_CANDIDATES,
+    ANIMA_DEFAULT_VAE_CANDIDATES,
+    EASY_USE_ANIMA_INPUT_SCHEMA,
+    EASY_USE_ANIMA_INPUT_SETTINGS_VERSION,
+)
+from ..aio.legacy_generation import _run_aio_legacy_generation
+from ..aio.model_preparation import _aio_lora_stack_signature
+from ..aio.resources import (
+    _comfy_clip_loader_types,
+    _comfy_diffusion_model_names,
+    _comfy_text_encoder_names,
+    _comfy_vae_names,
+    _normalize_aio_input_settings,
+    _preferred_clip_type_default,
+    _preferred_name_default,
+)
+from ..aio.sampling import _resolve_aio_runtime_seed
+from ..common.serialization import _json_clone, _stable_change_key
+from ..prompt.data import (
+    PROMPT_DATA_TYPE,
+    _copy_prompt_data_for_update,
+    _normalize_prompt_data,
+    _prompt_data_json_safe,
+)
 
-_RuntimeResolver: TypeAlias = Callable[[str], Any]
-_RUNTIME_RESOLVER: _RuntimeResolver | None = None
-
-
-def _bind_aio_node_runtime(*, resolve_helper: _RuntimeResolver) -> None:
-    """Bind root compatibility helpers without importing the root module."""
-
-    global _RUNTIME_RESOLVER
-    _RUNTIME_RESOLVER = resolve_helper
-
-
-def _runtime_helper(name: str) -> Any:
-    resolver = _RUNTIME_RESOLVER
-    if resolver is None:
-        raise RuntimeError(
-            f"[EasyUseAnima] AiO node runtime helper is not bound: {name}"
-        )
-    return resolver(name)
+EASY_USE_ANIMA_INPUT_TYPE = "EASY_USE_ANIMA_INPUT"
 
 
 def _aio_input_settings_json() -> str:
-    json_module = _runtime_helper("json")
-    return json_module.dumps(
-        _runtime_helper("AIO_INPUT_DEFAULT_SETTINGS"),
+    return json.dumps(
+        AIO_INPUT_DEFAULT_SETTINGS,
         ensure_ascii=False,
         separators=(",", ":"),
     )
 
 
 def _aio_generation_settings_json() -> str:
-    json_module = _runtime_helper("json")
-    return json_module.dumps(
-        _runtime_helper("AIO_GENERATION_DEFAULT_SETTINGS"),
+    return json.dumps(
+        AIO_GENERATION_DEFAULT_SETTINGS,
         ensure_ascii=False,
         separators=(",", ":"),
     )
@@ -65,51 +77,51 @@ class EasyUseAnimaInput:
 
     @classmethod
     def INPUT_TYPES(cls):
-        unet_names = _runtime_helper("_comfy_diffusion_model_names")()
-        vae_names = _runtime_helper("_comfy_vae_names")()
-        clip_names = _runtime_helper("_comfy_text_encoder_names")()
-        clip_types = _runtime_helper("_comfy_clip_loader_types")()
+        unet_names = _comfy_diffusion_model_names()
+        vae_names = _comfy_vae_names()
+        clip_names = _comfy_text_encoder_names()
+        clip_types = _comfy_clip_loader_types()
         return {
             "required": {
-                _runtime_helper("PROMPT_DATA_TYPE"): (_runtime_helper("PROMPT_DATA_TYPE"), {
+                PROMPT_DATA_TYPE: (PROMPT_DATA_TYPE, {
                     "forceInput": True,
                     "tooltip": "Structured prompt data from Anima Prompt Studio Advanced v2.",
                 }),
                 "unet_name": (unet_names, {
-                    "default": _runtime_helper("_preferred_name_default")(
+                    "default": _preferred_name_default(
                         unet_names,
-                        _runtime_helper("ANIMA_DEFAULT_DIFFUSION_MODEL_CANDIDATES"),
+                        ANIMA_DEFAULT_DIFFUSION_MODEL_CANDIDATES,
                     ),
                     "tooltip": "ANIMA diffusion model loaded with ComfyUI UNETLoader.",
                 }),
                 "vae_name": (vae_names, {
-                    "default": _runtime_helper("_preferred_name_default")(
+                    "default": _preferred_name_default(
                         vae_names,
-                        _runtime_helper("ANIMA_DEFAULT_VAE_CANDIDATES"),
+                        ANIMA_DEFAULT_VAE_CANDIDATES,
                     ),
                     "tooltip": "VAE loaded with ComfyUI VAELoader.",
                 }),
                 "clip_name": (clip_names, {
-                    "default": _runtime_helper("_preferred_name_default")(
+                    "default": _preferred_name_default(
                         clip_names,
-                        _runtime_helper("ANIMA_DEFAULT_CLIP_CANDIDATES"),
+                        ANIMA_DEFAULT_CLIP_CANDIDATES,
                     ),
                     "tooltip": "Text encoder loaded with ComfyUI CLIPLoader.",
                 }),
                 "clip_type": (clip_types, {
-                    "default": _runtime_helper("_preferred_clip_type_default")(clip_types),
+                    "default": _preferred_clip_type_default(clip_types),
                     "tooltip": "ComfyUI CLIPLoader type. Core ANIMA uses qwen_image.",
                 }),
                 "input_settings": ("STRING", {
                     "multiline": True,
-                    "default": _runtime_helper("_aio_input_settings_json")(),
+                    "default": _aio_input_settings_json(),
                     "hidden": True,
                     "tooltip": "Hidden versioned JSON storage for future resource settings. Kept serialized for workflow compatibility.",
                 }),
             },
         }
 
-    RETURN_TYPES = ("EASY_USE_ANIMA_INPUT",)
+    RETURN_TYPES = (EASY_USE_ANIMA_INPUT_TYPE,)
     RETURN_NAMES = ("easy use anima input",)
     FUNCTION = "build"
     CATEGORY = "EasyUse Anima/AiO"
@@ -125,10 +137,10 @@ class EasyUseAnimaInput:
         input_settings: str | dict | None = None,
         **kwargs,
     ):
-        return _runtime_helper("_stable_change_key")({
+        return _stable_change_key({
             "mode": "easy_use_anima_input",
-            "prompt_data": _runtime_helper("_prompt_data_json_safe")(
-                _runtime_helper("_normalize_prompt_data")(
+            "prompt_data": _prompt_data_json_safe(
+                _normalize_prompt_data(
                     EASYUSE_ANIMA_PROMPT_DATA
                 )
             ),
@@ -136,7 +148,7 @@ class EasyUseAnimaInput:
             "vae_name": str(vae_name or ""),
             "clip_name": str(clip_name or ""),
             "clip_type": str(clip_type or ""),
-            "input_settings": _runtime_helper("_normalize_aio_input_settings")(
+            "input_settings": _normalize_aio_input_settings(
                 input_settings
             ),
         })
@@ -150,8 +162,8 @@ class EasyUseAnimaInput:
         clip_type: str = "qwen_image",
         input_settings: str | dict | None = None,
     ):
-        settings = _runtime_helper("_normalize_aio_input_settings")(input_settings)
-        prompt_data = _runtime_helper("_copy_prompt_data_for_update")(
+        settings = _normalize_aio_input_settings(input_settings)
+        prompt_data = _copy_prompt_data_for_update(
             EASYUSE_ANIMA_PROMPT_DATA
         )
         resources = settings.get("resources", {})
@@ -165,13 +177,13 @@ class EasyUseAnimaInput:
             "clip_device": str(resources.get("clip_device") or "default"),
         }
         prompt_data["easy_use_anima_input"] = {
-            "schema": _runtime_helper("EASY_USE_ANIMA_INPUT_SCHEMA"),
-            "version": _runtime_helper("EASY_USE_ANIMA_INPUT_SETTINGS_VERSION"),
+            "schema": EASY_USE_ANIMA_INPUT_SCHEMA,
+            "version": EASY_USE_ANIMA_INPUT_SETTINGS_VERSION,
             "resource_info": dict(resource_info),
         }
         return ({
-            "schema": _runtime_helper("EASY_USE_ANIMA_INPUT_SCHEMA"),
-            "version": _runtime_helper("EASY_USE_ANIMA_INPUT_SETTINGS_VERSION"),
+            "schema": EASY_USE_ANIMA_INPUT_SCHEMA,
+            "version": EASY_USE_ANIMA_INPUT_SETTINGS_VERSION,
             "prompt_data": prompt_data,
             "resource_info": resource_info,
             "input_settings": settings,
@@ -198,7 +210,7 @@ class EasyUseAnimaAIOGenerator:
         return {
             "required": {
                 "easy_use_anima_input": (
-                    _runtime_helper("EASY_USE_ANIMA_INPUT_TYPE"),
+                    EASY_USE_ANIMA_INPUT_TYPE,
                     {
                         "forceInput": True,
                         "tooltip": "Context from Easy Use Anima Input.",
@@ -208,7 +220,7 @@ class EasyUseAnimaAIOGenerator:
                     "STRING",
                     {
                         "multiline": True,
-                        "default": _runtime_helper("_aio_generation_settings_json")(),
+                        "default": _aio_generation_settings_json(),
                         "hidden": True,
                         "tooltip": "Hidden versioned JSON storage for popup generation settings. Keep this field serialized.",
                     },
@@ -244,22 +256,20 @@ class EasyUseAnimaAIOGenerator:
         generation_settings: str | dict | None = None,
         **kwargs,
     ):
-        settings = _runtime_helper("_normalize_aio_generation_settings")(
+        settings = _normalize_aio_generation_settings(
             generation_settings
         )
-        if settings.get("sampler", {}).get("seed") in _runtime_helper(
-            "AIO_SPECIAL_SEEDS"
-        ):
-            change_settings = _runtime_helper("_json_clone")(settings)
-            change_settings["sampler"]["seed"] = _runtime_helper(
-                "_resolve_aio_runtime_seed"
-            )(change_settings["sampler"].get("seed"))
+        if settings.get("sampler", {}).get("seed") in AIO_SPECIAL_SEEDS:
+            change_settings = _json_clone(settings)
+            change_settings["sampler"]["seed"] = _resolve_aio_runtime_seed(
+                change_settings["sampler"].get("seed")
+            )
         else:
             change_settings = settings
-        return _runtime_helper("_stable_change_key")({
+        return _stable_change_key({
             "mode": "easy_use_anima_generator",
             "input": _easy_use_anima_input_signature(easy_use_anima_input),
-            "lora_stack": _runtime_helper("_aio_lora_stack_signature")(lora_stack),
+            "lora_stack": _aio_lora_stack_signature(lora_stack),
             "generation_settings": change_settings,
         })
 
@@ -272,7 +282,7 @@ class EasyUseAnimaAIOGenerator:
         extra_pnginfo=None,
         unique_id=None,
     ):
-        return _runtime_helper("_run_aio_legacy_generation")(
+        return _run_aio_legacy_generation(
             self,
             easy_use_anima_input,
             generation_settings,

--- a/nodes.py
+++ b/nodes.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 from __future__ import annotations
 
-import json
 import logging
 
 try:
@@ -382,11 +381,11 @@ try:
         # B-10b11 retires the unmapped legacy Extend root alias.
     )
     from .easyuse_anima.nodes.aio_nodes import (
+        EASY_USE_ANIMA_INPUT_TYPE as EASY_USE_ANIMA_INPUT_TYPE,
         EasyUseAnimaAIOGenerator as EasyUseAnimaAIOGenerator,
         EasyUseAnimaInput as EasyUseAnimaInput,
         _aio_generation_settings_json as _aio_generation_settings_json,
         _aio_input_settings_json as _aio_input_settings_json,
-        _bind_aio_node_runtime as _bind_aio_node_runtime,
     )
     from .easyuse_anima.image.geometry import (
         _align_down as _align_down,
@@ -941,11 +940,11 @@ except ImportError:  # allows simple local import tests outside ComfyUI's packag
         # B-10b11 retires the unmapped legacy Extend root alias.
     )
     from easyuse_anima.nodes.aio_nodes import (
+        EASY_USE_ANIMA_INPUT_TYPE as EASY_USE_ANIMA_INPUT_TYPE,
         EasyUseAnimaAIOGenerator as EasyUseAnimaAIOGenerator,
         EasyUseAnimaInput as EasyUseAnimaInput,
         _aio_generation_settings_json as _aio_generation_settings_json,
         _aio_input_settings_json as _aio_input_settings_json,
-        _bind_aio_node_runtime as _bind_aio_node_runtime,
     )
     from easyuse_anima.image.geometry import (
         _align_down as _align_down,
@@ -1125,13 +1124,9 @@ except ImportError:  # allows simple local import tests outside ComfyUI's packag
 
 logger = logging.getLogger("ComfyUI-EasyUseAnima")
 
-EASY_USE_ANIMA_INPUT_TYPE = "EASY_USE_ANIMA_INPUT"
 _TRIGGER_WORD_KEYS = ("trainedWords", "trained_words", "trigger_words", "activation_text")
 
 
-_bind_aio_node_runtime(
-    resolve_helper=lambda name: globals()[name],
-)
 _bind_wildcard_node_runtime(
     get_workflow_node=lambda *args, **kwargs: _get_workflow_node(*args, **kwargs),
     expand=lambda *args, **kwargs: expand_wildcards(*args, **kwargs),

--- a/tests/fixtures/python_backend_baseline.json
+++ b/tests/fixtures/python_backend_baseline.json
@@ -12403,54 +12403,74 @@
       },
       {
         "alias": null,
-        "bound_name": "Callable",
+        "bound_name": "json",
         "branch_context": [],
         "classification": "external",
         "column": 0,
         "conditional": false,
-        "imported": "collections.abc:Callable",
-        "kind": "static_from",
+        "imported": "json",
+        "kind": "static_import",
         "line": 5,
-        "name": "Callable",
+        "name": null,
         "optional": false,
-        "requested": "collections.abc",
+        "requested": "json",
         "role": "ordinary",
         "scope": "<module>",
         "source": "easyuse_anima/nodes/aio_nodes.py"
       },
       {
         "alias": null,
-        "bound_name": "Any",
+        "bound_name": "AIO_GENERATION_DEFAULT_SETTINGS",
         "branch_context": [],
-        "classification": "external",
+        "classification": "internal",
         "column": 0,
         "conditional": false,
-        "imported": "typing:Any",
+        "imported": "..aio.generation_defaults:AIO_GENERATION_DEFAULT_SETTINGS",
         "kind": "static_from",
-        "line": 6,
-        "name": "Any",
+        "line": 7,
+        "name": "AIO_GENERATION_DEFAULT_SETTINGS",
         "optional": false,
-        "requested": "typing",
+        "requested": "..aio.generation_defaults",
         "role": "ordinary",
         "scope": "<module>",
-        "source": "easyuse_anima/nodes/aio_nodes.py"
+        "source": "easyuse_anima/nodes/aio_nodes.py",
+        "target": "easyuse_anima/aio/generation_defaults.py"
       },
       {
         "alias": null,
-        "bound_name": "TypeAlias",
+        "bound_name": "AIO_SPECIAL_SEEDS",
         "branch_context": [],
-        "classification": "external",
+        "classification": "internal",
         "column": 0,
         "conditional": false,
-        "imported": "typing:TypeAlias",
+        "imported": "..aio.generation_defaults:AIO_SPECIAL_SEEDS",
         "kind": "static_from",
-        "line": 6,
-        "name": "TypeAlias",
+        "line": 7,
+        "name": "AIO_SPECIAL_SEEDS",
         "optional": false,
-        "requested": "typing",
+        "requested": "..aio.generation_defaults",
         "role": "ordinary",
         "scope": "<module>",
-        "source": "easyuse_anima/nodes/aio_nodes.py"
+        "source": "easyuse_anima/nodes/aio_nodes.py",
+        "target": "easyuse_anima/aio/generation_defaults.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_normalize_aio_generation_settings",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": "..aio.generation_normalization:_normalize_aio_generation_settings",
+        "kind": "static_from",
+        "line": 11,
+        "name": "_normalize_aio_generation_settings",
+        "optional": false,
+        "requested": "..aio.generation_normalization",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/nodes/aio_nodes.py",
+        "target": "easyuse_anima/aio/generation_normalization.py"
       },
       {
         "alias": "_easy_use_anima_input_signature",
@@ -12461,7 +12481,7 @@
         "conditional": false,
         "imported": "..aio.input_context:_easy_use_anima_input_signature",
         "kind": "static_from",
-        "line": 8,
+        "line": 12,
         "name": "_easy_use_anima_input_signature",
         "optional": false,
         "requested": "..aio.input_context",
@@ -12479,7 +12499,7 @@
         "conditional": false,
         "imported": "..aio.input_context:_require_easy_use_anima_input",
         "kind": "static_from",
-        "line": 11,
+        "line": 15,
         "name": "_require_easy_use_anima_input",
         "optional": false,
         "requested": "..aio.input_context",
@@ -12487,6 +12507,402 @@
         "scope": "<module>",
         "source": "easyuse_anima/nodes/aio_nodes.py",
         "target": "easyuse_anima/aio/input_context.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "AIO_INPUT_DEFAULT_SETTINGS",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": "..aio.input_defaults:AIO_INPUT_DEFAULT_SETTINGS",
+        "kind": "static_from",
+        "line": 18,
+        "name": "AIO_INPUT_DEFAULT_SETTINGS",
+        "optional": false,
+        "requested": "..aio.input_defaults",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/nodes/aio_nodes.py",
+        "target": "easyuse_anima/aio/input_defaults.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "ANIMA_DEFAULT_CLIP_CANDIDATES",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": "..aio.input_defaults:ANIMA_DEFAULT_CLIP_CANDIDATES",
+        "kind": "static_from",
+        "line": 18,
+        "name": "ANIMA_DEFAULT_CLIP_CANDIDATES",
+        "optional": false,
+        "requested": "..aio.input_defaults",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/nodes/aio_nodes.py",
+        "target": "easyuse_anima/aio/input_defaults.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "ANIMA_DEFAULT_DIFFUSION_MODEL_CANDIDATES",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": "..aio.input_defaults:ANIMA_DEFAULT_DIFFUSION_MODEL_CANDIDATES",
+        "kind": "static_from",
+        "line": 18,
+        "name": "ANIMA_DEFAULT_DIFFUSION_MODEL_CANDIDATES",
+        "optional": false,
+        "requested": "..aio.input_defaults",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/nodes/aio_nodes.py",
+        "target": "easyuse_anima/aio/input_defaults.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "ANIMA_DEFAULT_VAE_CANDIDATES",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": "..aio.input_defaults:ANIMA_DEFAULT_VAE_CANDIDATES",
+        "kind": "static_from",
+        "line": 18,
+        "name": "ANIMA_DEFAULT_VAE_CANDIDATES",
+        "optional": false,
+        "requested": "..aio.input_defaults",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/nodes/aio_nodes.py",
+        "target": "easyuse_anima/aio/input_defaults.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "EASY_USE_ANIMA_INPUT_SCHEMA",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": "..aio.input_defaults:EASY_USE_ANIMA_INPUT_SCHEMA",
+        "kind": "static_from",
+        "line": 18,
+        "name": "EASY_USE_ANIMA_INPUT_SCHEMA",
+        "optional": false,
+        "requested": "..aio.input_defaults",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/nodes/aio_nodes.py",
+        "target": "easyuse_anima/aio/input_defaults.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "EASY_USE_ANIMA_INPUT_SETTINGS_VERSION",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": "..aio.input_defaults:EASY_USE_ANIMA_INPUT_SETTINGS_VERSION",
+        "kind": "static_from",
+        "line": 18,
+        "name": "EASY_USE_ANIMA_INPUT_SETTINGS_VERSION",
+        "optional": false,
+        "requested": "..aio.input_defaults",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/nodes/aio_nodes.py",
+        "target": "easyuse_anima/aio/input_defaults.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_run_aio_legacy_generation",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": "..aio.legacy_generation:_run_aio_legacy_generation",
+        "kind": "static_from",
+        "line": 26,
+        "name": "_run_aio_legacy_generation",
+        "optional": false,
+        "requested": "..aio.legacy_generation",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/nodes/aio_nodes.py",
+        "target": "easyuse_anima/aio/legacy_generation.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_aio_lora_stack_signature",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": "..aio.model_preparation:_aio_lora_stack_signature",
+        "kind": "static_from",
+        "line": 27,
+        "name": "_aio_lora_stack_signature",
+        "optional": false,
+        "requested": "..aio.model_preparation",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/nodes/aio_nodes.py",
+        "target": "easyuse_anima/aio/model_preparation.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_comfy_clip_loader_types",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": "..aio.resources:_comfy_clip_loader_types",
+        "kind": "static_from",
+        "line": 28,
+        "name": "_comfy_clip_loader_types",
+        "optional": false,
+        "requested": "..aio.resources",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/nodes/aio_nodes.py",
+        "target": "easyuse_anima/aio/resources.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_comfy_diffusion_model_names",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": "..aio.resources:_comfy_diffusion_model_names",
+        "kind": "static_from",
+        "line": 28,
+        "name": "_comfy_diffusion_model_names",
+        "optional": false,
+        "requested": "..aio.resources",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/nodes/aio_nodes.py",
+        "target": "easyuse_anima/aio/resources.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_comfy_text_encoder_names",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": "..aio.resources:_comfy_text_encoder_names",
+        "kind": "static_from",
+        "line": 28,
+        "name": "_comfy_text_encoder_names",
+        "optional": false,
+        "requested": "..aio.resources",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/nodes/aio_nodes.py",
+        "target": "easyuse_anima/aio/resources.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_comfy_vae_names",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": "..aio.resources:_comfy_vae_names",
+        "kind": "static_from",
+        "line": 28,
+        "name": "_comfy_vae_names",
+        "optional": false,
+        "requested": "..aio.resources",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/nodes/aio_nodes.py",
+        "target": "easyuse_anima/aio/resources.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_normalize_aio_input_settings",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": "..aio.resources:_normalize_aio_input_settings",
+        "kind": "static_from",
+        "line": 28,
+        "name": "_normalize_aio_input_settings",
+        "optional": false,
+        "requested": "..aio.resources",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/nodes/aio_nodes.py",
+        "target": "easyuse_anima/aio/resources.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_preferred_clip_type_default",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": "..aio.resources:_preferred_clip_type_default",
+        "kind": "static_from",
+        "line": 28,
+        "name": "_preferred_clip_type_default",
+        "optional": false,
+        "requested": "..aio.resources",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/nodes/aio_nodes.py",
+        "target": "easyuse_anima/aio/resources.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_preferred_name_default",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": "..aio.resources:_preferred_name_default",
+        "kind": "static_from",
+        "line": 28,
+        "name": "_preferred_name_default",
+        "optional": false,
+        "requested": "..aio.resources",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/nodes/aio_nodes.py",
+        "target": "easyuse_anima/aio/resources.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_resolve_aio_runtime_seed",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": "..aio.sampling:_resolve_aio_runtime_seed",
+        "kind": "static_from",
+        "line": 37,
+        "name": "_resolve_aio_runtime_seed",
+        "optional": false,
+        "requested": "..aio.sampling",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/nodes/aio_nodes.py",
+        "target": "easyuse_anima/aio/sampling.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_json_clone",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": "..common.serialization:_json_clone",
+        "kind": "static_from",
+        "line": 38,
+        "name": "_json_clone",
+        "optional": false,
+        "requested": "..common.serialization",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/nodes/aio_nodes.py",
+        "target": "easyuse_anima/common/serialization.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_stable_change_key",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": "..common.serialization:_stable_change_key",
+        "kind": "static_from",
+        "line": 38,
+        "name": "_stable_change_key",
+        "optional": false,
+        "requested": "..common.serialization",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/nodes/aio_nodes.py",
+        "target": "easyuse_anima/common/serialization.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "PROMPT_DATA_TYPE",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": "..prompt.data:PROMPT_DATA_TYPE",
+        "kind": "static_from",
+        "line": 39,
+        "name": "PROMPT_DATA_TYPE",
+        "optional": false,
+        "requested": "..prompt.data",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/nodes/aio_nodes.py",
+        "target": "easyuse_anima/prompt/data.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_copy_prompt_data_for_update",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": "..prompt.data:_copy_prompt_data_for_update",
+        "kind": "static_from",
+        "line": 39,
+        "name": "_copy_prompt_data_for_update",
+        "optional": false,
+        "requested": "..prompt.data",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/nodes/aio_nodes.py",
+        "target": "easyuse_anima/prompt/data.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_normalize_prompt_data",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": "..prompt.data:_normalize_prompt_data",
+        "kind": "static_from",
+        "line": 39,
+        "name": "_normalize_prompt_data",
+        "optional": false,
+        "requested": "..prompt.data",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/nodes/aio_nodes.py",
+        "target": "easyuse_anima/prompt/data.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_prompt_data_json_safe",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": "..prompt.data:_prompt_data_json_safe",
+        "kind": "static_from",
+        "line": 39,
+        "name": "_prompt_data_json_safe",
+        "optional": false,
+        "requested": "..prompt.data",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/nodes/aio_nodes.py",
+        "target": "easyuse_anima/prompt/data.py"
       },
       {
         "alias": null,
@@ -20806,23 +21222,6 @@
       },
       {
         "alias": null,
-        "bound_name": "json",
-        "branch_context": [],
-        "classification": "external",
-        "column": 0,
-        "conditional": false,
-        "imported": "json",
-        "kind": "static_import",
-        "line": 4,
-        "name": null,
-        "optional": false,
-        "requested": "json",
-        "role": "ordinary",
-        "scope": "<module>",
-        "source": "nodes.py"
-      },
-      {
-        "alias": null,
         "bound_name": "logging",
         "branch_context": [],
         "classification": "external",
@@ -20830,7 +21229,7 @@
         "conditional": false,
         "imported": "logging",
         "kind": "static_import",
-        "line": 5,
+        "line": 4,
         "name": null,
         "optional": false,
         "requested": "logging",
@@ -20847,7 +21246,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -20855,12 +21254,12 @@
         "compatibility_pair": {
           "bound_name": "AIO_FIRST_PASS_CACHE_MAX_ENTRIES",
           "target": "easyuse_anima/aio/first_pass_cache.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.first_pass_cache:AIO_FIRST_PASS_CACHE_MAX_ENTRIES",
         "kind": "static_from",
-        "line": 8,
+        "line": 7,
         "name": "AIO_FIRST_PASS_CACHE_MAX_ENTRIES",
         "optional": false,
         "requested": ".easyuse_anima.aio.first_pass_cache",
@@ -20878,7 +21277,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -20886,12 +21285,12 @@
         "compatibility_pair": {
           "bound_name": "_AIO_FIRST_PASS_CACHE",
           "target": "easyuse_anima/aio/first_pass_cache.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.first_pass_cache:_AIO_FIRST_PASS_CACHE",
         "kind": "static_from",
-        "line": 8,
+        "line": 7,
         "name": "_AIO_FIRST_PASS_CACHE",
         "optional": false,
         "requested": ".easyuse_anima.aio.first_pass_cache",
@@ -20909,7 +21308,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -20917,12 +21316,12 @@
         "compatibility_pair": {
           "bound_name": "_AIO_FIRST_PASS_CACHE_ORDER",
           "target": "easyuse_anima/aio/first_pass_cache.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.first_pass_cache:_AIO_FIRST_PASS_CACHE_ORDER",
         "kind": "static_from",
-        "line": 8,
+        "line": 7,
         "name": "_AIO_FIRST_PASS_CACHE_ORDER",
         "optional": false,
         "requested": ".easyuse_anima.aio.first_pass_cache",
@@ -20940,7 +21339,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -20948,12 +21347,12 @@
         "compatibility_pair": {
           "bound_name": "_aio_first_pass_cache_key",
           "target": "easyuse_anima/aio/first_pass_cache.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.first_pass_cache:_aio_first_pass_cache_key",
         "kind": "static_from",
-        "line": 8,
+        "line": 7,
         "name": "_aio_first_pass_cache_key",
         "optional": false,
         "requested": ".easyuse_anima.aio.first_pass_cache",
@@ -20971,7 +21370,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -20979,12 +21378,12 @@
         "compatibility_pair": {
           "bound_name": "_clone_aio_cache_value",
           "target": "easyuse_anima/aio/first_pass_cache.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.first_pass_cache:_clone_aio_cache_value",
         "kind": "static_from",
-        "line": 8,
+        "line": 7,
         "name": "_clone_aio_cache_value",
         "optional": false,
         "requested": ".easyuse_anima.aio.first_pass_cache",
@@ -21002,7 +21401,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -21010,12 +21409,12 @@
         "compatibility_pair": {
           "bound_name": "_get_aio_first_pass_cache",
           "target": "easyuse_anima/aio/first_pass_cache.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.first_pass_cache:_get_aio_first_pass_cache",
         "kind": "static_from",
-        "line": 8,
+        "line": 7,
         "name": "_get_aio_first_pass_cache",
         "optional": false,
         "requested": ".easyuse_anima.aio.first_pass_cache",
@@ -21033,7 +21432,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -21041,12 +21440,12 @@
         "compatibility_pair": {
           "bound_name": "_put_aio_first_pass_cache",
           "target": "easyuse_anima/aio/first_pass_cache.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.first_pass_cache:_put_aio_first_pass_cache",
         "kind": "static_from",
-        "line": 8,
+        "line": 7,
         "name": "_put_aio_first_pass_cache",
         "optional": false,
         "requested": ".easyuse_anima.aio.first_pass_cache",
@@ -21064,7 +21463,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -21072,12 +21471,12 @@
         "compatibility_pair": {
           "bound_name": "_run_aio_detailer_stage",
           "target": "easyuse_anima/aio/legacy_generation.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.legacy_generation:_run_aio_detailer_stage",
         "kind": "static_from",
-        "line": 18,
+        "line": 17,
         "name": "_run_aio_detailer_stage",
         "optional": false,
         "requested": ".easyuse_anima.aio.legacy_generation",
@@ -21095,7 +21494,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -21103,12 +21502,12 @@
         "compatibility_pair": {
           "bound_name": "_run_aio_detailer_target",
           "target": "easyuse_anima/aio/legacy_generation.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.legacy_generation:_run_aio_detailer_target",
         "kind": "static_from",
-        "line": 18,
+        "line": 17,
         "name": "_run_aio_detailer_target",
         "optional": false,
         "requested": ".easyuse_anima.aio.legacy_generation",
@@ -21126,7 +21525,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -21134,12 +21533,12 @@
         "compatibility_pair": {
           "bound_name": "_run_aio_highres_stage",
           "target": "easyuse_anima/aio/legacy_generation.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.legacy_generation:_run_aio_highres_stage",
         "kind": "static_from",
-        "line": 18,
+        "line": 17,
         "name": "_run_aio_highres_stage",
         "optional": false,
         "requested": ".easyuse_anima.aio.legacy_generation",
@@ -21157,7 +21556,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -21165,12 +21564,12 @@
         "compatibility_pair": {
           "bound_name": "_run_aio_legacy_generation",
           "target": "easyuse_anima/aio/legacy_generation.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.legacy_generation:_run_aio_legacy_generation",
         "kind": "static_from",
-        "line": 18,
+        "line": 17,
         "name": "_run_aio_legacy_generation",
         "optional": false,
         "requested": ".easyuse_anima.aio.legacy_generation",
@@ -21188,7 +21587,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -21196,12 +21595,12 @@
         "compatibility_pair": {
           "bound_name": "_run_aio_resshift_upscale_stage",
           "target": "easyuse_anima/aio/legacy_generation.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.legacy_generation:_run_aio_resshift_upscale_stage",
         "kind": "static_from",
-        "line": 18,
+        "line": 17,
         "name": "_run_aio_resshift_upscale_stage",
         "optional": false,
         "requested": ".easyuse_anima.aio.legacy_generation",
@@ -21219,7 +21618,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -21227,12 +21626,12 @@
         "compatibility_pair": {
           "bound_name": "_run_aio_upscale_stage",
           "target": "easyuse_anima/aio/legacy_generation.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.legacy_generation:_run_aio_upscale_stage",
         "kind": "static_from",
-        "line": 18,
+        "line": 17,
         "name": "_run_aio_upscale_stage",
         "optional": false,
         "requested": ".easyuse_anima.aio.legacy_generation",
@@ -21250,7 +21649,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -21258,12 +21657,12 @@
         "compatibility_pair": {
           "bound_name": "_run_aio_usdu_upscale_stage",
           "target": "easyuse_anima/aio/legacy_generation.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.legacy_generation:_run_aio_usdu_upscale_stage",
         "kind": "static_from",
-        "line": 18,
+        "line": 17,
         "name": "_run_aio_usdu_upscale_stage",
         "optional": false,
         "requested": ".easyuse_anima.aio.legacy_generation",
@@ -21281,7 +21680,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -21289,12 +21688,12 @@
         "compatibility_pair": {
           "bound_name": "_AIO_DETAILER_CUSTOM_RE",
           "target": "easyuse_anima/aio/generation_normalization.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.generation_normalization:_AIO_DETAILER_CUSTOM_RE",
         "kind": "static_from",
-        "line": 27,
+        "line": 26,
         "name": "_AIO_DETAILER_CUSTOM_RE",
         "optional": false,
         "requested": ".easyuse_anima.aio.generation_normalization",
@@ -21312,7 +21711,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -21320,12 +21719,12 @@
         "compatibility_pair": {
           "bound_name": "_AIO_DETAILER_RESERVED_KEYS",
           "target": "easyuse_anima/aio/generation_normalization.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.generation_normalization:_AIO_DETAILER_RESERVED_KEYS",
         "kind": "static_from",
-        "line": 27,
+        "line": 26,
         "name": "_AIO_DETAILER_RESERVED_KEYS",
         "optional": false,
         "requested": ".easyuse_anima.aio.generation_normalization",
@@ -21343,7 +21742,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -21351,12 +21750,12 @@
         "compatibility_pair": {
           "bound_name": "_aio_detailer_has_enabled_targets",
           "target": "easyuse_anima/aio/generation_normalization.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.generation_normalization:_aio_detailer_has_enabled_targets",
         "kind": "static_from",
-        "line": 27,
+        "line": 26,
         "name": "_aio_detailer_has_enabled_targets",
         "optional": false,
         "requested": ".easyuse_anima.aio.generation_normalization",
@@ -21374,7 +21773,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -21382,12 +21781,12 @@
         "compatibility_pair": {
           "bound_name": "_aio_detailer_target_defaults",
           "target": "easyuse_anima/aio/generation_normalization.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.generation_normalization:_aio_detailer_target_defaults",
         "kind": "static_from",
-        "line": 27,
+        "line": 26,
         "name": "_aio_detailer_target_defaults",
         "optional": false,
         "requested": ".easyuse_anima.aio.generation_normalization",
@@ -21405,7 +21804,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -21413,12 +21812,12 @@
         "compatibility_pair": {
           "bound_name": "_aio_detailer_target_order",
           "target": "easyuse_anima/aio/generation_normalization.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.generation_normalization:_aio_detailer_target_order",
         "kind": "static_from",
-        "line": 27,
+        "line": 26,
         "name": "_aio_detailer_target_order",
         "optional": false,
         "requested": ".easyuse_anima.aio.generation_normalization",
@@ -21436,7 +21835,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -21444,12 +21843,12 @@
         "compatibility_pair": {
           "bound_name": "_is_aio_detailer_target_name",
           "target": "easyuse_anima/aio/generation_normalization.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.generation_normalization:_is_aio_detailer_target_name",
         "kind": "static_from",
-        "line": 27,
+        "line": 26,
         "name": "_is_aio_detailer_target_name",
         "optional": false,
         "requested": ".easyuse_anima.aio.generation_normalization",
@@ -21467,7 +21866,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -21475,12 +21874,12 @@
         "compatibility_pair": {
           "bound_name": "_merge_versioned_settings",
           "target": "easyuse_anima/aio/generation_normalization.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.generation_normalization:_merge_versioned_settings",
         "kind": "static_from",
-        "line": 27,
+        "line": 26,
         "name": "_merge_versioned_settings",
         "optional": false,
         "requested": ".easyuse_anima.aio.generation_normalization",
@@ -21498,7 +21897,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -21506,12 +21905,12 @@
         "compatibility_pair": {
           "bound_name": "_normalize_aio_dit_corrections_settings",
           "target": "easyuse_anima/aio/generation_normalization.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.generation_normalization:_normalize_aio_dit_corrections_settings",
         "kind": "static_from",
-        "line": 27,
+        "line": 26,
         "name": "_normalize_aio_dit_corrections_settings",
         "optional": false,
         "requested": ".easyuse_anima.aio.generation_normalization",
@@ -21529,7 +21928,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -21537,12 +21936,12 @@
         "compatibility_pair": {
           "bound_name": "_normalize_aio_generation_settings",
           "target": "easyuse_anima/aio/generation_normalization.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.generation_normalization:_normalize_aio_generation_settings",
         "kind": "static_from",
-        "line": 27,
+        "line": 26,
         "name": "_normalize_aio_generation_settings",
         "optional": false,
         "requested": ".easyuse_anima.aio.generation_normalization",
@@ -21560,7 +21959,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -21568,12 +21967,12 @@
         "compatibility_pair": {
           "bound_name": "_normalize_aio_seed",
           "target": "easyuse_anima/aio/generation_normalization.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.generation_normalization:_normalize_aio_seed",
         "kind": "static_from",
-        "line": 27,
+        "line": 26,
         "name": "_normalize_aio_seed",
         "optional": false,
         "requested": ".easyuse_anima.aio.generation_normalization",
@@ -21591,7 +21990,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -21599,12 +21998,12 @@
         "compatibility_pair": {
           "bound_name": "_normalize_aio_spectrum_settings",
           "target": "easyuse_anima/aio/generation_normalization.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.generation_normalization:_normalize_aio_spectrum_settings",
         "kind": "static_from",
-        "line": 27,
+        "line": 26,
         "name": "_normalize_aio_spectrum_settings",
         "optional": false,
         "requested": ".easyuse_anima.aio.generation_normalization",
@@ -21622,7 +22021,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -21630,12 +22029,12 @@
         "compatibility_pair": {
           "bound_name": "AIO_FINAL_FIT_MODES",
           "target": "easyuse_anima/aio/generation_defaults.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.generation_defaults:AIO_FINAL_FIT_MODES",
         "kind": "static_from",
-        "line": 40,
+        "line": 39,
         "name": "AIO_FINAL_FIT_MODES",
         "optional": false,
         "requested": ".easyuse_anima.aio.generation_defaults",
@@ -21653,7 +22052,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -21661,12 +22060,12 @@
         "compatibility_pair": {
           "bound_name": "AIO_FINAL_UPSCALE_BACKENDS",
           "target": "easyuse_anima/aio/generation_defaults.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.generation_defaults:AIO_FINAL_UPSCALE_BACKENDS",
         "kind": "static_from",
-        "line": 40,
+        "line": 39,
         "name": "AIO_FINAL_UPSCALE_BACKENDS",
         "optional": false,
         "requested": ".easyuse_anima.aio.generation_defaults",
@@ -21684,7 +22083,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -21692,12 +22091,12 @@
         "compatibility_pair": {
           "bound_name": "AIO_GENERATION_DEFAULT_SETTINGS",
           "target": "easyuse_anima/aio/generation_defaults.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.generation_defaults:AIO_GENERATION_DEFAULT_SETTINGS",
         "kind": "static_from",
-        "line": 40,
+        "line": 39,
         "name": "AIO_GENERATION_DEFAULT_SETTINGS",
         "optional": false,
         "requested": ".easyuse_anima.aio.generation_defaults",
@@ -21715,7 +22114,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -21723,12 +22122,12 @@
         "compatibility_pair": {
           "bound_name": "AIO_GENERATION_SETTINGS_SCHEMA",
           "target": "easyuse_anima/aio/generation_defaults.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.generation_defaults:AIO_GENERATION_SETTINGS_SCHEMA",
         "kind": "static_from",
-        "line": 40,
+        "line": 39,
         "name": "AIO_GENERATION_SETTINGS_SCHEMA",
         "optional": false,
         "requested": ".easyuse_anima.aio.generation_defaults",
@@ -21746,7 +22145,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -21754,12 +22153,12 @@
         "compatibility_pair": {
           "bound_name": "AIO_GENERATION_SETTINGS_VERSION",
           "target": "easyuse_anima/aio/generation_defaults.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.generation_defaults:AIO_GENERATION_SETTINGS_VERSION",
         "kind": "static_from",
-        "line": 40,
+        "line": 39,
         "name": "AIO_GENERATION_SETTINGS_VERSION",
         "optional": false,
         "requested": ".easyuse_anima.aio.generation_defaults",
@@ -21777,7 +22176,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -21785,12 +22184,12 @@
         "compatibility_pair": {
           "bound_name": "AIO_RESHIFT_DTYPES",
           "target": "easyuse_anima/aio/generation_defaults.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.generation_defaults:AIO_RESHIFT_DTYPES",
         "kind": "static_from",
-        "line": 40,
+        "line": 39,
         "name": "AIO_RESHIFT_DTYPES",
         "optional": false,
         "requested": ".easyuse_anima.aio.generation_defaults",
@@ -21808,7 +22207,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -21816,12 +22215,12 @@
         "compatibility_pair": {
           "bound_name": "AIO_RESHIFT_SCALES",
           "target": "easyuse_anima/aio/generation_defaults.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.generation_defaults:AIO_RESHIFT_SCALES",
         "kind": "static_from",
-        "line": 40,
+        "line": 39,
         "name": "AIO_RESHIFT_SCALES",
         "optional": false,
         "requested": ".easyuse_anima.aio.generation_defaults",
@@ -21839,7 +22238,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -21847,12 +22246,12 @@
         "compatibility_pair": {
           "bound_name": "AIO_SPECIAL_SEEDS",
           "target": "easyuse_anima/aio/generation_defaults.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.generation_defaults:AIO_SPECIAL_SEEDS",
         "kind": "static_from",
-        "line": 40,
+        "line": 39,
         "name": "AIO_SPECIAL_SEEDS",
         "optional": false,
         "requested": ".easyuse_anima.aio.generation_defaults",
@@ -21870,7 +22269,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -21878,12 +22277,12 @@
         "compatibility_pair": {
           "bound_name": "AIO_SPECIAL_SEED_DECREMENT",
           "target": "easyuse_anima/aio/generation_defaults.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.generation_defaults:AIO_SPECIAL_SEED_DECREMENT",
         "kind": "static_from",
-        "line": 40,
+        "line": 39,
         "name": "AIO_SPECIAL_SEED_DECREMENT",
         "optional": false,
         "requested": ".easyuse_anima.aio.generation_defaults",
@@ -21901,7 +22300,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -21909,12 +22308,12 @@
         "compatibility_pair": {
           "bound_name": "AIO_SPECIAL_SEED_INCREMENT",
           "target": "easyuse_anima/aio/generation_defaults.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.generation_defaults:AIO_SPECIAL_SEED_INCREMENT",
         "kind": "static_from",
-        "line": 40,
+        "line": 39,
         "name": "AIO_SPECIAL_SEED_INCREMENT",
         "optional": false,
         "requested": ".easyuse_anima.aio.generation_defaults",
@@ -21932,7 +22331,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -21940,12 +22339,12 @@
         "compatibility_pair": {
           "bound_name": "AIO_SPECIAL_SEED_RANDOM",
           "target": "easyuse_anima/aio/generation_defaults.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.generation_defaults:AIO_SPECIAL_SEED_RANDOM",
         "kind": "static_from",
-        "line": 40,
+        "line": 39,
         "name": "AIO_SPECIAL_SEED_RANDOM",
         "optional": false,
         "requested": ".easyuse_anima.aio.generation_defaults",
@@ -21963,7 +22362,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -21971,12 +22370,12 @@
         "compatibility_pair": {
           "bound_name": "AIO_USDU_MODE_TYPES",
           "target": "easyuse_anima/aio/generation_defaults.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.generation_defaults:AIO_USDU_MODE_TYPES",
         "kind": "static_from",
-        "line": 40,
+        "line": 39,
         "name": "AIO_USDU_MODE_TYPES",
         "optional": false,
         "requested": ".easyuse_anima.aio.generation_defaults",
@@ -21994,7 +22393,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -22002,12 +22401,12 @@
         "compatibility_pair": {
           "bound_name": "AIO_USDU_PROMPT_FULL",
           "target": "easyuse_anima/aio/generation_defaults.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.generation_defaults:AIO_USDU_PROMPT_FULL",
         "kind": "static_from",
-        "line": 40,
+        "line": 39,
         "name": "AIO_USDU_PROMPT_FULL",
         "optional": false,
         "requested": ".easyuse_anima.aio.generation_defaults",
@@ -22025,7 +22424,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -22033,12 +22432,12 @@
         "compatibility_pair": {
           "bound_name": "AIO_USDU_PROMPT_MODES",
           "target": "easyuse_anima/aio/generation_defaults.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.generation_defaults:AIO_USDU_PROMPT_MODES",
         "kind": "static_from",
-        "line": 40,
+        "line": 39,
         "name": "AIO_USDU_PROMPT_MODES",
         "optional": false,
         "requested": ".easyuse_anima.aio.generation_defaults",
@@ -22056,7 +22455,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -22064,12 +22463,12 @@
         "compatibility_pair": {
           "bound_name": "AIO_USDU_PROMPT_NO_GENERAL",
           "target": "easyuse_anima/aio/generation_defaults.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.generation_defaults:AIO_USDU_PROMPT_NO_GENERAL",
         "kind": "static_from",
-        "line": 40,
+        "line": 39,
         "name": "AIO_USDU_PROMPT_NO_GENERAL",
         "optional": false,
         "requested": ".easyuse_anima.aio.generation_defaults",
@@ -22087,7 +22486,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -22095,12 +22494,12 @@
         "compatibility_pair": {
           "bound_name": "AIO_USDU_SEAM_FIX_MODES",
           "target": "easyuse_anima/aio/generation_defaults.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.generation_defaults:AIO_USDU_SEAM_FIX_MODES",
         "kind": "static_from",
-        "line": 40,
+        "line": 39,
         "name": "AIO_USDU_SEAM_FIX_MODES",
         "optional": false,
         "requested": ".easyuse_anima.aio.generation_defaults",
@@ -22118,7 +22517,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -22126,12 +22525,12 @@
         "compatibility_pair": {
           "bound_name": "_round_trip_aio_generation_settings",
           "target": "easyuse_anima/aio/generation_settings.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.generation_settings:round_trip_aio_generation_settings",
         "kind": "static_from",
-        "line": 58,
+        "line": 57,
         "name": "round_trip_aio_generation_settings",
         "optional": false,
         "requested": ".easyuse_anima.aio.generation_settings",
@@ -22149,7 +22548,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -22157,12 +22556,12 @@
         "compatibility_pair": {
           "bound_name": "AIO_INPUT_DEFAULT_SETTINGS",
           "target": "easyuse_anima/aio/input_defaults.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.input_defaults:AIO_INPUT_DEFAULT_SETTINGS",
         "kind": "static_from",
-        "line": 61,
+        "line": 60,
         "name": "AIO_INPUT_DEFAULT_SETTINGS",
         "optional": false,
         "requested": ".easyuse_anima.aio.input_defaults",
@@ -22180,7 +22579,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -22188,12 +22587,12 @@
         "compatibility_pair": {
           "bound_name": "ANIMA_CLIP_DEVICES",
           "target": "easyuse_anima/aio/input_defaults.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.input_defaults:ANIMA_CLIP_DEVICES",
         "kind": "static_from",
-        "line": 61,
+        "line": 60,
         "name": "ANIMA_CLIP_DEVICES",
         "optional": false,
         "requested": ".easyuse_anima.aio.input_defaults",
@@ -22211,7 +22610,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -22219,12 +22618,12 @@
         "compatibility_pair": {
           "bound_name": "ANIMA_CLIP_TYPES",
           "target": "easyuse_anima/aio/input_defaults.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.input_defaults:ANIMA_CLIP_TYPES",
         "kind": "static_from",
-        "line": 61,
+        "line": 60,
         "name": "ANIMA_CLIP_TYPES",
         "optional": false,
         "requested": ".easyuse_anima.aio.input_defaults",
@@ -22242,7 +22641,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -22250,12 +22649,12 @@
         "compatibility_pair": {
           "bound_name": "ANIMA_DEFAULT_CLIP_CANDIDATES",
           "target": "easyuse_anima/aio/input_defaults.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.input_defaults:ANIMA_DEFAULT_CLIP_CANDIDATES",
         "kind": "static_from",
-        "line": 61,
+        "line": 60,
         "name": "ANIMA_DEFAULT_CLIP_CANDIDATES",
         "optional": false,
         "requested": ".easyuse_anima.aio.input_defaults",
@@ -22273,7 +22672,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -22281,12 +22680,12 @@
         "compatibility_pair": {
           "bound_name": "ANIMA_DEFAULT_DIFFUSION_MODEL_CANDIDATES",
           "target": "easyuse_anima/aio/input_defaults.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.input_defaults:ANIMA_DEFAULT_DIFFUSION_MODEL_CANDIDATES",
         "kind": "static_from",
-        "line": 61,
+        "line": 60,
         "name": "ANIMA_DEFAULT_DIFFUSION_MODEL_CANDIDATES",
         "optional": false,
         "requested": ".easyuse_anima.aio.input_defaults",
@@ -22304,7 +22703,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -22312,12 +22711,12 @@
         "compatibility_pair": {
           "bound_name": "ANIMA_DEFAULT_VAE_CANDIDATES",
           "target": "easyuse_anima/aio/input_defaults.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.input_defaults:ANIMA_DEFAULT_VAE_CANDIDATES",
         "kind": "static_from",
-        "line": 61,
+        "line": 60,
         "name": "ANIMA_DEFAULT_VAE_CANDIDATES",
         "optional": false,
         "requested": ".easyuse_anima.aio.input_defaults",
@@ -22335,7 +22734,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -22343,12 +22742,12 @@
         "compatibility_pair": {
           "bound_name": "ANIMA_UNET_WEIGHT_DTYPES",
           "target": "easyuse_anima/aio/input_defaults.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.input_defaults:ANIMA_UNET_WEIGHT_DTYPES",
         "kind": "static_from",
-        "line": 61,
+        "line": 60,
         "name": "ANIMA_UNET_WEIGHT_DTYPES",
         "optional": false,
         "requested": ".easyuse_anima.aio.input_defaults",
@@ -22366,7 +22765,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -22374,12 +22773,12 @@
         "compatibility_pair": {
           "bound_name": "EASY_USE_ANIMA_INPUT_SCHEMA",
           "target": "easyuse_anima/aio/input_defaults.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.input_defaults:EASY_USE_ANIMA_INPUT_SCHEMA",
         "kind": "static_from",
-        "line": 61,
+        "line": 60,
         "name": "EASY_USE_ANIMA_INPUT_SCHEMA",
         "optional": false,
         "requested": ".easyuse_anima.aio.input_defaults",
@@ -22397,7 +22796,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -22405,12 +22804,12 @@
         "compatibility_pair": {
           "bound_name": "EASY_USE_ANIMA_INPUT_SETTINGS_VERSION",
           "target": "easyuse_anima/aio/input_defaults.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.input_defaults:EASY_USE_ANIMA_INPUT_SETTINGS_VERSION",
         "kind": "static_from",
-        "line": 61,
+        "line": 60,
         "name": "EASY_USE_ANIMA_INPUT_SETTINGS_VERSION",
         "optional": false,
         "requested": ".easyuse_anima.aio.input_defaults",
@@ -22428,7 +22827,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -22436,12 +22835,12 @@
         "compatibility_pair": {
           "bound_name": "_easy_use_anima_input_signature",
           "target": "easyuse_anima/aio/input_context.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.input_context:_easy_use_anima_input_signature",
         "kind": "static_from",
-        "line": 72,
+        "line": 71,
         "name": "_easy_use_anima_input_signature",
         "optional": false,
         "requested": ".easyuse_anima.aio.input_context",
@@ -22459,7 +22858,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -22467,12 +22866,12 @@
         "compatibility_pair": {
           "bound_name": "_require_easy_use_anima_input",
           "target": "easyuse_anima/aio/input_context.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.input_context:_require_easy_use_anima_input",
         "kind": "static_from",
-        "line": 72,
+        "line": 71,
         "name": "_require_easy_use_anima_input",
         "optional": false,
         "requested": ".easyuse_anima.aio.input_context",
@@ -22490,7 +22889,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -22498,12 +22897,12 @@
         "compatibility_pair": {
           "bound_name": "_aio_usdu_auto_tile_dimension",
           "target": "easyuse_anima/aio/usdu.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.usdu:_aio_usdu_auto_tile_dimension",
         "kind": "static_from",
-        "line": 76,
+        "line": 75,
         "name": "_aio_usdu_auto_tile_dimension",
         "optional": false,
         "requested": ".easyuse_anima.aio.usdu",
@@ -22521,7 +22920,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -22529,12 +22928,12 @@
         "compatibility_pair": {
           "bound_name": "_aio_usdu_tile_plan",
           "target": "easyuse_anima/aio/usdu.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.usdu:_aio_usdu_tile_plan",
         "kind": "static_from",
-        "line": 76,
+        "line": 75,
         "name": "_aio_usdu_tile_plan",
         "optional": false,
         "requested": ".easyuse_anima.aio.usdu",
@@ -22552,7 +22951,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -22560,12 +22959,12 @@
         "compatibility_pair": {
           "bound_name": "_aio_final_fit_size",
           "target": "easyuse_anima/aio/postprocess.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.postprocess:_aio_final_fit_size",
         "kind": "static_from",
-        "line": 80,
+        "line": 79,
         "name": "_aio_final_fit_size",
         "optional": false,
         "requested": ".easyuse_anima.aio.postprocess",
@@ -22583,7 +22982,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -22591,12 +22990,12 @@
         "compatibility_pair": {
           "bound_name": "_apply_aio_final_fit",
           "target": "easyuse_anima/aio/postprocess.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.postprocess:_apply_aio_final_fit",
         "kind": "static_from",
-        "line": 80,
+        "line": 79,
         "name": "_apply_aio_final_fit",
         "optional": false,
         "requested": ".easyuse_anima.aio.postprocess",
@@ -22614,7 +23013,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -22622,12 +23021,12 @@
         "compatibility_pair": {
           "bound_name": "_resize_image_to_size_if_needed",
           "target": "easyuse_anima/aio/postprocess.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.postprocess:_resize_image_to_size_if_needed",
         "kind": "static_from",
-        "line": 80,
+        "line": 79,
         "name": "_resize_image_to_size_if_needed",
         "optional": false,
         "requested": ".easyuse_anima.aio.postprocess",
@@ -22645,7 +23044,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -22653,12 +23052,12 @@
         "compatibility_pair": {
           "bound_name": "_run_aio_postprocess_stage",
           "target": "easyuse_anima/aio/postprocess.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.postprocess:_run_aio_postprocess_stage",
         "kind": "static_from",
-        "line": 80,
+        "line": 79,
         "name": "_run_aio_postprocess_stage",
         "optional": false,
         "requested": ".easyuse_anima.aio.postprocess",
@@ -22676,7 +23075,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -22684,12 +23083,12 @@
         "compatibility_pair": {
           "bound_name": "_aio_prompt_data_fields_for_usdu",
           "target": "easyuse_anima/aio/conditioning.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.conditioning:_aio_prompt_data_fields_for_usdu",
         "kind": "static_from",
-        "line": 86,
+        "line": 85,
         "name": "_aio_prompt_data_fields_for_usdu",
         "optional": false,
         "requested": ".easyuse_anima.aio.conditioning",
@@ -22707,7 +23106,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -22715,12 +23114,12 @@
         "compatibility_pair": {
           "bound_name": "_aio_usdu_conditioning",
           "target": "easyuse_anima/aio/conditioning.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.conditioning:_aio_usdu_conditioning",
         "kind": "static_from",
-        "line": 86,
+        "line": 85,
         "name": "_aio_usdu_conditioning",
         "optional": false,
         "requested": ".easyuse_anima.aio.conditioning",
@@ -22738,7 +23137,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -22746,12 +23145,12 @@
         "compatibility_pair": {
           "bound_name": "_aio_usdu_prompt_without_general",
           "target": "easyuse_anima/aio/conditioning.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.conditioning:_aio_usdu_prompt_without_general",
         "kind": "static_from",
-        "line": 86,
+        "line": 85,
         "name": "_aio_usdu_prompt_without_general",
         "optional": false,
         "requested": ".easyuse_anima.aio.conditioning",
@@ -22769,7 +23168,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -22777,12 +23176,12 @@
         "compatibility_pair": {
           "bound_name": "_aio_lora_stack_signature",
           "target": "easyuse_anima/aio/model_preparation.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_aio_lora_stack_signature",
         "kind": "static_from",
-        "line": 91,
+        "line": 90,
         "name": "_aio_lora_stack_signature",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -22800,7 +23199,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -22808,12 +23207,12 @@
         "compatibility_pair": {
           "bound_name": "_apply_aio_anima_dave_patch",
           "target": "easyuse_anima/aio/model_preparation.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_apply_aio_anima_dave_patch",
         "kind": "static_from",
-        "line": 91,
+        "line": 90,
         "name": "_apply_aio_anima_dave_patch",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -22831,7 +23230,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -22839,12 +23238,12 @@
         "compatibility_pair": {
           "bound_name": "_apply_aio_kj_model_patches",
           "target": "easyuse_anima/aio/model_preparation.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_apply_aio_kj_model_patches",
         "kind": "static_from",
-        "line": 91,
+        "line": 90,
         "name": "_apply_aio_kj_model_patches",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -22862,7 +23261,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -22870,12 +23269,12 @@
         "compatibility_pair": {
           "bound_name": "_apply_aio_lora_stack",
           "target": "easyuse_anima/aio/model_preparation.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_apply_aio_lora_stack",
         "kind": "static_from",
-        "line": 91,
+        "line": 90,
         "name": "_apply_aio_lora_stack",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -22893,7 +23292,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -22901,12 +23300,12 @@
         "compatibility_pair": {
           "bound_name": "_apply_aio_model_patches",
           "target": "easyuse_anima/aio/model_preparation.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_apply_aio_model_patches",
         "kind": "static_from",
-        "line": 91,
+        "line": 90,
         "name": "_apply_aio_model_patches",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -22924,7 +23323,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -22932,12 +23331,12 @@
         "compatibility_pair": {
           "bound_name": "_apply_aio_safe_pag_patch",
           "target": "easyuse_anima/aio/model_preparation.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_apply_aio_safe_pag_patch",
         "kind": "static_from",
-        "line": 91,
+        "line": 90,
         "name": "_apply_aio_safe_pag_patch",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -22955,7 +23354,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -22963,12 +23362,12 @@
         "compatibility_pair": {
           "bound_name": "_apply_aio_spectrum_correction_patch_for_comfy_sampler",
           "target": "easyuse_anima/aio/model_preparation.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_apply_aio_spectrum_correction_patch_for_comfy_sampler",
         "kind": "static_from",
-        "line": 91,
+        "line": 90,
         "name": "_apply_aio_spectrum_correction_patch_for_comfy_sampler",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -22986,7 +23385,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -22994,12 +23393,12 @@
         "compatibility_pair": {
           "bound_name": "_apply_aio_spectrum_forecast_patch_for_comfy_sampler",
           "target": "easyuse_anima/aio/model_preparation.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_apply_aio_spectrum_forecast_patch_for_comfy_sampler",
         "kind": "static_from",
-        "line": 91,
+        "line": 90,
         "name": "_apply_aio_spectrum_forecast_patch_for_comfy_sampler",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -23017,7 +23416,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -23025,12 +23424,12 @@
         "compatibility_pair": {
           "bound_name": "_apply_aio_spectrum_model_patches_for_comfy_sampler",
           "target": "easyuse_anima/aio/model_preparation.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_apply_aio_spectrum_model_patches_for_comfy_sampler",
         "kind": "static_from",
-        "line": 91,
+        "line": 90,
         "name": "_apply_aio_spectrum_model_patches_for_comfy_sampler",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -23048,7 +23447,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -23056,12 +23455,12 @@
         "compatibility_pair": {
           "bound_name": "_cleanup_aio_ephemeral_model",
           "target": "easyuse_anima/aio/model_preparation.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_cleanup_aio_ephemeral_model",
         "kind": "static_from",
-        "line": 91,
+        "line": 90,
         "name": "_cleanup_aio_ephemeral_model",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -23079,7 +23478,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -23087,12 +23486,12 @@
         "compatibility_pair": {
           "bound_name": "_normalize_aio_lora_stack",
           "target": "easyuse_anima/aio/model_preparation.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_normalize_aio_lora_stack",
         "kind": "static_from",
-        "line": 91,
+        "line": 90,
         "name": "_normalize_aio_lora_stack",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -23110,7 +23509,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -23118,12 +23517,12 @@
         "compatibility_pair": {
           "bound_name": "_patch_model_sampling_aura_flow",
           "target": "easyuse_anima/aio/model_preparation.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_patch_model_sampling_aura_flow",
         "kind": "static_from",
-        "line": 91,
+        "line": 90,
         "name": "_patch_model_sampling_aura_flow",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -23141,7 +23540,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -23149,12 +23548,12 @@
         "compatibility_pair": {
           "bound_name": "_aio_highres_effective_backend",
           "target": "easyuse_anima/aio/sampling.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_aio_highres_effective_backend",
         "kind": "static_from",
-        "line": 105,
+        "line": 104,
         "name": "_aio_highres_effective_backend",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -23172,7 +23571,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -23180,12 +23579,12 @@
         "compatibility_pair": {
           "bound_name": "_aio_stage_sampler_settings",
           "target": "easyuse_anima/aio/sampling.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_aio_stage_sampler_settings",
         "kind": "static_from",
-        "line": 105,
+        "line": 104,
         "name": "_aio_stage_sampler_settings",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -23203,7 +23602,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -23211,12 +23610,12 @@
         "compatibility_pair": {
           "bound_name": "_decode_latent_with_comfy",
           "target": "easyuse_anima/aio/sampling.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_decode_latent_with_comfy",
         "kind": "static_from",
-        "line": 105,
+        "line": 104,
         "name": "_decode_latent_with_comfy",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -23234,7 +23633,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -23242,12 +23641,12 @@
         "compatibility_pair": {
           "bound_name": "_encode_image_with_comfy_vae",
           "target": "easyuse_anima/aio/sampling.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_encode_image_with_comfy_vae",
         "kind": "static_from",
-        "line": 105,
+        "line": 104,
         "name": "_encode_image_with_comfy_vae",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -23265,7 +23664,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -23273,12 +23672,12 @@
         "compatibility_pair": {
           "bound_name": "_generate_empty_latent_with_comfy",
           "target": "easyuse_anima/aio/sampling.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_generate_empty_latent_with_comfy",
         "kind": "static_from",
-        "line": 105,
+        "line": 104,
         "name": "_generate_empty_latent_with_comfy",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -23296,7 +23695,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -23304,12 +23703,12 @@
         "compatibility_pair": {
           "bound_name": "_new_aio_random_seed",
           "target": "easyuse_anima/aio/sampling.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_new_aio_random_seed",
         "kind": "static_from",
-        "line": 105,
+        "line": 104,
         "name": "_new_aio_random_seed",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -23327,7 +23726,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -23335,12 +23734,12 @@
         "compatibility_pair": {
           "bound_name": "_resolve_aio_runtime_seed",
           "target": "easyuse_anima/aio/sampling.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_resolve_aio_runtime_seed",
         "kind": "static_from",
-        "line": 105,
+        "line": 104,
         "name": "_resolve_aio_runtime_seed",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -23358,7 +23757,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -23366,12 +23765,12 @@
         "compatibility_pair": {
           "bound_name": "_sample_latent_with_aio_backend",
           "target": "easyuse_anima/aio/sampling.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_sample_latent_with_aio_backend",
         "kind": "static_from",
-        "line": 105,
+        "line": 104,
         "name": "_sample_latent_with_aio_backend",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -23389,7 +23788,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -23397,12 +23796,12 @@
         "compatibility_pair": {
           "bound_name": "_sample_latent_with_comfy",
           "target": "easyuse_anima/aio/sampling.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_sample_latent_with_comfy",
         "kind": "static_from",
-        "line": 105,
+        "line": 104,
         "name": "_sample_latent_with_comfy",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -23420,7 +23819,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -23428,12 +23827,12 @@
         "compatibility_pair": {
           "bound_name": "_sample_latent_with_spectrum_mod_guidance_advanced",
           "target": "easyuse_anima/aio/sampling.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_sample_latent_with_spectrum_mod_guidance_advanced",
         "kind": "static_from",
-        "line": 105,
+        "line": 104,
         "name": "_sample_latent_with_spectrum_mod_guidance_advanced",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -23451,7 +23850,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -23459,12 +23858,12 @@
         "compatibility_pair": {
           "bound_name": "_sample_latent_with_spectrum_spd",
           "target": "easyuse_anima/aio/sampling.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_sample_latent_with_spectrum_spd",
         "kind": "static_from",
-        "line": 105,
+        "line": 104,
         "name": "_sample_latent_with_spectrum_spd",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -23482,7 +23881,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -23490,12 +23889,12 @@
         "compatibility_pair": {
           "bound_name": "AIO_PREVIEW_CACHE_FORMAT",
           "target": "easyuse_anima/aio/preview.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.preview:AIO_PREVIEW_CACHE_FORMAT",
         "kind": "static_from",
-        "line": 118,
+        "line": 117,
         "name": "AIO_PREVIEW_CACHE_FORMAT",
         "optional": false,
         "requested": ".easyuse_anima.aio.preview",
@@ -23513,7 +23912,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -23521,12 +23920,12 @@
         "compatibility_pair": {
           "bound_name": "AIO_PREVIEW_CACHE_QUALITY",
           "target": "easyuse_anima/aio/preview.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.preview:AIO_PREVIEW_CACHE_QUALITY",
         "kind": "static_from",
-        "line": 118,
+        "line": 117,
         "name": "AIO_PREVIEW_CACHE_QUALITY",
         "optional": false,
         "requested": ".easyuse_anima.aio.preview",
@@ -23544,7 +23943,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -23552,12 +23951,12 @@
         "compatibility_pair": {
           "bound_name": "AIO_PREVIEW_EVENT",
           "target": "easyuse_anima/aio/preview.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.preview:AIO_PREVIEW_EVENT",
         "kind": "static_from",
-        "line": 118,
+        "line": 117,
         "name": "AIO_PREVIEW_EVENT",
         "optional": false,
         "requested": ".easyuse_anima.aio.preview",
@@ -23575,7 +23974,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -23583,12 +23982,12 @@
         "compatibility_pair": {
           "bound_name": "AIO_PREVIEW_STAGE_LABELS",
           "target": "easyuse_anima/aio/preview.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.preview:AIO_PREVIEW_STAGE_LABELS",
         "kind": "static_from",
-        "line": 118,
+        "line": 117,
         "name": "AIO_PREVIEW_STAGE_LABELS",
         "optional": false,
         "requested": ".easyuse_anima.aio.preview",
@@ -23606,7 +24005,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -23614,12 +24013,12 @@
         "compatibility_pair": {
           "bound_name": "_aio_preview_base_directory",
           "target": "easyuse_anima/aio/preview.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.preview:_aio_preview_base_directory",
         "kind": "static_from",
-        "line": 118,
+        "line": 117,
         "name": "_aio_preview_base_directory",
         "optional": false,
         "requested": ".easyuse_anima.aio.preview",
@@ -23637,7 +24036,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -23645,12 +24044,12 @@
         "compatibility_pair": {
           "bound_name": "_aio_preview_file_size_bytes",
           "target": "easyuse_anima/aio/preview.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.preview:_aio_preview_file_size_bytes",
         "kind": "static_from",
-        "line": 118,
+        "line": 117,
         "name": "_aio_preview_file_size_bytes",
         "optional": false,
         "requested": ".easyuse_anima.aio.preview",
@@ -23668,7 +24067,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -23676,12 +24075,12 @@
         "compatibility_pair": {
           "bound_name": "_save_aio_temp_preview_image",
           "target": "easyuse_anima/aio/preview.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.preview:_save_aio_temp_preview_image",
         "kind": "static_from",
-        "line": 118,
+        "line": 117,
         "name": "_save_aio_temp_preview_image",
         "optional": false,
         "requested": ".easyuse_anima.aio.preview",
@@ -23699,7 +24098,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -23707,12 +24106,12 @@
         "compatibility_pair": {
           "bound_name": "_send_aio_preview_event",
           "target": "easyuse_anima/aio/preview.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.preview:_send_aio_preview_event",
         "kind": "static_from",
-        "line": 118,
+        "line": 117,
         "name": "_send_aio_preview_event",
         "optional": false,
         "requested": ".easyuse_anima.aio.preview",
@@ -23730,7 +24129,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -23738,12 +24137,12 @@
         "compatibility_pair": {
           "bound_name": "_tag_aio_preview_images",
           "target": "easyuse_anima/aio/preview.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.preview:_tag_aio_preview_images",
         "kind": "static_from",
-        "line": 118,
+        "line": 117,
         "name": "_tag_aio_preview_images",
         "optional": false,
         "requested": ".easyuse_anima.aio.preview",
@@ -23761,7 +24160,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -23769,12 +24168,12 @@
         "compatibility_pair": {
           "bound_name": "_aio_image_saver_additional_hashes",
           "target": "easyuse_anima/aio/output.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.output:_aio_image_saver_additional_hashes",
         "kind": "static_from",
-        "line": 129,
+        "line": 128,
         "name": "_aio_image_saver_additional_hashes",
         "optional": false,
         "requested": ".easyuse_anima.aio.output",
@@ -23792,7 +24191,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -23800,12 +24199,12 @@
         "compatibility_pair": {
           "bound_name": "_aio_image_saver_civitai_hash_fetcher_entries",
           "target": "easyuse_anima/aio/output.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.output:_aio_image_saver_civitai_hash_fetcher_entries",
         "kind": "static_from",
-        "line": 129,
+        "line": 128,
         "name": "_aio_image_saver_civitai_hash_fetcher_entries",
         "optional": false,
         "requested": ".easyuse_anima.aio.output",
@@ -23823,7 +24222,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -23831,12 +24230,12 @@
         "compatibility_pair": {
           "bound_name": "_aio_lora_metadata_name",
           "target": "easyuse_anima/aio/output.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.output:_aio_lora_metadata_name",
         "kind": "static_from",
-        "line": 129,
+        "line": 128,
         "name": "_aio_lora_metadata_name",
         "optional": false,
         "requested": ".easyuse_anima.aio.output",
@@ -23854,7 +24253,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -23862,12 +24261,12 @@
         "compatibility_pair": {
           "bound_name": "_aio_prompt_with_lora_metadata",
           "target": "easyuse_anima/aio/output.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.output:_aio_prompt_with_lora_metadata",
         "kind": "static_from",
-        "line": 129,
+        "line": 128,
         "name": "_aio_prompt_with_lora_metadata",
         "optional": false,
         "requested": ".easyuse_anima.aio.output",
@@ -23885,7 +24284,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -23893,12 +24292,12 @@
         "compatibility_pair": {
           "bound_name": "_aio_save_filename_prefix",
           "target": "easyuse_anima/aio/output.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.output:_aio_save_filename_prefix",
         "kind": "static_from",
-        "line": 129,
+        "line": 128,
         "name": "_aio_save_filename_prefix",
         "optional": false,
         "requested": ".easyuse_anima.aio.output",
@@ -23916,7 +24315,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -23924,12 +24323,12 @@
         "compatibility_pair": {
           "bound_name": "_save_image_with_comfy",
           "target": "easyuse_anima/aio/output.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.output:_save_image_with_comfy",
         "kind": "static_from",
-        "line": 129,
+        "line": 128,
         "name": "_save_image_with_comfy",
         "optional": false,
         "requested": ".easyuse_anima.aio.output",
@@ -23947,7 +24346,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -23955,12 +24354,12 @@
         "compatibility_pair": {
           "bound_name": "_save_image_with_image_saver",
           "target": "easyuse_anima/aio/output.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.output:_save_image_with_image_saver",
         "kind": "static_from",
-        "line": 129,
+        "line": 128,
         "name": "_save_image_with_image_saver",
         "optional": false,
         "requested": ".easyuse_anima.aio.output",
@@ -23978,7 +24377,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -23986,12 +24385,12 @@
         "compatibility_pair": {
           "bound_name": "_normalize_aio_civitai_hash_fetchers",
           "target": "easyuse_anima/aio/output_settings.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.output_settings:_normalize_aio_civitai_hash_fetchers",
         "kind": "static_from",
-        "line": 138,
+        "line": 137,
         "name": "_normalize_aio_civitai_hash_fetchers",
         "optional": false,
         "requested": ".easyuse_anima.aio.output_settings",
@@ -24009,7 +24408,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -24017,12 +24416,12 @@
         "compatibility_pair": {
           "bound_name": "_normalize_aio_hash_bundles",
           "target": "easyuse_anima/aio/output_settings.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.output_settings:_normalize_aio_hash_bundles",
         "kind": "static_from",
-        "line": 138,
+        "line": 137,
         "name": "_normalize_aio_hash_bundles",
         "optional": false,
         "requested": ".easyuse_anima.aio.output_settings",
@@ -24040,7 +24439,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -24048,12 +24447,12 @@
         "compatibility_pair": {
           "bound_name": "_comfy_clip_loader_types",
           "target": "easyuse_anima/aio/resources.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_comfy_clip_loader_types",
         "kind": "static_from",
-        "line": 142,
+        "line": 141,
         "name": "_comfy_clip_loader_types",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -24071,7 +24470,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -24079,12 +24478,12 @@
         "compatibility_pair": {
           "bound_name": "_comfy_diffusion_model_names",
           "target": "easyuse_anima/aio/resources.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_comfy_diffusion_model_names",
         "kind": "static_from",
-        "line": 142,
+        "line": 141,
         "name": "_comfy_diffusion_model_names",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -24102,7 +24501,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -24110,12 +24509,12 @@
         "compatibility_pair": {
           "bound_name": "_comfy_text_encoder_names",
           "target": "easyuse_anima/aio/resources.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_comfy_text_encoder_names",
         "kind": "static_from",
-        "line": 142,
+        "line": 141,
         "name": "_comfy_text_encoder_names",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -24133,7 +24532,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -24141,12 +24540,12 @@
         "compatibility_pair": {
           "bound_name": "_comfy_vae_names",
           "target": "easyuse_anima/aio/resources.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_comfy_vae_names",
         "kind": "static_from",
-        "line": 142,
+        "line": 141,
         "name": "_comfy_vae_names",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -24164,7 +24563,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -24172,12 +24571,12 @@
         "compatibility_pair": {
           "bound_name": "_load_aio_resources_from_input_context",
           "target": "easyuse_anima/aio/resources.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_load_aio_resources_from_input_context",
         "kind": "static_from",
-        "line": 142,
+        "line": 141,
         "name": "_load_aio_resources_from_input_context",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -24195,7 +24594,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -24203,12 +24602,12 @@
         "compatibility_pair": {
           "bound_name": "_load_aio_sam3_context",
           "target": "easyuse_anima/aio/resources.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_load_aio_sam3_context",
         "kind": "static_from",
-        "line": 142,
+        "line": 141,
         "name": "_load_aio_sam3_context",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -24226,7 +24625,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -24234,12 +24633,12 @@
         "compatibility_pair": {
           "bound_name": "_load_checkpoint_with_comfy",
           "target": "easyuse_anima/aio/resources.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_load_checkpoint_with_comfy",
         "kind": "static_from",
-        "line": 142,
+        "line": 141,
         "name": "_load_checkpoint_with_comfy",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -24257,7 +24656,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -24265,12 +24664,12 @@
         "compatibility_pair": {
           "bound_name": "_load_clip_with_comfy",
           "target": "easyuse_anima/aio/resources.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_load_clip_with_comfy",
         "kind": "static_from",
-        "line": 142,
+        "line": 141,
         "name": "_load_clip_with_comfy",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -24288,7 +24687,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -24296,12 +24695,12 @@
         "compatibility_pair": {
           "bound_name": "_load_diffusion_model_with_comfy",
           "target": "easyuse_anima/aio/resources.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_load_diffusion_model_with_comfy",
         "kind": "static_from",
-        "line": 142,
+        "line": 141,
         "name": "_load_diffusion_model_with_comfy",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -24319,7 +24718,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -24327,12 +24726,12 @@
         "compatibility_pair": {
           "bound_name": "_load_upscale_model_with_comfy",
           "target": "easyuse_anima/aio/resources.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_load_upscale_model_with_comfy",
         "kind": "static_from",
-        "line": 142,
+        "line": 141,
         "name": "_load_upscale_model_with_comfy",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -24350,7 +24749,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -24358,12 +24757,12 @@
         "compatibility_pair": {
           "bound_name": "_load_vae_with_comfy",
           "target": "easyuse_anima/aio/resources.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_load_vae_with_comfy",
         "kind": "static_from",
-        "line": 142,
+        "line": 141,
         "name": "_load_vae_with_comfy",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -24381,7 +24780,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -24389,12 +24788,12 @@
         "compatibility_pair": {
           "bound_name": "_normalize_aio_input_settings",
           "target": "easyuse_anima/aio/resources.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_normalize_aio_input_settings",
         "kind": "static_from",
-        "line": 142,
+        "line": 141,
         "name": "_normalize_aio_input_settings",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -24412,7 +24811,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -24420,12 +24819,12 @@
         "compatibility_pair": {
           "bound_name": "_preferred_checkpoint_default",
           "target": "easyuse_anima/aio/resources.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_preferred_checkpoint_default",
         "kind": "static_from",
-        "line": 142,
+        "line": 141,
         "name": "_preferred_checkpoint_default",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -24443,7 +24842,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -24451,12 +24850,12 @@
         "compatibility_pair": {
           "bound_name": "_preferred_clip_type_default",
           "target": "easyuse_anima/aio/resources.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_preferred_clip_type_default",
         "kind": "static_from",
-        "line": 142,
+        "line": 141,
         "name": "_preferred_clip_type_default",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -24474,7 +24873,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -24482,12 +24881,12 @@
         "compatibility_pair": {
           "bound_name": "_preferred_name_default",
           "target": "easyuse_anima/aio/resources.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_preferred_name_default",
         "kind": "static_from",
-        "line": 142,
+        "line": 141,
         "name": "_preferred_name_default",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -24505,7 +24904,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -24513,12 +24912,12 @@
         "compatibility_pair": {
           "bound_name": "_json_clone",
           "target": "easyuse_anima/common/serialization.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.common.serialization:_json_clone",
         "kind": "static_from",
-        "line": 159,
+        "line": 158,
         "name": "_json_clone",
         "optional": false,
         "requested": ".easyuse_anima.common.serialization",
@@ -24536,7 +24935,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -24544,12 +24943,12 @@
         "compatibility_pair": {
           "bound_name": "_json_object",
           "target": "easyuse_anima/common/serialization.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.common.serialization:_json_object",
         "kind": "static_from",
-        "line": 159,
+        "line": 158,
         "name": "_json_object",
         "optional": false,
         "requested": ".easyuse_anima.common.serialization",
@@ -24567,7 +24966,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -24575,12 +24974,12 @@
         "compatibility_pair": {
           "bound_name": "_stable_change_key",
           "target": "easyuse_anima/common/serialization.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.common.serialization:_stable_change_key",
         "kind": "static_from",
-        "line": 159,
+        "line": 158,
         "name": "_stable_change_key",
         "optional": false,
         "requested": ".easyuse_anima.common.serialization",
@@ -24598,7 +24997,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -24606,12 +25005,12 @@
         "compatibility_pair": {
           "bound_name": "_as_bool",
           "target": "easyuse_anima/common/values.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.common.values:_as_bool",
         "kind": "static_from",
-        "line": 164,
+        "line": 163,
         "name": "_as_bool",
         "optional": false,
         "requested": ".easyuse_anima.common.values",
@@ -24629,7 +25028,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -24637,12 +25036,12 @@
         "compatibility_pair": {
           "bound_name": "_as_float",
           "target": "easyuse_anima/common/values.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.common.values:_as_float",
         "kind": "static_from",
-        "line": 164,
+        "line": 163,
         "name": "_as_float",
         "optional": false,
         "requested": ".easyuse_anima.common.values",
@@ -24660,7 +25059,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -24668,12 +25067,12 @@
         "compatibility_pair": {
           "bound_name": "_as_int",
           "target": "easyuse_anima/common/values.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.common.values:_as_int",
         "kind": "static_from",
-        "line": 164,
+        "line": 163,
         "name": "_as_int",
         "optional": false,
         "requested": ".easyuse_anima.common.values",
@@ -24691,7 +25090,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -24699,12 +25098,12 @@
         "compatibility_pair": {
           "bound_name": "_choice",
           "target": "easyuse_anima/common/values.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.common.values:_choice",
         "kind": "static_from",
-        "line": 164,
+        "line": 163,
         "name": "_choice",
         "optional": false,
         "requested": ".easyuse_anima.common.values",
@@ -24722,7 +25121,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -24730,12 +25129,12 @@
         "compatibility_pair": {
           "bound_name": "_single_value",
           "target": "easyuse_anima/common/values.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.common.values:_single_value",
         "kind": "static_from",
-        "line": 164,
+        "line": 163,
         "name": "_single_value",
         "optional": false,
         "requested": ".easyuse_anima.common.values",
@@ -24753,7 +25152,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -24761,12 +25160,12 @@
         "compatibility_pair": {
           "bound_name": "WILDCARD_QUEUE_MAX_SAFE_SEED",
           "target": "easyuse_anima/seed/compatibility.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.seed.compatibility:WILDCARD_QUEUE_MAX_SAFE_SEED",
         "kind": "static_from",
-        "line": 171,
+        "line": 170,
         "name": "WILDCARD_QUEUE_MAX_SAFE_SEED",
         "optional": false,
         "requested": ".easyuse_anima.seed.compatibility",
@@ -24784,7 +25183,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -24792,12 +25191,12 @@
         "compatibility_pair": {
           "bound_name": "WILDCARD_RESERVED_NEXT_SEED_INPUT",
           "target": "easyuse_anima/seed/compatibility.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.seed.compatibility:WILDCARD_RESERVED_NEXT_SEED_INPUT",
         "kind": "static_from",
-        "line": 171,
+        "line": 170,
         "name": "WILDCARD_RESERVED_NEXT_SEED_INPUT",
         "optional": false,
         "requested": ".easyuse_anima.seed.compatibility",
@@ -24815,7 +25214,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -24823,12 +25222,12 @@
         "compatibility_pair": {
           "bound_name": "_consume_reserved_wildcard_next_seed",
           "target": "easyuse_anima/seed/compatibility.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.seed.compatibility:_consume_reserved_wildcard_next_seed",
         "kind": "static_from",
-        "line": 171,
+        "line": 170,
         "name": "_consume_reserved_wildcard_next_seed",
         "optional": false,
         "requested": ".easyuse_anima.seed.compatibility",
@@ -24846,7 +25245,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -24854,12 +25253,12 @@
         "compatibility_pair": {
           "bound_name": "_get_workflow_node",
           "target": "easyuse_anima/workflow.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.workflow:_get_workflow_node",
         "kind": "static_from",
-        "line": 176,
+        "line": 175,
         "name": "_get_workflow_node",
         "optional": false,
         "requested": ".easyuse_anima.workflow",
@@ -24877,7 +25276,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -24885,12 +25284,12 @@
         "compatibility_pair": {
           "bound_name": "_prompt_translation_change_key",
           "target": "easyuse_anima/prompt/correction.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.correction:_prompt_translation_change_key",
         "kind": "static_from",
-        "line": 177,
+        "line": 176,
         "name": "_prompt_translation_change_key",
         "optional": false,
         "requested": ".easyuse_anima.prompt.correction",
@@ -24908,7 +25307,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -24916,12 +25315,12 @@
         "compatibility_pair": {
           "bound_name": "_split_tag_text",
           "target": "easyuse_anima/prompt/correction.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.correction:_split_tag_text",
         "kind": "static_from",
-        "line": 177,
+        "line": 176,
         "name": "_split_tag_text",
         "optional": false,
         "requested": ".easyuse_anima.prompt.correction",
@@ -24939,7 +25338,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -24947,12 +25346,12 @@
         "compatibility_pair": {
           "bound_name": "_translate_prompt_text",
           "target": "easyuse_anima/prompt/correction.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.correction:_translate_prompt_text",
         "kind": "static_from",
-        "line": 177,
+        "line": 176,
         "name": "_translate_prompt_text",
         "optional": false,
         "requested": ".easyuse_anima.prompt.correction",
@@ -24970,7 +25369,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -24978,12 +25377,12 @@
         "compatibility_pair": {
           "bound_name": "_HASH_COMMENT_RE",
           "target": "easyuse_anima/prompt/fields.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_HASH_COMMENT_RE",
         "kind": "static_from",
-        "line": 182,
+        "line": 181,
         "name": "_HASH_COMMENT_RE",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -25001,7 +25400,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -25009,12 +25408,12 @@
         "compatibility_pair": {
           "bound_name": "_INLINE_SPACE_RE",
           "target": "easyuse_anima/prompt/fields.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_INLINE_SPACE_RE",
         "kind": "static_from",
-        "line": 182,
+        "line": 181,
         "name": "_INLINE_SPACE_RE",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -25032,7 +25431,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -25040,12 +25439,12 @@
         "compatibility_pair": {
           "bound_name": "_WEIGHTED_TOKEN_RE",
           "target": "easyuse_anima/prompt/fields.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_WEIGHTED_TOKEN_RE",
         "kind": "static_from",
-        "line": 182,
+        "line": 181,
         "name": "_WEIGHTED_TOKEN_RE",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -25063,7 +25462,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -25071,12 +25470,12 @@
         "compatibility_pair": {
           "bound_name": "_correct_builder_prompt",
           "target": "easyuse_anima/prompt/fields.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_correct_builder_prompt",
         "kind": "static_from",
-        "line": 182,
+        "line": 181,
         "name": "_correct_builder_prompt",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -25094,7 +25493,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -25102,12 +25501,12 @@
         "compatibility_pair": {
           "bound_name": "_filter_metadata_prompt",
           "target": "easyuse_anima/prompt/fields.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_filter_metadata_prompt",
         "kind": "static_from",
-        "line": 182,
+        "line": 181,
         "name": "_filter_metadata_prompt",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -25125,7 +25524,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -25133,12 +25532,12 @@
         "compatibility_pair": {
           "bound_name": "_join_prompt_tokens",
           "target": "easyuse_anima/prompt/fields.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_join_prompt_tokens",
         "kind": "static_from",
-        "line": 182,
+        "line": 181,
         "name": "_join_prompt_tokens",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -25156,7 +25555,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -25164,12 +25563,12 @@
         "compatibility_pair": {
           "bound_name": "_metadata_filter_key",
           "target": "easyuse_anima/prompt/fields.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_metadata_filter_key",
         "kind": "static_from",
-        "line": 182,
+        "line": 181,
         "name": "_metadata_filter_key",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -25187,7 +25586,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -25195,12 +25594,12 @@
         "compatibility_pair": {
           "bound_name": "_metadata_filter_keys",
           "target": "easyuse_anima/prompt/fields.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_metadata_filter_keys",
         "kind": "static_from",
-        "line": 182,
+        "line": 181,
         "name": "_metadata_filter_keys",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -25218,7 +25617,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -25226,12 +25625,12 @@
         "compatibility_pair": {
           "bound_name": "_prompt_tokens",
           "target": "easyuse_anima/prompt/fields.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_prompt_tokens",
         "kind": "static_from",
-        "line": 182,
+        "line": 181,
         "name": "_prompt_tokens",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -25249,7 +25648,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -25257,12 +25656,12 @@
         "compatibility_pair": {
           "bound_name": "PROMPT_DATA_TYPE",
           "target": "easyuse_anima/prompt/data.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:PROMPT_DATA_TYPE",
         "kind": "static_from",
-        "line": 195,
+        "line": 194,
         "name": "PROMPT_DATA_TYPE",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -25280,7 +25679,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -25288,12 +25687,12 @@
         "compatibility_pair": {
           "bound_name": "_advanced_outputs_from_prompt_data",
           "target": "easyuse_anima/prompt/data.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:_advanced_outputs_from_prompt_data",
         "kind": "static_from",
-        "line": 195,
+        "line": 194,
         "name": "_advanced_outputs_from_prompt_data",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -25311,7 +25710,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -25319,12 +25718,12 @@
         "compatibility_pair": {
           "bound_name": "_apply_prompt_data_overrides",
           "target": "easyuse_anima/prompt/data.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:_apply_prompt_data_overrides",
         "kind": "static_from",
-        "line": 195,
+        "line": 194,
         "name": "_apply_prompt_data_overrides",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -25342,7 +25741,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -25350,12 +25749,12 @@
         "compatibility_pair": {
           "bound_name": "_copy_prompt_data_for_update",
           "target": "easyuse_anima/prompt/data.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:_copy_prompt_data_for_update",
         "kind": "static_from",
-        "line": 195,
+        "line": 194,
         "name": "_copy_prompt_data_for_update",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -25373,7 +25772,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -25381,12 +25780,12 @@
         "compatibility_pair": {
           "bound_name": "_normalize_prompt_data",
           "target": "easyuse_anima/prompt/data.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:_normalize_prompt_data",
         "kind": "static_from",
-        "line": 195,
+        "line": 194,
         "name": "_normalize_prompt_data",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -25404,7 +25803,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -25412,12 +25811,12 @@
         "compatibility_pair": {
           "bound_name": "_prompt_data_json_safe",
           "target": "easyuse_anima/prompt/data.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:_prompt_data_json_safe",
         "kind": "static_from",
-        "line": 195,
+        "line": 194,
         "name": "_prompt_data_json_safe",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -25435,7 +25834,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -25443,12 +25842,12 @@
         "compatibility_pair": {
           "bound_name": "_prompt_data_parameter_snapshot",
           "target": "easyuse_anima/prompt/data.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:_prompt_data_parameter_snapshot",
         "kind": "static_from",
-        "line": 195,
+        "line": 194,
         "name": "_prompt_data_parameter_snapshot",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -25466,7 +25865,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -25474,12 +25873,12 @@
         "compatibility_pair": {
           "bound_name": "_advanced_artist_field_prompt",
           "target": "easyuse_anima/prompt/advanced.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_artist_field_prompt",
         "kind": "static_from",
-        "line": 213,
+        "line": 212,
         "name": "_advanced_artist_field_prompt",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -25497,7 +25896,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -25505,12 +25904,12 @@
         "compatibility_pair": {
           "bound_name": "_advanced_default_fields",
           "target": "easyuse_anima/prompt/advanced.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_default_fields",
         "kind": "static_from",
-        "line": 213,
+        "line": 212,
         "name": "_advanced_default_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -25528,7 +25927,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -25536,12 +25935,12 @@
         "compatibility_pair": {
           "bound_name": "_advanced_enabled_naia_panes",
           "target": "easyuse_anima/prompt/advanced.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_enabled_naia_panes",
         "kind": "static_from",
-        "line": 213,
+        "line": 212,
         "name": "_advanced_enabled_naia_panes",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -25559,7 +25958,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -25567,12 +25966,12 @@
         "compatibility_pair": {
           "bound_name": "_advanced_enabled_pane_fields",
           "target": "easyuse_anima/prompt/advanced.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_enabled_pane_fields",
         "kind": "static_from",
-        "line": 213,
+        "line": 212,
         "name": "_advanced_enabled_pane_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -25590,7 +25989,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -25598,12 +25997,12 @@
         "compatibility_pair": {
           "bound_name": "_advanced_field_input_values",
           "target": "easyuse_anima/prompt/advanced.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_field_input_values",
         "kind": "static_from",
-        "line": 213,
+        "line": 212,
         "name": "_advanced_field_input_values",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -25621,7 +26020,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -25629,12 +26028,12 @@
         "compatibility_pair": {
           "bound_name": "_advanced_field_socket_name",
           "target": "easyuse_anima/prompt/advanced.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_field_socket_name",
         "kind": "static_from",
-        "line": 213,
+        "line": 212,
         "name": "_advanced_field_socket_name",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -25652,7 +26051,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -25660,12 +26059,12 @@
         "compatibility_pair": {
           "bound_name": "_advanced_fields_json",
           "target": "easyuse_anima/prompt/advanced.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_fields_json",
         "kind": "static_from",
-        "line": 213,
+        "line": 212,
         "name": "_advanced_fields_json",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -25683,7 +26082,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -25691,12 +26090,12 @@
         "compatibility_pair": {
           "bound_name": "_advanced_has_enabled_naia",
           "target": "easyuse_anima/prompt/advanced.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_has_enabled_naia",
         "kind": "static_from",
-        "line": 213,
+        "line": 212,
         "name": "_advanced_has_enabled_naia",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -25714,7 +26113,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -25722,12 +26121,12 @@
         "compatibility_pair": {
           "bound_name": "_advanced_prompt_with_artist_override",
           "target": "easyuse_anima/prompt/advanced.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_prompt_with_artist_override",
         "kind": "static_from",
-        "line": 213,
+        "line": 212,
         "name": "_advanced_prompt_with_artist_override",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -25745,7 +26144,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -25753,12 +26152,12 @@
         "compatibility_pair": {
           "bound_name": "_advanced_uses_naia_resolution",
           "target": "easyuse_anima/prompt/advanced.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_uses_naia_resolution",
         "kind": "static_from",
-        "line": 213,
+        "line": 212,
         "name": "_advanced_uses_naia_resolution",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -25776,7 +26175,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -25784,12 +26183,12 @@
         "compatibility_pair": {
           "bound_name": "_apply_advanced_field_inputs",
           "target": "easyuse_anima/prompt/advanced.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_apply_advanced_field_inputs",
         "kind": "static_from",
-        "line": 213,
+        "line": 212,
         "name": "_apply_advanced_field_inputs",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -25807,7 +26206,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -25815,12 +26214,12 @@
         "compatibility_pair": {
           "bound_name": "_as_advanced_height",
           "target": "easyuse_anima/prompt/advanced.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_as_advanced_height",
         "kind": "static_from",
-        "line": 213,
+        "line": 212,
         "name": "_as_advanced_height",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -25838,7 +26237,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -25846,12 +26245,12 @@
         "compatibility_pair": {
           "bound_name": "_build_advanced_prompt_data",
           "target": "easyuse_anima/prompt/advanced.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_build_advanced_prompt_data",
         "kind": "static_from",
-        "line": 213,
+        "line": 212,
         "name": "_build_advanced_prompt_data",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -25869,7 +26268,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -25877,12 +26276,12 @@
         "compatibility_pair": {
           "bound_name": "_build_advanced_prompts",
           "target": "easyuse_anima/prompt/advanced.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_build_advanced_prompts",
         "kind": "static_from",
-        "line": 213,
+        "line": 212,
         "name": "_build_advanced_prompts",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -25900,7 +26299,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -25908,12 +26307,12 @@
         "compatibility_pair": {
           "bound_name": "_clone_advanced_fields",
           "target": "easyuse_anima/prompt/advanced.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_clone_advanced_fields",
         "kind": "static_from",
-        "line": 213,
+        "line": 212,
         "name": "_clone_advanced_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -25931,7 +26330,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -25939,12 +26338,12 @@
         "compatibility_pair": {
           "bound_name": "_correct_advanced_field_sequence",
           "target": "easyuse_anima/prompt/advanced.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_correct_advanced_field_sequence",
         "kind": "static_from",
-        "line": 213,
+        "line": 212,
         "name": "_correct_advanced_field_sequence",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -25962,7 +26361,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -25970,12 +26369,12 @@
         "compatibility_pair": {
           "bound_name": "_expand_advanced_wildcard_fields",
           "target": "easyuse_anima/prompt/advanced.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_expand_advanced_wildcard_fields",
         "kind": "static_from",
-        "line": 213,
+        "line": 212,
         "name": "_expand_advanced_wildcard_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -25993,7 +26392,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -26001,12 +26400,12 @@
         "compatibility_pair": {
           "bound_name": "_normalize_advanced_fields",
           "target": "easyuse_anima/prompt/advanced.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_normalize_advanced_fields",
         "kind": "static_from",
-        "line": 213,
+        "line": 212,
         "name": "_normalize_advanced_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -26024,7 +26423,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -26032,12 +26431,12 @@
         "compatibility_pair": {
           "bound_name": "_normalize_prompt_studio_wildcard_seed_control",
           "target": "easyuse_anima/prompt/advanced.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_normalize_prompt_studio_wildcard_seed_control",
         "kind": "static_from",
-        "line": 213,
+        "line": 212,
         "name": "_normalize_prompt_studio_wildcard_seed_control",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -26055,7 +26454,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -26063,12 +26462,12 @@
         "compatibility_pair": {
           "bound_name": "_set_naia_field_text",
           "target": "easyuse_anima/prompt/advanced.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_set_naia_field_text",
         "kind": "static_from",
-        "line": 213,
+        "line": 212,
         "name": "_set_naia_field_text",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -26086,7 +26485,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -26094,12 +26493,12 @@
         "compatibility_pair": {
           "bound_name": "_translate_prompt_fields",
           "target": "easyuse_anima/prompt/advanced.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_translate_prompt_fields",
         "kind": "static_from",
-        "line": 213,
+        "line": 212,
         "name": "_translate_prompt_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -26117,7 +26516,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -26125,12 +26524,12 @@
         "compatibility_pair": {
           "bound_name": "_apply_regional_field_inputs",
           "target": "easyuse_anima/prompt/regional.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_apply_regional_field_inputs",
         "kind": "static_from",
-        "line": 248,
+        "line": 247,
         "name": "_apply_regional_field_inputs",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -26148,7 +26547,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -26156,12 +26555,12 @@
         "compatibility_pair": {
           "bound_name": "_build_regional_outputs",
           "target": "easyuse_anima/prompt/regional.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_build_regional_outputs",
         "kind": "static_from",
-        "line": 248,
+        "line": 247,
         "name": "_build_regional_outputs",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -26179,7 +26578,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -26187,12 +26586,12 @@
         "compatibility_pair": {
           "bound_name": "_clone_regional_fields",
           "target": "easyuse_anima/prompt/regional.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_clone_regional_fields",
         "kind": "static_from",
-        "line": 248,
+        "line": 247,
         "name": "_clone_regional_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -26210,7 +26609,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -26218,12 +26617,12 @@
         "compatibility_pair": {
           "bound_name": "_conditioning_set_values",
           "target": "easyuse_anima/prompt/regional.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_conditioning_set_values",
         "kind": "static_from",
-        "line": 248,
+        "line": 247,
         "name": "_conditioning_set_values",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -26241,7 +26640,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -26249,12 +26648,12 @@
         "compatibility_pair": {
           "bound_name": "_normalize_mask_ids",
           "target": "easyuse_anima/prompt/regional.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_normalize_mask_ids",
         "kind": "static_from",
-        "line": 248,
+        "line": 247,
         "name": "_normalize_mask_ids",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -26272,7 +26671,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -26280,12 +26679,12 @@
         "compatibility_pair": {
           "bound_name": "_normalize_regional_config",
           "target": "easyuse_anima/prompt/regional.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_normalize_regional_config",
         "kind": "static_from",
-        "line": 248,
+        "line": 247,
         "name": "_normalize_regional_config",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -26303,7 +26702,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -26311,12 +26710,12 @@
         "compatibility_pair": {
           "bound_name": "_normalize_regional_fields",
           "target": "easyuse_anima/prompt/regional.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_normalize_regional_fields",
         "kind": "static_from",
-        "line": 248,
+        "line": 247,
         "name": "_normalize_regional_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -26334,7 +26733,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -26342,12 +26741,12 @@
         "compatibility_pair": {
           "bound_name": "_parse_json_object",
           "target": "easyuse_anima/prompt/regional.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_parse_json_object",
         "kind": "static_from",
-        "line": 248,
+        "line": 247,
         "name": "_parse_json_object",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -26365,7 +26764,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -26373,12 +26772,12 @@
         "compatibility_pair": {
           "bound_name": "_regional_config_json",
           "target": "easyuse_anima/prompt/regional.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_regional_config_json",
         "kind": "static_from",
-        "line": 248,
+        "line": 247,
         "name": "_regional_config_json",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -26396,7 +26795,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -26404,12 +26803,12 @@
         "compatibility_pair": {
           "bound_name": "_regional_fields_json",
           "target": "easyuse_anima/prompt/regional.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_regional_fields_json",
         "kind": "static_from",
-        "line": 248,
+        "line": 247,
         "name": "_regional_fields_json",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -26427,7 +26826,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -26435,12 +26834,12 @@
         "compatibility_pair": {
           "bound_name": "_regional_mask_bounds_area",
           "target": "easyuse_anima/prompt/regional.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_regional_mask_bounds_area",
         "kind": "static_from",
-        "line": 248,
+        "line": 247,
         "name": "_regional_mask_bounds_area",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -26458,7 +26857,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -26466,12 +26865,12 @@
         "compatibility_pair": {
           "bound_name": "_regional_payload_canvas",
           "target": "easyuse_anima/prompt/regional.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_regional_payload_canvas",
         "kind": "static_from",
-        "line": 248,
+        "line": 247,
         "name": "_regional_payload_canvas",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -26489,7 +26888,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -26497,12 +26896,12 @@
         "compatibility_pair": {
           "bound_name": "_regional_union_mask_for_ids",
           "target": "easyuse_anima/prompt/regional.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_regional_union_mask_for_ids",
         "kind": "static_from",
-        "line": 248,
+        "line": 247,
         "name": "_regional_union_mask_for_ids",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -26520,7 +26919,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -26528,12 +26927,12 @@
         "compatibility_pair": {
           "bound_name": "ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
           "target": "easyuse_anima/prompt/conditioning.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
         "kind": "static_from",
-        "line": 275,
+        "line": 274,
         "name": "ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -26551,7 +26950,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -26559,12 +26958,12 @@
         "compatibility_pair": {
           "bound_name": "ANIMA_MOD_GUIDANCE_MODES",
           "target": "easyuse_anima/prompt/conditioning.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODES",
         "kind": "static_from",
-        "line": 275,
+        "line": 274,
         "name": "ANIMA_MOD_GUIDANCE_MODES",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -26582,7 +26981,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -26590,12 +26989,12 @@
         "compatibility_pair": {
           "bound_name": "ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
           "target": "easyuse_anima/prompt/conditioning.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 275,
+        "line": 274,
         "name": "ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -26613,7 +27012,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -26621,12 +27020,12 @@
         "compatibility_pair": {
           "bound_name": "ANIMA_MOD_GUIDANCE_PROFILE_OFF",
           "target": "easyuse_anima/prompt/conditioning.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_PROFILE_OFF",
         "kind": "static_from",
-        "line": 275,
+        "line": 274,
         "name": "ANIMA_MOD_GUIDANCE_PROFILE_OFF",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -26644,7 +27043,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -26652,12 +27051,12 @@
         "compatibility_pair": {
           "bound_name": "_apply_spectrum_anima_mod_guidance",
           "target": "easyuse_anima/prompt/conditioning.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:_apply_spectrum_anima_mod_guidance",
         "kind": "static_from",
-        "line": 275,
+        "line": 274,
         "name": "_apply_spectrum_anima_mod_guidance",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -26675,7 +27074,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -26683,12 +27082,12 @@
         "compatibility_pair": {
           "bound_name": "_find_spectrum_anima_mod_guidance_class",
           "target": "easyuse_anima/prompt/conditioning.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:_find_spectrum_anima_mod_guidance_class",
         "kind": "static_from",
-        "line": 275,
+        "line": 274,
         "name": "_find_spectrum_anima_mod_guidance_class",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -26706,7 +27105,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -26714,12 +27113,12 @@
         "compatibility_pair": {
           "bound_name": "_normalize_anima_mod_guidance_profile",
           "target": "easyuse_anima/prompt/conditioning.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:_normalize_anima_mod_guidance_profile",
         "kind": "static_from",
-        "line": 275,
+        "line": 274,
         "name": "_normalize_anima_mod_guidance_profile",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -26737,7 +27136,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -26745,12 +27144,12 @@
         "compatibility_pair": {
           "bound_name": "_resolve_anima_mod_guidance_enabled",
           "target": "easyuse_anima/prompt/conditioning.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:_resolve_anima_mod_guidance_enabled",
         "kind": "static_from",
-        "line": 275,
+        "line": 274,
         "name": "_resolve_anima_mod_guidance_enabled",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -26768,7 +27167,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -26776,12 +27175,12 @@
         "compatibility_pair": {
           "bound_name": "ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
           "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
         "kind": "static_from",
-        "line": 290,
+        "line": 289,
         "name": "ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -26799,7 +27198,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -26807,12 +27206,12 @@
         "compatibility_pair": {
           "bound_name": "ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
           "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
         "kind": "static_from",
-        "line": 290,
+        "line": 289,
         "name": "ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -26830,7 +27229,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -26838,12 +27237,12 @@
         "compatibility_pair": {
           "bound_name": "ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
           "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
         "kind": "static_from",
-        "line": 290,
+        "line": 289,
         "name": "ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -26861,7 +27260,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -26869,12 +27268,12 @@
         "compatibility_pair": {
           "bound_name": "ARTIST_MIX_DEFAULT_EXACT_TOP_K",
           "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_EXACT_TOP_K",
         "kind": "static_from",
-        "line": 290,
+        "line": 289,
         "name": "ARTIST_MIX_DEFAULT_EXACT_TOP_K",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -26892,7 +27291,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -26900,12 +27299,12 @@
         "compatibility_pair": {
           "bound_name": "ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
           "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
         "kind": "static_from",
-        "line": 290,
+        "line": 289,
         "name": "ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -26923,7 +27322,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -26931,12 +27330,12 @@
         "compatibility_pair": {
           "bound_name": "ARTIST_MIX_DEFAULT_START_PERCENT",
           "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_START_PERCENT",
         "kind": "static_from",
-        "line": 290,
+        "line": 289,
         "name": "ARTIST_MIX_DEFAULT_START_PERCENT",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -26954,7 +27353,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -26962,12 +27361,12 @@
         "compatibility_pair": {
           "bound_name": "ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
           "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
         "kind": "static_from",
-        "line": 290,
+        "line": 289,
         "name": "ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -26985,7 +27384,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -26993,12 +27392,12 @@
         "compatibility_pair": {
           "bound_name": "ARTIST_MIX_DEFAULT_STYLE_GAIN",
           "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STYLE_GAIN",
         "kind": "static_from",
-        "line": 290,
+        "line": 289,
         "name": "ARTIST_MIX_DEFAULT_STYLE_GAIN",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -27016,7 +27415,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -27024,12 +27423,12 @@
         "compatibility_pair": {
           "bound_name": "ARTIST_MIX_INPUT_MODES",
           "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_INPUT_MODES",
         "kind": "static_from",
-        "line": 290,
+        "line": 289,
         "name": "ARTIST_MIX_INPUT_MODES",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -27047,7 +27446,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -27055,12 +27454,12 @@
         "compatibility_pair": {
           "bound_name": "ARTIST_MIX_MODE_FROM_PROMPT_DATA",
           "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 290,
+        "line": 289,
         "name": "ARTIST_MIX_MODE_FROM_PROMPT_DATA",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -27078,7 +27477,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -27086,12 +27485,12 @@
         "compatibility_pair": {
           "bound_name": "_artist_mix_inline_prompt",
           "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_artist_mix_inline_prompt",
         "kind": "static_from",
-        "line": 290,
+        "line": 289,
         "name": "_artist_mix_inline_prompt",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -27109,7 +27508,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -27117,12 +27516,12 @@
         "compatibility_pair": {
           "bound_name": "_artist_mix_mode_tooltip",
           "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_artist_mix_mode_tooltip",
         "kind": "static_from",
-        "line": 290,
+        "line": 289,
         "name": "_artist_mix_mode_tooltip",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -27140,7 +27539,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -27148,12 +27547,12 @@
         "compatibility_pair": {
           "bound_name": "_artist_prompt_with_position",
           "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_artist_prompt_with_position",
         "kind": "static_from",
-        "line": 290,
+        "line": 289,
         "name": "_artist_prompt_with_position",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -27171,7 +27570,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -27179,12 +27578,12 @@
         "compatibility_pair": {
           "bound_name": "_artist_tags_from_prompt",
           "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_artist_tags_from_prompt",
         "kind": "static_from",
-        "line": 290,
+        "line": 289,
         "name": "_artist_tags_from_prompt",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -27202,7 +27601,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -27210,12 +27609,12 @@
         "compatibility_pair": {
           "bound_name": "_blend_conditionings",
           "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_blend_conditionings",
         "kind": "static_from",
-        "line": 290,
+        "line": 289,
         "name": "_blend_conditionings",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -27233,7 +27632,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -27241,12 +27640,12 @@
         "compatibility_pair": {
           "bound_name": "_bounded_artist_mix_float",
           "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_bounded_artist_mix_float",
         "kind": "static_from",
-        "line": 290,
+        "line": 289,
         "name": "_bounded_artist_mix_float",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -27264,7 +27663,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -27272,12 +27671,12 @@
         "compatibility_pair": {
           "bound_name": "_bounded_artist_mix_int",
           "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_bounded_artist_mix_int",
         "kind": "static_from",
-        "line": 290,
+        "line": 289,
         "name": "_bounded_artist_mix_int",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -27295,7 +27694,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -27303,12 +27702,12 @@
         "compatibility_pair": {
           "bound_name": "_encode_artist_clustered",
           "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_encode_artist_clustered",
         "kind": "static_from",
-        "line": 290,
+        "line": 289,
         "name": "_encode_artist_clustered",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -27326,7 +27725,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -27334,12 +27733,12 @@
         "compatibility_pair": {
           "bound_name": "_encode_artist_delta_rms",
           "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_encode_artist_delta_rms",
         "kind": "static_from",
-        "line": 290,
+        "line": 289,
         "name": "_encode_artist_delta_rms",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -27357,7 +27756,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -27365,12 +27764,12 @@
         "compatibility_pair": {
           "bound_name": "_encode_prompt_data_positive_conditioning",
           "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_encode_prompt_data_positive_conditioning",
         "kind": "static_from",
-        "line": 290,
+        "line": 289,
         "name": "_encode_prompt_data_positive_conditioning",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -27388,7 +27787,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -27396,12 +27795,12 @@
         "compatibility_pair": {
           "bound_name": "_join_artist_mix_source_prompts",
           "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_join_artist_mix_source_prompts",
         "kind": "static_from",
-        "line": 290,
+        "line": 289,
         "name": "_join_artist_mix_source_prompts",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -27419,7 +27818,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -27427,12 +27826,12 @@
         "compatibility_pair": {
           "bound_name": "_normalize_artist_mix_mode",
           "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_normalize_artist_mix_mode",
         "kind": "static_from",
-        "line": 290,
+        "line": 289,
         "name": "_normalize_artist_mix_mode",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -27450,7 +27849,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -27458,12 +27857,12 @@
         "compatibility_pair": {
           "bound_name": "_normalize_artist_tag_position",
           "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_normalize_artist_tag_position",
         "kind": "static_from",
-        "line": 290,
+        "line": 289,
         "name": "_normalize_artist_tag_position",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -27481,7 +27880,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -27489,12 +27888,12 @@
         "compatibility_pair": {
           "bound_name": "_parse_artist_mix_items",
           "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_parse_artist_mix_items",
         "kind": "static_from",
-        "line": 290,
+        "line": 289,
         "name": "_parse_artist_mix_items",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -27512,7 +27911,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -27520,12 +27919,12 @@
         "compatibility_pair": {
           "bound_name": "EasyUseAnimaArtistMixConditioning",
           "target": "easyuse_anima/nodes/prompt_data_nodes.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaArtistMixConditioning",
         "kind": "static_from",
-        "line": 369,
+        "line": 368,
         "name": "EasyUseAnimaArtistMixConditioning",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_data_nodes",
@@ -27543,7 +27942,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -27551,12 +27950,12 @@
         "compatibility_pair": {
           "bound_name": "EasyUseAnimaPromptDataConditioning",
           "target": "easyuse_anima/nodes/prompt_data_nodes.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataConditioning",
         "kind": "static_from",
-        "line": 369,
+        "line": 368,
         "name": "EasyUseAnimaPromptDataConditioning",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_data_nodes",
@@ -27574,7 +27973,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -27582,12 +27981,12 @@
         "compatibility_pair": {
           "bound_name": "EasyUseAnimaPromptDataUnpack",
           "target": "easyuse_anima/nodes/prompt_data_nodes.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataUnpack",
         "kind": "static_from",
-        "line": 369,
+        "line": 368,
         "name": "EasyUseAnimaPromptDataUnpack",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_data_nodes",
@@ -27605,7 +28004,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -27613,12 +28012,12 @@
         "compatibility_pair": {
           "bound_name": "_ANY_TYPE",
           "target": "easyuse_anima/nodes/input_types.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.nodes.input_types:_ANY_TYPE",
         "kind": "static_from",
-        "line": 374,
+        "line": 373,
         "name": "_ANY_TYPE",
         "optional": false,
         "requested": ".easyuse_anima.nodes.input_types",
@@ -27636,7 +28035,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -27644,12 +28043,12 @@
         "compatibility_pair": {
           "bound_name": "_AnyType",
           "target": "easyuse_anima/nodes/input_types.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.nodes.input_types:_AnyType",
         "kind": "static_from",
-        "line": 374,
+        "line": 373,
         "name": "_AnyType",
         "optional": false,
         "requested": ".easyuse_anima.nodes.input_types",
@@ -27667,7 +28066,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -27675,12 +28074,12 @@
         "compatibility_pair": {
           "bound_name": "_FlexibleOptionalInputType",
           "target": "easyuse_anima/nodes/input_types.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.nodes.input_types:_FlexibleOptionalInputType",
         "kind": "static_from",
-        "line": 374,
+        "line": 373,
         "name": "_FlexibleOptionalInputType",
         "optional": false,
         "requested": ".easyuse_anima.nodes.input_types",
@@ -27698,7 +28097,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -27706,12 +28105,12 @@
         "compatibility_pair": {
           "bound_name": "EasyUseAnimaPromptStudioAdvanced",
           "target": "easyuse_anima/nodes/prompt_advanced_nodes.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvanced",
         "kind": "static_from",
-        "line": 379,
+        "line": 378,
         "name": "EasyUseAnimaPromptStudioAdvanced",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_advanced_nodes",
@@ -27729,7 +28128,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -27737,12 +28136,12 @@
         "compatibility_pair": {
           "bound_name": "EasyUseAnimaPromptStudioAdvancedV2",
           "target": "easyuse_anima/nodes/prompt_advanced_nodes.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvancedV2",
         "kind": "static_from",
-        "line": 379,
+        "line": 378,
         "name": "EasyUseAnimaPromptStudioAdvancedV2",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_advanced_nodes",
@@ -27750,6 +28149,37 @@
         "scope": "<module>",
         "source": "nodes.py",
         "target": "easyuse_anima/nodes/prompt_advanced_nodes.py"
+      },
+      {
+        "alias": "EASY_USE_ANIMA_INPUT_TYPE",
+        "bound_name": "EASY_USE_ANIMA_INPUT_TYPE",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 6
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "EASY_USE_ANIMA_INPUT_TYPE",
+          "target": "easyuse_anima/nodes/aio_nodes.py",
+          "try_line": 6
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.nodes.aio_nodes:EASY_USE_ANIMA_INPUT_TYPE",
+        "kind": "static_from",
+        "line": 383,
+        "name": "EASY_USE_ANIMA_INPUT_TYPE",
+        "optional": false,
+        "requested": ".easyuse_anima.nodes.aio_nodes",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/nodes/aio_nodes.py"
       },
       {
         "alias": "EasyUseAnimaAIOGenerator",
@@ -27760,7 +28190,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -27768,12 +28198,12 @@
         "compatibility_pair": {
           "bound_name": "EasyUseAnimaAIOGenerator",
           "target": "easyuse_anima/nodes/aio_nodes.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.nodes.aio_nodes:EasyUseAnimaAIOGenerator",
         "kind": "static_from",
-        "line": 384,
+        "line": 383,
         "name": "EasyUseAnimaAIOGenerator",
         "optional": false,
         "requested": ".easyuse_anima.nodes.aio_nodes",
@@ -27791,7 +28221,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -27799,12 +28229,12 @@
         "compatibility_pair": {
           "bound_name": "EasyUseAnimaInput",
           "target": "easyuse_anima/nodes/aio_nodes.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.nodes.aio_nodes:EasyUseAnimaInput",
         "kind": "static_from",
-        "line": 384,
+        "line": 383,
         "name": "EasyUseAnimaInput",
         "optional": false,
         "requested": ".easyuse_anima.nodes.aio_nodes",
@@ -27822,7 +28252,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -27830,12 +28260,12 @@
         "compatibility_pair": {
           "bound_name": "_aio_generation_settings_json",
           "target": "easyuse_anima/nodes/aio_nodes.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.nodes.aio_nodes:_aio_generation_settings_json",
         "kind": "static_from",
-        "line": 384,
+        "line": 383,
         "name": "_aio_generation_settings_json",
         "optional": false,
         "requested": ".easyuse_anima.nodes.aio_nodes",
@@ -27853,7 +28283,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -27861,44 +28291,13 @@
         "compatibility_pair": {
           "bound_name": "_aio_input_settings_json",
           "target": "easyuse_anima/nodes/aio_nodes.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.nodes.aio_nodes:_aio_input_settings_json",
         "kind": "static_from",
-        "line": 384,
+        "line": 383,
         "name": "_aio_input_settings_json",
-        "optional": false,
-        "requested": ".easyuse_anima.nodes.aio_nodes",
-        "role": "compatibility_primary",
-        "scope": "<module>",
-        "source": "nodes.py",
-        "target": "easyuse_anima/nodes/aio_nodes.py"
-      },
-      {
-        "alias": "_bind_aio_node_runtime",
-        "bound_name": "_bind_aio_node_runtime",
-        "branch_context": [
-          {
-            "branch": "body",
-            "handles_import_failure": true,
-            "has_import_fallback_handler": true,
-            "kind": "try",
-            "line": 7
-          }
-        ],
-        "classification": "internal",
-        "column": 4,
-        "compatibility_pair": {
-          "bound_name": "_bind_aio_node_runtime",
-          "target": "easyuse_anima/nodes/aio_nodes.py",
-          "try_line": 7
-        },
-        "conditional": true,
-        "imported": ".easyuse_anima.nodes.aio_nodes:_bind_aio_node_runtime",
-        "kind": "static_from",
-        "line": 384,
-        "name": "_bind_aio_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.aio_nodes",
         "role": "compatibility_primary",
@@ -27915,7 +28314,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -27923,12 +28322,12 @@
         "compatibility_pair": {
           "bound_name": "_align_down",
           "target": "easyuse_anima/image/geometry.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.image.geometry:_align_down",
         "kind": "static_from",
-        "line": 391,
+        "line": 390,
         "name": "_align_down",
         "optional": false,
         "requested": ".easyuse_anima.image.geometry",
@@ -27946,7 +28345,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -27954,12 +28353,12 @@
         "compatibility_pair": {
           "bound_name": "_align_nearest",
           "target": "easyuse_anima/image/geometry.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.image.geometry:_align_nearest",
         "kind": "static_from",
-        "line": 391,
+        "line": 390,
         "name": "_align_nearest",
         "optional": false,
         "requested": ".easyuse_anima.image.geometry",
@@ -27977,7 +28376,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -27985,12 +28384,12 @@
         "compatibility_pair": {
           "bound_name": "_image_tensor_size",
           "target": "easyuse_anima/image/geometry.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.image.geometry:_image_tensor_size",
         "kind": "static_from",
-        "line": 391,
+        "line": 390,
         "name": "_image_tensor_size",
         "optional": false,
         "requested": ".easyuse_anima.image.geometry",
@@ -28008,7 +28407,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -28016,12 +28415,12 @@
         "compatibility_pair": {
           "bound_name": "_context_value",
           "target": "easyuse_anima/image/sam3.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.image.sam3:_context_value",
         "kind": "static_from",
-        "line": 402,
+        "line": 401,
         "name": "_context_value",
         "optional": false,
         "requested": ".easyuse_anima.image.sam3",
@@ -28039,7 +28438,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -28047,12 +28446,12 @@
         "compatibility_pair": {
           "bound_name": "_sam3_context",
           "target": "easyuse_anima/image/sam3.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.image.sam3:_sam3_context",
         "kind": "static_from",
-        "line": 402,
+        "line": 401,
         "name": "_sam3_context",
         "optional": false,
         "requested": ".easyuse_anima.image.sam3",
@@ -28070,7 +28469,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -28078,12 +28477,12 @@
         "compatibility_pair": {
           "bound_name": "_segs_has_items",
           "target": "easyuse_anima/image/sam3.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.image.sam3:_segs_has_items",
         "kind": "static_from",
-        "line": 402,
+        "line": 401,
         "name": "_segs_has_items",
         "optional": false,
         "requested": ".easyuse_anima.image.sam3",
@@ -28101,7 +28500,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -28109,12 +28508,12 @@
         "compatibility_pair": {
           "bound_name": "IMAGE_SCALE_MULTIPLES",
           "target": "easyuse_anima/image/scaling.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.image.scaling:IMAGE_SCALE_MULTIPLES",
         "kind": "static_from",
-        "line": 414,
+        "line": 413,
         "name": "IMAGE_SCALE_MULTIPLES",
         "optional": false,
         "requested": ".easyuse_anima.image.scaling",
@@ -28132,7 +28531,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -28140,12 +28539,12 @@
         "compatibility_pair": {
           "bound_name": "IMAGE_UPSCALE_METHODS",
           "target": "easyuse_anima/image/scaling.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.image.scaling:IMAGE_UPSCALE_METHODS",
         "kind": "static_from",
-        "line": 414,
+        "line": 413,
         "name": "IMAGE_UPSCALE_METHODS",
         "optional": false,
         "requested": ".easyuse_anima.image.scaling",
@@ -28163,7 +28562,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -28171,12 +28570,12 @@
         "compatibility_pair": {
           "bound_name": "_comfy_sampler_names",
           "target": "easyuse_anima/infrastructure/comfy/capabilities.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_comfy_sampler_names",
         "kind": "static_from",
-        "line": 422,
+        "line": 421,
         "name": "_comfy_sampler_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -28194,7 +28593,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -28202,12 +28601,12 @@
         "compatibility_pair": {
           "bound_name": "_comfy_scheduler_names",
           "target": "easyuse_anima/infrastructure/comfy/capabilities.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_comfy_scheduler_names",
         "kind": "static_from",
-        "line": 422,
+        "line": 421,
         "name": "_comfy_scheduler_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -28225,7 +28624,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -28233,12 +28632,12 @@
         "compatibility_pair": {
           "bound_name": "_impact_scheduler_names",
           "target": "easyuse_anima/infrastructure/comfy/capabilities.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_impact_scheduler_names",
         "kind": "static_from",
-        "line": 422,
+        "line": 421,
         "name": "_impact_scheduler_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -28256,7 +28655,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -28264,12 +28663,12 @@
         "compatibility_pair": {
           "bound_name": "_call_with_supported_kwargs",
           "target": "easyuse_anima/infrastructure/comfy/invocation.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.invocation:_call_with_supported_kwargs",
         "kind": "static_from",
-        "line": 428,
+        "line": 427,
         "name": "_call_with_supported_kwargs",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.invocation",
@@ -28287,7 +28686,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -28295,12 +28694,12 @@
         "compatibility_pair": {
           "bound_name": "_common_upscale_image",
           "target": "easyuse_anima/infrastructure/comfy/invocation.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.invocation:_common_upscale_image",
         "kind": "static_from",
-        "line": 428,
+        "line": 427,
         "name": "_common_upscale_image",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.invocation",
@@ -28318,7 +28717,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -28326,12 +28725,12 @@
         "compatibility_pair": {
           "bound_name": "_node_output_tuple",
           "target": "easyuse_anima/infrastructure/comfy/invocation.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.invocation:_node_output_tuple",
         "kind": "static_from",
-        "line": 428,
+        "line": 427,
         "name": "_node_output_tuple",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.invocation",
@@ -28349,7 +28748,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -28357,12 +28756,12 @@
         "compatibility_pair": {
           "bound_name": "_adapter_comfy_clip_loader_types",
           "target": "easyuse_anima/infrastructure/comfy/resources.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_comfy_clip_loader_types",
         "kind": "static_from",
-        "line": 433,
+        "line": 432,
         "name": "_comfy_clip_loader_types",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -28380,7 +28779,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -28388,12 +28787,12 @@
         "compatibility_pair": {
           "bound_name": "_adapter_comfy_diffusion_model_names",
           "target": "easyuse_anima/infrastructure/comfy/resources.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_comfy_diffusion_model_names",
         "kind": "static_from",
-        "line": 433,
+        "line": 432,
         "name": "_comfy_diffusion_model_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -28411,7 +28810,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -28419,12 +28818,12 @@
         "compatibility_pair": {
           "bound_name": "_adapter_comfy_text_encoder_names",
           "target": "easyuse_anima/infrastructure/comfy/resources.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_comfy_text_encoder_names",
         "kind": "static_from",
-        "line": 433,
+        "line": 432,
         "name": "_comfy_text_encoder_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -28442,7 +28841,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -28450,12 +28849,12 @@
         "compatibility_pair": {
           "bound_name": "_adapter_comfy_vae_names",
           "target": "easyuse_anima/infrastructure/comfy/resources.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_comfy_vae_names",
         "kind": "static_from",
-        "line": 433,
+        "line": 432,
         "name": "_comfy_vae_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -28473,7 +28872,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -28481,12 +28880,12 @@
         "compatibility_pair": {
           "bound_name": "_folder_path_names",
           "target": "easyuse_anima/infrastructure/comfy/resources.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_folder_path_names",
         "kind": "static_from",
-        "line": 433,
+        "line": 432,
         "name": "_folder_path_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -28504,7 +28903,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -28512,12 +28911,12 @@
         "compatibility_pair": {
           "bound_name": "EasyUseAnimaDetailerAlignHook",
           "target": "easyuse_anima/nodes/image_nodes.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.nodes.image_nodes:EasyUseAnimaDetailerAlignHook",
         "kind": "static_from",
-        "line": 441,
+        "line": 440,
         "name": "EasyUseAnimaDetailerAlignHook",
         "optional": false,
         "requested": ".easyuse_anima.nodes.image_nodes",
@@ -28535,7 +28934,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -28543,12 +28942,12 @@
         "compatibility_pair": {
           "bound_name": "EasyUseAnimaImageScaleByMultiple",
           "target": "easyuse_anima/nodes/image_nodes.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.nodes.image_nodes:EasyUseAnimaImageScaleByMultiple",
         "kind": "static_from",
-        "line": 441,
+        "line": 440,
         "name": "EasyUseAnimaImageScaleByMultiple",
         "optional": false,
         "requested": ".easyuse_anima.nodes.image_nodes",
@@ -28566,7 +28965,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -28574,12 +28973,12 @@
         "compatibility_pair": {
           "bound_name": "EasyUseAnimaSAM3Context",
           "target": "easyuse_anima/nodes/sam3_nodes.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Context",
         "kind": "static_from",
-        "line": 445,
+        "line": 444,
         "name": "EasyUseAnimaSAM3Context",
         "optional": false,
         "requested": ".easyuse_anima.nodes.sam3_nodes",
@@ -28597,7 +28996,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -28605,12 +29004,12 @@
         "compatibility_pair": {
           "bound_name": "EasyUseAnimaSAM3Detailer",
           "target": "easyuse_anima/nodes/sam3_nodes.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Detailer",
         "kind": "static_from",
-        "line": 445,
+        "line": 444,
         "name": "EasyUseAnimaSAM3Detailer",
         "optional": false,
         "requested": ".easyuse_anima.nodes.sam3_nodes",
@@ -28628,7 +29027,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -28636,12 +29035,12 @@
         "compatibility_pair": {
           "bound_name": "EasyUseAnimaPromptBuilder",
           "target": "easyuse_anima/nodes/prompt_nodes.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptBuilder",
         "kind": "static_from",
-        "line": 449,
+        "line": 448,
         "name": "EasyUseAnimaPromptBuilder",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_nodes",
@@ -28659,7 +29058,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -28667,12 +29066,12 @@
         "compatibility_pair": {
           "bound_name": "EasyUseAnimaPromptCorrector",
           "target": "easyuse_anima/nodes/prompt_nodes.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrector",
         "kind": "static_from",
-        "line": 449,
+        "line": 448,
         "name": "EasyUseAnimaPromptCorrector",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_nodes",
@@ -28690,7 +29089,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -28698,12 +29097,12 @@
         "compatibility_pair": {
           "bound_name": "EasyUseAnimaPromptCorrectorSimple",
           "target": "easyuse_anima/nodes/prompt_nodes.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrectorSimple",
         "kind": "static_from",
-        "line": 449,
+        "line": 448,
         "name": "EasyUseAnimaPromptCorrectorSimple",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_nodes",
@@ -28721,7 +29120,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -28729,12 +29128,12 @@
         "compatibility_pair": {
           "bound_name": "EasyUseAnimaPromptStudio",
           "target": "easyuse_anima/nodes/prompt_nodes.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptStudio",
         "kind": "static_from",
-        "line": 449,
+        "line": 448,
         "name": "EasyUseAnimaPromptStudio",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_nodes",
@@ -28752,7 +29151,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -28760,12 +29159,12 @@
         "compatibility_pair": {
           "bound_name": "EasyUseAnimaPromptStudioRegional",
           "target": "easyuse_anima/nodes/regional_nodes.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.nodes.regional_nodes:EasyUseAnimaPromptStudioRegional",
         "kind": "static_from",
-        "line": 455,
+        "line": 454,
         "name": "EasyUseAnimaPromptStudioRegional",
         "optional": false,
         "requested": ".easyuse_anima.nodes.regional_nodes",
@@ -28783,7 +29182,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -28791,12 +29190,12 @@
         "compatibility_pair": {
           "bound_name": "EasyUseAnimaRegionalConditioning",
           "target": "easyuse_anima/nodes/regional_nodes.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.nodes.regional_nodes:EasyUseAnimaRegionalConditioning",
         "kind": "static_from",
-        "line": 455,
+        "line": 454,
         "name": "EasyUseAnimaRegionalConditioning",
         "optional": false,
         "requested": ".easyuse_anima.nodes.regional_nodes",
@@ -28814,7 +29213,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -28822,12 +29221,12 @@
         "compatibility_pair": {
           "bound_name": "LATENT_ALIGN",
           "target": "easyuse_anima/naia/client.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.naia.client:LATENT_ALIGN",
         "kind": "static_from",
-        "line": 459,
+        "line": 458,
         "name": "LATENT_ALIGN",
         "optional": false,
         "requested": ".easyuse_anima.naia.client",
@@ -28845,7 +29244,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -28853,12 +29252,12 @@
         "compatibility_pair": {
           "bound_name": "_parse_random_response",
           "target": "easyuse_anima/naia/client.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.naia.client:_parse_random_response",
         "kind": "static_from",
-        "line": 459,
+        "line": 458,
         "name": "_parse_random_response",
         "optional": false,
         "requested": ".easyuse_anima.naia.client",
@@ -28876,7 +29275,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -28884,12 +29283,12 @@
         "compatibility_pair": {
           "bound_name": "_post_random",
           "target": "easyuse_anima/naia/client.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.naia.client:_post_random",
         "kind": "static_from",
-        "line": 459,
+        "line": 458,
         "name": "_post_random",
         "optional": false,
         "requested": ".easyuse_anima.naia.client",
@@ -28907,7 +29306,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -28915,12 +29314,12 @@
         "compatibility_pair": {
           "bound_name": "_advanced_resolution_from_selection",
           "target": "easyuse_anima/naia/resolution.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_advanced_resolution_from_selection",
         "kind": "static_from",
-        "line": 477,
+        "line": 476,
         "name": "_advanced_resolution_from_selection",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -28938,7 +29337,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -28946,12 +29345,12 @@
         "compatibility_pair": {
           "bound_name": "_normalize_resolution_bucket",
           "target": "easyuse_anima/naia/resolution.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_normalize_resolution_bucket",
         "kind": "static_from",
-        "line": 477,
+        "line": 476,
         "name": "_normalize_resolution_bucket",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -28969,7 +29368,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -28977,12 +29376,12 @@
         "compatibility_pair": {
           "bound_name": "_ratio_label",
           "target": "easyuse_anima/naia/resolution.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_ratio_label",
         "kind": "static_from",
-        "line": 477,
+        "line": 476,
         "name": "_ratio_label",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -29000,7 +29399,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -29008,12 +29407,12 @@
         "compatibility_pair": {
           "bound_name": "_resolution_label",
           "target": "easyuse_anima/naia/resolution.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_resolution_label",
         "kind": "static_from",
-        "line": 477,
+        "line": 476,
         "name": "_resolution_label",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -29031,7 +29430,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -29039,12 +29438,12 @@
         "compatibility_pair": {
           "bound_name": "_resolve_naia_resolution",
           "target": "easyuse_anima/naia/resolution.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_resolve_naia_resolution",
         "kind": "static_from",
-        "line": 477,
+        "line": 476,
         "name": "_resolve_naia_resolution",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -29062,7 +29461,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -29070,12 +29469,12 @@
         "compatibility_pair": {
           "bound_name": "EasyUseAnimaNAIARandomPrompt",
           "target": "easyuse_anima/nodes/naia_nodes.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.nodes.naia_nodes:EasyUseAnimaNAIARandomPrompt",
         "kind": "static_from",
-        "line": 500,
+        "line": 499,
         "name": "EasyUseAnimaNAIARandomPrompt",
         "optional": false,
         "requested": ".easyuse_anima.nodes.naia_nodes",
@@ -29093,7 +29492,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -29101,12 +29500,12 @@
         "compatibility_pair": {
           "bound_name": "_bind_naia_node_runtime",
           "target": "easyuse_anima/nodes/naia_nodes.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.nodes.naia_nodes:_bind_naia_node_runtime",
         "kind": "static_from",
-        "line": 500,
+        "line": 499,
         "name": "_bind_naia_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.naia_nodes",
@@ -29124,7 +29523,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -29132,12 +29531,12 @@
         "compatibility_pair": {
           "bound_name": "EasyUseAnimaWildcard",
           "target": "easyuse_anima/nodes/wildcard_nodes.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.nodes.wildcard_nodes:EasyUseAnimaWildcard",
         "kind": "static_from",
-        "line": 504,
+        "line": 503,
         "name": "EasyUseAnimaWildcard",
         "optional": false,
         "requested": ".easyuse_anima.nodes.wildcard_nodes",
@@ -29155,7 +29554,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -29163,12 +29562,12 @@
         "compatibility_pair": {
           "bound_name": "_bind_wildcard_node_runtime",
           "target": "easyuse_anima/nodes/wildcard_nodes.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.nodes.wildcard_nodes:_bind_wildcard_node_runtime",
         "kind": "static_from",
-        "line": 504,
+        "line": 503,
         "name": "_bind_wildcard_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.wildcard_nodes",
@@ -29186,7 +29585,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -29194,12 +29593,12 @@
         "compatibility_pair": {
           "bound_name": "_apply_lora_syntax_format",
           "target": "easyuse_anima/lora/metadata.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_apply_lora_syntax_format",
         "kind": "static_from",
-        "line": 509,
+        "line": 508,
         "name": "_apply_lora_syntax_format",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -29217,7 +29616,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -29225,12 +29624,12 @@
         "compatibility_pair": {
           "bound_name": "_dedupe_text_values",
           "target": "easyuse_anima/lora/metadata.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_dedupe_text_values",
         "kind": "static_from",
-        "line": 509,
+        "line": 508,
         "name": "_dedupe_text_values",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -29248,7 +29647,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -29256,12 +29655,12 @@
         "compatibility_pair": {
           "bound_name": "_fallback_lora_path",
           "target": "easyuse_anima/lora/metadata.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_fallback_lora_path",
         "kind": "static_from",
-        "line": 509,
+        "line": 508,
         "name": "_fallback_lora_path",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -29279,7 +29678,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -29287,12 +29686,12 @@
         "compatibility_pair": {
           "bound_name": "_get_lora_info",
           "target": "easyuse_anima/lora/metadata.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_get_lora_info",
         "kind": "static_from",
-        "line": 509,
+        "line": 508,
         "name": "_get_lora_info",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -29310,7 +29709,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -29318,12 +29717,12 @@
         "compatibility_pair": {
           "bound_name": "_get_lora_manager_trigger_words",
           "target": "easyuse_anima/lora/metadata.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_get_lora_manager_trigger_words",
         "kind": "static_from",
-        "line": 509,
+        "line": 508,
         "name": "_get_lora_manager_trigger_words",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -29341,7 +29740,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -29349,12 +29748,12 @@
         "compatibility_pair": {
           "bound_name": "_load_lora_manager_metadata",
           "target": "easyuse_anima/lora/metadata.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_load_lora_manager_metadata",
         "kind": "static_from",
-        "line": 509,
+        "line": 508,
         "name": "_load_lora_manager_metadata",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -29372,7 +29771,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -29380,12 +29779,12 @@
         "compatibility_pair": {
           "bound_name": "_lora_combo_values",
           "target": "easyuse_anima/lora/metadata.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_lora_combo_values",
         "kind": "static_from",
-        "line": 509,
+        "line": 508,
         "name": "_lora_combo_values",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -29403,7 +29802,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -29411,12 +29810,12 @@
         "compatibility_pair": {
           "bound_name": "_lora_manager_trigger_words_from_metadata",
           "target": "easyuse_anima/lora/metadata.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_lora_manager_trigger_words_from_metadata",
         "kind": "static_from",
-        "line": 509,
+        "line": 508,
         "name": "_lora_manager_trigger_words_from_metadata",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -29434,7 +29833,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -29442,12 +29841,12 @@
         "compatibility_pair": {
           "bound_name": "_lora_model_exists",
           "target": "easyuse_anima/lora/metadata.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_lora_model_exists",
         "kind": "static_from",
-        "line": 509,
+        "line": 508,
         "name": "_lora_model_exists",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -29465,7 +29864,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -29473,12 +29872,12 @@
         "compatibility_pair": {
           "bound_name": "_lora_stack_name",
           "target": "easyuse_anima/lora/metadata.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_lora_stack_name",
         "kind": "static_from",
-        "line": 509,
+        "line": 508,
         "name": "_lora_stack_name",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -29496,7 +29895,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -29504,12 +29903,12 @@
         "compatibility_pair": {
           "bound_name": "_metadata_json_paths_for_lora",
           "target": "easyuse_anima/lora/metadata.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_metadata_json_paths_for_lora",
         "kind": "static_from",
-        "line": 509,
+        "line": 508,
         "name": "_metadata_json_paths_for_lora",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -29527,7 +29926,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -29535,12 +29934,12 @@
         "compatibility_pair": {
           "bound_name": "_missing_lora_display_name",
           "target": "easyuse_anima/lora/metadata.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_missing_lora_display_name",
         "kind": "static_from",
-        "line": 509,
+        "line": 508,
         "name": "_missing_lora_display_name",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -29558,7 +29957,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -29566,12 +29965,12 @@
         "compatibility_pair": {
           "bound_name": "_raise_missing_loras",
           "target": "easyuse_anima/lora/metadata.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_raise_missing_loras",
         "kind": "static_from",
-        "line": 509,
+        "line": 508,
         "name": "_raise_missing_loras",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -29589,7 +29988,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -29597,12 +29996,12 @@
         "compatibility_pair": {
           "bound_name": "_trigger_words_from_value",
           "target": "easyuse_anima/lora/metadata.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_trigger_words_from_value",
         "kind": "static_from",
-        "line": 509,
+        "line": 508,
         "name": "_trigger_words_from_value",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -29620,7 +30019,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -29628,12 +30027,12 @@
         "compatibility_pair": {
           "bound_name": "_correct_style_prompt",
           "target": "easyuse_anima/lora/preset.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_correct_style_prompt",
         "kind": "static_from",
-        "line": 525,
+        "line": 524,
         "name": "_correct_style_prompt",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -29651,7 +30050,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -29659,12 +30058,12 @@
         "compatibility_pair": {
           "bound_name": "_format_strength",
           "target": "easyuse_anima/lora/preset.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_format_strength",
         "kind": "static_from",
-        "line": 525,
+        "line": 524,
         "name": "_format_strength",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -29682,7 +30081,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -29690,12 +30089,12 @@
         "compatibility_pair": {
           "bound_name": "_get_loras_list",
           "target": "easyuse_anima/lora/preset.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_get_loras_list",
         "kind": "static_from",
-        "line": 525,
+        "line": 524,
         "name": "_get_loras_list",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -29713,7 +30112,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -29721,12 +30120,12 @@
         "compatibility_pair": {
           "bound_name": "_load_profile_data",
           "target": "easyuse_anima/lora/preset.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_load_profile_data",
         "kind": "static_from",
-        "line": 525,
+        "line": 524,
         "name": "_load_profile_data",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -29744,7 +30143,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -29752,12 +30151,12 @@
         "compatibility_pair": {
           "bound_name": "_profile_key",
           "target": "easyuse_anima/lora/preset.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_profile_key",
         "kind": "static_from",
-        "line": 525,
+        "line": 524,
         "name": "_profile_key",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -29775,7 +30174,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -29783,12 +30182,12 @@
         "compatibility_pair": {
           "bound_name": "_select_profile_values",
           "target": "easyuse_anima/lora/preset.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_select_profile_values",
         "kind": "static_from",
-        "line": 525,
+        "line": 524,
         "name": "_select_profile_values",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -29806,7 +30205,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -29814,12 +30213,12 @@
         "compatibility_pair": {
           "bound_name": "_wrap_profile_index",
           "target": "easyuse_anima/lora/preset.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_wrap_profile_index",
         "kind": "static_from",
-        "line": 525,
+        "line": 524,
         "name": "_wrap_profile_index",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -29837,7 +30236,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -29845,12 +30244,12 @@
         "compatibility_pair": {
           "bound_name": "EasyUseAnimaLoraPreset",
           "target": "easyuse_anima/nodes/lora_nodes.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".easyuse_anima.nodes.lora_nodes:EasyUseAnimaLoraPreset",
         "kind": "static_from",
-        "line": 534,
+        "line": 533,
         "name": "EasyUseAnimaLoraPreset",
         "optional": false,
         "requested": ".easyuse_anima.nodes.lora_nodes",
@@ -29868,7 +30267,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -29876,12 +30275,12 @@
         "compatibility_pair": {
           "bound_name": "correct_prompt",
           "target": "anima_prompt/__init__.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".anima_prompt:correct_prompt",
         "kind": "static_from",
-        "line": 537,
+        "line": 536,
         "name": "correct_prompt",
         "optional": false,
         "requested": ".anima_prompt",
@@ -29899,7 +30298,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -29907,12 +30306,12 @@
         "compatibility_pair": {
           "bound_name": "load_knowledge_base",
           "target": "anima_prompt/__init__.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".anima_prompt:load_knowledge_base",
         "kind": "static_from",
-        "line": 537,
+        "line": 536,
         "name": "load_knowledge_base",
         "optional": false,
         "requested": ".anima_prompt",
@@ -29930,7 +30329,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -29938,12 +30337,12 @@
         "compatibility_pair": {
           "bound_name": "parse_prompt",
           "target": "anima_prompt/parser.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".anima_prompt.parser:parse_prompt",
         "kind": "static_from",
-        "line": 538,
+        "line": 537,
         "name": "parse_prompt",
         "optional": false,
         "requested": ".anima_prompt.parser",
@@ -29961,7 +30360,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -29969,12 +30368,12 @@
         "compatibility_pair": {
           "bound_name": "resolve_metadata_filter_words",
           "target": "settings.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".settings:resolve_metadata_filter_words",
         "kind": "static_from",
-        "line": 539,
+        "line": 538,
         "name": "resolve_metadata_filter_words",
         "optional": false,
         "requested": ".settings",
@@ -29992,7 +30391,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -30000,12 +30399,12 @@
         "compatibility_pair": {
           "bound_name": "resolve_naia_settings",
           "target": "settings.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".settings:resolve_naia_settings",
         "kind": "static_from",
-        "line": 539,
+        "line": 538,
         "name": "resolve_naia_settings",
         "optional": false,
         "requested": ".settings",
@@ -30023,7 +30422,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -30031,12 +30430,12 @@
         "compatibility_pair": {
           "bound_name": "resolve_prompt_translation_settings",
           "target": "settings.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".settings:resolve_prompt_translation_settings",
         "kind": "static_from",
-        "line": 539,
+        "line": 538,
         "name": "resolve_prompt_translation_settings",
         "optional": false,
         "requested": ".settings",
@@ -30054,7 +30453,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -30062,12 +30461,12 @@
         "compatibility_pair": {
           "bound_name": "has_prompt_translation_markers",
           "target": "prompt_translation.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".prompt_translation:has_prompt_translation_markers",
         "kind": "static_from",
-        "line": 544,
+        "line": 543,
         "name": "has_prompt_translation_markers",
         "optional": false,
         "requested": ".prompt_translation",
@@ -30085,7 +30484,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -30093,12 +30492,12 @@
         "compatibility_pair": {
           "bound_name": "translate_prompt_markers",
           "target": "prompt_translation.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".prompt_translation:translate_prompt_markers",
         "kind": "static_from",
-        "line": 544,
+        "line": 543,
         "name": "translate_prompt_markers",
         "optional": false,
         "requested": ".prompt_translation",
@@ -30116,7 +30515,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -30124,12 +30523,12 @@
         "compatibility_pair": {
           "bound_name": "MAX_SEED",
           "target": "wildcard_engine.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".wildcard_engine:MAX_SEED",
         "kind": "static_from",
-        "line": 545,
+        "line": 544,
         "name": "MAX_SEED",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -30147,7 +30546,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -30155,12 +30554,12 @@
         "compatibility_pair": {
           "bound_name": "PROMPT_STUDIO_WILDCARD_MODE_LABELS",
           "target": "wildcard_engine.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".wildcard_engine:PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "kind": "static_from",
-        "line": 545,
+        "line": 544,
         "name": "PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -30178,7 +30577,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -30186,12 +30585,12 @@
         "compatibility_pair": {
           "bound_name": "PUBLIC_MAX_SEED",
           "target": "wildcard_engine.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".wildcard_engine:PUBLIC_MAX_SEED",
         "kind": "static_from",
-        "line": 545,
+        "line": 544,
         "name": "PUBLIC_MAX_SEED",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -30209,7 +30608,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -30217,12 +30616,12 @@
         "compatibility_pair": {
           "bound_name": "SEED_CONTROL_DECREMENT",
           "target": "wildcard_engine.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_DECREMENT",
         "kind": "static_from",
-        "line": 545,
+        "line": 544,
         "name": "SEED_CONTROL_DECREMENT",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -30240,7 +30639,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -30248,12 +30647,12 @@
         "compatibility_pair": {
           "bound_name": "SEED_CONTROL_FIXED",
           "target": "wildcard_engine.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_FIXED",
         "kind": "static_from",
-        "line": 545,
+        "line": 544,
         "name": "SEED_CONTROL_FIXED",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -30271,7 +30670,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -30279,12 +30678,12 @@
         "compatibility_pair": {
           "bound_name": "SEED_CONTROL_INCREMENT",
           "target": "wildcard_engine.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_INCREMENT",
         "kind": "static_from",
-        "line": 545,
+        "line": 544,
         "name": "SEED_CONTROL_INCREMENT",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -30302,7 +30701,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -30310,12 +30709,12 @@
         "compatibility_pair": {
           "bound_name": "SEED_CONTROL_MODES",
           "target": "wildcard_engine.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_MODES",
         "kind": "static_from",
-        "line": 545,
+        "line": 544,
         "name": "SEED_CONTROL_MODES",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -30333,7 +30732,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -30341,12 +30740,12 @@
         "compatibility_pair": {
           "bound_name": "SEED_CONTROL_RANDOMIZE",
           "target": "wildcard_engine.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_RANDOMIZE",
         "kind": "static_from",
-        "line": 545,
+        "line": 544,
         "name": "SEED_CONTROL_RANDOMIZE",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -30364,7 +30763,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -30372,12 +30771,12 @@
         "compatibility_pair": {
           "bound_name": "WILDCARD_MODE_FIXED",
           "target": "wildcard_engine.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".wildcard_engine:WILDCARD_MODE_FIXED",
         "kind": "static_from",
-        "line": 545,
+        "line": 544,
         "name": "WILDCARD_MODE_FIXED",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -30395,7 +30794,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -30403,12 +30802,12 @@
         "compatibility_pair": {
           "bound_name": "WILDCARD_MODE_POPULATE",
           "target": "wildcard_engine.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".wildcard_engine:WILDCARD_MODE_POPULATE",
         "kind": "static_from",
-        "line": 545,
+        "line": 544,
         "name": "WILDCARD_MODE_POPULATE",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -30426,7 +30825,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -30434,12 +30833,12 @@
         "compatibility_pair": {
           "bound_name": "WILDCARD_MODE_SEQUENTIAL",
           "target": "wildcard_engine.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".wildcard_engine:WILDCARD_MODE_SEQUENTIAL",
         "kind": "static_from",
-        "line": 545,
+        "line": 544,
         "name": "WILDCARD_MODE_SEQUENTIAL",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -30457,7 +30856,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -30465,12 +30864,12 @@
         "compatibility_pair": {
           "bound_name": "expand_wildcard_texts",
           "target": "wildcard_engine.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".wildcard_engine:expand_wildcard_texts",
         "kind": "static_from",
-        "line": 545,
+        "line": 544,
         "name": "expand_wildcard_texts",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -30488,7 +30887,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -30496,12 +30895,12 @@
         "compatibility_pair": {
           "bound_name": "expand_wildcards",
           "target": "wildcard_engine.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".wildcard_engine:expand_wildcards",
         "kind": "static_from",
-        "line": 545,
+        "line": 544,
         "name": "expand_wildcards",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -30519,7 +30918,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -30527,12 +30926,12 @@
         "compatibility_pair": {
           "bound_name": "has_wildcard_syntax",
           "target": "wildcard_engine.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".wildcard_engine:has_wildcard_syntax",
         "kind": "static_from",
-        "line": 545,
+        "line": 544,
         "name": "has_wildcard_syntax",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -30550,7 +30949,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -30558,12 +30957,12 @@
         "compatibility_pair": {
           "bound_name": "next_seed",
           "target": "wildcard_engine.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".wildcard_engine:next_seed",
         "kind": "static_from",
-        "line": 545,
+        "line": 544,
         "name": "next_seed",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -30581,7 +30980,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -30589,12 +30988,12 @@
         "compatibility_pair": {
           "bound_name": "normalize_prompt_studio_wildcard_mode",
           "target": "wildcard_engine.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".wildcard_engine:normalize_prompt_studio_wildcard_mode",
         "kind": "static_from",
-        "line": 545,
+        "line": 544,
         "name": "normalize_prompt_studio_wildcard_mode",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -30612,7 +31011,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -30620,12 +31019,12 @@
         "compatibility_pair": {
           "bound_name": "normalize_seed",
           "target": "wildcard_engine.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".wildcard_engine:normalize_seed",
         "kind": "static_from",
-        "line": 545,
+        "line": 544,
         "name": "normalize_seed",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -30643,7 +31042,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -30651,12 +31050,12 @@
         "compatibility_pair": {
           "bound_name": "normalize_wildcard_mode",
           "target": "wildcard_engine.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".wildcard_engine:normalize_wildcard_mode",
         "kind": "static_from",
-        "line": 545,
+        "line": 544,
         "name": "normalize_wildcard_mode",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -30674,7 +31073,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "internal",
@@ -30682,12 +31081,12 @@
         "compatibility_pair": {
           "bound_name": "wildcard_sources_signature",
           "target": "wildcard_engine.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": ".wildcard_engine:wildcard_sources_signature",
         "kind": "static_from",
-        "line": 545,
+        "line": 544,
         "name": "wildcard_sources_signature",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -30706,9 +31105,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -30716,12 +31115,12 @@
         "compatibility_pair": {
           "bound_name": "AIO_FIRST_PASS_CACHE_MAX_ENTRIES",
           "target": "easyuse_anima/aio/first_pass_cache.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:AIO_FIRST_PASS_CACHE_MAX_ENTRIES",
         "kind": "static_from",
-        "line": 567,
+        "line": 566,
         "name": "AIO_FIRST_PASS_CACHE_MAX_ENTRIES",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -30740,9 +31139,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -30750,12 +31149,12 @@
         "compatibility_pair": {
           "bound_name": "_AIO_FIRST_PASS_CACHE",
           "target": "easyuse_anima/aio/first_pass_cache.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_AIO_FIRST_PASS_CACHE",
         "kind": "static_from",
-        "line": 567,
+        "line": 566,
         "name": "_AIO_FIRST_PASS_CACHE",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -30774,9 +31173,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -30784,12 +31183,12 @@
         "compatibility_pair": {
           "bound_name": "_AIO_FIRST_PASS_CACHE_ORDER",
           "target": "easyuse_anima/aio/first_pass_cache.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_AIO_FIRST_PASS_CACHE_ORDER",
         "kind": "static_from",
-        "line": 567,
+        "line": 566,
         "name": "_AIO_FIRST_PASS_CACHE_ORDER",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -30808,9 +31207,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -30818,12 +31217,12 @@
         "compatibility_pair": {
           "bound_name": "_aio_first_pass_cache_key",
           "target": "easyuse_anima/aio/first_pass_cache.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_aio_first_pass_cache_key",
         "kind": "static_from",
-        "line": 567,
+        "line": 566,
         "name": "_aio_first_pass_cache_key",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -30842,9 +31241,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -30852,12 +31251,12 @@
         "compatibility_pair": {
           "bound_name": "_clone_aio_cache_value",
           "target": "easyuse_anima/aio/first_pass_cache.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_clone_aio_cache_value",
         "kind": "static_from",
-        "line": 567,
+        "line": 566,
         "name": "_clone_aio_cache_value",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -30876,9 +31275,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -30886,12 +31285,12 @@
         "compatibility_pair": {
           "bound_name": "_get_aio_first_pass_cache",
           "target": "easyuse_anima/aio/first_pass_cache.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_get_aio_first_pass_cache",
         "kind": "static_from",
-        "line": 567,
+        "line": 566,
         "name": "_get_aio_first_pass_cache",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -30910,9 +31309,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -30920,12 +31319,12 @@
         "compatibility_pair": {
           "bound_name": "_put_aio_first_pass_cache",
           "target": "easyuse_anima/aio/first_pass_cache.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_put_aio_first_pass_cache",
         "kind": "static_from",
-        "line": 567,
+        "line": 566,
         "name": "_put_aio_first_pass_cache",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -30944,9 +31343,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -30954,12 +31353,12 @@
         "compatibility_pair": {
           "bound_name": "_run_aio_detailer_stage",
           "target": "easyuse_anima/aio/legacy_generation.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_detailer_stage",
         "kind": "static_from",
-        "line": 577,
+        "line": 576,
         "name": "_run_aio_detailer_stage",
         "optional": false,
         "requested": "easyuse_anima.aio.legacy_generation",
@@ -30978,9 +31377,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -30988,12 +31387,12 @@
         "compatibility_pair": {
           "bound_name": "_run_aio_detailer_target",
           "target": "easyuse_anima/aio/legacy_generation.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_detailer_target",
         "kind": "static_from",
-        "line": 577,
+        "line": 576,
         "name": "_run_aio_detailer_target",
         "optional": false,
         "requested": "easyuse_anima.aio.legacy_generation",
@@ -31012,9 +31411,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -31022,12 +31421,12 @@
         "compatibility_pair": {
           "bound_name": "_run_aio_highres_stage",
           "target": "easyuse_anima/aio/legacy_generation.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_highres_stage",
         "kind": "static_from",
-        "line": 577,
+        "line": 576,
         "name": "_run_aio_highres_stage",
         "optional": false,
         "requested": "easyuse_anima.aio.legacy_generation",
@@ -31046,9 +31445,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -31056,12 +31455,12 @@
         "compatibility_pair": {
           "bound_name": "_run_aio_legacy_generation",
           "target": "easyuse_anima/aio/legacy_generation.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_legacy_generation",
         "kind": "static_from",
-        "line": 577,
+        "line": 576,
         "name": "_run_aio_legacy_generation",
         "optional": false,
         "requested": "easyuse_anima.aio.legacy_generation",
@@ -31080,9 +31479,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -31090,12 +31489,12 @@
         "compatibility_pair": {
           "bound_name": "_run_aio_resshift_upscale_stage",
           "target": "easyuse_anima/aio/legacy_generation.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_resshift_upscale_stage",
         "kind": "static_from",
-        "line": 577,
+        "line": 576,
         "name": "_run_aio_resshift_upscale_stage",
         "optional": false,
         "requested": "easyuse_anima.aio.legacy_generation",
@@ -31114,9 +31513,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -31124,12 +31523,12 @@
         "compatibility_pair": {
           "bound_name": "_run_aio_upscale_stage",
           "target": "easyuse_anima/aio/legacy_generation.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_upscale_stage",
         "kind": "static_from",
-        "line": 577,
+        "line": 576,
         "name": "_run_aio_upscale_stage",
         "optional": false,
         "requested": "easyuse_anima.aio.legacy_generation",
@@ -31148,9 +31547,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -31158,12 +31557,12 @@
         "compatibility_pair": {
           "bound_name": "_run_aio_usdu_upscale_stage",
           "target": "easyuse_anima/aio/legacy_generation.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_usdu_upscale_stage",
         "kind": "static_from",
-        "line": 577,
+        "line": 576,
         "name": "_run_aio_usdu_upscale_stage",
         "optional": false,
         "requested": "easyuse_anima.aio.legacy_generation",
@@ -31182,9 +31581,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -31192,12 +31591,12 @@
         "compatibility_pair": {
           "bound_name": "_AIO_DETAILER_CUSTOM_RE",
           "target": "easyuse_anima/aio/generation_normalization.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_AIO_DETAILER_CUSTOM_RE",
         "kind": "static_from",
-        "line": 586,
+        "line": 585,
         "name": "_AIO_DETAILER_CUSTOM_RE",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -31216,9 +31615,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -31226,12 +31625,12 @@
         "compatibility_pair": {
           "bound_name": "_AIO_DETAILER_RESERVED_KEYS",
           "target": "easyuse_anima/aio/generation_normalization.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_AIO_DETAILER_RESERVED_KEYS",
         "kind": "static_from",
-        "line": 586,
+        "line": 585,
         "name": "_AIO_DETAILER_RESERVED_KEYS",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -31250,9 +31649,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -31260,12 +31659,12 @@
         "compatibility_pair": {
           "bound_name": "_aio_detailer_has_enabled_targets",
           "target": "easyuse_anima/aio/generation_normalization.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_aio_detailer_has_enabled_targets",
         "kind": "static_from",
-        "line": 586,
+        "line": 585,
         "name": "_aio_detailer_has_enabled_targets",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -31284,9 +31683,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -31294,12 +31693,12 @@
         "compatibility_pair": {
           "bound_name": "_aio_detailer_target_defaults",
           "target": "easyuse_anima/aio/generation_normalization.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_aio_detailer_target_defaults",
         "kind": "static_from",
-        "line": 586,
+        "line": 585,
         "name": "_aio_detailer_target_defaults",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -31318,9 +31717,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -31328,12 +31727,12 @@
         "compatibility_pair": {
           "bound_name": "_aio_detailer_target_order",
           "target": "easyuse_anima/aio/generation_normalization.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_aio_detailer_target_order",
         "kind": "static_from",
-        "line": 586,
+        "line": 585,
         "name": "_aio_detailer_target_order",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -31352,9 +31751,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -31362,12 +31761,12 @@
         "compatibility_pair": {
           "bound_name": "_is_aio_detailer_target_name",
           "target": "easyuse_anima/aio/generation_normalization.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_is_aio_detailer_target_name",
         "kind": "static_from",
-        "line": 586,
+        "line": 585,
         "name": "_is_aio_detailer_target_name",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -31386,9 +31785,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -31396,12 +31795,12 @@
         "compatibility_pair": {
           "bound_name": "_merge_versioned_settings",
           "target": "easyuse_anima/aio/generation_normalization.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_merge_versioned_settings",
         "kind": "static_from",
-        "line": 586,
+        "line": 585,
         "name": "_merge_versioned_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -31420,9 +31819,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -31430,12 +31829,12 @@
         "compatibility_pair": {
           "bound_name": "_normalize_aio_dit_corrections_settings",
           "target": "easyuse_anima/aio/generation_normalization.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_dit_corrections_settings",
         "kind": "static_from",
-        "line": 586,
+        "line": 585,
         "name": "_normalize_aio_dit_corrections_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -31454,9 +31853,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -31464,12 +31863,12 @@
         "compatibility_pair": {
           "bound_name": "_normalize_aio_generation_settings",
           "target": "easyuse_anima/aio/generation_normalization.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_generation_settings",
         "kind": "static_from",
-        "line": 586,
+        "line": 585,
         "name": "_normalize_aio_generation_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -31488,9 +31887,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -31498,12 +31897,12 @@
         "compatibility_pair": {
           "bound_name": "_normalize_aio_seed",
           "target": "easyuse_anima/aio/generation_normalization.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_seed",
         "kind": "static_from",
-        "line": 586,
+        "line": 585,
         "name": "_normalize_aio_seed",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -31522,9 +31921,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -31532,12 +31931,12 @@
         "compatibility_pair": {
           "bound_name": "_normalize_aio_spectrum_settings",
           "target": "easyuse_anima/aio/generation_normalization.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_spectrum_settings",
         "kind": "static_from",
-        "line": 586,
+        "line": 585,
         "name": "_normalize_aio_spectrum_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -31556,9 +31955,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -31566,12 +31965,12 @@
         "compatibility_pair": {
           "bound_name": "AIO_FINAL_FIT_MODES",
           "target": "easyuse_anima/aio/generation_defaults.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_FINAL_FIT_MODES",
         "kind": "static_from",
-        "line": 599,
+        "line": 598,
         "name": "AIO_FINAL_FIT_MODES",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_defaults",
@@ -31590,9 +31989,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -31600,12 +31999,12 @@
         "compatibility_pair": {
           "bound_name": "AIO_FINAL_UPSCALE_BACKENDS",
           "target": "easyuse_anima/aio/generation_defaults.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_FINAL_UPSCALE_BACKENDS",
         "kind": "static_from",
-        "line": 599,
+        "line": 598,
         "name": "AIO_FINAL_UPSCALE_BACKENDS",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_defaults",
@@ -31624,9 +32023,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -31634,12 +32033,12 @@
         "compatibility_pair": {
           "bound_name": "AIO_GENERATION_DEFAULT_SETTINGS",
           "target": "easyuse_anima/aio/generation_defaults.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_GENERATION_DEFAULT_SETTINGS",
         "kind": "static_from",
-        "line": 599,
+        "line": 598,
         "name": "AIO_GENERATION_DEFAULT_SETTINGS",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_defaults",
@@ -31658,9 +32057,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -31668,12 +32067,12 @@
         "compatibility_pair": {
           "bound_name": "AIO_GENERATION_SETTINGS_SCHEMA",
           "target": "easyuse_anima/aio/generation_defaults.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_GENERATION_SETTINGS_SCHEMA",
         "kind": "static_from",
-        "line": 599,
+        "line": 598,
         "name": "AIO_GENERATION_SETTINGS_SCHEMA",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_defaults",
@@ -31692,9 +32091,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -31702,12 +32101,12 @@
         "compatibility_pair": {
           "bound_name": "AIO_GENERATION_SETTINGS_VERSION",
           "target": "easyuse_anima/aio/generation_defaults.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_GENERATION_SETTINGS_VERSION",
         "kind": "static_from",
-        "line": 599,
+        "line": 598,
         "name": "AIO_GENERATION_SETTINGS_VERSION",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_defaults",
@@ -31726,9 +32125,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -31736,12 +32135,12 @@
         "compatibility_pair": {
           "bound_name": "AIO_RESHIFT_DTYPES",
           "target": "easyuse_anima/aio/generation_defaults.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_RESHIFT_DTYPES",
         "kind": "static_from",
-        "line": 599,
+        "line": 598,
         "name": "AIO_RESHIFT_DTYPES",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_defaults",
@@ -31760,9 +32159,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -31770,12 +32169,12 @@
         "compatibility_pair": {
           "bound_name": "AIO_RESHIFT_SCALES",
           "target": "easyuse_anima/aio/generation_defaults.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_RESHIFT_SCALES",
         "kind": "static_from",
-        "line": 599,
+        "line": 598,
         "name": "AIO_RESHIFT_SCALES",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_defaults",
@@ -31794,9 +32193,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -31804,12 +32203,12 @@
         "compatibility_pair": {
           "bound_name": "AIO_SPECIAL_SEEDS",
           "target": "easyuse_anima/aio/generation_defaults.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_SPECIAL_SEEDS",
         "kind": "static_from",
-        "line": 599,
+        "line": 598,
         "name": "AIO_SPECIAL_SEEDS",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_defaults",
@@ -31828,9 +32227,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -31838,12 +32237,12 @@
         "compatibility_pair": {
           "bound_name": "AIO_SPECIAL_SEED_DECREMENT",
           "target": "easyuse_anima/aio/generation_defaults.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_SPECIAL_SEED_DECREMENT",
         "kind": "static_from",
-        "line": 599,
+        "line": 598,
         "name": "AIO_SPECIAL_SEED_DECREMENT",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_defaults",
@@ -31862,9 +32261,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -31872,12 +32271,12 @@
         "compatibility_pair": {
           "bound_name": "AIO_SPECIAL_SEED_INCREMENT",
           "target": "easyuse_anima/aio/generation_defaults.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_SPECIAL_SEED_INCREMENT",
         "kind": "static_from",
-        "line": 599,
+        "line": 598,
         "name": "AIO_SPECIAL_SEED_INCREMENT",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_defaults",
@@ -31896,9 +32295,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -31906,12 +32305,12 @@
         "compatibility_pair": {
           "bound_name": "AIO_SPECIAL_SEED_RANDOM",
           "target": "easyuse_anima/aio/generation_defaults.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_SPECIAL_SEED_RANDOM",
         "kind": "static_from",
-        "line": 599,
+        "line": 598,
         "name": "AIO_SPECIAL_SEED_RANDOM",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_defaults",
@@ -31930,9 +32329,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -31940,12 +32339,12 @@
         "compatibility_pair": {
           "bound_name": "AIO_USDU_MODE_TYPES",
           "target": "easyuse_anima/aio/generation_defaults.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_USDU_MODE_TYPES",
         "kind": "static_from",
-        "line": 599,
+        "line": 598,
         "name": "AIO_USDU_MODE_TYPES",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_defaults",
@@ -31964,9 +32363,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -31974,12 +32373,12 @@
         "compatibility_pair": {
           "bound_name": "AIO_USDU_PROMPT_FULL",
           "target": "easyuse_anima/aio/generation_defaults.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_USDU_PROMPT_FULL",
         "kind": "static_from",
-        "line": 599,
+        "line": 598,
         "name": "AIO_USDU_PROMPT_FULL",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_defaults",
@@ -31998,9 +32397,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -32008,12 +32407,12 @@
         "compatibility_pair": {
           "bound_name": "AIO_USDU_PROMPT_MODES",
           "target": "easyuse_anima/aio/generation_defaults.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_USDU_PROMPT_MODES",
         "kind": "static_from",
-        "line": 599,
+        "line": 598,
         "name": "AIO_USDU_PROMPT_MODES",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_defaults",
@@ -32032,9 +32431,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -32042,12 +32441,12 @@
         "compatibility_pair": {
           "bound_name": "AIO_USDU_PROMPT_NO_GENERAL",
           "target": "easyuse_anima/aio/generation_defaults.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_USDU_PROMPT_NO_GENERAL",
         "kind": "static_from",
-        "line": 599,
+        "line": 598,
         "name": "AIO_USDU_PROMPT_NO_GENERAL",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_defaults",
@@ -32066,9 +32465,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -32076,12 +32475,12 @@
         "compatibility_pair": {
           "bound_name": "AIO_USDU_SEAM_FIX_MODES",
           "target": "easyuse_anima/aio/generation_defaults.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_USDU_SEAM_FIX_MODES",
         "kind": "static_from",
-        "line": 599,
+        "line": 598,
         "name": "AIO_USDU_SEAM_FIX_MODES",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_defaults",
@@ -32100,9 +32499,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -32110,12 +32509,12 @@
         "compatibility_pair": {
           "bound_name": "_round_trip_aio_generation_settings",
           "target": "easyuse_anima/aio/generation_settings.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_settings:round_trip_aio_generation_settings",
         "kind": "static_from",
-        "line": 617,
+        "line": 616,
         "name": "round_trip_aio_generation_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_settings",
@@ -32134,9 +32533,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -32144,12 +32543,12 @@
         "compatibility_pair": {
           "bound_name": "AIO_INPUT_DEFAULT_SETTINGS",
           "target": "easyuse_anima/aio/input_defaults.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.input_defaults:AIO_INPUT_DEFAULT_SETTINGS",
         "kind": "static_from",
-        "line": 620,
+        "line": 619,
         "name": "AIO_INPUT_DEFAULT_SETTINGS",
         "optional": false,
         "requested": "easyuse_anima.aio.input_defaults",
@@ -32168,9 +32567,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -32178,12 +32577,12 @@
         "compatibility_pair": {
           "bound_name": "ANIMA_CLIP_DEVICES",
           "target": "easyuse_anima/aio/input_defaults.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.input_defaults:ANIMA_CLIP_DEVICES",
         "kind": "static_from",
-        "line": 620,
+        "line": 619,
         "name": "ANIMA_CLIP_DEVICES",
         "optional": false,
         "requested": "easyuse_anima.aio.input_defaults",
@@ -32202,9 +32601,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -32212,12 +32611,12 @@
         "compatibility_pair": {
           "bound_name": "ANIMA_CLIP_TYPES",
           "target": "easyuse_anima/aio/input_defaults.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.input_defaults:ANIMA_CLIP_TYPES",
         "kind": "static_from",
-        "line": 620,
+        "line": 619,
         "name": "ANIMA_CLIP_TYPES",
         "optional": false,
         "requested": "easyuse_anima.aio.input_defaults",
@@ -32236,9 +32635,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -32246,12 +32645,12 @@
         "compatibility_pair": {
           "bound_name": "ANIMA_DEFAULT_CLIP_CANDIDATES",
           "target": "easyuse_anima/aio/input_defaults.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.input_defaults:ANIMA_DEFAULT_CLIP_CANDIDATES",
         "kind": "static_from",
-        "line": 620,
+        "line": 619,
         "name": "ANIMA_DEFAULT_CLIP_CANDIDATES",
         "optional": false,
         "requested": "easyuse_anima.aio.input_defaults",
@@ -32270,9 +32669,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -32280,12 +32679,12 @@
         "compatibility_pair": {
           "bound_name": "ANIMA_DEFAULT_DIFFUSION_MODEL_CANDIDATES",
           "target": "easyuse_anima/aio/input_defaults.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.input_defaults:ANIMA_DEFAULT_DIFFUSION_MODEL_CANDIDATES",
         "kind": "static_from",
-        "line": 620,
+        "line": 619,
         "name": "ANIMA_DEFAULT_DIFFUSION_MODEL_CANDIDATES",
         "optional": false,
         "requested": "easyuse_anima.aio.input_defaults",
@@ -32304,9 +32703,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -32314,12 +32713,12 @@
         "compatibility_pair": {
           "bound_name": "ANIMA_DEFAULT_VAE_CANDIDATES",
           "target": "easyuse_anima/aio/input_defaults.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.input_defaults:ANIMA_DEFAULT_VAE_CANDIDATES",
         "kind": "static_from",
-        "line": 620,
+        "line": 619,
         "name": "ANIMA_DEFAULT_VAE_CANDIDATES",
         "optional": false,
         "requested": "easyuse_anima.aio.input_defaults",
@@ -32338,9 +32737,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -32348,12 +32747,12 @@
         "compatibility_pair": {
           "bound_name": "ANIMA_UNET_WEIGHT_DTYPES",
           "target": "easyuse_anima/aio/input_defaults.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.input_defaults:ANIMA_UNET_WEIGHT_DTYPES",
         "kind": "static_from",
-        "line": 620,
+        "line": 619,
         "name": "ANIMA_UNET_WEIGHT_DTYPES",
         "optional": false,
         "requested": "easyuse_anima.aio.input_defaults",
@@ -32372,9 +32771,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -32382,12 +32781,12 @@
         "compatibility_pair": {
           "bound_name": "EASY_USE_ANIMA_INPUT_SCHEMA",
           "target": "easyuse_anima/aio/input_defaults.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.input_defaults:EASY_USE_ANIMA_INPUT_SCHEMA",
         "kind": "static_from",
-        "line": 620,
+        "line": 619,
         "name": "EASY_USE_ANIMA_INPUT_SCHEMA",
         "optional": false,
         "requested": "easyuse_anima.aio.input_defaults",
@@ -32406,9 +32805,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -32416,12 +32815,12 @@
         "compatibility_pair": {
           "bound_name": "EASY_USE_ANIMA_INPUT_SETTINGS_VERSION",
           "target": "easyuse_anima/aio/input_defaults.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.input_defaults:EASY_USE_ANIMA_INPUT_SETTINGS_VERSION",
         "kind": "static_from",
-        "line": 620,
+        "line": 619,
         "name": "EASY_USE_ANIMA_INPUT_SETTINGS_VERSION",
         "optional": false,
         "requested": "easyuse_anima.aio.input_defaults",
@@ -32440,9 +32839,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -32450,12 +32849,12 @@
         "compatibility_pair": {
           "bound_name": "_easy_use_anima_input_signature",
           "target": "easyuse_anima/aio/input_context.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.input_context:_easy_use_anima_input_signature",
         "kind": "static_from",
-        "line": 631,
+        "line": 630,
         "name": "_easy_use_anima_input_signature",
         "optional": false,
         "requested": "easyuse_anima.aio.input_context",
@@ -32474,9 +32873,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -32484,12 +32883,12 @@
         "compatibility_pair": {
           "bound_name": "_require_easy_use_anima_input",
           "target": "easyuse_anima/aio/input_context.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.input_context:_require_easy_use_anima_input",
         "kind": "static_from",
-        "line": 631,
+        "line": 630,
         "name": "_require_easy_use_anima_input",
         "optional": false,
         "requested": "easyuse_anima.aio.input_context",
@@ -32508,9 +32907,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -32518,12 +32917,12 @@
         "compatibility_pair": {
           "bound_name": "_aio_usdu_auto_tile_dimension",
           "target": "easyuse_anima/aio/usdu.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.usdu:_aio_usdu_auto_tile_dimension",
         "kind": "static_from",
-        "line": 635,
+        "line": 634,
         "name": "_aio_usdu_auto_tile_dimension",
         "optional": false,
         "requested": "easyuse_anima.aio.usdu",
@@ -32542,9 +32941,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -32552,12 +32951,12 @@
         "compatibility_pair": {
           "bound_name": "_aio_usdu_tile_plan",
           "target": "easyuse_anima/aio/usdu.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.usdu:_aio_usdu_tile_plan",
         "kind": "static_from",
-        "line": 635,
+        "line": 634,
         "name": "_aio_usdu_tile_plan",
         "optional": false,
         "requested": "easyuse_anima.aio.usdu",
@@ -32576,9 +32975,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -32586,12 +32985,12 @@
         "compatibility_pair": {
           "bound_name": "_aio_final_fit_size",
           "target": "easyuse_anima/aio/postprocess.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_aio_final_fit_size",
         "kind": "static_from",
-        "line": 639,
+        "line": 638,
         "name": "_aio_final_fit_size",
         "optional": false,
         "requested": "easyuse_anima.aio.postprocess",
@@ -32610,9 +33009,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -32620,12 +33019,12 @@
         "compatibility_pair": {
           "bound_name": "_apply_aio_final_fit",
           "target": "easyuse_anima/aio/postprocess.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_apply_aio_final_fit",
         "kind": "static_from",
-        "line": 639,
+        "line": 638,
         "name": "_apply_aio_final_fit",
         "optional": false,
         "requested": "easyuse_anima.aio.postprocess",
@@ -32644,9 +33043,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -32654,12 +33053,12 @@
         "compatibility_pair": {
           "bound_name": "_resize_image_to_size_if_needed",
           "target": "easyuse_anima/aio/postprocess.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_resize_image_to_size_if_needed",
         "kind": "static_from",
-        "line": 639,
+        "line": 638,
         "name": "_resize_image_to_size_if_needed",
         "optional": false,
         "requested": "easyuse_anima.aio.postprocess",
@@ -32678,9 +33077,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -32688,12 +33087,12 @@
         "compatibility_pair": {
           "bound_name": "_run_aio_postprocess_stage",
           "target": "easyuse_anima/aio/postprocess.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_run_aio_postprocess_stage",
         "kind": "static_from",
-        "line": 639,
+        "line": 638,
         "name": "_run_aio_postprocess_stage",
         "optional": false,
         "requested": "easyuse_anima.aio.postprocess",
@@ -32712,9 +33111,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -32722,12 +33121,12 @@
         "compatibility_pair": {
           "bound_name": "_aio_prompt_data_fields_for_usdu",
           "target": "easyuse_anima/aio/conditioning.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_prompt_data_fields_for_usdu",
         "kind": "static_from",
-        "line": 645,
+        "line": 644,
         "name": "_aio_prompt_data_fields_for_usdu",
         "optional": false,
         "requested": "easyuse_anima.aio.conditioning",
@@ -32746,9 +33145,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -32756,12 +33155,12 @@
         "compatibility_pair": {
           "bound_name": "_aio_usdu_conditioning",
           "target": "easyuse_anima/aio/conditioning.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_usdu_conditioning",
         "kind": "static_from",
-        "line": 645,
+        "line": 644,
         "name": "_aio_usdu_conditioning",
         "optional": false,
         "requested": "easyuse_anima.aio.conditioning",
@@ -32780,9 +33179,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -32790,12 +33189,12 @@
         "compatibility_pair": {
           "bound_name": "_aio_usdu_prompt_without_general",
           "target": "easyuse_anima/aio/conditioning.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_usdu_prompt_without_general",
         "kind": "static_from",
-        "line": 645,
+        "line": 644,
         "name": "_aio_usdu_prompt_without_general",
         "optional": false,
         "requested": "easyuse_anima.aio.conditioning",
@@ -32814,9 +33213,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -32824,12 +33223,12 @@
         "compatibility_pair": {
           "bound_name": "_aio_lora_stack_signature",
           "target": "easyuse_anima/aio/model_preparation.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_aio_lora_stack_signature",
         "kind": "static_from",
-        "line": 650,
+        "line": 649,
         "name": "_aio_lora_stack_signature",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -32848,9 +33247,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -32858,12 +33257,12 @@
         "compatibility_pair": {
           "bound_name": "_apply_aio_anima_dave_patch",
           "target": "easyuse_anima/aio/model_preparation.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_anima_dave_patch",
         "kind": "static_from",
-        "line": 650,
+        "line": 649,
         "name": "_apply_aio_anima_dave_patch",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -32882,9 +33281,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -32892,12 +33291,12 @@
         "compatibility_pair": {
           "bound_name": "_apply_aio_kj_model_patches",
           "target": "easyuse_anima/aio/model_preparation.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_kj_model_patches",
         "kind": "static_from",
-        "line": 650,
+        "line": 649,
         "name": "_apply_aio_kj_model_patches",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -32916,9 +33315,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -32926,12 +33325,12 @@
         "compatibility_pair": {
           "bound_name": "_apply_aio_lora_stack",
           "target": "easyuse_anima/aio/model_preparation.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_lora_stack",
         "kind": "static_from",
-        "line": 650,
+        "line": 649,
         "name": "_apply_aio_lora_stack",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -32950,9 +33349,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -32960,12 +33359,12 @@
         "compatibility_pair": {
           "bound_name": "_apply_aio_model_patches",
           "target": "easyuse_anima/aio/model_preparation.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_model_patches",
         "kind": "static_from",
-        "line": 650,
+        "line": 649,
         "name": "_apply_aio_model_patches",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -32984,9 +33383,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -32994,12 +33393,12 @@
         "compatibility_pair": {
           "bound_name": "_apply_aio_safe_pag_patch",
           "target": "easyuse_anima/aio/model_preparation.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_safe_pag_patch",
         "kind": "static_from",
-        "line": 650,
+        "line": 649,
         "name": "_apply_aio_safe_pag_patch",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -33018,9 +33417,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -33028,12 +33427,12 @@
         "compatibility_pair": {
           "bound_name": "_apply_aio_spectrum_correction_patch_for_comfy_sampler",
           "target": "easyuse_anima/aio/model_preparation.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_correction_patch_for_comfy_sampler",
         "kind": "static_from",
-        "line": 650,
+        "line": 649,
         "name": "_apply_aio_spectrum_correction_patch_for_comfy_sampler",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -33052,9 +33451,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -33062,12 +33461,12 @@
         "compatibility_pair": {
           "bound_name": "_apply_aio_spectrum_forecast_patch_for_comfy_sampler",
           "target": "easyuse_anima/aio/model_preparation.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_forecast_patch_for_comfy_sampler",
         "kind": "static_from",
-        "line": 650,
+        "line": 649,
         "name": "_apply_aio_spectrum_forecast_patch_for_comfy_sampler",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -33086,9 +33485,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -33096,12 +33495,12 @@
         "compatibility_pair": {
           "bound_name": "_apply_aio_spectrum_model_patches_for_comfy_sampler",
           "target": "easyuse_anima/aio/model_preparation.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_model_patches_for_comfy_sampler",
         "kind": "static_from",
-        "line": 650,
+        "line": 649,
         "name": "_apply_aio_spectrum_model_patches_for_comfy_sampler",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -33120,9 +33519,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -33130,12 +33529,12 @@
         "compatibility_pair": {
           "bound_name": "_cleanup_aio_ephemeral_model",
           "target": "easyuse_anima/aio/model_preparation.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_cleanup_aio_ephemeral_model",
         "kind": "static_from",
-        "line": 650,
+        "line": 649,
         "name": "_cleanup_aio_ephemeral_model",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -33154,9 +33553,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -33164,12 +33563,12 @@
         "compatibility_pair": {
           "bound_name": "_normalize_aio_lora_stack",
           "target": "easyuse_anima/aio/model_preparation.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_normalize_aio_lora_stack",
         "kind": "static_from",
-        "line": 650,
+        "line": 649,
         "name": "_normalize_aio_lora_stack",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -33188,9 +33587,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -33198,12 +33597,12 @@
         "compatibility_pair": {
           "bound_name": "_patch_model_sampling_aura_flow",
           "target": "easyuse_anima/aio/model_preparation.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_patch_model_sampling_aura_flow",
         "kind": "static_from",
-        "line": 650,
+        "line": 649,
         "name": "_patch_model_sampling_aura_flow",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -33222,9 +33621,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -33232,12 +33631,12 @@
         "compatibility_pair": {
           "bound_name": "_aio_highres_effective_backend",
           "target": "easyuse_anima/aio/sampling.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_aio_highres_effective_backend",
         "kind": "static_from",
-        "line": 664,
+        "line": 663,
         "name": "_aio_highres_effective_backend",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -33256,9 +33655,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -33266,12 +33665,12 @@
         "compatibility_pair": {
           "bound_name": "_aio_stage_sampler_settings",
           "target": "easyuse_anima/aio/sampling.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_aio_stage_sampler_settings",
         "kind": "static_from",
-        "line": 664,
+        "line": 663,
         "name": "_aio_stage_sampler_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -33290,9 +33689,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -33300,12 +33699,12 @@
         "compatibility_pair": {
           "bound_name": "_decode_latent_with_comfy",
           "target": "easyuse_anima/aio/sampling.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_decode_latent_with_comfy",
         "kind": "static_from",
-        "line": 664,
+        "line": 663,
         "name": "_decode_latent_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -33324,9 +33723,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -33334,12 +33733,12 @@
         "compatibility_pair": {
           "bound_name": "_encode_image_with_comfy_vae",
           "target": "easyuse_anima/aio/sampling.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_encode_image_with_comfy_vae",
         "kind": "static_from",
-        "line": 664,
+        "line": 663,
         "name": "_encode_image_with_comfy_vae",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -33358,9 +33757,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -33368,12 +33767,12 @@
         "compatibility_pair": {
           "bound_name": "_generate_empty_latent_with_comfy",
           "target": "easyuse_anima/aio/sampling.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_generate_empty_latent_with_comfy",
         "kind": "static_from",
-        "line": 664,
+        "line": 663,
         "name": "_generate_empty_latent_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -33392,9 +33791,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -33402,12 +33801,12 @@
         "compatibility_pair": {
           "bound_name": "_new_aio_random_seed",
           "target": "easyuse_anima/aio/sampling.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_new_aio_random_seed",
         "kind": "static_from",
-        "line": 664,
+        "line": 663,
         "name": "_new_aio_random_seed",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -33426,9 +33825,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -33436,12 +33835,12 @@
         "compatibility_pair": {
           "bound_name": "_resolve_aio_runtime_seed",
           "target": "easyuse_anima/aio/sampling.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_resolve_aio_runtime_seed",
         "kind": "static_from",
-        "line": 664,
+        "line": 663,
         "name": "_resolve_aio_runtime_seed",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -33460,9 +33859,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -33470,12 +33869,12 @@
         "compatibility_pair": {
           "bound_name": "_sample_latent_with_aio_backend",
           "target": "easyuse_anima/aio/sampling.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_aio_backend",
         "kind": "static_from",
-        "line": 664,
+        "line": 663,
         "name": "_sample_latent_with_aio_backend",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -33494,9 +33893,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -33504,12 +33903,12 @@
         "compatibility_pair": {
           "bound_name": "_sample_latent_with_comfy",
           "target": "easyuse_anima/aio/sampling.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_comfy",
         "kind": "static_from",
-        "line": 664,
+        "line": 663,
         "name": "_sample_latent_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -33528,9 +33927,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -33538,12 +33937,12 @@
         "compatibility_pair": {
           "bound_name": "_sample_latent_with_spectrum_mod_guidance_advanced",
           "target": "easyuse_anima/aio/sampling.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_spectrum_mod_guidance_advanced",
         "kind": "static_from",
-        "line": 664,
+        "line": 663,
         "name": "_sample_latent_with_spectrum_mod_guidance_advanced",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -33562,9 +33961,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -33572,12 +33971,12 @@
         "compatibility_pair": {
           "bound_name": "_sample_latent_with_spectrum_spd",
           "target": "easyuse_anima/aio/sampling.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_spectrum_spd",
         "kind": "static_from",
-        "line": 664,
+        "line": 663,
         "name": "_sample_latent_with_spectrum_spd",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -33596,9 +33995,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -33606,12 +34005,12 @@
         "compatibility_pair": {
           "bound_name": "AIO_PREVIEW_CACHE_FORMAT",
           "target": "easyuse_anima/aio/preview.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_CACHE_FORMAT",
         "kind": "static_from",
-        "line": 677,
+        "line": 676,
         "name": "AIO_PREVIEW_CACHE_FORMAT",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -33630,9 +34029,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -33640,12 +34039,12 @@
         "compatibility_pair": {
           "bound_name": "AIO_PREVIEW_CACHE_QUALITY",
           "target": "easyuse_anima/aio/preview.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_CACHE_QUALITY",
         "kind": "static_from",
-        "line": 677,
+        "line": 676,
         "name": "AIO_PREVIEW_CACHE_QUALITY",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -33664,9 +34063,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -33674,12 +34073,12 @@
         "compatibility_pair": {
           "bound_name": "AIO_PREVIEW_EVENT",
           "target": "easyuse_anima/aio/preview.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_EVENT",
         "kind": "static_from",
-        "line": 677,
+        "line": 676,
         "name": "AIO_PREVIEW_EVENT",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -33698,9 +34097,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -33708,12 +34107,12 @@
         "compatibility_pair": {
           "bound_name": "AIO_PREVIEW_STAGE_LABELS",
           "target": "easyuse_anima/aio/preview.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_STAGE_LABELS",
         "kind": "static_from",
-        "line": 677,
+        "line": 676,
         "name": "AIO_PREVIEW_STAGE_LABELS",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -33732,9 +34131,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -33742,12 +34141,12 @@
         "compatibility_pair": {
           "bound_name": "_aio_preview_base_directory",
           "target": "easyuse_anima/aio/preview.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_aio_preview_base_directory",
         "kind": "static_from",
-        "line": 677,
+        "line": 676,
         "name": "_aio_preview_base_directory",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -33766,9 +34165,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -33776,12 +34175,12 @@
         "compatibility_pair": {
           "bound_name": "_aio_preview_file_size_bytes",
           "target": "easyuse_anima/aio/preview.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_aio_preview_file_size_bytes",
         "kind": "static_from",
-        "line": 677,
+        "line": 676,
         "name": "_aio_preview_file_size_bytes",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -33800,9 +34199,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -33810,12 +34209,12 @@
         "compatibility_pair": {
           "bound_name": "_save_aio_temp_preview_image",
           "target": "easyuse_anima/aio/preview.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_save_aio_temp_preview_image",
         "kind": "static_from",
-        "line": 677,
+        "line": 676,
         "name": "_save_aio_temp_preview_image",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -33834,9 +34233,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -33844,12 +34243,12 @@
         "compatibility_pair": {
           "bound_name": "_send_aio_preview_event",
           "target": "easyuse_anima/aio/preview.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_send_aio_preview_event",
         "kind": "static_from",
-        "line": 677,
+        "line": 676,
         "name": "_send_aio_preview_event",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -33868,9 +34267,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -33878,12 +34277,12 @@
         "compatibility_pair": {
           "bound_name": "_tag_aio_preview_images",
           "target": "easyuse_anima/aio/preview.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_tag_aio_preview_images",
         "kind": "static_from",
-        "line": 677,
+        "line": 676,
         "name": "_tag_aio_preview_images",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -33902,9 +34301,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -33912,12 +34311,12 @@
         "compatibility_pair": {
           "bound_name": "_aio_image_saver_additional_hashes",
           "target": "easyuse_anima/aio/output.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_image_saver_additional_hashes",
         "kind": "static_from",
-        "line": 688,
+        "line": 687,
         "name": "_aio_image_saver_additional_hashes",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -33936,9 +34335,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -33946,12 +34345,12 @@
         "compatibility_pair": {
           "bound_name": "_aio_image_saver_civitai_hash_fetcher_entries",
           "target": "easyuse_anima/aio/output.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_image_saver_civitai_hash_fetcher_entries",
         "kind": "static_from",
-        "line": 688,
+        "line": 687,
         "name": "_aio_image_saver_civitai_hash_fetcher_entries",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -33970,9 +34369,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -33980,12 +34379,12 @@
         "compatibility_pair": {
           "bound_name": "_aio_lora_metadata_name",
           "target": "easyuse_anima/aio/output.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_lora_metadata_name",
         "kind": "static_from",
-        "line": 688,
+        "line": 687,
         "name": "_aio_lora_metadata_name",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -34004,9 +34403,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -34014,12 +34413,12 @@
         "compatibility_pair": {
           "bound_name": "_aio_prompt_with_lora_metadata",
           "target": "easyuse_anima/aio/output.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_prompt_with_lora_metadata",
         "kind": "static_from",
-        "line": 688,
+        "line": 687,
         "name": "_aio_prompt_with_lora_metadata",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -34038,9 +34437,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -34048,12 +34447,12 @@
         "compatibility_pair": {
           "bound_name": "_aio_save_filename_prefix",
           "target": "easyuse_anima/aio/output.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_save_filename_prefix",
         "kind": "static_from",
-        "line": 688,
+        "line": 687,
         "name": "_aio_save_filename_prefix",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -34072,9 +34471,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -34082,12 +34481,12 @@
         "compatibility_pair": {
           "bound_name": "_save_image_with_comfy",
           "target": "easyuse_anima/aio/output.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_save_image_with_comfy",
         "kind": "static_from",
-        "line": 688,
+        "line": 687,
         "name": "_save_image_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -34106,9 +34505,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -34116,12 +34515,12 @@
         "compatibility_pair": {
           "bound_name": "_save_image_with_image_saver",
           "target": "easyuse_anima/aio/output.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_save_image_with_image_saver",
         "kind": "static_from",
-        "line": 688,
+        "line": 687,
         "name": "_save_image_with_image_saver",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -34140,9 +34539,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -34150,12 +34549,12 @@
         "compatibility_pair": {
           "bound_name": "_normalize_aio_civitai_hash_fetchers",
           "target": "easyuse_anima/aio/output_settings.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.output_settings:_normalize_aio_civitai_hash_fetchers",
         "kind": "static_from",
-        "line": 697,
+        "line": 696,
         "name": "_normalize_aio_civitai_hash_fetchers",
         "optional": false,
         "requested": "easyuse_anima.aio.output_settings",
@@ -34174,9 +34573,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -34184,12 +34583,12 @@
         "compatibility_pair": {
           "bound_name": "_normalize_aio_hash_bundles",
           "target": "easyuse_anima/aio/output_settings.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.output_settings:_normalize_aio_hash_bundles",
         "kind": "static_from",
-        "line": 697,
+        "line": 696,
         "name": "_normalize_aio_hash_bundles",
         "optional": false,
         "requested": "easyuse_anima.aio.output_settings",
@@ -34208,9 +34607,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -34218,12 +34617,12 @@
         "compatibility_pair": {
           "bound_name": "_comfy_clip_loader_types",
           "target": "easyuse_anima/aio/resources.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_clip_loader_types",
         "kind": "static_from",
-        "line": 701,
+        "line": 700,
         "name": "_comfy_clip_loader_types",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -34242,9 +34641,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -34252,12 +34651,12 @@
         "compatibility_pair": {
           "bound_name": "_comfy_diffusion_model_names",
           "target": "easyuse_anima/aio/resources.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_diffusion_model_names",
         "kind": "static_from",
-        "line": 701,
+        "line": 700,
         "name": "_comfy_diffusion_model_names",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -34276,9 +34675,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -34286,12 +34685,12 @@
         "compatibility_pair": {
           "bound_name": "_comfy_text_encoder_names",
           "target": "easyuse_anima/aio/resources.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_text_encoder_names",
         "kind": "static_from",
-        "line": 701,
+        "line": 700,
         "name": "_comfy_text_encoder_names",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -34310,9 +34709,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -34320,12 +34719,12 @@
         "compatibility_pair": {
           "bound_name": "_comfy_vae_names",
           "target": "easyuse_anima/aio/resources.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_vae_names",
         "kind": "static_from",
-        "line": 701,
+        "line": 700,
         "name": "_comfy_vae_names",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -34344,9 +34743,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -34354,12 +34753,12 @@
         "compatibility_pair": {
           "bound_name": "_load_aio_resources_from_input_context",
           "target": "easyuse_anima/aio/resources.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_aio_resources_from_input_context",
         "kind": "static_from",
-        "line": 701,
+        "line": 700,
         "name": "_load_aio_resources_from_input_context",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -34378,9 +34777,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -34388,12 +34787,12 @@
         "compatibility_pair": {
           "bound_name": "_load_aio_sam3_context",
           "target": "easyuse_anima/aio/resources.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_aio_sam3_context",
         "kind": "static_from",
-        "line": 701,
+        "line": 700,
         "name": "_load_aio_sam3_context",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -34412,9 +34811,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -34422,12 +34821,12 @@
         "compatibility_pair": {
           "bound_name": "_load_checkpoint_with_comfy",
           "target": "easyuse_anima/aio/resources.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_checkpoint_with_comfy",
         "kind": "static_from",
-        "line": 701,
+        "line": 700,
         "name": "_load_checkpoint_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -34446,9 +34845,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -34456,12 +34855,12 @@
         "compatibility_pair": {
           "bound_name": "_load_clip_with_comfy",
           "target": "easyuse_anima/aio/resources.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_clip_with_comfy",
         "kind": "static_from",
-        "line": 701,
+        "line": 700,
         "name": "_load_clip_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -34480,9 +34879,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -34490,12 +34889,12 @@
         "compatibility_pair": {
           "bound_name": "_load_diffusion_model_with_comfy",
           "target": "easyuse_anima/aio/resources.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_diffusion_model_with_comfy",
         "kind": "static_from",
-        "line": 701,
+        "line": 700,
         "name": "_load_diffusion_model_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -34514,9 +34913,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -34524,12 +34923,12 @@
         "compatibility_pair": {
           "bound_name": "_load_upscale_model_with_comfy",
           "target": "easyuse_anima/aio/resources.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_upscale_model_with_comfy",
         "kind": "static_from",
-        "line": 701,
+        "line": 700,
         "name": "_load_upscale_model_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -34548,9 +34947,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -34558,12 +34957,12 @@
         "compatibility_pair": {
           "bound_name": "_load_vae_with_comfy",
           "target": "easyuse_anima/aio/resources.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_vae_with_comfy",
         "kind": "static_from",
-        "line": 701,
+        "line": 700,
         "name": "_load_vae_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -34582,9 +34981,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -34592,12 +34991,12 @@
         "compatibility_pair": {
           "bound_name": "_normalize_aio_input_settings",
           "target": "easyuse_anima/aio/resources.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_normalize_aio_input_settings",
         "kind": "static_from",
-        "line": 701,
+        "line": 700,
         "name": "_normalize_aio_input_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -34616,9 +35015,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -34626,12 +35025,12 @@
         "compatibility_pair": {
           "bound_name": "_preferred_checkpoint_default",
           "target": "easyuse_anima/aio/resources.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_checkpoint_default",
         "kind": "static_from",
-        "line": 701,
+        "line": 700,
         "name": "_preferred_checkpoint_default",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -34650,9 +35049,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -34660,12 +35059,12 @@
         "compatibility_pair": {
           "bound_name": "_preferred_clip_type_default",
           "target": "easyuse_anima/aio/resources.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_clip_type_default",
         "kind": "static_from",
-        "line": 701,
+        "line": 700,
         "name": "_preferred_clip_type_default",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -34684,9 +35083,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -34694,12 +35093,12 @@
         "compatibility_pair": {
           "bound_name": "_preferred_name_default",
           "target": "easyuse_anima/aio/resources.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_name_default",
         "kind": "static_from",
-        "line": 701,
+        "line": 700,
         "name": "_preferred_name_default",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -34718,9 +35117,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -34728,12 +35127,12 @@
         "compatibility_pair": {
           "bound_name": "_json_clone",
           "target": "easyuse_anima/common/serialization.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_json_clone",
         "kind": "static_from",
-        "line": 718,
+        "line": 717,
         "name": "_json_clone",
         "optional": false,
         "requested": "easyuse_anima.common.serialization",
@@ -34752,9 +35151,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -34762,12 +35161,12 @@
         "compatibility_pair": {
           "bound_name": "_json_object",
           "target": "easyuse_anima/common/serialization.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_json_object",
         "kind": "static_from",
-        "line": 718,
+        "line": 717,
         "name": "_json_object",
         "optional": false,
         "requested": "easyuse_anima.common.serialization",
@@ -34786,9 +35185,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -34796,12 +35195,12 @@
         "compatibility_pair": {
           "bound_name": "_stable_change_key",
           "target": "easyuse_anima/common/serialization.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_stable_change_key",
         "kind": "static_from",
-        "line": 718,
+        "line": 717,
         "name": "_stable_change_key",
         "optional": false,
         "requested": "easyuse_anima.common.serialization",
@@ -34820,9 +35219,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -34830,12 +35229,12 @@
         "compatibility_pair": {
           "bound_name": "_as_bool",
           "target": "easyuse_anima/common/values.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_bool",
         "kind": "static_from",
-        "line": 723,
+        "line": 722,
         "name": "_as_bool",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -34854,9 +35253,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -34864,12 +35263,12 @@
         "compatibility_pair": {
           "bound_name": "_as_float",
           "target": "easyuse_anima/common/values.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_float",
         "kind": "static_from",
-        "line": 723,
+        "line": 722,
         "name": "_as_float",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -34888,9 +35287,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -34898,12 +35297,12 @@
         "compatibility_pair": {
           "bound_name": "_as_int",
           "target": "easyuse_anima/common/values.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_int",
         "kind": "static_from",
-        "line": 723,
+        "line": 722,
         "name": "_as_int",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -34922,9 +35321,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -34932,12 +35331,12 @@
         "compatibility_pair": {
           "bound_name": "_choice",
           "target": "easyuse_anima/common/values.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.common.values:_choice",
         "kind": "static_from",
-        "line": 723,
+        "line": 722,
         "name": "_choice",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -34956,9 +35355,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -34966,12 +35365,12 @@
         "compatibility_pair": {
           "bound_name": "_single_value",
           "target": "easyuse_anima/common/values.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.common.values:_single_value",
         "kind": "static_from",
-        "line": 723,
+        "line": 722,
         "name": "_single_value",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -34990,9 +35389,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -35000,12 +35399,12 @@
         "compatibility_pair": {
           "bound_name": "WILDCARD_QUEUE_MAX_SAFE_SEED",
           "target": "easyuse_anima/seed/compatibility.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.seed.compatibility:WILDCARD_QUEUE_MAX_SAFE_SEED",
         "kind": "static_from",
-        "line": 730,
+        "line": 729,
         "name": "WILDCARD_QUEUE_MAX_SAFE_SEED",
         "optional": false,
         "requested": "easyuse_anima.seed.compatibility",
@@ -35024,9 +35423,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -35034,12 +35433,12 @@
         "compatibility_pair": {
           "bound_name": "WILDCARD_RESERVED_NEXT_SEED_INPUT",
           "target": "easyuse_anima/seed/compatibility.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.seed.compatibility:WILDCARD_RESERVED_NEXT_SEED_INPUT",
         "kind": "static_from",
-        "line": 730,
+        "line": 729,
         "name": "WILDCARD_RESERVED_NEXT_SEED_INPUT",
         "optional": false,
         "requested": "easyuse_anima.seed.compatibility",
@@ -35058,9 +35457,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -35068,12 +35467,12 @@
         "compatibility_pair": {
           "bound_name": "_consume_reserved_wildcard_next_seed",
           "target": "easyuse_anima/seed/compatibility.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.seed.compatibility:_consume_reserved_wildcard_next_seed",
         "kind": "static_from",
-        "line": 730,
+        "line": 729,
         "name": "_consume_reserved_wildcard_next_seed",
         "optional": false,
         "requested": "easyuse_anima.seed.compatibility",
@@ -35092,9 +35491,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -35102,12 +35501,12 @@
         "compatibility_pair": {
           "bound_name": "_get_workflow_node",
           "target": "easyuse_anima/workflow.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.workflow:_get_workflow_node",
         "kind": "static_from",
-        "line": 735,
+        "line": 734,
         "name": "_get_workflow_node",
         "optional": false,
         "requested": "easyuse_anima.workflow",
@@ -35126,9 +35525,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -35136,12 +35535,12 @@
         "compatibility_pair": {
           "bound_name": "_prompt_translation_change_key",
           "target": "easyuse_anima/prompt/correction.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_prompt_translation_change_key",
         "kind": "static_from",
-        "line": 736,
+        "line": 735,
         "name": "_prompt_translation_change_key",
         "optional": false,
         "requested": "easyuse_anima.prompt.correction",
@@ -35160,9 +35559,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -35170,12 +35569,12 @@
         "compatibility_pair": {
           "bound_name": "_split_tag_text",
           "target": "easyuse_anima/prompt/correction.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_split_tag_text",
         "kind": "static_from",
-        "line": 736,
+        "line": 735,
         "name": "_split_tag_text",
         "optional": false,
         "requested": "easyuse_anima.prompt.correction",
@@ -35194,9 +35593,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -35204,12 +35603,12 @@
         "compatibility_pair": {
           "bound_name": "_translate_prompt_text",
           "target": "easyuse_anima/prompt/correction.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_translate_prompt_text",
         "kind": "static_from",
-        "line": 736,
+        "line": 735,
         "name": "_translate_prompt_text",
         "optional": false,
         "requested": "easyuse_anima.prompt.correction",
@@ -35228,9 +35627,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -35238,12 +35637,12 @@
         "compatibility_pair": {
           "bound_name": "_HASH_COMMENT_RE",
           "target": "easyuse_anima/prompt/fields.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_HASH_COMMENT_RE",
         "kind": "static_from",
-        "line": 741,
+        "line": 740,
         "name": "_HASH_COMMENT_RE",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -35262,9 +35661,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -35272,12 +35671,12 @@
         "compatibility_pair": {
           "bound_name": "_INLINE_SPACE_RE",
           "target": "easyuse_anima/prompt/fields.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_INLINE_SPACE_RE",
         "kind": "static_from",
-        "line": 741,
+        "line": 740,
         "name": "_INLINE_SPACE_RE",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -35296,9 +35695,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -35306,12 +35705,12 @@
         "compatibility_pair": {
           "bound_name": "_WEIGHTED_TOKEN_RE",
           "target": "easyuse_anima/prompt/fields.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_WEIGHTED_TOKEN_RE",
         "kind": "static_from",
-        "line": 741,
+        "line": 740,
         "name": "_WEIGHTED_TOKEN_RE",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -35330,9 +35729,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -35340,12 +35739,12 @@
         "compatibility_pair": {
           "bound_name": "_correct_builder_prompt",
           "target": "easyuse_anima/prompt/fields.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_correct_builder_prompt",
         "kind": "static_from",
-        "line": 741,
+        "line": 740,
         "name": "_correct_builder_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -35364,9 +35763,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -35374,12 +35773,12 @@
         "compatibility_pair": {
           "bound_name": "_filter_metadata_prompt",
           "target": "easyuse_anima/prompt/fields.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_filter_metadata_prompt",
         "kind": "static_from",
-        "line": 741,
+        "line": 740,
         "name": "_filter_metadata_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -35398,9 +35797,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -35408,12 +35807,12 @@
         "compatibility_pair": {
           "bound_name": "_join_prompt_tokens",
           "target": "easyuse_anima/prompt/fields.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_join_prompt_tokens",
         "kind": "static_from",
-        "line": 741,
+        "line": 740,
         "name": "_join_prompt_tokens",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -35432,9 +35831,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -35442,12 +35841,12 @@
         "compatibility_pair": {
           "bound_name": "_metadata_filter_key",
           "target": "easyuse_anima/prompt/fields.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_metadata_filter_key",
         "kind": "static_from",
-        "line": 741,
+        "line": 740,
         "name": "_metadata_filter_key",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -35466,9 +35865,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -35476,12 +35875,12 @@
         "compatibility_pair": {
           "bound_name": "_metadata_filter_keys",
           "target": "easyuse_anima/prompt/fields.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_metadata_filter_keys",
         "kind": "static_from",
-        "line": 741,
+        "line": 740,
         "name": "_metadata_filter_keys",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -35500,9 +35899,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -35510,12 +35909,12 @@
         "compatibility_pair": {
           "bound_name": "_prompt_tokens",
           "target": "easyuse_anima/prompt/fields.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_prompt_tokens",
         "kind": "static_from",
-        "line": 741,
+        "line": 740,
         "name": "_prompt_tokens",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -35534,9 +35933,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -35544,12 +35943,12 @@
         "compatibility_pair": {
           "bound_name": "PROMPT_DATA_TYPE",
           "target": "easyuse_anima/prompt/data.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:PROMPT_DATA_TYPE",
         "kind": "static_from",
-        "line": 754,
+        "line": 753,
         "name": "PROMPT_DATA_TYPE",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -35568,9 +35967,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -35578,12 +35977,12 @@
         "compatibility_pair": {
           "bound_name": "_advanced_outputs_from_prompt_data",
           "target": "easyuse_anima/prompt/data.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_advanced_outputs_from_prompt_data",
         "kind": "static_from",
-        "line": 754,
+        "line": 753,
         "name": "_advanced_outputs_from_prompt_data",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -35602,9 +36001,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -35612,12 +36011,12 @@
         "compatibility_pair": {
           "bound_name": "_apply_prompt_data_overrides",
           "target": "easyuse_anima/prompt/data.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_apply_prompt_data_overrides",
         "kind": "static_from",
-        "line": 754,
+        "line": 753,
         "name": "_apply_prompt_data_overrides",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -35636,9 +36035,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -35646,12 +36045,12 @@
         "compatibility_pair": {
           "bound_name": "_copy_prompt_data_for_update",
           "target": "easyuse_anima/prompt/data.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_copy_prompt_data_for_update",
         "kind": "static_from",
-        "line": 754,
+        "line": 753,
         "name": "_copy_prompt_data_for_update",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -35670,9 +36069,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -35680,12 +36079,12 @@
         "compatibility_pair": {
           "bound_name": "_normalize_prompt_data",
           "target": "easyuse_anima/prompt/data.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_normalize_prompt_data",
         "kind": "static_from",
-        "line": 754,
+        "line": 753,
         "name": "_normalize_prompt_data",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -35704,9 +36103,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -35714,12 +36113,12 @@
         "compatibility_pair": {
           "bound_name": "_prompt_data_json_safe",
           "target": "easyuse_anima/prompt/data.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_prompt_data_json_safe",
         "kind": "static_from",
-        "line": 754,
+        "line": 753,
         "name": "_prompt_data_json_safe",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -35738,9 +36137,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -35748,12 +36147,12 @@
         "compatibility_pair": {
           "bound_name": "_prompt_data_parameter_snapshot",
           "target": "easyuse_anima/prompt/data.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_prompt_data_parameter_snapshot",
         "kind": "static_from",
-        "line": 754,
+        "line": 753,
         "name": "_prompt_data_parameter_snapshot",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -35772,9 +36171,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -35782,12 +36181,12 @@
         "compatibility_pair": {
           "bound_name": "_advanced_artist_field_prompt",
           "target": "easyuse_anima/prompt/advanced.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_artist_field_prompt",
         "kind": "static_from",
-        "line": 772,
+        "line": 771,
         "name": "_advanced_artist_field_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -35806,9 +36205,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -35816,12 +36215,12 @@
         "compatibility_pair": {
           "bound_name": "_advanced_default_fields",
           "target": "easyuse_anima/prompt/advanced.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_default_fields",
         "kind": "static_from",
-        "line": 772,
+        "line": 771,
         "name": "_advanced_default_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -35840,9 +36239,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -35850,12 +36249,12 @@
         "compatibility_pair": {
           "bound_name": "_advanced_enabled_naia_panes",
           "target": "easyuse_anima/prompt/advanced.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_enabled_naia_panes",
         "kind": "static_from",
-        "line": 772,
+        "line": 771,
         "name": "_advanced_enabled_naia_panes",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -35874,9 +36273,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -35884,12 +36283,12 @@
         "compatibility_pair": {
           "bound_name": "_advanced_enabled_pane_fields",
           "target": "easyuse_anima/prompt/advanced.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_enabled_pane_fields",
         "kind": "static_from",
-        "line": 772,
+        "line": 771,
         "name": "_advanced_enabled_pane_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -35908,9 +36307,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -35918,12 +36317,12 @@
         "compatibility_pair": {
           "bound_name": "_advanced_field_input_values",
           "target": "easyuse_anima/prompt/advanced.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_field_input_values",
         "kind": "static_from",
-        "line": 772,
+        "line": 771,
         "name": "_advanced_field_input_values",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -35942,9 +36341,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -35952,12 +36351,12 @@
         "compatibility_pair": {
           "bound_name": "_advanced_field_socket_name",
           "target": "easyuse_anima/prompt/advanced.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_field_socket_name",
         "kind": "static_from",
-        "line": 772,
+        "line": 771,
         "name": "_advanced_field_socket_name",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -35976,9 +36375,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -35986,12 +36385,12 @@
         "compatibility_pair": {
           "bound_name": "_advanced_fields_json",
           "target": "easyuse_anima/prompt/advanced.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_fields_json",
         "kind": "static_from",
-        "line": 772,
+        "line": 771,
         "name": "_advanced_fields_json",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -36010,9 +36409,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -36020,12 +36419,12 @@
         "compatibility_pair": {
           "bound_name": "_advanced_has_enabled_naia",
           "target": "easyuse_anima/prompt/advanced.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_has_enabled_naia",
         "kind": "static_from",
-        "line": 772,
+        "line": 771,
         "name": "_advanced_has_enabled_naia",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -36044,9 +36443,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -36054,12 +36453,12 @@
         "compatibility_pair": {
           "bound_name": "_advanced_prompt_with_artist_override",
           "target": "easyuse_anima/prompt/advanced.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_prompt_with_artist_override",
         "kind": "static_from",
-        "line": 772,
+        "line": 771,
         "name": "_advanced_prompt_with_artist_override",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -36078,9 +36477,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -36088,12 +36487,12 @@
         "compatibility_pair": {
           "bound_name": "_advanced_uses_naia_resolution",
           "target": "easyuse_anima/prompt/advanced.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_uses_naia_resolution",
         "kind": "static_from",
-        "line": 772,
+        "line": 771,
         "name": "_advanced_uses_naia_resolution",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -36112,9 +36511,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -36122,12 +36521,12 @@
         "compatibility_pair": {
           "bound_name": "_apply_advanced_field_inputs",
           "target": "easyuse_anima/prompt/advanced.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_apply_advanced_field_inputs",
         "kind": "static_from",
-        "line": 772,
+        "line": 771,
         "name": "_apply_advanced_field_inputs",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -36146,9 +36545,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -36156,12 +36555,12 @@
         "compatibility_pair": {
           "bound_name": "_as_advanced_height",
           "target": "easyuse_anima/prompt/advanced.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_as_advanced_height",
         "kind": "static_from",
-        "line": 772,
+        "line": 771,
         "name": "_as_advanced_height",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -36180,9 +36579,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -36190,12 +36589,12 @@
         "compatibility_pair": {
           "bound_name": "_build_advanced_prompt_data",
           "target": "easyuse_anima/prompt/advanced.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_build_advanced_prompt_data",
         "kind": "static_from",
-        "line": 772,
+        "line": 771,
         "name": "_build_advanced_prompt_data",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -36214,9 +36613,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -36224,12 +36623,12 @@
         "compatibility_pair": {
           "bound_name": "_build_advanced_prompts",
           "target": "easyuse_anima/prompt/advanced.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_build_advanced_prompts",
         "kind": "static_from",
-        "line": 772,
+        "line": 771,
         "name": "_build_advanced_prompts",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -36248,9 +36647,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -36258,12 +36657,12 @@
         "compatibility_pair": {
           "bound_name": "_clone_advanced_fields",
           "target": "easyuse_anima/prompt/advanced.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_clone_advanced_fields",
         "kind": "static_from",
-        "line": 772,
+        "line": 771,
         "name": "_clone_advanced_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -36282,9 +36681,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -36292,12 +36691,12 @@
         "compatibility_pair": {
           "bound_name": "_correct_advanced_field_sequence",
           "target": "easyuse_anima/prompt/advanced.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_correct_advanced_field_sequence",
         "kind": "static_from",
-        "line": 772,
+        "line": 771,
         "name": "_correct_advanced_field_sequence",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -36316,9 +36715,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -36326,12 +36725,12 @@
         "compatibility_pair": {
           "bound_name": "_expand_advanced_wildcard_fields",
           "target": "easyuse_anima/prompt/advanced.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_expand_advanced_wildcard_fields",
         "kind": "static_from",
-        "line": 772,
+        "line": 771,
         "name": "_expand_advanced_wildcard_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -36350,9 +36749,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -36360,12 +36759,12 @@
         "compatibility_pair": {
           "bound_name": "_normalize_advanced_fields",
           "target": "easyuse_anima/prompt/advanced.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_normalize_advanced_fields",
         "kind": "static_from",
-        "line": 772,
+        "line": 771,
         "name": "_normalize_advanced_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -36384,9 +36783,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -36394,12 +36793,12 @@
         "compatibility_pair": {
           "bound_name": "_normalize_prompt_studio_wildcard_seed_control",
           "target": "easyuse_anima/prompt/advanced.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_normalize_prompt_studio_wildcard_seed_control",
         "kind": "static_from",
-        "line": 772,
+        "line": 771,
         "name": "_normalize_prompt_studio_wildcard_seed_control",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -36418,9 +36817,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -36428,12 +36827,12 @@
         "compatibility_pair": {
           "bound_name": "_set_naia_field_text",
           "target": "easyuse_anima/prompt/advanced.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_set_naia_field_text",
         "kind": "static_from",
-        "line": 772,
+        "line": 771,
         "name": "_set_naia_field_text",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -36452,9 +36851,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -36462,12 +36861,12 @@
         "compatibility_pair": {
           "bound_name": "_translate_prompt_fields",
           "target": "easyuse_anima/prompt/advanced.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_translate_prompt_fields",
         "kind": "static_from",
-        "line": 772,
+        "line": 771,
         "name": "_translate_prompt_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -36486,9 +36885,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -36496,12 +36895,12 @@
         "compatibility_pair": {
           "bound_name": "_apply_regional_field_inputs",
           "target": "easyuse_anima/prompt/regional.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_apply_regional_field_inputs",
         "kind": "static_from",
-        "line": 807,
+        "line": 806,
         "name": "_apply_regional_field_inputs",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -36520,9 +36919,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -36530,12 +36929,12 @@
         "compatibility_pair": {
           "bound_name": "_build_regional_outputs",
           "target": "easyuse_anima/prompt/regional.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_build_regional_outputs",
         "kind": "static_from",
-        "line": 807,
+        "line": 806,
         "name": "_build_regional_outputs",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -36554,9 +36953,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -36564,12 +36963,12 @@
         "compatibility_pair": {
           "bound_name": "_clone_regional_fields",
           "target": "easyuse_anima/prompt/regional.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_clone_regional_fields",
         "kind": "static_from",
-        "line": 807,
+        "line": 806,
         "name": "_clone_regional_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -36588,9 +36987,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -36598,12 +36997,12 @@
         "compatibility_pair": {
           "bound_name": "_conditioning_set_values",
           "target": "easyuse_anima/prompt/regional.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_conditioning_set_values",
         "kind": "static_from",
-        "line": 807,
+        "line": 806,
         "name": "_conditioning_set_values",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -36622,9 +37021,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -36632,12 +37031,12 @@
         "compatibility_pair": {
           "bound_name": "_normalize_mask_ids",
           "target": "easyuse_anima/prompt/regional.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_mask_ids",
         "kind": "static_from",
-        "line": 807,
+        "line": 806,
         "name": "_normalize_mask_ids",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -36656,9 +37055,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -36666,12 +37065,12 @@
         "compatibility_pair": {
           "bound_name": "_normalize_regional_config",
           "target": "easyuse_anima/prompt/regional.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_regional_config",
         "kind": "static_from",
-        "line": 807,
+        "line": 806,
         "name": "_normalize_regional_config",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -36690,9 +37089,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -36700,12 +37099,12 @@
         "compatibility_pair": {
           "bound_name": "_normalize_regional_fields",
           "target": "easyuse_anima/prompt/regional.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_regional_fields",
         "kind": "static_from",
-        "line": 807,
+        "line": 806,
         "name": "_normalize_regional_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -36724,9 +37123,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -36734,12 +37133,12 @@
         "compatibility_pair": {
           "bound_name": "_parse_json_object",
           "target": "easyuse_anima/prompt/regional.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_parse_json_object",
         "kind": "static_from",
-        "line": 807,
+        "line": 806,
         "name": "_parse_json_object",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -36758,9 +37157,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -36768,12 +37167,12 @@
         "compatibility_pair": {
           "bound_name": "_regional_config_json",
           "target": "easyuse_anima/prompt/regional.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_config_json",
         "kind": "static_from",
-        "line": 807,
+        "line": 806,
         "name": "_regional_config_json",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -36792,9 +37191,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -36802,12 +37201,12 @@
         "compatibility_pair": {
           "bound_name": "_regional_fields_json",
           "target": "easyuse_anima/prompt/regional.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_fields_json",
         "kind": "static_from",
-        "line": 807,
+        "line": 806,
         "name": "_regional_fields_json",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -36826,9 +37225,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -36836,12 +37235,12 @@
         "compatibility_pair": {
           "bound_name": "_regional_mask_bounds_area",
           "target": "easyuse_anima/prompt/regional.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_mask_bounds_area",
         "kind": "static_from",
-        "line": 807,
+        "line": 806,
         "name": "_regional_mask_bounds_area",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -36860,9 +37259,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -36870,12 +37269,12 @@
         "compatibility_pair": {
           "bound_name": "_regional_payload_canvas",
           "target": "easyuse_anima/prompt/regional.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_payload_canvas",
         "kind": "static_from",
-        "line": 807,
+        "line": 806,
         "name": "_regional_payload_canvas",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -36894,9 +37293,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -36904,12 +37303,12 @@
         "compatibility_pair": {
           "bound_name": "_regional_union_mask_for_ids",
           "target": "easyuse_anima/prompt/regional.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_union_mask_for_ids",
         "kind": "static_from",
-        "line": 807,
+        "line": 806,
         "name": "_regional_union_mask_for_ids",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -36928,9 +37327,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -36938,12 +37337,12 @@
         "compatibility_pair": {
           "bound_name": "ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
           "target": "easyuse_anima/prompt/conditioning.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
         "kind": "static_from",
-        "line": 834,
+        "line": 833,
         "name": "ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -36962,9 +37361,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -36972,12 +37371,12 @@
         "compatibility_pair": {
           "bound_name": "ANIMA_MOD_GUIDANCE_MODES",
           "target": "easyuse_anima/prompt/conditioning.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODES",
         "kind": "static_from",
-        "line": 834,
+        "line": 833,
         "name": "ANIMA_MOD_GUIDANCE_MODES",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -36996,9 +37395,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -37006,12 +37405,12 @@
         "compatibility_pair": {
           "bound_name": "ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
           "target": "easyuse_anima/prompt/conditioning.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 834,
+        "line": 833,
         "name": "ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -37030,9 +37429,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -37040,12 +37439,12 @@
         "compatibility_pair": {
           "bound_name": "ANIMA_MOD_GUIDANCE_PROFILE_OFF",
           "target": "easyuse_anima/prompt/conditioning.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_PROFILE_OFF",
         "kind": "static_from",
-        "line": 834,
+        "line": 833,
         "name": "ANIMA_MOD_GUIDANCE_PROFILE_OFF",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -37064,9 +37463,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -37074,12 +37473,12 @@
         "compatibility_pair": {
           "bound_name": "_apply_spectrum_anima_mod_guidance",
           "target": "easyuse_anima/prompt/conditioning.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_apply_spectrum_anima_mod_guidance",
         "kind": "static_from",
-        "line": 834,
+        "line": 833,
         "name": "_apply_spectrum_anima_mod_guidance",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -37098,9 +37497,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -37108,12 +37507,12 @@
         "compatibility_pair": {
           "bound_name": "_find_spectrum_anima_mod_guidance_class",
           "target": "easyuse_anima/prompt/conditioning.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_find_spectrum_anima_mod_guidance_class",
         "kind": "static_from",
-        "line": 834,
+        "line": 833,
         "name": "_find_spectrum_anima_mod_guidance_class",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -37132,9 +37531,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -37142,12 +37541,12 @@
         "compatibility_pair": {
           "bound_name": "_normalize_anima_mod_guidance_profile",
           "target": "easyuse_anima/prompt/conditioning.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_normalize_anima_mod_guidance_profile",
         "kind": "static_from",
-        "line": 834,
+        "line": 833,
         "name": "_normalize_anima_mod_guidance_profile",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -37166,9 +37565,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -37176,12 +37575,12 @@
         "compatibility_pair": {
           "bound_name": "_resolve_anima_mod_guidance_enabled",
           "target": "easyuse_anima/prompt/conditioning.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_resolve_anima_mod_guidance_enabled",
         "kind": "static_from",
-        "line": 834,
+        "line": 833,
         "name": "_resolve_anima_mod_guidance_enabled",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -37200,9 +37599,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -37210,12 +37609,12 @@
         "compatibility_pair": {
           "bound_name": "ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
           "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
         "kind": "static_from",
-        "line": 849,
+        "line": 848,
         "name": "ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -37234,9 +37633,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -37244,12 +37643,12 @@
         "compatibility_pair": {
           "bound_name": "ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
           "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
         "kind": "static_from",
-        "line": 849,
+        "line": 848,
         "name": "ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -37268,9 +37667,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -37278,12 +37677,12 @@
         "compatibility_pair": {
           "bound_name": "ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
           "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
         "kind": "static_from",
-        "line": 849,
+        "line": 848,
         "name": "ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -37302,9 +37701,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -37312,12 +37711,12 @@
         "compatibility_pair": {
           "bound_name": "ARTIST_MIX_DEFAULT_EXACT_TOP_K",
           "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_EXACT_TOP_K",
         "kind": "static_from",
-        "line": 849,
+        "line": 848,
         "name": "ARTIST_MIX_DEFAULT_EXACT_TOP_K",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -37336,9 +37735,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -37346,12 +37745,12 @@
         "compatibility_pair": {
           "bound_name": "ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
           "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
         "kind": "static_from",
-        "line": 849,
+        "line": 848,
         "name": "ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -37370,9 +37769,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -37380,12 +37779,12 @@
         "compatibility_pair": {
           "bound_name": "ARTIST_MIX_DEFAULT_START_PERCENT",
           "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_START_PERCENT",
         "kind": "static_from",
-        "line": 849,
+        "line": 848,
         "name": "ARTIST_MIX_DEFAULT_START_PERCENT",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -37404,9 +37803,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -37414,12 +37813,12 @@
         "compatibility_pair": {
           "bound_name": "ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
           "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
         "kind": "static_from",
-        "line": 849,
+        "line": 848,
         "name": "ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -37438,9 +37837,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -37448,12 +37847,12 @@
         "compatibility_pair": {
           "bound_name": "ARTIST_MIX_DEFAULT_STYLE_GAIN",
           "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STYLE_GAIN",
         "kind": "static_from",
-        "line": 849,
+        "line": 848,
         "name": "ARTIST_MIX_DEFAULT_STYLE_GAIN",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -37472,9 +37871,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -37482,12 +37881,12 @@
         "compatibility_pair": {
           "bound_name": "ARTIST_MIX_INPUT_MODES",
           "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_INPUT_MODES",
         "kind": "static_from",
-        "line": 849,
+        "line": 848,
         "name": "ARTIST_MIX_INPUT_MODES",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -37506,9 +37905,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -37516,12 +37915,12 @@
         "compatibility_pair": {
           "bound_name": "ARTIST_MIX_MODE_FROM_PROMPT_DATA",
           "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 849,
+        "line": 848,
         "name": "ARTIST_MIX_MODE_FROM_PROMPT_DATA",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -37540,9 +37939,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -37550,12 +37949,12 @@
         "compatibility_pair": {
           "bound_name": "_artist_mix_inline_prompt",
           "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_mix_inline_prompt",
         "kind": "static_from",
-        "line": 849,
+        "line": 848,
         "name": "_artist_mix_inline_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -37574,9 +37973,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -37584,12 +37983,12 @@
         "compatibility_pair": {
           "bound_name": "_artist_mix_mode_tooltip",
           "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_mix_mode_tooltip",
         "kind": "static_from",
-        "line": 849,
+        "line": 848,
         "name": "_artist_mix_mode_tooltip",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -37608,9 +38007,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -37618,12 +38017,12 @@
         "compatibility_pair": {
           "bound_name": "_artist_prompt_with_position",
           "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_prompt_with_position",
         "kind": "static_from",
-        "line": 849,
+        "line": 848,
         "name": "_artist_prompt_with_position",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -37642,9 +38041,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -37652,12 +38051,12 @@
         "compatibility_pair": {
           "bound_name": "_artist_tags_from_prompt",
           "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_tags_from_prompt",
         "kind": "static_from",
-        "line": 849,
+        "line": 848,
         "name": "_artist_tags_from_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -37676,9 +38075,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -37686,12 +38085,12 @@
         "compatibility_pair": {
           "bound_name": "_blend_conditionings",
           "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_blend_conditionings",
         "kind": "static_from",
-        "line": 849,
+        "line": 848,
         "name": "_blend_conditionings",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -37710,9 +38109,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -37720,12 +38119,12 @@
         "compatibility_pair": {
           "bound_name": "_bounded_artist_mix_float",
           "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bounded_artist_mix_float",
         "kind": "static_from",
-        "line": 849,
+        "line": 848,
         "name": "_bounded_artist_mix_float",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -37744,9 +38143,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -37754,12 +38153,12 @@
         "compatibility_pair": {
           "bound_name": "_bounded_artist_mix_int",
           "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bounded_artist_mix_int",
         "kind": "static_from",
-        "line": 849,
+        "line": 848,
         "name": "_bounded_artist_mix_int",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -37778,9 +38177,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -37788,12 +38187,12 @@
         "compatibility_pair": {
           "bound_name": "_encode_artist_clustered",
           "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_clustered",
         "kind": "static_from",
-        "line": 849,
+        "line": 848,
         "name": "_encode_artist_clustered",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -37812,9 +38211,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -37822,12 +38221,12 @@
         "compatibility_pair": {
           "bound_name": "_encode_artist_delta_rms",
           "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_delta_rms",
         "kind": "static_from",
-        "line": 849,
+        "line": 848,
         "name": "_encode_artist_delta_rms",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -37846,9 +38245,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -37856,12 +38255,12 @@
         "compatibility_pair": {
           "bound_name": "_encode_prompt_data_positive_conditioning",
           "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_prompt_data_positive_conditioning",
         "kind": "static_from",
-        "line": 849,
+        "line": 848,
         "name": "_encode_prompt_data_positive_conditioning",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -37880,9 +38279,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -37890,12 +38289,12 @@
         "compatibility_pair": {
           "bound_name": "_join_artist_mix_source_prompts",
           "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_join_artist_mix_source_prompts",
         "kind": "static_from",
-        "line": 849,
+        "line": 848,
         "name": "_join_artist_mix_source_prompts",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -37914,9 +38313,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -37924,12 +38323,12 @@
         "compatibility_pair": {
           "bound_name": "_normalize_artist_mix_mode",
           "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_normalize_artist_mix_mode",
         "kind": "static_from",
-        "line": 849,
+        "line": 848,
         "name": "_normalize_artist_mix_mode",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -37948,9 +38347,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -37958,12 +38357,12 @@
         "compatibility_pair": {
           "bound_name": "_normalize_artist_tag_position",
           "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_normalize_artist_tag_position",
         "kind": "static_from",
-        "line": 849,
+        "line": 848,
         "name": "_normalize_artist_tag_position",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -37982,9 +38381,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -37992,12 +38391,12 @@
         "compatibility_pair": {
           "bound_name": "_parse_artist_mix_items",
           "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_parse_artist_mix_items",
         "kind": "static_from",
-        "line": 849,
+        "line": 848,
         "name": "_parse_artist_mix_items",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -38016,9 +38415,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -38026,12 +38425,12 @@
         "compatibility_pair": {
           "bound_name": "EasyUseAnimaArtistMixConditioning",
           "target": "easyuse_anima/nodes/prompt_data_nodes.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaArtistMixConditioning",
         "kind": "static_from",
-        "line": 928,
+        "line": 927,
         "name": "EasyUseAnimaArtistMixConditioning",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_data_nodes",
@@ -38050,9 +38449,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -38060,12 +38459,12 @@
         "compatibility_pair": {
           "bound_name": "EasyUseAnimaPromptDataConditioning",
           "target": "easyuse_anima/nodes/prompt_data_nodes.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataConditioning",
         "kind": "static_from",
-        "line": 928,
+        "line": 927,
         "name": "EasyUseAnimaPromptDataConditioning",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_data_nodes",
@@ -38084,9 +38483,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -38094,12 +38493,12 @@
         "compatibility_pair": {
           "bound_name": "EasyUseAnimaPromptDataUnpack",
           "target": "easyuse_anima/nodes/prompt_data_nodes.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataUnpack",
         "kind": "static_from",
-        "line": 928,
+        "line": 927,
         "name": "EasyUseAnimaPromptDataUnpack",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_data_nodes",
@@ -38118,9 +38517,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -38128,12 +38527,12 @@
         "compatibility_pair": {
           "bound_name": "_ANY_TYPE",
           "target": "easyuse_anima/nodes/input_types.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_ANY_TYPE",
         "kind": "static_from",
-        "line": 933,
+        "line": 932,
         "name": "_ANY_TYPE",
         "optional": false,
         "requested": "easyuse_anima.nodes.input_types",
@@ -38152,9 +38551,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -38162,12 +38561,12 @@
         "compatibility_pair": {
           "bound_name": "_AnyType",
           "target": "easyuse_anima/nodes/input_types.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_AnyType",
         "kind": "static_from",
-        "line": 933,
+        "line": 932,
         "name": "_AnyType",
         "optional": false,
         "requested": "easyuse_anima.nodes.input_types",
@@ -38186,9 +38585,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -38196,12 +38595,12 @@
         "compatibility_pair": {
           "bound_name": "_FlexibleOptionalInputType",
           "target": "easyuse_anima/nodes/input_types.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_FlexibleOptionalInputType",
         "kind": "static_from",
-        "line": 933,
+        "line": 932,
         "name": "_FlexibleOptionalInputType",
         "optional": false,
         "requested": "easyuse_anima.nodes.input_types",
@@ -38220,9 +38619,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -38230,12 +38629,12 @@
         "compatibility_pair": {
           "bound_name": "EasyUseAnimaPromptStudioAdvanced",
           "target": "easyuse_anima/nodes/prompt_advanced_nodes.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvanced",
         "kind": "static_from",
-        "line": 938,
+        "line": 937,
         "name": "EasyUseAnimaPromptStudioAdvanced",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_advanced_nodes",
@@ -38254,9 +38653,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -38264,12 +38663,12 @@
         "compatibility_pair": {
           "bound_name": "EasyUseAnimaPromptStudioAdvancedV2",
           "target": "easyuse_anima/nodes/prompt_advanced_nodes.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvancedV2",
         "kind": "static_from",
-        "line": 938,
+        "line": 937,
         "name": "EasyUseAnimaPromptStudioAdvancedV2",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_advanced_nodes",
@@ -38277,6 +38676,40 @@
         "scope": "<module>",
         "source": "nodes.py",
         "target": "easyuse_anima/nodes/prompt_advanced_nodes.py"
+      },
+      {
+        "alias": "EASY_USE_ANIMA_INPUT_TYPE",
+        "bound_name": "EASY_USE_ANIMA_INPUT_TYPE",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 565,
+            "kind": "try",
+            "line": 6
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "EASY_USE_ANIMA_INPUT_TYPE",
+          "target": "easyuse_anima/nodes/aio_nodes.py",
+          "try_line": 6
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.nodes.aio_nodes:EASY_USE_ANIMA_INPUT_TYPE",
+        "kind": "static_from",
+        "line": 942,
+        "name": "EASY_USE_ANIMA_INPUT_TYPE",
+        "optional": false,
+        "requested": "easyuse_anima.nodes.aio_nodes",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/nodes/aio_nodes.py"
       },
       {
         "alias": "EasyUseAnimaAIOGenerator",
@@ -38288,9 +38721,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -38298,12 +38731,12 @@
         "compatibility_pair": {
           "bound_name": "EasyUseAnimaAIOGenerator",
           "target": "easyuse_anima/nodes/aio_nodes.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:EasyUseAnimaAIOGenerator",
         "kind": "static_from",
-        "line": 943,
+        "line": 942,
         "name": "EasyUseAnimaAIOGenerator",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -38322,9 +38755,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -38332,12 +38765,12 @@
         "compatibility_pair": {
           "bound_name": "EasyUseAnimaInput",
           "target": "easyuse_anima/nodes/aio_nodes.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:EasyUseAnimaInput",
         "kind": "static_from",
-        "line": 943,
+        "line": 942,
         "name": "EasyUseAnimaInput",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -38356,9 +38789,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -38366,12 +38799,12 @@
         "compatibility_pair": {
           "bound_name": "_aio_generation_settings_json",
           "target": "easyuse_anima/nodes/aio_nodes.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_aio_generation_settings_json",
         "kind": "static_from",
-        "line": 943,
+        "line": 942,
         "name": "_aio_generation_settings_json",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -38390,9 +38823,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -38400,47 +38833,13 @@
         "compatibility_pair": {
           "bound_name": "_aio_input_settings_json",
           "target": "easyuse_anima/nodes/aio_nodes.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_aio_input_settings_json",
         "kind": "static_from",
-        "line": 943,
+        "line": 942,
         "name": "_aio_input_settings_json",
-        "optional": false,
-        "requested": "easyuse_anima.nodes.aio_nodes",
-        "role": "compatibility_fallback",
-        "scope": "<module>",
-        "source": "nodes.py",
-        "target": "easyuse_anima/nodes/aio_nodes.py"
-      },
-      {
-        "alias": "_bind_aio_node_runtime",
-        "bound_name": "_bind_aio_node_runtime",
-        "branch_context": [
-          {
-            "branch": "except",
-            "catches_import_error": true,
-            "exceptions": [
-              "ImportError"
-            ],
-            "handler_line": 566,
-            "kind": "try",
-            "line": 7
-          }
-        ],
-        "classification": "compatibility_fallback",
-        "column": 4,
-        "compatibility_pair": {
-          "bound_name": "_bind_aio_node_runtime",
-          "target": "easyuse_anima/nodes/aio_nodes.py",
-          "try_line": 7
-        },
-        "conditional": true,
-        "imported": "easyuse_anima.nodes.aio_nodes:_bind_aio_node_runtime",
-        "kind": "static_from",
-        "line": 943,
-        "name": "_bind_aio_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
         "role": "compatibility_fallback",
@@ -38458,9 +38857,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -38468,12 +38867,12 @@
         "compatibility_pair": {
           "bound_name": "_align_down",
           "target": "easyuse_anima/image/geometry.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_align_down",
         "kind": "static_from",
-        "line": 950,
+        "line": 949,
         "name": "_align_down",
         "optional": false,
         "requested": "easyuse_anima.image.geometry",
@@ -38492,9 +38891,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -38502,12 +38901,12 @@
         "compatibility_pair": {
           "bound_name": "_align_nearest",
           "target": "easyuse_anima/image/geometry.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_align_nearest",
         "kind": "static_from",
-        "line": 950,
+        "line": 949,
         "name": "_align_nearest",
         "optional": false,
         "requested": "easyuse_anima.image.geometry",
@@ -38526,9 +38925,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -38536,12 +38935,12 @@
         "compatibility_pair": {
           "bound_name": "_image_tensor_size",
           "target": "easyuse_anima/image/geometry.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_image_tensor_size",
         "kind": "static_from",
-        "line": 950,
+        "line": 949,
         "name": "_image_tensor_size",
         "optional": false,
         "requested": "easyuse_anima.image.geometry",
@@ -38560,9 +38959,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -38570,12 +38969,12 @@
         "compatibility_pair": {
           "bound_name": "_context_value",
           "target": "easyuse_anima/image/sam3.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_context_value",
         "kind": "static_from",
-        "line": 961,
+        "line": 960,
         "name": "_context_value",
         "optional": false,
         "requested": "easyuse_anima.image.sam3",
@@ -38594,9 +38993,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -38604,12 +39003,12 @@
         "compatibility_pair": {
           "bound_name": "_sam3_context",
           "target": "easyuse_anima/image/sam3.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_sam3_context",
         "kind": "static_from",
-        "line": 961,
+        "line": 960,
         "name": "_sam3_context",
         "optional": false,
         "requested": "easyuse_anima.image.sam3",
@@ -38628,9 +39027,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -38638,12 +39037,12 @@
         "compatibility_pair": {
           "bound_name": "_segs_has_items",
           "target": "easyuse_anima/image/sam3.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_segs_has_items",
         "kind": "static_from",
-        "line": 961,
+        "line": 960,
         "name": "_segs_has_items",
         "optional": false,
         "requested": "easyuse_anima.image.sam3",
@@ -38662,9 +39061,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -38672,12 +39071,12 @@
         "compatibility_pair": {
           "bound_name": "IMAGE_SCALE_MULTIPLES",
           "target": "easyuse_anima/image/scaling.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:IMAGE_SCALE_MULTIPLES",
         "kind": "static_from",
-        "line": 973,
+        "line": 972,
         "name": "IMAGE_SCALE_MULTIPLES",
         "optional": false,
         "requested": "easyuse_anima.image.scaling",
@@ -38696,9 +39095,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -38706,12 +39105,12 @@
         "compatibility_pair": {
           "bound_name": "IMAGE_UPSCALE_METHODS",
           "target": "easyuse_anima/image/scaling.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:IMAGE_UPSCALE_METHODS",
         "kind": "static_from",
-        "line": 973,
+        "line": 972,
         "name": "IMAGE_UPSCALE_METHODS",
         "optional": false,
         "requested": "easyuse_anima.image.scaling",
@@ -38730,9 +39129,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -38740,12 +39139,12 @@
         "compatibility_pair": {
           "bound_name": "_comfy_sampler_names",
           "target": "easyuse_anima/infrastructure/comfy/capabilities.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_sampler_names",
         "kind": "static_from",
-        "line": 981,
+        "line": 980,
         "name": "_comfy_sampler_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -38764,9 +39163,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -38774,12 +39173,12 @@
         "compatibility_pair": {
           "bound_name": "_comfy_scheduler_names",
           "target": "easyuse_anima/infrastructure/comfy/capabilities.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_scheduler_names",
         "kind": "static_from",
-        "line": 981,
+        "line": 980,
         "name": "_comfy_scheduler_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -38798,9 +39197,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -38808,12 +39207,12 @@
         "compatibility_pair": {
           "bound_name": "_impact_scheduler_names",
           "target": "easyuse_anima/infrastructure/comfy/capabilities.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_impact_scheduler_names",
         "kind": "static_from",
-        "line": 981,
+        "line": 980,
         "name": "_impact_scheduler_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -38832,9 +39231,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -38842,12 +39241,12 @@
         "compatibility_pair": {
           "bound_name": "_call_with_supported_kwargs",
           "target": "easyuse_anima/infrastructure/comfy/invocation.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_call_with_supported_kwargs",
         "kind": "static_from",
-        "line": 987,
+        "line": 986,
         "name": "_call_with_supported_kwargs",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.invocation",
@@ -38866,9 +39265,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -38876,12 +39275,12 @@
         "compatibility_pair": {
           "bound_name": "_common_upscale_image",
           "target": "easyuse_anima/infrastructure/comfy/invocation.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_common_upscale_image",
         "kind": "static_from",
-        "line": 987,
+        "line": 986,
         "name": "_common_upscale_image",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.invocation",
@@ -38900,9 +39299,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -38910,12 +39309,12 @@
         "compatibility_pair": {
           "bound_name": "_node_output_tuple",
           "target": "easyuse_anima/infrastructure/comfy/invocation.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_node_output_tuple",
         "kind": "static_from",
-        "line": 987,
+        "line": 986,
         "name": "_node_output_tuple",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.invocation",
@@ -38934,9 +39333,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -38944,12 +39343,12 @@
         "compatibility_pair": {
           "bound_name": "_adapter_comfy_clip_loader_types",
           "target": "easyuse_anima/infrastructure/comfy/resources.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_clip_loader_types",
         "kind": "static_from",
-        "line": 992,
+        "line": 991,
         "name": "_comfy_clip_loader_types",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -38968,9 +39367,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -38978,12 +39377,12 @@
         "compatibility_pair": {
           "bound_name": "_adapter_comfy_diffusion_model_names",
           "target": "easyuse_anima/infrastructure/comfy/resources.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_diffusion_model_names",
         "kind": "static_from",
-        "line": 992,
+        "line": 991,
         "name": "_comfy_diffusion_model_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -39002,9 +39401,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -39012,12 +39411,12 @@
         "compatibility_pair": {
           "bound_name": "_adapter_comfy_text_encoder_names",
           "target": "easyuse_anima/infrastructure/comfy/resources.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_text_encoder_names",
         "kind": "static_from",
-        "line": 992,
+        "line": 991,
         "name": "_comfy_text_encoder_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -39036,9 +39435,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -39046,12 +39445,12 @@
         "compatibility_pair": {
           "bound_name": "_adapter_comfy_vae_names",
           "target": "easyuse_anima/infrastructure/comfy/resources.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_vae_names",
         "kind": "static_from",
-        "line": 992,
+        "line": 991,
         "name": "_comfy_vae_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -39070,9 +39469,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -39080,12 +39479,12 @@
         "compatibility_pair": {
           "bound_name": "_folder_path_names",
           "target": "easyuse_anima/infrastructure/comfy/resources.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_folder_path_names",
         "kind": "static_from",
-        "line": 992,
+        "line": 991,
         "name": "_folder_path_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -39104,9 +39503,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -39114,12 +39513,12 @@
         "compatibility_pair": {
           "bound_name": "EasyUseAnimaDetailerAlignHook",
           "target": "easyuse_anima/nodes/image_nodes.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.nodes.image_nodes:EasyUseAnimaDetailerAlignHook",
         "kind": "static_from",
-        "line": 1000,
+        "line": 999,
         "name": "EasyUseAnimaDetailerAlignHook",
         "optional": false,
         "requested": "easyuse_anima.nodes.image_nodes",
@@ -39138,9 +39537,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -39148,12 +39547,12 @@
         "compatibility_pair": {
           "bound_name": "EasyUseAnimaImageScaleByMultiple",
           "target": "easyuse_anima/nodes/image_nodes.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.nodes.image_nodes:EasyUseAnimaImageScaleByMultiple",
         "kind": "static_from",
-        "line": 1000,
+        "line": 999,
         "name": "EasyUseAnimaImageScaleByMultiple",
         "optional": false,
         "requested": "easyuse_anima.nodes.image_nodes",
@@ -39172,9 +39571,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -39182,12 +39581,12 @@
         "compatibility_pair": {
           "bound_name": "EasyUseAnimaSAM3Context",
           "target": "easyuse_anima/nodes/sam3_nodes.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Context",
         "kind": "static_from",
-        "line": 1004,
+        "line": 1003,
         "name": "EasyUseAnimaSAM3Context",
         "optional": false,
         "requested": "easyuse_anima.nodes.sam3_nodes",
@@ -39206,9 +39605,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -39216,12 +39615,12 @@
         "compatibility_pair": {
           "bound_name": "EasyUseAnimaSAM3Detailer",
           "target": "easyuse_anima/nodes/sam3_nodes.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Detailer",
         "kind": "static_from",
-        "line": 1004,
+        "line": 1003,
         "name": "EasyUseAnimaSAM3Detailer",
         "optional": false,
         "requested": "easyuse_anima.nodes.sam3_nodes",
@@ -39240,9 +39639,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -39250,12 +39649,12 @@
         "compatibility_pair": {
           "bound_name": "EasyUseAnimaPromptBuilder",
           "target": "easyuse_anima/nodes/prompt_nodes.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptBuilder",
         "kind": "static_from",
-        "line": 1008,
+        "line": 1007,
         "name": "EasyUseAnimaPromptBuilder",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -39274,9 +39673,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -39284,12 +39683,12 @@
         "compatibility_pair": {
           "bound_name": "EasyUseAnimaPromptCorrector",
           "target": "easyuse_anima/nodes/prompt_nodes.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrector",
         "kind": "static_from",
-        "line": 1008,
+        "line": 1007,
         "name": "EasyUseAnimaPromptCorrector",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -39308,9 +39707,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -39318,12 +39717,12 @@
         "compatibility_pair": {
           "bound_name": "EasyUseAnimaPromptCorrectorSimple",
           "target": "easyuse_anima/nodes/prompt_nodes.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrectorSimple",
         "kind": "static_from",
-        "line": 1008,
+        "line": 1007,
         "name": "EasyUseAnimaPromptCorrectorSimple",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -39342,9 +39741,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -39352,12 +39751,12 @@
         "compatibility_pair": {
           "bound_name": "EasyUseAnimaPromptStudio",
           "target": "easyuse_anima/nodes/prompt_nodes.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptStudio",
         "kind": "static_from",
-        "line": 1008,
+        "line": 1007,
         "name": "EasyUseAnimaPromptStudio",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -39376,9 +39775,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -39386,12 +39785,12 @@
         "compatibility_pair": {
           "bound_name": "EasyUseAnimaPromptStudioRegional",
           "target": "easyuse_anima/nodes/regional_nodes.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:EasyUseAnimaPromptStudioRegional",
         "kind": "static_from",
-        "line": 1014,
+        "line": 1013,
         "name": "EasyUseAnimaPromptStudioRegional",
         "optional": false,
         "requested": "easyuse_anima.nodes.regional_nodes",
@@ -39410,9 +39809,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -39420,12 +39819,12 @@
         "compatibility_pair": {
           "bound_name": "EasyUseAnimaRegionalConditioning",
           "target": "easyuse_anima/nodes/regional_nodes.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:EasyUseAnimaRegionalConditioning",
         "kind": "static_from",
-        "line": 1014,
+        "line": 1013,
         "name": "EasyUseAnimaRegionalConditioning",
         "optional": false,
         "requested": "easyuse_anima.nodes.regional_nodes",
@@ -39444,9 +39843,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -39454,12 +39853,12 @@
         "compatibility_pair": {
           "bound_name": "LATENT_ALIGN",
           "target": "easyuse_anima/naia/client.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.naia.client:LATENT_ALIGN",
         "kind": "static_from",
-        "line": 1018,
+        "line": 1017,
         "name": "LATENT_ALIGN",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -39478,9 +39877,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -39488,12 +39887,12 @@
         "compatibility_pair": {
           "bound_name": "_parse_random_response",
           "target": "easyuse_anima/naia/client.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_parse_random_response",
         "kind": "static_from",
-        "line": 1018,
+        "line": 1017,
         "name": "_parse_random_response",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -39512,9 +39911,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -39522,12 +39921,12 @@
         "compatibility_pair": {
           "bound_name": "_post_random",
           "target": "easyuse_anima/naia/client.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_post_random",
         "kind": "static_from",
-        "line": 1018,
+        "line": 1017,
         "name": "_post_random",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -39546,9 +39945,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -39556,12 +39955,12 @@
         "compatibility_pair": {
           "bound_name": "_advanced_resolution_from_selection",
           "target": "easyuse_anima/naia/resolution.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_advanced_resolution_from_selection",
         "kind": "static_from",
-        "line": 1036,
+        "line": 1035,
         "name": "_advanced_resolution_from_selection",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -39580,9 +39979,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -39590,12 +39989,12 @@
         "compatibility_pair": {
           "bound_name": "_normalize_resolution_bucket",
           "target": "easyuse_anima/naia/resolution.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_normalize_resolution_bucket",
         "kind": "static_from",
-        "line": 1036,
+        "line": 1035,
         "name": "_normalize_resolution_bucket",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -39614,9 +40013,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -39624,12 +40023,12 @@
         "compatibility_pair": {
           "bound_name": "_ratio_label",
           "target": "easyuse_anima/naia/resolution.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_ratio_label",
         "kind": "static_from",
-        "line": 1036,
+        "line": 1035,
         "name": "_ratio_label",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -39648,9 +40047,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -39658,12 +40057,12 @@
         "compatibility_pair": {
           "bound_name": "_resolution_label",
           "target": "easyuse_anima/naia/resolution.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolution_label",
         "kind": "static_from",
-        "line": 1036,
+        "line": 1035,
         "name": "_resolution_label",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -39682,9 +40081,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -39692,12 +40091,12 @@
         "compatibility_pair": {
           "bound_name": "_resolve_naia_resolution",
           "target": "easyuse_anima/naia/resolution.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolve_naia_resolution",
         "kind": "static_from",
-        "line": 1036,
+        "line": 1035,
         "name": "_resolve_naia_resolution",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -39716,9 +40115,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -39726,12 +40125,12 @@
         "compatibility_pair": {
           "bound_name": "EasyUseAnimaNAIARandomPrompt",
           "target": "easyuse_anima/nodes/naia_nodes.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.nodes.naia_nodes:EasyUseAnimaNAIARandomPrompt",
         "kind": "static_from",
-        "line": 1059,
+        "line": 1058,
         "name": "EasyUseAnimaNAIARandomPrompt",
         "optional": false,
         "requested": "easyuse_anima.nodes.naia_nodes",
@@ -39750,9 +40149,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -39760,12 +40159,12 @@
         "compatibility_pair": {
           "bound_name": "_bind_naia_node_runtime",
           "target": "easyuse_anima/nodes/naia_nodes.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.nodes.naia_nodes:_bind_naia_node_runtime",
         "kind": "static_from",
-        "line": 1059,
+        "line": 1058,
         "name": "_bind_naia_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.naia_nodes",
@@ -39784,9 +40183,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -39794,12 +40193,12 @@
         "compatibility_pair": {
           "bound_name": "EasyUseAnimaWildcard",
           "target": "easyuse_anima/nodes/wildcard_nodes.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.nodes.wildcard_nodes:EasyUseAnimaWildcard",
         "kind": "static_from",
-        "line": 1063,
+        "line": 1062,
         "name": "EasyUseAnimaWildcard",
         "optional": false,
         "requested": "easyuse_anima.nodes.wildcard_nodes",
@@ -39818,9 +40217,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -39828,12 +40227,12 @@
         "compatibility_pair": {
           "bound_name": "_bind_wildcard_node_runtime",
           "target": "easyuse_anima/nodes/wildcard_nodes.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.nodes.wildcard_nodes:_bind_wildcard_node_runtime",
         "kind": "static_from",
-        "line": 1063,
+        "line": 1062,
         "name": "_bind_wildcard_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.wildcard_nodes",
@@ -39852,9 +40251,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -39862,12 +40261,12 @@
         "compatibility_pair": {
           "bound_name": "_apply_lora_syntax_format",
           "target": "easyuse_anima/lora/metadata.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_apply_lora_syntax_format",
         "kind": "static_from",
-        "line": 1068,
+        "line": 1067,
         "name": "_apply_lora_syntax_format",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -39886,9 +40285,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -39896,12 +40295,12 @@
         "compatibility_pair": {
           "bound_name": "_dedupe_text_values",
           "target": "easyuse_anima/lora/metadata.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_dedupe_text_values",
         "kind": "static_from",
-        "line": 1068,
+        "line": 1067,
         "name": "_dedupe_text_values",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -39920,9 +40319,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -39930,12 +40329,12 @@
         "compatibility_pair": {
           "bound_name": "_fallback_lora_path",
           "target": "easyuse_anima/lora/metadata.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_fallback_lora_path",
         "kind": "static_from",
-        "line": 1068,
+        "line": 1067,
         "name": "_fallback_lora_path",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -39954,9 +40353,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -39964,12 +40363,12 @@
         "compatibility_pair": {
           "bound_name": "_get_lora_info",
           "target": "easyuse_anima/lora/metadata.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_get_lora_info",
         "kind": "static_from",
-        "line": 1068,
+        "line": 1067,
         "name": "_get_lora_info",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -39988,9 +40387,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -39998,12 +40397,12 @@
         "compatibility_pair": {
           "bound_name": "_get_lora_manager_trigger_words",
           "target": "easyuse_anima/lora/metadata.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_get_lora_manager_trigger_words",
         "kind": "static_from",
-        "line": 1068,
+        "line": 1067,
         "name": "_get_lora_manager_trigger_words",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -40022,9 +40421,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -40032,12 +40431,12 @@
         "compatibility_pair": {
           "bound_name": "_load_lora_manager_metadata",
           "target": "easyuse_anima/lora/metadata.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_load_lora_manager_metadata",
         "kind": "static_from",
-        "line": 1068,
+        "line": 1067,
         "name": "_load_lora_manager_metadata",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -40056,9 +40455,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -40066,12 +40465,12 @@
         "compatibility_pair": {
           "bound_name": "_lora_combo_values",
           "target": "easyuse_anima/lora/metadata.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_combo_values",
         "kind": "static_from",
-        "line": 1068,
+        "line": 1067,
         "name": "_lora_combo_values",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -40090,9 +40489,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -40100,12 +40499,12 @@
         "compatibility_pair": {
           "bound_name": "_lora_manager_trigger_words_from_metadata",
           "target": "easyuse_anima/lora/metadata.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_manager_trigger_words_from_metadata",
         "kind": "static_from",
-        "line": 1068,
+        "line": 1067,
         "name": "_lora_manager_trigger_words_from_metadata",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -40124,9 +40523,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -40134,12 +40533,12 @@
         "compatibility_pair": {
           "bound_name": "_lora_model_exists",
           "target": "easyuse_anima/lora/metadata.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_model_exists",
         "kind": "static_from",
-        "line": 1068,
+        "line": 1067,
         "name": "_lora_model_exists",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -40158,9 +40557,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -40168,12 +40567,12 @@
         "compatibility_pair": {
           "bound_name": "_lora_stack_name",
           "target": "easyuse_anima/lora/metadata.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_stack_name",
         "kind": "static_from",
-        "line": 1068,
+        "line": 1067,
         "name": "_lora_stack_name",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -40192,9 +40591,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -40202,12 +40601,12 @@
         "compatibility_pair": {
           "bound_name": "_metadata_json_paths_for_lora",
           "target": "easyuse_anima/lora/metadata.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_metadata_json_paths_for_lora",
         "kind": "static_from",
-        "line": 1068,
+        "line": 1067,
         "name": "_metadata_json_paths_for_lora",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -40226,9 +40625,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -40236,12 +40635,12 @@
         "compatibility_pair": {
           "bound_name": "_missing_lora_display_name",
           "target": "easyuse_anima/lora/metadata.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_missing_lora_display_name",
         "kind": "static_from",
-        "line": 1068,
+        "line": 1067,
         "name": "_missing_lora_display_name",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -40260,9 +40659,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -40270,12 +40669,12 @@
         "compatibility_pair": {
           "bound_name": "_raise_missing_loras",
           "target": "easyuse_anima/lora/metadata.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_raise_missing_loras",
         "kind": "static_from",
-        "line": 1068,
+        "line": 1067,
         "name": "_raise_missing_loras",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -40294,9 +40693,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -40304,12 +40703,12 @@
         "compatibility_pair": {
           "bound_name": "_trigger_words_from_value",
           "target": "easyuse_anima/lora/metadata.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_trigger_words_from_value",
         "kind": "static_from",
-        "line": 1068,
+        "line": 1067,
         "name": "_trigger_words_from_value",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -40328,9 +40727,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -40338,12 +40737,12 @@
         "compatibility_pair": {
           "bound_name": "_correct_style_prompt",
           "target": "easyuse_anima/lora/preset.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_correct_style_prompt",
         "kind": "static_from",
-        "line": 1084,
+        "line": 1083,
         "name": "_correct_style_prompt",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -40362,9 +40761,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -40372,12 +40771,12 @@
         "compatibility_pair": {
           "bound_name": "_format_strength",
           "target": "easyuse_anima/lora/preset.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_format_strength",
         "kind": "static_from",
-        "line": 1084,
+        "line": 1083,
         "name": "_format_strength",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -40396,9 +40795,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -40406,12 +40805,12 @@
         "compatibility_pair": {
           "bound_name": "_get_loras_list",
           "target": "easyuse_anima/lora/preset.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_get_loras_list",
         "kind": "static_from",
-        "line": 1084,
+        "line": 1083,
         "name": "_get_loras_list",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -40430,9 +40829,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -40440,12 +40839,12 @@
         "compatibility_pair": {
           "bound_name": "_load_profile_data",
           "target": "easyuse_anima/lora/preset.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_load_profile_data",
         "kind": "static_from",
-        "line": 1084,
+        "line": 1083,
         "name": "_load_profile_data",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -40464,9 +40863,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -40474,12 +40873,12 @@
         "compatibility_pair": {
           "bound_name": "_profile_key",
           "target": "easyuse_anima/lora/preset.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_profile_key",
         "kind": "static_from",
-        "line": 1084,
+        "line": 1083,
         "name": "_profile_key",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -40498,9 +40897,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -40508,12 +40907,12 @@
         "compatibility_pair": {
           "bound_name": "_select_profile_values",
           "target": "easyuse_anima/lora/preset.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_select_profile_values",
         "kind": "static_from",
-        "line": 1084,
+        "line": 1083,
         "name": "_select_profile_values",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -40532,9 +40931,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -40542,12 +40941,12 @@
         "compatibility_pair": {
           "bound_name": "_wrap_profile_index",
           "target": "easyuse_anima/lora/preset.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_wrap_profile_index",
         "kind": "static_from",
-        "line": 1084,
+        "line": 1083,
         "name": "_wrap_profile_index",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -40566,9 +40965,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -40576,12 +40975,12 @@
         "compatibility_pair": {
           "bound_name": "EasyUseAnimaLoraPreset",
           "target": "easyuse_anima/nodes/lora_nodes.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "easyuse_anima.nodes.lora_nodes:EasyUseAnimaLoraPreset",
         "kind": "static_from",
-        "line": 1093,
+        "line": 1092,
         "name": "EasyUseAnimaLoraPreset",
         "optional": false,
         "requested": "easyuse_anima.nodes.lora_nodes",
@@ -40600,9 +40999,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -40610,12 +41009,12 @@
         "compatibility_pair": {
           "bound_name": "correct_prompt",
           "target": "anima_prompt/__init__.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "anima_prompt:correct_prompt",
         "kind": "static_from",
-        "line": 1096,
+        "line": 1095,
         "name": "correct_prompt",
         "optional": false,
         "requested": "anima_prompt",
@@ -40634,9 +41033,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -40644,12 +41043,12 @@
         "compatibility_pair": {
           "bound_name": "load_knowledge_base",
           "target": "anima_prompt/__init__.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "anima_prompt:load_knowledge_base",
         "kind": "static_from",
-        "line": 1096,
+        "line": 1095,
         "name": "load_knowledge_base",
         "optional": false,
         "requested": "anima_prompt",
@@ -40668,9 +41067,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -40678,12 +41077,12 @@
         "compatibility_pair": {
           "bound_name": "parse_prompt",
           "target": "anima_prompt/parser.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "anima_prompt.parser:parse_prompt",
         "kind": "static_from",
-        "line": 1097,
+        "line": 1096,
         "name": "parse_prompt",
         "optional": false,
         "requested": "anima_prompt.parser",
@@ -40702,9 +41101,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -40712,12 +41111,12 @@
         "compatibility_pair": {
           "bound_name": "resolve_metadata_filter_words",
           "target": "settings.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "settings:resolve_metadata_filter_words",
         "kind": "static_from",
-        "line": 1098,
+        "line": 1097,
         "name": "resolve_metadata_filter_words",
         "optional": false,
         "requested": "settings",
@@ -40736,9 +41135,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -40746,12 +41145,12 @@
         "compatibility_pair": {
           "bound_name": "resolve_naia_settings",
           "target": "settings.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "settings:resolve_naia_settings",
         "kind": "static_from",
-        "line": 1098,
+        "line": 1097,
         "name": "resolve_naia_settings",
         "optional": false,
         "requested": "settings",
@@ -40770,9 +41169,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -40780,12 +41179,12 @@
         "compatibility_pair": {
           "bound_name": "resolve_prompt_translation_settings",
           "target": "settings.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "settings:resolve_prompt_translation_settings",
         "kind": "static_from",
-        "line": 1098,
+        "line": 1097,
         "name": "resolve_prompt_translation_settings",
         "optional": false,
         "requested": "settings",
@@ -40804,9 +41203,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -40814,12 +41213,12 @@
         "compatibility_pair": {
           "bound_name": "has_prompt_translation_markers",
           "target": "prompt_translation.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "prompt_translation:has_prompt_translation_markers",
         "kind": "static_from",
-        "line": 1103,
+        "line": 1102,
         "name": "has_prompt_translation_markers",
         "optional": false,
         "requested": "prompt_translation",
@@ -40838,9 +41237,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -40848,12 +41247,12 @@
         "compatibility_pair": {
           "bound_name": "translate_prompt_markers",
           "target": "prompt_translation.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "prompt_translation:translate_prompt_markers",
         "kind": "static_from",
-        "line": 1103,
+        "line": 1102,
         "name": "translate_prompt_markers",
         "optional": false,
         "requested": "prompt_translation",
@@ -40872,9 +41271,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -40882,12 +41281,12 @@
         "compatibility_pair": {
           "bound_name": "MAX_SEED",
           "target": "wildcard_engine.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "wildcard_engine:MAX_SEED",
         "kind": "static_from",
-        "line": 1104,
+        "line": 1103,
         "name": "MAX_SEED",
         "optional": false,
         "requested": "wildcard_engine",
@@ -40906,9 +41305,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -40916,12 +41315,12 @@
         "compatibility_pair": {
           "bound_name": "PROMPT_STUDIO_WILDCARD_MODE_LABELS",
           "target": "wildcard_engine.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "wildcard_engine:PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "kind": "static_from",
-        "line": 1104,
+        "line": 1103,
         "name": "PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "optional": false,
         "requested": "wildcard_engine",
@@ -40940,9 +41339,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -40950,12 +41349,12 @@
         "compatibility_pair": {
           "bound_name": "PUBLIC_MAX_SEED",
           "target": "wildcard_engine.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "wildcard_engine:PUBLIC_MAX_SEED",
         "kind": "static_from",
-        "line": 1104,
+        "line": 1103,
         "name": "PUBLIC_MAX_SEED",
         "optional": false,
         "requested": "wildcard_engine",
@@ -40974,9 +41373,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -40984,12 +41383,12 @@
         "compatibility_pair": {
           "bound_name": "SEED_CONTROL_DECREMENT",
           "target": "wildcard_engine.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_DECREMENT",
         "kind": "static_from",
-        "line": 1104,
+        "line": 1103,
         "name": "SEED_CONTROL_DECREMENT",
         "optional": false,
         "requested": "wildcard_engine",
@@ -41008,9 +41407,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -41018,12 +41417,12 @@
         "compatibility_pair": {
           "bound_name": "SEED_CONTROL_FIXED",
           "target": "wildcard_engine.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_FIXED",
         "kind": "static_from",
-        "line": 1104,
+        "line": 1103,
         "name": "SEED_CONTROL_FIXED",
         "optional": false,
         "requested": "wildcard_engine",
@@ -41042,9 +41441,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -41052,12 +41451,12 @@
         "compatibility_pair": {
           "bound_name": "SEED_CONTROL_INCREMENT",
           "target": "wildcard_engine.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_INCREMENT",
         "kind": "static_from",
-        "line": 1104,
+        "line": 1103,
         "name": "SEED_CONTROL_INCREMENT",
         "optional": false,
         "requested": "wildcard_engine",
@@ -41076,9 +41475,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -41086,12 +41485,12 @@
         "compatibility_pair": {
           "bound_name": "SEED_CONTROL_MODES",
           "target": "wildcard_engine.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_MODES",
         "kind": "static_from",
-        "line": 1104,
+        "line": 1103,
         "name": "SEED_CONTROL_MODES",
         "optional": false,
         "requested": "wildcard_engine",
@@ -41110,9 +41509,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -41120,12 +41519,12 @@
         "compatibility_pair": {
           "bound_name": "SEED_CONTROL_RANDOMIZE",
           "target": "wildcard_engine.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_RANDOMIZE",
         "kind": "static_from",
-        "line": 1104,
+        "line": 1103,
         "name": "SEED_CONTROL_RANDOMIZE",
         "optional": false,
         "requested": "wildcard_engine",
@@ -41144,9 +41543,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -41154,12 +41553,12 @@
         "compatibility_pair": {
           "bound_name": "WILDCARD_MODE_FIXED",
           "target": "wildcard_engine.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_FIXED",
         "kind": "static_from",
-        "line": 1104,
+        "line": 1103,
         "name": "WILDCARD_MODE_FIXED",
         "optional": false,
         "requested": "wildcard_engine",
@@ -41178,9 +41577,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -41188,12 +41587,12 @@
         "compatibility_pair": {
           "bound_name": "WILDCARD_MODE_POPULATE",
           "target": "wildcard_engine.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_POPULATE",
         "kind": "static_from",
-        "line": 1104,
+        "line": 1103,
         "name": "WILDCARD_MODE_POPULATE",
         "optional": false,
         "requested": "wildcard_engine",
@@ -41212,9 +41611,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -41222,12 +41621,12 @@
         "compatibility_pair": {
           "bound_name": "WILDCARD_MODE_SEQUENTIAL",
           "target": "wildcard_engine.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_SEQUENTIAL",
         "kind": "static_from",
-        "line": 1104,
+        "line": 1103,
         "name": "WILDCARD_MODE_SEQUENTIAL",
         "optional": false,
         "requested": "wildcard_engine",
@@ -41246,9 +41645,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -41256,12 +41655,12 @@
         "compatibility_pair": {
           "bound_name": "expand_wildcard_texts",
           "target": "wildcard_engine.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "wildcard_engine:expand_wildcard_texts",
         "kind": "static_from",
-        "line": 1104,
+        "line": 1103,
         "name": "expand_wildcard_texts",
         "optional": false,
         "requested": "wildcard_engine",
@@ -41280,9 +41679,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -41290,12 +41689,12 @@
         "compatibility_pair": {
           "bound_name": "expand_wildcards",
           "target": "wildcard_engine.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "wildcard_engine:expand_wildcards",
         "kind": "static_from",
-        "line": 1104,
+        "line": 1103,
         "name": "expand_wildcards",
         "optional": false,
         "requested": "wildcard_engine",
@@ -41314,9 +41713,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -41324,12 +41723,12 @@
         "compatibility_pair": {
           "bound_name": "has_wildcard_syntax",
           "target": "wildcard_engine.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "wildcard_engine:has_wildcard_syntax",
         "kind": "static_from",
-        "line": 1104,
+        "line": 1103,
         "name": "has_wildcard_syntax",
         "optional": false,
         "requested": "wildcard_engine",
@@ -41348,9 +41747,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -41358,12 +41757,12 @@
         "compatibility_pair": {
           "bound_name": "next_seed",
           "target": "wildcard_engine.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "wildcard_engine:next_seed",
         "kind": "static_from",
-        "line": 1104,
+        "line": 1103,
         "name": "next_seed",
         "optional": false,
         "requested": "wildcard_engine",
@@ -41382,9 +41781,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -41392,12 +41791,12 @@
         "compatibility_pair": {
           "bound_name": "normalize_prompt_studio_wildcard_mode",
           "target": "wildcard_engine.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "wildcard_engine:normalize_prompt_studio_wildcard_mode",
         "kind": "static_from",
-        "line": 1104,
+        "line": 1103,
         "name": "normalize_prompt_studio_wildcard_mode",
         "optional": false,
         "requested": "wildcard_engine",
@@ -41416,9 +41815,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -41426,12 +41825,12 @@
         "compatibility_pair": {
           "bound_name": "normalize_seed",
           "target": "wildcard_engine.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "wildcard_engine:normalize_seed",
         "kind": "static_from",
-        "line": 1104,
+        "line": 1103,
         "name": "normalize_seed",
         "optional": false,
         "requested": "wildcard_engine",
@@ -41450,9 +41849,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -41460,12 +41859,12 @@
         "compatibility_pair": {
           "bound_name": "normalize_wildcard_mode",
           "target": "wildcard_engine.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "wildcard_engine:normalize_wildcard_mode",
         "kind": "static_from",
-        "line": 1104,
+        "line": 1103,
         "name": "normalize_wildcard_mode",
         "optional": false,
         "requested": "wildcard_engine",
@@ -41484,9 +41883,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
@@ -41494,12 +41893,12 @@
         "compatibility_pair": {
           "bound_name": "wildcard_sources_signature",
           "target": "wildcard_engine.py",
-          "try_line": 7
+          "try_line": 6
         },
         "conditional": true,
         "imported": "wildcard_engine:wildcard_sources_signature",
         "kind": "static_from",
-        "line": 1104,
+        "line": 1103,
         "name": "wildcard_sources_signature",
         "optional": false,
         "requested": "wildcard_engine",
@@ -43567,7 +43966,43 @@
       },
       {
         "from": "easyuse_anima/nodes/aio_nodes.py",
+        "to": "easyuse_anima/aio/generation_defaults.py"
+      },
+      {
+        "from": "easyuse_anima/nodes/aio_nodes.py",
+        "to": "easyuse_anima/aio/generation_normalization.py"
+      },
+      {
+        "from": "easyuse_anima/nodes/aio_nodes.py",
         "to": "easyuse_anima/aio/input_context.py"
+      },
+      {
+        "from": "easyuse_anima/nodes/aio_nodes.py",
+        "to": "easyuse_anima/aio/input_defaults.py"
+      },
+      {
+        "from": "easyuse_anima/nodes/aio_nodes.py",
+        "to": "easyuse_anima/aio/legacy_generation.py"
+      },
+      {
+        "from": "easyuse_anima/nodes/aio_nodes.py",
+        "to": "easyuse_anima/aio/model_preparation.py"
+      },
+      {
+        "from": "easyuse_anima/nodes/aio_nodes.py",
+        "to": "easyuse_anima/aio/resources.py"
+      },
+      {
+        "from": "easyuse_anima/nodes/aio_nodes.py",
+        "to": "easyuse_anima/aio/sampling.py"
+      },
+      {
+        "from": "easyuse_anima/nodes/aio_nodes.py",
+        "to": "easyuse_anima/common/serialization.py"
+      },
+      {
+        "from": "easyuse_anima/nodes/aio_nodes.py",
+        "to": "easyuse_anima/prompt/data.py"
       },
       {
         "from": "easyuse_anima/nodes/image_nodes.py",
@@ -45515,14 +45950,14 @@
       },
       {
         "is_package": false,
-        "loc": 286,
+        "loc": 296,
         "module": "easyuse_anima.nodes.aio_nodes",
-        "normalized_git_blob_sha1": "b473871bb7b2f5e516832d12a523f2d12f97e92c",
+        "normalized_git_blob_sha1": "6799cbe3465ce9c970c606750ee545eab00ec5e9",
         "path": "easyuse_anima/nodes/aio_nodes.py",
         "top_level": {
           "class_count": 2,
-          "function_count": 4,
-          "global_count": 3
+          "function_count": 2,
+          "global_count": 2
         }
       },
       {
@@ -45863,14 +46298,14 @@
       },
       {
         "is_package": false,
-        "loc": 1147,
+        "loc": 1142,
         "module": "nodes",
-        "normalized_git_blob_sha1": "735f1fcd3249adb58b2e64eb35d78ca264a7ec1d",
+        "normalized_git_blob_sha1": "1384982bc24cb74f8e68c0f11f66de7965036e21",
         "path": "nodes.py",
         "top_level": {
           "class_count": 0,
           "function_count": 0,
-          "global_count": 3
+          "global_count": 2
         }
       },
       {
@@ -47413,16 +47848,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:AIO_FIRST_PASS_CACHE_MAX_ENTRIES",
         "kind": "static_from",
-        "line": 567,
+        "line": 566,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47436,16 +47871,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_AIO_FIRST_PASS_CACHE",
         "kind": "static_from",
-        "line": 567,
+        "line": 566,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47459,16 +47894,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_AIO_FIRST_PASS_CACHE_ORDER",
         "kind": "static_from",
-        "line": 567,
+        "line": 566,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47482,16 +47917,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_aio_first_pass_cache_key",
         "kind": "static_from",
-        "line": 567,
+        "line": 566,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47505,16 +47940,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_clone_aio_cache_value",
         "kind": "static_from",
-        "line": 567,
+        "line": 566,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47528,16 +47963,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_get_aio_first_pass_cache",
         "kind": "static_from",
-        "line": 567,
+        "line": 566,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47551,16 +47986,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_put_aio_first_pass_cache",
         "kind": "static_from",
-        "line": 567,
+        "line": 566,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47574,16 +48009,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_detailer_stage",
         "kind": "static_from",
-        "line": 577,
+        "line": 576,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47597,16 +48032,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_detailer_target",
         "kind": "static_from",
-        "line": 577,
+        "line": 576,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47620,16 +48055,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_highres_stage",
         "kind": "static_from",
-        "line": 577,
+        "line": 576,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47643,16 +48078,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_legacy_generation",
         "kind": "static_from",
-        "line": 577,
+        "line": 576,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47666,16 +48101,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_resshift_upscale_stage",
         "kind": "static_from",
-        "line": 577,
+        "line": 576,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47689,16 +48124,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_upscale_stage",
         "kind": "static_from",
-        "line": 577,
+        "line": 576,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47712,16 +48147,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_usdu_upscale_stage",
         "kind": "static_from",
-        "line": 577,
+        "line": 576,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47735,16 +48170,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_AIO_DETAILER_CUSTOM_RE",
         "kind": "static_from",
-        "line": 586,
+        "line": 585,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47758,16 +48193,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_AIO_DETAILER_RESERVED_KEYS",
         "kind": "static_from",
-        "line": 586,
+        "line": 585,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47781,16 +48216,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_aio_detailer_has_enabled_targets",
         "kind": "static_from",
-        "line": 586,
+        "line": 585,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47804,16 +48239,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_aio_detailer_target_defaults",
         "kind": "static_from",
-        "line": 586,
+        "line": 585,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47827,16 +48262,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_aio_detailer_target_order",
         "kind": "static_from",
-        "line": 586,
+        "line": 585,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47850,16 +48285,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_is_aio_detailer_target_name",
         "kind": "static_from",
-        "line": 586,
+        "line": 585,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47873,16 +48308,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_merge_versioned_settings",
         "kind": "static_from",
-        "line": 586,
+        "line": 585,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47896,16 +48331,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_dit_corrections_settings",
         "kind": "static_from",
-        "line": 586,
+        "line": 585,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47919,16 +48354,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_generation_settings",
         "kind": "static_from",
-        "line": 586,
+        "line": 585,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47942,16 +48377,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_seed",
         "kind": "static_from",
-        "line": 586,
+        "line": 585,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47965,16 +48400,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_spectrum_settings",
         "kind": "static_from",
-        "line": 586,
+        "line": 585,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47988,16 +48423,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_FINAL_FIT_MODES",
         "kind": "static_from",
-        "line": 599,
+        "line": 598,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48011,16 +48446,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_FINAL_UPSCALE_BACKENDS",
         "kind": "static_from",
-        "line": 599,
+        "line": 598,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48034,16 +48469,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_GENERATION_DEFAULT_SETTINGS",
         "kind": "static_from",
-        "line": 599,
+        "line": 598,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48057,16 +48492,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_GENERATION_SETTINGS_SCHEMA",
         "kind": "static_from",
-        "line": 599,
+        "line": 598,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48080,16 +48515,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_GENERATION_SETTINGS_VERSION",
         "kind": "static_from",
-        "line": 599,
+        "line": 598,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48103,16 +48538,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_RESHIFT_DTYPES",
         "kind": "static_from",
-        "line": 599,
+        "line": 598,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48126,16 +48561,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_RESHIFT_SCALES",
         "kind": "static_from",
-        "line": 599,
+        "line": 598,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48149,16 +48584,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_SPECIAL_SEEDS",
         "kind": "static_from",
-        "line": 599,
+        "line": 598,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48172,16 +48607,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_SPECIAL_SEED_DECREMENT",
         "kind": "static_from",
-        "line": 599,
+        "line": 598,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48195,16 +48630,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_SPECIAL_SEED_INCREMENT",
         "kind": "static_from",
-        "line": 599,
+        "line": 598,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48218,16 +48653,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_SPECIAL_SEED_RANDOM",
         "kind": "static_from",
-        "line": 599,
+        "line": 598,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48241,16 +48676,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_USDU_MODE_TYPES",
         "kind": "static_from",
-        "line": 599,
+        "line": 598,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48264,16 +48699,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_USDU_PROMPT_FULL",
         "kind": "static_from",
-        "line": 599,
+        "line": 598,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48287,16 +48722,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_USDU_PROMPT_MODES",
         "kind": "static_from",
-        "line": 599,
+        "line": 598,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48310,16 +48745,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_USDU_PROMPT_NO_GENERAL",
         "kind": "static_from",
-        "line": 599,
+        "line": 598,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48333,16 +48768,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_USDU_SEAM_FIX_MODES",
         "kind": "static_from",
-        "line": 599,
+        "line": 598,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48356,16 +48791,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_settings:round_trip_aio_generation_settings",
         "kind": "static_from",
-        "line": 617,
+        "line": 616,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48379,16 +48814,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.input_defaults:AIO_INPUT_DEFAULT_SETTINGS",
         "kind": "static_from",
-        "line": 620,
+        "line": 619,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48402,16 +48837,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.input_defaults:ANIMA_CLIP_DEVICES",
         "kind": "static_from",
-        "line": 620,
+        "line": 619,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48425,16 +48860,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.input_defaults:ANIMA_CLIP_TYPES",
         "kind": "static_from",
-        "line": 620,
+        "line": 619,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48448,16 +48883,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.input_defaults:ANIMA_DEFAULT_CLIP_CANDIDATES",
         "kind": "static_from",
-        "line": 620,
+        "line": 619,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48471,16 +48906,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.input_defaults:ANIMA_DEFAULT_DIFFUSION_MODEL_CANDIDATES",
         "kind": "static_from",
-        "line": 620,
+        "line": 619,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48494,16 +48929,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.input_defaults:ANIMA_DEFAULT_VAE_CANDIDATES",
         "kind": "static_from",
-        "line": 620,
+        "line": 619,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48517,16 +48952,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.input_defaults:ANIMA_UNET_WEIGHT_DTYPES",
         "kind": "static_from",
-        "line": 620,
+        "line": 619,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48540,16 +48975,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.input_defaults:EASY_USE_ANIMA_INPUT_SCHEMA",
         "kind": "static_from",
-        "line": 620,
+        "line": 619,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48563,16 +48998,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.input_defaults:EASY_USE_ANIMA_INPUT_SETTINGS_VERSION",
         "kind": "static_from",
-        "line": 620,
+        "line": 619,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48586,16 +49021,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.input_context:_easy_use_anima_input_signature",
         "kind": "static_from",
-        "line": 631,
+        "line": 630,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48609,16 +49044,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.input_context:_require_easy_use_anima_input",
         "kind": "static_from",
-        "line": 631,
+        "line": 630,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48632,16 +49067,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.usdu:_aio_usdu_auto_tile_dimension",
         "kind": "static_from",
-        "line": 635,
+        "line": 634,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48655,16 +49090,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.usdu:_aio_usdu_tile_plan",
         "kind": "static_from",
-        "line": 635,
+        "line": 634,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48678,16 +49113,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_aio_final_fit_size",
         "kind": "static_from",
-        "line": 639,
+        "line": 638,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48701,16 +49136,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_apply_aio_final_fit",
         "kind": "static_from",
-        "line": 639,
+        "line": 638,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48724,16 +49159,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_resize_image_to_size_if_needed",
         "kind": "static_from",
-        "line": 639,
+        "line": 638,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48747,16 +49182,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_run_aio_postprocess_stage",
         "kind": "static_from",
-        "line": 639,
+        "line": 638,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48770,16 +49205,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_prompt_data_fields_for_usdu",
         "kind": "static_from",
-        "line": 645,
+        "line": 644,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48793,16 +49228,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_usdu_conditioning",
         "kind": "static_from",
-        "line": 645,
+        "line": 644,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48816,16 +49251,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_usdu_prompt_without_general",
         "kind": "static_from",
-        "line": 645,
+        "line": 644,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48839,16 +49274,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_aio_lora_stack_signature",
         "kind": "static_from",
-        "line": 650,
+        "line": 649,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48862,16 +49297,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_anima_dave_patch",
         "kind": "static_from",
-        "line": 650,
+        "line": 649,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48885,16 +49320,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_kj_model_patches",
         "kind": "static_from",
-        "line": 650,
+        "line": 649,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48908,16 +49343,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_lora_stack",
         "kind": "static_from",
-        "line": 650,
+        "line": 649,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48931,16 +49366,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_model_patches",
         "kind": "static_from",
-        "line": 650,
+        "line": 649,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48954,16 +49389,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_safe_pag_patch",
         "kind": "static_from",
-        "line": 650,
+        "line": 649,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48977,16 +49412,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_correction_patch_for_comfy_sampler",
         "kind": "static_from",
-        "line": 650,
+        "line": 649,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49000,16 +49435,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_forecast_patch_for_comfy_sampler",
         "kind": "static_from",
-        "line": 650,
+        "line": 649,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49023,16 +49458,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_model_patches_for_comfy_sampler",
         "kind": "static_from",
-        "line": 650,
+        "line": 649,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49046,16 +49481,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_cleanup_aio_ephemeral_model",
         "kind": "static_from",
-        "line": 650,
+        "line": 649,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49069,16 +49504,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_normalize_aio_lora_stack",
         "kind": "static_from",
-        "line": 650,
+        "line": 649,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49092,16 +49527,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_patch_model_sampling_aura_flow",
         "kind": "static_from",
-        "line": 650,
+        "line": 649,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49115,16 +49550,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_aio_highres_effective_backend",
         "kind": "static_from",
-        "line": 664,
+        "line": 663,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49138,16 +49573,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_aio_stage_sampler_settings",
         "kind": "static_from",
-        "line": 664,
+        "line": 663,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49161,16 +49596,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_decode_latent_with_comfy",
         "kind": "static_from",
-        "line": 664,
+        "line": 663,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49184,16 +49619,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_encode_image_with_comfy_vae",
         "kind": "static_from",
-        "line": 664,
+        "line": 663,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49207,16 +49642,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_generate_empty_latent_with_comfy",
         "kind": "static_from",
-        "line": 664,
+        "line": 663,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49230,16 +49665,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_new_aio_random_seed",
         "kind": "static_from",
-        "line": 664,
+        "line": 663,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49253,16 +49688,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_resolve_aio_runtime_seed",
         "kind": "static_from",
-        "line": 664,
+        "line": 663,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49276,16 +49711,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_aio_backend",
         "kind": "static_from",
-        "line": 664,
+        "line": 663,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49299,16 +49734,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_comfy",
         "kind": "static_from",
-        "line": 664,
+        "line": 663,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49322,16 +49757,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_spectrum_mod_guidance_advanced",
         "kind": "static_from",
-        "line": 664,
+        "line": 663,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49345,16 +49780,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_spectrum_spd",
         "kind": "static_from",
-        "line": 664,
+        "line": 663,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49368,16 +49803,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_CACHE_FORMAT",
         "kind": "static_from",
-        "line": 677,
+        "line": 676,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49391,16 +49826,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_CACHE_QUALITY",
         "kind": "static_from",
-        "line": 677,
+        "line": 676,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49414,16 +49849,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_EVENT",
         "kind": "static_from",
-        "line": 677,
+        "line": 676,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49437,16 +49872,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_STAGE_LABELS",
         "kind": "static_from",
-        "line": 677,
+        "line": 676,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49460,16 +49895,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_aio_preview_base_directory",
         "kind": "static_from",
-        "line": 677,
+        "line": 676,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49483,16 +49918,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_aio_preview_file_size_bytes",
         "kind": "static_from",
-        "line": 677,
+        "line": 676,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49506,16 +49941,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_save_aio_temp_preview_image",
         "kind": "static_from",
-        "line": 677,
+        "line": 676,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49529,16 +49964,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_send_aio_preview_event",
         "kind": "static_from",
-        "line": 677,
+        "line": 676,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49552,16 +49987,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_tag_aio_preview_images",
         "kind": "static_from",
-        "line": 677,
+        "line": 676,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49575,16 +50010,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_image_saver_additional_hashes",
         "kind": "static_from",
-        "line": 688,
+        "line": 687,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49598,16 +50033,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_image_saver_civitai_hash_fetcher_entries",
         "kind": "static_from",
-        "line": 688,
+        "line": 687,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49621,16 +50056,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_lora_metadata_name",
         "kind": "static_from",
-        "line": 688,
+        "line": 687,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49644,16 +50079,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_prompt_with_lora_metadata",
         "kind": "static_from",
-        "line": 688,
+        "line": 687,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49667,16 +50102,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_save_filename_prefix",
         "kind": "static_from",
-        "line": 688,
+        "line": 687,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49690,16 +50125,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_save_image_with_comfy",
         "kind": "static_from",
-        "line": 688,
+        "line": 687,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49713,16 +50148,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_save_image_with_image_saver",
         "kind": "static_from",
-        "line": 688,
+        "line": 687,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49736,16 +50171,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.output_settings:_normalize_aio_civitai_hash_fetchers",
         "kind": "static_from",
-        "line": 697,
+        "line": 696,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49759,16 +50194,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.output_settings:_normalize_aio_hash_bundles",
         "kind": "static_from",
-        "line": 697,
+        "line": 696,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49782,16 +50217,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_clip_loader_types",
         "kind": "static_from",
-        "line": 701,
+        "line": 700,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49805,16 +50240,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_diffusion_model_names",
         "kind": "static_from",
-        "line": 701,
+        "line": 700,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49828,16 +50263,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_text_encoder_names",
         "kind": "static_from",
-        "line": 701,
+        "line": 700,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49851,16 +50286,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_vae_names",
         "kind": "static_from",
-        "line": 701,
+        "line": 700,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49874,16 +50309,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_aio_resources_from_input_context",
         "kind": "static_from",
-        "line": 701,
+        "line": 700,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49897,16 +50332,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_aio_sam3_context",
         "kind": "static_from",
-        "line": 701,
+        "line": 700,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49920,16 +50355,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_checkpoint_with_comfy",
         "kind": "static_from",
-        "line": 701,
+        "line": 700,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49943,16 +50378,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_clip_with_comfy",
         "kind": "static_from",
-        "line": 701,
+        "line": 700,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49966,16 +50401,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_diffusion_model_with_comfy",
         "kind": "static_from",
-        "line": 701,
+        "line": 700,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49989,16 +50424,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_upscale_model_with_comfy",
         "kind": "static_from",
-        "line": 701,
+        "line": 700,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50012,16 +50447,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_vae_with_comfy",
         "kind": "static_from",
-        "line": 701,
+        "line": 700,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50035,16 +50470,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_normalize_aio_input_settings",
         "kind": "static_from",
-        "line": 701,
+        "line": 700,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50058,16 +50493,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_checkpoint_default",
         "kind": "static_from",
-        "line": 701,
+        "line": 700,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50081,16 +50516,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_clip_type_default",
         "kind": "static_from",
-        "line": 701,
+        "line": 700,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50104,16 +50539,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_name_default",
         "kind": "static_from",
-        "line": 701,
+        "line": 700,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50127,16 +50562,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_json_clone",
         "kind": "static_from",
-        "line": 718,
+        "line": 717,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50150,16 +50585,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_json_object",
         "kind": "static_from",
-        "line": 718,
+        "line": 717,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50173,16 +50608,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_stable_change_key",
         "kind": "static_from",
-        "line": 718,
+        "line": 717,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50196,16 +50631,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_bool",
         "kind": "static_from",
-        "line": 723,
+        "line": 722,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50219,16 +50654,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_float",
         "kind": "static_from",
-        "line": 723,
+        "line": 722,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50242,16 +50677,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_int",
         "kind": "static_from",
-        "line": 723,
+        "line": 722,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50265,16 +50700,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.common.values:_choice",
         "kind": "static_from",
-        "line": 723,
+        "line": 722,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50288,16 +50723,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.common.values:_single_value",
         "kind": "static_from",
-        "line": 723,
+        "line": 722,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50311,16 +50746,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.seed.compatibility:WILDCARD_QUEUE_MAX_SAFE_SEED",
         "kind": "static_from",
-        "line": 730,
+        "line": 729,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50334,16 +50769,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.seed.compatibility:WILDCARD_RESERVED_NEXT_SEED_INPUT",
         "kind": "static_from",
-        "line": 730,
+        "line": 729,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50357,16 +50792,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.seed.compatibility:_consume_reserved_wildcard_next_seed",
         "kind": "static_from",
-        "line": 730,
+        "line": 729,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50380,16 +50815,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.workflow:_get_workflow_node",
         "kind": "static_from",
-        "line": 735,
+        "line": 734,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50403,16 +50838,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_prompt_translation_change_key",
         "kind": "static_from",
-        "line": 736,
+        "line": 735,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50426,16 +50861,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_split_tag_text",
         "kind": "static_from",
-        "line": 736,
+        "line": 735,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50449,16 +50884,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_translate_prompt_text",
         "kind": "static_from",
-        "line": 736,
+        "line": 735,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50472,16 +50907,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_HASH_COMMENT_RE",
         "kind": "static_from",
-        "line": 741,
+        "line": 740,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50495,16 +50930,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_INLINE_SPACE_RE",
         "kind": "static_from",
-        "line": 741,
+        "line": 740,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50518,16 +50953,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_WEIGHTED_TOKEN_RE",
         "kind": "static_from",
-        "line": 741,
+        "line": 740,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50541,16 +50976,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_correct_builder_prompt",
         "kind": "static_from",
-        "line": 741,
+        "line": 740,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50564,16 +50999,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_filter_metadata_prompt",
         "kind": "static_from",
-        "line": 741,
+        "line": 740,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50587,16 +51022,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_join_prompt_tokens",
         "kind": "static_from",
-        "line": 741,
+        "line": 740,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50610,16 +51045,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_metadata_filter_key",
         "kind": "static_from",
-        "line": 741,
+        "line": 740,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50633,16 +51068,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_metadata_filter_keys",
         "kind": "static_from",
-        "line": 741,
+        "line": 740,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50656,16 +51091,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_prompt_tokens",
         "kind": "static_from",
-        "line": 741,
+        "line": 740,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50679,16 +51114,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:PROMPT_DATA_TYPE",
         "kind": "static_from",
-        "line": 754,
+        "line": 753,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50702,16 +51137,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_advanced_outputs_from_prompt_data",
         "kind": "static_from",
-        "line": 754,
+        "line": 753,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50725,16 +51160,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_apply_prompt_data_overrides",
         "kind": "static_from",
-        "line": 754,
+        "line": 753,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50748,16 +51183,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_copy_prompt_data_for_update",
         "kind": "static_from",
-        "line": 754,
+        "line": 753,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50771,16 +51206,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_normalize_prompt_data",
         "kind": "static_from",
-        "line": 754,
+        "line": 753,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50794,16 +51229,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_prompt_data_json_safe",
         "kind": "static_from",
-        "line": 754,
+        "line": 753,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50817,16 +51252,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_prompt_data_parameter_snapshot",
         "kind": "static_from",
-        "line": 754,
+        "line": 753,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50840,16 +51275,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_artist_field_prompt",
         "kind": "static_from",
-        "line": 772,
+        "line": 771,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50863,16 +51298,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_default_fields",
         "kind": "static_from",
-        "line": 772,
+        "line": 771,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50886,16 +51321,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_enabled_naia_panes",
         "kind": "static_from",
-        "line": 772,
+        "line": 771,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50909,16 +51344,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_enabled_pane_fields",
         "kind": "static_from",
-        "line": 772,
+        "line": 771,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50932,16 +51367,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_field_input_values",
         "kind": "static_from",
-        "line": 772,
+        "line": 771,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50955,16 +51390,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_field_socket_name",
         "kind": "static_from",
-        "line": 772,
+        "line": 771,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50978,16 +51413,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_fields_json",
         "kind": "static_from",
-        "line": 772,
+        "line": 771,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51001,16 +51436,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_has_enabled_naia",
         "kind": "static_from",
-        "line": 772,
+        "line": 771,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51024,16 +51459,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_prompt_with_artist_override",
         "kind": "static_from",
-        "line": 772,
+        "line": 771,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51047,16 +51482,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_uses_naia_resolution",
         "kind": "static_from",
-        "line": 772,
+        "line": 771,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51070,16 +51505,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_apply_advanced_field_inputs",
         "kind": "static_from",
-        "line": 772,
+        "line": 771,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51093,16 +51528,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_as_advanced_height",
         "kind": "static_from",
-        "line": 772,
+        "line": 771,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51116,16 +51551,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_build_advanced_prompt_data",
         "kind": "static_from",
-        "line": 772,
+        "line": 771,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51139,16 +51574,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_build_advanced_prompts",
         "kind": "static_from",
-        "line": 772,
+        "line": 771,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51162,16 +51597,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_clone_advanced_fields",
         "kind": "static_from",
-        "line": 772,
+        "line": 771,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51185,16 +51620,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_correct_advanced_field_sequence",
         "kind": "static_from",
-        "line": 772,
+        "line": 771,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51208,16 +51643,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_expand_advanced_wildcard_fields",
         "kind": "static_from",
-        "line": 772,
+        "line": 771,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51231,16 +51666,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_normalize_advanced_fields",
         "kind": "static_from",
-        "line": 772,
+        "line": 771,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51254,16 +51689,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_normalize_prompt_studio_wildcard_seed_control",
         "kind": "static_from",
-        "line": 772,
+        "line": 771,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51277,16 +51712,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_set_naia_field_text",
         "kind": "static_from",
-        "line": 772,
+        "line": 771,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51300,16 +51735,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_translate_prompt_fields",
         "kind": "static_from",
-        "line": 772,
+        "line": 771,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51323,16 +51758,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_apply_regional_field_inputs",
         "kind": "static_from",
-        "line": 807,
+        "line": 806,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51346,16 +51781,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_build_regional_outputs",
         "kind": "static_from",
-        "line": 807,
+        "line": 806,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51369,16 +51804,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_clone_regional_fields",
         "kind": "static_from",
-        "line": 807,
+        "line": 806,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51392,16 +51827,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_conditioning_set_values",
         "kind": "static_from",
-        "line": 807,
+        "line": 806,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51415,16 +51850,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_mask_ids",
         "kind": "static_from",
-        "line": 807,
+        "line": 806,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51438,16 +51873,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_regional_config",
         "kind": "static_from",
-        "line": 807,
+        "line": 806,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51461,16 +51896,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_regional_fields",
         "kind": "static_from",
-        "line": 807,
+        "line": 806,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51484,16 +51919,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_parse_json_object",
         "kind": "static_from",
-        "line": 807,
+        "line": 806,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51507,16 +51942,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_config_json",
         "kind": "static_from",
-        "line": 807,
+        "line": 806,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51530,16 +51965,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_fields_json",
         "kind": "static_from",
-        "line": 807,
+        "line": 806,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51553,16 +51988,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_mask_bounds_area",
         "kind": "static_from",
-        "line": 807,
+        "line": 806,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51576,16 +52011,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_payload_canvas",
         "kind": "static_from",
-        "line": 807,
+        "line": 806,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51599,16 +52034,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_union_mask_for_ids",
         "kind": "static_from",
-        "line": 807,
+        "line": 806,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51622,16 +52057,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
         "kind": "static_from",
-        "line": 834,
+        "line": 833,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51645,16 +52080,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODES",
         "kind": "static_from",
-        "line": 834,
+        "line": 833,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51668,16 +52103,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 834,
+        "line": 833,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51691,16 +52126,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_PROFILE_OFF",
         "kind": "static_from",
-        "line": 834,
+        "line": 833,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51714,16 +52149,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_apply_spectrum_anima_mod_guidance",
         "kind": "static_from",
-        "line": 834,
+        "line": 833,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51737,16 +52172,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_find_spectrum_anima_mod_guidance_class",
         "kind": "static_from",
-        "line": 834,
+        "line": 833,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51760,16 +52195,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_normalize_anima_mod_guidance_profile",
         "kind": "static_from",
-        "line": 834,
+        "line": 833,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51783,16 +52218,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_resolve_anima_mod_guidance_enabled",
         "kind": "static_from",
-        "line": 834,
+        "line": 833,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51806,16 +52241,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
         "kind": "static_from",
-        "line": 849,
+        "line": 848,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51829,16 +52264,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
         "kind": "static_from",
-        "line": 849,
+        "line": 848,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51852,16 +52287,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
         "kind": "static_from",
-        "line": 849,
+        "line": 848,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51875,16 +52310,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_EXACT_TOP_K",
         "kind": "static_from",
-        "line": 849,
+        "line": 848,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51898,16 +52333,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
         "kind": "static_from",
-        "line": 849,
+        "line": 848,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51921,16 +52356,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_START_PERCENT",
         "kind": "static_from",
-        "line": 849,
+        "line": 848,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51944,16 +52379,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
         "kind": "static_from",
-        "line": 849,
+        "line": 848,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51967,16 +52402,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STYLE_GAIN",
         "kind": "static_from",
-        "line": 849,
+        "line": 848,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51990,16 +52425,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_INPUT_MODES",
         "kind": "static_from",
-        "line": 849,
+        "line": 848,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52013,16 +52448,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 849,
+        "line": 848,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52036,16 +52471,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_mix_inline_prompt",
         "kind": "static_from",
-        "line": 849,
+        "line": 848,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52059,16 +52494,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_mix_mode_tooltip",
         "kind": "static_from",
-        "line": 849,
+        "line": 848,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52082,16 +52517,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_prompt_with_position",
         "kind": "static_from",
-        "line": 849,
+        "line": 848,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52105,16 +52540,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_tags_from_prompt",
         "kind": "static_from",
-        "line": 849,
+        "line": 848,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52128,16 +52563,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_blend_conditionings",
         "kind": "static_from",
-        "line": 849,
+        "line": 848,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52151,16 +52586,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bounded_artist_mix_float",
         "kind": "static_from",
-        "line": 849,
+        "line": 848,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52174,16 +52609,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bounded_artist_mix_int",
         "kind": "static_from",
-        "line": 849,
+        "line": 848,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52197,16 +52632,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_clustered",
         "kind": "static_from",
-        "line": 849,
+        "line": 848,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52220,16 +52655,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_delta_rms",
         "kind": "static_from",
-        "line": 849,
+        "line": 848,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52243,16 +52678,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_prompt_data_positive_conditioning",
         "kind": "static_from",
-        "line": 849,
+        "line": 848,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52266,16 +52701,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_join_artist_mix_source_prompts",
         "kind": "static_from",
-        "line": 849,
+        "line": 848,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52289,16 +52724,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_normalize_artist_mix_mode",
         "kind": "static_from",
-        "line": 849,
+        "line": 848,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52312,16 +52747,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_normalize_artist_tag_position",
         "kind": "static_from",
-        "line": 849,
+        "line": 848,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52335,16 +52770,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_parse_artist_mix_items",
         "kind": "static_from",
-        "line": 849,
+        "line": 848,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52358,16 +52793,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaArtistMixConditioning",
         "kind": "static_from",
-        "line": 928,
+        "line": 927,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52381,16 +52816,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataConditioning",
         "kind": "static_from",
-        "line": 928,
+        "line": 927,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52404,16 +52839,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataUnpack",
         "kind": "static_from",
-        "line": 928,
+        "line": 927,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52427,16 +52862,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_ANY_TYPE",
         "kind": "static_from",
-        "line": 933,
+        "line": 932,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52450,16 +52885,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_AnyType",
         "kind": "static_from",
-        "line": 933,
+        "line": 932,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52473,16 +52908,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_FlexibleOptionalInputType",
         "kind": "static_from",
-        "line": 933,
+        "line": 932,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52496,16 +52931,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvanced",
         "kind": "static_from",
-        "line": 938,
+        "line": 937,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52519,16 +52954,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvancedV2",
         "kind": "static_from",
-        "line": 938,
+        "line": 937,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52542,16 +52977,39 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.nodes.aio_nodes:EASY_USE_ANIMA_INPUT_TYPE",
+        "kind": "static_from",
+        "line": 942,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "nodes.py",
+        "target": "easyuse_anima/nodes/aio_nodes.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 565,
+            "kind": "try",
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:EasyUseAnimaAIOGenerator",
         "kind": "static_from",
-        "line": 943,
+        "line": 942,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52565,16 +53023,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:EasyUseAnimaInput",
         "kind": "static_from",
-        "line": 943,
+        "line": 942,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52588,16 +53046,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_aio_generation_settings_json",
         "kind": "static_from",
-        "line": 943,
+        "line": 942,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52611,16 +53069,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_aio_input_settings_json",
         "kind": "static_from",
-        "line": 943,
+        "line": 942,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52634,39 +53092,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
-          }
-        ],
-        "classification": "compatibility_fallback",
-        "conditional": true,
-        "imported": "easyuse_anima.nodes.aio_nodes:_bind_aio_node_runtime",
-        "kind": "static_from",
-        "line": 943,
-        "optional": false,
-        "role": "compatibility_fallback",
-        "source": "nodes.py",
-        "target": "easyuse_anima/nodes/aio_nodes.py"
-      },
-      {
-        "branch_context": [
-          {
-            "branch": "except",
-            "catches_import_error": true,
-            "exceptions": [
-              "ImportError"
-            ],
-            "handler_line": 566,
-            "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_align_down",
         "kind": "static_from",
-        "line": 950,
+        "line": 949,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52680,16 +53115,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_align_nearest",
         "kind": "static_from",
-        "line": 950,
+        "line": 949,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52703,16 +53138,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_image_tensor_size",
         "kind": "static_from",
-        "line": 950,
+        "line": 949,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52726,16 +53161,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_context_value",
         "kind": "static_from",
-        "line": 961,
+        "line": 960,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52749,16 +53184,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_sam3_context",
         "kind": "static_from",
-        "line": 961,
+        "line": 960,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52772,16 +53207,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_segs_has_items",
         "kind": "static_from",
-        "line": 961,
+        "line": 960,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52795,16 +53230,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:IMAGE_SCALE_MULTIPLES",
         "kind": "static_from",
-        "line": 973,
+        "line": 972,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52818,16 +53253,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:IMAGE_UPSCALE_METHODS",
         "kind": "static_from",
-        "line": 973,
+        "line": 972,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52841,16 +53276,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_sampler_names",
         "kind": "static_from",
-        "line": 981,
+        "line": 980,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52864,16 +53299,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_scheduler_names",
         "kind": "static_from",
-        "line": 981,
+        "line": 980,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52887,16 +53322,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_impact_scheduler_names",
         "kind": "static_from",
-        "line": 981,
+        "line": 980,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52910,16 +53345,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_call_with_supported_kwargs",
         "kind": "static_from",
-        "line": 987,
+        "line": 986,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52933,16 +53368,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_common_upscale_image",
         "kind": "static_from",
-        "line": 987,
+        "line": 986,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52956,16 +53391,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_node_output_tuple",
         "kind": "static_from",
-        "line": 987,
+        "line": 986,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52979,16 +53414,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_clip_loader_types",
         "kind": "static_from",
-        "line": 992,
+        "line": 991,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53002,16 +53437,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_diffusion_model_names",
         "kind": "static_from",
-        "line": 992,
+        "line": 991,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53025,16 +53460,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_text_encoder_names",
         "kind": "static_from",
-        "line": 992,
+        "line": 991,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53048,16 +53483,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_vae_names",
         "kind": "static_from",
-        "line": 992,
+        "line": 991,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53071,16 +53506,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_folder_path_names",
         "kind": "static_from",
-        "line": 992,
+        "line": 991,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53094,16 +53529,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.nodes.image_nodes:EasyUseAnimaDetailerAlignHook",
         "kind": "static_from",
-        "line": 1000,
+        "line": 999,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53117,16 +53552,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.nodes.image_nodes:EasyUseAnimaImageScaleByMultiple",
         "kind": "static_from",
-        "line": 1000,
+        "line": 999,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53140,16 +53575,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Context",
         "kind": "static_from",
-        "line": 1004,
+        "line": 1003,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53163,16 +53598,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Detailer",
         "kind": "static_from",
-        "line": 1004,
+        "line": 1003,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53186,16 +53621,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptBuilder",
         "kind": "static_from",
-        "line": 1008,
+        "line": 1007,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53209,16 +53644,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrector",
         "kind": "static_from",
-        "line": 1008,
+        "line": 1007,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53232,16 +53667,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrectorSimple",
         "kind": "static_from",
-        "line": 1008,
+        "line": 1007,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53255,16 +53690,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptStudio",
         "kind": "static_from",
-        "line": 1008,
+        "line": 1007,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53278,16 +53713,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:EasyUseAnimaPromptStudioRegional",
         "kind": "static_from",
-        "line": 1014,
+        "line": 1013,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53301,16 +53736,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:EasyUseAnimaRegionalConditioning",
         "kind": "static_from",
-        "line": 1014,
+        "line": 1013,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53324,16 +53759,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.naia.client:LATENT_ALIGN",
         "kind": "static_from",
-        "line": 1018,
+        "line": 1017,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53347,16 +53782,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_parse_random_response",
         "kind": "static_from",
-        "line": 1018,
+        "line": 1017,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53370,16 +53805,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_post_random",
         "kind": "static_from",
-        "line": 1018,
+        "line": 1017,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53393,16 +53828,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_advanced_resolution_from_selection",
         "kind": "static_from",
-        "line": 1036,
+        "line": 1035,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53416,16 +53851,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_normalize_resolution_bucket",
         "kind": "static_from",
-        "line": 1036,
+        "line": 1035,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53439,16 +53874,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_ratio_label",
         "kind": "static_from",
-        "line": 1036,
+        "line": 1035,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53462,16 +53897,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolution_label",
         "kind": "static_from",
-        "line": 1036,
+        "line": 1035,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53485,16 +53920,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolve_naia_resolution",
         "kind": "static_from",
-        "line": 1036,
+        "line": 1035,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53508,16 +53943,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.nodes.naia_nodes:EasyUseAnimaNAIARandomPrompt",
         "kind": "static_from",
-        "line": 1059,
+        "line": 1058,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53531,16 +53966,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.nodes.naia_nodes:_bind_naia_node_runtime",
         "kind": "static_from",
-        "line": 1059,
+        "line": 1058,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53554,16 +53989,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.nodes.wildcard_nodes:EasyUseAnimaWildcard",
         "kind": "static_from",
-        "line": 1063,
+        "line": 1062,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53577,16 +54012,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.nodes.wildcard_nodes:_bind_wildcard_node_runtime",
         "kind": "static_from",
-        "line": 1063,
+        "line": 1062,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53600,16 +54035,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_apply_lora_syntax_format",
         "kind": "static_from",
-        "line": 1068,
+        "line": 1067,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53623,16 +54058,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_dedupe_text_values",
         "kind": "static_from",
-        "line": 1068,
+        "line": 1067,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53646,16 +54081,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_fallback_lora_path",
         "kind": "static_from",
-        "line": 1068,
+        "line": 1067,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53669,16 +54104,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_get_lora_info",
         "kind": "static_from",
-        "line": 1068,
+        "line": 1067,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53692,16 +54127,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_get_lora_manager_trigger_words",
         "kind": "static_from",
-        "line": 1068,
+        "line": 1067,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53715,16 +54150,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_load_lora_manager_metadata",
         "kind": "static_from",
-        "line": 1068,
+        "line": 1067,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53738,16 +54173,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_combo_values",
         "kind": "static_from",
-        "line": 1068,
+        "line": 1067,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53761,16 +54196,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_manager_trigger_words_from_metadata",
         "kind": "static_from",
-        "line": 1068,
+        "line": 1067,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53784,16 +54219,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_model_exists",
         "kind": "static_from",
-        "line": 1068,
+        "line": 1067,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53807,16 +54242,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_stack_name",
         "kind": "static_from",
-        "line": 1068,
+        "line": 1067,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53830,16 +54265,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_metadata_json_paths_for_lora",
         "kind": "static_from",
-        "line": 1068,
+        "line": 1067,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53853,16 +54288,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_missing_lora_display_name",
         "kind": "static_from",
-        "line": 1068,
+        "line": 1067,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53876,16 +54311,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_raise_missing_loras",
         "kind": "static_from",
-        "line": 1068,
+        "line": 1067,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53899,16 +54334,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_trigger_words_from_value",
         "kind": "static_from",
-        "line": 1068,
+        "line": 1067,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53922,16 +54357,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_correct_style_prompt",
         "kind": "static_from",
-        "line": 1084,
+        "line": 1083,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53945,16 +54380,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_format_strength",
         "kind": "static_from",
-        "line": 1084,
+        "line": 1083,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53968,16 +54403,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_get_loras_list",
         "kind": "static_from",
-        "line": 1084,
+        "line": 1083,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53991,16 +54426,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_load_profile_data",
         "kind": "static_from",
-        "line": 1084,
+        "line": 1083,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54014,16 +54449,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_profile_key",
         "kind": "static_from",
-        "line": 1084,
+        "line": 1083,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54037,16 +54472,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_select_profile_values",
         "kind": "static_from",
-        "line": 1084,
+        "line": 1083,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54060,16 +54495,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_wrap_profile_index",
         "kind": "static_from",
-        "line": 1084,
+        "line": 1083,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54083,16 +54518,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.nodes.lora_nodes:EasyUseAnimaLoraPreset",
         "kind": "static_from",
-        "line": 1093,
+        "line": 1092,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54106,16 +54541,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "anima_prompt:correct_prompt",
         "kind": "static_from",
-        "line": 1096,
+        "line": 1095,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54129,16 +54564,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "anima_prompt:load_knowledge_base",
         "kind": "static_from",
-        "line": 1096,
+        "line": 1095,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54152,16 +54587,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "anima_prompt.parser:parse_prompt",
         "kind": "static_from",
-        "line": 1097,
+        "line": 1096,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54175,16 +54610,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "settings:resolve_metadata_filter_words",
         "kind": "static_from",
-        "line": 1098,
+        "line": 1097,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54198,16 +54633,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "settings:resolve_naia_settings",
         "kind": "static_from",
-        "line": 1098,
+        "line": 1097,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54221,16 +54656,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "settings:resolve_prompt_translation_settings",
         "kind": "static_from",
-        "line": 1098,
+        "line": 1097,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54244,16 +54679,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "prompt_translation:has_prompt_translation_markers",
         "kind": "static_from",
-        "line": 1103,
+        "line": 1102,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54267,16 +54702,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "prompt_translation:translate_prompt_markers",
         "kind": "static_from",
-        "line": 1103,
+        "line": 1102,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54290,16 +54725,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "wildcard_engine:MAX_SEED",
         "kind": "static_from",
-        "line": 1104,
+        "line": 1103,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54313,16 +54748,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "wildcard_engine:PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "kind": "static_from",
-        "line": 1104,
+        "line": 1103,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54336,16 +54771,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "wildcard_engine:PUBLIC_MAX_SEED",
         "kind": "static_from",
-        "line": 1104,
+        "line": 1103,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54359,16 +54794,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_DECREMENT",
         "kind": "static_from",
-        "line": 1104,
+        "line": 1103,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54382,16 +54817,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_FIXED",
         "kind": "static_from",
-        "line": 1104,
+        "line": 1103,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54405,16 +54840,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_INCREMENT",
         "kind": "static_from",
-        "line": 1104,
+        "line": 1103,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54428,16 +54863,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_MODES",
         "kind": "static_from",
-        "line": 1104,
+        "line": 1103,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54451,16 +54886,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_RANDOMIZE",
         "kind": "static_from",
-        "line": 1104,
+        "line": 1103,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54474,16 +54909,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_FIXED",
         "kind": "static_from",
-        "line": 1104,
+        "line": 1103,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54497,16 +54932,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_POPULATE",
         "kind": "static_from",
-        "line": 1104,
+        "line": 1103,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54520,16 +54955,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_SEQUENTIAL",
         "kind": "static_from",
-        "line": 1104,
+        "line": 1103,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54543,16 +54978,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "wildcard_engine:expand_wildcard_texts",
         "kind": "static_from",
-        "line": 1104,
+        "line": 1103,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54566,16 +55001,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "wildcard_engine:expand_wildcards",
         "kind": "static_from",
-        "line": 1104,
+        "line": 1103,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54589,16 +55024,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "wildcard_engine:has_wildcard_syntax",
         "kind": "static_from",
-        "line": 1104,
+        "line": 1103,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54612,16 +55047,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "wildcard_engine:next_seed",
         "kind": "static_from",
-        "line": 1104,
+        "line": 1103,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54635,16 +55070,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "wildcard_engine:normalize_prompt_studio_wildcard_mode",
         "kind": "static_from",
-        "line": 1104,
+        "line": 1103,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54658,16 +55093,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "wildcard_engine:normalize_seed",
         "kind": "static_from",
-        "line": 1104,
+        "line": 1103,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54681,16 +55116,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "wildcard_engine:normalize_wildcard_mode",
         "kind": "static_from",
-        "line": 1104,
+        "line": 1103,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54704,16 +55139,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 565,
             "kind": "try",
-            "line": 7
+            "line": 6
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "wildcard_engine:wildcard_sources_signature",
         "kind": "static_from",
-        "line": 1104,
+        "line": 1103,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -57686,31 +58121,9 @@
         "branch_context": [],
         "classification": "external",
         "conditional": false,
-        "imported": "collections.abc:Callable",
-        "kind": "static_from",
+        "imported": "json",
+        "kind": "static_import",
         "line": 5,
-        "optional": false,
-        "role": "ordinary",
-        "source": "easyuse_anima/nodes/aio_nodes.py"
-      },
-      {
-        "branch_context": [],
-        "classification": "external",
-        "conditional": false,
-        "imported": "typing:Any",
-        "kind": "static_from",
-        "line": 6,
-        "optional": false,
-        "role": "ordinary",
-        "source": "easyuse_anima/nodes/aio_nodes.py"
-      },
-      {
-        "branch_context": [],
-        "classification": "external",
-        "conditional": false,
-        "imported": "typing:TypeAlias",
-        "kind": "static_from",
-        "line": 6,
         "optional": false,
         "role": "ordinary",
         "source": "easyuse_anima/nodes/aio_nodes.py"
@@ -58611,20 +59024,9 @@
         "branch_context": [],
         "classification": "external",
         "conditional": false,
-        "imported": "json",
-        "kind": "static_import",
-        "line": 4,
-        "optional": false,
-        "role": "ordinary",
-        "source": "nodes.py"
-      },
-      {
-        "branch_context": [],
-        "classification": "external",
-        "conditional": false,
         "imported": "logging",
         "kind": "static_import",
-        "line": 5,
+        "line": 4,
         "optional": false,
         "role": "ordinary",
         "source": "nodes.py"
@@ -61397,16 +61799,7 @@
         "column": 9,
         "context": "assign:logger",
         "kind": "import_time_call",
-        "line": 1126,
-        "module": "nodes.py",
-        "scope": "<module>"
-      },
-      {
-        "callee": "_bind_aio_node_runtime",
-        "column": 0,
-        "context": "expression",
-        "kind": "import_time_call",
-        "line": 1132,
+        "line": 1125,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -61415,7 +61808,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1135,
+        "line": 1130,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -61424,7 +61817,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1142,
+        "line": 1137,
         "module": "nodes.py",
         "scope": "<module>"
       },

--- a/tests/fixtures/python_compatibility_surface.v1.json
+++ b/tests/fixtures/python_compatibility_surface.v1.json
@@ -80,7 +80,8 @@
       "B-11c30d3",
       "B-11c30d4",
       "B-11c30d0b",
-      "B-11c30d5"
+      "B-11c30d5",
+      "B-11c30d6"
     ]
   },
   "enums": {
@@ -114,15 +115,15 @@
   },
   "expected_counts": {
     "root_entrypoints": 3,
-    "excluded_preamble_implementation_bindings": 2,
+    "excluded_preamble_implementation_bindings": 1,
     "nodes_canonical_bindings": 291,
     "nodes_legacy_bindings": 27,
     "mapped_public_classes": 18,
     "unmapped_classes": 2,
     "root_residual_functions": 0,
     "root_residual_classes": 0,
-    "root_residual_globals": 3,
-    "runtime_binders": 3,
+    "root_residual_globals": 2,
+    "runtime_binders": 2,
     "direct_nodes_import_test_files": 21
   },
   "mapped_public_classes": [
@@ -150,123 +151,33 @@
     "EasyUseAnimaSAM3Detailer"
   ],
   "excluded_preamble_implementation_bindings": {
-    "json": "json:json",
     "logging": "logging:logging"
   },
   "runtime_binders": [
-    "_bind_aio_node_runtime",
     "_bind_wildcard_node_runtime",
     "_bind_naia_node_runtime"
   ],
-  "runtime_resolver_consumers": {
-    "AIO_GENERATION_DEFAULT_SETTINGS": [
-      "easyuse_anima.nodes.aio_nodes"
-    ],
-    "AIO_INPUT_DEFAULT_SETTINGS": [
-      "easyuse_anima.nodes.aio_nodes"
-    ],
-    "AIO_SPECIAL_SEEDS": [
-      "easyuse_anima.nodes.aio_nodes"
-    ],
-    "ANIMA_DEFAULT_CLIP_CANDIDATES": [
-      "easyuse_anima.nodes.aio_nodes"
-    ],
-    "ANIMA_DEFAULT_DIFFUSION_MODEL_CANDIDATES": [
-      "easyuse_anima.nodes.aio_nodes"
-    ],
-    "ANIMA_DEFAULT_VAE_CANDIDATES": [
-      "easyuse_anima.nodes.aio_nodes"
-    ],
-    "EASY_USE_ANIMA_INPUT_SCHEMA": [
-      "easyuse_anima.nodes.aio_nodes"
-    ],
-    "EASY_USE_ANIMA_INPUT_SETTINGS_VERSION": [
-      "easyuse_anima.nodes.aio_nodes"
-    ],
-    "EASY_USE_ANIMA_INPUT_TYPE": [
-      "easyuse_anima.nodes.aio_nodes"
-    ],
-    "PROMPT_DATA_TYPE": [
-      "easyuse_anima.nodes.aio_nodes"
-    ],
-    "_aio_generation_settings_json": [
-      "easyuse_anima.nodes.aio_nodes"
-    ],
-    "_aio_input_settings_json": [
-      "easyuse_anima.nodes.aio_nodes"
-    ],
-    "_aio_lora_stack_signature": [
-      "easyuse_anima.nodes.aio_nodes"
-    ],
-    "_comfy_clip_loader_types": [
-      "easyuse_anima.nodes.aio_nodes"
-    ],
-    "_comfy_diffusion_model_names": [
-      "easyuse_anima.nodes.aio_nodes"
-    ],
-    "_comfy_text_encoder_names": [
-      "easyuse_anima.nodes.aio_nodes"
-    ],
-    "_comfy_vae_names": [
-      "easyuse_anima.nodes.aio_nodes"
-    ],
-    "_copy_prompt_data_for_update": [
-      "easyuse_anima.nodes.aio_nodes"
-    ],
-    "_json_clone": [
-      "easyuse_anima.nodes.aio_nodes"
-    ],
-    "_normalize_aio_generation_settings": [
-      "easyuse_anima.nodes.aio_nodes"
-    ],
-    "_normalize_aio_input_settings": [
-      "easyuse_anima.nodes.aio_nodes"
-    ],
-    "_normalize_prompt_data": [
-      "easyuse_anima.nodes.aio_nodes"
-    ],
-    "_preferred_clip_type_default": [
-      "easyuse_anima.nodes.aio_nodes"
-    ],
-    "_preferred_name_default": [
-      "easyuse_anima.nodes.aio_nodes"
-    ],
-    "_prompt_data_json_safe": [
-      "easyuse_anima.nodes.aio_nodes"
-    ],
-    "_resolve_aio_runtime_seed": [
-      "easyuse_anima.nodes.aio_nodes"
-    ],
-    "_run_aio_legacy_generation": [
-      "easyuse_anima.nodes.aio_nodes"
-    ],
-    "_stable_change_key": [
-      "easyuse_anima.nodes.aio_nodes"
-    ]
-  },
+  "runtime_resolver_consumers": {},
   "runtime_binder_audit": {
     "summary": {
-      "binder_count": 3,
-      "family_count": 2,
+      "binder_count": 2,
+      "family_count": 1,
       "mode_counts": {
         "comfy_provider_then_root": 0,
-        "root_globals": 1,
+        "root_globals": 0,
         "explicit_callbacks": 2
       },
-      "unique_resolver_names": 29,
-      "unique_root_resolver_names": 29,
+      "unique_resolver_names": 0,
+      "unique_root_resolver_names": 0,
       "unique_provider_resolver_names": 0,
       "unique_direct_root_dependencies": 8,
       "direct_root_dependency_slots": 9,
       "provider_consumer_slots": 0,
       "provider_consumer_modules": 0,
-      "repository_replacement_names": 32,
-      "repository_replacement_files": 5
+      "repository_replacement_names": 5,
+      "repository_replacement_files": 3
     },
     "families": {
-      "aio": [
-        "_bind_aio_node_runtime"
-      ],
       "wildcard_naia": [
         "_bind_wildcard_node_runtime",
         "_bind_naia_node_runtime"
@@ -286,36 +197,10 @@
         "B-11c30d2_normalization_planning",
         "B-11c30d3_io_boundary",
         "B-11c30d4_execution_services",
-        "B-11c30d5_legacy_orchestration"
+        "B-11c30d5_legacy_orchestration",
+        "B-11c30d6_node_adapter"
       ],
-      "subgroups": {
-        "B-11c30d6_node_adapter": {
-          "binders": [
-            "_bind_aio_node_runtime"
-          ],
-          "mode_counts": {
-            "comfy_provider_then_root": 0,
-            "root_globals": 1
-          },
-          "bound_global_slots": 1,
-          "unique_bound_globals": [
-            "_RUNTIME_RESOLVER"
-          ],
-          "root_resolver_slots": 29,
-          "unique_root_resolver_names": 29,
-          "provider_resolver_slots": 0,
-          "unique_provider_resolver_names": 0,
-          "direct_root_dependency_slots": 0,
-          "unique_direct_root_dependencies": 0,
-          "repository_replacement_slots": 27,
-          "unique_repository_replacement_names": 27,
-          "repository_replacement_files": [
-            "tests/test_aio_legacy_generation.py",
-            "tests/test_aio_nodes.py",
-            "tests/test_node_contracts.py"
-          ]
-        }
-      },
+      "subgroups": {},
       "prerequisite_moves": [
         {
           "id": "B-11c30d0a_output_settings_owner",
@@ -366,132 +251,17 @@
         }
       ]
     },
-    "root_resolver_names": [
-      "AIO_GENERATION_DEFAULT_SETTINGS",
-      "AIO_INPUT_DEFAULT_SETTINGS",
-      "AIO_SPECIAL_SEEDS",
-      "ANIMA_DEFAULT_CLIP_CANDIDATES",
-      "ANIMA_DEFAULT_DIFFUSION_MODEL_CANDIDATES",
-      "ANIMA_DEFAULT_VAE_CANDIDATES",
-      "EASY_USE_ANIMA_INPUT_SCHEMA",
-      "EASY_USE_ANIMA_INPUT_SETTINGS_VERSION",
-      "EASY_USE_ANIMA_INPUT_TYPE",
-      "PROMPT_DATA_TYPE",
-      "_aio_generation_settings_json",
-      "_aio_input_settings_json",
-      "_aio_lora_stack_signature",
-      "_comfy_clip_loader_types",
-      "_comfy_diffusion_model_names",
-      "_comfy_text_encoder_names",
-      "_comfy_vae_names",
-      "_copy_prompt_data_for_update",
-      "_json_clone",
-      "_normalize_aio_generation_settings",
-      "_normalize_aio_input_settings",
-      "_normalize_prompt_data",
-      "_preferred_clip_type_default",
-      "_preferred_name_default",
-      "_prompt_data_json_safe",
-      "_resolve_aio_runtime_seed",
-      "_run_aio_legacy_generation",
-      "_stable_change_key",
-      "json"
-    ],
+    "root_resolver_names": [],
     "provider_resolver_names": [],
     "repository_root_replacements": {
-      "AIO_GENERATION_DEFAULT_SETTINGS": [
-        "tests/test_node_contracts.py"
-      ],
-      "AIO_INPUT_DEFAULT_SETTINGS": [
-        "tests/test_node_contracts.py"
-      ],
-      "AIO_SPECIAL_SEEDS": [
-        "tests/test_aio_nodes.py"
-      ],
-      "ANIMA_DEFAULT_CLIP_CANDIDATES": [
-        "tests/test_aio_nodes.py"
-      ],
-      "ANIMA_DEFAULT_DIFFUSION_MODEL_CANDIDATES": [
-        "tests/test_aio_nodes.py"
-      ],
-      "ANIMA_DEFAULT_VAE_CANDIDATES": [
-        "tests/test_aio_nodes.py"
-      ],
-      "EASY_USE_ANIMA_INPUT_TYPE": [
-        "tests/test_aio_nodes.py"
-      ],
-      "PROMPT_DATA_TYPE": [
-        "tests/test_aio_nodes.py"
-      ],
-      "_aio_generation_settings_json": [
-        "tests/test_aio_nodes.py"
-      ],
-      "_aio_input_settings_json": [
-        "tests/test_aio_nodes.py"
-      ],
-      "_aio_lora_stack_signature": [
-        "tests/test_aio_nodes.py"
-      ],
-      "_comfy_clip_loader_types": [
-        "tests/test_aio_nodes.py",
-        "tests/test_node_contracts.py"
-      ],
-      "_comfy_diffusion_model_names": [
-        "tests/test_aio_nodes.py",
-        "tests/test_node_contracts.py"
-      ],
-      "_comfy_text_encoder_names": [
-        "tests/test_aio_nodes.py",
-        "tests/test_node_contracts.py"
-      ],
-      "_comfy_vae_names": [
-        "tests/test_aio_nodes.py",
-        "tests/test_node_contracts.py"
-      ],
-      "_copy_prompt_data_for_update": [
-        "tests/test_aio_nodes.py"
-      ],
       "_get_workflow_node": [
         "tests/test_node_contracts.py"
-      ],
-      "_json_clone": [
-        "tests/test_aio_nodes.py"
-      ],
-      "_normalize_aio_generation_settings": [
-        "tests/test_aio_nodes.py"
-      ],
-      "_normalize_aio_input_settings": [
-        "tests/test_aio_nodes.py"
-      ],
-      "_normalize_prompt_data": [
-        "tests/test_aio_nodes.py"
       ],
       "_post_random": [
         "tests/test_naia_settings.py"
       ],
-      "_preferred_clip_type_default": [
-        "tests/test_aio_nodes.py"
-      ],
-      "_preferred_name_default": [
-        "tests/test_aio_nodes.py"
-      ],
-      "_prompt_data_json_safe": [
-        "tests/test_aio_nodes.py"
-      ],
-      "_resolve_aio_runtime_seed": [
-        "tests/test_aio_nodes.py"
-      ],
-      "_run_aio_legacy_generation": [
-        "tests/test_aio_legacy_generation.py"
-      ],
-      "_stable_change_key": [
-        "tests/test_aio_nodes.py"
-      ],
       "expand_wildcards": [
         "tests/test_wildcards.py"
-      ],
-      "json": [
-        "tests/test_node_contracts.py"
       ],
       "resolve_naia_settings": [
         "tests/test_naia_settings.py",
@@ -502,112 +272,6 @@
       ]
     },
     "entries": [
-      {
-        "binder": "_bind_aio_node_runtime",
-        "module": "easyuse_anima.nodes.aio_nodes",
-        "family": "aio",
-        "mode": "root_globals",
-        "root_observation": "call_time_resolver",
-        "root_keywords": [
-          "resolve_helper"
-        ],
-        "bound_globals": [
-          "_RUNTIME_RESOLVER"
-        ],
-        "direct_root_dependencies": [],
-        "resolver_names": [
-          "AIO_GENERATION_DEFAULT_SETTINGS",
-          "AIO_INPUT_DEFAULT_SETTINGS",
-          "AIO_SPECIAL_SEEDS",
-          "ANIMA_DEFAULT_CLIP_CANDIDATES",
-          "ANIMA_DEFAULT_DIFFUSION_MODEL_CANDIDATES",
-          "ANIMA_DEFAULT_VAE_CANDIDATES",
-          "EASY_USE_ANIMA_INPUT_SCHEMA",
-          "EASY_USE_ANIMA_INPUT_SETTINGS_VERSION",
-          "EASY_USE_ANIMA_INPUT_TYPE",
-          "PROMPT_DATA_TYPE",
-          "_aio_generation_settings_json",
-          "_aio_input_settings_json",
-          "_aio_lora_stack_signature",
-          "_comfy_clip_loader_types",
-          "_comfy_diffusion_model_names",
-          "_comfy_text_encoder_names",
-          "_comfy_vae_names",
-          "_copy_prompt_data_for_update",
-          "_json_clone",
-          "_normalize_aio_generation_settings",
-          "_normalize_aio_input_settings",
-          "_normalize_prompt_data",
-          "_preferred_clip_type_default",
-          "_preferred_name_default",
-          "_prompt_data_json_safe",
-          "_resolve_aio_runtime_seed",
-          "_run_aio_legacy_generation",
-          "_stable_change_key",
-          "json"
-        ],
-        "root_resolver_names": [
-          "AIO_GENERATION_DEFAULT_SETTINGS",
-          "AIO_INPUT_DEFAULT_SETTINGS",
-          "AIO_SPECIAL_SEEDS",
-          "ANIMA_DEFAULT_CLIP_CANDIDATES",
-          "ANIMA_DEFAULT_DIFFUSION_MODEL_CANDIDATES",
-          "ANIMA_DEFAULT_VAE_CANDIDATES",
-          "EASY_USE_ANIMA_INPUT_SCHEMA",
-          "EASY_USE_ANIMA_INPUT_SETTINGS_VERSION",
-          "EASY_USE_ANIMA_INPUT_TYPE",
-          "PROMPT_DATA_TYPE",
-          "_aio_generation_settings_json",
-          "_aio_input_settings_json",
-          "_aio_lora_stack_signature",
-          "_comfy_clip_loader_types",
-          "_comfy_diffusion_model_names",
-          "_comfy_text_encoder_names",
-          "_comfy_vae_names",
-          "_copy_prompt_data_for_update",
-          "_json_clone",
-          "_normalize_aio_generation_settings",
-          "_normalize_aio_input_settings",
-          "_normalize_prompt_data",
-          "_preferred_clip_type_default",
-          "_preferred_name_default",
-          "_prompt_data_json_safe",
-          "_resolve_aio_runtime_seed",
-          "_run_aio_legacy_generation",
-          "_stable_change_key",
-          "json"
-        ],
-        "provider_resolver_names": [],
-        "repository_replacement_names": [
-          "AIO_GENERATION_DEFAULT_SETTINGS",
-          "AIO_INPUT_DEFAULT_SETTINGS",
-          "AIO_SPECIAL_SEEDS",
-          "ANIMA_DEFAULT_CLIP_CANDIDATES",
-          "ANIMA_DEFAULT_DIFFUSION_MODEL_CANDIDATES",
-          "ANIMA_DEFAULT_VAE_CANDIDATES",
-          "EASY_USE_ANIMA_INPUT_TYPE",
-          "PROMPT_DATA_TYPE",
-          "_aio_generation_settings_json",
-          "_aio_input_settings_json",
-          "_aio_lora_stack_signature",
-          "_comfy_clip_loader_types",
-          "_comfy_diffusion_model_names",
-          "_comfy_text_encoder_names",
-          "_comfy_vae_names",
-          "_copy_prompt_data_for_update",
-          "_json_clone",
-          "_normalize_aio_generation_settings",
-          "_normalize_aio_input_settings",
-          "_normalize_prompt_data",
-          "_preferred_clip_type_default",
-          "_preferred_name_default",
-          "_prompt_data_json_safe",
-          "_resolve_aio_runtime_seed",
-          "_run_aio_legacy_generation",
-          "_stable_change_key",
-          "json"
-        ]
-      },
       {
         "binder": "_bind_wildcard_node_runtime",
         "module": "easyuse_anima.nodes.wildcard_nodes",
@@ -1493,44 +1157,17 @@
       "lifecycle_state": "unsupported"
     },
     {
-      "id": "nodes_canonical_bindings:easyuse_anima.aio.generation_defaults:transitional_private_seam",
-      "surface": "nodes_canonical_bindings",
-      "symbols": {
-        "AIO_GENERATION_DEFAULT_SETTINGS": "AIO_GENERATION_DEFAULT_SETTINGS",
-        "AIO_SPECIAL_SEEDS": "AIO_SPECIAL_SEEDS"
-      },
-      "classification": "transitional_private_seam",
-      "current_target": "nodes.py",
-      "canonical_target": "easyuse_anima.aio.generation_defaults",
-      "target_state": "canonical",
-      "identity_requirement": "required",
-      "binding_shape": "direct_import",
-      "import_target": "easyuse_anima.aio.generation_defaults",
-      "owner": "#184/#188",
-      "first_release": null,
-      "known_consumers": [
-        "canonical runtime resolver: easyuse_anima.nodes.aio_nodes"
-      ],
-      "evidence": [
-        "AST:easyuse_anima.nodes.aio_nodes string runtime lookup"
-      ],
-      "removal_gates": [
-        "canonical production consumer migration",
-        "focused monkeypatch and identity contract review",
-        "separate B-10b or B-11 rollback unit"
-      ],
-      "lifecycle_state": "transitional"
-    },
-    {
       "id": "nodes_canonical_bindings:easyuse_anima.aio.generation_defaults:unsupported_test_only",
       "surface": "nodes_canonical_bindings",
       "symbols": {
         "AIO_FINAL_FIT_MODES": "AIO_FINAL_FIT_MODES",
         "AIO_FINAL_UPSCALE_BACKENDS": "AIO_FINAL_UPSCALE_BACKENDS",
+        "AIO_GENERATION_DEFAULT_SETTINGS": "AIO_GENERATION_DEFAULT_SETTINGS",
         "AIO_GENERATION_SETTINGS_SCHEMA": "AIO_GENERATION_SETTINGS_SCHEMA",
         "AIO_GENERATION_SETTINGS_VERSION": "AIO_GENERATION_SETTINGS_VERSION",
         "AIO_RESHIFT_DTYPES": "AIO_RESHIFT_DTYPES",
         "AIO_RESHIFT_SCALES": "AIO_RESHIFT_SCALES",
+        "AIO_SPECIAL_SEEDS": "AIO_SPECIAL_SEEDS",
         "AIO_SPECIAL_SEED_DECREMENT": "AIO_SPECIAL_SEED_DECREMENT",
         "AIO_SPECIAL_SEED_INCREMENT": "AIO_SPECIAL_SEED_INCREMENT",
         "AIO_SPECIAL_SEED_RANDOM": "AIO_SPECIAL_SEED_RANDOM",
@@ -1564,34 +1201,6 @@
       "lifecycle_state": "unsupported"
     },
     {
-      "id": "nodes_canonical_bindings:easyuse_anima.aio.generation_normalization:transitional_private_seam",
-      "surface": "nodes_canonical_bindings",
-      "symbols": {
-        "_normalize_aio_generation_settings": "_normalize_aio_generation_settings"
-      },
-      "classification": "transitional_private_seam",
-      "current_target": "nodes.py",
-      "canonical_target": "easyuse_anima.aio.generation_normalization",
-      "target_state": "canonical",
-      "identity_requirement": "required",
-      "binding_shape": "direct_import",
-      "import_target": "easyuse_anima.aio.generation_normalization",
-      "owner": "#184/#188",
-      "first_release": null,
-      "known_consumers": [
-        "canonical runtime resolver: easyuse_anima.nodes.aio_nodes"
-      ],
-      "evidence": [
-        "AST:easyuse_anima.nodes.aio_nodes string runtime lookup"
-      ],
-      "removal_gates": [
-        "canonical production consumer migration",
-        "focused monkeypatch and identity contract review",
-        "separate B-10b or B-11 rollback unit"
-      ],
-      "lifecycle_state": "transitional"
-    },
-    {
       "id": "nodes_canonical_bindings:easyuse_anima.aio.generation_normalization:unsupported_test_only",
       "surface": "nodes_canonical_bindings",
       "symbols": {
@@ -1603,6 +1212,7 @@
         "_is_aio_detailer_target_name": "_is_aio_detailer_target_name",
         "_merge_versioned_settings": "_merge_versioned_settings",
         "_normalize_aio_dit_corrections_settings": "_normalize_aio_dit_corrections_settings",
+        "_normalize_aio_generation_settings": "_normalize_aio_generation_settings",
         "_normalize_aio_seed": "_normalize_aio_seed",
         "_normalize_aio_spectrum_settings": "_normalize_aio_spectrum_settings"
       },
@@ -1689,45 +1299,18 @@
       "lifecycle_state": "unsupported"
     },
     {
-      "id": "nodes_canonical_bindings:easyuse_anima.aio.input_defaults:transitional_private_seam",
-      "surface": "nodes_canonical_bindings",
-      "symbols": {
-        "AIO_INPUT_DEFAULT_SETTINGS": "AIO_INPUT_DEFAULT_SETTINGS",
-        "ANIMA_DEFAULT_CLIP_CANDIDATES": "ANIMA_DEFAULT_CLIP_CANDIDATES",
-        "ANIMA_DEFAULT_DIFFUSION_MODEL_CANDIDATES": "ANIMA_DEFAULT_DIFFUSION_MODEL_CANDIDATES",
-        "ANIMA_DEFAULT_VAE_CANDIDATES": "ANIMA_DEFAULT_VAE_CANDIDATES",
-        "EASY_USE_ANIMA_INPUT_SCHEMA": "EASY_USE_ANIMA_INPUT_SCHEMA",
-        "EASY_USE_ANIMA_INPUT_SETTINGS_VERSION": "EASY_USE_ANIMA_INPUT_SETTINGS_VERSION"
-      },
-      "classification": "transitional_private_seam",
-      "current_target": "nodes.py",
-      "canonical_target": "easyuse_anima.aio.input_defaults",
-      "target_state": "canonical",
-      "identity_requirement": "required",
-      "binding_shape": "direct_import",
-      "import_target": "easyuse_anima.aio.input_defaults",
-      "owner": "#184/#188",
-      "first_release": null,
-      "known_consumers": [
-        "canonical runtime resolver: easyuse_anima.nodes.aio_nodes"
-      ],
-      "evidence": [
-        "AST:easyuse_anima.nodes.aio_nodes string runtime lookup"
-      ],
-      "removal_gates": [
-        "canonical production consumer migration",
-        "focused monkeypatch and identity contract review",
-        "separate B-10b or B-11 rollback unit"
-      ],
-      "lifecycle_state": "transitional"
-    },
-    {
       "id": "nodes_canonical_bindings:easyuse_anima.aio.input_defaults:unsupported_test_only",
       "surface": "nodes_canonical_bindings",
       "symbols": {
+        "AIO_INPUT_DEFAULT_SETTINGS": "AIO_INPUT_DEFAULT_SETTINGS",
         "ANIMA_CLIP_DEVICES": "ANIMA_CLIP_DEVICES",
         "ANIMA_CLIP_TYPES": "ANIMA_CLIP_TYPES",
-        "ANIMA_UNET_WEIGHT_DTYPES": "ANIMA_UNET_WEIGHT_DTYPES"
+        "ANIMA_DEFAULT_CLIP_CANDIDATES": "ANIMA_DEFAULT_CLIP_CANDIDATES",
+        "ANIMA_DEFAULT_DIFFUSION_MODEL_CANDIDATES": "ANIMA_DEFAULT_DIFFUSION_MODEL_CANDIDATES",
+        "ANIMA_DEFAULT_VAE_CANDIDATES": "ANIMA_DEFAULT_VAE_CANDIDATES",
+        "ANIMA_UNET_WEIGHT_DTYPES": "ANIMA_UNET_WEIGHT_DTYPES",
+        "EASY_USE_ANIMA_INPUT_SCHEMA": "EASY_USE_ANIMA_INPUT_SCHEMA",
+        "EASY_USE_ANIMA_INPUT_SETTINGS_VERSION": "EASY_USE_ANIMA_INPUT_SETTINGS_VERSION"
       },
       "classification": "unsupported_test_only",
       "current_target": "nodes.py",
@@ -1753,40 +1336,13 @@
       "lifecycle_state": "unsupported"
     },
     {
-      "id": "nodes_canonical_bindings:easyuse_anima.aio.legacy_generation:transitional_private_seam",
-      "surface": "nodes_canonical_bindings",
-      "symbols": {
-        "_run_aio_legacy_generation": "_run_aio_legacy_generation"
-      },
-      "classification": "transitional_private_seam",
-      "current_target": "nodes.py",
-      "canonical_target": "easyuse_anima.aio.legacy_generation",
-      "target_state": "canonical",
-      "identity_requirement": "required",
-      "binding_shape": "direct_import",
-      "import_target": "easyuse_anima.aio.legacy_generation",
-      "owner": "#184/#188",
-      "first_release": null,
-      "known_consumers": [
-        "canonical runtime resolver: easyuse_anima.nodes.aio_nodes"
-      ],
-      "evidence": [
-        "AST:easyuse_anima.nodes.aio_nodes string runtime lookup"
-      ],
-      "removal_gates": [
-        "canonical production consumer migration",
-        "focused monkeypatch and identity contract review",
-        "separate B-10b or B-11 rollback unit"
-      ],
-      "lifecycle_state": "transitional"
-    },
-    {
       "id": "nodes_canonical_bindings:easyuse_anima.aio.legacy_generation:unsupported_test_only",
       "surface": "nodes_canonical_bindings",
       "symbols": {
         "_run_aio_detailer_stage": "_run_aio_detailer_stage",
         "_run_aio_detailer_target": "_run_aio_detailer_target",
         "_run_aio_highres_stage": "_run_aio_highres_stage",
+        "_run_aio_legacy_generation": "_run_aio_legacy_generation",
         "_run_aio_resshift_upscale_stage": "_run_aio_resshift_upscale_stage",
         "_run_aio_upscale_stage": "_run_aio_upscale_stage",
         "_run_aio_usdu_upscale_stage": "_run_aio_usdu_upscale_stage"
@@ -1815,37 +1371,10 @@
       "lifecycle_state": "unsupported"
     },
     {
-      "id": "nodes_canonical_bindings:easyuse_anima.aio.model_preparation:transitional_private_seam",
-      "surface": "nodes_canonical_bindings",
-      "symbols": {
-        "_aio_lora_stack_signature": "_aio_lora_stack_signature"
-      },
-      "classification": "transitional_private_seam",
-      "current_target": "nodes.py",
-      "canonical_target": "easyuse_anima.aio.model_preparation",
-      "target_state": "canonical",
-      "identity_requirement": "required",
-      "binding_shape": "direct_import",
-      "import_target": "easyuse_anima.aio.model_preparation",
-      "owner": "#184/#188",
-      "first_release": null,
-      "known_consumers": [
-        "canonical runtime resolver: easyuse_anima.nodes.aio_nodes"
-      ],
-      "evidence": [
-        "AST:easyuse_anima.nodes.aio_nodes string runtime lookup"
-      ],
-      "removal_gates": [
-        "canonical production consumer migration",
-        "focused monkeypatch and identity contract review",
-        "separate B-10b or B-11 rollback unit"
-      ],
-      "lifecycle_state": "transitional"
-    },
-    {
       "id": "nodes_canonical_bindings:easyuse_anima.aio.model_preparation:unsupported_test_only",
       "surface": "nodes_canonical_bindings",
       "symbols": {
+        "_aio_lora_stack_signature": "_aio_lora_stack_signature",
         "_apply_aio_anima_dave_patch": "_apply_aio_anima_dave_patch",
         "_apply_aio_kj_model_patches": "_apply_aio_kj_model_patches",
         "_apply_aio_lora_stack": "_apply_aio_lora_stack",
@@ -2016,43 +1545,13 @@
       "lifecycle_state": "unsupported"
     },
     {
-      "id": "nodes_canonical_bindings:easyuse_anima.aio.resources:transitional_private_seam",
+      "id": "nodes_canonical_bindings:easyuse_anima.aio.resources:unsupported_test_only",
       "surface": "nodes_canonical_bindings",
       "symbols": {
         "_comfy_clip_loader_types": "_comfy_clip_loader_types",
         "_comfy_diffusion_model_names": "_comfy_diffusion_model_names",
         "_comfy_text_encoder_names": "_comfy_text_encoder_names",
         "_comfy_vae_names": "_comfy_vae_names",
-        "_normalize_aio_input_settings": "_normalize_aio_input_settings",
-        "_preferred_clip_type_default": "_preferred_clip_type_default",
-        "_preferred_name_default": "_preferred_name_default"
-      },
-      "classification": "transitional_private_seam",
-      "current_target": "nodes.py",
-      "canonical_target": "easyuse_anima.aio.resources",
-      "target_state": "canonical",
-      "identity_requirement": "required",
-      "binding_shape": "direct_import",
-      "import_target": "easyuse_anima.aio.resources",
-      "owner": "#184/#188",
-      "first_release": null,
-      "known_consumers": [
-        "canonical runtime resolver: easyuse_anima.nodes.aio_nodes"
-      ],
-      "evidence": [
-        "AST:easyuse_anima.nodes.aio_nodes string runtime lookup"
-      ],
-      "removal_gates": [
-        "canonical production consumer migration",
-        "focused monkeypatch and identity contract review",
-        "separate B-10b or B-11 rollback unit"
-      ],
-      "lifecycle_state": "transitional"
-    },
-    {
-      "id": "nodes_canonical_bindings:easyuse_anima.aio.resources:unsupported_test_only",
-      "surface": "nodes_canonical_bindings",
-      "symbols": {
         "_load_aio_resources_from_input_context": "_load_aio_resources_from_input_context",
         "_load_aio_sam3_context": "_load_aio_sam3_context",
         "_load_checkpoint_with_comfy": "_load_checkpoint_with_comfy",
@@ -2060,7 +1559,10 @@
         "_load_diffusion_model_with_comfy": "_load_diffusion_model_with_comfy",
         "_load_upscale_model_with_comfy": "_load_upscale_model_with_comfy",
         "_load_vae_with_comfy": "_load_vae_with_comfy",
-        "_preferred_checkpoint_default": "_preferred_checkpoint_default"
+        "_normalize_aio_input_settings": "_normalize_aio_input_settings",
+        "_preferred_checkpoint_default": "_preferred_checkpoint_default",
+        "_preferred_clip_type_default": "_preferred_clip_type_default",
+        "_preferred_name_default": "_preferred_name_default"
       },
       "classification": "unsupported_test_only",
       "current_target": "nodes.py",
@@ -2086,34 +1588,6 @@
       "lifecycle_state": "unsupported"
     },
     {
-      "id": "nodes_canonical_bindings:easyuse_anima.aio.sampling:transitional_private_seam",
-      "surface": "nodes_canonical_bindings",
-      "symbols": {
-        "_resolve_aio_runtime_seed": "_resolve_aio_runtime_seed"
-      },
-      "classification": "transitional_private_seam",
-      "current_target": "nodes.py",
-      "canonical_target": "easyuse_anima.aio.sampling",
-      "target_state": "canonical",
-      "identity_requirement": "required",
-      "binding_shape": "direct_import",
-      "import_target": "easyuse_anima.aio.sampling",
-      "owner": "#184/#188",
-      "first_release": null,
-      "known_consumers": [
-        "canonical runtime resolver: easyuse_anima.nodes.aio_nodes"
-      ],
-      "evidence": [
-        "AST:easyuse_anima.nodes.aio_nodes string runtime lookup"
-      ],
-      "removal_gates": [
-        "canonical production consumer migration",
-        "focused monkeypatch and identity contract review",
-        "separate B-10b or B-11 rollback unit"
-      ],
-      "lifecycle_state": "transitional"
-    },
-    {
       "id": "nodes_canonical_bindings:easyuse_anima.aio.sampling:unsupported_test_only",
       "surface": "nodes_canonical_bindings",
       "symbols": {
@@ -2123,6 +1597,7 @@
         "_encode_image_with_comfy_vae": "_encode_image_with_comfy_vae",
         "_generate_empty_latent_with_comfy": "_generate_empty_latent_with_comfy",
         "_new_aio_random_seed": "_new_aio_random_seed",
+        "_resolve_aio_runtime_seed": "_resolve_aio_runtime_seed",
         "_sample_latent_with_aio_backend": "_sample_latent_with_aio_backend",
         "_sample_latent_with_comfy": "_sample_latent_with_comfy",
         "_sample_latent_with_spectrum_mod_guidance_advanced": "_sample_latent_with_spectrum_mod_guidance_advanced",
@@ -2182,39 +1657,12 @@
       "lifecycle_state": "unsupported"
     },
     {
-      "id": "nodes_canonical_bindings:easyuse_anima.common.serialization:transitional_private_seam",
-      "surface": "nodes_canonical_bindings",
-      "symbols": {
-        "_json_clone": "_json_clone",
-        "_stable_change_key": "_stable_change_key"
-      },
-      "classification": "transitional_private_seam",
-      "current_target": "nodes.py",
-      "canonical_target": "easyuse_anima.common.serialization",
-      "target_state": "canonical",
-      "identity_requirement": "required",
-      "binding_shape": "direct_import",
-      "import_target": "easyuse_anima.common.serialization",
-      "owner": "#184/#188",
-      "first_release": null,
-      "known_consumers": [
-        "canonical runtime resolver: easyuse_anima.nodes.aio_nodes"
-      ],
-      "evidence": [
-        "AST:easyuse_anima.nodes.aio_nodes string runtime lookup"
-      ],
-      "removal_gates": [
-        "canonical production consumer migration",
-        "focused monkeypatch and identity contract review",
-        "separate B-10b or B-11 rollback unit"
-      ],
-      "lifecycle_state": "transitional"
-    },
-    {
       "id": "nodes_canonical_bindings:easyuse_anima.common.serialization:unsupported_test_only",
       "surface": "nodes_canonical_bindings",
       "symbols": {
-        "_json_object": "_json_object"
+        "_json_clone": "_json_clone",
+        "_json_object": "_json_object",
+        "_stable_change_key": "_stable_change_key"
       },
       "classification": "unsupported_test_only",
       "current_target": "nodes.py",
@@ -2659,36 +2107,35 @@
       "lifecycle_state": "supported"
     },
     {
-      "id": "nodes_canonical_bindings:easyuse_anima.nodes.aio_nodes:transitional_private_seam",
+      "id": "nodes_canonical_bindings:easyuse_anima.nodes.aio_nodes:unsupported_test_only",
       "surface": "nodes_canonical_bindings",
       "symbols": {
+        "EASY_USE_ANIMA_INPUT_TYPE": "EASY_USE_ANIMA_INPUT_TYPE",
         "_aio_generation_settings_json": "_aio_generation_settings_json",
-        "_aio_input_settings_json": "_aio_input_settings_json",
-        "_bind_aio_node_runtime": "_bind_aio_node_runtime"
+        "_aio_input_settings_json": "_aio_input_settings_json"
       },
-      "classification": "transitional_private_seam",
+      "classification": "unsupported_test_only",
       "current_target": "nodes.py",
       "canonical_target": "easyuse_anima.nodes.aio_nodes",
       "target_state": "canonical",
-      "identity_requirement": "required",
+      "identity_requirement": "not_applicable",
       "binding_shape": "direct_import",
       "import_target": "easyuse_anima.nodes.aio_nodes",
       "owner": "#184/#188",
       "first_release": null,
       "known_consumers": [
-        "nodes.py residual runtime",
-        "canonical runtime resolver: easyuse_anima.nodes.aio_nodes"
+        "repository tests may import this root name"
       ],
       "evidence": [
-        "AST:nodes.py direct runtime load",
-        "AST:easyuse_anima.nodes.aio_nodes string runtime lookup"
+        "AST:no nodes.py runtime load",
+        "test-only consumption is not public support evidence"
       ],
       "removal_gates": [
-        "canonical production consumer migration",
-        "focused monkeypatch and identity contract review",
-        "separate B-10b or B-11 rollback unit"
+        "test imports migrate to canonical targets",
+        "no production consumer evidence",
+        "separate B-10b removal review"
       ],
-      "lifecycle_state": "transitional"
+      "lifecycle_state": "unsupported"
     },
     {
       "id": "nodes_canonical_bindings:easyuse_anima.nodes.image_nodes:supported_public_reexport",
@@ -3251,42 +2698,15 @@
       "lifecycle_state": "unsupported"
     },
     {
-      "id": "nodes_canonical_bindings:easyuse_anima.prompt.data:transitional_private_seam",
-      "surface": "nodes_canonical_bindings",
-      "symbols": {
-        "PROMPT_DATA_TYPE": "PROMPT_DATA_TYPE",
-        "_copy_prompt_data_for_update": "_copy_prompt_data_for_update",
-        "_normalize_prompt_data": "_normalize_prompt_data",
-        "_prompt_data_json_safe": "_prompt_data_json_safe"
-      },
-      "classification": "transitional_private_seam",
-      "current_target": "nodes.py",
-      "canonical_target": "easyuse_anima.prompt.data",
-      "target_state": "canonical",
-      "identity_requirement": "required",
-      "binding_shape": "direct_import",
-      "import_target": "easyuse_anima.prompt.data",
-      "owner": "#184/#188",
-      "first_release": null,
-      "known_consumers": [
-        "canonical runtime resolver: easyuse_anima.nodes.aio_nodes"
-      ],
-      "evidence": [
-        "AST:easyuse_anima.nodes.aio_nodes string runtime lookup"
-      ],
-      "removal_gates": [
-        "canonical production consumer migration",
-        "focused monkeypatch and identity contract review",
-        "separate B-10b or B-11 rollback unit"
-      ],
-      "lifecycle_state": "transitional"
-    },
-    {
       "id": "nodes_canonical_bindings:easyuse_anima.prompt.data:unsupported_test_only",
       "surface": "nodes_canonical_bindings",
       "symbols": {
+        "PROMPT_DATA_TYPE": "PROMPT_DATA_TYPE",
         "_advanced_outputs_from_prompt_data": "_advanced_outputs_from_prompt_data",
         "_apply_prompt_data_overrides": "_apply_prompt_data_overrides",
+        "_copy_prompt_data_for_update": "_copy_prompt_data_for_update",
+        "_normalize_prompt_data": "_normalize_prompt_data",
+        "_prompt_data_json_safe": "_prompt_data_json_safe",
         "_prompt_data_parameter_snapshot": "_prompt_data_parameter_snapshot"
       },
       "classification": "unsupported_test_only",
@@ -3729,7 +3149,6 @@
       "surface": "nodes_root_residuals",
       "kind": "globals",
       "symbols": {
-        "EASY_USE_ANIMA_INPUT_TYPE": "EASY_USE_ANIMA_INPUT_TYPE",
         "_TRIGGER_WORD_KEYS": "_TRIGGER_WORD_KEYS",
         "logger": "logger"
       },

--- a/tests/test_aio_legacy_generation.py
+++ b/tests/test_aio_legacy_generation.py
@@ -10,6 +10,7 @@ from unittest.mock import patch
 
 import nodes
 from easyuse_anima.aio import legacy_generation
+from easyuse_anima.nodes import aio_nodes
 from tests.comfy_host_fakes import patch_comfy_helper
 from tests.test_node_contracts import _loaded_package_entrypoint
 
@@ -1790,7 +1791,7 @@ class AIOGeneratorLegacyMoveTests(unittest.TestCase):
         generator = nodes.EasyUseAnimaAIOGenerator()
         forwarded = object()
         with patch.object(
-            nodes,
+            aio_nodes,
             "_run_aio_legacy_generation",
             return_value=forwarded,
         ) as run:

--- a/tests/test_aio_nodes.py
+++ b/tests/test_aio_nodes.py
@@ -132,7 +132,7 @@ class AIONodeContractTests(unittest.TestCase):
             return '{"schema":"input-test"}'
 
         with patch.multiple(
-            nodes,
+            aio_nodes,
             PROMPT_DATA_TYPE="PROMPT_DATA_TEST",
             ANIMA_DEFAULT_DIFFUSION_MODEL_CANDIDATES=("unet-a",),
             ANIMA_DEFAULT_VAE_CANDIDATES=("vae-a",),
@@ -215,7 +215,7 @@ class AIONodeContractTests(unittest.TestCase):
             return "change-key"
 
         with patch.multiple(
-            nodes,
+            aio_nodes,
             _normalize_prompt_data=normalize_prompt,
             _prompt_data_json_safe=json_safe,
             _normalize_aio_input_settings=normalize_settings,
@@ -263,14 +263,14 @@ class AIONodeContractTests(unittest.TestCase):
 
         with (
             patch.object(
-                nodes,
+                aio_nodes,
                 "_normalize_aio_input_settings",
                 return_value=settings,
             ) as normalize_settings,
             patch.object(
-                nodes,
+                aio_nodes,
                 "_copy_prompt_data_for_update",
-                wraps=nodes._copy_prompt_data_for_update,
+                wraps=aio_nodes._copy_prompt_data_for_update,
             ) as copy_prompt,
         ):
             context = nodes.EasyUseAnimaInput().build(
@@ -371,7 +371,7 @@ class AIONodeContractTests(unittest.TestCase):
             return '{"schema":"generation-test"}'
 
         with patch.multiple(
-            nodes,
+            aio_nodes,
             EASY_USE_ANIMA_INPUT_TYPE="EASY_USE_ANIMA_INPUT_TEST",
             _aio_generation_settings_json=generation_settings_json,
         ):
@@ -431,7 +431,7 @@ class AIONodeContractTests(unittest.TestCase):
 
         with (
             patch.multiple(
-                nodes,
+                aio_nodes,
                 AIO_SPECIAL_SEEDS=special_seeds,
                 _normalize_aio_generation_settings=normalize,
                 _json_clone=clone,

--- a/tests/test_node_contracts.py
+++ b/tests/test_node_contracts.py
@@ -215,6 +215,17 @@ def _deterministic_comfy_inputs():
     with (
         patch.multiple(nodes, **replacements),
         patch.multiple(
+            aio_nodes,
+            _comfy_diffusion_model_names=replacements[
+                "_comfy_diffusion_model_names"
+            ],
+            _comfy_text_encoder_names=replacements[
+                "_comfy_text_encoder_names"
+            ],
+            _comfy_vae_names=replacements["_comfy_vae_names"],
+            _comfy_clip_loader_types=replacements["_comfy_clip_loader_types"],
+        ),
+        patch.multiple(
             aio_generation_normalization,
             _comfy_sampler_names=replacements["_comfy_sampler_names"],
             _comfy_scheduler_names=replacements["_comfy_scheduler_names"],
@@ -1923,10 +1934,14 @@ class AioWidgetDefaultSerializerMoveContractTests(unittest.TestCase):
             return "input-json" if value is input_defaults else "generation-json"
 
         with (
-            patch.object(root_module, "json", types.SimpleNamespace(dumps=dumps)),
-            patch.object(root_module, "AIO_INPUT_DEFAULT_SETTINGS", input_defaults),
+            patch.object(canonical_module, "json", types.SimpleNamespace(dumps=dumps)),
             patch.object(
-                root_module,
+                canonical_module,
+                "AIO_INPUT_DEFAULT_SETTINGS",
+                input_defaults,
+            ),
+            patch.object(
+                canonical_module,
                 "AIO_GENERATION_DEFAULT_SETTINGS",
                 generation_defaults,
             ),
@@ -1947,7 +1962,7 @@ class AioWidgetDefaultSerializerMoveContractTests(unittest.TestCase):
 
         mutable_defaults = {"schema": "가"}
         with patch.object(
-            root_module,
+            canonical_module,
             "AIO_INPUT_DEFAULT_SETTINGS",
             mutable_defaults,
         ):

--- a/tests/test_nodes_module_analyzer.py
+++ b/tests/test_nodes_module_analyzer.py
@@ -73,12 +73,12 @@ def load_dynamic():
     def test_current_nodes_module_shape_matches_recorded_baseline(self):
         report = analyzer.analyze_path(ROOT / "nodes.py")
 
-        self.assertEqual(report["git_blob_sha1"], "735f1fcd3249adb58b2e64eb35d78ca264a7ec1d")
-        # B-11c30d5 removes the legacy-orchestration binder import and
+        self.assertEqual(report["git_blob_sha1"], "1384982bc24cb74f8e68c0f11f66de7965036e21")
+        # B-11c30d6 removes the AiO node-adapter binder import and
         # initialization without changing the public class surface.
         self.assertEqual(report["top_level"]["function_count"], 0)
         self.assertEqual(report["top_level"]["class_count"], 0)
-        self.assertEqual(report["line_count"], 1_147)
+        self.assertEqual(report["line_count"], 1_142)
         class_names = {item["name"] for item in report["top_level"]["classes"]}
         self.assertNotIn("EasyUseAnimaAIOGenerator", class_names)
         self.assertNotIn("EasyUseAnimaInput", class_names)

--- a/tests/test_python_compatibility_surface.py
+++ b/tests/test_python_compatibility_surface.py
@@ -77,7 +77,6 @@ RUNTIME_LOOKUP_CALLS = {
     "runtime_proxy",
 }
 PREAMBLE_IMPLEMENTATION_BINDINGS = {
-    "json": "json:json",
     "logging": "logging:logging",
 }
 PROMPT_SERVICE_RUNTIME_BINDERS = (
@@ -95,9 +94,6 @@ PROMPT_NODE_ADAPTER_RETIRED_RUNTIME_BINDERS = (
     "_bind_prompt_advanced_node_runtime",
 )
 RUNTIME_BINDER_FAMILIES = {
-    "aio": (
-        "_bind_aio_node_runtime",
-    ),
     "wildcard_naia": (
         "_bind_wildcard_node_runtime",
         "_bind_naia_node_runtime",
@@ -135,6 +131,7 @@ AIO_RUNTIME_RETIRED_SUBGROUPS = (
     "B-11c30d3_io_boundary",
     "B-11c30d4_execution_services",
     "B-11c30d5_legacy_orchestration",
+    "B-11c30d6_node_adapter",
 )
 AIO_RUNTIME_PREREQUISITE_MOVES = (
     {
@@ -1726,7 +1723,7 @@ def _aio_runtime_split_gate(
     ]
     if len(classified_binders) != len(set(classified_binders)):
         raise AssertionError("AiO runtime binder subgroup classification overlaps")
-    if set(classified_binders) != set(RUNTIME_BINDER_FAMILIES["aio"]):
+    if set(classified_binders) != set(RUNTIME_BINDER_FAMILIES.get("aio", ())):
         raise AssertionError("AiO runtime binder subgroup classification is incomplete")
 
     subgroups = {}
@@ -2314,6 +2311,7 @@ def _build_document() -> dict[str, Any]:
                 "B-11c30d4",
                 "B-11c30d0b",
                 "B-11c30d5",
+                "B-11c30d6",
             ],
         },
         "enums": {
@@ -2325,15 +2323,15 @@ def _build_document() -> dict[str, Any]:
         },
         "expected_counts": {
             "root_entrypoints": 3,
-            "excluded_preamble_implementation_bindings": 2,
+            "excluded_preamble_implementation_bindings": 1,
             "nodes_canonical_bindings": 291,
             "nodes_legacy_bindings": 27,
             "mapped_public_classes": 18,
             "unmapped_classes": 2,
             "root_residual_functions": 0,
             "root_residual_classes": 0,
-            "root_residual_globals": 3,
-            "runtime_binders": 3,
+            "root_residual_globals": 2,
+            "runtime_binders": 2,
             "direct_nodes_import_test_files": 21,
         },
         "mapped_public_classes": sorted(mapped_classes),
@@ -2565,7 +2563,7 @@ class PythonCompatibilitySurfaceTests(unittest.TestCase):
             len(self.document["direct_nodes_import_test_files"]),
             counts["direct_nodes_import_test_files"],
         )
-        self.assertEqual(len(set(self.document["runtime_binders"])), 3)
+        self.assertEqual(len(set(self.document["runtime_binders"])), 2)
         self.assertEqual(len(set(self.document["direct_nodes_import_test_files"])), 21)
 
     def test_runtime_binder_audit_covers_provider_and_root_names(self):
@@ -2573,30 +2571,26 @@ class PythonCompatibilitySurfaceTests(unittest.TestCase):
         self.assertEqual(
             audit["summary"],
             {
-                "binder_count": 3,
-                "family_count": 2,
+                "binder_count": 2,
+                "family_count": 1,
                 "mode_counts": {
                     "comfy_provider_then_root": 0,
-                    "root_globals": 1,
+                    "root_globals": 0,
                     "explicit_callbacks": 2,
                 },
-                "unique_resolver_names": 29,
-                "unique_root_resolver_names": 29,
+                "unique_resolver_names": 0,
+                "unique_root_resolver_names": 0,
                 "unique_provider_resolver_names": 0,
                 "unique_direct_root_dependencies": 8,
                 "direct_root_dependency_slots": 9,
                 "provider_consumer_slots": 0,
                 "provider_consumer_modules": 0,
-                "repository_replacement_names": 32,
-                "repository_replacement_files": 5,
+                "repository_replacement_names": 5,
+                "repository_replacement_files": 3,
             },
         )
         self.assertEqual(audit["provider_resolver_names"], [])
-        self.assertEqual(
-            set(audit["root_resolver_names"])
-            - set(self.document["runtime_resolver_consumers"]),
-            {"json"},
-        )
+        self.assertEqual(audit["root_resolver_names"], [])
         self.assertTrue(
             set(self.document["runtime_resolver_consumers"]).issubset(
                 audit["root_resolver_names"]
@@ -2662,7 +2656,7 @@ class PythonCompatibilitySurfaceTests(unittest.TestCase):
                 for subgroup in gate["subgroups"].values()
                 for binder in subgroup["binders"]
             },
-            set(RUNTIME_BINDER_FAMILIES["aio"]),
+            set(RUNTIME_BINDER_FAMILIES.get("aio", ())),
         )
         summaries = {
             subgroup: {
@@ -2682,16 +2676,7 @@ class PythonCompatibilitySurfaceTests(unittest.TestCase):
         }
         self.assertEqual(
             summaries,
-            {
-                "B-11c30d6_node_adapter": {
-                    "root_resolver_slots": 29,
-                    "unique_root_resolver_names": 29,
-                    "provider_resolver_slots": 0,
-                    "direct_root_dependency_slots": 0,
-                    "repository_replacement_slots": 27,
-                    "unique_repository_replacement_names": 27,
-                },
-            },
+            {},
         )
         self.assertEqual(
             [move["id"] for move in gate["prerequisite_moves"]],
@@ -2773,6 +2758,7 @@ class PythonCompatibilitySurfaceTests(unittest.TestCase):
             "_bind_aio_legacy_generation_runtime": (
                 "easyuse_anima.aio.legacy_generation"
             ),
+            "_bind_aio_node_runtime": "easyuse_anima.nodes.aio_nodes",
         }
         for binder, module in retired_modules.items():
             functions = {
@@ -2835,13 +2821,41 @@ class PythonCompatibilitySurfaceTests(unittest.TestCase):
         self.assertNotIn("_runtime_helper", functions)
         self.assertNotIn("_bind_aio_legacy_generation_runtime", functions)
 
-    def test_string_runtime_resolvers_keep_production_seams_transitional(self):
-        representative = {
-            "_run_aio_legacy_generation",
-            "_aio_generation_settings_json",
-            "_resolve_aio_runtime_seed",
+    def test_aio_node_adapter_runtime_resolver_is_retired(self):
+        tree = _read_tree(_module_path("easyuse_anima.nodes.aio_nodes"))
+        top_level_names = {
+            target.id
+            for node in tree.body
+            if isinstance(node, (ast.Assign, ast.AnnAssign))
+            for target in (
+                node.targets
+                if isinstance(node, ast.Assign)
+                else [node.target]
+            )
+            if isinstance(target, ast.Name)
         }
-        consumers = self.document["runtime_resolver_consumers"]
+        functions = {
+            node.name
+            for node in tree.body
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+        }
+        self.assertNotIn("_RUNTIME_RESOLVER", top_level_names)
+        self.assertNotIn("_runtime_helper", functions)
+        self.assertNotIn("_bind_aio_node_runtime", functions)
+
+    def test_only_explicit_callback_runtime_seams_remain_transitional(self):
+        representative = {
+            "_get_workflow_node",
+            "_post_random",
+            "expand_wildcards",
+            "resolve_naia_settings",
+        }
+        self.assertEqual(self.document["runtime_resolver_consumers"], {})
+        callback_dependencies = {
+            name
+            for entry in self.document["runtime_binder_audit"]["entries"]
+            for name in entry["direct_root_dependencies"]
+        }
         classifications = {
             symbol: group["classification"]
             for group in self.document["groups"]
@@ -2850,8 +2864,7 @@ class PythonCompatibilitySurfaceTests(unittest.TestCase):
             for symbol in group["symbols"]
         }
         for symbol in representative:
-            self.assertIn(symbol, consumers)
-            self.assertTrue(consumers[symbol])
+            self.assertIn(symbol, callback_dependencies)
             self.assertEqual(
                 classifications[symbol],
                 "transitional_private_seam",


### PR DESCRIPTION
## 변경 요약

B-11c30d6 frozen subgroup의 `_bind_aio_node_runtime` 하나만 퇴역시키는 Move PR입니다.

- `easyuse_anima.nodes.aio_nodes`가 기존 canonical owner를 직접 import하도록 전환했습니다.
- `_RUNTIME_RESOLVER`, `_runtime_helper`, root binder import/call을 제거했습니다.
- `EASY_USE_ANIMA_INPUT_TYPE`의 소유권을 canonical adapter로 옮기고 root에는 package/flat exact alias를 유지했습니다.
- AiO의 여섯 retirement subgroup을 모두 완료 상태로 고정했습니다.
- 활성 runtime 결합은 Wildcard/NAIA explicit callback binder 2개, 1개 family만 남습니다.

## 사전 symbol/caller/alias/global-state inventory

- binder: `_bind_aio_node_runtime`
- owner: `easyuse_anima.nodes.aio_nodes`
- mutable global: `_RUNTIME_RESOLVER` 1개
- dispatcher: `_runtime_helper` 1개
- frozen cost after d5:
  - root resolver: 29 slots / 29 unique names
  - provider/direct root dependency: 0
  - repository replacement: 27 slots / 27 names / 3 files
- root exact aliases:
  - `EasyUseAnimaInput`
  - `EasyUseAnimaAIOGenerator`
  - `_aio_input_settings_json`
  - `_aio_generation_settings_json`
- callers:
  - `easyuse_anima.registration`이 두 mapped class를 직접 소비
  - ComfyUI가 class method를 호출
  - `EasyUseAnimaAIOGenerator.generate`가 canonical legacy orchestrator를 호출
- direct owner groups:
  - Python `json`
  - common serialization
  - Prompt Data
  - AiO defaults/normalization/resources/model/sampling/input-context/legacy orchestration

상세 inventory와 exact resolver ownership은 `docs/architecture/comfy-host-provider-bridge.md`에 기록했습니다.

## 변경한 주요 파일

- `easyuse_anima/nodes/aio_nodes.py`
- `nodes.py`
- d6 replacement-owner 테스트 3개
- Python compatibility/backend/nodes analyzer gate와 생성 fixture
- backend roadmap/provider bridge/compatibility registry 문서

## 고정 경계

- Move only이며 Contract/Behavior/performance/dependency 변경을 섞지 않았습니다.
- Wildcard/NAIA binder는 변경하지 않았습니다.
- hidden JSON shape/order, input/resource defaults, mutable settings, special seed와 `IS_CHANGED`, context copy, generation forwarding, node signature/ID/mapping, error/schema/workflow 동작을 변경하지 않았습니다.

## 검증

- focused unittest 176개: 통과
- consolidated focused unittest 233개: 통과
- exact ownership closure 1개: 통과
- backend analyzer fixture closure 18개: 통과
- targeted Ruff 0.15.22 (`easyuse_anima/nodes/aio_nodes.py`): 통과
- 공식 `tools/check_project.ps1 -Profile full` 1회: 통과
  - Python unittest: 985개 통과
  - Pyright baseline ratchet: 76 files, 기존 14 errors, 증가 없음
  - import boundary: 6 groups, 0 violations
  - frontend: 114 JavaScript files 및 TypeScript 6.0.3 표면 통과
  - Git diff check: 통과
  - Ruff report-only: 기존 G-01 부채 76건, blocking 아님
- ComfyUI Codex test surface: package/import/frontend module smoke
- Live ComfyUI smoke: 실행하지 않음 (node behavior가 없는 기계적 Move)

## 결과와 남은 위험

- root `nodes.py`: 1,142 lines
- compatibility inventory: canonical 291, residual globals 2, preamble implementation import 1
- string runtime resolver: 0
- 남은 runtime binder: Wildcard/NAIA explicit callbacks 2개
- 현재 증거에서 behavior/compatibility drift는 발견되지 않았습니다.
- 다음 rollback unit은 B-11c30e Wildcard/NAIA이며 이 PR 범위에 포함하지 않습니다.

Owner: #184  
Behavior boundary: #167
