### PR TITLE
B-11c30e: retire Wildcard and NAIA callback binders

### DIFF
--- a/docs/architecture/comfy-host-provider-bridge.md
+++ b/docs/architecture/comfy-host-provider-bridge.md
@@ -2475,7 +2475,7 @@ Forbidden:
 
 ### B-11c30e — Wildcard/NAIA callback-binder Move
 
-- **State:** IN PROGRESS
+- **State:** COMPLETE IN PR #355
 - **Owner:** #184
 - **Behavior boundaries:** #167, #236, D-12
 - **Type:** Move
@@ -2538,6 +2538,24 @@ Exit:
   node schemas/mappings, workflows, errors, and optional timing remain
   unchanged.
 
+Implementation result:
+
+- both adapters import `easyuse_anima.workflow._get_workflow_node` directly.
+  Wildcard keeps its existing package/flat legacy-engine imports, while NAIA
+  imports its existing settings owner with the same package/flat fallback and
+  retains direct client imports;
+- the two binder definitions and all nine bind-time callback installations are
+  absent. Root no longer imports or invokes either binder;
+- tests patch the canonical adapter dependency instead of the root callback
+  seam. Root mapped-class identity, workflow lookup identity, Wildcard/NAIA
+  behavior, and exact package/flat imports remain frozen;
+- the runtime audit contains zero binders, families, resolver names, direct
+  callback dependencies, and repository replacement names;
+- the compatibility inventory contains 289 canonical root bindings, two
+  residual root globals, one root implementation import, 93 shipped/reachable
+  Python modules, and a 1,124-line root shim; and
+- B-11d is the next separate root-shim Move.
+
 Forbidden:
 
 - moving or consolidating `wildcard_engine.py` or `settings.py`;
@@ -2550,7 +2568,7 @@ Forbidden:
 
 ### B-11d — Final root shim
 
-- **State:** BLOCKED by the remaining Wildcard/NAIA binder family
+- **State:** READY after B-11c30e / PR #355
 - **Owner:** #184
 - **Type:** Move
 
@@ -2602,8 +2620,8 @@ COMPLETE: B-11c30d4 execution-service Move / PR #351
 COMPLETE: B-11c30d0b input-context owner Move / PR #352
 COMPLETE: B-11c30d5 legacy-orchestration Move / PR #353
 COMPLETE: B-11c30d6 node-adapter Move / PR #354
-PLANNED:  B-11c30e Wildcard/NAIA callback binder Move
-BLOCKED:  B-11d final root shim
+COMPLETE: B-11c30e Wildcard/NAIA callback binder Move / PR #355
+READY:    B-11d final root shim
 
 LATER:    #167 seed reservation
 LATER:    #169 stage/cache Behavior

--- a/docs/architecture/comfy-host-provider-bridge.md
+++ b/docs/architecture/comfy-host-provider-bridge.md
@@ -2473,6 +2473,81 @@ Forbidden:
 - beginning #167 Behavior, Wildcard/NAIA, final root-shim, Contract,
   performance, dependency, or broad formatting work.
 
+### B-11c30e — Wildcard/NAIA callback-binder Move
+
+- **State:** IN PROGRESS
+- **Owner:** #184
+- **Behavior boundaries:** #167, #236, D-12
+- **Type:** Move
+- **Base:** `dev@bc59822eb4f1141ffc3697aac352c5fc2c25a0f7`
+
+Pre-edit inventory:
+
+- the only remaining runtime family contains exactly
+  `_bind_wildcard_node_runtime` and `_bind_naia_node_runtime`;
+- both binders use explicit root-calling closures. They contain no string
+  resolver, provider lookup, cache, I/O, or business-state owner;
+- the Wildcard binder installs five module globals:
+  `_get_workflow_node`, `expand_wildcards`, `normalize_seed`,
+  `normalize_wildcard_mode`, and `wildcard_sources_signature`;
+- the NAIA binder installs four module globals:
+  `resolve_naia_settings`, `_get_workflow_node`, `_post_random`, and
+  `_parse_random_response`;
+- combined scope is nine direct callback slots over eight unique root names.
+  The compatibility audit records five repository replacement names in
+  `tests/test_wildcards.py`, `tests/test_naia_settings.py`, and
+  `tests/test_node_contracts.py`;
+- `easyuse_anima.workflow` already owns `_get_workflow_node`;
+  `wildcard_engine` already owns the four Wildcard functions; `settings`
+  already owns `resolve_naia_settings`; and `easyuse_anima.naia.client`
+  already owns `_post_random` and `_parse_random_response`;
+- the Wildcard adapter already imports its legacy engine in relative-package
+  and flat fallback modes. The NAIA adapter already imports its client owner
+  directly. This Move adds no new owner, service, provider, or contract;
+- root imports both mapped classes and both private binder functions in package
+  and flat modes, then calls each binder once during module initialization;
+- `easyuse_anima.registration` consumes the two mapped classes directly; and
+- existing tests freeze Wildcard source signatures, mode/seed normalization,
+  expansion and metadata cache behavior, NAIA settings/request/response and
+  frozen-output behavior, workflow lookup, exact class aliases, schemas,
+  workflows, errors, and HTTP policy.
+
+Allowed production files:
+
+```text
+nodes.py
+easyuse_anima/nodes/wildcard_nodes.py
+easyuse_anima/nodes/naia_nodes.py
+```
+
+Allowed supporting files are the three replacement-owner tests, Python
+compatibility and backend/nodes analyzer gates/fixtures, workflow/package
+contract coverage, and the three architecture documents.
+
+Exit:
+
+- both binder definitions and root imports/calls are absent;
+- the adapters import their existing workflow, Wildcard, settings, and NAIA
+  owners directly in supported package/flat modes;
+- repository tests patch the canonical consumer or true owner rather than root
+  callback installation;
+- both mapped classes retain exact package/flat root identity;
+- runtime binder families, binder calls, string resolvers, and callback
+  installations all reach zero; and
+- Wildcard modes/seeds/expansion/metadata, NAIA settings/HTTP/cache/result,
+  node schemas/mappings, workflows, errors, and optional timing remain
+  unchanged.
+
+Forbidden:
+
+- moving or consolidating `wildcard_engine.py` or `settings.py`;
+- changing Wildcard syntax, source discovery, seed/reservation, sequential,
+  fixed/reproduce, populated-text, workflow metadata, or cache behavior;
+- changing NAIA host policy, request body, response parsing, timeout, frozen
+  output, settings, persistence, or errors;
+- beginning #167/#236 Behavior, D-12/D-09 consolidation, final root-shim,
+  Contract, performance, dependency, or broad formatting work.
+
 ### B-11d — Final root shim
 
 - **State:** BLOCKED by the remaining Wildcard/NAIA binder family

--- a/docs/architecture/comfy-host-provider-bridge.md
+++ b/docs/architecture/comfy-host-provider-bridge.md
@@ -2553,7 +2553,7 @@ Implementation result:
   callback dependencies, and repository replacement names;
 - the compatibility inventory contains 289 canonical root bindings, two
   residual root globals, one root implementation import, 93 shipped/reachable
-  Python modules, and a 1,124-line root shim; and
+  Python modules, and a 1,123-line root shim; and
 - B-11d is the next separate root-shim Move.
 
 Forbidden:

--- a/docs/architecture/python-backend-execution-roadmap.md
+++ b/docs/architecture/python-backend-execution-roadmap.md
@@ -31,7 +31,7 @@ merged PR, the owning issue's evidence record, and every stated exit gate.
 | Phase | Integrated snapshot / open implementation state | Remaining exit work |
 | --- | --- | --- |
 | A - baseline | Complete; #191 is closed | Keep fixtures and analyzers current during later moves |
-| B - `nodes.py` extraction | Integrated through B-11c30d5 / PR #353; B-11c30d6 completes in PR #354 | Execute Wildcard/NAIA and the final root shim as separate rollback units |
+| B - `nodes.py` extraction | Integrated through B-11c30d6 / PR #354; B-11c30e completes in PR #355 | Execute the final root shim as a separate rollback unit |
 | C - feature contracts/behavior | Partially complete through S167-01a / PR #344 | Continue #167 and #169 in separate Contract/Move/Behavior PRs |
 | D - root consolidation | Not started | Execute #186 feature by feature after the corresponding behavior contracts are stable |
 | E - runtime ownership | Partial: E-02a and E-07a/E-07b integrated | Continue #187 only where canonical feature owners and explicit contracts exist |
@@ -42,9 +42,9 @@ merged PR, the owning issue's evidence record, and every stated exit gate.
 ### Measured Phase B progress
 
 - The Phase A baseline recorded root `nodes.py` at 12,663 lines.
-- In B-11c30d6 / PR #354, the analyzer measures root `nodes.py` at 1,142 lines.
-- The mechanical extraction has removed 11,521
-  lines, approximately 91.0% of the Phase A baseline, while preserving the root
+- In B-11c30e / PR #355, the analyzer measures root `nodes.py` at 1,124 lines.
+- The mechanical extraction has removed 11,539
+  lines, approximately 91.1% of the Phase A baseline, while preserving the root
   compatibility surface.
 - B-01 through B-09b2 are integrated. The latest completed implementation slice
   is the AiO generator adapter Move in PR #270.
@@ -156,6 +156,10 @@ merged PR, the owning issue's evidence record, and every stated exit gate.
   constant to the canonical module, and preserves exact root aliases, node
   signatures, widget defaults, change keys, seed behavior, context copies, and
   generation forwarding. Two explicit Wildcard/NAIA callback binders remain.
+  B-11c30e / PR #355 retires those final two callbacks. The adapters consume
+  the existing workflow, Wildcard engine, settings, and NAIA client owners
+  directly while preserving package/flat imports and all node/workflow
+  behavior. Runtime binder and resolver counts reach zero.
 
 ### Current quality baseline
 
@@ -399,7 +403,7 @@ mechanical retirement series.
 | 11 | B-09b2 AiO generator adapter move | COMPLETE on `dev` | Move | #184 | PR #270 / `57d40b4` |
 | 12 | B-10a machine-readable compatibility audit | COMPLETE on `dev` | Contract/gate | #184/#188 | PR #271 / `3c7b857` |
 | 13 | B-10b private alias reduction | COMPLETE on `dev` through PR #291 / `c6b4680` | Contract/cleanup, split PRs | #184/#188 | Audited alias surface integrated |
-| 14 | B-11 registration/bootstrap/root shim | IN PROGRESS through B-11c30d6 PR #354; Wildcard/NAIA is the next separate Move | Move/Contract, split PRs | #184 | Frozen AiO split gate; S167-01 contract |
+| 14 | B-11 registration/bootstrap/root shim | IN PROGRESS through B-11c30e PR #355; final root shim is the next separate Move | Move/Contract, split PRs | #184 | Zero runtime binders; frozen compatibility audit |
 | 15 | S167 backend seed reservation series | S167-01 Contract COMPLETE in PR #343 and S167-01a consumer Move COMPLETE in PR #344; Behavior and Adapter remain | Contract then Move then Behavior | #167 | Canonical AiO/node seams |
 | 16 | A169 stage pipeline series | BLOCKED by #168 and B exit | Contract then Behavior | #169 | Typed config and mechanical AiO move |
 | 17 | A169 first-pass cache policy | BLOCKED by stage/cache ownership seam | Behavior | #169 | Mechanical cache move and benchmark harness |
@@ -1137,6 +1141,13 @@ unchanged. The separate legacy Wildcard unsupported alias remains for D-12.
     hidden widget serialization, change keys, seed handling, context copies,
     and generation forwarding. The root shim falls to 1,142 lines. Only the two
     Wildcard/NAIA callback binders remain before the final root shim.
+  - B-11c30e retires only `_bind_wildcard_node_runtime` and
+    `_bind_naia_node_runtime` in PR #355. Both adapters consume their existing
+    workflow, Wildcard engine, settings, and NAIA client owners directly.
+    Wildcard modes/seeds/expansion/metadata, NAIA settings/HTTP/cache/results,
+    package/flat imports, mappings, workflows, and exact errors remain frozen.
+    Runtime binder/resolver counts reach zero and the root shim falls to 1,124
+    lines. B-11d is the next READY Move.
   - The final B-11c cutover removes remaining root execution ownership and
     leaves the explicit supported `nodes.py` compatibility shim.
 - Add `easyuse_anima/registration.py` as pure mapping composition. It performs no

--- a/docs/architecture/python-backend-execution-roadmap.md
+++ b/docs/architecture/python-backend-execution-roadmap.md
@@ -42,8 +42,8 @@ merged PR, the owning issue's evidence record, and every stated exit gate.
 ### Measured Phase B progress
 
 - The Phase A baseline recorded root `nodes.py` at 12,663 lines.
-- In B-11c30e / PR #355, the analyzer measures root `nodes.py` at 1,124 lines.
-- The mechanical extraction has removed 11,539
+- In B-11c30e / PR #355, the analyzer measures root `nodes.py` at 1,123 lines.
+- The mechanical extraction has removed 11,540
   lines, approximately 91.1% of the Phase A baseline, while preserving the root
   compatibility surface.
 - B-01 through B-09b2 are integrated. The latest completed implementation slice
@@ -1146,7 +1146,7 @@ unchanged. The separate legacy Wildcard unsupported alias remains for D-12.
     workflow, Wildcard engine, settings, and NAIA client owners directly.
     Wildcard modes/seeds/expansion/metadata, NAIA settings/HTTP/cache/results,
     package/flat imports, mappings, workflows, and exact errors remain frozen.
-    Runtime binder/resolver counts reach zero and the root shim falls to 1,124
+    Runtime binder/resolver counts reach zero and the root shim falls to 1,123
     lines. B-11d is the next READY Move.
   - The final B-11c cutover removes remaining root execution ownership and
     leaves the explicit supported `nodes.py` compatibility shim.

--- a/docs/architecture/python-compatibility-shims.md
+++ b/docs/architecture/python-compatibility-shims.md
@@ -1065,7 +1065,7 @@ convenience-node compatibility; it remains unmapped and is not public support.
   binder-owned repository replacement names all reach zero.
 - The compatibility inventory contains 289 canonical root bindings, two
   residual root globals, one preamble implementation import, 93 shipped and
-  reachable Python modules, and a 1,124-line root shim.
+  reachable Python modules, and a 1,123-line root shim.
 - B-11d final root shim is the next separate Move; #167/#236 Behavior and
   D-09/D-12 consolidation remain outside PR #355.
 

--- a/docs/architecture/python-compatibility-shims.md
+++ b/docs/architecture/python-compatibility-shims.md
@@ -8,11 +8,11 @@
 - Policy: [ADR-002](adr-002-compatibility-shims.md)
 - Machine-readable audit:
   [`python_compatibility_surface.v1.json`](../../tests/fixtures/python_compatibility_surface.v1.json)
-- Current state: B-11a through B-11c30d5 / PR #353 are integrated in the
-  reviewed sequence, and B-11c30d6 / PR #354 retires the final AiO
-  node-adapter resolver. S167-01a / PR #344 supplies the canonical
-  reserved-seed compatibility consumer while retaining its root aliases. Only
-  the two Wildcard/NAIA callback binders remain before the final root shim.
+- Current state: B-11a through B-11c30d6 / PR #354 are integrated in the
+  reviewed sequence, and B-11c30e / PR #355 retires the final two
+  Wildcard/NAIA callbacks. S167-01a / PR #344 supplies the canonical
+  reserved-seed compatibility consumer while retaining its root aliases. No
+  runtime binder or resolver remains before the final root shim.
 
 This is an actionable registry, not a removal schedule. `N` means the first
 published Registry release containing both a canonical target and its root
@@ -77,8 +77,8 @@ inferring public support from spelling or test imports:
 - `nodes.py` preamble implementation imports: 1 (`logging`), excluded from
   compatibility classification
   by an exact AST allowlist and drift gate;
-- `nodes.py` bindings with an `easyuse_anima` canonical target: 291 in
-  B-11c30d6 (258 at the integrated B-10b20 baseline), with exact
+- `nodes.py` bindings with an `easyuse_anima` canonical target: 289 in
+  B-11c30e (258 at the integrated B-10b20 baseline), with exact
   relative-package/flat-fallback parity;
 - bindings still owned by `anima_prompt`, `settings`, `prompt_translation`, or
   `wildcard_engine`: 27, with the same fallback parity;
@@ -87,10 +87,9 @@ inferring public support from spelling or test imports:
   `EasyUseAnimaSAM3Detailer`; the canonical legacy Extend class remains in its
   owner module without a root alias or backend mapping;
 - root-owned residual implementation: 0 functions, 0 classes, and 2 assigned
-  globals in B-11c30d6 (41/2/33 at the integrated B-10b20 baseline).
-- import-time runtime binders: 2 exact top-level `_bind_*_runtime` calls;
-- no string runtime resolver remains. The two explicit Wildcard/NAIA callback
-  binders reach eight unique direct root dependencies across nine slots;
+  globals in B-11c30e (41/2/33 at the integrated B-10b20 baseline).
+- import-time runtime binders: 0;
+- no string runtime resolver or explicit callback installation remains;
 - retired private bindings: `_comfy_checkpoint_names`,
   `_EasyUseAnimaAlignedDetailerHook`, and
   `_EasyUseAnimaImpactDetailerDelegate`, plus `_impact_core_module`,
@@ -1047,6 +1046,28 @@ convenience-node compatibility; it remains unmapped and is not public support.
   reachable Python modules, and a 1,142-line root shim.
 - B-11c30e Wildcard/NAIA is the next separate Move; #168/#169 Behavior and the
   final root shim remain outside PR #354.
+
+### B-11c30e Wildcard/NAIA callback-binder retirement
+
+- PR #355 retires exactly `_bind_wildcard_node_runtime` and
+  `_bind_naia_node_runtime`.
+- Both adapters import `easyuse_anima.workflow._get_workflow_node` directly.
+  Wildcard keeps its existing package/flat legacy-engine imports. NAIA imports
+  the existing settings owner with the same fallback and retains its direct
+  client imports.
+- The nine bind-time callback installations over eight unique names are
+  absent. Root no longer imports or invokes either binder.
+- Tests patch canonical consumers rather than root callbacks. Wildcard
+  syntax/sources/modes/seeds/expansion/metadata, NAIA
+  settings/HTTP/cache/results, mapped classes, package/flat imports, workflows,
+  and exact errors remain unchanged.
+- Runtime binder families, string resolvers, direct callback dependencies, and
+  binder-owned repository replacement names all reach zero.
+- The compatibility inventory contains 289 canonical root bindings, two
+  residual root globals, one preamble implementation import, 93 shipped and
+  reachable Python modules, and a 1,124-line root shim.
+- B-11d final root shim is the next separate Move; #167/#236 Behavior and
+  D-09/D-12 consolidation remain outside PR #355.
 
 ### `nodes.py` public node-class surface
 

--- a/easyuse_anima/nodes/naia_nodes.py
+++ b/easyuse_anima/nodes/naia_nodes.py
@@ -18,27 +18,14 @@ from ..naia.client import (
     _parse_random_response,
     _post_random,
 )
+from ..workflow import _get_workflow_node
 
+try:
+    from ...settings import resolve_naia_settings
+except ImportError:
+    from settings import resolve_naia_settings
 
 logger = logging.getLogger("ComfyUI-EasyUseAnima")
-
-
-def _unbound_runtime(*_args, **_kwargs):
-    raise RuntimeError("NAIA node runtime dependencies are not bound.")
-
-
-resolve_naia_settings = _unbound_runtime
-_get_workflow_node = _unbound_runtime
-
-
-def _bind_naia_node_runtime(*, resolve_settings, get_workflow_node, post_random, parse_random_response) -> None:
-    global resolve_naia_settings, _get_workflow_node
-    global _post_random, _parse_random_response
-
-    resolve_naia_settings = resolve_settings
-    _get_workflow_node = get_workflow_node
-    _post_random = post_random
-    _parse_random_response = parse_random_response
 
 
 class EasyUseAnimaNAIARandomPrompt:

--- a/easyuse_anima/nodes/wildcard_nodes.py
+++ b/easyuse_anima/nodes/wildcard_nodes.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from ..common.serialization import _stable_change_key
 from ..common.values import _single_value
+from ..workflow import _get_workflow_node
 from .input_types import _FlexibleOptionalInputType
 
 try:
@@ -49,25 +50,6 @@ WILDCARD_MODE_DISPLAY_LABELS = {
     WILDCARD_MODE_SEQUENTIAL: WILDCARD_MODE_LABELS[2],
     WILDCARD_MODE_REPRODUCE: WILDCARD_MODE_LABELS[3],
 }
-
-
-def _unbound_runtime(*_args, **_kwargs):
-    raise RuntimeError("Wildcard node runtime dependencies are not bound.")
-
-
-_get_workflow_node = _unbound_runtime
-
-
-def _bind_wildcard_node_runtime(*, get_workflow_node, expand, normalize_seed_value, normalize_mode, sources_signature) -> None:
-    global _get_workflow_node
-    global expand_wildcards
-    global normalize_seed, normalize_wildcard_mode, wildcard_sources_signature
-
-    _get_workflow_node = get_workflow_node
-    expand_wildcards = expand
-    normalize_seed = normalize_seed_value
-    normalize_wildcard_mode = normalize_mode
-    wildcard_sources_signature = sources_signature
 
 
 class EasyUseAnimaWildcard:

--- a/nodes.py
+++ b/nodes.py
@@ -498,12 +498,10 @@ try:
     )
     from .easyuse_anima.nodes.naia_nodes import (
         EasyUseAnimaNAIARandomPrompt as EasyUseAnimaNAIARandomPrompt,
-        _bind_naia_node_runtime as _bind_naia_node_runtime,
     )
     from .easyuse_anima.nodes.wildcard_nodes import (
         EasyUseAnimaWildcard as EasyUseAnimaWildcard,
         # B-10b8 retires the test-only root wildcard-note alias.
-        _bind_wildcard_node_runtime as _bind_wildcard_node_runtime,
     )
     from .easyuse_anima.lora.metadata import (
         _apply_lora_syntax_format as _apply_lora_syntax_format,
@@ -1057,12 +1055,10 @@ except ImportError:  # allows simple local import tests outside ComfyUI's packag
     )
     from easyuse_anima.nodes.naia_nodes import (
         EasyUseAnimaNAIARandomPrompt as EasyUseAnimaNAIARandomPrompt,
-        _bind_naia_node_runtime as _bind_naia_node_runtime,
     )
     from easyuse_anima.nodes.wildcard_nodes import (
         EasyUseAnimaWildcard as EasyUseAnimaWildcard,
         # B-10b8 retires the test-only root wildcard-note alias.
-        _bind_wildcard_node_runtime as _bind_wildcard_node_runtime,
     )
     from easyuse_anima.lora.metadata import (
         _apply_lora_syntax_format as _apply_lora_syntax_format,
@@ -1125,18 +1121,3 @@ except ImportError:  # allows simple local import tests outside ComfyUI's packag
 logger = logging.getLogger("ComfyUI-EasyUseAnima")
 
 _TRIGGER_WORD_KEYS = ("trainedWords", "trained_words", "trigger_words", "activation_text")
-
-
-_bind_wildcard_node_runtime(
-    get_workflow_node=lambda *args, **kwargs: _get_workflow_node(*args, **kwargs),
-    expand=lambda *args, **kwargs: expand_wildcards(*args, **kwargs),
-    normalize_seed_value=lambda *args, **kwargs: normalize_seed(*args, **kwargs),
-    normalize_mode=lambda *args, **kwargs: normalize_wildcard_mode(*args, **kwargs),
-    sources_signature=lambda *args, **kwargs: wildcard_sources_signature(*args, **kwargs),
-)
-_bind_naia_node_runtime(
-    resolve_settings=lambda: resolve_naia_settings(),
-    get_workflow_node=lambda *args, **kwargs: _get_workflow_node(*args, **kwargs),
-    post_random=lambda *args, **kwargs: _post_random(*args, **kwargs),
-    parse_random_response=lambda *args, **kwargs: _parse_random_response(*args, **kwargs),
-)

--- a/tests/fixtures/python_backend_baseline.json
+++ b/tests/fixtures/python_backend_baseline.json
@@ -46281,9 +46281,9 @@
       },
       {
         "is_package": false,
-        "loc": 1124,
+        "loc": 1123,
         "module": "nodes",
-        "normalized_git_blob_sha1": "c58b9044c1aa8c768ea8dc739ca346713ff7dbfb",
+        "normalized_git_blob_sha1": "d91507b0c3836e0964979ddaa735f277d0a5934d",
         "path": "nodes.py",
         "top_level": {
           "class_count": 0,

--- a/tests/fixtures/python_backend_baseline.json
+++ b/tests/fixtures/python_backend_baseline.json
@@ -13814,6 +13814,89 @@
       },
       {
         "alias": null,
+        "bound_name": "_get_workflow_node",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": "..workflow:_get_workflow_node",
+        "kind": "static_from",
+        "line": 21,
+        "name": "_get_workflow_node",
+        "optional": false,
+        "requested": "..workflow",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/nodes/naia_nodes.py",
+        "target": "easyuse_anima/workflow.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "resolve_naia_settings",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 23
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "resolve_naia_settings",
+          "target": "settings.py",
+          "try_line": 23
+        },
+        "conditional": true,
+        "imported": "...settings:resolve_naia_settings",
+        "kind": "static_from",
+        "line": 24,
+        "name": "resolve_naia_settings",
+        "optional": false,
+        "requested": "...settings",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "easyuse_anima/nodes/naia_nodes.py",
+        "target": "settings.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "resolve_naia_settings",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 25,
+            "kind": "try",
+            "line": 23
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "resolve_naia_settings",
+          "target": "settings.py",
+          "try_line": 23
+        },
+        "conditional": true,
+        "imported": "settings:resolve_naia_settings",
+        "kind": "static_from",
+        "line": 26,
+        "name": "resolve_naia_settings",
+        "optional": false,
+        "requested": "settings",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "easyuse_anima/nodes/naia_nodes.py",
+        "target": "settings.py"
+      },
+      {
+        "alias": null,
         "bound_name": "annotations",
         "branch_context": [],
         "classification": "external",
@@ -17289,6 +17372,24 @@
       },
       {
         "alias": null,
+        "bound_name": "_get_workflow_node",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": "..workflow:_get_workflow_node",
+        "kind": "static_from",
+        "line": 7,
+        "name": "_get_workflow_node",
+        "optional": false,
+        "requested": "..workflow",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/nodes/wildcard_nodes.py",
+        "target": "easyuse_anima/workflow.py"
+      },
+      {
+        "alias": null,
         "bound_name": "_FlexibleOptionalInputType",
         "branch_context": [],
         "classification": "internal",
@@ -17296,7 +17397,7 @@
         "conditional": false,
         "imported": ".input_types:_FlexibleOptionalInputType",
         "kind": "static_from",
-        "line": 7,
+        "line": 8,
         "name": "_FlexibleOptionalInputType",
         "optional": false,
         "requested": ".input_types",
@@ -17314,7 +17415,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 9
+            "line": 10
           }
         ],
         "classification": "internal",
@@ -17322,12 +17423,12 @@
         "compatibility_pair": {
           "bound_name": "MAX_SEED",
           "target": "wildcard_engine.py",
-          "try_line": 9
+          "try_line": 10
         },
         "conditional": true,
         "imported": "...wildcard_engine:MAX_SEED",
         "kind": "static_from",
-        "line": 10,
+        "line": 11,
         "name": "MAX_SEED",
         "optional": false,
         "requested": "...wildcard_engine",
@@ -17345,7 +17446,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 9
+            "line": 10
           }
         ],
         "classification": "internal",
@@ -17353,12 +17454,12 @@
         "compatibility_pair": {
           "bound_name": "PUBLIC_MAX_SEED",
           "target": "wildcard_engine.py",
-          "try_line": 9
+          "try_line": 10
         },
         "conditional": true,
         "imported": "...wildcard_engine:PUBLIC_MAX_SEED",
         "kind": "static_from",
-        "line": 10,
+        "line": 11,
         "name": "PUBLIC_MAX_SEED",
         "optional": false,
         "requested": "...wildcard_engine",
@@ -17376,7 +17477,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 9
+            "line": 10
           }
         ],
         "classification": "internal",
@@ -17384,12 +17485,12 @@
         "compatibility_pair": {
           "bound_name": "WILDCARD_MODE_FIXED",
           "target": "wildcard_engine.py",
-          "try_line": 9
+          "try_line": 10
         },
         "conditional": true,
         "imported": "...wildcard_engine:WILDCARD_MODE_FIXED",
         "kind": "static_from",
-        "line": 10,
+        "line": 11,
         "name": "WILDCARD_MODE_FIXED",
         "optional": false,
         "requested": "...wildcard_engine",
@@ -17407,7 +17508,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 9
+            "line": 10
           }
         ],
         "classification": "internal",
@@ -17415,12 +17516,12 @@
         "compatibility_pair": {
           "bound_name": "WILDCARD_MODE_LABELS",
           "target": "wildcard_engine.py",
-          "try_line": 9
+          "try_line": 10
         },
         "conditional": true,
         "imported": "...wildcard_engine:WILDCARD_MODE_LABELS",
         "kind": "static_from",
-        "line": 10,
+        "line": 11,
         "name": "WILDCARD_MODE_LABELS",
         "optional": false,
         "requested": "...wildcard_engine",
@@ -17438,7 +17539,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 9
+            "line": 10
           }
         ],
         "classification": "internal",
@@ -17446,12 +17547,12 @@
         "compatibility_pair": {
           "bound_name": "WILDCARD_MODE_POPULATE",
           "target": "wildcard_engine.py",
-          "try_line": 9
+          "try_line": 10
         },
         "conditional": true,
         "imported": "...wildcard_engine:WILDCARD_MODE_POPULATE",
         "kind": "static_from",
-        "line": 10,
+        "line": 11,
         "name": "WILDCARD_MODE_POPULATE",
         "optional": false,
         "requested": "...wildcard_engine",
@@ -17469,7 +17570,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 9
+            "line": 10
           }
         ],
         "classification": "internal",
@@ -17477,12 +17578,12 @@
         "compatibility_pair": {
           "bound_name": "WILDCARD_MODE_REPRODUCE",
           "target": "wildcard_engine.py",
-          "try_line": 9
+          "try_line": 10
         },
         "conditional": true,
         "imported": "...wildcard_engine:WILDCARD_MODE_REPRODUCE",
         "kind": "static_from",
-        "line": 10,
+        "line": 11,
         "name": "WILDCARD_MODE_REPRODUCE",
         "optional": false,
         "requested": "...wildcard_engine",
@@ -17500,7 +17601,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 9
+            "line": 10
           }
         ],
         "classification": "internal",
@@ -17508,12 +17609,12 @@
         "compatibility_pair": {
           "bound_name": "WILDCARD_MODE_SEQUENTIAL",
           "target": "wildcard_engine.py",
-          "try_line": 9
+          "try_line": 10
         },
         "conditional": true,
         "imported": "...wildcard_engine:WILDCARD_MODE_SEQUENTIAL",
         "kind": "static_from",
-        "line": 10,
+        "line": 11,
         "name": "WILDCARD_MODE_SEQUENTIAL",
         "optional": false,
         "requested": "...wildcard_engine",
@@ -17531,7 +17632,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 9
+            "line": 10
           }
         ],
         "classification": "internal",
@@ -17539,12 +17640,12 @@
         "compatibility_pair": {
           "bound_name": "expand_wildcards",
           "target": "wildcard_engine.py",
-          "try_line": 9
+          "try_line": 10
         },
         "conditional": true,
         "imported": "...wildcard_engine:expand_wildcards",
         "kind": "static_from",
-        "line": 10,
+        "line": 11,
         "name": "expand_wildcards",
         "optional": false,
         "requested": "...wildcard_engine",
@@ -17562,7 +17663,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 9
+            "line": 10
           }
         ],
         "classification": "internal",
@@ -17570,12 +17671,12 @@
         "compatibility_pair": {
           "bound_name": "normalize_seed",
           "target": "wildcard_engine.py",
-          "try_line": 9
+          "try_line": 10
         },
         "conditional": true,
         "imported": "...wildcard_engine:normalize_seed",
         "kind": "static_from",
-        "line": 10,
+        "line": 11,
         "name": "normalize_seed",
         "optional": false,
         "requested": "...wildcard_engine",
@@ -17593,7 +17694,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 9
+            "line": 10
           }
         ],
         "classification": "internal",
@@ -17601,12 +17702,12 @@
         "compatibility_pair": {
           "bound_name": "normalize_wildcard_mode",
           "target": "wildcard_engine.py",
-          "try_line": 9
+          "try_line": 10
         },
         "conditional": true,
         "imported": "...wildcard_engine:normalize_wildcard_mode",
         "kind": "static_from",
-        "line": 10,
+        "line": 11,
         "name": "normalize_wildcard_mode",
         "optional": false,
         "requested": "...wildcard_engine",
@@ -17624,7 +17725,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 9
+            "line": 10
           }
         ],
         "classification": "internal",
@@ -17632,12 +17733,12 @@
         "compatibility_pair": {
           "bound_name": "wildcard_sources_signature",
           "target": "wildcard_engine.py",
-          "try_line": 9
+          "try_line": 10
         },
         "conditional": true,
         "imported": "...wildcard_engine:wildcard_sources_signature",
         "kind": "static_from",
-        "line": 10,
+        "line": 11,
         "name": "wildcard_sources_signature",
         "optional": false,
         "requested": "...wildcard_engine",
@@ -17656,9 +17757,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 23,
+            "handler_line": 24,
             "kind": "try",
-            "line": 9
+            "line": 10
           }
         ],
         "classification": "compatibility_fallback",
@@ -17666,12 +17767,12 @@
         "compatibility_pair": {
           "bound_name": "MAX_SEED",
           "target": "wildcard_engine.py",
-          "try_line": 9
+          "try_line": 10
         },
         "conditional": true,
         "imported": "wildcard_engine:MAX_SEED",
         "kind": "static_from",
-        "line": 24,
+        "line": 25,
         "name": "MAX_SEED",
         "optional": false,
         "requested": "wildcard_engine",
@@ -17690,9 +17791,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 23,
+            "handler_line": 24,
             "kind": "try",
-            "line": 9
+            "line": 10
           }
         ],
         "classification": "compatibility_fallback",
@@ -17700,12 +17801,12 @@
         "compatibility_pair": {
           "bound_name": "PUBLIC_MAX_SEED",
           "target": "wildcard_engine.py",
-          "try_line": 9
+          "try_line": 10
         },
         "conditional": true,
         "imported": "wildcard_engine:PUBLIC_MAX_SEED",
         "kind": "static_from",
-        "line": 24,
+        "line": 25,
         "name": "PUBLIC_MAX_SEED",
         "optional": false,
         "requested": "wildcard_engine",
@@ -17724,9 +17825,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 23,
+            "handler_line": 24,
             "kind": "try",
-            "line": 9
+            "line": 10
           }
         ],
         "classification": "compatibility_fallback",
@@ -17734,12 +17835,12 @@
         "compatibility_pair": {
           "bound_name": "WILDCARD_MODE_FIXED",
           "target": "wildcard_engine.py",
-          "try_line": 9
+          "try_line": 10
         },
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_FIXED",
         "kind": "static_from",
-        "line": 24,
+        "line": 25,
         "name": "WILDCARD_MODE_FIXED",
         "optional": false,
         "requested": "wildcard_engine",
@@ -17758,9 +17859,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 23,
+            "handler_line": 24,
             "kind": "try",
-            "line": 9
+            "line": 10
           }
         ],
         "classification": "compatibility_fallback",
@@ -17768,12 +17869,12 @@
         "compatibility_pair": {
           "bound_name": "WILDCARD_MODE_LABELS",
           "target": "wildcard_engine.py",
-          "try_line": 9
+          "try_line": 10
         },
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_LABELS",
         "kind": "static_from",
-        "line": 24,
+        "line": 25,
         "name": "WILDCARD_MODE_LABELS",
         "optional": false,
         "requested": "wildcard_engine",
@@ -17792,9 +17893,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 23,
+            "handler_line": 24,
             "kind": "try",
-            "line": 9
+            "line": 10
           }
         ],
         "classification": "compatibility_fallback",
@@ -17802,12 +17903,12 @@
         "compatibility_pair": {
           "bound_name": "WILDCARD_MODE_POPULATE",
           "target": "wildcard_engine.py",
-          "try_line": 9
+          "try_line": 10
         },
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_POPULATE",
         "kind": "static_from",
-        "line": 24,
+        "line": 25,
         "name": "WILDCARD_MODE_POPULATE",
         "optional": false,
         "requested": "wildcard_engine",
@@ -17826,9 +17927,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 23,
+            "handler_line": 24,
             "kind": "try",
-            "line": 9
+            "line": 10
           }
         ],
         "classification": "compatibility_fallback",
@@ -17836,12 +17937,12 @@
         "compatibility_pair": {
           "bound_name": "WILDCARD_MODE_REPRODUCE",
           "target": "wildcard_engine.py",
-          "try_line": 9
+          "try_line": 10
         },
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_REPRODUCE",
         "kind": "static_from",
-        "line": 24,
+        "line": 25,
         "name": "WILDCARD_MODE_REPRODUCE",
         "optional": false,
         "requested": "wildcard_engine",
@@ -17860,9 +17961,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 23,
+            "handler_line": 24,
             "kind": "try",
-            "line": 9
+            "line": 10
           }
         ],
         "classification": "compatibility_fallback",
@@ -17870,12 +17971,12 @@
         "compatibility_pair": {
           "bound_name": "WILDCARD_MODE_SEQUENTIAL",
           "target": "wildcard_engine.py",
-          "try_line": 9
+          "try_line": 10
         },
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_SEQUENTIAL",
         "kind": "static_from",
-        "line": 24,
+        "line": 25,
         "name": "WILDCARD_MODE_SEQUENTIAL",
         "optional": false,
         "requested": "wildcard_engine",
@@ -17894,9 +17995,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 23,
+            "handler_line": 24,
             "kind": "try",
-            "line": 9
+            "line": 10
           }
         ],
         "classification": "compatibility_fallback",
@@ -17904,12 +18005,12 @@
         "compatibility_pair": {
           "bound_name": "expand_wildcards",
           "target": "wildcard_engine.py",
-          "try_line": 9
+          "try_line": 10
         },
         "conditional": true,
         "imported": "wildcard_engine:expand_wildcards",
         "kind": "static_from",
-        "line": 24,
+        "line": 25,
         "name": "expand_wildcards",
         "optional": false,
         "requested": "wildcard_engine",
@@ -17928,9 +18029,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 23,
+            "handler_line": 24,
             "kind": "try",
-            "line": 9
+            "line": 10
           }
         ],
         "classification": "compatibility_fallback",
@@ -17938,12 +18039,12 @@
         "compatibility_pair": {
           "bound_name": "normalize_seed",
           "target": "wildcard_engine.py",
-          "try_line": 9
+          "try_line": 10
         },
         "conditional": true,
         "imported": "wildcard_engine:normalize_seed",
         "kind": "static_from",
-        "line": 24,
+        "line": 25,
         "name": "normalize_seed",
         "optional": false,
         "requested": "wildcard_engine",
@@ -17962,9 +18063,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 23,
+            "handler_line": 24,
             "kind": "try",
-            "line": 9
+            "line": 10
           }
         ],
         "classification": "compatibility_fallback",
@@ -17972,12 +18073,12 @@
         "compatibility_pair": {
           "bound_name": "normalize_wildcard_mode",
           "target": "wildcard_engine.py",
-          "try_line": 9
+          "try_line": 10
         },
         "conditional": true,
         "imported": "wildcard_engine:normalize_wildcard_mode",
         "kind": "static_from",
-        "line": 24,
+        "line": 25,
         "name": "normalize_wildcard_mode",
         "optional": false,
         "requested": "wildcard_engine",
@@ -17996,9 +18097,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 23,
+            "handler_line": 24,
             "kind": "try",
-            "line": 9
+            "line": 10
           }
         ],
         "classification": "compatibility_fallback",
@@ -18006,12 +18107,12 @@
         "compatibility_pair": {
           "bound_name": "wildcard_sources_signature",
           "target": "wildcard_engine.py",
-          "try_line": 9
+          "try_line": 10
         },
         "conditional": true,
         "imported": "wildcard_engine:wildcard_sources_signature",
         "kind": "static_from",
-        "line": 24,
+        "line": 25,
         "name": "wildcard_sources_signature",
         "optional": false,
         "requested": "wildcard_engine",
@@ -29484,37 +29585,6 @@
         "target": "easyuse_anima/nodes/naia_nodes.py"
       },
       {
-        "alias": "_bind_naia_node_runtime",
-        "bound_name": "_bind_naia_node_runtime",
-        "branch_context": [
-          {
-            "branch": "body",
-            "handles_import_failure": true,
-            "has_import_fallback_handler": true,
-            "kind": "try",
-            "line": 6
-          }
-        ],
-        "classification": "internal",
-        "column": 4,
-        "compatibility_pair": {
-          "bound_name": "_bind_naia_node_runtime",
-          "target": "easyuse_anima/nodes/naia_nodes.py",
-          "try_line": 6
-        },
-        "conditional": true,
-        "imported": ".easyuse_anima.nodes.naia_nodes:_bind_naia_node_runtime",
-        "kind": "static_from",
-        "line": 499,
-        "name": "_bind_naia_node_runtime",
-        "optional": false,
-        "requested": ".easyuse_anima.nodes.naia_nodes",
-        "role": "compatibility_primary",
-        "scope": "<module>",
-        "source": "nodes.py",
-        "target": "easyuse_anima/nodes/naia_nodes.py"
-      },
-      {
         "alias": "EasyUseAnimaWildcard",
         "bound_name": "EasyUseAnimaWildcard",
         "branch_context": [
@@ -29536,39 +29606,8 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.wildcard_nodes:EasyUseAnimaWildcard",
         "kind": "static_from",
-        "line": 503,
+        "line": 502,
         "name": "EasyUseAnimaWildcard",
-        "optional": false,
-        "requested": ".easyuse_anima.nodes.wildcard_nodes",
-        "role": "compatibility_primary",
-        "scope": "<module>",
-        "source": "nodes.py",
-        "target": "easyuse_anima/nodes/wildcard_nodes.py"
-      },
-      {
-        "alias": "_bind_wildcard_node_runtime",
-        "bound_name": "_bind_wildcard_node_runtime",
-        "branch_context": [
-          {
-            "branch": "body",
-            "handles_import_failure": true,
-            "has_import_fallback_handler": true,
-            "kind": "try",
-            "line": 6
-          }
-        ],
-        "classification": "internal",
-        "column": 4,
-        "compatibility_pair": {
-          "bound_name": "_bind_wildcard_node_runtime",
-          "target": "easyuse_anima/nodes/wildcard_nodes.py",
-          "try_line": 6
-        },
-        "conditional": true,
-        "imported": ".easyuse_anima.nodes.wildcard_nodes:_bind_wildcard_node_runtime",
-        "kind": "static_from",
-        "line": 503,
-        "name": "_bind_wildcard_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.wildcard_nodes",
         "role": "compatibility_primary",
@@ -29598,7 +29637,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_apply_lora_syntax_format",
         "kind": "static_from",
-        "line": 508,
+        "line": 506,
         "name": "_apply_lora_syntax_format",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -29629,7 +29668,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_dedupe_text_values",
         "kind": "static_from",
-        "line": 508,
+        "line": 506,
         "name": "_dedupe_text_values",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -29660,7 +29699,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_fallback_lora_path",
         "kind": "static_from",
-        "line": 508,
+        "line": 506,
         "name": "_fallback_lora_path",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -29691,7 +29730,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_get_lora_info",
         "kind": "static_from",
-        "line": 508,
+        "line": 506,
         "name": "_get_lora_info",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -29722,7 +29761,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_get_lora_manager_trigger_words",
         "kind": "static_from",
-        "line": 508,
+        "line": 506,
         "name": "_get_lora_manager_trigger_words",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -29753,7 +29792,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_load_lora_manager_metadata",
         "kind": "static_from",
-        "line": 508,
+        "line": 506,
         "name": "_load_lora_manager_metadata",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -29784,7 +29823,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_lora_combo_values",
         "kind": "static_from",
-        "line": 508,
+        "line": 506,
         "name": "_lora_combo_values",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -29815,7 +29854,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_lora_manager_trigger_words_from_metadata",
         "kind": "static_from",
-        "line": 508,
+        "line": 506,
         "name": "_lora_manager_trigger_words_from_metadata",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -29846,7 +29885,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_lora_model_exists",
         "kind": "static_from",
-        "line": 508,
+        "line": 506,
         "name": "_lora_model_exists",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -29877,7 +29916,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_lora_stack_name",
         "kind": "static_from",
-        "line": 508,
+        "line": 506,
         "name": "_lora_stack_name",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -29908,7 +29947,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_metadata_json_paths_for_lora",
         "kind": "static_from",
-        "line": 508,
+        "line": 506,
         "name": "_metadata_json_paths_for_lora",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -29939,7 +29978,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_missing_lora_display_name",
         "kind": "static_from",
-        "line": 508,
+        "line": 506,
         "name": "_missing_lora_display_name",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -29970,7 +30009,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_raise_missing_loras",
         "kind": "static_from",
-        "line": 508,
+        "line": 506,
         "name": "_raise_missing_loras",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -30001,7 +30040,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_trigger_words_from_value",
         "kind": "static_from",
-        "line": 508,
+        "line": 506,
         "name": "_trigger_words_from_value",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -30032,7 +30071,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_correct_style_prompt",
         "kind": "static_from",
-        "line": 524,
+        "line": 522,
         "name": "_correct_style_prompt",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -30063,7 +30102,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_format_strength",
         "kind": "static_from",
-        "line": 524,
+        "line": 522,
         "name": "_format_strength",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -30094,7 +30133,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_get_loras_list",
         "kind": "static_from",
-        "line": 524,
+        "line": 522,
         "name": "_get_loras_list",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -30125,7 +30164,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_load_profile_data",
         "kind": "static_from",
-        "line": 524,
+        "line": 522,
         "name": "_load_profile_data",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -30156,7 +30195,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_profile_key",
         "kind": "static_from",
-        "line": 524,
+        "line": 522,
         "name": "_profile_key",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -30187,7 +30226,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_select_profile_values",
         "kind": "static_from",
-        "line": 524,
+        "line": 522,
         "name": "_select_profile_values",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -30218,7 +30257,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_wrap_profile_index",
         "kind": "static_from",
-        "line": 524,
+        "line": 522,
         "name": "_wrap_profile_index",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -30249,7 +30288,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.lora_nodes:EasyUseAnimaLoraPreset",
         "kind": "static_from",
-        "line": 533,
+        "line": 531,
         "name": "EasyUseAnimaLoraPreset",
         "optional": false,
         "requested": ".easyuse_anima.nodes.lora_nodes",
@@ -30280,7 +30319,7 @@
         "conditional": true,
         "imported": ".anima_prompt:correct_prompt",
         "kind": "static_from",
-        "line": 536,
+        "line": 534,
         "name": "correct_prompt",
         "optional": false,
         "requested": ".anima_prompt",
@@ -30311,7 +30350,7 @@
         "conditional": true,
         "imported": ".anima_prompt:load_knowledge_base",
         "kind": "static_from",
-        "line": 536,
+        "line": 534,
         "name": "load_knowledge_base",
         "optional": false,
         "requested": ".anima_prompt",
@@ -30342,7 +30381,7 @@
         "conditional": true,
         "imported": ".anima_prompt.parser:parse_prompt",
         "kind": "static_from",
-        "line": 537,
+        "line": 535,
         "name": "parse_prompt",
         "optional": false,
         "requested": ".anima_prompt.parser",
@@ -30373,7 +30412,7 @@
         "conditional": true,
         "imported": ".settings:resolve_metadata_filter_words",
         "kind": "static_from",
-        "line": 538,
+        "line": 536,
         "name": "resolve_metadata_filter_words",
         "optional": false,
         "requested": ".settings",
@@ -30404,7 +30443,7 @@
         "conditional": true,
         "imported": ".settings:resolve_naia_settings",
         "kind": "static_from",
-        "line": 538,
+        "line": 536,
         "name": "resolve_naia_settings",
         "optional": false,
         "requested": ".settings",
@@ -30435,7 +30474,7 @@
         "conditional": true,
         "imported": ".settings:resolve_prompt_translation_settings",
         "kind": "static_from",
-        "line": 538,
+        "line": 536,
         "name": "resolve_prompt_translation_settings",
         "optional": false,
         "requested": ".settings",
@@ -30466,7 +30505,7 @@
         "conditional": true,
         "imported": ".prompt_translation:has_prompt_translation_markers",
         "kind": "static_from",
-        "line": 543,
+        "line": 541,
         "name": "has_prompt_translation_markers",
         "optional": false,
         "requested": ".prompt_translation",
@@ -30497,7 +30536,7 @@
         "conditional": true,
         "imported": ".prompt_translation:translate_prompt_markers",
         "kind": "static_from",
-        "line": 543,
+        "line": 541,
         "name": "translate_prompt_markers",
         "optional": false,
         "requested": ".prompt_translation",
@@ -30528,7 +30567,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:MAX_SEED",
         "kind": "static_from",
-        "line": 544,
+        "line": 542,
         "name": "MAX_SEED",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -30559,7 +30598,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "kind": "static_from",
-        "line": 544,
+        "line": 542,
         "name": "PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -30590,7 +30629,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:PUBLIC_MAX_SEED",
         "kind": "static_from",
-        "line": 544,
+        "line": 542,
         "name": "PUBLIC_MAX_SEED",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -30621,7 +30660,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_DECREMENT",
         "kind": "static_from",
-        "line": 544,
+        "line": 542,
         "name": "SEED_CONTROL_DECREMENT",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -30652,7 +30691,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_FIXED",
         "kind": "static_from",
-        "line": 544,
+        "line": 542,
         "name": "SEED_CONTROL_FIXED",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -30683,7 +30722,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_INCREMENT",
         "kind": "static_from",
-        "line": 544,
+        "line": 542,
         "name": "SEED_CONTROL_INCREMENT",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -30714,7 +30753,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_MODES",
         "kind": "static_from",
-        "line": 544,
+        "line": 542,
         "name": "SEED_CONTROL_MODES",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -30745,7 +30784,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_RANDOMIZE",
         "kind": "static_from",
-        "line": 544,
+        "line": 542,
         "name": "SEED_CONTROL_RANDOMIZE",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -30776,7 +30815,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:WILDCARD_MODE_FIXED",
         "kind": "static_from",
-        "line": 544,
+        "line": 542,
         "name": "WILDCARD_MODE_FIXED",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -30807,7 +30846,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:WILDCARD_MODE_POPULATE",
         "kind": "static_from",
-        "line": 544,
+        "line": 542,
         "name": "WILDCARD_MODE_POPULATE",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -30838,7 +30877,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:WILDCARD_MODE_SEQUENTIAL",
         "kind": "static_from",
-        "line": 544,
+        "line": 542,
         "name": "WILDCARD_MODE_SEQUENTIAL",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -30869,7 +30908,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:expand_wildcard_texts",
         "kind": "static_from",
-        "line": 544,
+        "line": 542,
         "name": "expand_wildcard_texts",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -30900,7 +30939,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:expand_wildcards",
         "kind": "static_from",
-        "line": 544,
+        "line": 542,
         "name": "expand_wildcards",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -30931,7 +30970,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:has_wildcard_syntax",
         "kind": "static_from",
-        "line": 544,
+        "line": 542,
         "name": "has_wildcard_syntax",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -30962,7 +31001,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:next_seed",
         "kind": "static_from",
-        "line": 544,
+        "line": 542,
         "name": "next_seed",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -30993,7 +31032,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:normalize_prompt_studio_wildcard_mode",
         "kind": "static_from",
-        "line": 544,
+        "line": 542,
         "name": "normalize_prompt_studio_wildcard_mode",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -31024,7 +31063,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:normalize_seed",
         "kind": "static_from",
-        "line": 544,
+        "line": 542,
         "name": "normalize_seed",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -31055,7 +31094,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:normalize_wildcard_mode",
         "kind": "static_from",
-        "line": 544,
+        "line": 542,
         "name": "normalize_wildcard_mode",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -31086,7 +31125,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:wildcard_sources_signature",
         "kind": "static_from",
-        "line": 544,
+        "line": 542,
         "name": "wildcard_sources_signature",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -31105,7 +31144,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -31120,7 +31159,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:AIO_FIRST_PASS_CACHE_MAX_ENTRIES",
         "kind": "static_from",
-        "line": 566,
+        "line": 564,
         "name": "AIO_FIRST_PASS_CACHE_MAX_ENTRIES",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -31139,7 +31178,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -31154,7 +31193,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_AIO_FIRST_PASS_CACHE",
         "kind": "static_from",
-        "line": 566,
+        "line": 564,
         "name": "_AIO_FIRST_PASS_CACHE",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -31173,7 +31212,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -31188,7 +31227,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_AIO_FIRST_PASS_CACHE_ORDER",
         "kind": "static_from",
-        "line": 566,
+        "line": 564,
         "name": "_AIO_FIRST_PASS_CACHE_ORDER",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -31207,7 +31246,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -31222,7 +31261,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_aio_first_pass_cache_key",
         "kind": "static_from",
-        "line": 566,
+        "line": 564,
         "name": "_aio_first_pass_cache_key",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -31241,7 +31280,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -31256,7 +31295,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_clone_aio_cache_value",
         "kind": "static_from",
-        "line": 566,
+        "line": 564,
         "name": "_clone_aio_cache_value",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -31275,7 +31314,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -31290,7 +31329,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_get_aio_first_pass_cache",
         "kind": "static_from",
-        "line": 566,
+        "line": 564,
         "name": "_get_aio_first_pass_cache",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -31309,7 +31348,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -31324,7 +31363,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_put_aio_first_pass_cache",
         "kind": "static_from",
-        "line": 566,
+        "line": 564,
         "name": "_put_aio_first_pass_cache",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -31343,7 +31382,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -31358,7 +31397,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_detailer_stage",
         "kind": "static_from",
-        "line": 576,
+        "line": 574,
         "name": "_run_aio_detailer_stage",
         "optional": false,
         "requested": "easyuse_anima.aio.legacy_generation",
@@ -31377,7 +31416,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -31392,7 +31431,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_detailer_target",
         "kind": "static_from",
-        "line": 576,
+        "line": 574,
         "name": "_run_aio_detailer_target",
         "optional": false,
         "requested": "easyuse_anima.aio.legacy_generation",
@@ -31411,7 +31450,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -31426,7 +31465,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_highres_stage",
         "kind": "static_from",
-        "line": 576,
+        "line": 574,
         "name": "_run_aio_highres_stage",
         "optional": false,
         "requested": "easyuse_anima.aio.legacy_generation",
@@ -31445,7 +31484,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -31460,7 +31499,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_legacy_generation",
         "kind": "static_from",
-        "line": 576,
+        "line": 574,
         "name": "_run_aio_legacy_generation",
         "optional": false,
         "requested": "easyuse_anima.aio.legacy_generation",
@@ -31479,7 +31518,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -31494,7 +31533,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_resshift_upscale_stage",
         "kind": "static_from",
-        "line": 576,
+        "line": 574,
         "name": "_run_aio_resshift_upscale_stage",
         "optional": false,
         "requested": "easyuse_anima.aio.legacy_generation",
@@ -31513,7 +31552,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -31528,7 +31567,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_upscale_stage",
         "kind": "static_from",
-        "line": 576,
+        "line": 574,
         "name": "_run_aio_upscale_stage",
         "optional": false,
         "requested": "easyuse_anima.aio.legacy_generation",
@@ -31547,7 +31586,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -31562,7 +31601,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_usdu_upscale_stage",
         "kind": "static_from",
-        "line": 576,
+        "line": 574,
         "name": "_run_aio_usdu_upscale_stage",
         "optional": false,
         "requested": "easyuse_anima.aio.legacy_generation",
@@ -31581,7 +31620,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -31596,7 +31635,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_AIO_DETAILER_CUSTOM_RE",
         "kind": "static_from",
-        "line": 585,
+        "line": 583,
         "name": "_AIO_DETAILER_CUSTOM_RE",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -31615,7 +31654,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -31630,7 +31669,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_AIO_DETAILER_RESERVED_KEYS",
         "kind": "static_from",
-        "line": 585,
+        "line": 583,
         "name": "_AIO_DETAILER_RESERVED_KEYS",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -31649,7 +31688,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -31664,7 +31703,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_aio_detailer_has_enabled_targets",
         "kind": "static_from",
-        "line": 585,
+        "line": 583,
         "name": "_aio_detailer_has_enabled_targets",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -31683,7 +31722,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -31698,7 +31737,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_aio_detailer_target_defaults",
         "kind": "static_from",
-        "line": 585,
+        "line": 583,
         "name": "_aio_detailer_target_defaults",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -31717,7 +31756,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -31732,7 +31771,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_aio_detailer_target_order",
         "kind": "static_from",
-        "line": 585,
+        "line": 583,
         "name": "_aio_detailer_target_order",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -31751,7 +31790,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -31766,7 +31805,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_is_aio_detailer_target_name",
         "kind": "static_from",
-        "line": 585,
+        "line": 583,
         "name": "_is_aio_detailer_target_name",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -31785,7 +31824,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -31800,7 +31839,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_merge_versioned_settings",
         "kind": "static_from",
-        "line": 585,
+        "line": 583,
         "name": "_merge_versioned_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -31819,7 +31858,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -31834,7 +31873,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_dit_corrections_settings",
         "kind": "static_from",
-        "line": 585,
+        "line": 583,
         "name": "_normalize_aio_dit_corrections_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -31853,7 +31892,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -31868,7 +31907,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_generation_settings",
         "kind": "static_from",
-        "line": 585,
+        "line": 583,
         "name": "_normalize_aio_generation_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -31887,7 +31926,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -31902,7 +31941,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_seed",
         "kind": "static_from",
-        "line": 585,
+        "line": 583,
         "name": "_normalize_aio_seed",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -31921,7 +31960,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -31936,7 +31975,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_spectrum_settings",
         "kind": "static_from",
-        "line": 585,
+        "line": 583,
         "name": "_normalize_aio_spectrum_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -31955,7 +31994,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -31970,7 +32009,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_FINAL_FIT_MODES",
         "kind": "static_from",
-        "line": 598,
+        "line": 596,
         "name": "AIO_FINAL_FIT_MODES",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_defaults",
@@ -31989,7 +32028,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -32004,7 +32043,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_FINAL_UPSCALE_BACKENDS",
         "kind": "static_from",
-        "line": 598,
+        "line": 596,
         "name": "AIO_FINAL_UPSCALE_BACKENDS",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_defaults",
@@ -32023,7 +32062,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -32038,7 +32077,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_GENERATION_DEFAULT_SETTINGS",
         "kind": "static_from",
-        "line": 598,
+        "line": 596,
         "name": "AIO_GENERATION_DEFAULT_SETTINGS",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_defaults",
@@ -32057,7 +32096,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -32072,7 +32111,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_GENERATION_SETTINGS_SCHEMA",
         "kind": "static_from",
-        "line": 598,
+        "line": 596,
         "name": "AIO_GENERATION_SETTINGS_SCHEMA",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_defaults",
@@ -32091,7 +32130,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -32106,7 +32145,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_GENERATION_SETTINGS_VERSION",
         "kind": "static_from",
-        "line": 598,
+        "line": 596,
         "name": "AIO_GENERATION_SETTINGS_VERSION",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_defaults",
@@ -32125,7 +32164,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -32140,7 +32179,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_RESHIFT_DTYPES",
         "kind": "static_from",
-        "line": 598,
+        "line": 596,
         "name": "AIO_RESHIFT_DTYPES",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_defaults",
@@ -32159,7 +32198,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -32174,7 +32213,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_RESHIFT_SCALES",
         "kind": "static_from",
-        "line": 598,
+        "line": 596,
         "name": "AIO_RESHIFT_SCALES",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_defaults",
@@ -32193,7 +32232,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -32208,7 +32247,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_SPECIAL_SEEDS",
         "kind": "static_from",
-        "line": 598,
+        "line": 596,
         "name": "AIO_SPECIAL_SEEDS",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_defaults",
@@ -32227,7 +32266,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -32242,7 +32281,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_SPECIAL_SEED_DECREMENT",
         "kind": "static_from",
-        "line": 598,
+        "line": 596,
         "name": "AIO_SPECIAL_SEED_DECREMENT",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_defaults",
@@ -32261,7 +32300,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -32276,7 +32315,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_SPECIAL_SEED_INCREMENT",
         "kind": "static_from",
-        "line": 598,
+        "line": 596,
         "name": "AIO_SPECIAL_SEED_INCREMENT",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_defaults",
@@ -32295,7 +32334,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -32310,7 +32349,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_SPECIAL_SEED_RANDOM",
         "kind": "static_from",
-        "line": 598,
+        "line": 596,
         "name": "AIO_SPECIAL_SEED_RANDOM",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_defaults",
@@ -32329,7 +32368,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -32344,7 +32383,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_USDU_MODE_TYPES",
         "kind": "static_from",
-        "line": 598,
+        "line": 596,
         "name": "AIO_USDU_MODE_TYPES",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_defaults",
@@ -32363,7 +32402,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -32378,7 +32417,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_USDU_PROMPT_FULL",
         "kind": "static_from",
-        "line": 598,
+        "line": 596,
         "name": "AIO_USDU_PROMPT_FULL",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_defaults",
@@ -32397,7 +32436,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -32412,7 +32451,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_USDU_PROMPT_MODES",
         "kind": "static_from",
-        "line": 598,
+        "line": 596,
         "name": "AIO_USDU_PROMPT_MODES",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_defaults",
@@ -32431,7 +32470,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -32446,7 +32485,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_USDU_PROMPT_NO_GENERAL",
         "kind": "static_from",
-        "line": 598,
+        "line": 596,
         "name": "AIO_USDU_PROMPT_NO_GENERAL",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_defaults",
@@ -32465,7 +32504,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -32480,7 +32519,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_USDU_SEAM_FIX_MODES",
         "kind": "static_from",
-        "line": 598,
+        "line": 596,
         "name": "AIO_USDU_SEAM_FIX_MODES",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_defaults",
@@ -32499,7 +32538,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -32514,7 +32553,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_settings:round_trip_aio_generation_settings",
         "kind": "static_from",
-        "line": 616,
+        "line": 614,
         "name": "round_trip_aio_generation_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_settings",
@@ -32533,7 +32572,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -32548,7 +32587,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.input_defaults:AIO_INPUT_DEFAULT_SETTINGS",
         "kind": "static_from",
-        "line": 619,
+        "line": 617,
         "name": "AIO_INPUT_DEFAULT_SETTINGS",
         "optional": false,
         "requested": "easyuse_anima.aio.input_defaults",
@@ -32567,7 +32606,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -32582,7 +32621,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.input_defaults:ANIMA_CLIP_DEVICES",
         "kind": "static_from",
-        "line": 619,
+        "line": 617,
         "name": "ANIMA_CLIP_DEVICES",
         "optional": false,
         "requested": "easyuse_anima.aio.input_defaults",
@@ -32601,7 +32640,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -32616,7 +32655,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.input_defaults:ANIMA_CLIP_TYPES",
         "kind": "static_from",
-        "line": 619,
+        "line": 617,
         "name": "ANIMA_CLIP_TYPES",
         "optional": false,
         "requested": "easyuse_anima.aio.input_defaults",
@@ -32635,7 +32674,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -32650,7 +32689,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.input_defaults:ANIMA_DEFAULT_CLIP_CANDIDATES",
         "kind": "static_from",
-        "line": 619,
+        "line": 617,
         "name": "ANIMA_DEFAULT_CLIP_CANDIDATES",
         "optional": false,
         "requested": "easyuse_anima.aio.input_defaults",
@@ -32669,7 +32708,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -32684,7 +32723,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.input_defaults:ANIMA_DEFAULT_DIFFUSION_MODEL_CANDIDATES",
         "kind": "static_from",
-        "line": 619,
+        "line": 617,
         "name": "ANIMA_DEFAULT_DIFFUSION_MODEL_CANDIDATES",
         "optional": false,
         "requested": "easyuse_anima.aio.input_defaults",
@@ -32703,7 +32742,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -32718,7 +32757,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.input_defaults:ANIMA_DEFAULT_VAE_CANDIDATES",
         "kind": "static_from",
-        "line": 619,
+        "line": 617,
         "name": "ANIMA_DEFAULT_VAE_CANDIDATES",
         "optional": false,
         "requested": "easyuse_anima.aio.input_defaults",
@@ -32737,7 +32776,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -32752,7 +32791,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.input_defaults:ANIMA_UNET_WEIGHT_DTYPES",
         "kind": "static_from",
-        "line": 619,
+        "line": 617,
         "name": "ANIMA_UNET_WEIGHT_DTYPES",
         "optional": false,
         "requested": "easyuse_anima.aio.input_defaults",
@@ -32771,7 +32810,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -32786,7 +32825,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.input_defaults:EASY_USE_ANIMA_INPUT_SCHEMA",
         "kind": "static_from",
-        "line": 619,
+        "line": 617,
         "name": "EASY_USE_ANIMA_INPUT_SCHEMA",
         "optional": false,
         "requested": "easyuse_anima.aio.input_defaults",
@@ -32805,7 +32844,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -32820,7 +32859,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.input_defaults:EASY_USE_ANIMA_INPUT_SETTINGS_VERSION",
         "kind": "static_from",
-        "line": 619,
+        "line": 617,
         "name": "EASY_USE_ANIMA_INPUT_SETTINGS_VERSION",
         "optional": false,
         "requested": "easyuse_anima.aio.input_defaults",
@@ -32839,7 +32878,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -32854,7 +32893,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.input_context:_easy_use_anima_input_signature",
         "kind": "static_from",
-        "line": 630,
+        "line": 628,
         "name": "_easy_use_anima_input_signature",
         "optional": false,
         "requested": "easyuse_anima.aio.input_context",
@@ -32873,7 +32912,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -32888,7 +32927,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.input_context:_require_easy_use_anima_input",
         "kind": "static_from",
-        "line": 630,
+        "line": 628,
         "name": "_require_easy_use_anima_input",
         "optional": false,
         "requested": "easyuse_anima.aio.input_context",
@@ -32907,7 +32946,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -32922,7 +32961,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.usdu:_aio_usdu_auto_tile_dimension",
         "kind": "static_from",
-        "line": 634,
+        "line": 632,
         "name": "_aio_usdu_auto_tile_dimension",
         "optional": false,
         "requested": "easyuse_anima.aio.usdu",
@@ -32941,7 +32980,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -32956,7 +32995,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.usdu:_aio_usdu_tile_plan",
         "kind": "static_from",
-        "line": 634,
+        "line": 632,
         "name": "_aio_usdu_tile_plan",
         "optional": false,
         "requested": "easyuse_anima.aio.usdu",
@@ -32975,7 +33014,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -32990,7 +33029,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_aio_final_fit_size",
         "kind": "static_from",
-        "line": 638,
+        "line": 636,
         "name": "_aio_final_fit_size",
         "optional": false,
         "requested": "easyuse_anima.aio.postprocess",
@@ -33009,7 +33048,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -33024,7 +33063,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_apply_aio_final_fit",
         "kind": "static_from",
-        "line": 638,
+        "line": 636,
         "name": "_apply_aio_final_fit",
         "optional": false,
         "requested": "easyuse_anima.aio.postprocess",
@@ -33043,7 +33082,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -33058,7 +33097,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_resize_image_to_size_if_needed",
         "kind": "static_from",
-        "line": 638,
+        "line": 636,
         "name": "_resize_image_to_size_if_needed",
         "optional": false,
         "requested": "easyuse_anima.aio.postprocess",
@@ -33077,7 +33116,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -33092,7 +33131,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_run_aio_postprocess_stage",
         "kind": "static_from",
-        "line": 638,
+        "line": 636,
         "name": "_run_aio_postprocess_stage",
         "optional": false,
         "requested": "easyuse_anima.aio.postprocess",
@@ -33111,7 +33150,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -33126,7 +33165,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_prompt_data_fields_for_usdu",
         "kind": "static_from",
-        "line": 644,
+        "line": 642,
         "name": "_aio_prompt_data_fields_for_usdu",
         "optional": false,
         "requested": "easyuse_anima.aio.conditioning",
@@ -33145,7 +33184,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -33160,7 +33199,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_usdu_conditioning",
         "kind": "static_from",
-        "line": 644,
+        "line": 642,
         "name": "_aio_usdu_conditioning",
         "optional": false,
         "requested": "easyuse_anima.aio.conditioning",
@@ -33179,7 +33218,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -33194,7 +33233,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_usdu_prompt_without_general",
         "kind": "static_from",
-        "line": 644,
+        "line": 642,
         "name": "_aio_usdu_prompt_without_general",
         "optional": false,
         "requested": "easyuse_anima.aio.conditioning",
@@ -33213,7 +33252,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -33228,7 +33267,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_aio_lora_stack_signature",
         "kind": "static_from",
-        "line": 649,
+        "line": 647,
         "name": "_aio_lora_stack_signature",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -33247,7 +33286,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -33262,7 +33301,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_anima_dave_patch",
         "kind": "static_from",
-        "line": 649,
+        "line": 647,
         "name": "_apply_aio_anima_dave_patch",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -33281,7 +33320,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -33296,7 +33335,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_kj_model_patches",
         "kind": "static_from",
-        "line": 649,
+        "line": 647,
         "name": "_apply_aio_kj_model_patches",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -33315,7 +33354,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -33330,7 +33369,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_lora_stack",
         "kind": "static_from",
-        "line": 649,
+        "line": 647,
         "name": "_apply_aio_lora_stack",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -33349,7 +33388,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -33364,7 +33403,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_model_patches",
         "kind": "static_from",
-        "line": 649,
+        "line": 647,
         "name": "_apply_aio_model_patches",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -33383,7 +33422,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -33398,7 +33437,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_safe_pag_patch",
         "kind": "static_from",
-        "line": 649,
+        "line": 647,
         "name": "_apply_aio_safe_pag_patch",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -33417,7 +33456,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -33432,7 +33471,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_correction_patch_for_comfy_sampler",
         "kind": "static_from",
-        "line": 649,
+        "line": 647,
         "name": "_apply_aio_spectrum_correction_patch_for_comfy_sampler",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -33451,7 +33490,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -33466,7 +33505,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_forecast_patch_for_comfy_sampler",
         "kind": "static_from",
-        "line": 649,
+        "line": 647,
         "name": "_apply_aio_spectrum_forecast_patch_for_comfy_sampler",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -33485,7 +33524,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -33500,7 +33539,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_model_patches_for_comfy_sampler",
         "kind": "static_from",
-        "line": 649,
+        "line": 647,
         "name": "_apply_aio_spectrum_model_patches_for_comfy_sampler",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -33519,7 +33558,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -33534,7 +33573,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_cleanup_aio_ephemeral_model",
         "kind": "static_from",
-        "line": 649,
+        "line": 647,
         "name": "_cleanup_aio_ephemeral_model",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -33553,7 +33592,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -33568,7 +33607,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_normalize_aio_lora_stack",
         "kind": "static_from",
-        "line": 649,
+        "line": 647,
         "name": "_normalize_aio_lora_stack",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -33587,7 +33626,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -33602,7 +33641,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_patch_model_sampling_aura_flow",
         "kind": "static_from",
-        "line": 649,
+        "line": 647,
         "name": "_patch_model_sampling_aura_flow",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -33621,7 +33660,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -33636,7 +33675,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_aio_highres_effective_backend",
         "kind": "static_from",
-        "line": 663,
+        "line": 661,
         "name": "_aio_highres_effective_backend",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -33655,7 +33694,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -33670,7 +33709,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_aio_stage_sampler_settings",
         "kind": "static_from",
-        "line": 663,
+        "line": 661,
         "name": "_aio_stage_sampler_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -33689,7 +33728,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -33704,7 +33743,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_decode_latent_with_comfy",
         "kind": "static_from",
-        "line": 663,
+        "line": 661,
         "name": "_decode_latent_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -33723,7 +33762,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -33738,7 +33777,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_encode_image_with_comfy_vae",
         "kind": "static_from",
-        "line": 663,
+        "line": 661,
         "name": "_encode_image_with_comfy_vae",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -33757,7 +33796,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -33772,7 +33811,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_generate_empty_latent_with_comfy",
         "kind": "static_from",
-        "line": 663,
+        "line": 661,
         "name": "_generate_empty_latent_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -33791,7 +33830,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -33806,7 +33845,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_new_aio_random_seed",
         "kind": "static_from",
-        "line": 663,
+        "line": 661,
         "name": "_new_aio_random_seed",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -33825,7 +33864,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -33840,7 +33879,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_resolve_aio_runtime_seed",
         "kind": "static_from",
-        "line": 663,
+        "line": 661,
         "name": "_resolve_aio_runtime_seed",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -33859,7 +33898,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -33874,7 +33913,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_aio_backend",
         "kind": "static_from",
-        "line": 663,
+        "line": 661,
         "name": "_sample_latent_with_aio_backend",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -33893,7 +33932,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -33908,7 +33947,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_comfy",
         "kind": "static_from",
-        "line": 663,
+        "line": 661,
         "name": "_sample_latent_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -33927,7 +33966,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -33942,7 +33981,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_spectrum_mod_guidance_advanced",
         "kind": "static_from",
-        "line": 663,
+        "line": 661,
         "name": "_sample_latent_with_spectrum_mod_guidance_advanced",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -33961,7 +34000,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -33976,7 +34015,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_spectrum_spd",
         "kind": "static_from",
-        "line": 663,
+        "line": 661,
         "name": "_sample_latent_with_spectrum_spd",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -33995,7 +34034,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -34010,7 +34049,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_CACHE_FORMAT",
         "kind": "static_from",
-        "line": 676,
+        "line": 674,
         "name": "AIO_PREVIEW_CACHE_FORMAT",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -34029,7 +34068,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -34044,7 +34083,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_CACHE_QUALITY",
         "kind": "static_from",
-        "line": 676,
+        "line": 674,
         "name": "AIO_PREVIEW_CACHE_QUALITY",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -34063,7 +34102,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -34078,7 +34117,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_EVENT",
         "kind": "static_from",
-        "line": 676,
+        "line": 674,
         "name": "AIO_PREVIEW_EVENT",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -34097,7 +34136,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -34112,7 +34151,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_STAGE_LABELS",
         "kind": "static_from",
-        "line": 676,
+        "line": 674,
         "name": "AIO_PREVIEW_STAGE_LABELS",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -34131,7 +34170,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -34146,7 +34185,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_aio_preview_base_directory",
         "kind": "static_from",
-        "line": 676,
+        "line": 674,
         "name": "_aio_preview_base_directory",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -34165,7 +34204,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -34180,7 +34219,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_aio_preview_file_size_bytes",
         "kind": "static_from",
-        "line": 676,
+        "line": 674,
         "name": "_aio_preview_file_size_bytes",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -34199,7 +34238,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -34214,7 +34253,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_save_aio_temp_preview_image",
         "kind": "static_from",
-        "line": 676,
+        "line": 674,
         "name": "_save_aio_temp_preview_image",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -34233,7 +34272,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -34248,7 +34287,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_send_aio_preview_event",
         "kind": "static_from",
-        "line": 676,
+        "line": 674,
         "name": "_send_aio_preview_event",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -34267,7 +34306,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -34282,7 +34321,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_tag_aio_preview_images",
         "kind": "static_from",
-        "line": 676,
+        "line": 674,
         "name": "_tag_aio_preview_images",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -34301,7 +34340,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -34316,7 +34355,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_image_saver_additional_hashes",
         "kind": "static_from",
-        "line": 687,
+        "line": 685,
         "name": "_aio_image_saver_additional_hashes",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -34335,7 +34374,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -34350,7 +34389,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_image_saver_civitai_hash_fetcher_entries",
         "kind": "static_from",
-        "line": 687,
+        "line": 685,
         "name": "_aio_image_saver_civitai_hash_fetcher_entries",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -34369,7 +34408,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -34384,7 +34423,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_lora_metadata_name",
         "kind": "static_from",
-        "line": 687,
+        "line": 685,
         "name": "_aio_lora_metadata_name",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -34403,7 +34442,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -34418,7 +34457,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_prompt_with_lora_metadata",
         "kind": "static_from",
-        "line": 687,
+        "line": 685,
         "name": "_aio_prompt_with_lora_metadata",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -34437,7 +34476,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -34452,7 +34491,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_save_filename_prefix",
         "kind": "static_from",
-        "line": 687,
+        "line": 685,
         "name": "_aio_save_filename_prefix",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -34471,7 +34510,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -34486,7 +34525,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_save_image_with_comfy",
         "kind": "static_from",
-        "line": 687,
+        "line": 685,
         "name": "_save_image_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -34505,7 +34544,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -34520,7 +34559,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_save_image_with_image_saver",
         "kind": "static_from",
-        "line": 687,
+        "line": 685,
         "name": "_save_image_with_image_saver",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -34539,7 +34578,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -34554,7 +34593,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output_settings:_normalize_aio_civitai_hash_fetchers",
         "kind": "static_from",
-        "line": 696,
+        "line": 694,
         "name": "_normalize_aio_civitai_hash_fetchers",
         "optional": false,
         "requested": "easyuse_anima.aio.output_settings",
@@ -34573,7 +34612,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -34588,7 +34627,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output_settings:_normalize_aio_hash_bundles",
         "kind": "static_from",
-        "line": 696,
+        "line": 694,
         "name": "_normalize_aio_hash_bundles",
         "optional": false,
         "requested": "easyuse_anima.aio.output_settings",
@@ -34607,7 +34646,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -34622,7 +34661,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_clip_loader_types",
         "kind": "static_from",
-        "line": 700,
+        "line": 698,
         "name": "_comfy_clip_loader_types",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -34641,7 +34680,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -34656,7 +34695,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_diffusion_model_names",
         "kind": "static_from",
-        "line": 700,
+        "line": 698,
         "name": "_comfy_diffusion_model_names",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -34675,7 +34714,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -34690,7 +34729,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_text_encoder_names",
         "kind": "static_from",
-        "line": 700,
+        "line": 698,
         "name": "_comfy_text_encoder_names",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -34709,7 +34748,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -34724,7 +34763,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_vae_names",
         "kind": "static_from",
-        "line": 700,
+        "line": 698,
         "name": "_comfy_vae_names",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -34743,7 +34782,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -34758,7 +34797,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_aio_resources_from_input_context",
         "kind": "static_from",
-        "line": 700,
+        "line": 698,
         "name": "_load_aio_resources_from_input_context",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -34777,7 +34816,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -34792,7 +34831,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_aio_sam3_context",
         "kind": "static_from",
-        "line": 700,
+        "line": 698,
         "name": "_load_aio_sam3_context",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -34811,7 +34850,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -34826,7 +34865,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_checkpoint_with_comfy",
         "kind": "static_from",
-        "line": 700,
+        "line": 698,
         "name": "_load_checkpoint_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -34845,7 +34884,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -34860,7 +34899,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_clip_with_comfy",
         "kind": "static_from",
-        "line": 700,
+        "line": 698,
         "name": "_load_clip_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -34879,7 +34918,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -34894,7 +34933,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_diffusion_model_with_comfy",
         "kind": "static_from",
-        "line": 700,
+        "line": 698,
         "name": "_load_diffusion_model_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -34913,7 +34952,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -34928,7 +34967,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_upscale_model_with_comfy",
         "kind": "static_from",
-        "line": 700,
+        "line": 698,
         "name": "_load_upscale_model_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -34947,7 +34986,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -34962,7 +35001,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_vae_with_comfy",
         "kind": "static_from",
-        "line": 700,
+        "line": 698,
         "name": "_load_vae_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -34981,7 +35020,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -34996,7 +35035,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_normalize_aio_input_settings",
         "kind": "static_from",
-        "line": 700,
+        "line": 698,
         "name": "_normalize_aio_input_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -35015,7 +35054,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -35030,7 +35069,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_checkpoint_default",
         "kind": "static_from",
-        "line": 700,
+        "line": 698,
         "name": "_preferred_checkpoint_default",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -35049,7 +35088,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -35064,7 +35103,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_clip_type_default",
         "kind": "static_from",
-        "line": 700,
+        "line": 698,
         "name": "_preferred_clip_type_default",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -35083,7 +35122,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -35098,7 +35137,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_name_default",
         "kind": "static_from",
-        "line": 700,
+        "line": 698,
         "name": "_preferred_name_default",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -35117,7 +35156,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -35132,7 +35171,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_json_clone",
         "kind": "static_from",
-        "line": 717,
+        "line": 715,
         "name": "_json_clone",
         "optional": false,
         "requested": "easyuse_anima.common.serialization",
@@ -35151,7 +35190,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -35166,7 +35205,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_json_object",
         "kind": "static_from",
-        "line": 717,
+        "line": 715,
         "name": "_json_object",
         "optional": false,
         "requested": "easyuse_anima.common.serialization",
@@ -35185,7 +35224,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -35200,7 +35239,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_stable_change_key",
         "kind": "static_from",
-        "line": 717,
+        "line": 715,
         "name": "_stable_change_key",
         "optional": false,
         "requested": "easyuse_anima.common.serialization",
@@ -35219,7 +35258,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -35234,7 +35273,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_bool",
         "kind": "static_from",
-        "line": 722,
+        "line": 720,
         "name": "_as_bool",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -35253,7 +35292,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -35268,7 +35307,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_float",
         "kind": "static_from",
-        "line": 722,
+        "line": 720,
         "name": "_as_float",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -35287,7 +35326,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -35302,7 +35341,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_int",
         "kind": "static_from",
-        "line": 722,
+        "line": 720,
         "name": "_as_int",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -35321,7 +35360,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -35336,7 +35375,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_choice",
         "kind": "static_from",
-        "line": 722,
+        "line": 720,
         "name": "_choice",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -35355,7 +35394,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -35370,7 +35409,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_single_value",
         "kind": "static_from",
-        "line": 722,
+        "line": 720,
         "name": "_single_value",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -35389,7 +35428,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -35404,7 +35443,7 @@
         "conditional": true,
         "imported": "easyuse_anima.seed.compatibility:WILDCARD_QUEUE_MAX_SAFE_SEED",
         "kind": "static_from",
-        "line": 729,
+        "line": 727,
         "name": "WILDCARD_QUEUE_MAX_SAFE_SEED",
         "optional": false,
         "requested": "easyuse_anima.seed.compatibility",
@@ -35423,7 +35462,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -35438,7 +35477,7 @@
         "conditional": true,
         "imported": "easyuse_anima.seed.compatibility:WILDCARD_RESERVED_NEXT_SEED_INPUT",
         "kind": "static_from",
-        "line": 729,
+        "line": 727,
         "name": "WILDCARD_RESERVED_NEXT_SEED_INPUT",
         "optional": false,
         "requested": "easyuse_anima.seed.compatibility",
@@ -35457,7 +35496,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -35472,7 +35511,7 @@
         "conditional": true,
         "imported": "easyuse_anima.seed.compatibility:_consume_reserved_wildcard_next_seed",
         "kind": "static_from",
-        "line": 729,
+        "line": 727,
         "name": "_consume_reserved_wildcard_next_seed",
         "optional": false,
         "requested": "easyuse_anima.seed.compatibility",
@@ -35491,7 +35530,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -35506,7 +35545,7 @@
         "conditional": true,
         "imported": "easyuse_anima.workflow:_get_workflow_node",
         "kind": "static_from",
-        "line": 734,
+        "line": 732,
         "name": "_get_workflow_node",
         "optional": false,
         "requested": "easyuse_anima.workflow",
@@ -35525,7 +35564,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -35540,7 +35579,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_prompt_translation_change_key",
         "kind": "static_from",
-        "line": 735,
+        "line": 733,
         "name": "_prompt_translation_change_key",
         "optional": false,
         "requested": "easyuse_anima.prompt.correction",
@@ -35559,7 +35598,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -35574,7 +35613,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_split_tag_text",
         "kind": "static_from",
-        "line": 735,
+        "line": 733,
         "name": "_split_tag_text",
         "optional": false,
         "requested": "easyuse_anima.prompt.correction",
@@ -35593,7 +35632,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -35608,7 +35647,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_translate_prompt_text",
         "kind": "static_from",
-        "line": 735,
+        "line": 733,
         "name": "_translate_prompt_text",
         "optional": false,
         "requested": "easyuse_anima.prompt.correction",
@@ -35627,7 +35666,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -35642,7 +35681,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_HASH_COMMENT_RE",
         "kind": "static_from",
-        "line": 740,
+        "line": 738,
         "name": "_HASH_COMMENT_RE",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -35661,7 +35700,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -35676,7 +35715,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_INLINE_SPACE_RE",
         "kind": "static_from",
-        "line": 740,
+        "line": 738,
         "name": "_INLINE_SPACE_RE",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -35695,7 +35734,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -35710,7 +35749,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_WEIGHTED_TOKEN_RE",
         "kind": "static_from",
-        "line": 740,
+        "line": 738,
         "name": "_WEIGHTED_TOKEN_RE",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -35729,7 +35768,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -35744,7 +35783,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_correct_builder_prompt",
         "kind": "static_from",
-        "line": 740,
+        "line": 738,
         "name": "_correct_builder_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -35763,7 +35802,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -35778,7 +35817,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_filter_metadata_prompt",
         "kind": "static_from",
-        "line": 740,
+        "line": 738,
         "name": "_filter_metadata_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -35797,7 +35836,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -35812,7 +35851,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_join_prompt_tokens",
         "kind": "static_from",
-        "line": 740,
+        "line": 738,
         "name": "_join_prompt_tokens",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -35831,7 +35870,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -35846,7 +35885,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_metadata_filter_key",
         "kind": "static_from",
-        "line": 740,
+        "line": 738,
         "name": "_metadata_filter_key",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -35865,7 +35904,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -35880,7 +35919,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_metadata_filter_keys",
         "kind": "static_from",
-        "line": 740,
+        "line": 738,
         "name": "_metadata_filter_keys",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -35899,7 +35938,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -35914,7 +35953,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_prompt_tokens",
         "kind": "static_from",
-        "line": 740,
+        "line": 738,
         "name": "_prompt_tokens",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -35933,7 +35972,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -35948,7 +35987,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:PROMPT_DATA_TYPE",
         "kind": "static_from",
-        "line": 753,
+        "line": 751,
         "name": "PROMPT_DATA_TYPE",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -35967,7 +36006,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -35982,7 +36021,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_advanced_outputs_from_prompt_data",
         "kind": "static_from",
-        "line": 753,
+        "line": 751,
         "name": "_advanced_outputs_from_prompt_data",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -36001,7 +36040,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -36016,7 +36055,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_apply_prompt_data_overrides",
         "kind": "static_from",
-        "line": 753,
+        "line": 751,
         "name": "_apply_prompt_data_overrides",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -36035,7 +36074,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -36050,7 +36089,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_copy_prompt_data_for_update",
         "kind": "static_from",
-        "line": 753,
+        "line": 751,
         "name": "_copy_prompt_data_for_update",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -36069,7 +36108,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -36084,7 +36123,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_normalize_prompt_data",
         "kind": "static_from",
-        "line": 753,
+        "line": 751,
         "name": "_normalize_prompt_data",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -36103,7 +36142,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -36118,7 +36157,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_prompt_data_json_safe",
         "kind": "static_from",
-        "line": 753,
+        "line": 751,
         "name": "_prompt_data_json_safe",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -36137,7 +36176,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -36152,7 +36191,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_prompt_data_parameter_snapshot",
         "kind": "static_from",
-        "line": 753,
+        "line": 751,
         "name": "_prompt_data_parameter_snapshot",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -36171,7 +36210,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -36186,7 +36225,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_artist_field_prompt",
         "kind": "static_from",
-        "line": 771,
+        "line": 769,
         "name": "_advanced_artist_field_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -36205,7 +36244,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -36220,7 +36259,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_default_fields",
         "kind": "static_from",
-        "line": 771,
+        "line": 769,
         "name": "_advanced_default_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -36239,7 +36278,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -36254,7 +36293,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_enabled_naia_panes",
         "kind": "static_from",
-        "line": 771,
+        "line": 769,
         "name": "_advanced_enabled_naia_panes",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -36273,7 +36312,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -36288,7 +36327,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_enabled_pane_fields",
         "kind": "static_from",
-        "line": 771,
+        "line": 769,
         "name": "_advanced_enabled_pane_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -36307,7 +36346,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -36322,7 +36361,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_field_input_values",
         "kind": "static_from",
-        "line": 771,
+        "line": 769,
         "name": "_advanced_field_input_values",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -36341,7 +36380,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -36356,7 +36395,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_field_socket_name",
         "kind": "static_from",
-        "line": 771,
+        "line": 769,
         "name": "_advanced_field_socket_name",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -36375,7 +36414,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -36390,7 +36429,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_fields_json",
         "kind": "static_from",
-        "line": 771,
+        "line": 769,
         "name": "_advanced_fields_json",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -36409,7 +36448,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -36424,7 +36463,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_has_enabled_naia",
         "kind": "static_from",
-        "line": 771,
+        "line": 769,
         "name": "_advanced_has_enabled_naia",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -36443,7 +36482,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -36458,7 +36497,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_prompt_with_artist_override",
         "kind": "static_from",
-        "line": 771,
+        "line": 769,
         "name": "_advanced_prompt_with_artist_override",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -36477,7 +36516,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -36492,7 +36531,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_uses_naia_resolution",
         "kind": "static_from",
-        "line": 771,
+        "line": 769,
         "name": "_advanced_uses_naia_resolution",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -36511,7 +36550,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -36526,7 +36565,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_apply_advanced_field_inputs",
         "kind": "static_from",
-        "line": 771,
+        "line": 769,
         "name": "_apply_advanced_field_inputs",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -36545,7 +36584,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -36560,7 +36599,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_as_advanced_height",
         "kind": "static_from",
-        "line": 771,
+        "line": 769,
         "name": "_as_advanced_height",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -36579,7 +36618,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -36594,7 +36633,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_build_advanced_prompt_data",
         "kind": "static_from",
-        "line": 771,
+        "line": 769,
         "name": "_build_advanced_prompt_data",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -36613,7 +36652,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -36628,7 +36667,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_build_advanced_prompts",
         "kind": "static_from",
-        "line": 771,
+        "line": 769,
         "name": "_build_advanced_prompts",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -36647,7 +36686,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -36662,7 +36701,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_clone_advanced_fields",
         "kind": "static_from",
-        "line": 771,
+        "line": 769,
         "name": "_clone_advanced_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -36681,7 +36720,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -36696,7 +36735,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_correct_advanced_field_sequence",
         "kind": "static_from",
-        "line": 771,
+        "line": 769,
         "name": "_correct_advanced_field_sequence",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -36715,7 +36754,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -36730,7 +36769,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_expand_advanced_wildcard_fields",
         "kind": "static_from",
-        "line": 771,
+        "line": 769,
         "name": "_expand_advanced_wildcard_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -36749,7 +36788,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -36764,7 +36803,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_normalize_advanced_fields",
         "kind": "static_from",
-        "line": 771,
+        "line": 769,
         "name": "_normalize_advanced_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -36783,7 +36822,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -36798,7 +36837,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_normalize_prompt_studio_wildcard_seed_control",
         "kind": "static_from",
-        "line": 771,
+        "line": 769,
         "name": "_normalize_prompt_studio_wildcard_seed_control",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -36817,7 +36856,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -36832,7 +36871,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_set_naia_field_text",
         "kind": "static_from",
-        "line": 771,
+        "line": 769,
         "name": "_set_naia_field_text",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -36851,7 +36890,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -36866,7 +36905,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_translate_prompt_fields",
         "kind": "static_from",
-        "line": 771,
+        "line": 769,
         "name": "_translate_prompt_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -36885,7 +36924,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -36900,7 +36939,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_apply_regional_field_inputs",
         "kind": "static_from",
-        "line": 806,
+        "line": 804,
         "name": "_apply_regional_field_inputs",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -36919,7 +36958,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -36934,7 +36973,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_build_regional_outputs",
         "kind": "static_from",
-        "line": 806,
+        "line": 804,
         "name": "_build_regional_outputs",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -36953,7 +36992,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -36968,7 +37007,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_clone_regional_fields",
         "kind": "static_from",
-        "line": 806,
+        "line": 804,
         "name": "_clone_regional_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -36987,7 +37026,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -37002,7 +37041,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_conditioning_set_values",
         "kind": "static_from",
-        "line": 806,
+        "line": 804,
         "name": "_conditioning_set_values",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -37021,7 +37060,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -37036,7 +37075,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_mask_ids",
         "kind": "static_from",
-        "line": 806,
+        "line": 804,
         "name": "_normalize_mask_ids",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -37055,7 +37094,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -37070,7 +37109,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_regional_config",
         "kind": "static_from",
-        "line": 806,
+        "line": 804,
         "name": "_normalize_regional_config",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -37089,7 +37128,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -37104,7 +37143,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_regional_fields",
         "kind": "static_from",
-        "line": 806,
+        "line": 804,
         "name": "_normalize_regional_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -37123,7 +37162,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -37138,7 +37177,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_parse_json_object",
         "kind": "static_from",
-        "line": 806,
+        "line": 804,
         "name": "_parse_json_object",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -37157,7 +37196,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -37172,7 +37211,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_config_json",
         "kind": "static_from",
-        "line": 806,
+        "line": 804,
         "name": "_regional_config_json",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -37191,7 +37230,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -37206,7 +37245,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_fields_json",
         "kind": "static_from",
-        "line": 806,
+        "line": 804,
         "name": "_regional_fields_json",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -37225,7 +37264,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -37240,7 +37279,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_mask_bounds_area",
         "kind": "static_from",
-        "line": 806,
+        "line": 804,
         "name": "_regional_mask_bounds_area",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -37259,7 +37298,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -37274,7 +37313,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_payload_canvas",
         "kind": "static_from",
-        "line": 806,
+        "line": 804,
         "name": "_regional_payload_canvas",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -37293,7 +37332,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -37308,7 +37347,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_union_mask_for_ids",
         "kind": "static_from",
-        "line": 806,
+        "line": 804,
         "name": "_regional_union_mask_for_ids",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -37327,7 +37366,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -37342,7 +37381,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
         "kind": "static_from",
-        "line": 833,
+        "line": 831,
         "name": "ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -37361,7 +37400,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -37376,7 +37415,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODES",
         "kind": "static_from",
-        "line": 833,
+        "line": 831,
         "name": "ANIMA_MOD_GUIDANCE_MODES",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -37395,7 +37434,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -37410,7 +37449,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 833,
+        "line": 831,
         "name": "ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -37429,7 +37468,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -37444,7 +37483,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_PROFILE_OFF",
         "kind": "static_from",
-        "line": 833,
+        "line": 831,
         "name": "ANIMA_MOD_GUIDANCE_PROFILE_OFF",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -37463,7 +37502,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -37478,7 +37517,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_apply_spectrum_anima_mod_guidance",
         "kind": "static_from",
-        "line": 833,
+        "line": 831,
         "name": "_apply_spectrum_anima_mod_guidance",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -37497,7 +37536,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -37512,7 +37551,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_find_spectrum_anima_mod_guidance_class",
         "kind": "static_from",
-        "line": 833,
+        "line": 831,
         "name": "_find_spectrum_anima_mod_guidance_class",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -37531,7 +37570,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -37546,7 +37585,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_normalize_anima_mod_guidance_profile",
         "kind": "static_from",
-        "line": 833,
+        "line": 831,
         "name": "_normalize_anima_mod_guidance_profile",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -37565,7 +37604,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -37580,7 +37619,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_resolve_anima_mod_guidance_enabled",
         "kind": "static_from",
-        "line": 833,
+        "line": 831,
         "name": "_resolve_anima_mod_guidance_enabled",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -37599,7 +37638,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -37614,7 +37653,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
         "kind": "static_from",
-        "line": 848,
+        "line": 846,
         "name": "ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -37633,7 +37672,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -37648,7 +37687,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
         "kind": "static_from",
-        "line": 848,
+        "line": 846,
         "name": "ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -37667,7 +37706,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -37682,7 +37721,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
         "kind": "static_from",
-        "line": 848,
+        "line": 846,
         "name": "ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -37701,7 +37740,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -37716,7 +37755,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_EXACT_TOP_K",
         "kind": "static_from",
-        "line": 848,
+        "line": 846,
         "name": "ARTIST_MIX_DEFAULT_EXACT_TOP_K",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -37735,7 +37774,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -37750,7 +37789,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
         "kind": "static_from",
-        "line": 848,
+        "line": 846,
         "name": "ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -37769,7 +37808,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -37784,7 +37823,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_START_PERCENT",
         "kind": "static_from",
-        "line": 848,
+        "line": 846,
         "name": "ARTIST_MIX_DEFAULT_START_PERCENT",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -37803,7 +37842,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -37818,7 +37857,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
         "kind": "static_from",
-        "line": 848,
+        "line": 846,
         "name": "ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -37837,7 +37876,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -37852,7 +37891,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STYLE_GAIN",
         "kind": "static_from",
-        "line": 848,
+        "line": 846,
         "name": "ARTIST_MIX_DEFAULT_STYLE_GAIN",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -37871,7 +37910,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -37886,7 +37925,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_INPUT_MODES",
         "kind": "static_from",
-        "line": 848,
+        "line": 846,
         "name": "ARTIST_MIX_INPUT_MODES",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -37905,7 +37944,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -37920,7 +37959,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 848,
+        "line": 846,
         "name": "ARTIST_MIX_MODE_FROM_PROMPT_DATA",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -37939,7 +37978,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -37954,7 +37993,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_mix_inline_prompt",
         "kind": "static_from",
-        "line": 848,
+        "line": 846,
         "name": "_artist_mix_inline_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -37973,7 +38012,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -37988,7 +38027,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_mix_mode_tooltip",
         "kind": "static_from",
-        "line": 848,
+        "line": 846,
         "name": "_artist_mix_mode_tooltip",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -38007,7 +38046,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -38022,7 +38061,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_prompt_with_position",
         "kind": "static_from",
-        "line": 848,
+        "line": 846,
         "name": "_artist_prompt_with_position",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -38041,7 +38080,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -38056,7 +38095,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_tags_from_prompt",
         "kind": "static_from",
-        "line": 848,
+        "line": 846,
         "name": "_artist_tags_from_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -38075,7 +38114,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -38090,7 +38129,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_blend_conditionings",
         "kind": "static_from",
-        "line": 848,
+        "line": 846,
         "name": "_blend_conditionings",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -38109,7 +38148,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -38124,7 +38163,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bounded_artist_mix_float",
         "kind": "static_from",
-        "line": 848,
+        "line": 846,
         "name": "_bounded_artist_mix_float",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -38143,7 +38182,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -38158,7 +38197,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bounded_artist_mix_int",
         "kind": "static_from",
-        "line": 848,
+        "line": 846,
         "name": "_bounded_artist_mix_int",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -38177,7 +38216,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -38192,7 +38231,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_clustered",
         "kind": "static_from",
-        "line": 848,
+        "line": 846,
         "name": "_encode_artist_clustered",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -38211,7 +38250,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -38226,7 +38265,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_delta_rms",
         "kind": "static_from",
-        "line": 848,
+        "line": 846,
         "name": "_encode_artist_delta_rms",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -38245,7 +38284,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -38260,7 +38299,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_prompt_data_positive_conditioning",
         "kind": "static_from",
-        "line": 848,
+        "line": 846,
         "name": "_encode_prompt_data_positive_conditioning",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -38279,7 +38318,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -38294,7 +38333,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_join_artist_mix_source_prompts",
         "kind": "static_from",
-        "line": 848,
+        "line": 846,
         "name": "_join_artist_mix_source_prompts",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -38313,7 +38352,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -38328,7 +38367,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_normalize_artist_mix_mode",
         "kind": "static_from",
-        "line": 848,
+        "line": 846,
         "name": "_normalize_artist_mix_mode",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -38347,7 +38386,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -38362,7 +38401,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_normalize_artist_tag_position",
         "kind": "static_from",
-        "line": 848,
+        "line": 846,
         "name": "_normalize_artist_tag_position",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -38381,7 +38420,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -38396,7 +38435,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_parse_artist_mix_items",
         "kind": "static_from",
-        "line": 848,
+        "line": 846,
         "name": "_parse_artist_mix_items",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -38415,7 +38454,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -38430,7 +38469,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaArtistMixConditioning",
         "kind": "static_from",
-        "line": 927,
+        "line": 925,
         "name": "EasyUseAnimaArtistMixConditioning",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_data_nodes",
@@ -38449,7 +38488,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -38464,7 +38503,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataConditioning",
         "kind": "static_from",
-        "line": 927,
+        "line": 925,
         "name": "EasyUseAnimaPromptDataConditioning",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_data_nodes",
@@ -38483,7 +38522,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -38498,7 +38537,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataUnpack",
         "kind": "static_from",
-        "line": 927,
+        "line": 925,
         "name": "EasyUseAnimaPromptDataUnpack",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_data_nodes",
@@ -38517,7 +38556,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -38532,7 +38571,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_ANY_TYPE",
         "kind": "static_from",
-        "line": 932,
+        "line": 930,
         "name": "_ANY_TYPE",
         "optional": false,
         "requested": "easyuse_anima.nodes.input_types",
@@ -38551,7 +38590,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -38566,7 +38605,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_AnyType",
         "kind": "static_from",
-        "line": 932,
+        "line": 930,
         "name": "_AnyType",
         "optional": false,
         "requested": "easyuse_anima.nodes.input_types",
@@ -38585,7 +38624,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -38600,7 +38639,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_FlexibleOptionalInputType",
         "kind": "static_from",
-        "line": 932,
+        "line": 930,
         "name": "_FlexibleOptionalInputType",
         "optional": false,
         "requested": "easyuse_anima.nodes.input_types",
@@ -38619,7 +38658,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -38634,7 +38673,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvanced",
         "kind": "static_from",
-        "line": 937,
+        "line": 935,
         "name": "EasyUseAnimaPromptStudioAdvanced",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_advanced_nodes",
@@ -38653,7 +38692,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -38668,7 +38707,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvancedV2",
         "kind": "static_from",
-        "line": 937,
+        "line": 935,
         "name": "EasyUseAnimaPromptStudioAdvancedV2",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_advanced_nodes",
@@ -38687,7 +38726,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -38702,7 +38741,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:EASY_USE_ANIMA_INPUT_TYPE",
         "kind": "static_from",
-        "line": 942,
+        "line": 940,
         "name": "EASY_USE_ANIMA_INPUT_TYPE",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -38721,7 +38760,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -38736,7 +38775,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:EasyUseAnimaAIOGenerator",
         "kind": "static_from",
-        "line": 942,
+        "line": 940,
         "name": "EasyUseAnimaAIOGenerator",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -38755,7 +38794,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -38770,7 +38809,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:EasyUseAnimaInput",
         "kind": "static_from",
-        "line": 942,
+        "line": 940,
         "name": "EasyUseAnimaInput",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -38789,7 +38828,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -38804,7 +38843,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_aio_generation_settings_json",
         "kind": "static_from",
-        "line": 942,
+        "line": 940,
         "name": "_aio_generation_settings_json",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -38823,7 +38862,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -38838,7 +38877,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_aio_input_settings_json",
         "kind": "static_from",
-        "line": 942,
+        "line": 940,
         "name": "_aio_input_settings_json",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -38857,7 +38896,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -38872,7 +38911,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_align_down",
         "kind": "static_from",
-        "line": 949,
+        "line": 947,
         "name": "_align_down",
         "optional": false,
         "requested": "easyuse_anima.image.geometry",
@@ -38891,7 +38930,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -38906,7 +38945,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_align_nearest",
         "kind": "static_from",
-        "line": 949,
+        "line": 947,
         "name": "_align_nearest",
         "optional": false,
         "requested": "easyuse_anima.image.geometry",
@@ -38925,7 +38964,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -38940,7 +38979,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_image_tensor_size",
         "kind": "static_from",
-        "line": 949,
+        "line": 947,
         "name": "_image_tensor_size",
         "optional": false,
         "requested": "easyuse_anima.image.geometry",
@@ -38959,7 +38998,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -38974,7 +39013,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_context_value",
         "kind": "static_from",
-        "line": 960,
+        "line": 958,
         "name": "_context_value",
         "optional": false,
         "requested": "easyuse_anima.image.sam3",
@@ -38993,7 +39032,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -39008,7 +39047,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_sam3_context",
         "kind": "static_from",
-        "line": 960,
+        "line": 958,
         "name": "_sam3_context",
         "optional": false,
         "requested": "easyuse_anima.image.sam3",
@@ -39027,7 +39066,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -39042,7 +39081,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_segs_has_items",
         "kind": "static_from",
-        "line": 960,
+        "line": 958,
         "name": "_segs_has_items",
         "optional": false,
         "requested": "easyuse_anima.image.sam3",
@@ -39061,7 +39100,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -39076,7 +39115,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:IMAGE_SCALE_MULTIPLES",
         "kind": "static_from",
-        "line": 972,
+        "line": 970,
         "name": "IMAGE_SCALE_MULTIPLES",
         "optional": false,
         "requested": "easyuse_anima.image.scaling",
@@ -39095,7 +39134,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -39110,7 +39149,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:IMAGE_UPSCALE_METHODS",
         "kind": "static_from",
-        "line": 972,
+        "line": 970,
         "name": "IMAGE_UPSCALE_METHODS",
         "optional": false,
         "requested": "easyuse_anima.image.scaling",
@@ -39129,7 +39168,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -39144,7 +39183,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_sampler_names",
         "kind": "static_from",
-        "line": 980,
+        "line": 978,
         "name": "_comfy_sampler_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -39163,7 +39202,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -39178,7 +39217,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_scheduler_names",
         "kind": "static_from",
-        "line": 980,
+        "line": 978,
         "name": "_comfy_scheduler_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -39197,7 +39236,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -39212,7 +39251,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_impact_scheduler_names",
         "kind": "static_from",
-        "line": 980,
+        "line": 978,
         "name": "_impact_scheduler_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -39231,7 +39270,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -39246,7 +39285,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_call_with_supported_kwargs",
         "kind": "static_from",
-        "line": 986,
+        "line": 984,
         "name": "_call_with_supported_kwargs",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.invocation",
@@ -39265,7 +39304,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -39280,7 +39319,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_common_upscale_image",
         "kind": "static_from",
-        "line": 986,
+        "line": 984,
         "name": "_common_upscale_image",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.invocation",
@@ -39299,7 +39338,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -39314,7 +39353,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_node_output_tuple",
         "kind": "static_from",
-        "line": 986,
+        "line": 984,
         "name": "_node_output_tuple",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.invocation",
@@ -39333,7 +39372,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -39348,7 +39387,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_clip_loader_types",
         "kind": "static_from",
-        "line": 991,
+        "line": 989,
         "name": "_comfy_clip_loader_types",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -39367,7 +39406,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -39382,7 +39421,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_diffusion_model_names",
         "kind": "static_from",
-        "line": 991,
+        "line": 989,
         "name": "_comfy_diffusion_model_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -39401,7 +39440,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -39416,7 +39455,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_text_encoder_names",
         "kind": "static_from",
-        "line": 991,
+        "line": 989,
         "name": "_comfy_text_encoder_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -39435,7 +39474,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -39450,7 +39489,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_vae_names",
         "kind": "static_from",
-        "line": 991,
+        "line": 989,
         "name": "_comfy_vae_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -39469,7 +39508,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -39484,7 +39523,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_folder_path_names",
         "kind": "static_from",
-        "line": 991,
+        "line": 989,
         "name": "_folder_path_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -39503,7 +39542,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -39518,7 +39557,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.image_nodes:EasyUseAnimaDetailerAlignHook",
         "kind": "static_from",
-        "line": 999,
+        "line": 997,
         "name": "EasyUseAnimaDetailerAlignHook",
         "optional": false,
         "requested": "easyuse_anima.nodes.image_nodes",
@@ -39537,7 +39576,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -39552,7 +39591,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.image_nodes:EasyUseAnimaImageScaleByMultiple",
         "kind": "static_from",
-        "line": 999,
+        "line": 997,
         "name": "EasyUseAnimaImageScaleByMultiple",
         "optional": false,
         "requested": "easyuse_anima.nodes.image_nodes",
@@ -39571,7 +39610,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -39586,7 +39625,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Context",
         "kind": "static_from",
-        "line": 1003,
+        "line": 1001,
         "name": "EasyUseAnimaSAM3Context",
         "optional": false,
         "requested": "easyuse_anima.nodes.sam3_nodes",
@@ -39605,7 +39644,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -39620,7 +39659,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Detailer",
         "kind": "static_from",
-        "line": 1003,
+        "line": 1001,
         "name": "EasyUseAnimaSAM3Detailer",
         "optional": false,
         "requested": "easyuse_anima.nodes.sam3_nodes",
@@ -39639,7 +39678,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -39654,7 +39693,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptBuilder",
         "kind": "static_from",
-        "line": 1007,
+        "line": 1005,
         "name": "EasyUseAnimaPromptBuilder",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -39673,7 +39712,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -39688,7 +39727,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrector",
         "kind": "static_from",
-        "line": 1007,
+        "line": 1005,
         "name": "EasyUseAnimaPromptCorrector",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -39707,7 +39746,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -39722,7 +39761,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrectorSimple",
         "kind": "static_from",
-        "line": 1007,
+        "line": 1005,
         "name": "EasyUseAnimaPromptCorrectorSimple",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -39741,7 +39780,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -39756,7 +39795,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptStudio",
         "kind": "static_from",
-        "line": 1007,
+        "line": 1005,
         "name": "EasyUseAnimaPromptStudio",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -39775,7 +39814,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -39790,7 +39829,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:EasyUseAnimaPromptStudioRegional",
         "kind": "static_from",
-        "line": 1013,
+        "line": 1011,
         "name": "EasyUseAnimaPromptStudioRegional",
         "optional": false,
         "requested": "easyuse_anima.nodes.regional_nodes",
@@ -39809,7 +39848,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -39824,7 +39863,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:EasyUseAnimaRegionalConditioning",
         "kind": "static_from",
-        "line": 1013,
+        "line": 1011,
         "name": "EasyUseAnimaRegionalConditioning",
         "optional": false,
         "requested": "easyuse_anima.nodes.regional_nodes",
@@ -39843,7 +39882,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -39858,7 +39897,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:LATENT_ALIGN",
         "kind": "static_from",
-        "line": 1017,
+        "line": 1015,
         "name": "LATENT_ALIGN",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -39877,7 +39916,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -39892,7 +39931,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_parse_random_response",
         "kind": "static_from",
-        "line": 1017,
+        "line": 1015,
         "name": "_parse_random_response",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -39911,7 +39950,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -39926,7 +39965,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_post_random",
         "kind": "static_from",
-        "line": 1017,
+        "line": 1015,
         "name": "_post_random",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -39945,7 +39984,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -39960,7 +39999,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_advanced_resolution_from_selection",
         "kind": "static_from",
-        "line": 1035,
+        "line": 1033,
         "name": "_advanced_resolution_from_selection",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -39979,7 +40018,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -39994,7 +40033,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_normalize_resolution_bucket",
         "kind": "static_from",
-        "line": 1035,
+        "line": 1033,
         "name": "_normalize_resolution_bucket",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -40013,7 +40052,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -40028,7 +40067,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_ratio_label",
         "kind": "static_from",
-        "line": 1035,
+        "line": 1033,
         "name": "_ratio_label",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -40047,7 +40086,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -40062,7 +40101,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolution_label",
         "kind": "static_from",
-        "line": 1035,
+        "line": 1033,
         "name": "_resolution_label",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -40081,7 +40120,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -40096,7 +40135,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolve_naia_resolution",
         "kind": "static_from",
-        "line": 1035,
+        "line": 1033,
         "name": "_resolve_naia_resolution",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -40115,7 +40154,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -40130,42 +40169,8 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.naia_nodes:EasyUseAnimaNAIARandomPrompt",
         "kind": "static_from",
-        "line": 1058,
+        "line": 1056,
         "name": "EasyUseAnimaNAIARandomPrompt",
-        "optional": false,
-        "requested": "easyuse_anima.nodes.naia_nodes",
-        "role": "compatibility_fallback",
-        "scope": "<module>",
-        "source": "nodes.py",
-        "target": "easyuse_anima/nodes/naia_nodes.py"
-      },
-      {
-        "alias": "_bind_naia_node_runtime",
-        "bound_name": "_bind_naia_node_runtime",
-        "branch_context": [
-          {
-            "branch": "except",
-            "catches_import_error": true,
-            "exceptions": [
-              "ImportError"
-            ],
-            "handler_line": 565,
-            "kind": "try",
-            "line": 6
-          }
-        ],
-        "classification": "compatibility_fallback",
-        "column": 4,
-        "compatibility_pair": {
-          "bound_name": "_bind_naia_node_runtime",
-          "target": "easyuse_anima/nodes/naia_nodes.py",
-          "try_line": 6
-        },
-        "conditional": true,
-        "imported": "easyuse_anima.nodes.naia_nodes:_bind_naia_node_runtime",
-        "kind": "static_from",
-        "line": 1058,
-        "name": "_bind_naia_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.naia_nodes",
         "role": "compatibility_fallback",
@@ -40183,7 +40188,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -40198,42 +40203,8 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.wildcard_nodes:EasyUseAnimaWildcard",
         "kind": "static_from",
-        "line": 1062,
+        "line": 1059,
         "name": "EasyUseAnimaWildcard",
-        "optional": false,
-        "requested": "easyuse_anima.nodes.wildcard_nodes",
-        "role": "compatibility_fallback",
-        "scope": "<module>",
-        "source": "nodes.py",
-        "target": "easyuse_anima/nodes/wildcard_nodes.py"
-      },
-      {
-        "alias": "_bind_wildcard_node_runtime",
-        "bound_name": "_bind_wildcard_node_runtime",
-        "branch_context": [
-          {
-            "branch": "except",
-            "catches_import_error": true,
-            "exceptions": [
-              "ImportError"
-            ],
-            "handler_line": 565,
-            "kind": "try",
-            "line": 6
-          }
-        ],
-        "classification": "compatibility_fallback",
-        "column": 4,
-        "compatibility_pair": {
-          "bound_name": "_bind_wildcard_node_runtime",
-          "target": "easyuse_anima/nodes/wildcard_nodes.py",
-          "try_line": 6
-        },
-        "conditional": true,
-        "imported": "easyuse_anima.nodes.wildcard_nodes:_bind_wildcard_node_runtime",
-        "kind": "static_from",
-        "line": 1062,
-        "name": "_bind_wildcard_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.wildcard_nodes",
         "role": "compatibility_fallback",
@@ -40251,7 +40222,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -40266,7 +40237,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_apply_lora_syntax_format",
         "kind": "static_from",
-        "line": 1067,
+        "line": 1063,
         "name": "_apply_lora_syntax_format",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -40285,7 +40256,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -40300,7 +40271,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_dedupe_text_values",
         "kind": "static_from",
-        "line": 1067,
+        "line": 1063,
         "name": "_dedupe_text_values",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -40319,7 +40290,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -40334,7 +40305,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_fallback_lora_path",
         "kind": "static_from",
-        "line": 1067,
+        "line": 1063,
         "name": "_fallback_lora_path",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -40353,7 +40324,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -40368,7 +40339,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_get_lora_info",
         "kind": "static_from",
-        "line": 1067,
+        "line": 1063,
         "name": "_get_lora_info",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -40387,7 +40358,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -40402,7 +40373,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_get_lora_manager_trigger_words",
         "kind": "static_from",
-        "line": 1067,
+        "line": 1063,
         "name": "_get_lora_manager_trigger_words",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -40421,7 +40392,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -40436,7 +40407,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_load_lora_manager_metadata",
         "kind": "static_from",
-        "line": 1067,
+        "line": 1063,
         "name": "_load_lora_manager_metadata",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -40455,7 +40426,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -40470,7 +40441,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_combo_values",
         "kind": "static_from",
-        "line": 1067,
+        "line": 1063,
         "name": "_lora_combo_values",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -40489,7 +40460,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -40504,7 +40475,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_manager_trigger_words_from_metadata",
         "kind": "static_from",
-        "line": 1067,
+        "line": 1063,
         "name": "_lora_manager_trigger_words_from_metadata",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -40523,7 +40494,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -40538,7 +40509,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_model_exists",
         "kind": "static_from",
-        "line": 1067,
+        "line": 1063,
         "name": "_lora_model_exists",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -40557,7 +40528,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -40572,7 +40543,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_stack_name",
         "kind": "static_from",
-        "line": 1067,
+        "line": 1063,
         "name": "_lora_stack_name",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -40591,7 +40562,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -40606,7 +40577,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_metadata_json_paths_for_lora",
         "kind": "static_from",
-        "line": 1067,
+        "line": 1063,
         "name": "_metadata_json_paths_for_lora",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -40625,7 +40596,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -40640,7 +40611,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_missing_lora_display_name",
         "kind": "static_from",
-        "line": 1067,
+        "line": 1063,
         "name": "_missing_lora_display_name",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -40659,7 +40630,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -40674,7 +40645,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_raise_missing_loras",
         "kind": "static_from",
-        "line": 1067,
+        "line": 1063,
         "name": "_raise_missing_loras",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -40693,7 +40664,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -40708,7 +40679,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_trigger_words_from_value",
         "kind": "static_from",
-        "line": 1067,
+        "line": 1063,
         "name": "_trigger_words_from_value",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -40727,7 +40698,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -40742,7 +40713,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_correct_style_prompt",
         "kind": "static_from",
-        "line": 1083,
+        "line": 1079,
         "name": "_correct_style_prompt",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -40761,7 +40732,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -40776,7 +40747,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_format_strength",
         "kind": "static_from",
-        "line": 1083,
+        "line": 1079,
         "name": "_format_strength",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -40795,7 +40766,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -40810,7 +40781,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_get_loras_list",
         "kind": "static_from",
-        "line": 1083,
+        "line": 1079,
         "name": "_get_loras_list",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -40829,7 +40800,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -40844,7 +40815,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_load_profile_data",
         "kind": "static_from",
-        "line": 1083,
+        "line": 1079,
         "name": "_load_profile_data",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -40863,7 +40834,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -40878,7 +40849,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_profile_key",
         "kind": "static_from",
-        "line": 1083,
+        "line": 1079,
         "name": "_profile_key",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -40897,7 +40868,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -40912,7 +40883,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_select_profile_values",
         "kind": "static_from",
-        "line": 1083,
+        "line": 1079,
         "name": "_select_profile_values",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -40931,7 +40902,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -40946,7 +40917,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_wrap_profile_index",
         "kind": "static_from",
-        "line": 1083,
+        "line": 1079,
         "name": "_wrap_profile_index",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -40965,7 +40936,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -40980,7 +40951,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.lora_nodes:EasyUseAnimaLoraPreset",
         "kind": "static_from",
-        "line": 1092,
+        "line": 1088,
         "name": "EasyUseAnimaLoraPreset",
         "optional": false,
         "requested": "easyuse_anima.nodes.lora_nodes",
@@ -40999,7 +40970,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -41014,7 +40985,7 @@
         "conditional": true,
         "imported": "anima_prompt:correct_prompt",
         "kind": "static_from",
-        "line": 1095,
+        "line": 1091,
         "name": "correct_prompt",
         "optional": false,
         "requested": "anima_prompt",
@@ -41033,7 +41004,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -41048,7 +41019,7 @@
         "conditional": true,
         "imported": "anima_prompt:load_knowledge_base",
         "kind": "static_from",
-        "line": 1095,
+        "line": 1091,
         "name": "load_knowledge_base",
         "optional": false,
         "requested": "anima_prompt",
@@ -41067,7 +41038,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -41082,7 +41053,7 @@
         "conditional": true,
         "imported": "anima_prompt.parser:parse_prompt",
         "kind": "static_from",
-        "line": 1096,
+        "line": 1092,
         "name": "parse_prompt",
         "optional": false,
         "requested": "anima_prompt.parser",
@@ -41101,7 +41072,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -41116,7 +41087,7 @@
         "conditional": true,
         "imported": "settings:resolve_metadata_filter_words",
         "kind": "static_from",
-        "line": 1097,
+        "line": 1093,
         "name": "resolve_metadata_filter_words",
         "optional": false,
         "requested": "settings",
@@ -41135,7 +41106,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -41150,7 +41121,7 @@
         "conditional": true,
         "imported": "settings:resolve_naia_settings",
         "kind": "static_from",
-        "line": 1097,
+        "line": 1093,
         "name": "resolve_naia_settings",
         "optional": false,
         "requested": "settings",
@@ -41169,7 +41140,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -41184,7 +41155,7 @@
         "conditional": true,
         "imported": "settings:resolve_prompt_translation_settings",
         "kind": "static_from",
-        "line": 1097,
+        "line": 1093,
         "name": "resolve_prompt_translation_settings",
         "optional": false,
         "requested": "settings",
@@ -41203,7 +41174,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -41218,7 +41189,7 @@
         "conditional": true,
         "imported": "prompt_translation:has_prompt_translation_markers",
         "kind": "static_from",
-        "line": 1102,
+        "line": 1098,
         "name": "has_prompt_translation_markers",
         "optional": false,
         "requested": "prompt_translation",
@@ -41237,7 +41208,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -41252,7 +41223,7 @@
         "conditional": true,
         "imported": "prompt_translation:translate_prompt_markers",
         "kind": "static_from",
-        "line": 1102,
+        "line": 1098,
         "name": "translate_prompt_markers",
         "optional": false,
         "requested": "prompt_translation",
@@ -41271,7 +41242,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -41286,7 +41257,7 @@
         "conditional": true,
         "imported": "wildcard_engine:MAX_SEED",
         "kind": "static_from",
-        "line": 1103,
+        "line": 1099,
         "name": "MAX_SEED",
         "optional": false,
         "requested": "wildcard_engine",
@@ -41305,7 +41276,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -41320,7 +41291,7 @@
         "conditional": true,
         "imported": "wildcard_engine:PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "kind": "static_from",
-        "line": 1103,
+        "line": 1099,
         "name": "PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "optional": false,
         "requested": "wildcard_engine",
@@ -41339,7 +41310,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -41354,7 +41325,7 @@
         "conditional": true,
         "imported": "wildcard_engine:PUBLIC_MAX_SEED",
         "kind": "static_from",
-        "line": 1103,
+        "line": 1099,
         "name": "PUBLIC_MAX_SEED",
         "optional": false,
         "requested": "wildcard_engine",
@@ -41373,7 +41344,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -41388,7 +41359,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_DECREMENT",
         "kind": "static_from",
-        "line": 1103,
+        "line": 1099,
         "name": "SEED_CONTROL_DECREMENT",
         "optional": false,
         "requested": "wildcard_engine",
@@ -41407,7 +41378,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -41422,7 +41393,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_FIXED",
         "kind": "static_from",
-        "line": 1103,
+        "line": 1099,
         "name": "SEED_CONTROL_FIXED",
         "optional": false,
         "requested": "wildcard_engine",
@@ -41441,7 +41412,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -41456,7 +41427,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_INCREMENT",
         "kind": "static_from",
-        "line": 1103,
+        "line": 1099,
         "name": "SEED_CONTROL_INCREMENT",
         "optional": false,
         "requested": "wildcard_engine",
@@ -41475,7 +41446,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -41490,7 +41461,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_MODES",
         "kind": "static_from",
-        "line": 1103,
+        "line": 1099,
         "name": "SEED_CONTROL_MODES",
         "optional": false,
         "requested": "wildcard_engine",
@@ -41509,7 +41480,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -41524,7 +41495,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_RANDOMIZE",
         "kind": "static_from",
-        "line": 1103,
+        "line": 1099,
         "name": "SEED_CONTROL_RANDOMIZE",
         "optional": false,
         "requested": "wildcard_engine",
@@ -41543,7 +41514,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -41558,7 +41529,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_FIXED",
         "kind": "static_from",
-        "line": 1103,
+        "line": 1099,
         "name": "WILDCARD_MODE_FIXED",
         "optional": false,
         "requested": "wildcard_engine",
@@ -41577,7 +41548,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -41592,7 +41563,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_POPULATE",
         "kind": "static_from",
-        "line": 1103,
+        "line": 1099,
         "name": "WILDCARD_MODE_POPULATE",
         "optional": false,
         "requested": "wildcard_engine",
@@ -41611,7 +41582,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -41626,7 +41597,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_SEQUENTIAL",
         "kind": "static_from",
-        "line": 1103,
+        "line": 1099,
         "name": "WILDCARD_MODE_SEQUENTIAL",
         "optional": false,
         "requested": "wildcard_engine",
@@ -41645,7 +41616,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -41660,7 +41631,7 @@
         "conditional": true,
         "imported": "wildcard_engine:expand_wildcard_texts",
         "kind": "static_from",
-        "line": 1103,
+        "line": 1099,
         "name": "expand_wildcard_texts",
         "optional": false,
         "requested": "wildcard_engine",
@@ -41679,7 +41650,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -41694,7 +41665,7 @@
         "conditional": true,
         "imported": "wildcard_engine:expand_wildcards",
         "kind": "static_from",
-        "line": 1103,
+        "line": 1099,
         "name": "expand_wildcards",
         "optional": false,
         "requested": "wildcard_engine",
@@ -41713,7 +41684,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -41728,7 +41699,7 @@
         "conditional": true,
         "imported": "wildcard_engine:has_wildcard_syntax",
         "kind": "static_from",
-        "line": 1103,
+        "line": 1099,
         "name": "has_wildcard_syntax",
         "optional": false,
         "requested": "wildcard_engine",
@@ -41747,7 +41718,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -41762,7 +41733,7 @@
         "conditional": true,
         "imported": "wildcard_engine:next_seed",
         "kind": "static_from",
-        "line": 1103,
+        "line": 1099,
         "name": "next_seed",
         "optional": false,
         "requested": "wildcard_engine",
@@ -41781,7 +41752,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -41796,7 +41767,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_prompt_studio_wildcard_mode",
         "kind": "static_from",
-        "line": 1103,
+        "line": 1099,
         "name": "normalize_prompt_studio_wildcard_mode",
         "optional": false,
         "requested": "wildcard_engine",
@@ -41815,7 +41786,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -41830,7 +41801,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_seed",
         "kind": "static_from",
-        "line": 1103,
+        "line": 1099,
         "name": "normalize_seed",
         "optional": false,
         "requested": "wildcard_engine",
@@ -41849,7 +41820,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -41864,7 +41835,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_wildcard_mode",
         "kind": "static_from",
-        "line": 1103,
+        "line": 1099,
         "name": "normalize_wildcard_mode",
         "optional": false,
         "requested": "wildcard_engine",
@@ -41883,7 +41854,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -41898,7 +41869,7 @@
         "conditional": true,
         "imported": "wildcard_engine:wildcard_sources_signature",
         "kind": "static_from",
-        "line": 1103,
+        "line": 1099,
         "name": "wildcard_sources_signature",
         "optional": false,
         "requested": "wildcard_engine",
@@ -44077,6 +44048,14 @@
         "to": "easyuse_anima/naia/client.py"
       },
       {
+        "from": "easyuse_anima/nodes/naia_nodes.py",
+        "to": "easyuse_anima/workflow.py"
+      },
+      {
+        "from": "easyuse_anima/nodes/naia_nodes.py",
+        "to": "settings.py"
+      },
+      {
         "from": "easyuse_anima/nodes/prompt_advanced_nodes.py",
         "to": "easyuse_anima/common/serialization.py"
       },
@@ -44267,6 +44246,10 @@
       {
         "from": "easyuse_anima/nodes/wildcard_nodes.py",
         "to": "easyuse_anima/nodes/input_types.py"
+      },
+      {
+        "from": "easyuse_anima/nodes/wildcard_nodes.py",
+        "to": "easyuse_anima/workflow.py"
       },
       {
         "from": "easyuse_anima/nodes/wildcard_nodes.py",
@@ -46010,14 +45993,14 @@
       },
       {
         "is_package": false,
-        "loc": 594,
+        "loc": 581,
         "module": "easyuse_anima.nodes.naia_nodes",
-        "normalized_git_blob_sha1": "1a29810f320f3d35e3d2119c5a2c857fe50ced70",
+        "normalized_git_blob_sha1": "967ad4a85fbd33a999c9a1663bdd43bcf450f240",
         "path": "easyuse_anima/nodes/naia_nodes.py",
         "top_level": {
           "class_count": 1,
-          "function_count": 2,
-          "global_count": 4
+          "function_count": 0,
+          "global_count": 2
         }
       },
       {
@@ -46082,14 +46065,14 @@
       },
       {
         "is_package": false,
-        "loc": 272,
+        "loc": 254,
         "module": "easyuse_anima.nodes.wildcard_nodes",
-        "normalized_git_blob_sha1": "f4d70f01713c109700bfebecf0cc44f85cf7240e",
+        "normalized_git_blob_sha1": "ea0ad42c9eeca28b688af0a9b194abdd89e81696",
         "path": "easyuse_anima/nodes/wildcard_nodes.py",
         "top_level": {
           "class_count": 1,
-          "function_count": 2,
-          "global_count": 4
+          "function_count": 0,
+          "global_count": 3
         }
       },
       {
@@ -46298,9 +46281,9 @@
       },
       {
         "is_package": false,
-        "loc": 1142,
+        "loc": 1124,
         "module": "nodes",
-        "normalized_git_blob_sha1": "1384982bc24cb74f8e68c0f11f66de7965036e21",
+        "normalized_git_blob_sha1": "c58b9044c1aa8c768ea8dc739ca346713ff7dbfb",
         "path": "nodes.py",
         "top_level": {
           "class_count": 0,
@@ -47204,6 +47187,29 @@
             "exceptions": [
               "ImportError"
             ],
+            "handler_line": 25,
+            "kind": "try",
+            "line": 23
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "settings:resolve_naia_settings",
+        "kind": "static_from",
+        "line": 26,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "easyuse_anima/nodes/naia_nodes.py",
+        "target": "settings.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
             "handler_line": 74,
             "kind": "try",
             "line": 69
@@ -47342,16 +47348,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 23,
+            "handler_line": 24,
             "kind": "try",
-            "line": 9
+            "line": 10
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "wildcard_engine:MAX_SEED",
         "kind": "static_from",
-        "line": 24,
+        "line": 25,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "easyuse_anima/nodes/wildcard_nodes.py",
@@ -47365,16 +47371,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 23,
+            "handler_line": 24,
             "kind": "try",
-            "line": 9
+            "line": 10
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "wildcard_engine:PUBLIC_MAX_SEED",
         "kind": "static_from",
-        "line": 24,
+        "line": 25,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "easyuse_anima/nodes/wildcard_nodes.py",
@@ -47388,16 +47394,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 23,
+            "handler_line": 24,
             "kind": "try",
-            "line": 9
+            "line": 10
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_FIXED",
         "kind": "static_from",
-        "line": 24,
+        "line": 25,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "easyuse_anima/nodes/wildcard_nodes.py",
@@ -47411,16 +47417,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 23,
+            "handler_line": 24,
             "kind": "try",
-            "line": 9
+            "line": 10
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_LABELS",
         "kind": "static_from",
-        "line": 24,
+        "line": 25,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "easyuse_anima/nodes/wildcard_nodes.py",
@@ -47434,16 +47440,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 23,
+            "handler_line": 24,
             "kind": "try",
-            "line": 9
+            "line": 10
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_POPULATE",
         "kind": "static_from",
-        "line": 24,
+        "line": 25,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "easyuse_anima/nodes/wildcard_nodes.py",
@@ -47457,16 +47463,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 23,
+            "handler_line": 24,
             "kind": "try",
-            "line": 9
+            "line": 10
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_REPRODUCE",
         "kind": "static_from",
-        "line": 24,
+        "line": 25,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "easyuse_anima/nodes/wildcard_nodes.py",
@@ -47480,16 +47486,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 23,
+            "handler_line": 24,
             "kind": "try",
-            "line": 9
+            "line": 10
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_SEQUENTIAL",
         "kind": "static_from",
-        "line": 24,
+        "line": 25,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "easyuse_anima/nodes/wildcard_nodes.py",
@@ -47503,16 +47509,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 23,
+            "handler_line": 24,
             "kind": "try",
-            "line": 9
+            "line": 10
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "wildcard_engine:expand_wildcards",
         "kind": "static_from",
-        "line": 24,
+        "line": 25,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "easyuse_anima/nodes/wildcard_nodes.py",
@@ -47526,16 +47532,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 23,
+            "handler_line": 24,
             "kind": "try",
-            "line": 9
+            "line": 10
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "wildcard_engine:normalize_seed",
         "kind": "static_from",
-        "line": 24,
+        "line": 25,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "easyuse_anima/nodes/wildcard_nodes.py",
@@ -47549,16 +47555,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 23,
+            "handler_line": 24,
             "kind": "try",
-            "line": 9
+            "line": 10
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "wildcard_engine:normalize_wildcard_mode",
         "kind": "static_from",
-        "line": 24,
+        "line": 25,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "easyuse_anima/nodes/wildcard_nodes.py",
@@ -47572,16 +47578,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 23,
+            "handler_line": 24,
             "kind": "try",
-            "line": 9
+            "line": 10
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "wildcard_engine:wildcard_sources_signature",
         "kind": "static_from",
-        "line": 24,
+        "line": 25,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "easyuse_anima/nodes/wildcard_nodes.py",
@@ -47848,7 +47854,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -47857,7 +47863,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:AIO_FIRST_PASS_CACHE_MAX_ENTRIES",
         "kind": "static_from",
-        "line": 566,
+        "line": 564,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47871,7 +47877,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -47880,7 +47886,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_AIO_FIRST_PASS_CACHE",
         "kind": "static_from",
-        "line": 566,
+        "line": 564,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47894,7 +47900,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -47903,7 +47909,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_AIO_FIRST_PASS_CACHE_ORDER",
         "kind": "static_from",
-        "line": 566,
+        "line": 564,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47917,7 +47923,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -47926,7 +47932,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_aio_first_pass_cache_key",
         "kind": "static_from",
-        "line": 566,
+        "line": 564,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47940,7 +47946,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -47949,7 +47955,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_clone_aio_cache_value",
         "kind": "static_from",
-        "line": 566,
+        "line": 564,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47963,7 +47969,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -47972,7 +47978,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_get_aio_first_pass_cache",
         "kind": "static_from",
-        "line": 566,
+        "line": 564,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47986,7 +47992,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -47995,7 +48001,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_put_aio_first_pass_cache",
         "kind": "static_from",
-        "line": 566,
+        "line": 564,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48009,7 +48015,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -48018,7 +48024,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_detailer_stage",
         "kind": "static_from",
-        "line": 576,
+        "line": 574,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48032,7 +48038,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -48041,7 +48047,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_detailer_target",
         "kind": "static_from",
-        "line": 576,
+        "line": 574,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48055,7 +48061,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -48064,7 +48070,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_highres_stage",
         "kind": "static_from",
-        "line": 576,
+        "line": 574,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48078,7 +48084,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -48087,7 +48093,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_legacy_generation",
         "kind": "static_from",
-        "line": 576,
+        "line": 574,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48101,7 +48107,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -48110,7 +48116,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_resshift_upscale_stage",
         "kind": "static_from",
-        "line": 576,
+        "line": 574,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48124,7 +48130,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -48133,7 +48139,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_upscale_stage",
         "kind": "static_from",
-        "line": 576,
+        "line": 574,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48147,7 +48153,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -48156,7 +48162,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_usdu_upscale_stage",
         "kind": "static_from",
-        "line": 576,
+        "line": 574,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48170,7 +48176,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -48179,7 +48185,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_AIO_DETAILER_CUSTOM_RE",
         "kind": "static_from",
-        "line": 585,
+        "line": 583,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48193,7 +48199,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -48202,7 +48208,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_AIO_DETAILER_RESERVED_KEYS",
         "kind": "static_from",
-        "line": 585,
+        "line": 583,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48216,7 +48222,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -48225,7 +48231,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_aio_detailer_has_enabled_targets",
         "kind": "static_from",
-        "line": 585,
+        "line": 583,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48239,7 +48245,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -48248,7 +48254,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_aio_detailer_target_defaults",
         "kind": "static_from",
-        "line": 585,
+        "line": 583,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48262,7 +48268,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -48271,7 +48277,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_aio_detailer_target_order",
         "kind": "static_from",
-        "line": 585,
+        "line": 583,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48285,7 +48291,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -48294,7 +48300,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_is_aio_detailer_target_name",
         "kind": "static_from",
-        "line": 585,
+        "line": 583,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48308,7 +48314,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -48317,7 +48323,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_merge_versioned_settings",
         "kind": "static_from",
-        "line": 585,
+        "line": 583,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48331,7 +48337,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -48340,7 +48346,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_dit_corrections_settings",
         "kind": "static_from",
-        "line": 585,
+        "line": 583,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48354,7 +48360,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -48363,7 +48369,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_generation_settings",
         "kind": "static_from",
-        "line": 585,
+        "line": 583,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48377,7 +48383,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -48386,7 +48392,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_seed",
         "kind": "static_from",
-        "line": 585,
+        "line": 583,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48400,7 +48406,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -48409,7 +48415,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_spectrum_settings",
         "kind": "static_from",
-        "line": 585,
+        "line": 583,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48423,7 +48429,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -48432,7 +48438,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_FINAL_FIT_MODES",
         "kind": "static_from",
-        "line": 598,
+        "line": 596,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48446,7 +48452,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -48455,7 +48461,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_FINAL_UPSCALE_BACKENDS",
         "kind": "static_from",
-        "line": 598,
+        "line": 596,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48469,7 +48475,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -48478,7 +48484,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_GENERATION_DEFAULT_SETTINGS",
         "kind": "static_from",
-        "line": 598,
+        "line": 596,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48492,7 +48498,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -48501,7 +48507,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_GENERATION_SETTINGS_SCHEMA",
         "kind": "static_from",
-        "line": 598,
+        "line": 596,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48515,7 +48521,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -48524,7 +48530,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_GENERATION_SETTINGS_VERSION",
         "kind": "static_from",
-        "line": 598,
+        "line": 596,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48538,7 +48544,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -48547,7 +48553,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_RESHIFT_DTYPES",
         "kind": "static_from",
-        "line": 598,
+        "line": 596,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48561,7 +48567,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -48570,7 +48576,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_RESHIFT_SCALES",
         "kind": "static_from",
-        "line": 598,
+        "line": 596,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48584,7 +48590,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -48593,7 +48599,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_SPECIAL_SEEDS",
         "kind": "static_from",
-        "line": 598,
+        "line": 596,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48607,7 +48613,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -48616,7 +48622,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_SPECIAL_SEED_DECREMENT",
         "kind": "static_from",
-        "line": 598,
+        "line": 596,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48630,7 +48636,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -48639,7 +48645,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_SPECIAL_SEED_INCREMENT",
         "kind": "static_from",
-        "line": 598,
+        "line": 596,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48653,7 +48659,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -48662,7 +48668,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_SPECIAL_SEED_RANDOM",
         "kind": "static_from",
-        "line": 598,
+        "line": 596,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48676,7 +48682,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -48685,7 +48691,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_USDU_MODE_TYPES",
         "kind": "static_from",
-        "line": 598,
+        "line": 596,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48699,7 +48705,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -48708,7 +48714,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_USDU_PROMPT_FULL",
         "kind": "static_from",
-        "line": 598,
+        "line": 596,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48722,7 +48728,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -48731,7 +48737,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_USDU_PROMPT_MODES",
         "kind": "static_from",
-        "line": 598,
+        "line": 596,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48745,7 +48751,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -48754,7 +48760,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_USDU_PROMPT_NO_GENERAL",
         "kind": "static_from",
-        "line": 598,
+        "line": 596,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48768,7 +48774,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -48777,7 +48783,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_USDU_SEAM_FIX_MODES",
         "kind": "static_from",
-        "line": 598,
+        "line": 596,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48791,7 +48797,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -48800,7 +48806,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_settings:round_trip_aio_generation_settings",
         "kind": "static_from",
-        "line": 616,
+        "line": 614,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48814,7 +48820,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -48823,7 +48829,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.input_defaults:AIO_INPUT_DEFAULT_SETTINGS",
         "kind": "static_from",
-        "line": 619,
+        "line": 617,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48837,7 +48843,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -48846,7 +48852,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.input_defaults:ANIMA_CLIP_DEVICES",
         "kind": "static_from",
-        "line": 619,
+        "line": 617,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48860,7 +48866,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -48869,7 +48875,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.input_defaults:ANIMA_CLIP_TYPES",
         "kind": "static_from",
-        "line": 619,
+        "line": 617,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48883,7 +48889,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -48892,7 +48898,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.input_defaults:ANIMA_DEFAULT_CLIP_CANDIDATES",
         "kind": "static_from",
-        "line": 619,
+        "line": 617,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48906,7 +48912,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -48915,7 +48921,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.input_defaults:ANIMA_DEFAULT_DIFFUSION_MODEL_CANDIDATES",
         "kind": "static_from",
-        "line": 619,
+        "line": 617,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48929,7 +48935,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -48938,7 +48944,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.input_defaults:ANIMA_DEFAULT_VAE_CANDIDATES",
         "kind": "static_from",
-        "line": 619,
+        "line": 617,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48952,7 +48958,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -48961,7 +48967,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.input_defaults:ANIMA_UNET_WEIGHT_DTYPES",
         "kind": "static_from",
-        "line": 619,
+        "line": 617,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48975,7 +48981,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -48984,7 +48990,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.input_defaults:EASY_USE_ANIMA_INPUT_SCHEMA",
         "kind": "static_from",
-        "line": 619,
+        "line": 617,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48998,7 +49004,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -49007,7 +49013,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.input_defaults:EASY_USE_ANIMA_INPUT_SETTINGS_VERSION",
         "kind": "static_from",
-        "line": 619,
+        "line": 617,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49021,7 +49027,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -49030,7 +49036,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.input_context:_easy_use_anima_input_signature",
         "kind": "static_from",
-        "line": 630,
+        "line": 628,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49044,7 +49050,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -49053,7 +49059,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.input_context:_require_easy_use_anima_input",
         "kind": "static_from",
-        "line": 630,
+        "line": 628,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49067,7 +49073,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -49076,7 +49082,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.usdu:_aio_usdu_auto_tile_dimension",
         "kind": "static_from",
-        "line": 634,
+        "line": 632,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49090,7 +49096,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -49099,7 +49105,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.usdu:_aio_usdu_tile_plan",
         "kind": "static_from",
-        "line": 634,
+        "line": 632,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49113,7 +49119,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -49122,7 +49128,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_aio_final_fit_size",
         "kind": "static_from",
-        "line": 638,
+        "line": 636,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49136,7 +49142,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -49145,7 +49151,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_apply_aio_final_fit",
         "kind": "static_from",
-        "line": 638,
+        "line": 636,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49159,7 +49165,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -49168,7 +49174,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_resize_image_to_size_if_needed",
         "kind": "static_from",
-        "line": 638,
+        "line": 636,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49182,7 +49188,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -49191,7 +49197,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_run_aio_postprocess_stage",
         "kind": "static_from",
-        "line": 638,
+        "line": 636,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49205,7 +49211,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -49214,7 +49220,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_prompt_data_fields_for_usdu",
         "kind": "static_from",
-        "line": 644,
+        "line": 642,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49228,7 +49234,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -49237,7 +49243,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_usdu_conditioning",
         "kind": "static_from",
-        "line": 644,
+        "line": 642,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49251,7 +49257,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -49260,7 +49266,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_usdu_prompt_without_general",
         "kind": "static_from",
-        "line": 644,
+        "line": 642,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49274,7 +49280,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -49283,7 +49289,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_aio_lora_stack_signature",
         "kind": "static_from",
-        "line": 649,
+        "line": 647,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49297,7 +49303,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -49306,7 +49312,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_anima_dave_patch",
         "kind": "static_from",
-        "line": 649,
+        "line": 647,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49320,7 +49326,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -49329,7 +49335,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_kj_model_patches",
         "kind": "static_from",
-        "line": 649,
+        "line": 647,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49343,7 +49349,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -49352,7 +49358,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_lora_stack",
         "kind": "static_from",
-        "line": 649,
+        "line": 647,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49366,7 +49372,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -49375,7 +49381,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_model_patches",
         "kind": "static_from",
-        "line": 649,
+        "line": 647,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49389,7 +49395,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -49398,7 +49404,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_safe_pag_patch",
         "kind": "static_from",
-        "line": 649,
+        "line": 647,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49412,7 +49418,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -49421,7 +49427,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_correction_patch_for_comfy_sampler",
         "kind": "static_from",
-        "line": 649,
+        "line": 647,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49435,7 +49441,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -49444,7 +49450,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_forecast_patch_for_comfy_sampler",
         "kind": "static_from",
-        "line": 649,
+        "line": 647,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49458,7 +49464,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -49467,7 +49473,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_model_patches_for_comfy_sampler",
         "kind": "static_from",
-        "line": 649,
+        "line": 647,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49481,7 +49487,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -49490,7 +49496,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_cleanup_aio_ephemeral_model",
         "kind": "static_from",
-        "line": 649,
+        "line": 647,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49504,7 +49510,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -49513,7 +49519,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_normalize_aio_lora_stack",
         "kind": "static_from",
-        "line": 649,
+        "line": 647,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49527,7 +49533,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -49536,7 +49542,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_patch_model_sampling_aura_flow",
         "kind": "static_from",
-        "line": 649,
+        "line": 647,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49550,7 +49556,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -49559,7 +49565,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_aio_highres_effective_backend",
         "kind": "static_from",
-        "line": 663,
+        "line": 661,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49573,7 +49579,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -49582,7 +49588,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_aio_stage_sampler_settings",
         "kind": "static_from",
-        "line": 663,
+        "line": 661,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49596,7 +49602,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -49605,7 +49611,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_decode_latent_with_comfy",
         "kind": "static_from",
-        "line": 663,
+        "line": 661,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49619,7 +49625,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -49628,7 +49634,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_encode_image_with_comfy_vae",
         "kind": "static_from",
-        "line": 663,
+        "line": 661,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49642,7 +49648,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -49651,7 +49657,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_generate_empty_latent_with_comfy",
         "kind": "static_from",
-        "line": 663,
+        "line": 661,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49665,7 +49671,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -49674,7 +49680,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_new_aio_random_seed",
         "kind": "static_from",
-        "line": 663,
+        "line": 661,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49688,7 +49694,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -49697,7 +49703,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_resolve_aio_runtime_seed",
         "kind": "static_from",
-        "line": 663,
+        "line": 661,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49711,7 +49717,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -49720,7 +49726,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_aio_backend",
         "kind": "static_from",
-        "line": 663,
+        "line": 661,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49734,7 +49740,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -49743,7 +49749,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_comfy",
         "kind": "static_from",
-        "line": 663,
+        "line": 661,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49757,7 +49763,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -49766,7 +49772,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_spectrum_mod_guidance_advanced",
         "kind": "static_from",
-        "line": 663,
+        "line": 661,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49780,7 +49786,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -49789,7 +49795,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_spectrum_spd",
         "kind": "static_from",
-        "line": 663,
+        "line": 661,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49803,7 +49809,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -49812,7 +49818,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_CACHE_FORMAT",
         "kind": "static_from",
-        "line": 676,
+        "line": 674,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49826,7 +49832,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -49835,7 +49841,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_CACHE_QUALITY",
         "kind": "static_from",
-        "line": 676,
+        "line": 674,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49849,7 +49855,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -49858,7 +49864,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_EVENT",
         "kind": "static_from",
-        "line": 676,
+        "line": 674,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49872,7 +49878,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -49881,7 +49887,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_STAGE_LABELS",
         "kind": "static_from",
-        "line": 676,
+        "line": 674,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49895,7 +49901,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -49904,7 +49910,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_aio_preview_base_directory",
         "kind": "static_from",
-        "line": 676,
+        "line": 674,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49918,7 +49924,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -49927,7 +49933,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_aio_preview_file_size_bytes",
         "kind": "static_from",
-        "line": 676,
+        "line": 674,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49941,7 +49947,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -49950,7 +49956,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_save_aio_temp_preview_image",
         "kind": "static_from",
-        "line": 676,
+        "line": 674,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49964,7 +49970,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -49973,7 +49979,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_send_aio_preview_event",
         "kind": "static_from",
-        "line": 676,
+        "line": 674,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49987,7 +49993,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -49996,7 +50002,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_tag_aio_preview_images",
         "kind": "static_from",
-        "line": 676,
+        "line": 674,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50010,7 +50016,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -50019,7 +50025,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_image_saver_additional_hashes",
         "kind": "static_from",
-        "line": 687,
+        "line": 685,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50033,7 +50039,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -50042,7 +50048,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_image_saver_civitai_hash_fetcher_entries",
         "kind": "static_from",
-        "line": 687,
+        "line": 685,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50056,7 +50062,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -50065,7 +50071,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_lora_metadata_name",
         "kind": "static_from",
-        "line": 687,
+        "line": 685,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50079,7 +50085,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -50088,7 +50094,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_prompt_with_lora_metadata",
         "kind": "static_from",
-        "line": 687,
+        "line": 685,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50102,7 +50108,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -50111,7 +50117,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_save_filename_prefix",
         "kind": "static_from",
-        "line": 687,
+        "line": 685,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50125,7 +50131,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -50134,7 +50140,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_save_image_with_comfy",
         "kind": "static_from",
-        "line": 687,
+        "line": 685,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50148,7 +50154,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -50157,7 +50163,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_save_image_with_image_saver",
         "kind": "static_from",
-        "line": 687,
+        "line": 685,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50171,7 +50177,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -50180,7 +50186,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output_settings:_normalize_aio_civitai_hash_fetchers",
         "kind": "static_from",
-        "line": 696,
+        "line": 694,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50194,7 +50200,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -50203,7 +50209,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output_settings:_normalize_aio_hash_bundles",
         "kind": "static_from",
-        "line": 696,
+        "line": 694,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50217,7 +50223,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -50226,7 +50232,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_clip_loader_types",
         "kind": "static_from",
-        "line": 700,
+        "line": 698,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50240,7 +50246,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -50249,7 +50255,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_diffusion_model_names",
         "kind": "static_from",
-        "line": 700,
+        "line": 698,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50263,7 +50269,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -50272,7 +50278,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_text_encoder_names",
         "kind": "static_from",
-        "line": 700,
+        "line": 698,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50286,7 +50292,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -50295,7 +50301,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_vae_names",
         "kind": "static_from",
-        "line": 700,
+        "line": 698,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50309,7 +50315,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -50318,7 +50324,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_aio_resources_from_input_context",
         "kind": "static_from",
-        "line": 700,
+        "line": 698,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50332,7 +50338,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -50341,7 +50347,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_aio_sam3_context",
         "kind": "static_from",
-        "line": 700,
+        "line": 698,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50355,7 +50361,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -50364,7 +50370,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_checkpoint_with_comfy",
         "kind": "static_from",
-        "line": 700,
+        "line": 698,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50378,7 +50384,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -50387,7 +50393,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_clip_with_comfy",
         "kind": "static_from",
-        "line": 700,
+        "line": 698,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50401,7 +50407,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -50410,7 +50416,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_diffusion_model_with_comfy",
         "kind": "static_from",
-        "line": 700,
+        "line": 698,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50424,7 +50430,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -50433,7 +50439,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_upscale_model_with_comfy",
         "kind": "static_from",
-        "line": 700,
+        "line": 698,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50447,7 +50453,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -50456,7 +50462,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_vae_with_comfy",
         "kind": "static_from",
-        "line": 700,
+        "line": 698,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50470,7 +50476,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -50479,7 +50485,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_normalize_aio_input_settings",
         "kind": "static_from",
-        "line": 700,
+        "line": 698,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50493,7 +50499,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -50502,7 +50508,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_checkpoint_default",
         "kind": "static_from",
-        "line": 700,
+        "line": 698,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50516,7 +50522,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -50525,7 +50531,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_clip_type_default",
         "kind": "static_from",
-        "line": 700,
+        "line": 698,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50539,7 +50545,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -50548,7 +50554,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_name_default",
         "kind": "static_from",
-        "line": 700,
+        "line": 698,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50562,7 +50568,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -50571,7 +50577,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_json_clone",
         "kind": "static_from",
-        "line": 717,
+        "line": 715,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50585,7 +50591,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -50594,7 +50600,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_json_object",
         "kind": "static_from",
-        "line": 717,
+        "line": 715,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50608,7 +50614,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -50617,7 +50623,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_stable_change_key",
         "kind": "static_from",
-        "line": 717,
+        "line": 715,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50631,7 +50637,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -50640,7 +50646,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_bool",
         "kind": "static_from",
-        "line": 722,
+        "line": 720,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50654,7 +50660,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -50663,7 +50669,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_float",
         "kind": "static_from",
-        "line": 722,
+        "line": 720,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50677,7 +50683,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -50686,7 +50692,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_int",
         "kind": "static_from",
-        "line": 722,
+        "line": 720,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50700,7 +50706,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -50709,7 +50715,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_choice",
         "kind": "static_from",
-        "line": 722,
+        "line": 720,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50723,7 +50729,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -50732,7 +50738,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_single_value",
         "kind": "static_from",
-        "line": 722,
+        "line": 720,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50746,7 +50752,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -50755,7 +50761,7 @@
         "conditional": true,
         "imported": "easyuse_anima.seed.compatibility:WILDCARD_QUEUE_MAX_SAFE_SEED",
         "kind": "static_from",
-        "line": 729,
+        "line": 727,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50769,7 +50775,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -50778,7 +50784,7 @@
         "conditional": true,
         "imported": "easyuse_anima.seed.compatibility:WILDCARD_RESERVED_NEXT_SEED_INPUT",
         "kind": "static_from",
-        "line": 729,
+        "line": 727,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50792,7 +50798,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -50801,7 +50807,7 @@
         "conditional": true,
         "imported": "easyuse_anima.seed.compatibility:_consume_reserved_wildcard_next_seed",
         "kind": "static_from",
-        "line": 729,
+        "line": 727,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50815,7 +50821,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -50824,7 +50830,7 @@
         "conditional": true,
         "imported": "easyuse_anima.workflow:_get_workflow_node",
         "kind": "static_from",
-        "line": 734,
+        "line": 732,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50838,7 +50844,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -50847,7 +50853,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_prompt_translation_change_key",
         "kind": "static_from",
-        "line": 735,
+        "line": 733,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50861,7 +50867,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -50870,7 +50876,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_split_tag_text",
         "kind": "static_from",
-        "line": 735,
+        "line": 733,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50884,7 +50890,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -50893,7 +50899,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_translate_prompt_text",
         "kind": "static_from",
-        "line": 735,
+        "line": 733,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50907,7 +50913,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -50916,7 +50922,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_HASH_COMMENT_RE",
         "kind": "static_from",
-        "line": 740,
+        "line": 738,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50930,7 +50936,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -50939,7 +50945,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_INLINE_SPACE_RE",
         "kind": "static_from",
-        "line": 740,
+        "line": 738,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50953,7 +50959,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -50962,7 +50968,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_WEIGHTED_TOKEN_RE",
         "kind": "static_from",
-        "line": 740,
+        "line": 738,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50976,7 +50982,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -50985,7 +50991,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_correct_builder_prompt",
         "kind": "static_from",
-        "line": 740,
+        "line": 738,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50999,7 +51005,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -51008,7 +51014,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_filter_metadata_prompt",
         "kind": "static_from",
-        "line": 740,
+        "line": 738,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51022,7 +51028,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -51031,7 +51037,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_join_prompt_tokens",
         "kind": "static_from",
-        "line": 740,
+        "line": 738,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51045,7 +51051,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -51054,7 +51060,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_metadata_filter_key",
         "kind": "static_from",
-        "line": 740,
+        "line": 738,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51068,7 +51074,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -51077,7 +51083,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_metadata_filter_keys",
         "kind": "static_from",
-        "line": 740,
+        "line": 738,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51091,7 +51097,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -51100,7 +51106,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_prompt_tokens",
         "kind": "static_from",
-        "line": 740,
+        "line": 738,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51114,7 +51120,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -51123,7 +51129,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:PROMPT_DATA_TYPE",
         "kind": "static_from",
-        "line": 753,
+        "line": 751,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51137,7 +51143,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -51146,7 +51152,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_advanced_outputs_from_prompt_data",
         "kind": "static_from",
-        "line": 753,
+        "line": 751,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51160,7 +51166,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -51169,7 +51175,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_apply_prompt_data_overrides",
         "kind": "static_from",
-        "line": 753,
+        "line": 751,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51183,7 +51189,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -51192,7 +51198,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_copy_prompt_data_for_update",
         "kind": "static_from",
-        "line": 753,
+        "line": 751,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51206,7 +51212,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -51215,7 +51221,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_normalize_prompt_data",
         "kind": "static_from",
-        "line": 753,
+        "line": 751,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51229,7 +51235,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -51238,7 +51244,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_prompt_data_json_safe",
         "kind": "static_from",
-        "line": 753,
+        "line": 751,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51252,7 +51258,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -51261,7 +51267,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_prompt_data_parameter_snapshot",
         "kind": "static_from",
-        "line": 753,
+        "line": 751,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51275,7 +51281,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -51284,7 +51290,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_artist_field_prompt",
         "kind": "static_from",
-        "line": 771,
+        "line": 769,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51298,7 +51304,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -51307,7 +51313,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_default_fields",
         "kind": "static_from",
-        "line": 771,
+        "line": 769,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51321,7 +51327,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -51330,7 +51336,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_enabled_naia_panes",
         "kind": "static_from",
-        "line": 771,
+        "line": 769,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51344,7 +51350,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -51353,7 +51359,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_enabled_pane_fields",
         "kind": "static_from",
-        "line": 771,
+        "line": 769,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51367,7 +51373,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -51376,7 +51382,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_field_input_values",
         "kind": "static_from",
-        "line": 771,
+        "line": 769,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51390,7 +51396,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -51399,7 +51405,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_field_socket_name",
         "kind": "static_from",
-        "line": 771,
+        "line": 769,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51413,7 +51419,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -51422,7 +51428,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_fields_json",
         "kind": "static_from",
-        "line": 771,
+        "line": 769,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51436,7 +51442,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -51445,7 +51451,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_has_enabled_naia",
         "kind": "static_from",
-        "line": 771,
+        "line": 769,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51459,7 +51465,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -51468,7 +51474,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_prompt_with_artist_override",
         "kind": "static_from",
-        "line": 771,
+        "line": 769,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51482,7 +51488,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -51491,7 +51497,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_uses_naia_resolution",
         "kind": "static_from",
-        "line": 771,
+        "line": 769,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51505,7 +51511,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -51514,7 +51520,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_apply_advanced_field_inputs",
         "kind": "static_from",
-        "line": 771,
+        "line": 769,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51528,7 +51534,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -51537,7 +51543,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_as_advanced_height",
         "kind": "static_from",
-        "line": 771,
+        "line": 769,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51551,7 +51557,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -51560,7 +51566,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_build_advanced_prompt_data",
         "kind": "static_from",
-        "line": 771,
+        "line": 769,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51574,7 +51580,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -51583,7 +51589,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_build_advanced_prompts",
         "kind": "static_from",
-        "line": 771,
+        "line": 769,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51597,7 +51603,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -51606,7 +51612,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_clone_advanced_fields",
         "kind": "static_from",
-        "line": 771,
+        "line": 769,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51620,7 +51626,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -51629,7 +51635,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_correct_advanced_field_sequence",
         "kind": "static_from",
-        "line": 771,
+        "line": 769,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51643,7 +51649,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -51652,7 +51658,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_expand_advanced_wildcard_fields",
         "kind": "static_from",
-        "line": 771,
+        "line": 769,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51666,7 +51672,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -51675,7 +51681,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_normalize_advanced_fields",
         "kind": "static_from",
-        "line": 771,
+        "line": 769,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51689,7 +51695,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -51698,7 +51704,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_normalize_prompt_studio_wildcard_seed_control",
         "kind": "static_from",
-        "line": 771,
+        "line": 769,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51712,7 +51718,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -51721,7 +51727,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_set_naia_field_text",
         "kind": "static_from",
-        "line": 771,
+        "line": 769,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51735,7 +51741,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -51744,7 +51750,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_translate_prompt_fields",
         "kind": "static_from",
-        "line": 771,
+        "line": 769,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51758,7 +51764,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -51767,7 +51773,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_apply_regional_field_inputs",
         "kind": "static_from",
-        "line": 806,
+        "line": 804,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51781,7 +51787,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -51790,7 +51796,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_build_regional_outputs",
         "kind": "static_from",
-        "line": 806,
+        "line": 804,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51804,7 +51810,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -51813,7 +51819,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_clone_regional_fields",
         "kind": "static_from",
-        "line": 806,
+        "line": 804,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51827,7 +51833,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -51836,7 +51842,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_conditioning_set_values",
         "kind": "static_from",
-        "line": 806,
+        "line": 804,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51850,7 +51856,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -51859,7 +51865,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_mask_ids",
         "kind": "static_from",
-        "line": 806,
+        "line": 804,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51873,7 +51879,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -51882,7 +51888,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_regional_config",
         "kind": "static_from",
-        "line": 806,
+        "line": 804,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51896,7 +51902,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -51905,7 +51911,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_regional_fields",
         "kind": "static_from",
-        "line": 806,
+        "line": 804,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51919,7 +51925,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -51928,7 +51934,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_parse_json_object",
         "kind": "static_from",
-        "line": 806,
+        "line": 804,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51942,7 +51948,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -51951,7 +51957,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_config_json",
         "kind": "static_from",
-        "line": 806,
+        "line": 804,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51965,7 +51971,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -51974,7 +51980,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_fields_json",
         "kind": "static_from",
-        "line": 806,
+        "line": 804,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51988,7 +51994,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -51997,7 +52003,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_mask_bounds_area",
         "kind": "static_from",
-        "line": 806,
+        "line": 804,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52011,7 +52017,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -52020,7 +52026,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_payload_canvas",
         "kind": "static_from",
-        "line": 806,
+        "line": 804,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52034,7 +52040,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -52043,7 +52049,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_union_mask_for_ids",
         "kind": "static_from",
-        "line": 806,
+        "line": 804,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52057,7 +52063,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -52066,7 +52072,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
         "kind": "static_from",
-        "line": 833,
+        "line": 831,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52080,7 +52086,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -52089,7 +52095,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODES",
         "kind": "static_from",
-        "line": 833,
+        "line": 831,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52103,7 +52109,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -52112,7 +52118,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 833,
+        "line": 831,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52126,7 +52132,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -52135,7 +52141,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_PROFILE_OFF",
         "kind": "static_from",
-        "line": 833,
+        "line": 831,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52149,7 +52155,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -52158,7 +52164,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_apply_spectrum_anima_mod_guidance",
         "kind": "static_from",
-        "line": 833,
+        "line": 831,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52172,7 +52178,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -52181,7 +52187,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_find_spectrum_anima_mod_guidance_class",
         "kind": "static_from",
-        "line": 833,
+        "line": 831,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52195,7 +52201,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -52204,7 +52210,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_normalize_anima_mod_guidance_profile",
         "kind": "static_from",
-        "line": 833,
+        "line": 831,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52218,7 +52224,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -52227,7 +52233,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_resolve_anima_mod_guidance_enabled",
         "kind": "static_from",
-        "line": 833,
+        "line": 831,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52241,7 +52247,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -52250,7 +52256,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
         "kind": "static_from",
-        "line": 848,
+        "line": 846,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52264,7 +52270,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -52273,7 +52279,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
         "kind": "static_from",
-        "line": 848,
+        "line": 846,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52287,7 +52293,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -52296,7 +52302,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
         "kind": "static_from",
-        "line": 848,
+        "line": 846,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52310,7 +52316,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -52319,7 +52325,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_EXACT_TOP_K",
         "kind": "static_from",
-        "line": 848,
+        "line": 846,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52333,7 +52339,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -52342,7 +52348,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
         "kind": "static_from",
-        "line": 848,
+        "line": 846,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52356,7 +52362,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -52365,7 +52371,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_START_PERCENT",
         "kind": "static_from",
-        "line": 848,
+        "line": 846,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52379,7 +52385,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -52388,7 +52394,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
         "kind": "static_from",
-        "line": 848,
+        "line": 846,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52402,7 +52408,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -52411,7 +52417,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STYLE_GAIN",
         "kind": "static_from",
-        "line": 848,
+        "line": 846,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52425,7 +52431,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -52434,7 +52440,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_INPUT_MODES",
         "kind": "static_from",
-        "line": 848,
+        "line": 846,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52448,7 +52454,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -52457,7 +52463,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 848,
+        "line": 846,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52471,7 +52477,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -52480,7 +52486,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_mix_inline_prompt",
         "kind": "static_from",
-        "line": 848,
+        "line": 846,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52494,7 +52500,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -52503,7 +52509,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_mix_mode_tooltip",
         "kind": "static_from",
-        "line": 848,
+        "line": 846,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52517,7 +52523,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -52526,7 +52532,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_prompt_with_position",
         "kind": "static_from",
-        "line": 848,
+        "line": 846,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52540,7 +52546,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -52549,7 +52555,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_tags_from_prompt",
         "kind": "static_from",
-        "line": 848,
+        "line": 846,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52563,7 +52569,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -52572,7 +52578,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_blend_conditionings",
         "kind": "static_from",
-        "line": 848,
+        "line": 846,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52586,7 +52592,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -52595,7 +52601,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bounded_artist_mix_float",
         "kind": "static_from",
-        "line": 848,
+        "line": 846,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52609,7 +52615,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -52618,7 +52624,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bounded_artist_mix_int",
         "kind": "static_from",
-        "line": 848,
+        "line": 846,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52632,7 +52638,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -52641,7 +52647,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_clustered",
         "kind": "static_from",
-        "line": 848,
+        "line": 846,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52655,7 +52661,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -52664,7 +52670,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_delta_rms",
         "kind": "static_from",
-        "line": 848,
+        "line": 846,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52678,7 +52684,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -52687,7 +52693,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_prompt_data_positive_conditioning",
         "kind": "static_from",
-        "line": 848,
+        "line": 846,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52701,7 +52707,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -52710,7 +52716,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_join_artist_mix_source_prompts",
         "kind": "static_from",
-        "line": 848,
+        "line": 846,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52724,7 +52730,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -52733,7 +52739,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_normalize_artist_mix_mode",
         "kind": "static_from",
-        "line": 848,
+        "line": 846,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52747,7 +52753,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -52756,7 +52762,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_normalize_artist_tag_position",
         "kind": "static_from",
-        "line": 848,
+        "line": 846,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52770,7 +52776,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -52779,7 +52785,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_parse_artist_mix_items",
         "kind": "static_from",
-        "line": 848,
+        "line": 846,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52793,7 +52799,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -52802,7 +52808,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaArtistMixConditioning",
         "kind": "static_from",
-        "line": 927,
+        "line": 925,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52816,7 +52822,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -52825,7 +52831,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataConditioning",
         "kind": "static_from",
-        "line": 927,
+        "line": 925,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52839,7 +52845,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -52848,7 +52854,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataUnpack",
         "kind": "static_from",
-        "line": 927,
+        "line": 925,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52862,7 +52868,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -52871,7 +52877,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_ANY_TYPE",
         "kind": "static_from",
-        "line": 932,
+        "line": 930,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52885,7 +52891,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -52894,7 +52900,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_AnyType",
         "kind": "static_from",
-        "line": 932,
+        "line": 930,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52908,7 +52914,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -52917,7 +52923,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_FlexibleOptionalInputType",
         "kind": "static_from",
-        "line": 932,
+        "line": 930,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52931,7 +52937,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -52940,7 +52946,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvanced",
         "kind": "static_from",
-        "line": 937,
+        "line": 935,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52954,7 +52960,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -52963,7 +52969,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvancedV2",
         "kind": "static_from",
-        "line": 937,
+        "line": 935,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52977,7 +52983,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -52986,7 +52992,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:EASY_USE_ANIMA_INPUT_TYPE",
         "kind": "static_from",
-        "line": 942,
+        "line": 940,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53000,7 +53006,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -53009,7 +53015,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:EasyUseAnimaAIOGenerator",
         "kind": "static_from",
-        "line": 942,
+        "line": 940,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53023,7 +53029,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -53032,7 +53038,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:EasyUseAnimaInput",
         "kind": "static_from",
-        "line": 942,
+        "line": 940,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53046,7 +53052,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -53055,7 +53061,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_aio_generation_settings_json",
         "kind": "static_from",
-        "line": 942,
+        "line": 940,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53069,7 +53075,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -53078,7 +53084,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_aio_input_settings_json",
         "kind": "static_from",
-        "line": 942,
+        "line": 940,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53092,7 +53098,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -53101,7 +53107,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_align_down",
         "kind": "static_from",
-        "line": 949,
+        "line": 947,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53115,7 +53121,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -53124,7 +53130,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_align_nearest",
         "kind": "static_from",
-        "line": 949,
+        "line": 947,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53138,7 +53144,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -53147,7 +53153,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_image_tensor_size",
         "kind": "static_from",
-        "line": 949,
+        "line": 947,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53161,7 +53167,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -53170,7 +53176,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_context_value",
         "kind": "static_from",
-        "line": 960,
+        "line": 958,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53184,7 +53190,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -53193,7 +53199,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_sam3_context",
         "kind": "static_from",
-        "line": 960,
+        "line": 958,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53207,7 +53213,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -53216,7 +53222,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_segs_has_items",
         "kind": "static_from",
-        "line": 960,
+        "line": 958,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53230,7 +53236,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -53239,7 +53245,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:IMAGE_SCALE_MULTIPLES",
         "kind": "static_from",
-        "line": 972,
+        "line": 970,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53253,7 +53259,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -53262,7 +53268,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:IMAGE_UPSCALE_METHODS",
         "kind": "static_from",
-        "line": 972,
+        "line": 970,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53276,7 +53282,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -53285,7 +53291,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_sampler_names",
         "kind": "static_from",
-        "line": 980,
+        "line": 978,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53299,7 +53305,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -53308,7 +53314,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_scheduler_names",
         "kind": "static_from",
-        "line": 980,
+        "line": 978,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53322,7 +53328,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -53331,7 +53337,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_impact_scheduler_names",
         "kind": "static_from",
-        "line": 980,
+        "line": 978,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53345,7 +53351,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -53354,7 +53360,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_call_with_supported_kwargs",
         "kind": "static_from",
-        "line": 986,
+        "line": 984,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53368,7 +53374,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -53377,7 +53383,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_common_upscale_image",
         "kind": "static_from",
-        "line": 986,
+        "line": 984,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53391,7 +53397,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -53400,7 +53406,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_node_output_tuple",
         "kind": "static_from",
-        "line": 986,
+        "line": 984,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53414,7 +53420,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -53423,7 +53429,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_clip_loader_types",
         "kind": "static_from",
-        "line": 991,
+        "line": 989,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53437,7 +53443,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -53446,7 +53452,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_diffusion_model_names",
         "kind": "static_from",
-        "line": 991,
+        "line": 989,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53460,7 +53466,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -53469,7 +53475,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_text_encoder_names",
         "kind": "static_from",
-        "line": 991,
+        "line": 989,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53483,7 +53489,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -53492,7 +53498,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_vae_names",
         "kind": "static_from",
-        "line": 991,
+        "line": 989,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53506,7 +53512,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -53515,7 +53521,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_folder_path_names",
         "kind": "static_from",
-        "line": 991,
+        "line": 989,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53529,7 +53535,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -53538,7 +53544,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.image_nodes:EasyUseAnimaDetailerAlignHook",
         "kind": "static_from",
-        "line": 999,
+        "line": 997,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53552,7 +53558,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -53561,7 +53567,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.image_nodes:EasyUseAnimaImageScaleByMultiple",
         "kind": "static_from",
-        "line": 999,
+        "line": 997,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53575,7 +53581,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -53584,7 +53590,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Context",
         "kind": "static_from",
-        "line": 1003,
+        "line": 1001,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53598,7 +53604,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -53607,7 +53613,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Detailer",
         "kind": "static_from",
-        "line": 1003,
+        "line": 1001,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53621,7 +53627,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -53630,7 +53636,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptBuilder",
         "kind": "static_from",
-        "line": 1007,
+        "line": 1005,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53644,7 +53650,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -53653,7 +53659,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrector",
         "kind": "static_from",
-        "line": 1007,
+        "line": 1005,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53667,7 +53673,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -53676,7 +53682,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrectorSimple",
         "kind": "static_from",
-        "line": 1007,
+        "line": 1005,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53690,7 +53696,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -53699,7 +53705,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptStudio",
         "kind": "static_from",
-        "line": 1007,
+        "line": 1005,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53713,7 +53719,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -53722,7 +53728,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:EasyUseAnimaPromptStudioRegional",
         "kind": "static_from",
-        "line": 1013,
+        "line": 1011,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53736,7 +53742,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -53745,7 +53751,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:EasyUseAnimaRegionalConditioning",
         "kind": "static_from",
-        "line": 1013,
+        "line": 1011,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53759,7 +53765,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -53768,7 +53774,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:LATENT_ALIGN",
         "kind": "static_from",
-        "line": 1017,
+        "line": 1015,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53782,7 +53788,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -53791,7 +53797,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_parse_random_response",
         "kind": "static_from",
-        "line": 1017,
+        "line": 1015,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53805,7 +53811,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -53814,7 +53820,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_post_random",
         "kind": "static_from",
-        "line": 1017,
+        "line": 1015,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53828,7 +53834,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -53837,7 +53843,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_advanced_resolution_from_selection",
         "kind": "static_from",
-        "line": 1035,
+        "line": 1033,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53851,7 +53857,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -53860,7 +53866,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_normalize_resolution_bucket",
         "kind": "static_from",
-        "line": 1035,
+        "line": 1033,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53874,7 +53880,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -53883,7 +53889,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_ratio_label",
         "kind": "static_from",
-        "line": 1035,
+        "line": 1033,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53897,7 +53903,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -53906,7 +53912,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolution_label",
         "kind": "static_from",
-        "line": 1035,
+        "line": 1033,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53920,7 +53926,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -53929,7 +53935,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolve_naia_resolution",
         "kind": "static_from",
-        "line": 1035,
+        "line": 1033,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53943,7 +53949,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -53952,7 +53958,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.naia_nodes:EasyUseAnimaNAIARandomPrompt",
         "kind": "static_from",
-        "line": 1058,
+        "line": 1056,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53966,30 +53972,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
-            "kind": "try",
-            "line": 6
-          }
-        ],
-        "classification": "compatibility_fallback",
-        "conditional": true,
-        "imported": "easyuse_anima.nodes.naia_nodes:_bind_naia_node_runtime",
-        "kind": "static_from",
-        "line": 1058,
-        "optional": false,
-        "role": "compatibility_fallback",
-        "source": "nodes.py",
-        "target": "easyuse_anima/nodes/naia_nodes.py"
-      },
-      {
-        "branch_context": [
-          {
-            "branch": "except",
-            "catches_import_error": true,
-            "exceptions": [
-              "ImportError"
-            ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -53998,7 +53981,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.wildcard_nodes:EasyUseAnimaWildcard",
         "kind": "static_from",
-        "line": 1062,
+        "line": 1059,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54012,30 +53995,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
-            "kind": "try",
-            "line": 6
-          }
-        ],
-        "classification": "compatibility_fallback",
-        "conditional": true,
-        "imported": "easyuse_anima.nodes.wildcard_nodes:_bind_wildcard_node_runtime",
-        "kind": "static_from",
-        "line": 1062,
-        "optional": false,
-        "role": "compatibility_fallback",
-        "source": "nodes.py",
-        "target": "easyuse_anima/nodes/wildcard_nodes.py"
-      },
-      {
-        "branch_context": [
-          {
-            "branch": "except",
-            "catches_import_error": true,
-            "exceptions": [
-              "ImportError"
-            ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -54044,7 +54004,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_apply_lora_syntax_format",
         "kind": "static_from",
-        "line": 1067,
+        "line": 1063,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54058,7 +54018,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -54067,7 +54027,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_dedupe_text_values",
         "kind": "static_from",
-        "line": 1067,
+        "line": 1063,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54081,7 +54041,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -54090,7 +54050,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_fallback_lora_path",
         "kind": "static_from",
-        "line": 1067,
+        "line": 1063,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54104,7 +54064,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -54113,7 +54073,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_get_lora_info",
         "kind": "static_from",
-        "line": 1067,
+        "line": 1063,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54127,7 +54087,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -54136,7 +54096,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_get_lora_manager_trigger_words",
         "kind": "static_from",
-        "line": 1067,
+        "line": 1063,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54150,7 +54110,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -54159,7 +54119,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_load_lora_manager_metadata",
         "kind": "static_from",
-        "line": 1067,
+        "line": 1063,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54173,7 +54133,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -54182,7 +54142,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_combo_values",
         "kind": "static_from",
-        "line": 1067,
+        "line": 1063,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54196,7 +54156,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -54205,7 +54165,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_manager_trigger_words_from_metadata",
         "kind": "static_from",
-        "line": 1067,
+        "line": 1063,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54219,7 +54179,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -54228,7 +54188,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_model_exists",
         "kind": "static_from",
-        "line": 1067,
+        "line": 1063,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54242,7 +54202,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -54251,7 +54211,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_stack_name",
         "kind": "static_from",
-        "line": 1067,
+        "line": 1063,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54265,7 +54225,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -54274,7 +54234,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_metadata_json_paths_for_lora",
         "kind": "static_from",
-        "line": 1067,
+        "line": 1063,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54288,7 +54248,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -54297,7 +54257,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_missing_lora_display_name",
         "kind": "static_from",
-        "line": 1067,
+        "line": 1063,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54311,7 +54271,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -54320,7 +54280,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_raise_missing_loras",
         "kind": "static_from",
-        "line": 1067,
+        "line": 1063,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54334,7 +54294,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -54343,7 +54303,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_trigger_words_from_value",
         "kind": "static_from",
-        "line": 1067,
+        "line": 1063,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54357,7 +54317,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -54366,7 +54326,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_correct_style_prompt",
         "kind": "static_from",
-        "line": 1083,
+        "line": 1079,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54380,7 +54340,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -54389,7 +54349,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_format_strength",
         "kind": "static_from",
-        "line": 1083,
+        "line": 1079,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54403,7 +54363,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -54412,7 +54372,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_get_loras_list",
         "kind": "static_from",
-        "line": 1083,
+        "line": 1079,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54426,7 +54386,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -54435,7 +54395,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_load_profile_data",
         "kind": "static_from",
-        "line": 1083,
+        "line": 1079,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54449,7 +54409,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -54458,7 +54418,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_profile_key",
         "kind": "static_from",
-        "line": 1083,
+        "line": 1079,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54472,7 +54432,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -54481,7 +54441,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_select_profile_values",
         "kind": "static_from",
-        "line": 1083,
+        "line": 1079,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54495,7 +54455,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -54504,7 +54464,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_wrap_profile_index",
         "kind": "static_from",
-        "line": 1083,
+        "line": 1079,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54518,7 +54478,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -54527,7 +54487,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.lora_nodes:EasyUseAnimaLoraPreset",
         "kind": "static_from",
-        "line": 1092,
+        "line": 1088,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54541,7 +54501,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -54550,7 +54510,7 @@
         "conditional": true,
         "imported": "anima_prompt:correct_prompt",
         "kind": "static_from",
-        "line": 1095,
+        "line": 1091,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54564,7 +54524,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -54573,7 +54533,7 @@
         "conditional": true,
         "imported": "anima_prompt:load_knowledge_base",
         "kind": "static_from",
-        "line": 1095,
+        "line": 1091,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54587,7 +54547,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -54596,7 +54556,7 @@
         "conditional": true,
         "imported": "anima_prompt.parser:parse_prompt",
         "kind": "static_from",
-        "line": 1096,
+        "line": 1092,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54610,7 +54570,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -54619,7 +54579,7 @@
         "conditional": true,
         "imported": "settings:resolve_metadata_filter_words",
         "kind": "static_from",
-        "line": 1097,
+        "line": 1093,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54633,7 +54593,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -54642,7 +54602,7 @@
         "conditional": true,
         "imported": "settings:resolve_naia_settings",
         "kind": "static_from",
-        "line": 1097,
+        "line": 1093,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54656,7 +54616,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -54665,7 +54625,7 @@
         "conditional": true,
         "imported": "settings:resolve_prompt_translation_settings",
         "kind": "static_from",
-        "line": 1097,
+        "line": 1093,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54679,7 +54639,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -54688,7 +54648,7 @@
         "conditional": true,
         "imported": "prompt_translation:has_prompt_translation_markers",
         "kind": "static_from",
-        "line": 1102,
+        "line": 1098,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54702,7 +54662,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -54711,7 +54671,7 @@
         "conditional": true,
         "imported": "prompt_translation:translate_prompt_markers",
         "kind": "static_from",
-        "line": 1102,
+        "line": 1098,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54725,7 +54685,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -54734,7 +54694,7 @@
         "conditional": true,
         "imported": "wildcard_engine:MAX_SEED",
         "kind": "static_from",
-        "line": 1103,
+        "line": 1099,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54748,7 +54708,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -54757,7 +54717,7 @@
         "conditional": true,
         "imported": "wildcard_engine:PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "kind": "static_from",
-        "line": 1103,
+        "line": 1099,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54771,7 +54731,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -54780,7 +54740,7 @@
         "conditional": true,
         "imported": "wildcard_engine:PUBLIC_MAX_SEED",
         "kind": "static_from",
-        "line": 1103,
+        "line": 1099,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54794,7 +54754,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -54803,7 +54763,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_DECREMENT",
         "kind": "static_from",
-        "line": 1103,
+        "line": 1099,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54817,7 +54777,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -54826,7 +54786,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_FIXED",
         "kind": "static_from",
-        "line": 1103,
+        "line": 1099,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54840,7 +54800,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -54849,7 +54809,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_INCREMENT",
         "kind": "static_from",
-        "line": 1103,
+        "line": 1099,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54863,7 +54823,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -54872,7 +54832,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_MODES",
         "kind": "static_from",
-        "line": 1103,
+        "line": 1099,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54886,7 +54846,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -54895,7 +54855,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_RANDOMIZE",
         "kind": "static_from",
-        "line": 1103,
+        "line": 1099,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54909,7 +54869,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -54918,7 +54878,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_FIXED",
         "kind": "static_from",
-        "line": 1103,
+        "line": 1099,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54932,7 +54892,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -54941,7 +54901,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_POPULATE",
         "kind": "static_from",
-        "line": 1103,
+        "line": 1099,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54955,7 +54915,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -54964,7 +54924,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_SEQUENTIAL",
         "kind": "static_from",
-        "line": 1103,
+        "line": 1099,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54978,7 +54938,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -54987,7 +54947,7 @@
         "conditional": true,
         "imported": "wildcard_engine:expand_wildcard_texts",
         "kind": "static_from",
-        "line": 1103,
+        "line": 1099,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -55001,7 +54961,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -55010,7 +54970,7 @@
         "conditional": true,
         "imported": "wildcard_engine:expand_wildcards",
         "kind": "static_from",
-        "line": 1103,
+        "line": 1099,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -55024,7 +54984,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -55033,7 +54993,7 @@
         "conditional": true,
         "imported": "wildcard_engine:has_wildcard_syntax",
         "kind": "static_from",
-        "line": 1103,
+        "line": 1099,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -55047,7 +55007,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -55056,7 +55016,7 @@
         "conditional": true,
         "imported": "wildcard_engine:next_seed",
         "kind": "static_from",
-        "line": 1103,
+        "line": 1099,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -55070,7 +55030,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -55079,7 +55039,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_prompt_studio_wildcard_mode",
         "kind": "static_from",
-        "line": 1103,
+        "line": 1099,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -55093,7 +55053,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -55102,7 +55062,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_seed",
         "kind": "static_from",
-        "line": 1103,
+        "line": 1099,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -55116,7 +55076,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -55125,7 +55085,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_wildcard_mode",
         "kind": "static_from",
-        "line": 1103,
+        "line": 1099,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -55139,7 +55099,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 563,
             "kind": "try",
             "line": 6
           }
@@ -55148,7 +55108,7 @@
         "conditional": true,
         "imported": "wildcard_engine:wildcard_sources_signature",
         "kind": "static_from",
-        "line": 1103,
+        "line": 1099,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -61610,7 +61570,7 @@
         "column": 9,
         "context": "assign:logger",
         "kind": "import_time_call",
-        "line": 23,
+        "line": 28,
         "module": "easyuse_anima/nodes/naia_nodes.py",
         "scope": "<module>"
       },
@@ -61799,25 +61759,7 @@
         "column": 9,
         "context": "assign:logger",
         "kind": "import_time_call",
-        "line": 1125,
-        "module": "nodes.py",
-        "scope": "<module>"
-      },
-      {
-        "callee": "_bind_wildcard_node_runtime",
-        "column": 0,
-        "context": "expression",
-        "kind": "import_time_call",
-        "line": 1130,
-        "module": "nodes.py",
-        "scope": "<module>"
-      },
-      {
-        "callee": "_bind_naia_node_runtime",
-        "column": 0,
-        "context": "expression",
-        "kind": "import_time_call",
-        "line": 1137,
+        "line": 1121,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -62241,7 +62183,7 @@
       },
       {
         "kind": "dict",
-        "line": 46,
+        "line": 47,
         "module": "easyuse_anima/nodes/wildcard_nodes.py",
         "name": "WILDCARD_MODE_DISPLAY_LABELS"
       },

--- a/tests/fixtures/python_compatibility_surface.v1.json
+++ b/tests/fixtures/python_compatibility_surface.v1.json
@@ -81,7 +81,8 @@
       "B-11c30d4",
       "B-11c30d0b",
       "B-11c30d5",
-      "B-11c30d6"
+      "B-11c30d6",
+      "B-11c30e"
     ]
   },
   "enums": {
@@ -116,14 +117,14 @@
   "expected_counts": {
     "root_entrypoints": 3,
     "excluded_preamble_implementation_bindings": 1,
-    "nodes_canonical_bindings": 291,
+    "nodes_canonical_bindings": 289,
     "nodes_legacy_bindings": 27,
     "mapped_public_classes": 18,
     "unmapped_classes": 2,
     "root_residual_functions": 0,
     "root_residual_classes": 0,
     "root_residual_globals": 2,
-    "runtime_binders": 2,
+    "runtime_binders": 0,
     "direct_nodes_import_test_files": 21
   },
   "mapped_public_classes": [
@@ -153,36 +154,28 @@
   "excluded_preamble_implementation_bindings": {
     "logging": "logging:logging"
   },
-  "runtime_binders": [
-    "_bind_wildcard_node_runtime",
-    "_bind_naia_node_runtime"
-  ],
+  "runtime_binders": [],
   "runtime_resolver_consumers": {},
   "runtime_binder_audit": {
     "summary": {
-      "binder_count": 2,
-      "family_count": 1,
+      "binder_count": 0,
+      "family_count": 0,
       "mode_counts": {
         "comfy_provider_then_root": 0,
         "root_globals": 0,
-        "explicit_callbacks": 2
+        "explicit_callbacks": 0
       },
       "unique_resolver_names": 0,
       "unique_root_resolver_names": 0,
       "unique_provider_resolver_names": 0,
-      "unique_direct_root_dependencies": 8,
-      "direct_root_dependency_slots": 9,
+      "unique_direct_root_dependencies": 0,
+      "direct_root_dependency_slots": 0,
       "provider_consumer_slots": 0,
       "provider_consumer_modules": 0,
-      "repository_replacement_names": 5,
-      "repository_replacement_files": 3
+      "repository_replacement_names": 0,
+      "repository_replacement_files": 0
     },
-    "families": {
-      "wildcard_naia": [
-        "_bind_wildcard_node_runtime",
-        "_bind_naia_node_runtime"
-      ]
-    },
+    "families": {},
     "aio_split_gate": {
       "subgroup_order": [
         "B-11c30d1_cache_state",
@@ -253,95 +246,8 @@
     },
     "root_resolver_names": [],
     "provider_resolver_names": [],
-    "repository_root_replacements": {
-      "_get_workflow_node": [
-        "tests/test_node_contracts.py"
-      ],
-      "_post_random": [
-        "tests/test_naia_settings.py"
-      ],
-      "expand_wildcards": [
-        "tests/test_wildcards.py"
-      ],
-      "resolve_naia_settings": [
-        "tests/test_naia_settings.py",
-        "tests/test_node_contracts.py"
-      ],
-      "wildcard_sources_signature": [
-        "tests/test_node_contracts.py"
-      ]
-    },
-    "entries": [
-      {
-        "binder": "_bind_wildcard_node_runtime",
-        "module": "easyuse_anima.nodes.wildcard_nodes",
-        "family": "wildcard_naia",
-        "mode": "explicit_callbacks",
-        "root_observation": "call_time_callback",
-        "root_keywords": [
-          "expand",
-          "get_workflow_node",
-          "normalize_mode",
-          "normalize_seed_value",
-          "sources_signature"
-        ],
-        "bound_globals": [
-          "_get_workflow_node",
-          "expand_wildcards",
-          "normalize_seed",
-          "normalize_wildcard_mode",
-          "wildcard_sources_signature"
-        ],
-        "direct_root_dependencies": [
-          "_get_workflow_node",
-          "expand_wildcards",
-          "normalize_seed",
-          "normalize_wildcard_mode",
-          "wildcard_sources_signature"
-        ],
-        "resolver_names": [],
-        "root_resolver_names": [],
-        "provider_resolver_names": [],
-        "repository_replacement_names": [
-          "_get_workflow_node",
-          "expand_wildcards",
-          "wildcard_sources_signature"
-        ]
-      },
-      {
-        "binder": "_bind_naia_node_runtime",
-        "module": "easyuse_anima.nodes.naia_nodes",
-        "family": "wildcard_naia",
-        "mode": "explicit_callbacks",
-        "root_observation": "call_time_callback",
-        "root_keywords": [
-          "get_workflow_node",
-          "parse_random_response",
-          "post_random",
-          "resolve_settings"
-        ],
-        "bound_globals": [
-          "_get_workflow_node",
-          "_parse_random_response",
-          "_post_random",
-          "resolve_naia_settings"
-        ],
-        "direct_root_dependencies": [
-          "_get_workflow_node",
-          "_parse_random_response",
-          "_post_random",
-          "resolve_naia_settings"
-        ],
-        "resolver_names": [],
-        "root_resolver_names": [],
-        "provider_resolver_names": [],
-        "repository_replacement_names": [
-          "_get_workflow_node",
-          "_post_random",
-          "resolve_naia_settings"
-        ]
-      }
-    ]
+    "repository_root_replacements": {},
+    "entries": []
   },
   "documented_transitional_aliases": {
     "EasyUseAnimaSAM3Context": {
@@ -1985,39 +1891,12 @@
       "lifecycle_state": "unsupported"
     },
     {
-      "id": "nodes_canonical_bindings:easyuse_anima.naia.client:transitional_private_seam",
-      "surface": "nodes_canonical_bindings",
-      "symbols": {
-        "_parse_random_response": "_parse_random_response",
-        "_post_random": "_post_random"
-      },
-      "classification": "transitional_private_seam",
-      "current_target": "nodes.py",
-      "canonical_target": "easyuse_anima.naia.client",
-      "target_state": "canonical",
-      "identity_requirement": "required",
-      "binding_shape": "direct_import",
-      "import_target": "easyuse_anima.naia.client",
-      "owner": "#184/#188",
-      "first_release": null,
-      "known_consumers": [
-        "nodes.py residual runtime"
-      ],
-      "evidence": [
-        "AST:nodes.py direct runtime load"
-      ],
-      "removal_gates": [
-        "canonical production consumer migration",
-        "focused monkeypatch and identity contract review",
-        "separate B-10b or B-11 rollback unit"
-      ],
-      "lifecycle_state": "transitional"
-    },
-    {
       "id": "nodes_canonical_bindings:easyuse_anima.naia.client:unsupported_test_only",
       "surface": "nodes_canonical_bindings",
       "symbols": {
-        "LATENT_ALIGN": "LATENT_ALIGN"
+        "LATENT_ALIGN": "LATENT_ALIGN",
+        "_parse_random_response": "_parse_random_response",
+        "_post_random": "_post_random"
       },
       "classification": "unsupported_test_only",
       "current_target": "nodes.py",
@@ -2260,34 +2139,6 @@
       "lifecycle_state": "supported"
     },
     {
-      "id": "nodes_canonical_bindings:easyuse_anima.nodes.naia_nodes:transitional_private_seam",
-      "surface": "nodes_canonical_bindings",
-      "symbols": {
-        "_bind_naia_node_runtime": "_bind_naia_node_runtime"
-      },
-      "classification": "transitional_private_seam",
-      "current_target": "nodes.py",
-      "canonical_target": "easyuse_anima.nodes.naia_nodes",
-      "target_state": "canonical",
-      "identity_requirement": "required",
-      "binding_shape": "direct_import",
-      "import_target": "easyuse_anima.nodes.naia_nodes",
-      "owner": "#184/#188",
-      "first_release": null,
-      "known_consumers": [
-        "nodes.py residual runtime"
-      ],
-      "evidence": [
-        "AST:nodes.py direct runtime load"
-      ],
-      "removal_gates": [
-        "canonical production consumer migration",
-        "focused monkeypatch and identity contract review",
-        "separate B-10b or B-11 rollback unit"
-      ],
-      "lifecycle_state": "transitional"
-    },
-    {
       "id": "nodes_canonical_bindings:easyuse_anima.nodes.prompt_advanced_nodes:supported_public_reexport",
       "surface": "nodes_canonical_bindings",
       "symbols": {
@@ -2500,34 +2351,6 @@
         "mapping, workflow, and direct identity parity"
       ],
       "lifecycle_state": "supported"
-    },
-    {
-      "id": "nodes_canonical_bindings:easyuse_anima.nodes.wildcard_nodes:transitional_private_seam",
-      "surface": "nodes_canonical_bindings",
-      "symbols": {
-        "_bind_wildcard_node_runtime": "_bind_wildcard_node_runtime"
-      },
-      "classification": "transitional_private_seam",
-      "current_target": "nodes.py",
-      "canonical_target": "easyuse_anima.nodes.wildcard_nodes",
-      "target_state": "canonical",
-      "identity_requirement": "required",
-      "binding_shape": "direct_import",
-      "import_target": "easyuse_anima.nodes.wildcard_nodes",
-      "owner": "#184/#188",
-      "first_release": null,
-      "known_consumers": [
-        "nodes.py residual runtime"
-      ],
-      "evidence": [
-        "AST:nodes.py direct runtime load"
-      ],
-      "removal_gates": [
-        "canonical production consumer migration",
-        "focused monkeypatch and identity contract review",
-        "separate B-10b or B-11 rollback unit"
-      ],
-      "lifecycle_state": "transitional"
     },
     {
       "id": "nodes_canonical_bindings:easyuse_anima.prompt.advanced:unsupported_test_only",
@@ -2842,32 +2665,33 @@
       "lifecycle_state": "unsupported"
     },
     {
-      "id": "nodes_canonical_bindings:easyuse_anima.workflow:transitional_private_seam",
+      "id": "nodes_canonical_bindings:easyuse_anima.workflow:unsupported_test_only",
       "surface": "nodes_canonical_bindings",
       "symbols": {
         "_get_workflow_node": "_get_workflow_node"
       },
-      "classification": "transitional_private_seam",
+      "classification": "unsupported_test_only",
       "current_target": "nodes.py",
       "canonical_target": "easyuse_anima.workflow",
       "target_state": "canonical",
-      "identity_requirement": "required",
+      "identity_requirement": "not_applicable",
       "binding_shape": "direct_import",
       "import_target": "easyuse_anima.workflow",
       "owner": "#184/#188",
       "first_release": null,
       "known_consumers": [
-        "nodes.py residual runtime"
+        "repository tests may import this root name"
       ],
       "evidence": [
-        "AST:nodes.py direct runtime load"
+        "AST:no nodes.py runtime load",
+        "test-only consumption is not public support evidence"
       ],
       "removal_gates": [
-        "canonical production consumer migration",
-        "focused monkeypatch and identity contract review",
-        "separate B-10b or B-11 rollback unit"
+        "test imports migrate to canonical targets",
+        "no production consumer evidence",
+        "separate B-10b removal review"
       ],
-      "lifecycle_state": "transitional"
+      "lifecycle_state": "unsupported"
     },
     {
       "id": "nodes_legacy_bindings:anima_prompt.parser:unsupported_test_only",
@@ -2959,38 +2783,11 @@
       "lifecycle_state": "unsupported"
     },
     {
-      "id": "nodes_legacy_bindings:settings:transitional_private_seam",
-      "surface": "nodes_legacy_bindings",
-      "symbols": {
-        "resolve_naia_settings": "resolve_naia_settings"
-      },
-      "classification": "transitional_private_seam",
-      "current_target": "nodes.py",
-      "canonical_target": null,
-      "target_state": "legacy_owner",
-      "identity_requirement": "required",
-      "binding_shape": "direct_import",
-      "import_target": "settings",
-      "owner": "#163/#186",
-      "first_release": null,
-      "known_consumers": [
-        "nodes.py residual runtime"
-      ],
-      "evidence": [
-        "AST:nodes.py direct runtime load"
-      ],
-      "removal_gates": [
-        "canonical production consumer migration",
-        "focused monkeypatch and identity contract review",
-        "separate B-10b or B-11 rollback unit"
-      ],
-      "lifecycle_state": "transitional"
-    },
-    {
       "id": "nodes_legacy_bindings:settings:unsupported_test_only",
       "surface": "nodes_legacy_bindings",
       "symbols": {
         "resolve_metadata_filter_words": "resolve_metadata_filter_words",
+        "resolve_naia_settings": "resolve_naia_settings",
         "resolve_prompt_translation_settings": "resolve_prompt_translation_settings"
       },
       "classification": "unsupported_test_only",
@@ -3017,37 +2814,6 @@
       "lifecycle_state": "unsupported"
     },
     {
-      "id": "nodes_legacy_bindings:wildcard_engine:transitional_private_seam",
-      "surface": "nodes_legacy_bindings",
-      "symbols": {
-        "expand_wildcards": "expand_wildcards",
-        "normalize_seed": "normalize_seed",
-        "normalize_wildcard_mode": "normalize_wildcard_mode",
-        "wildcard_sources_signature": "wildcard_sources_signature"
-      },
-      "classification": "transitional_private_seam",
-      "current_target": "nodes.py",
-      "canonical_target": null,
-      "target_state": "legacy_owner",
-      "identity_requirement": "required",
-      "binding_shape": "direct_import",
-      "import_target": "wildcard_engine",
-      "owner": "#184/#186",
-      "first_release": null,
-      "known_consumers": [
-        "nodes.py residual runtime"
-      ],
-      "evidence": [
-        "AST:nodes.py direct runtime load"
-      ],
-      "removal_gates": [
-        "canonical production consumer migration",
-        "focused monkeypatch and identity contract review",
-        "separate B-10b or B-11 rollback unit"
-      ],
-      "lifecycle_state": "transitional"
-    },
-    {
       "id": "nodes_legacy_bindings:wildcard_engine:unsupported_test_only",
       "surface": "nodes_legacy_bindings",
       "symbols": {
@@ -3063,9 +2829,13 @@
         "WILDCARD_MODE_POPULATE": "WILDCARD_MODE_POPULATE",
         "WILDCARD_MODE_SEQUENTIAL": "WILDCARD_MODE_SEQUENTIAL",
         "expand_wildcard_texts": "expand_wildcard_texts",
+        "expand_wildcards": "expand_wildcards",
         "has_wildcard_syntax": "has_wildcard_syntax",
         "next_seed": "next_seed",
-        "normalize_prompt_studio_wildcard_mode": "normalize_prompt_studio_wildcard_mode"
+        "normalize_prompt_studio_wildcard_mode": "normalize_prompt_studio_wildcard_mode",
+        "normalize_seed": "normalize_seed",
+        "normalize_wildcard_mode": "normalize_wildcard_mode",
+        "wildcard_sources_signature": "wildcard_sources_signature"
       },
       "classification": "unsupported_test_only",
       "current_target": "nodes.py",

--- a/tests/test_naia_settings.py
+++ b/tests/test_naia_settings.py
@@ -7,6 +7,7 @@ from easyuse_anima.naia.client import (
     _build_naia_random_url,
     _fit_to_1mp,
 )
+from easyuse_anima.nodes import naia_nodes
 from nodes import (
     LATENT_ALIGN,
     EasyUseAnimaNAIARandomPrompt,
@@ -121,8 +122,8 @@ class NaiaSettingsTests(unittest.TestCase):
             }
 
         with (
-            patch("nodes.resolve_naia_settings", lambda: settings()),
-            patch("nodes._post_random", fake_post),
+            patch.object(naia_nodes, "resolve_naia_settings", lambda: settings()),
+            patch.object(naia_nodes, "_post_random", fake_post),
         ):
             result = EasyUseAnimaNAIARandomPrompt().request(
                 use_naia_bridge=True,
@@ -161,7 +162,11 @@ class NaiaSettingsTests(unittest.TestCase):
         )
 
     def test_desktop_naia_settings_skip_peng_override(self):
-        with patch("nodes.resolve_naia_settings", lambda: settings(use_naia_settings=True)):
+        with patch.object(
+            naia_nodes,
+            "resolve_naia_settings",
+            lambda: settings(use_naia_settings=True),
+        ):
             body = EasyUseAnimaNAIARandomPrompt._make_request_body(
                 use_naia_settings=True,
                 pre_prompt="unused",

--- a/tests/test_node_contracts.py
+++ b/tests/test_node_contracts.py
@@ -265,6 +265,16 @@ def _deterministic_comfy_inputs():
                 "wildcard_sources_signature"
             ],
         ),
+        patch.multiple(
+            wildcard_nodes,
+            wildcard_sources_signature=replacements[
+                "wildcard_sources_signature"
+            ],
+        ),
+        patch.multiple(
+            naia_nodes,
+            resolve_naia_settings=replacements["resolve_naia_settings"],
+        ),
         patch_comfy_helper(
             nodes,
             "_comfy_max_resolution",
@@ -2545,22 +2555,13 @@ class WorkflowLookupMoveContractTests(unittest.TestCase):
                 package_workflow._get_workflow_node,
             )
 
-    def test_existing_binders_keep_the_call_time_root_patch_seam(self):
-        patched_result = object()
-        with patch.object(
-            nodes,
-            "_get_workflow_node",
-            return_value=patched_result,
-        ):
-            for adapter in (
-                wildcard_nodes,
-                naia_nodes,
-            ):
-                with self.subTest(adapter=adapter.__name__):
-                    self.assertIs(
-                        adapter._get_workflow_node(None, "3"),
-                        patched_result,
-                    )
+    def test_wildcard_naia_adapters_use_the_canonical_workflow_lookup(self):
+        for adapter in (wildcard_nodes, naia_nodes):
+            with self.subTest(adapter=adapter.__name__):
+                self.assertIs(
+                    adapter._get_workflow_node,
+                    workflow._get_workflow_node,
+                )
 
     def test_retired_prompt_adapters_use_the_canonical_workflow_lookup(self):
         for adapter in (prompt_advanced_nodes, regional_nodes):

--- a/tests/test_nodes_module_analyzer.py
+++ b/tests/test_nodes_module_analyzer.py
@@ -73,12 +73,12 @@ def load_dynamic():
     def test_current_nodes_module_shape_matches_recorded_baseline(self):
         report = analyzer.analyze_path(ROOT / "nodes.py")
 
-        self.assertEqual(report["git_blob_sha1"], "c58b9044c1aa8c768ea8dc739ca346713ff7dbfb")
+        self.assertEqual(report["git_blob_sha1"], "d91507b0c3836e0964979ddaa735f277d0a5934d")
         # B-11c30e removes the Wildcard/NAIA callback binder imports and
         # initialization without changing the public class surface.
         self.assertEqual(report["top_level"]["function_count"], 0)
         self.assertEqual(report["top_level"]["class_count"], 0)
-        self.assertEqual(report["line_count"], 1_124)
+        self.assertEqual(report["line_count"], 1_123)
         class_names = {item["name"] for item in report["top_level"]["classes"]}
         self.assertNotIn("EasyUseAnimaAIOGenerator", class_names)
         self.assertNotIn("EasyUseAnimaInput", class_names)

--- a/tests/test_nodes_module_analyzer.py
+++ b/tests/test_nodes_module_analyzer.py
@@ -73,12 +73,12 @@ def load_dynamic():
     def test_current_nodes_module_shape_matches_recorded_baseline(self):
         report = analyzer.analyze_path(ROOT / "nodes.py")
 
-        self.assertEqual(report["git_blob_sha1"], "1384982bc24cb74f8e68c0f11f66de7965036e21")
-        # B-11c30d6 removes the AiO node-adapter binder import and
+        self.assertEqual(report["git_blob_sha1"], "c58b9044c1aa8c768ea8dc739ca346713ff7dbfb")
+        # B-11c30e removes the Wildcard/NAIA callback binder imports and
         # initialization without changing the public class surface.
         self.assertEqual(report["top_level"]["function_count"], 0)
         self.assertEqual(report["top_level"]["class_count"], 0)
-        self.assertEqual(report["line_count"], 1_142)
+        self.assertEqual(report["line_count"], 1_124)
         class_names = {item["name"] for item in report["top_level"]["classes"]}
         self.assertNotIn("EasyUseAnimaAIOGenerator", class_names)
         self.assertNotIn("EasyUseAnimaInput", class_names)

--- a/tests/test_python_compatibility_surface.py
+++ b/tests/test_python_compatibility_surface.py
@@ -93,12 +93,7 @@ PROMPT_NODE_ADAPTER_RETIRED_RUNTIME_BINDERS = (
     "_bind_regional_node_runtime",
     "_bind_prompt_advanced_node_runtime",
 )
-RUNTIME_BINDER_FAMILIES = {
-    "wildcard_naia": (
-        "_bind_wildcard_node_runtime",
-        "_bind_naia_node_runtime",
-    ),
-}
+RUNTIME_BINDER_FAMILIES: dict[str, tuple[str, ...]] = {}
 AIO_RUNTIME_BINDER_SUBGROUPS = {
     "B-11c30d1_cache_state": (
         "_bind_aio_first_pass_cache_runtime",
@@ -2312,6 +2307,7 @@ def _build_document() -> dict[str, Any]:
                 "B-11c30d0b",
                 "B-11c30d5",
                 "B-11c30d6",
+                "B-11c30e",
             ],
         },
         "enums": {
@@ -2324,14 +2320,14 @@ def _build_document() -> dict[str, Any]:
         "expected_counts": {
             "root_entrypoints": 3,
             "excluded_preamble_implementation_bindings": 1,
-            "nodes_canonical_bindings": 291,
+            "nodes_canonical_bindings": 289,
             "nodes_legacy_bindings": 27,
             "mapped_public_classes": 18,
             "unmapped_classes": 2,
             "root_residual_functions": 0,
             "root_residual_classes": 0,
             "root_residual_globals": 2,
-            "runtime_binders": 2,
+            "runtime_binders": 0,
             "direct_nodes_import_test_files": 21,
         },
         "mapped_public_classes": sorted(mapped_classes),
@@ -2563,7 +2559,7 @@ class PythonCompatibilitySurfaceTests(unittest.TestCase):
             len(self.document["direct_nodes_import_test_files"]),
             counts["direct_nodes_import_test_files"],
         )
-        self.assertEqual(len(set(self.document["runtime_binders"])), 2)
+        self.assertEqual(len(set(self.document["runtime_binders"])), 0)
         self.assertEqual(len(set(self.document["direct_nodes_import_test_files"])), 21)
 
     def test_runtime_binder_audit_covers_provider_and_root_names(self):
@@ -2571,22 +2567,22 @@ class PythonCompatibilitySurfaceTests(unittest.TestCase):
         self.assertEqual(
             audit["summary"],
             {
-                "binder_count": 2,
-                "family_count": 1,
+                "binder_count": 0,
+                "family_count": 0,
                 "mode_counts": {
                     "comfy_provider_then_root": 0,
                     "root_globals": 0,
-                    "explicit_callbacks": 2,
+                    "explicit_callbacks": 0,
                 },
                 "unique_resolver_names": 0,
                 "unique_root_resolver_names": 0,
                 "unique_provider_resolver_names": 0,
-                "unique_direct_root_dependencies": 8,
-                "direct_root_dependency_slots": 9,
+                "unique_direct_root_dependencies": 0,
+                "direct_root_dependency_slots": 0,
                 "provider_consumer_slots": 0,
                 "provider_consumer_modules": 0,
-                "repository_replacement_names": 5,
-                "repository_replacement_files": 3,
+                "repository_replacement_names": 0,
+                "repository_replacement_files": 0,
             },
         )
         self.assertEqual(audit["provider_resolver_names"], [])
@@ -2759,6 +2755,10 @@ class PythonCompatibilitySurfaceTests(unittest.TestCase):
                 "easyuse_anima.aio.legacy_generation"
             ),
             "_bind_aio_node_runtime": "easyuse_anima.nodes.aio_nodes",
+            "_bind_wildcard_node_runtime": (
+                "easyuse_anima.nodes.wildcard_nodes"
+            ),
+            "_bind_naia_node_runtime": "easyuse_anima.nodes.naia_nodes",
         }
         for binder, module in retired_modules.items():
             functions = {
@@ -2843,32 +2843,17 @@ class PythonCompatibilitySurfaceTests(unittest.TestCase):
         self.assertNotIn("_runtime_helper", functions)
         self.assertNotIn("_bind_aio_node_runtime", functions)
 
-    def test_only_explicit_callback_runtime_seams_remain_transitional(self):
-        representative = {
-            "_get_workflow_node",
-            "_post_random",
-            "expand_wildcards",
-            "resolve_naia_settings",
-        }
+    def test_all_runtime_binders_and_resolvers_are_retired(self):
         self.assertEqual(self.document["runtime_resolver_consumers"], {})
-        callback_dependencies = {
-            name
-            for entry in self.document["runtime_binder_audit"]["entries"]
-            for name in entry["direct_root_dependencies"]
-        }
-        classifications = {
-            symbol: group["classification"]
-            for group in self.document["groups"]
-            if group["surface"]
-            in {"nodes_canonical_bindings", "nodes_legacy_bindings"}
-            for symbol in group["symbols"]
-        }
-        for symbol in representative:
-            self.assertIn(symbol, callback_dependencies)
-            self.assertEqual(
-                classifications[symbol],
-                "transitional_private_seam",
-            )
+        self.assertEqual(self.document["runtime_binders"], [])
+        self.assertEqual(
+            self.document["runtime_binder_audit"]["families"],
+            {},
+        )
+        self.assertEqual(
+            self.document["runtime_binder_audit"]["entries"],
+            [],
+        )
 
     def test_documented_unmapped_convenience_alias_stays_transitional(self):
         symbol = "EasyUseAnimaSAM3Context"

--- a/tests/test_wildcards.py
+++ b/tests/test_wildcards.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from unittest.mock import patch
 
 import nodes as nodes_module
+from easyuse_anima.nodes import wildcard_nodes
 from easyuse_anima.prompt import advanced as prompt_advanced
 from easyuse_anima.seed import compatibility as seed_compatibility
 from nodes import (
@@ -979,7 +980,11 @@ class WildcardSeedContractTests(unittest.TestCase):
             missing_keys=(),
         )
 
-        with patch("nodes.expand_wildcards", return_value=expansion) as expand:
+        with patch.object(
+            wildcard_nodes,
+            "expand_wildcards",
+            return_value=expansion,
+        ) as expand:
             result = EasyUseAnimaWildcard().generate(
                 "__style__",
                 "",
@@ -1360,7 +1365,7 @@ class WildcardNodeTests(unittest.TestCase):
 
         with (
             patch(
-                "nodes.expand_wildcards",
+                "easyuse_anima.nodes.wildcard_nodes.expand_wildcards",
                 return_value=WildcardExpansionResult(
                     text="expanded style",
                     changed=True,
@@ -1408,7 +1413,7 @@ class WildcardNodeTests(unittest.TestCase):
         }
 
         with patch(
-            "nodes.expand_wildcards",
+            "easyuse_anima.nodes.wildcard_nodes.expand_wildcards",
             return_value=WildcardExpansionResult(
                 text="expanded style",
                 changed=True,
@@ -1465,7 +1470,11 @@ class WildcardNodeTests(unittest.TestCase):
                     used_keys=("style",),
                     missing_keys=(),
                 )
-                with patch("nodes.expand_wildcards", return_value=expansion) as expand:
+                with patch.object(
+                    wildcard_nodes,
+                    "expand_wildcards",
+                    return_value=expansion,
+                ) as expand:
                     result = EasyUseAnimaWildcard().generate(
                         "source text",
                         "cached text",
@@ -1525,7 +1534,7 @@ class WildcardNodeTests(unittest.TestCase):
 
     def test_native_fixed_uses_populated_text_and_current_seed(self):
         with patch(
-            "nodes.expand_wildcards",
+            "easyuse_anima.nodes.wildcard_nodes.expand_wildcards",
             return_value=WildcardExpansionResult(
                 text="expanded style",
                 changed=False,
@@ -1546,7 +1555,7 @@ class WildcardNodeTests(unittest.TestCase):
 
     def test_native_fixed_keeps_empty_populated_text_empty(self):
         with patch(
-            "nodes.expand_wildcards",
+            "easyuse_anima.nodes.wildcard_nodes.expand_wildcards",
             return_value=WildcardExpansionResult(
                 text="",
                 changed=False,
@@ -1577,7 +1586,11 @@ class WildcardNodeTests(unittest.TestCase):
             def expand_from_test_root(text, *, seed, mode):
                 return expand_wildcards(text, seed=seed, mode=mode, roots=[root])
 
-            with patch("nodes.expand_wildcards", side_effect=expand_from_test_root) as expand:
+            with patch.object(
+                wildcard_nodes,
+                "expand_wildcards",
+                side_effect=expand_from_test_root,
+            ) as expand:
                 first = EasyUseAnimaWildcard().generate(
                     "ignored source",
                     "__samples/flower__",


### PR DESCRIPTION
## 변경 요약

B-11c30e의 Wildcard/NAIA explicit callback binder 두 개만 퇴역시키는 **Move 전용 PR**입니다.

- 두 adapter가 기존 workflow/Wildcard/settings/NAIA client owner를 직접 소비합니다.
- root binder 정의·import·호출과 9개 bind-time callback slot을 제거했습니다.
- runtime binder/resolver audit는 모두 0이 되었습니다.
- `nodes.py`는 1,123줄, canonical root binding 289개, residual global 2개입니다.
- Wildcard/NAIA 동작과 public class/schema/workflow 계약은 변경하지 않았습니다.

## 사전 symbol/caller/alias/global-state inventory

- binders:
  - `_bind_wildcard_node_runtime`
  - `_bind_naia_node_runtime`
- owners:
  - `easyuse_anima.nodes.wildcard_nodes`
  - `easyuse_anima.nodes.naia_nodes`
- bind-time module globals:
  - Wildcard 5개: `_get_workflow_node`, `expand_wildcards`, `normalize_seed`, `normalize_wildcard_mode`, `wildcard_sources_signature`
  - NAIA 4개: `resolve_naia_settings`, `_get_workflow_node`, `_post_random`, `_parse_random_response`
- total direct callbacks: 9 slots / 8 unique names
- provider/string resolver/cache/I/O/business state: 없음
- repository replacement: 5 names / 3 files
  - `tests/test_wildcards.py`
  - `tests/test_naia_settings.py`
  - `tests/test_node_contracts.py`
- existing true owners:
  - workflow lookup: `easyuse_anima.workflow`
  - Wildcard functions: `wildcard_engine`
  - NAIA settings: `settings`
  - NAIA HTTP/parse: `easyuse_anima.naia.client`
- root exact class aliases:
  - `EasyUseAnimaWildcard`
  - `EasyUseAnimaNAIARandomPrompt`
- callers:
  - `easyuse_anima.registration`이 두 mapped class를 직접 소비
  - ComfyUI가 adapter class methods를 호출

상세 inventory와 exit/forbidden 조건은 `docs/architecture/comfy-host-provider-bridge.md`에 기록했습니다.

## Allowed production boundary

- `nodes.py`
- `easyuse_anima/nodes/wildcard_nodes.py`
- `easyuse_anima/nodes/naia_nodes.py`

Supporting 범위는 replacement-owner test 3개, Python compatibility/backend/nodes analyzer gate와 fixture, workflow/package contract coverage, architecture 문서 3개입니다.

## 변경한 주요 파일

- `nodes.py`
- `easyuse_anima/nodes/wildcard_nodes.py`
- `easyuse_anima/nodes/naia_nodes.py`
- `tests/test_wildcards.py`
- `tests/test_naia_settings.py`
- `tests/test_node_contracts.py`
- `tests/test_python_compatibility_surface.py`
- `tests/test_nodes_module_analyzer.py`
- Python analyzer/compatibility fixtures
- backend roadmap/bridge/shim architecture 문서

## 검증

- focused checkpoint: 145 tests passed
- production Python compile: passed
- changed-import/name Ruff (`I001,F401,F811`): passed
- `git diff --check`: passed
- official full: **정책대로 1회만 실행**
  - Python compile: passed
  - Ruff G-01: report-only 80 findings; 변경 파일의 3개 `UP045`는 기존 debt
  - Pyright G-02a: 76 files, baseline 14 errors, ratchet passed
  - import boundary G-03a: 6 groups, 0 violations
  - Python unittest: 985 tests 실행, 983 passed / analyzer baseline drift 2 failures
  - 원인: 최종 EOF 정리 뒤 `nodes.py` SHA/line fixture가 이전 값(1,124줄)을 유지한 결정적 gate drift
  - exact closure: 실패한 analyzer test 2개를 정확한 SHA/1,123줄 fixture로 갱신 후 **2 tests passed in 0.911s**
  - 같은 full은 재실행하지 않았습니다. full 중단 이후 frontend phase는 도달하지 않았고 이 PR에는 frontend 변경이 없습니다.
- Live ComfyUI smoke: not run

## 고정 경계 / 남은 위험

- Move only: Contract/Behavior/performance/dependency 변경을 섞지 않았습니다.
- `wildcard_engine.py`/`settings.py` consolidation을 시작하지 않았습니다.
- Wildcard syntax/source/seed/reservation/mode/populated-text/workflow metadata 동작을 변경하지 않았습니다.
- NAIA settings/host policy/request/response/timeout/frozen output/persistence/error 동작을 변경하지 않았습니다.
- 기존 G-01 Ruff debt는 별도 lane입니다.
- 다음 작업은 별도 rollback unit인 B-11d final root shim입니다.

Owner: #184  
Behavior boundaries: #167, #236, D-12
