### PR TITLE
B-11d: cut over the final explicit root shim

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from .nodes import (  # noqa: F401 - root class attributes stay public until B-11c
+from .easyuse_anima.registration import (  # noqa: F401 - mapped class attributes stay public
     EasyUseAnimaAIOGenerator,
     EasyUseAnimaDetailerAlignHook,
     EasyUseAnimaArtistMixConditioning,
@@ -19,13 +19,11 @@ from .nodes import (  # noqa: F401 - root class attributes stay public until B-1
     EasyUseAnimaPromptStudioRegional,
     EasyUseAnimaRegionalConditioning,
     EasyUseAnimaWildcard,
-)
-from . import api
-from .easyuse_anima.bootstrap import initialize as _initialize
-from .easyuse_anima.registration import (
     NODE_CLASS_MAPPINGS,
     NODE_DISPLAY_NAME_MAPPINGS,
 )
+from . import api
+from .easyuse_anima.bootstrap import initialize as _initialize
 from .wildcard_engine import ensure_default_wildcard_root
 
 

--- a/docs/architecture/comfy-host-provider-bridge.md
+++ b/docs/architecture/comfy-host-provider-bridge.md
@@ -2568,11 +2568,66 @@ Forbidden:
 
 ### B-11d — Final root shim
 
-- **State:** READY after B-11c30e / PR #355
+- **State:** IN PROGRESS after B-11c30e / PR #355
 - **Owner:** #184
 - **Type:** Move
 
-Final conditions remain:
+Pre-edit inventory:
+
+- root `nodes.py` is 1,123 lines with two exact relative-package/flat-fallback
+  import branches. It contains 289 canonical and 27 legacy direct bindings,
+  including the 18 mapped supported class re-exports;
+- the two unmapped class aliases are `EasyUseAnimaSAM3Context`, with documented
+  historical convenience-node evidence, and unsupported/test-only
+  `EasyUseAnimaSAM3Detailer`. ADR-002 keeps both outside the supported
+  `__all__`; any future removal remains a separate per-alias review;
+- all 297 unsupported/test-only symbols remain audited compatibility debt.
+  B-11d does not mass-retire them because ADR-002 requires maintained-consumer
+  migration, a published support window, archive evidence, and a separate
+  reviewed removal unit;
+- root owns zero functions, zero classes, zero binders/resolvers, and two
+  residual assigned globals: `logger` and `_TRIGGER_WORD_KEYS`. The preamble
+  `logging` import exists only for that unused root logger;
+- root `__init__.py` exposes 18 mapped class attributes by importing the
+  compatibility `nodes.py`, then imports mapping objects from pure
+  `easyuse_anima.registration`, and performs one guarded bootstrap call;
+- internal `easyuse_anima` package imports of root `nodes.py` are zero. The
+  root package entrypoint is the only production path still consuming the shim;
+- 21 repository test files import root `nodes.py`. Their explicit mapped-class
+  and compatibility assertions remain allowed; test-only imports do not
+  promote private aliases to supported API; and
+- package mappings, display order, workflow fixtures, bootstrap idempotence,
+  Registry scanner safety, package closure, and the root/canonical identity
+  surface are already covered by checked-in gates.
+
+Allowed production files:
+
+```text
+nodes.py
+__init__.py
+```
+
+Allowed supporting files are the Python compatibility and nodes/backend
+analyzer gates/fixtures, the public node contract coverage, and the three
+architecture documents. Registry metadata, node behavior, canonical feature
+modules, frontend files, and release versioning are outside this Move.
+
+Implementation plan:
+
+- remove only the unused root `logging`, `logger`, and `_TRIGGER_WORD_KEYS`
+  implementation residue;
+- add an explicit root `nodes.py.__all__` containing exactly the 18 mapped
+  supported class names in registration order;
+- make root `__init__.py` obtain its preserved class attributes from pure
+  `easyuse_anima.registration`, not the compatibility shim;
+- teach the compatibility gate to classify root `__all__` as shim metadata,
+  require exact equality with the mapped classes, and require zero residual
+  root implementation; and
+- preserve every existing direct alias binding, object identity, package/flat
+  fallback, mapping/display order, schema, workflow, error, and optional-import
+  behavior.
+
+Exit:
 
 - root `nodes.py` contains explicit supported direct re-exports and `__all__`;
 - no node execution, host discovery, prompt processing, sampling, cache,
@@ -2583,6 +2638,18 @@ Final conditions remain:
 - package-to-root production imports are zero;
 - actual package/Registry archive closure passes; and
 - representative live ComfyUI execution is recorded.
+
+Forbidden:
+
+- removing or promoting any of the audited private/test-only aliases;
+- changing `NODE_CLASS_MAPPINGS`, display names/order, node schemas, workflows,
+  class identity, package/flat import targets, or optional dependency timing;
+- moving or consolidating `wildcard_engine.py`, `settings.py`,
+  `prompt_translation.py`, or `anima_prompt`;
+- changing bootstrap, route, wildcard initialization, runtime provider, seed,
+  Wildcard, NAIA, Prompt, AiO, cache, or persistence behavior; and
+- beginning #167/#169 Behavior, Phase D consolidation, release, dependency,
+  performance, or broad quality cleanup.
 
 S167-01a / PR #344 supplies the behavior-preserving reserved-seed owner, and
 B-11c30c2b / PR #345 consumes it directly from both canonical adapters. The
@@ -2621,7 +2688,7 @@ COMPLETE: B-11c30d0b input-context owner Move / PR #352
 COMPLETE: B-11c30d5 legacy-orchestration Move / PR #353
 COMPLETE: B-11c30d6 node-adapter Move / PR #354
 COMPLETE: B-11c30e Wildcard/NAIA callback binder Move / PR #355
-READY:    B-11d final root shim
+IN PROGRESS: B-11d final root shim
 
 LATER:    #167 seed reservation
 LATER:    #169 stage/cache Behavior

--- a/docs/architecture/comfy-host-provider-bridge.md
+++ b/docs/architecture/comfy-host-provider-bridge.md
@@ -2568,7 +2568,7 @@ Forbidden:
 
 ### B-11d — Final root shim
 
-- **State:** IMPLEMENTED IN PR #356; final gates pending
+- **State:** COMPLETE IN PR #356
 - **Owner:** #184
 - **Type:** Move
 
@@ -2647,6 +2647,17 @@ Implementation result:
 - focused compatibility, analyzer, node-contract, package-skeleton, and runtime
   tests pass without changing node behavior.
 
+Validation result:
+
+- the official full runner passed once: 986 Python tests and the frontend
+  checks for 114 JavaScript files;
+- `comfy node validate` and `comfy node pack` passed. The 225-entry archive
+  contains exactly the 93 expected Python modules with zero missing or
+  unexpected Python paths; and
+- the isolated ComfyUI v0.27.0 instance exposed all 18 mapped node IDs. Two
+  queued `EasyUseAnimaWildcard` executions with the same text and seed both
+  completed successfully with the same `blue flower` result.
+
 Exit:
 
 - root `nodes.py` contains explicit supported direct re-exports and `__all__`;
@@ -2708,7 +2719,7 @@ COMPLETE: B-11c30d0b input-context owner Move / PR #352
 COMPLETE: B-11c30d5 legacy-orchestration Move / PR #353
 COMPLETE: B-11c30d6 node-adapter Move / PR #354
 COMPLETE: B-11c30e Wildcard/NAIA callback binder Move / PR #355
-IN PROGRESS: B-11d final root shim / PR #356
+COMPLETE: B-11d final root shim / PR #356
 
 LATER:    #167 seed reservation
 LATER:    #169 stage/cache Behavior

--- a/docs/architecture/comfy-host-provider-bridge.md
+++ b/docs/architecture/comfy-host-provider-bridge.md
@@ -2568,7 +2568,7 @@ Forbidden:
 
 ### B-11d — Final root shim
 
-- **State:** IN PROGRESS after B-11c30e / PR #355
+- **State:** IMPLEMENTED IN PR #356; final gates pending
 - **Owner:** #184
 - **Type:** Move
 
@@ -2626,6 +2626,26 @@ Implementation plan:
 - preserve every existing direct alias binding, object identity, package/flat
   fallback, mapping/display order, schema, workflow, error, and optional-import
   behavior.
+
+Implementation result:
+
+- root `logging`, `logger`, and `_TRIGGER_WORD_KEYS` are absent. The
+  compatibility audit records zero preamble implementation imports and zero
+  residual functions, classes, globals, binders, or resolvers;
+- `nodes.py.__all__` contains exactly the 18 mapped classes in registration
+  order. All 289 canonical and 27 legacy direct compatibility bindings remain
+  unchanged outside that explicit supported surface;
+- root `__init__.py` preserves all 18 class attributes through pure
+  `easyuse_anima.registration` and no longer imports compatibility `nodes.py`;
+- the backend analyzer treats the two shipped root entry modules,
+  `__init__.py` and `nodes.py`, independently. All 93 shipped Python modules
+  remain in the Registry runtime/archive closure with zero missing or
+  unreachable modules;
+- root `nodes.py` is a 1,138-line explicit compatibility shim. The added public
+  export list accounts for the line increase from the pre-edit 1,123-line
+  import-only surface; and
+- focused compatibility, analyzer, node-contract, package-skeleton, and runtime
+  tests pass without changing node behavior.
 
 Exit:
 
@@ -2688,7 +2708,7 @@ COMPLETE: B-11c30d0b input-context owner Move / PR #352
 COMPLETE: B-11c30d5 legacy-orchestration Move / PR #353
 COMPLETE: B-11c30d6 node-adapter Move / PR #354
 COMPLETE: B-11c30e Wildcard/NAIA callback binder Move / PR #355
-IN PROGRESS: B-11d final root shim
+IN PROGRESS: B-11d final root shim / PR #356
 
 LATER:    #167 seed reservation
 LATER:    #169 stage/cache Behavior

--- a/docs/architecture/python-backend-execution-roadmap.md
+++ b/docs/architecture/python-backend-execution-roadmap.md
@@ -403,7 +403,7 @@ mechanical retirement series.
 | 11 | B-09b2 AiO generator adapter move | COMPLETE on `dev` | Move | #184 | PR #270 / `57d40b4` |
 | 12 | B-10a machine-readable compatibility audit | COMPLETE on `dev` | Contract/gate | #184/#188 | PR #271 / `3c7b857` |
 | 13 | B-10b private alias reduction | COMPLETE on `dev` through PR #291 / `c6b4680` | Contract/cleanup, split PRs | #184/#188 | Audited alias surface integrated |
-| 14 | B-11 registration/bootstrap/root shim | IN PROGRESS through B-11c30e PR #355; final root shim is the next separate Move | Move/Contract, split PRs | #184 | Zero runtime binders; frozen compatibility audit |
+| 14 | B-11 registration/bootstrap/root shim | B-11c30e PR #355 integrated; B-11d final root shim IN PROGRESS | Move/Contract, split PRs | #184 | Zero runtime binders; explicit root `__all__`; frozen compatibility audit |
 | 15 | S167 backend seed reservation series | S167-01 Contract COMPLETE in PR #343 and S167-01a consumer Move COMPLETE in PR #344; Behavior and Adapter remain | Contract then Move then Behavior | #167 | Canonical AiO/node seams |
 | 16 | A169 stage pipeline series | BLOCKED by #168 and B exit | Contract then Behavior | #169 | Typed config and mechanical AiO move |
 | 17 | A169 first-pass cache policy | BLOCKED by stage/cache ownership seam | Behavior | #169 | Mechanical cache move and benchmark harness |
@@ -1148,6 +1148,11 @@ unchanged. The separate legacy Wildcard unsupported alias remains for D-12.
     package/flat imports, mappings, workflows, and exact errors remain frozen.
     Runtime binder/resolver counts reach zero and the root shim falls to 1,123
     lines. B-11d is the next READY Move.
+  - B-11d removes only the final unused root `logging`/`logger` and
+    `_TRIGGER_WORD_KEYS` implementation residue, adds an explicit supported
+    class `__all__`, and stops the package entrypoint from consuming the root
+    compatibility shim. Audited private/test-only aliases remain outside
+    `__all__` under ADR-002 and are not mass-retired in this Move.
   - The final B-11c cutover removes remaining root execution ownership and
     leaves the explicit supported `nodes.py` compatibility shim.
 - Add `easyuse_anima/registration.py` as pure mapping composition. It performs no

--- a/docs/architecture/python-backend-execution-roadmap.md
+++ b/docs/architecture/python-backend-execution-roadmap.md
@@ -5,7 +5,7 @@
 - Status: operational execution runbook
 - Snapshot date: 2026-07-24
 - Snapshot branch: `dev`
-- Integrated `dev` snapshot commit: `cf772f1d8c0fe47999deb2af1a25621587717939`
+- Integrated `dev` snapshot commit: `a45e69b18ac21574f959a9a55a534d3f4d39cda9`
 - Scope: Python backend only
 - Target architecture: [`python-backend.md`](python-backend.md)
 - Architecture decisions: [ADR-001](adr-001-modular-monolith.md) and
@@ -31,7 +31,7 @@ merged PR, the owning issue's evidence record, and every stated exit gate.
 | Phase | Integrated snapshot / open implementation state | Remaining exit work |
 | --- | --- | --- |
 | A - baseline | Complete; #191 is closed | Keep fixtures and analyzers current during later moves |
-| B - `nodes.py` extraction | Integrated through B-11c30e / PR #355; B-11d final shim completes in PR #356 | Finish package/pack/live gates, then close Phase B |
+| B - `nodes.py` extraction | Complete in B-11d / PR #356 | Preserve the audited compatibility shim until ADR-002 retirement gates are met |
 | C - feature contracts/behavior | Partially complete through S167-01a / PR #344 | Continue #167 and #169 in separate Contract/Move/Behavior PRs |
 | D - root consolidation | Not started | Execute #186 feature by feature after the corresponding behavior contracts are stable |
 | E - runtime ownership | Partial: E-02a and E-07a/E-07b integrated | Continue #187 only where canonical feature owners and explicit contracts exist |
@@ -404,9 +404,9 @@ mechanical retirement series.
 | 11 | B-09b2 AiO generator adapter move | COMPLETE on `dev` | Move | #184 | PR #270 / `57d40b4` |
 | 12 | B-10a machine-readable compatibility audit | COMPLETE on `dev` | Contract/gate | #184/#188 | PR #271 / `3c7b857` |
 | 13 | B-10b private alias reduction | COMPLETE on `dev` through PR #291 / `c6b4680` | Contract/cleanup, split PRs | #184/#188 | Audited alias surface integrated |
-| 14 | B-11 registration/bootstrap/root shim | B-11c30e PR #355 integrated; B-11d final root shim implemented in PR #356 with final gates pending | Move/Contract, split PRs | #184 | Zero runtime binders/residual implementation; explicit root `__all__`; frozen compatibility audit |
+| 14 | B-11 registration/bootstrap/root shim | COMPLETE in PR #356 | Move/Contract, split PRs | #184 | Zero runtime binders/residual implementation; explicit root `__all__`; frozen compatibility audit |
 | 15 | S167 backend seed reservation series | S167-01 Contract COMPLETE in PR #343 and S167-01a consumer Move COMPLETE in PR #344; Behavior and Adapter remain | Contract then Move then Behavior | #167 | Canonical AiO/node seams |
-| 16 | A169 stage pipeline series | BLOCKED by #168 and B exit | Contract then Behavior | #169 | Typed config and mechanical AiO move |
+| 16 | A169 stage pipeline series | READY after #168 and Phase B completion; begin with A169-01 Contract | Contract then Behavior | #169 | Typed config and mechanical AiO move |
 | 17 | A169 first-pass cache policy | BLOCKED by stage/cache ownership seam | Behavior | #169 | Mechanical cache move and benchmark harness |
 | 18 | D-series canonical root consolidation | BLOCKED by relevant C contracts | Move | #186 | Phase B exit; per-feature behavior stable |
 | 19 | E-series RuntimeServices/lifecycle | BLOCKED by canonical owners | Move/Contract, split PRs | #187 | Relevant D moves |
@@ -1155,7 +1155,10 @@ unchanged. The separate legacy Wildcard unsupported alias remains for D-12.
     compatibility shim. Audited private/test-only aliases remain outside
     `__all__` under ADR-002 and are not mass-retired in this Move. The backend
     analyzer recognizes both shipped root entry modules independently, keeping
-    all 93 Python modules in the package closure.
+    all 93 Python modules in the package closure. The official full runner,
+    Registry validate/pack archive closure, all 18 live mapped registrations,
+    and representative same-seed Wildcard execution pass in PR #356, completing
+    the Phase B exit gates.
   - The final B-11c cutover removes remaining root execution ownership and
     leaves the explicit supported `nodes.py` compatibility shim.
 - Add `easyuse_anima/registration.py` as pure mapping composition. It performs no

--- a/docs/architecture/python-backend-execution-roadmap.md
+++ b/docs/architecture/python-backend-execution-roadmap.md
@@ -31,7 +31,7 @@ merged PR, the owning issue's evidence record, and every stated exit gate.
 | Phase | Integrated snapshot / open implementation state | Remaining exit work |
 | --- | --- | --- |
 | A - baseline | Complete; #191 is closed | Keep fixtures and analyzers current during later moves |
-| B - `nodes.py` extraction | Integrated through B-11c30d6 / PR #354; B-11c30e completes in PR #355 | Execute the final root shim as a separate rollback unit |
+| B - `nodes.py` extraction | Integrated through B-11c30e / PR #355; B-11d final shim completes in PR #356 | Finish package/pack/live gates, then close Phase B |
 | C - feature contracts/behavior | Partially complete through S167-01a / PR #344 | Continue #167 and #169 in separate Contract/Move/Behavior PRs |
 | D - root consolidation | Not started | Execute #186 feature by feature after the corresponding behavior contracts are stable |
 | E - runtime ownership | Partial: E-02a and E-07a/E-07b integrated | Continue #187 only where canonical feature owners and explicit contracts exist |
@@ -42,9 +42,10 @@ merged PR, the owning issue's evidence record, and every stated exit gate.
 ### Measured Phase B progress
 
 - The Phase A baseline recorded root `nodes.py` at 12,663 lines.
-- In B-11c30e / PR #355, the analyzer measures root `nodes.py` at 1,123 lines.
-- The mechanical extraction has removed 11,540
-  lines, approximately 91.1% of the Phase A baseline, while preserving the root
+- In B-11d / PR #356, the analyzer measures the explicit root `nodes.py` shim
+  at 1,138 lines.
+- The mechanical extraction has removed 11,525
+  lines, approximately 91.0% of the Phase A baseline, while preserving the root
   compatibility surface.
 - B-01 through B-09b2 are integrated. The latest completed implementation slice
   is the AiO generator adapter Move in PR #270.
@@ -403,7 +404,7 @@ mechanical retirement series.
 | 11 | B-09b2 AiO generator adapter move | COMPLETE on `dev` | Move | #184 | PR #270 / `57d40b4` |
 | 12 | B-10a machine-readable compatibility audit | COMPLETE on `dev` | Contract/gate | #184/#188 | PR #271 / `3c7b857` |
 | 13 | B-10b private alias reduction | COMPLETE on `dev` through PR #291 / `c6b4680` | Contract/cleanup, split PRs | #184/#188 | Audited alias surface integrated |
-| 14 | B-11 registration/bootstrap/root shim | B-11c30e PR #355 integrated; B-11d final root shim IN PROGRESS | Move/Contract, split PRs | #184 | Zero runtime binders; explicit root `__all__`; frozen compatibility audit |
+| 14 | B-11 registration/bootstrap/root shim | B-11c30e PR #355 integrated; B-11d final root shim implemented in PR #356 with final gates pending | Move/Contract, split PRs | #184 | Zero runtime binders/residual implementation; explicit root `__all__`; frozen compatibility audit |
 | 15 | S167 backend seed reservation series | S167-01 Contract COMPLETE in PR #343 and S167-01a consumer Move COMPLETE in PR #344; Behavior and Adapter remain | Contract then Move then Behavior | #167 | Canonical AiO/node seams |
 | 16 | A169 stage pipeline series | BLOCKED by #168 and B exit | Contract then Behavior | #169 | Typed config and mechanical AiO move |
 | 17 | A169 first-pass cache policy | BLOCKED by stage/cache ownership seam | Behavior | #169 | Mechanical cache move and benchmark harness |
@@ -1152,7 +1153,9 @@ unchanged. The separate legacy Wildcard unsupported alias remains for D-12.
     `_TRIGGER_WORD_KEYS` implementation residue, adds an explicit supported
     class `__all__`, and stops the package entrypoint from consuming the root
     compatibility shim. Audited private/test-only aliases remain outside
-    `__all__` under ADR-002 and are not mass-retired in this Move.
+    `__all__` under ADR-002 and are not mass-retired in this Move. The backend
+    analyzer recognizes both shipped root entry modules independently, keeping
+    all 93 Python modules in the package closure.
   - The final B-11c cutover removes remaining root execution ownership and
     leaves the explicit supported `nodes.py` compatibility shim.
 - Add `easyuse_anima/registration.py` as pure mapping composition. It performs no

--- a/docs/architecture/python-compatibility-shims.md
+++ b/docs/architecture/python-compatibility-shims.md
@@ -1069,6 +1069,24 @@ convenience-node compatibility; it remains unmapped and is not public support.
 - B-11d final root shim is the next separate Move; #167/#236 Behavior and
   D-09/D-12 consolidation remain outside PR #355.
 
+### B-11d final root-shim cutover inventory
+
+- Pre-edit `nodes.py` contains 289 canonical and 27 legacy direct bindings,
+  18 mapped supported classes, two unmapped class aliases, no
+  functions/classes/binders/resolvers, and two residual globals.
+- The supported `nodes.py.__all__` is exactly the 18 mapped classes in
+  registration order. Existing audited private/test-only aliases remain
+  explicit direct bindings outside `__all__`; B-11d does not promote or remove
+  them.
+- Root `__init__.py` preserves its mapped class attributes and permanent
+  mapping/display/`WEB_DIRECTORY` entrypoints through
+  `easyuse_anima.registration`, without consuming the compatibility
+  `nodes.py`.
+- `logger`, `_TRIGGER_WORD_KEYS`, and their `logging` import are unused root
+  implementation residue and are the only production symbols retired here.
+- Any private alias retirement still follows ADR-002 as a separate reviewed
+  unit after maintained-consumer, published-release, and packed-archive gates.
+
 ### `nodes.py` public node-class surface
 
 The confirmed 0.5.2 mapped classes are:

--- a/docs/architecture/python-compatibility-shims.md
+++ b/docs/architecture/python-compatibility-shims.md
@@ -1095,6 +1095,9 @@ convenience-node compatibility; it remains unmapped and is not public support.
   `easyuse_anima.registration` rather than consuming the compatibility shim.
   The backend analyzer treats both root modules as Registry entry modules and
   records all 93 shipped Python modules as reachable.
+- The B-11d exit evidence passes in PR #356: one official full run, Registry
+  validate/pack with exact Python archive closure, all 18 live mapped node
+  registrations, and representative same-seed Wildcard queue execution.
 
 ### `nodes.py` public node-class surface
 

--- a/docs/architecture/python-compatibility-shims.md
+++ b/docs/architecture/python-compatibility-shims.md
@@ -8,11 +8,12 @@
 - Policy: [ADR-002](adr-002-compatibility-shims.md)
 - Machine-readable audit:
   [`python_compatibility_surface.v1.json`](../../tests/fixtures/python_compatibility_surface.v1.json)
-- Current state: B-11a through B-11c30d6 / PR #354 are integrated in the
-  reviewed sequence, and B-11c30e / PR #355 retires the final two
-  Wildcard/NAIA callbacks. S167-01a / PR #344 supplies the canonical
-  reserved-seed compatibility consumer while retaining its root aliases. No
-  runtime binder or resolver remains before the final root shim.
+- Current state: B-11a through B-11c30e / PR #355 are integrated in the
+  reviewed sequence, and B-11d / PR #356 implements the final explicit root
+  shim with package/pack/live gates pending. S167-01a / PR #344 supplies the
+  canonical reserved-seed compatibility consumer while retaining its root
+  aliases. No runtime binder, resolver, or residual root implementation
+  remains.
 
 This is an actionable registry, not a removal schedule. `N` means the first
 published Registry release containing both a canonical target and its root
@@ -1086,6 +1087,14 @@ convenience-node compatibility; it remains unmapped and is not public support.
   implementation residue and are the only production symbols retired here.
 - Any private alias retirement still follows ADR-002 as a separate reviewed
   unit after maintained-consumer, published-release, and packed-archive gates.
+- The implemented B-11d surface has zero preamble implementation imports and
+  zero residual functions/classes/globals. `nodes.py.__all__` is exactly the
+  18 mapped classes, while all 316 audited direct alias bindings remain
+  unchanged outside that supported list.
+- Root `__init__.py` obtains the same class objects from
+  `easyuse_anima.registration` rather than consuming the compatibility shim.
+  The backend analyzer treats both root modules as Registry entry modules and
+  records all 93 shipped Python modules as reachable.
 
 ### `nodes.py` public node-class surface
 

--- a/nodes.py
+++ b/nodes.py
@@ -1,8 +1,6 @@
 # -*- coding: utf-8 -*-
 from __future__ import annotations
 
-import logging
-
 try:
     from .easyuse_anima.aio.first_pass_cache import (
         AIO_FIRST_PASS_CACHE_MAX_ENTRIES as AIO_FIRST_PASS_CACHE_MAX_ENTRIES,
@@ -1118,6 +1116,23 @@ except ImportError:  # allows simple local import tests outside ComfyUI's packag
         wildcard_sources_signature,
     )
 
-logger = logging.getLogger("ComfyUI-EasyUseAnima")
-
-_TRIGGER_WORD_KEYS = ("trainedWords", "trained_words", "trigger_words", "activation_text")
+__all__ = [
+    "EasyUseAnimaAIOGenerator",
+    "EasyUseAnimaDetailerAlignHook",
+    "EasyUseAnimaArtistMixConditioning",
+    "EasyUseAnimaInput",
+    "EasyUseAnimaImageScaleByMultiple",
+    "EasyUseAnimaLoraPreset",
+    "EasyUseAnimaNAIARandomPrompt",
+    "EasyUseAnimaPromptDataConditioning",
+    "EasyUseAnimaPromptDataUnpack",
+    "EasyUseAnimaPromptBuilder",
+    "EasyUseAnimaPromptCorrector",
+    "EasyUseAnimaPromptCorrectorSimple",
+    "EasyUseAnimaPromptStudio",
+    "EasyUseAnimaPromptStudioAdvanced",
+    "EasyUseAnimaPromptStudioAdvancedV2",
+    "EasyUseAnimaPromptStudioRegional",
+    "EasyUseAnimaRegionalConditioning",
+    "EasyUseAnimaWildcard",
+]

--- a/tests/fixtures/python_backend_baseline.json
+++ b/tests/fixtures/python_backend_baseline.json
@@ -18,16 +18,16 @@
         "classification": "internal",
         "column": 0,
         "conditional": false,
-        "imported": ".nodes:EasyUseAnimaAIOGenerator",
+        "imported": ".easyuse_anima.registration:EasyUseAnimaAIOGenerator",
         "kind": "static_from",
         "line": 3,
         "name": "EasyUseAnimaAIOGenerator",
         "optional": false,
-        "requested": ".nodes",
+        "requested": ".easyuse_anima.registration",
         "role": "ordinary",
         "scope": "<module>",
         "source": "__init__.py",
-        "target": "nodes.py"
+        "target": "easyuse_anima/registration.py"
       },
       {
         "alias": null,
@@ -36,16 +36,16 @@
         "classification": "internal",
         "column": 0,
         "conditional": false,
-        "imported": ".nodes:EasyUseAnimaArtistMixConditioning",
+        "imported": ".easyuse_anima.registration:EasyUseAnimaArtistMixConditioning",
         "kind": "static_from",
         "line": 3,
         "name": "EasyUseAnimaArtistMixConditioning",
         "optional": false,
-        "requested": ".nodes",
+        "requested": ".easyuse_anima.registration",
         "role": "ordinary",
         "scope": "<module>",
         "source": "__init__.py",
-        "target": "nodes.py"
+        "target": "easyuse_anima/registration.py"
       },
       {
         "alias": null,
@@ -54,16 +54,16 @@
         "classification": "internal",
         "column": 0,
         "conditional": false,
-        "imported": ".nodes:EasyUseAnimaDetailerAlignHook",
+        "imported": ".easyuse_anima.registration:EasyUseAnimaDetailerAlignHook",
         "kind": "static_from",
         "line": 3,
         "name": "EasyUseAnimaDetailerAlignHook",
         "optional": false,
-        "requested": ".nodes",
+        "requested": ".easyuse_anima.registration",
         "role": "ordinary",
         "scope": "<module>",
         "source": "__init__.py",
-        "target": "nodes.py"
+        "target": "easyuse_anima/registration.py"
       },
       {
         "alias": null,
@@ -72,16 +72,16 @@
         "classification": "internal",
         "column": 0,
         "conditional": false,
-        "imported": ".nodes:EasyUseAnimaImageScaleByMultiple",
+        "imported": ".easyuse_anima.registration:EasyUseAnimaImageScaleByMultiple",
         "kind": "static_from",
         "line": 3,
         "name": "EasyUseAnimaImageScaleByMultiple",
         "optional": false,
-        "requested": ".nodes",
+        "requested": ".easyuse_anima.registration",
         "role": "ordinary",
         "scope": "<module>",
         "source": "__init__.py",
-        "target": "nodes.py"
+        "target": "easyuse_anima/registration.py"
       },
       {
         "alias": null,
@@ -90,16 +90,16 @@
         "classification": "internal",
         "column": 0,
         "conditional": false,
-        "imported": ".nodes:EasyUseAnimaInput",
+        "imported": ".easyuse_anima.registration:EasyUseAnimaInput",
         "kind": "static_from",
         "line": 3,
         "name": "EasyUseAnimaInput",
         "optional": false,
-        "requested": ".nodes",
+        "requested": ".easyuse_anima.registration",
         "role": "ordinary",
         "scope": "<module>",
         "source": "__init__.py",
-        "target": "nodes.py"
+        "target": "easyuse_anima/registration.py"
       },
       {
         "alias": null,
@@ -108,16 +108,16 @@
         "classification": "internal",
         "column": 0,
         "conditional": false,
-        "imported": ".nodes:EasyUseAnimaLoraPreset",
+        "imported": ".easyuse_anima.registration:EasyUseAnimaLoraPreset",
         "kind": "static_from",
         "line": 3,
         "name": "EasyUseAnimaLoraPreset",
         "optional": false,
-        "requested": ".nodes",
+        "requested": ".easyuse_anima.registration",
         "role": "ordinary",
         "scope": "<module>",
         "source": "__init__.py",
-        "target": "nodes.py"
+        "target": "easyuse_anima/registration.py"
       },
       {
         "alias": null,
@@ -126,16 +126,16 @@
         "classification": "internal",
         "column": 0,
         "conditional": false,
-        "imported": ".nodes:EasyUseAnimaNAIARandomPrompt",
+        "imported": ".easyuse_anima.registration:EasyUseAnimaNAIARandomPrompt",
         "kind": "static_from",
         "line": 3,
         "name": "EasyUseAnimaNAIARandomPrompt",
         "optional": false,
-        "requested": ".nodes",
+        "requested": ".easyuse_anima.registration",
         "role": "ordinary",
         "scope": "<module>",
         "source": "__init__.py",
-        "target": "nodes.py"
+        "target": "easyuse_anima/registration.py"
       },
       {
         "alias": null,
@@ -144,16 +144,16 @@
         "classification": "internal",
         "column": 0,
         "conditional": false,
-        "imported": ".nodes:EasyUseAnimaPromptBuilder",
+        "imported": ".easyuse_anima.registration:EasyUseAnimaPromptBuilder",
         "kind": "static_from",
         "line": 3,
         "name": "EasyUseAnimaPromptBuilder",
         "optional": false,
-        "requested": ".nodes",
+        "requested": ".easyuse_anima.registration",
         "role": "ordinary",
         "scope": "<module>",
         "source": "__init__.py",
-        "target": "nodes.py"
+        "target": "easyuse_anima/registration.py"
       },
       {
         "alias": null,
@@ -162,16 +162,16 @@
         "classification": "internal",
         "column": 0,
         "conditional": false,
-        "imported": ".nodes:EasyUseAnimaPromptCorrector",
+        "imported": ".easyuse_anima.registration:EasyUseAnimaPromptCorrector",
         "kind": "static_from",
         "line": 3,
         "name": "EasyUseAnimaPromptCorrector",
         "optional": false,
-        "requested": ".nodes",
+        "requested": ".easyuse_anima.registration",
         "role": "ordinary",
         "scope": "<module>",
         "source": "__init__.py",
-        "target": "nodes.py"
+        "target": "easyuse_anima/registration.py"
       },
       {
         "alias": null,
@@ -180,16 +180,16 @@
         "classification": "internal",
         "column": 0,
         "conditional": false,
-        "imported": ".nodes:EasyUseAnimaPromptCorrectorSimple",
+        "imported": ".easyuse_anima.registration:EasyUseAnimaPromptCorrectorSimple",
         "kind": "static_from",
         "line": 3,
         "name": "EasyUseAnimaPromptCorrectorSimple",
         "optional": false,
-        "requested": ".nodes",
+        "requested": ".easyuse_anima.registration",
         "role": "ordinary",
         "scope": "<module>",
         "source": "__init__.py",
-        "target": "nodes.py"
+        "target": "easyuse_anima/registration.py"
       },
       {
         "alias": null,
@@ -198,16 +198,16 @@
         "classification": "internal",
         "column": 0,
         "conditional": false,
-        "imported": ".nodes:EasyUseAnimaPromptDataConditioning",
+        "imported": ".easyuse_anima.registration:EasyUseAnimaPromptDataConditioning",
         "kind": "static_from",
         "line": 3,
         "name": "EasyUseAnimaPromptDataConditioning",
         "optional": false,
-        "requested": ".nodes",
+        "requested": ".easyuse_anima.registration",
         "role": "ordinary",
         "scope": "<module>",
         "source": "__init__.py",
-        "target": "nodes.py"
+        "target": "easyuse_anima/registration.py"
       },
       {
         "alias": null,
@@ -216,16 +216,16 @@
         "classification": "internal",
         "column": 0,
         "conditional": false,
-        "imported": ".nodes:EasyUseAnimaPromptDataUnpack",
+        "imported": ".easyuse_anima.registration:EasyUseAnimaPromptDataUnpack",
         "kind": "static_from",
         "line": 3,
         "name": "EasyUseAnimaPromptDataUnpack",
         "optional": false,
-        "requested": ".nodes",
+        "requested": ".easyuse_anima.registration",
         "role": "ordinary",
         "scope": "<module>",
         "source": "__init__.py",
-        "target": "nodes.py"
+        "target": "easyuse_anima/registration.py"
       },
       {
         "alias": null,
@@ -234,16 +234,16 @@
         "classification": "internal",
         "column": 0,
         "conditional": false,
-        "imported": ".nodes:EasyUseAnimaPromptStudio",
+        "imported": ".easyuse_anima.registration:EasyUseAnimaPromptStudio",
         "kind": "static_from",
         "line": 3,
         "name": "EasyUseAnimaPromptStudio",
         "optional": false,
-        "requested": ".nodes",
+        "requested": ".easyuse_anima.registration",
         "role": "ordinary",
         "scope": "<module>",
         "source": "__init__.py",
-        "target": "nodes.py"
+        "target": "easyuse_anima/registration.py"
       },
       {
         "alias": null,
@@ -252,16 +252,16 @@
         "classification": "internal",
         "column": 0,
         "conditional": false,
-        "imported": ".nodes:EasyUseAnimaPromptStudioAdvanced",
+        "imported": ".easyuse_anima.registration:EasyUseAnimaPromptStudioAdvanced",
         "kind": "static_from",
         "line": 3,
         "name": "EasyUseAnimaPromptStudioAdvanced",
         "optional": false,
-        "requested": ".nodes",
+        "requested": ".easyuse_anima.registration",
         "role": "ordinary",
         "scope": "<module>",
         "source": "__init__.py",
-        "target": "nodes.py"
+        "target": "easyuse_anima/registration.py"
       },
       {
         "alias": null,
@@ -270,16 +270,16 @@
         "classification": "internal",
         "column": 0,
         "conditional": false,
-        "imported": ".nodes:EasyUseAnimaPromptStudioAdvancedV2",
+        "imported": ".easyuse_anima.registration:EasyUseAnimaPromptStudioAdvancedV2",
         "kind": "static_from",
         "line": 3,
         "name": "EasyUseAnimaPromptStudioAdvancedV2",
         "optional": false,
-        "requested": ".nodes",
+        "requested": ".easyuse_anima.registration",
         "role": "ordinary",
         "scope": "<module>",
         "source": "__init__.py",
-        "target": "nodes.py"
+        "target": "easyuse_anima/registration.py"
       },
       {
         "alias": null,
@@ -288,16 +288,16 @@
         "classification": "internal",
         "column": 0,
         "conditional": false,
-        "imported": ".nodes:EasyUseAnimaPromptStudioRegional",
+        "imported": ".easyuse_anima.registration:EasyUseAnimaPromptStudioRegional",
         "kind": "static_from",
         "line": 3,
         "name": "EasyUseAnimaPromptStudioRegional",
         "optional": false,
-        "requested": ".nodes",
+        "requested": ".easyuse_anima.registration",
         "role": "ordinary",
         "scope": "<module>",
         "source": "__init__.py",
-        "target": "nodes.py"
+        "target": "easyuse_anima/registration.py"
       },
       {
         "alias": null,
@@ -306,16 +306,16 @@
         "classification": "internal",
         "column": 0,
         "conditional": false,
-        "imported": ".nodes:EasyUseAnimaRegionalConditioning",
+        "imported": ".easyuse_anima.registration:EasyUseAnimaRegionalConditioning",
         "kind": "static_from",
         "line": 3,
         "name": "EasyUseAnimaRegionalConditioning",
         "optional": false,
-        "requested": ".nodes",
+        "requested": ".easyuse_anima.registration",
         "role": "ordinary",
         "scope": "<module>",
         "source": "__init__.py",
-        "target": "nodes.py"
+        "target": "easyuse_anima/registration.py"
       },
       {
         "alias": null,
@@ -324,52 +324,16 @@
         "classification": "internal",
         "column": 0,
         "conditional": false,
-        "imported": ".nodes:EasyUseAnimaWildcard",
+        "imported": ".easyuse_anima.registration:EasyUseAnimaWildcard",
         "kind": "static_from",
         "line": 3,
         "name": "EasyUseAnimaWildcard",
         "optional": false,
-        "requested": ".nodes",
+        "requested": ".easyuse_anima.registration",
         "role": "ordinary",
         "scope": "<module>",
         "source": "__init__.py",
-        "target": "nodes.py"
-      },
-      {
-        "alias": null,
-        "bound_name": "api",
-        "branch_context": [],
-        "classification": "internal",
-        "column": 0,
-        "conditional": false,
-        "imported": ".:api",
-        "kind": "static_from",
-        "line": 23,
-        "name": "api",
-        "optional": false,
-        "requested": ".",
-        "role": "ordinary",
-        "scope": "<module>",
-        "source": "__init__.py",
-        "target": "api.py"
-      },
-      {
-        "alias": "_initialize",
-        "bound_name": "_initialize",
-        "branch_context": [],
-        "classification": "internal",
-        "column": 0,
-        "conditional": false,
-        "imported": ".easyuse_anima.bootstrap:initialize",
-        "kind": "static_from",
-        "line": 24,
-        "name": "initialize",
-        "optional": false,
-        "requested": ".easyuse_anima.bootstrap",
-        "role": "ordinary",
-        "scope": "<module>",
-        "source": "__init__.py",
-        "target": "easyuse_anima/bootstrap.py"
+        "target": "easyuse_anima/registration.py"
       },
       {
         "alias": null,
@@ -380,7 +344,7 @@
         "conditional": false,
         "imported": ".easyuse_anima.registration:NODE_CLASS_MAPPINGS",
         "kind": "static_from",
-        "line": 25,
+        "line": 3,
         "name": "NODE_CLASS_MAPPINGS",
         "optional": false,
         "requested": ".easyuse_anima.registration",
@@ -398,7 +362,7 @@
         "conditional": false,
         "imported": ".easyuse_anima.registration:NODE_DISPLAY_NAME_MAPPINGS",
         "kind": "static_from",
-        "line": 25,
+        "line": 3,
         "name": "NODE_DISPLAY_NAME_MAPPINGS",
         "optional": false,
         "requested": ".easyuse_anima.registration",
@@ -409,6 +373,42 @@
       },
       {
         "alias": null,
+        "bound_name": "api",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".:api",
+        "kind": "static_from",
+        "line": 25,
+        "name": "api",
+        "optional": false,
+        "requested": ".",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "__init__.py",
+        "target": "api.py"
+      },
+      {
+        "alias": "_initialize",
+        "bound_name": "_initialize",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".easyuse_anima.bootstrap:initialize",
+        "kind": "static_from",
+        "line": 26,
+        "name": "initialize",
+        "optional": false,
+        "requested": ".easyuse_anima.bootstrap",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "__init__.py",
+        "target": "easyuse_anima/bootstrap.py"
+      },
+      {
+        "alias": null,
         "bound_name": "ensure_default_wildcard_root",
         "branch_context": [],
         "classification": "internal",
@@ -416,7 +416,7 @@
         "conditional": false,
         "imported": ".wildcard_engine:ensure_default_wildcard_root",
         "kind": "static_from",
-        "line": 29,
+        "line": 27,
         "name": "ensure_default_wildcard_root",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -434,7 +434,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 33
+            "line": 31
           }
         ],
         "classification": "external",
@@ -442,7 +442,7 @@
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 34,
+        "line": 32,
         "name": null,
         "optional": true,
         "requested": "nodes",
@@ -21322,23 +21322,6 @@
         "source": "nodes.py"
       },
       {
-        "alias": null,
-        "bound_name": "logging",
-        "branch_context": [],
-        "classification": "external",
-        "column": 0,
-        "conditional": false,
-        "imported": "logging",
-        "kind": "static_import",
-        "line": 4,
-        "name": null,
-        "optional": false,
-        "requested": "logging",
-        "role": "ordinary",
-        "scope": "<module>",
-        "source": "nodes.py"
-      },
-      {
         "alias": "AIO_FIRST_PASS_CACHE_MAX_ENTRIES",
         "bound_name": "AIO_FIRST_PASS_CACHE_MAX_ENTRIES",
         "branch_context": [
@@ -21347,7 +21330,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -21355,12 +21338,12 @@
         "compatibility_pair": {
           "bound_name": "AIO_FIRST_PASS_CACHE_MAX_ENTRIES",
           "target": "easyuse_anima/aio/first_pass_cache.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.first_pass_cache:AIO_FIRST_PASS_CACHE_MAX_ENTRIES",
         "kind": "static_from",
-        "line": 7,
+        "line": 5,
         "name": "AIO_FIRST_PASS_CACHE_MAX_ENTRIES",
         "optional": false,
         "requested": ".easyuse_anima.aio.first_pass_cache",
@@ -21378,7 +21361,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -21386,12 +21369,12 @@
         "compatibility_pair": {
           "bound_name": "_AIO_FIRST_PASS_CACHE",
           "target": "easyuse_anima/aio/first_pass_cache.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.first_pass_cache:_AIO_FIRST_PASS_CACHE",
         "kind": "static_from",
-        "line": 7,
+        "line": 5,
         "name": "_AIO_FIRST_PASS_CACHE",
         "optional": false,
         "requested": ".easyuse_anima.aio.first_pass_cache",
@@ -21409,7 +21392,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -21417,12 +21400,12 @@
         "compatibility_pair": {
           "bound_name": "_AIO_FIRST_PASS_CACHE_ORDER",
           "target": "easyuse_anima/aio/first_pass_cache.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.first_pass_cache:_AIO_FIRST_PASS_CACHE_ORDER",
         "kind": "static_from",
-        "line": 7,
+        "line": 5,
         "name": "_AIO_FIRST_PASS_CACHE_ORDER",
         "optional": false,
         "requested": ".easyuse_anima.aio.first_pass_cache",
@@ -21440,7 +21423,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -21448,12 +21431,12 @@
         "compatibility_pair": {
           "bound_name": "_aio_first_pass_cache_key",
           "target": "easyuse_anima/aio/first_pass_cache.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.first_pass_cache:_aio_first_pass_cache_key",
         "kind": "static_from",
-        "line": 7,
+        "line": 5,
         "name": "_aio_first_pass_cache_key",
         "optional": false,
         "requested": ".easyuse_anima.aio.first_pass_cache",
@@ -21471,7 +21454,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -21479,12 +21462,12 @@
         "compatibility_pair": {
           "bound_name": "_clone_aio_cache_value",
           "target": "easyuse_anima/aio/first_pass_cache.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.first_pass_cache:_clone_aio_cache_value",
         "kind": "static_from",
-        "line": 7,
+        "line": 5,
         "name": "_clone_aio_cache_value",
         "optional": false,
         "requested": ".easyuse_anima.aio.first_pass_cache",
@@ -21502,7 +21485,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -21510,12 +21493,12 @@
         "compatibility_pair": {
           "bound_name": "_get_aio_first_pass_cache",
           "target": "easyuse_anima/aio/first_pass_cache.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.first_pass_cache:_get_aio_first_pass_cache",
         "kind": "static_from",
-        "line": 7,
+        "line": 5,
         "name": "_get_aio_first_pass_cache",
         "optional": false,
         "requested": ".easyuse_anima.aio.first_pass_cache",
@@ -21533,7 +21516,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -21541,12 +21524,12 @@
         "compatibility_pair": {
           "bound_name": "_put_aio_first_pass_cache",
           "target": "easyuse_anima/aio/first_pass_cache.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.first_pass_cache:_put_aio_first_pass_cache",
         "kind": "static_from",
-        "line": 7,
+        "line": 5,
         "name": "_put_aio_first_pass_cache",
         "optional": false,
         "requested": ".easyuse_anima.aio.first_pass_cache",
@@ -21564,7 +21547,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -21572,12 +21555,12 @@
         "compatibility_pair": {
           "bound_name": "_run_aio_detailer_stage",
           "target": "easyuse_anima/aio/legacy_generation.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.legacy_generation:_run_aio_detailer_stage",
         "kind": "static_from",
-        "line": 17,
+        "line": 15,
         "name": "_run_aio_detailer_stage",
         "optional": false,
         "requested": ".easyuse_anima.aio.legacy_generation",
@@ -21595,7 +21578,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -21603,12 +21586,12 @@
         "compatibility_pair": {
           "bound_name": "_run_aio_detailer_target",
           "target": "easyuse_anima/aio/legacy_generation.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.legacy_generation:_run_aio_detailer_target",
         "kind": "static_from",
-        "line": 17,
+        "line": 15,
         "name": "_run_aio_detailer_target",
         "optional": false,
         "requested": ".easyuse_anima.aio.legacy_generation",
@@ -21626,7 +21609,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -21634,12 +21617,12 @@
         "compatibility_pair": {
           "bound_name": "_run_aio_highres_stage",
           "target": "easyuse_anima/aio/legacy_generation.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.legacy_generation:_run_aio_highres_stage",
         "kind": "static_from",
-        "line": 17,
+        "line": 15,
         "name": "_run_aio_highres_stage",
         "optional": false,
         "requested": ".easyuse_anima.aio.legacy_generation",
@@ -21657,7 +21640,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -21665,12 +21648,12 @@
         "compatibility_pair": {
           "bound_name": "_run_aio_legacy_generation",
           "target": "easyuse_anima/aio/legacy_generation.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.legacy_generation:_run_aio_legacy_generation",
         "kind": "static_from",
-        "line": 17,
+        "line": 15,
         "name": "_run_aio_legacy_generation",
         "optional": false,
         "requested": ".easyuse_anima.aio.legacy_generation",
@@ -21688,7 +21671,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -21696,12 +21679,12 @@
         "compatibility_pair": {
           "bound_name": "_run_aio_resshift_upscale_stage",
           "target": "easyuse_anima/aio/legacy_generation.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.legacy_generation:_run_aio_resshift_upscale_stage",
         "kind": "static_from",
-        "line": 17,
+        "line": 15,
         "name": "_run_aio_resshift_upscale_stage",
         "optional": false,
         "requested": ".easyuse_anima.aio.legacy_generation",
@@ -21719,7 +21702,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -21727,12 +21710,12 @@
         "compatibility_pair": {
           "bound_name": "_run_aio_upscale_stage",
           "target": "easyuse_anima/aio/legacy_generation.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.legacy_generation:_run_aio_upscale_stage",
         "kind": "static_from",
-        "line": 17,
+        "line": 15,
         "name": "_run_aio_upscale_stage",
         "optional": false,
         "requested": ".easyuse_anima.aio.legacy_generation",
@@ -21750,7 +21733,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -21758,12 +21741,12 @@
         "compatibility_pair": {
           "bound_name": "_run_aio_usdu_upscale_stage",
           "target": "easyuse_anima/aio/legacy_generation.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.legacy_generation:_run_aio_usdu_upscale_stage",
         "kind": "static_from",
-        "line": 17,
+        "line": 15,
         "name": "_run_aio_usdu_upscale_stage",
         "optional": false,
         "requested": ".easyuse_anima.aio.legacy_generation",
@@ -21781,7 +21764,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -21789,12 +21772,12 @@
         "compatibility_pair": {
           "bound_name": "_AIO_DETAILER_CUSTOM_RE",
           "target": "easyuse_anima/aio/generation_normalization.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.generation_normalization:_AIO_DETAILER_CUSTOM_RE",
         "kind": "static_from",
-        "line": 26,
+        "line": 24,
         "name": "_AIO_DETAILER_CUSTOM_RE",
         "optional": false,
         "requested": ".easyuse_anima.aio.generation_normalization",
@@ -21812,7 +21795,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -21820,12 +21803,12 @@
         "compatibility_pair": {
           "bound_name": "_AIO_DETAILER_RESERVED_KEYS",
           "target": "easyuse_anima/aio/generation_normalization.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.generation_normalization:_AIO_DETAILER_RESERVED_KEYS",
         "kind": "static_from",
-        "line": 26,
+        "line": 24,
         "name": "_AIO_DETAILER_RESERVED_KEYS",
         "optional": false,
         "requested": ".easyuse_anima.aio.generation_normalization",
@@ -21843,7 +21826,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -21851,12 +21834,12 @@
         "compatibility_pair": {
           "bound_name": "_aio_detailer_has_enabled_targets",
           "target": "easyuse_anima/aio/generation_normalization.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.generation_normalization:_aio_detailer_has_enabled_targets",
         "kind": "static_from",
-        "line": 26,
+        "line": 24,
         "name": "_aio_detailer_has_enabled_targets",
         "optional": false,
         "requested": ".easyuse_anima.aio.generation_normalization",
@@ -21874,7 +21857,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -21882,12 +21865,12 @@
         "compatibility_pair": {
           "bound_name": "_aio_detailer_target_defaults",
           "target": "easyuse_anima/aio/generation_normalization.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.generation_normalization:_aio_detailer_target_defaults",
         "kind": "static_from",
-        "line": 26,
+        "line": 24,
         "name": "_aio_detailer_target_defaults",
         "optional": false,
         "requested": ".easyuse_anima.aio.generation_normalization",
@@ -21905,7 +21888,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -21913,12 +21896,12 @@
         "compatibility_pair": {
           "bound_name": "_aio_detailer_target_order",
           "target": "easyuse_anima/aio/generation_normalization.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.generation_normalization:_aio_detailer_target_order",
         "kind": "static_from",
-        "line": 26,
+        "line": 24,
         "name": "_aio_detailer_target_order",
         "optional": false,
         "requested": ".easyuse_anima.aio.generation_normalization",
@@ -21936,7 +21919,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -21944,12 +21927,12 @@
         "compatibility_pair": {
           "bound_name": "_is_aio_detailer_target_name",
           "target": "easyuse_anima/aio/generation_normalization.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.generation_normalization:_is_aio_detailer_target_name",
         "kind": "static_from",
-        "line": 26,
+        "line": 24,
         "name": "_is_aio_detailer_target_name",
         "optional": false,
         "requested": ".easyuse_anima.aio.generation_normalization",
@@ -21967,7 +21950,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -21975,12 +21958,12 @@
         "compatibility_pair": {
           "bound_name": "_merge_versioned_settings",
           "target": "easyuse_anima/aio/generation_normalization.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.generation_normalization:_merge_versioned_settings",
         "kind": "static_from",
-        "line": 26,
+        "line": 24,
         "name": "_merge_versioned_settings",
         "optional": false,
         "requested": ".easyuse_anima.aio.generation_normalization",
@@ -21998,7 +21981,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -22006,12 +21989,12 @@
         "compatibility_pair": {
           "bound_name": "_normalize_aio_dit_corrections_settings",
           "target": "easyuse_anima/aio/generation_normalization.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.generation_normalization:_normalize_aio_dit_corrections_settings",
         "kind": "static_from",
-        "line": 26,
+        "line": 24,
         "name": "_normalize_aio_dit_corrections_settings",
         "optional": false,
         "requested": ".easyuse_anima.aio.generation_normalization",
@@ -22029,7 +22012,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -22037,12 +22020,12 @@
         "compatibility_pair": {
           "bound_name": "_normalize_aio_generation_settings",
           "target": "easyuse_anima/aio/generation_normalization.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.generation_normalization:_normalize_aio_generation_settings",
         "kind": "static_from",
-        "line": 26,
+        "line": 24,
         "name": "_normalize_aio_generation_settings",
         "optional": false,
         "requested": ".easyuse_anima.aio.generation_normalization",
@@ -22060,7 +22043,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -22068,12 +22051,12 @@
         "compatibility_pair": {
           "bound_name": "_normalize_aio_seed",
           "target": "easyuse_anima/aio/generation_normalization.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.generation_normalization:_normalize_aio_seed",
         "kind": "static_from",
-        "line": 26,
+        "line": 24,
         "name": "_normalize_aio_seed",
         "optional": false,
         "requested": ".easyuse_anima.aio.generation_normalization",
@@ -22091,7 +22074,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -22099,12 +22082,12 @@
         "compatibility_pair": {
           "bound_name": "_normalize_aio_spectrum_settings",
           "target": "easyuse_anima/aio/generation_normalization.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.generation_normalization:_normalize_aio_spectrum_settings",
         "kind": "static_from",
-        "line": 26,
+        "line": 24,
         "name": "_normalize_aio_spectrum_settings",
         "optional": false,
         "requested": ".easyuse_anima.aio.generation_normalization",
@@ -22122,7 +22105,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -22130,12 +22113,12 @@
         "compatibility_pair": {
           "bound_name": "AIO_FINAL_FIT_MODES",
           "target": "easyuse_anima/aio/generation_defaults.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.generation_defaults:AIO_FINAL_FIT_MODES",
         "kind": "static_from",
-        "line": 39,
+        "line": 37,
         "name": "AIO_FINAL_FIT_MODES",
         "optional": false,
         "requested": ".easyuse_anima.aio.generation_defaults",
@@ -22153,7 +22136,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -22161,12 +22144,12 @@
         "compatibility_pair": {
           "bound_name": "AIO_FINAL_UPSCALE_BACKENDS",
           "target": "easyuse_anima/aio/generation_defaults.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.generation_defaults:AIO_FINAL_UPSCALE_BACKENDS",
         "kind": "static_from",
-        "line": 39,
+        "line": 37,
         "name": "AIO_FINAL_UPSCALE_BACKENDS",
         "optional": false,
         "requested": ".easyuse_anima.aio.generation_defaults",
@@ -22184,7 +22167,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -22192,12 +22175,12 @@
         "compatibility_pair": {
           "bound_name": "AIO_GENERATION_DEFAULT_SETTINGS",
           "target": "easyuse_anima/aio/generation_defaults.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.generation_defaults:AIO_GENERATION_DEFAULT_SETTINGS",
         "kind": "static_from",
-        "line": 39,
+        "line": 37,
         "name": "AIO_GENERATION_DEFAULT_SETTINGS",
         "optional": false,
         "requested": ".easyuse_anima.aio.generation_defaults",
@@ -22215,7 +22198,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -22223,12 +22206,12 @@
         "compatibility_pair": {
           "bound_name": "AIO_GENERATION_SETTINGS_SCHEMA",
           "target": "easyuse_anima/aio/generation_defaults.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.generation_defaults:AIO_GENERATION_SETTINGS_SCHEMA",
         "kind": "static_from",
-        "line": 39,
+        "line": 37,
         "name": "AIO_GENERATION_SETTINGS_SCHEMA",
         "optional": false,
         "requested": ".easyuse_anima.aio.generation_defaults",
@@ -22246,7 +22229,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -22254,12 +22237,12 @@
         "compatibility_pair": {
           "bound_name": "AIO_GENERATION_SETTINGS_VERSION",
           "target": "easyuse_anima/aio/generation_defaults.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.generation_defaults:AIO_GENERATION_SETTINGS_VERSION",
         "kind": "static_from",
-        "line": 39,
+        "line": 37,
         "name": "AIO_GENERATION_SETTINGS_VERSION",
         "optional": false,
         "requested": ".easyuse_anima.aio.generation_defaults",
@@ -22277,7 +22260,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -22285,12 +22268,12 @@
         "compatibility_pair": {
           "bound_name": "AIO_RESHIFT_DTYPES",
           "target": "easyuse_anima/aio/generation_defaults.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.generation_defaults:AIO_RESHIFT_DTYPES",
         "kind": "static_from",
-        "line": 39,
+        "line": 37,
         "name": "AIO_RESHIFT_DTYPES",
         "optional": false,
         "requested": ".easyuse_anima.aio.generation_defaults",
@@ -22308,7 +22291,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -22316,12 +22299,12 @@
         "compatibility_pair": {
           "bound_name": "AIO_RESHIFT_SCALES",
           "target": "easyuse_anima/aio/generation_defaults.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.generation_defaults:AIO_RESHIFT_SCALES",
         "kind": "static_from",
-        "line": 39,
+        "line": 37,
         "name": "AIO_RESHIFT_SCALES",
         "optional": false,
         "requested": ".easyuse_anima.aio.generation_defaults",
@@ -22339,7 +22322,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -22347,12 +22330,12 @@
         "compatibility_pair": {
           "bound_name": "AIO_SPECIAL_SEEDS",
           "target": "easyuse_anima/aio/generation_defaults.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.generation_defaults:AIO_SPECIAL_SEEDS",
         "kind": "static_from",
-        "line": 39,
+        "line": 37,
         "name": "AIO_SPECIAL_SEEDS",
         "optional": false,
         "requested": ".easyuse_anima.aio.generation_defaults",
@@ -22370,7 +22353,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -22378,12 +22361,12 @@
         "compatibility_pair": {
           "bound_name": "AIO_SPECIAL_SEED_DECREMENT",
           "target": "easyuse_anima/aio/generation_defaults.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.generation_defaults:AIO_SPECIAL_SEED_DECREMENT",
         "kind": "static_from",
-        "line": 39,
+        "line": 37,
         "name": "AIO_SPECIAL_SEED_DECREMENT",
         "optional": false,
         "requested": ".easyuse_anima.aio.generation_defaults",
@@ -22401,7 +22384,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -22409,12 +22392,12 @@
         "compatibility_pair": {
           "bound_name": "AIO_SPECIAL_SEED_INCREMENT",
           "target": "easyuse_anima/aio/generation_defaults.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.generation_defaults:AIO_SPECIAL_SEED_INCREMENT",
         "kind": "static_from",
-        "line": 39,
+        "line": 37,
         "name": "AIO_SPECIAL_SEED_INCREMENT",
         "optional": false,
         "requested": ".easyuse_anima.aio.generation_defaults",
@@ -22432,7 +22415,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -22440,12 +22423,12 @@
         "compatibility_pair": {
           "bound_name": "AIO_SPECIAL_SEED_RANDOM",
           "target": "easyuse_anima/aio/generation_defaults.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.generation_defaults:AIO_SPECIAL_SEED_RANDOM",
         "kind": "static_from",
-        "line": 39,
+        "line": 37,
         "name": "AIO_SPECIAL_SEED_RANDOM",
         "optional": false,
         "requested": ".easyuse_anima.aio.generation_defaults",
@@ -22463,7 +22446,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -22471,12 +22454,12 @@
         "compatibility_pair": {
           "bound_name": "AIO_USDU_MODE_TYPES",
           "target": "easyuse_anima/aio/generation_defaults.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.generation_defaults:AIO_USDU_MODE_TYPES",
         "kind": "static_from",
-        "line": 39,
+        "line": 37,
         "name": "AIO_USDU_MODE_TYPES",
         "optional": false,
         "requested": ".easyuse_anima.aio.generation_defaults",
@@ -22494,7 +22477,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -22502,12 +22485,12 @@
         "compatibility_pair": {
           "bound_name": "AIO_USDU_PROMPT_FULL",
           "target": "easyuse_anima/aio/generation_defaults.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.generation_defaults:AIO_USDU_PROMPT_FULL",
         "kind": "static_from",
-        "line": 39,
+        "line": 37,
         "name": "AIO_USDU_PROMPT_FULL",
         "optional": false,
         "requested": ".easyuse_anima.aio.generation_defaults",
@@ -22525,7 +22508,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -22533,12 +22516,12 @@
         "compatibility_pair": {
           "bound_name": "AIO_USDU_PROMPT_MODES",
           "target": "easyuse_anima/aio/generation_defaults.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.generation_defaults:AIO_USDU_PROMPT_MODES",
         "kind": "static_from",
-        "line": 39,
+        "line": 37,
         "name": "AIO_USDU_PROMPT_MODES",
         "optional": false,
         "requested": ".easyuse_anima.aio.generation_defaults",
@@ -22556,7 +22539,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -22564,12 +22547,12 @@
         "compatibility_pair": {
           "bound_name": "AIO_USDU_PROMPT_NO_GENERAL",
           "target": "easyuse_anima/aio/generation_defaults.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.generation_defaults:AIO_USDU_PROMPT_NO_GENERAL",
         "kind": "static_from",
-        "line": 39,
+        "line": 37,
         "name": "AIO_USDU_PROMPT_NO_GENERAL",
         "optional": false,
         "requested": ".easyuse_anima.aio.generation_defaults",
@@ -22587,7 +22570,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -22595,12 +22578,12 @@
         "compatibility_pair": {
           "bound_name": "AIO_USDU_SEAM_FIX_MODES",
           "target": "easyuse_anima/aio/generation_defaults.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.generation_defaults:AIO_USDU_SEAM_FIX_MODES",
         "kind": "static_from",
-        "line": 39,
+        "line": 37,
         "name": "AIO_USDU_SEAM_FIX_MODES",
         "optional": false,
         "requested": ".easyuse_anima.aio.generation_defaults",
@@ -22618,7 +22601,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -22626,12 +22609,12 @@
         "compatibility_pair": {
           "bound_name": "_round_trip_aio_generation_settings",
           "target": "easyuse_anima/aio/generation_settings.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.generation_settings:round_trip_aio_generation_settings",
         "kind": "static_from",
-        "line": 57,
+        "line": 55,
         "name": "round_trip_aio_generation_settings",
         "optional": false,
         "requested": ".easyuse_anima.aio.generation_settings",
@@ -22649,7 +22632,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -22657,12 +22640,12 @@
         "compatibility_pair": {
           "bound_name": "AIO_INPUT_DEFAULT_SETTINGS",
           "target": "easyuse_anima/aio/input_defaults.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.input_defaults:AIO_INPUT_DEFAULT_SETTINGS",
         "kind": "static_from",
-        "line": 60,
+        "line": 58,
         "name": "AIO_INPUT_DEFAULT_SETTINGS",
         "optional": false,
         "requested": ".easyuse_anima.aio.input_defaults",
@@ -22680,7 +22663,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -22688,12 +22671,12 @@
         "compatibility_pair": {
           "bound_name": "ANIMA_CLIP_DEVICES",
           "target": "easyuse_anima/aio/input_defaults.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.input_defaults:ANIMA_CLIP_DEVICES",
         "kind": "static_from",
-        "line": 60,
+        "line": 58,
         "name": "ANIMA_CLIP_DEVICES",
         "optional": false,
         "requested": ".easyuse_anima.aio.input_defaults",
@@ -22711,7 +22694,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -22719,12 +22702,12 @@
         "compatibility_pair": {
           "bound_name": "ANIMA_CLIP_TYPES",
           "target": "easyuse_anima/aio/input_defaults.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.input_defaults:ANIMA_CLIP_TYPES",
         "kind": "static_from",
-        "line": 60,
+        "line": 58,
         "name": "ANIMA_CLIP_TYPES",
         "optional": false,
         "requested": ".easyuse_anima.aio.input_defaults",
@@ -22742,7 +22725,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -22750,12 +22733,12 @@
         "compatibility_pair": {
           "bound_name": "ANIMA_DEFAULT_CLIP_CANDIDATES",
           "target": "easyuse_anima/aio/input_defaults.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.input_defaults:ANIMA_DEFAULT_CLIP_CANDIDATES",
         "kind": "static_from",
-        "line": 60,
+        "line": 58,
         "name": "ANIMA_DEFAULT_CLIP_CANDIDATES",
         "optional": false,
         "requested": ".easyuse_anima.aio.input_defaults",
@@ -22773,7 +22756,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -22781,12 +22764,12 @@
         "compatibility_pair": {
           "bound_name": "ANIMA_DEFAULT_DIFFUSION_MODEL_CANDIDATES",
           "target": "easyuse_anima/aio/input_defaults.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.input_defaults:ANIMA_DEFAULT_DIFFUSION_MODEL_CANDIDATES",
         "kind": "static_from",
-        "line": 60,
+        "line": 58,
         "name": "ANIMA_DEFAULT_DIFFUSION_MODEL_CANDIDATES",
         "optional": false,
         "requested": ".easyuse_anima.aio.input_defaults",
@@ -22804,7 +22787,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -22812,12 +22795,12 @@
         "compatibility_pair": {
           "bound_name": "ANIMA_DEFAULT_VAE_CANDIDATES",
           "target": "easyuse_anima/aio/input_defaults.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.input_defaults:ANIMA_DEFAULT_VAE_CANDIDATES",
         "kind": "static_from",
-        "line": 60,
+        "line": 58,
         "name": "ANIMA_DEFAULT_VAE_CANDIDATES",
         "optional": false,
         "requested": ".easyuse_anima.aio.input_defaults",
@@ -22835,7 +22818,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -22843,12 +22826,12 @@
         "compatibility_pair": {
           "bound_name": "ANIMA_UNET_WEIGHT_DTYPES",
           "target": "easyuse_anima/aio/input_defaults.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.input_defaults:ANIMA_UNET_WEIGHT_DTYPES",
         "kind": "static_from",
-        "line": 60,
+        "line": 58,
         "name": "ANIMA_UNET_WEIGHT_DTYPES",
         "optional": false,
         "requested": ".easyuse_anima.aio.input_defaults",
@@ -22866,7 +22849,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -22874,12 +22857,12 @@
         "compatibility_pair": {
           "bound_name": "EASY_USE_ANIMA_INPUT_SCHEMA",
           "target": "easyuse_anima/aio/input_defaults.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.input_defaults:EASY_USE_ANIMA_INPUT_SCHEMA",
         "kind": "static_from",
-        "line": 60,
+        "line": 58,
         "name": "EASY_USE_ANIMA_INPUT_SCHEMA",
         "optional": false,
         "requested": ".easyuse_anima.aio.input_defaults",
@@ -22897,7 +22880,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -22905,12 +22888,12 @@
         "compatibility_pair": {
           "bound_name": "EASY_USE_ANIMA_INPUT_SETTINGS_VERSION",
           "target": "easyuse_anima/aio/input_defaults.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.input_defaults:EASY_USE_ANIMA_INPUT_SETTINGS_VERSION",
         "kind": "static_from",
-        "line": 60,
+        "line": 58,
         "name": "EASY_USE_ANIMA_INPUT_SETTINGS_VERSION",
         "optional": false,
         "requested": ".easyuse_anima.aio.input_defaults",
@@ -22928,7 +22911,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -22936,12 +22919,12 @@
         "compatibility_pair": {
           "bound_name": "_easy_use_anima_input_signature",
           "target": "easyuse_anima/aio/input_context.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.input_context:_easy_use_anima_input_signature",
         "kind": "static_from",
-        "line": 71,
+        "line": 69,
         "name": "_easy_use_anima_input_signature",
         "optional": false,
         "requested": ".easyuse_anima.aio.input_context",
@@ -22959,7 +22942,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -22967,12 +22950,12 @@
         "compatibility_pair": {
           "bound_name": "_require_easy_use_anima_input",
           "target": "easyuse_anima/aio/input_context.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.input_context:_require_easy_use_anima_input",
         "kind": "static_from",
-        "line": 71,
+        "line": 69,
         "name": "_require_easy_use_anima_input",
         "optional": false,
         "requested": ".easyuse_anima.aio.input_context",
@@ -22990,7 +22973,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -22998,12 +22981,12 @@
         "compatibility_pair": {
           "bound_name": "_aio_usdu_auto_tile_dimension",
           "target": "easyuse_anima/aio/usdu.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.usdu:_aio_usdu_auto_tile_dimension",
         "kind": "static_from",
-        "line": 75,
+        "line": 73,
         "name": "_aio_usdu_auto_tile_dimension",
         "optional": false,
         "requested": ".easyuse_anima.aio.usdu",
@@ -23021,7 +23004,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -23029,12 +23012,12 @@
         "compatibility_pair": {
           "bound_name": "_aio_usdu_tile_plan",
           "target": "easyuse_anima/aio/usdu.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.usdu:_aio_usdu_tile_plan",
         "kind": "static_from",
-        "line": 75,
+        "line": 73,
         "name": "_aio_usdu_tile_plan",
         "optional": false,
         "requested": ".easyuse_anima.aio.usdu",
@@ -23052,7 +23035,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -23060,12 +23043,12 @@
         "compatibility_pair": {
           "bound_name": "_aio_final_fit_size",
           "target": "easyuse_anima/aio/postprocess.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.postprocess:_aio_final_fit_size",
         "kind": "static_from",
-        "line": 79,
+        "line": 77,
         "name": "_aio_final_fit_size",
         "optional": false,
         "requested": ".easyuse_anima.aio.postprocess",
@@ -23083,7 +23066,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -23091,12 +23074,12 @@
         "compatibility_pair": {
           "bound_name": "_apply_aio_final_fit",
           "target": "easyuse_anima/aio/postprocess.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.postprocess:_apply_aio_final_fit",
         "kind": "static_from",
-        "line": 79,
+        "line": 77,
         "name": "_apply_aio_final_fit",
         "optional": false,
         "requested": ".easyuse_anima.aio.postprocess",
@@ -23114,7 +23097,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -23122,12 +23105,12 @@
         "compatibility_pair": {
           "bound_name": "_resize_image_to_size_if_needed",
           "target": "easyuse_anima/aio/postprocess.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.postprocess:_resize_image_to_size_if_needed",
         "kind": "static_from",
-        "line": 79,
+        "line": 77,
         "name": "_resize_image_to_size_if_needed",
         "optional": false,
         "requested": ".easyuse_anima.aio.postprocess",
@@ -23145,7 +23128,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -23153,12 +23136,12 @@
         "compatibility_pair": {
           "bound_name": "_run_aio_postprocess_stage",
           "target": "easyuse_anima/aio/postprocess.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.postprocess:_run_aio_postprocess_stage",
         "kind": "static_from",
-        "line": 79,
+        "line": 77,
         "name": "_run_aio_postprocess_stage",
         "optional": false,
         "requested": ".easyuse_anima.aio.postprocess",
@@ -23176,7 +23159,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -23184,12 +23167,12 @@
         "compatibility_pair": {
           "bound_name": "_aio_prompt_data_fields_for_usdu",
           "target": "easyuse_anima/aio/conditioning.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.conditioning:_aio_prompt_data_fields_for_usdu",
         "kind": "static_from",
-        "line": 85,
+        "line": 83,
         "name": "_aio_prompt_data_fields_for_usdu",
         "optional": false,
         "requested": ".easyuse_anima.aio.conditioning",
@@ -23207,7 +23190,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -23215,12 +23198,12 @@
         "compatibility_pair": {
           "bound_name": "_aio_usdu_conditioning",
           "target": "easyuse_anima/aio/conditioning.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.conditioning:_aio_usdu_conditioning",
         "kind": "static_from",
-        "line": 85,
+        "line": 83,
         "name": "_aio_usdu_conditioning",
         "optional": false,
         "requested": ".easyuse_anima.aio.conditioning",
@@ -23238,7 +23221,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -23246,12 +23229,12 @@
         "compatibility_pair": {
           "bound_name": "_aio_usdu_prompt_without_general",
           "target": "easyuse_anima/aio/conditioning.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.conditioning:_aio_usdu_prompt_without_general",
         "kind": "static_from",
-        "line": 85,
+        "line": 83,
         "name": "_aio_usdu_prompt_without_general",
         "optional": false,
         "requested": ".easyuse_anima.aio.conditioning",
@@ -23269,7 +23252,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -23277,12 +23260,12 @@
         "compatibility_pair": {
           "bound_name": "_aio_lora_stack_signature",
           "target": "easyuse_anima/aio/model_preparation.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_aio_lora_stack_signature",
         "kind": "static_from",
-        "line": 90,
+        "line": 88,
         "name": "_aio_lora_stack_signature",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -23300,7 +23283,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -23308,12 +23291,12 @@
         "compatibility_pair": {
           "bound_name": "_apply_aio_anima_dave_patch",
           "target": "easyuse_anima/aio/model_preparation.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_apply_aio_anima_dave_patch",
         "kind": "static_from",
-        "line": 90,
+        "line": 88,
         "name": "_apply_aio_anima_dave_patch",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -23331,7 +23314,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -23339,12 +23322,12 @@
         "compatibility_pair": {
           "bound_name": "_apply_aio_kj_model_patches",
           "target": "easyuse_anima/aio/model_preparation.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_apply_aio_kj_model_patches",
         "kind": "static_from",
-        "line": 90,
+        "line": 88,
         "name": "_apply_aio_kj_model_patches",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -23362,7 +23345,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -23370,12 +23353,12 @@
         "compatibility_pair": {
           "bound_name": "_apply_aio_lora_stack",
           "target": "easyuse_anima/aio/model_preparation.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_apply_aio_lora_stack",
         "kind": "static_from",
-        "line": 90,
+        "line": 88,
         "name": "_apply_aio_lora_stack",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -23393,7 +23376,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -23401,12 +23384,12 @@
         "compatibility_pair": {
           "bound_name": "_apply_aio_model_patches",
           "target": "easyuse_anima/aio/model_preparation.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_apply_aio_model_patches",
         "kind": "static_from",
-        "line": 90,
+        "line": 88,
         "name": "_apply_aio_model_patches",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -23424,7 +23407,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -23432,12 +23415,12 @@
         "compatibility_pair": {
           "bound_name": "_apply_aio_safe_pag_patch",
           "target": "easyuse_anima/aio/model_preparation.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_apply_aio_safe_pag_patch",
         "kind": "static_from",
-        "line": 90,
+        "line": 88,
         "name": "_apply_aio_safe_pag_patch",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -23455,7 +23438,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -23463,12 +23446,12 @@
         "compatibility_pair": {
           "bound_name": "_apply_aio_spectrum_correction_patch_for_comfy_sampler",
           "target": "easyuse_anima/aio/model_preparation.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_apply_aio_spectrum_correction_patch_for_comfy_sampler",
         "kind": "static_from",
-        "line": 90,
+        "line": 88,
         "name": "_apply_aio_spectrum_correction_patch_for_comfy_sampler",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -23486,7 +23469,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -23494,12 +23477,12 @@
         "compatibility_pair": {
           "bound_name": "_apply_aio_spectrum_forecast_patch_for_comfy_sampler",
           "target": "easyuse_anima/aio/model_preparation.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_apply_aio_spectrum_forecast_patch_for_comfy_sampler",
         "kind": "static_from",
-        "line": 90,
+        "line": 88,
         "name": "_apply_aio_spectrum_forecast_patch_for_comfy_sampler",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -23517,7 +23500,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -23525,12 +23508,12 @@
         "compatibility_pair": {
           "bound_name": "_apply_aio_spectrum_model_patches_for_comfy_sampler",
           "target": "easyuse_anima/aio/model_preparation.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_apply_aio_spectrum_model_patches_for_comfy_sampler",
         "kind": "static_from",
-        "line": 90,
+        "line": 88,
         "name": "_apply_aio_spectrum_model_patches_for_comfy_sampler",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -23548,7 +23531,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -23556,12 +23539,12 @@
         "compatibility_pair": {
           "bound_name": "_cleanup_aio_ephemeral_model",
           "target": "easyuse_anima/aio/model_preparation.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_cleanup_aio_ephemeral_model",
         "kind": "static_from",
-        "line": 90,
+        "line": 88,
         "name": "_cleanup_aio_ephemeral_model",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -23579,7 +23562,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -23587,12 +23570,12 @@
         "compatibility_pair": {
           "bound_name": "_normalize_aio_lora_stack",
           "target": "easyuse_anima/aio/model_preparation.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_normalize_aio_lora_stack",
         "kind": "static_from",
-        "line": 90,
+        "line": 88,
         "name": "_normalize_aio_lora_stack",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -23610,7 +23593,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -23618,12 +23601,12 @@
         "compatibility_pair": {
           "bound_name": "_patch_model_sampling_aura_flow",
           "target": "easyuse_anima/aio/model_preparation.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_patch_model_sampling_aura_flow",
         "kind": "static_from",
-        "line": 90,
+        "line": 88,
         "name": "_patch_model_sampling_aura_flow",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -23641,7 +23624,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -23649,12 +23632,12 @@
         "compatibility_pair": {
           "bound_name": "_aio_highres_effective_backend",
           "target": "easyuse_anima/aio/sampling.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_aio_highres_effective_backend",
         "kind": "static_from",
-        "line": 104,
+        "line": 102,
         "name": "_aio_highres_effective_backend",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -23672,7 +23655,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -23680,12 +23663,12 @@
         "compatibility_pair": {
           "bound_name": "_aio_stage_sampler_settings",
           "target": "easyuse_anima/aio/sampling.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_aio_stage_sampler_settings",
         "kind": "static_from",
-        "line": 104,
+        "line": 102,
         "name": "_aio_stage_sampler_settings",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -23703,7 +23686,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -23711,12 +23694,12 @@
         "compatibility_pair": {
           "bound_name": "_decode_latent_with_comfy",
           "target": "easyuse_anima/aio/sampling.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_decode_latent_with_comfy",
         "kind": "static_from",
-        "line": 104,
+        "line": 102,
         "name": "_decode_latent_with_comfy",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -23734,7 +23717,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -23742,12 +23725,12 @@
         "compatibility_pair": {
           "bound_name": "_encode_image_with_comfy_vae",
           "target": "easyuse_anima/aio/sampling.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_encode_image_with_comfy_vae",
         "kind": "static_from",
-        "line": 104,
+        "line": 102,
         "name": "_encode_image_with_comfy_vae",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -23765,7 +23748,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -23773,12 +23756,12 @@
         "compatibility_pair": {
           "bound_name": "_generate_empty_latent_with_comfy",
           "target": "easyuse_anima/aio/sampling.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_generate_empty_latent_with_comfy",
         "kind": "static_from",
-        "line": 104,
+        "line": 102,
         "name": "_generate_empty_latent_with_comfy",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -23796,7 +23779,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -23804,12 +23787,12 @@
         "compatibility_pair": {
           "bound_name": "_new_aio_random_seed",
           "target": "easyuse_anima/aio/sampling.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_new_aio_random_seed",
         "kind": "static_from",
-        "line": 104,
+        "line": 102,
         "name": "_new_aio_random_seed",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -23827,7 +23810,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -23835,12 +23818,12 @@
         "compatibility_pair": {
           "bound_name": "_resolve_aio_runtime_seed",
           "target": "easyuse_anima/aio/sampling.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_resolve_aio_runtime_seed",
         "kind": "static_from",
-        "line": 104,
+        "line": 102,
         "name": "_resolve_aio_runtime_seed",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -23858,7 +23841,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -23866,12 +23849,12 @@
         "compatibility_pair": {
           "bound_name": "_sample_latent_with_aio_backend",
           "target": "easyuse_anima/aio/sampling.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_sample_latent_with_aio_backend",
         "kind": "static_from",
-        "line": 104,
+        "line": 102,
         "name": "_sample_latent_with_aio_backend",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -23889,7 +23872,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -23897,12 +23880,12 @@
         "compatibility_pair": {
           "bound_name": "_sample_latent_with_comfy",
           "target": "easyuse_anima/aio/sampling.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_sample_latent_with_comfy",
         "kind": "static_from",
-        "line": 104,
+        "line": 102,
         "name": "_sample_latent_with_comfy",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -23920,7 +23903,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -23928,12 +23911,12 @@
         "compatibility_pair": {
           "bound_name": "_sample_latent_with_spectrum_mod_guidance_advanced",
           "target": "easyuse_anima/aio/sampling.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_sample_latent_with_spectrum_mod_guidance_advanced",
         "kind": "static_from",
-        "line": 104,
+        "line": 102,
         "name": "_sample_latent_with_spectrum_mod_guidance_advanced",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -23951,7 +23934,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -23959,12 +23942,12 @@
         "compatibility_pair": {
           "bound_name": "_sample_latent_with_spectrum_spd",
           "target": "easyuse_anima/aio/sampling.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_sample_latent_with_spectrum_spd",
         "kind": "static_from",
-        "line": 104,
+        "line": 102,
         "name": "_sample_latent_with_spectrum_spd",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -23982,7 +23965,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -23990,12 +23973,12 @@
         "compatibility_pair": {
           "bound_name": "AIO_PREVIEW_CACHE_FORMAT",
           "target": "easyuse_anima/aio/preview.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.preview:AIO_PREVIEW_CACHE_FORMAT",
         "kind": "static_from",
-        "line": 117,
+        "line": 115,
         "name": "AIO_PREVIEW_CACHE_FORMAT",
         "optional": false,
         "requested": ".easyuse_anima.aio.preview",
@@ -24013,7 +23996,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -24021,12 +24004,12 @@
         "compatibility_pair": {
           "bound_name": "AIO_PREVIEW_CACHE_QUALITY",
           "target": "easyuse_anima/aio/preview.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.preview:AIO_PREVIEW_CACHE_QUALITY",
         "kind": "static_from",
-        "line": 117,
+        "line": 115,
         "name": "AIO_PREVIEW_CACHE_QUALITY",
         "optional": false,
         "requested": ".easyuse_anima.aio.preview",
@@ -24044,7 +24027,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -24052,12 +24035,12 @@
         "compatibility_pair": {
           "bound_name": "AIO_PREVIEW_EVENT",
           "target": "easyuse_anima/aio/preview.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.preview:AIO_PREVIEW_EVENT",
         "kind": "static_from",
-        "line": 117,
+        "line": 115,
         "name": "AIO_PREVIEW_EVENT",
         "optional": false,
         "requested": ".easyuse_anima.aio.preview",
@@ -24075,7 +24058,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -24083,12 +24066,12 @@
         "compatibility_pair": {
           "bound_name": "AIO_PREVIEW_STAGE_LABELS",
           "target": "easyuse_anima/aio/preview.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.preview:AIO_PREVIEW_STAGE_LABELS",
         "kind": "static_from",
-        "line": 117,
+        "line": 115,
         "name": "AIO_PREVIEW_STAGE_LABELS",
         "optional": false,
         "requested": ".easyuse_anima.aio.preview",
@@ -24106,7 +24089,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -24114,12 +24097,12 @@
         "compatibility_pair": {
           "bound_name": "_aio_preview_base_directory",
           "target": "easyuse_anima/aio/preview.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.preview:_aio_preview_base_directory",
         "kind": "static_from",
-        "line": 117,
+        "line": 115,
         "name": "_aio_preview_base_directory",
         "optional": false,
         "requested": ".easyuse_anima.aio.preview",
@@ -24137,7 +24120,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -24145,12 +24128,12 @@
         "compatibility_pair": {
           "bound_name": "_aio_preview_file_size_bytes",
           "target": "easyuse_anima/aio/preview.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.preview:_aio_preview_file_size_bytes",
         "kind": "static_from",
-        "line": 117,
+        "line": 115,
         "name": "_aio_preview_file_size_bytes",
         "optional": false,
         "requested": ".easyuse_anima.aio.preview",
@@ -24168,7 +24151,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -24176,12 +24159,12 @@
         "compatibility_pair": {
           "bound_name": "_save_aio_temp_preview_image",
           "target": "easyuse_anima/aio/preview.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.preview:_save_aio_temp_preview_image",
         "kind": "static_from",
-        "line": 117,
+        "line": 115,
         "name": "_save_aio_temp_preview_image",
         "optional": false,
         "requested": ".easyuse_anima.aio.preview",
@@ -24199,7 +24182,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -24207,12 +24190,12 @@
         "compatibility_pair": {
           "bound_name": "_send_aio_preview_event",
           "target": "easyuse_anima/aio/preview.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.preview:_send_aio_preview_event",
         "kind": "static_from",
-        "line": 117,
+        "line": 115,
         "name": "_send_aio_preview_event",
         "optional": false,
         "requested": ".easyuse_anima.aio.preview",
@@ -24230,7 +24213,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -24238,12 +24221,12 @@
         "compatibility_pair": {
           "bound_name": "_tag_aio_preview_images",
           "target": "easyuse_anima/aio/preview.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.preview:_tag_aio_preview_images",
         "kind": "static_from",
-        "line": 117,
+        "line": 115,
         "name": "_tag_aio_preview_images",
         "optional": false,
         "requested": ".easyuse_anima.aio.preview",
@@ -24261,7 +24244,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -24269,12 +24252,12 @@
         "compatibility_pair": {
           "bound_name": "_aio_image_saver_additional_hashes",
           "target": "easyuse_anima/aio/output.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.output:_aio_image_saver_additional_hashes",
         "kind": "static_from",
-        "line": 128,
+        "line": 126,
         "name": "_aio_image_saver_additional_hashes",
         "optional": false,
         "requested": ".easyuse_anima.aio.output",
@@ -24292,7 +24275,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -24300,12 +24283,12 @@
         "compatibility_pair": {
           "bound_name": "_aio_image_saver_civitai_hash_fetcher_entries",
           "target": "easyuse_anima/aio/output.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.output:_aio_image_saver_civitai_hash_fetcher_entries",
         "kind": "static_from",
-        "line": 128,
+        "line": 126,
         "name": "_aio_image_saver_civitai_hash_fetcher_entries",
         "optional": false,
         "requested": ".easyuse_anima.aio.output",
@@ -24323,7 +24306,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -24331,12 +24314,12 @@
         "compatibility_pair": {
           "bound_name": "_aio_lora_metadata_name",
           "target": "easyuse_anima/aio/output.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.output:_aio_lora_metadata_name",
         "kind": "static_from",
-        "line": 128,
+        "line": 126,
         "name": "_aio_lora_metadata_name",
         "optional": false,
         "requested": ".easyuse_anima.aio.output",
@@ -24354,7 +24337,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -24362,12 +24345,12 @@
         "compatibility_pair": {
           "bound_name": "_aio_prompt_with_lora_metadata",
           "target": "easyuse_anima/aio/output.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.output:_aio_prompt_with_lora_metadata",
         "kind": "static_from",
-        "line": 128,
+        "line": 126,
         "name": "_aio_prompt_with_lora_metadata",
         "optional": false,
         "requested": ".easyuse_anima.aio.output",
@@ -24385,7 +24368,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -24393,12 +24376,12 @@
         "compatibility_pair": {
           "bound_name": "_aio_save_filename_prefix",
           "target": "easyuse_anima/aio/output.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.output:_aio_save_filename_prefix",
         "kind": "static_from",
-        "line": 128,
+        "line": 126,
         "name": "_aio_save_filename_prefix",
         "optional": false,
         "requested": ".easyuse_anima.aio.output",
@@ -24416,7 +24399,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -24424,12 +24407,12 @@
         "compatibility_pair": {
           "bound_name": "_save_image_with_comfy",
           "target": "easyuse_anima/aio/output.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.output:_save_image_with_comfy",
         "kind": "static_from",
-        "line": 128,
+        "line": 126,
         "name": "_save_image_with_comfy",
         "optional": false,
         "requested": ".easyuse_anima.aio.output",
@@ -24447,7 +24430,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -24455,12 +24438,12 @@
         "compatibility_pair": {
           "bound_name": "_save_image_with_image_saver",
           "target": "easyuse_anima/aio/output.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.output:_save_image_with_image_saver",
         "kind": "static_from",
-        "line": 128,
+        "line": 126,
         "name": "_save_image_with_image_saver",
         "optional": false,
         "requested": ".easyuse_anima.aio.output",
@@ -24478,7 +24461,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -24486,12 +24469,12 @@
         "compatibility_pair": {
           "bound_name": "_normalize_aio_civitai_hash_fetchers",
           "target": "easyuse_anima/aio/output_settings.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.output_settings:_normalize_aio_civitai_hash_fetchers",
         "kind": "static_from",
-        "line": 137,
+        "line": 135,
         "name": "_normalize_aio_civitai_hash_fetchers",
         "optional": false,
         "requested": ".easyuse_anima.aio.output_settings",
@@ -24509,7 +24492,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -24517,12 +24500,12 @@
         "compatibility_pair": {
           "bound_name": "_normalize_aio_hash_bundles",
           "target": "easyuse_anima/aio/output_settings.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.output_settings:_normalize_aio_hash_bundles",
         "kind": "static_from",
-        "line": 137,
+        "line": 135,
         "name": "_normalize_aio_hash_bundles",
         "optional": false,
         "requested": ".easyuse_anima.aio.output_settings",
@@ -24540,7 +24523,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -24548,12 +24531,12 @@
         "compatibility_pair": {
           "bound_name": "_comfy_clip_loader_types",
           "target": "easyuse_anima/aio/resources.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_comfy_clip_loader_types",
         "kind": "static_from",
-        "line": 141,
+        "line": 139,
         "name": "_comfy_clip_loader_types",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -24571,7 +24554,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -24579,12 +24562,12 @@
         "compatibility_pair": {
           "bound_name": "_comfy_diffusion_model_names",
           "target": "easyuse_anima/aio/resources.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_comfy_diffusion_model_names",
         "kind": "static_from",
-        "line": 141,
+        "line": 139,
         "name": "_comfy_diffusion_model_names",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -24602,7 +24585,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -24610,12 +24593,12 @@
         "compatibility_pair": {
           "bound_name": "_comfy_text_encoder_names",
           "target": "easyuse_anima/aio/resources.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_comfy_text_encoder_names",
         "kind": "static_from",
-        "line": 141,
+        "line": 139,
         "name": "_comfy_text_encoder_names",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -24633,7 +24616,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -24641,12 +24624,12 @@
         "compatibility_pair": {
           "bound_name": "_comfy_vae_names",
           "target": "easyuse_anima/aio/resources.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_comfy_vae_names",
         "kind": "static_from",
-        "line": 141,
+        "line": 139,
         "name": "_comfy_vae_names",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -24664,7 +24647,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -24672,12 +24655,12 @@
         "compatibility_pair": {
           "bound_name": "_load_aio_resources_from_input_context",
           "target": "easyuse_anima/aio/resources.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_load_aio_resources_from_input_context",
         "kind": "static_from",
-        "line": 141,
+        "line": 139,
         "name": "_load_aio_resources_from_input_context",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -24695,7 +24678,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -24703,12 +24686,12 @@
         "compatibility_pair": {
           "bound_name": "_load_aio_sam3_context",
           "target": "easyuse_anima/aio/resources.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_load_aio_sam3_context",
         "kind": "static_from",
-        "line": 141,
+        "line": 139,
         "name": "_load_aio_sam3_context",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -24726,7 +24709,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -24734,12 +24717,12 @@
         "compatibility_pair": {
           "bound_name": "_load_checkpoint_with_comfy",
           "target": "easyuse_anima/aio/resources.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_load_checkpoint_with_comfy",
         "kind": "static_from",
-        "line": 141,
+        "line": 139,
         "name": "_load_checkpoint_with_comfy",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -24757,7 +24740,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -24765,12 +24748,12 @@
         "compatibility_pair": {
           "bound_name": "_load_clip_with_comfy",
           "target": "easyuse_anima/aio/resources.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_load_clip_with_comfy",
         "kind": "static_from",
-        "line": 141,
+        "line": 139,
         "name": "_load_clip_with_comfy",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -24788,7 +24771,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -24796,12 +24779,12 @@
         "compatibility_pair": {
           "bound_name": "_load_diffusion_model_with_comfy",
           "target": "easyuse_anima/aio/resources.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_load_diffusion_model_with_comfy",
         "kind": "static_from",
-        "line": 141,
+        "line": 139,
         "name": "_load_diffusion_model_with_comfy",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -24819,7 +24802,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -24827,12 +24810,12 @@
         "compatibility_pair": {
           "bound_name": "_load_upscale_model_with_comfy",
           "target": "easyuse_anima/aio/resources.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_load_upscale_model_with_comfy",
         "kind": "static_from",
-        "line": 141,
+        "line": 139,
         "name": "_load_upscale_model_with_comfy",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -24850,7 +24833,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -24858,12 +24841,12 @@
         "compatibility_pair": {
           "bound_name": "_load_vae_with_comfy",
           "target": "easyuse_anima/aio/resources.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_load_vae_with_comfy",
         "kind": "static_from",
-        "line": 141,
+        "line": 139,
         "name": "_load_vae_with_comfy",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -24881,7 +24864,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -24889,12 +24872,12 @@
         "compatibility_pair": {
           "bound_name": "_normalize_aio_input_settings",
           "target": "easyuse_anima/aio/resources.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_normalize_aio_input_settings",
         "kind": "static_from",
-        "line": 141,
+        "line": 139,
         "name": "_normalize_aio_input_settings",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -24912,7 +24895,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -24920,12 +24903,12 @@
         "compatibility_pair": {
           "bound_name": "_preferred_checkpoint_default",
           "target": "easyuse_anima/aio/resources.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_preferred_checkpoint_default",
         "kind": "static_from",
-        "line": 141,
+        "line": 139,
         "name": "_preferred_checkpoint_default",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -24943,7 +24926,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -24951,12 +24934,12 @@
         "compatibility_pair": {
           "bound_name": "_preferred_clip_type_default",
           "target": "easyuse_anima/aio/resources.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_preferred_clip_type_default",
         "kind": "static_from",
-        "line": 141,
+        "line": 139,
         "name": "_preferred_clip_type_default",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -24974,7 +24957,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -24982,12 +24965,12 @@
         "compatibility_pair": {
           "bound_name": "_preferred_name_default",
           "target": "easyuse_anima/aio/resources.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_preferred_name_default",
         "kind": "static_from",
-        "line": 141,
+        "line": 139,
         "name": "_preferred_name_default",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -25005,7 +24988,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -25013,12 +24996,12 @@
         "compatibility_pair": {
           "bound_name": "_json_clone",
           "target": "easyuse_anima/common/serialization.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.common.serialization:_json_clone",
         "kind": "static_from",
-        "line": 158,
+        "line": 156,
         "name": "_json_clone",
         "optional": false,
         "requested": ".easyuse_anima.common.serialization",
@@ -25036,7 +25019,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -25044,12 +25027,12 @@
         "compatibility_pair": {
           "bound_name": "_json_object",
           "target": "easyuse_anima/common/serialization.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.common.serialization:_json_object",
         "kind": "static_from",
-        "line": 158,
+        "line": 156,
         "name": "_json_object",
         "optional": false,
         "requested": ".easyuse_anima.common.serialization",
@@ -25067,7 +25050,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -25075,12 +25058,12 @@
         "compatibility_pair": {
           "bound_name": "_stable_change_key",
           "target": "easyuse_anima/common/serialization.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.common.serialization:_stable_change_key",
         "kind": "static_from",
-        "line": 158,
+        "line": 156,
         "name": "_stable_change_key",
         "optional": false,
         "requested": ".easyuse_anima.common.serialization",
@@ -25098,7 +25081,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -25106,12 +25089,12 @@
         "compatibility_pair": {
           "bound_name": "_as_bool",
           "target": "easyuse_anima/common/values.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.common.values:_as_bool",
         "kind": "static_from",
-        "line": 163,
+        "line": 161,
         "name": "_as_bool",
         "optional": false,
         "requested": ".easyuse_anima.common.values",
@@ -25129,7 +25112,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -25137,12 +25120,12 @@
         "compatibility_pair": {
           "bound_name": "_as_float",
           "target": "easyuse_anima/common/values.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.common.values:_as_float",
         "kind": "static_from",
-        "line": 163,
+        "line": 161,
         "name": "_as_float",
         "optional": false,
         "requested": ".easyuse_anima.common.values",
@@ -25160,7 +25143,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -25168,12 +25151,12 @@
         "compatibility_pair": {
           "bound_name": "_as_int",
           "target": "easyuse_anima/common/values.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.common.values:_as_int",
         "kind": "static_from",
-        "line": 163,
+        "line": 161,
         "name": "_as_int",
         "optional": false,
         "requested": ".easyuse_anima.common.values",
@@ -25191,7 +25174,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -25199,12 +25182,12 @@
         "compatibility_pair": {
           "bound_name": "_choice",
           "target": "easyuse_anima/common/values.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.common.values:_choice",
         "kind": "static_from",
-        "line": 163,
+        "line": 161,
         "name": "_choice",
         "optional": false,
         "requested": ".easyuse_anima.common.values",
@@ -25222,7 +25205,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -25230,12 +25213,12 @@
         "compatibility_pair": {
           "bound_name": "_single_value",
           "target": "easyuse_anima/common/values.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.common.values:_single_value",
         "kind": "static_from",
-        "line": 163,
+        "line": 161,
         "name": "_single_value",
         "optional": false,
         "requested": ".easyuse_anima.common.values",
@@ -25253,7 +25236,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -25261,12 +25244,12 @@
         "compatibility_pair": {
           "bound_name": "WILDCARD_QUEUE_MAX_SAFE_SEED",
           "target": "easyuse_anima/seed/compatibility.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.seed.compatibility:WILDCARD_QUEUE_MAX_SAFE_SEED",
         "kind": "static_from",
-        "line": 170,
+        "line": 168,
         "name": "WILDCARD_QUEUE_MAX_SAFE_SEED",
         "optional": false,
         "requested": ".easyuse_anima.seed.compatibility",
@@ -25284,7 +25267,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -25292,12 +25275,12 @@
         "compatibility_pair": {
           "bound_name": "WILDCARD_RESERVED_NEXT_SEED_INPUT",
           "target": "easyuse_anima/seed/compatibility.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.seed.compatibility:WILDCARD_RESERVED_NEXT_SEED_INPUT",
         "kind": "static_from",
-        "line": 170,
+        "line": 168,
         "name": "WILDCARD_RESERVED_NEXT_SEED_INPUT",
         "optional": false,
         "requested": ".easyuse_anima.seed.compatibility",
@@ -25315,7 +25298,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -25323,12 +25306,12 @@
         "compatibility_pair": {
           "bound_name": "_consume_reserved_wildcard_next_seed",
           "target": "easyuse_anima/seed/compatibility.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.seed.compatibility:_consume_reserved_wildcard_next_seed",
         "kind": "static_from",
-        "line": 170,
+        "line": 168,
         "name": "_consume_reserved_wildcard_next_seed",
         "optional": false,
         "requested": ".easyuse_anima.seed.compatibility",
@@ -25346,7 +25329,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -25354,12 +25337,12 @@
         "compatibility_pair": {
           "bound_name": "_get_workflow_node",
           "target": "easyuse_anima/workflow.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.workflow:_get_workflow_node",
         "kind": "static_from",
-        "line": 175,
+        "line": 173,
         "name": "_get_workflow_node",
         "optional": false,
         "requested": ".easyuse_anima.workflow",
@@ -25377,7 +25360,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -25385,12 +25368,12 @@
         "compatibility_pair": {
           "bound_name": "_prompt_translation_change_key",
           "target": "easyuse_anima/prompt/correction.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.correction:_prompt_translation_change_key",
         "kind": "static_from",
-        "line": 176,
+        "line": 174,
         "name": "_prompt_translation_change_key",
         "optional": false,
         "requested": ".easyuse_anima.prompt.correction",
@@ -25408,7 +25391,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -25416,12 +25399,12 @@
         "compatibility_pair": {
           "bound_name": "_split_tag_text",
           "target": "easyuse_anima/prompt/correction.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.correction:_split_tag_text",
         "kind": "static_from",
-        "line": 176,
+        "line": 174,
         "name": "_split_tag_text",
         "optional": false,
         "requested": ".easyuse_anima.prompt.correction",
@@ -25439,7 +25422,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -25447,12 +25430,12 @@
         "compatibility_pair": {
           "bound_name": "_translate_prompt_text",
           "target": "easyuse_anima/prompt/correction.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.correction:_translate_prompt_text",
         "kind": "static_from",
-        "line": 176,
+        "line": 174,
         "name": "_translate_prompt_text",
         "optional": false,
         "requested": ".easyuse_anima.prompt.correction",
@@ -25470,7 +25453,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -25478,12 +25461,12 @@
         "compatibility_pair": {
           "bound_name": "_HASH_COMMENT_RE",
           "target": "easyuse_anima/prompt/fields.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_HASH_COMMENT_RE",
         "kind": "static_from",
-        "line": 181,
+        "line": 179,
         "name": "_HASH_COMMENT_RE",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -25501,7 +25484,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -25509,12 +25492,12 @@
         "compatibility_pair": {
           "bound_name": "_INLINE_SPACE_RE",
           "target": "easyuse_anima/prompt/fields.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_INLINE_SPACE_RE",
         "kind": "static_from",
-        "line": 181,
+        "line": 179,
         "name": "_INLINE_SPACE_RE",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -25532,7 +25515,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -25540,12 +25523,12 @@
         "compatibility_pair": {
           "bound_name": "_WEIGHTED_TOKEN_RE",
           "target": "easyuse_anima/prompt/fields.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_WEIGHTED_TOKEN_RE",
         "kind": "static_from",
-        "line": 181,
+        "line": 179,
         "name": "_WEIGHTED_TOKEN_RE",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -25563,7 +25546,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -25571,12 +25554,12 @@
         "compatibility_pair": {
           "bound_name": "_correct_builder_prompt",
           "target": "easyuse_anima/prompt/fields.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_correct_builder_prompt",
         "kind": "static_from",
-        "line": 181,
+        "line": 179,
         "name": "_correct_builder_prompt",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -25594,7 +25577,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -25602,12 +25585,12 @@
         "compatibility_pair": {
           "bound_name": "_filter_metadata_prompt",
           "target": "easyuse_anima/prompt/fields.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_filter_metadata_prompt",
         "kind": "static_from",
-        "line": 181,
+        "line": 179,
         "name": "_filter_metadata_prompt",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -25625,7 +25608,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -25633,12 +25616,12 @@
         "compatibility_pair": {
           "bound_name": "_join_prompt_tokens",
           "target": "easyuse_anima/prompt/fields.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_join_prompt_tokens",
         "kind": "static_from",
-        "line": 181,
+        "line": 179,
         "name": "_join_prompt_tokens",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -25656,7 +25639,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -25664,12 +25647,12 @@
         "compatibility_pair": {
           "bound_name": "_metadata_filter_key",
           "target": "easyuse_anima/prompt/fields.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_metadata_filter_key",
         "kind": "static_from",
-        "line": 181,
+        "line": 179,
         "name": "_metadata_filter_key",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -25687,7 +25670,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -25695,12 +25678,12 @@
         "compatibility_pair": {
           "bound_name": "_metadata_filter_keys",
           "target": "easyuse_anima/prompt/fields.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_metadata_filter_keys",
         "kind": "static_from",
-        "line": 181,
+        "line": 179,
         "name": "_metadata_filter_keys",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -25718,7 +25701,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -25726,12 +25709,12 @@
         "compatibility_pair": {
           "bound_name": "_prompt_tokens",
           "target": "easyuse_anima/prompt/fields.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_prompt_tokens",
         "kind": "static_from",
-        "line": 181,
+        "line": 179,
         "name": "_prompt_tokens",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -25749,7 +25732,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -25757,12 +25740,12 @@
         "compatibility_pair": {
           "bound_name": "PROMPT_DATA_TYPE",
           "target": "easyuse_anima/prompt/data.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:PROMPT_DATA_TYPE",
         "kind": "static_from",
-        "line": 194,
+        "line": 192,
         "name": "PROMPT_DATA_TYPE",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -25780,7 +25763,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -25788,12 +25771,12 @@
         "compatibility_pair": {
           "bound_name": "_advanced_outputs_from_prompt_data",
           "target": "easyuse_anima/prompt/data.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:_advanced_outputs_from_prompt_data",
         "kind": "static_from",
-        "line": 194,
+        "line": 192,
         "name": "_advanced_outputs_from_prompt_data",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -25811,7 +25794,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -25819,12 +25802,12 @@
         "compatibility_pair": {
           "bound_name": "_apply_prompt_data_overrides",
           "target": "easyuse_anima/prompt/data.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:_apply_prompt_data_overrides",
         "kind": "static_from",
-        "line": 194,
+        "line": 192,
         "name": "_apply_prompt_data_overrides",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -25842,7 +25825,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -25850,12 +25833,12 @@
         "compatibility_pair": {
           "bound_name": "_copy_prompt_data_for_update",
           "target": "easyuse_anima/prompt/data.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:_copy_prompt_data_for_update",
         "kind": "static_from",
-        "line": 194,
+        "line": 192,
         "name": "_copy_prompt_data_for_update",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -25873,7 +25856,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -25881,12 +25864,12 @@
         "compatibility_pair": {
           "bound_name": "_normalize_prompt_data",
           "target": "easyuse_anima/prompt/data.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:_normalize_prompt_data",
         "kind": "static_from",
-        "line": 194,
+        "line": 192,
         "name": "_normalize_prompt_data",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -25904,7 +25887,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -25912,12 +25895,12 @@
         "compatibility_pair": {
           "bound_name": "_prompt_data_json_safe",
           "target": "easyuse_anima/prompt/data.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:_prompt_data_json_safe",
         "kind": "static_from",
-        "line": 194,
+        "line": 192,
         "name": "_prompt_data_json_safe",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -25935,7 +25918,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -25943,12 +25926,12 @@
         "compatibility_pair": {
           "bound_name": "_prompt_data_parameter_snapshot",
           "target": "easyuse_anima/prompt/data.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:_prompt_data_parameter_snapshot",
         "kind": "static_from",
-        "line": 194,
+        "line": 192,
         "name": "_prompt_data_parameter_snapshot",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -25966,7 +25949,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -25974,12 +25957,12 @@
         "compatibility_pair": {
           "bound_name": "_advanced_artist_field_prompt",
           "target": "easyuse_anima/prompt/advanced.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_artist_field_prompt",
         "kind": "static_from",
-        "line": 212,
+        "line": 210,
         "name": "_advanced_artist_field_prompt",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -25997,7 +25980,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -26005,12 +25988,12 @@
         "compatibility_pair": {
           "bound_name": "_advanced_default_fields",
           "target": "easyuse_anima/prompt/advanced.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_default_fields",
         "kind": "static_from",
-        "line": 212,
+        "line": 210,
         "name": "_advanced_default_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -26028,7 +26011,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -26036,12 +26019,12 @@
         "compatibility_pair": {
           "bound_name": "_advanced_enabled_naia_panes",
           "target": "easyuse_anima/prompt/advanced.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_enabled_naia_panes",
         "kind": "static_from",
-        "line": 212,
+        "line": 210,
         "name": "_advanced_enabled_naia_panes",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -26059,7 +26042,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -26067,12 +26050,12 @@
         "compatibility_pair": {
           "bound_name": "_advanced_enabled_pane_fields",
           "target": "easyuse_anima/prompt/advanced.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_enabled_pane_fields",
         "kind": "static_from",
-        "line": 212,
+        "line": 210,
         "name": "_advanced_enabled_pane_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -26090,7 +26073,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -26098,12 +26081,12 @@
         "compatibility_pair": {
           "bound_name": "_advanced_field_input_values",
           "target": "easyuse_anima/prompt/advanced.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_field_input_values",
         "kind": "static_from",
-        "line": 212,
+        "line": 210,
         "name": "_advanced_field_input_values",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -26121,7 +26104,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -26129,12 +26112,12 @@
         "compatibility_pair": {
           "bound_name": "_advanced_field_socket_name",
           "target": "easyuse_anima/prompt/advanced.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_field_socket_name",
         "kind": "static_from",
-        "line": 212,
+        "line": 210,
         "name": "_advanced_field_socket_name",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -26152,7 +26135,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -26160,12 +26143,12 @@
         "compatibility_pair": {
           "bound_name": "_advanced_fields_json",
           "target": "easyuse_anima/prompt/advanced.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_fields_json",
         "kind": "static_from",
-        "line": 212,
+        "line": 210,
         "name": "_advanced_fields_json",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -26183,7 +26166,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -26191,12 +26174,12 @@
         "compatibility_pair": {
           "bound_name": "_advanced_has_enabled_naia",
           "target": "easyuse_anima/prompt/advanced.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_has_enabled_naia",
         "kind": "static_from",
-        "line": 212,
+        "line": 210,
         "name": "_advanced_has_enabled_naia",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -26214,7 +26197,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -26222,12 +26205,12 @@
         "compatibility_pair": {
           "bound_name": "_advanced_prompt_with_artist_override",
           "target": "easyuse_anima/prompt/advanced.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_prompt_with_artist_override",
         "kind": "static_from",
-        "line": 212,
+        "line": 210,
         "name": "_advanced_prompt_with_artist_override",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -26245,7 +26228,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -26253,12 +26236,12 @@
         "compatibility_pair": {
           "bound_name": "_advanced_uses_naia_resolution",
           "target": "easyuse_anima/prompt/advanced.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_uses_naia_resolution",
         "kind": "static_from",
-        "line": 212,
+        "line": 210,
         "name": "_advanced_uses_naia_resolution",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -26276,7 +26259,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -26284,12 +26267,12 @@
         "compatibility_pair": {
           "bound_name": "_apply_advanced_field_inputs",
           "target": "easyuse_anima/prompt/advanced.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_apply_advanced_field_inputs",
         "kind": "static_from",
-        "line": 212,
+        "line": 210,
         "name": "_apply_advanced_field_inputs",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -26307,7 +26290,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -26315,12 +26298,12 @@
         "compatibility_pair": {
           "bound_name": "_as_advanced_height",
           "target": "easyuse_anima/prompt/advanced.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_as_advanced_height",
         "kind": "static_from",
-        "line": 212,
+        "line": 210,
         "name": "_as_advanced_height",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -26338,7 +26321,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -26346,12 +26329,12 @@
         "compatibility_pair": {
           "bound_name": "_build_advanced_prompt_data",
           "target": "easyuse_anima/prompt/advanced.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_build_advanced_prompt_data",
         "kind": "static_from",
-        "line": 212,
+        "line": 210,
         "name": "_build_advanced_prompt_data",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -26369,7 +26352,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -26377,12 +26360,12 @@
         "compatibility_pair": {
           "bound_name": "_build_advanced_prompts",
           "target": "easyuse_anima/prompt/advanced.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_build_advanced_prompts",
         "kind": "static_from",
-        "line": 212,
+        "line": 210,
         "name": "_build_advanced_prompts",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -26400,7 +26383,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -26408,12 +26391,12 @@
         "compatibility_pair": {
           "bound_name": "_clone_advanced_fields",
           "target": "easyuse_anima/prompt/advanced.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_clone_advanced_fields",
         "kind": "static_from",
-        "line": 212,
+        "line": 210,
         "name": "_clone_advanced_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -26431,7 +26414,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -26439,12 +26422,12 @@
         "compatibility_pair": {
           "bound_name": "_correct_advanced_field_sequence",
           "target": "easyuse_anima/prompt/advanced.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_correct_advanced_field_sequence",
         "kind": "static_from",
-        "line": 212,
+        "line": 210,
         "name": "_correct_advanced_field_sequence",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -26462,7 +26445,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -26470,12 +26453,12 @@
         "compatibility_pair": {
           "bound_name": "_expand_advanced_wildcard_fields",
           "target": "easyuse_anima/prompt/advanced.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_expand_advanced_wildcard_fields",
         "kind": "static_from",
-        "line": 212,
+        "line": 210,
         "name": "_expand_advanced_wildcard_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -26493,7 +26476,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -26501,12 +26484,12 @@
         "compatibility_pair": {
           "bound_name": "_normalize_advanced_fields",
           "target": "easyuse_anima/prompt/advanced.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_normalize_advanced_fields",
         "kind": "static_from",
-        "line": 212,
+        "line": 210,
         "name": "_normalize_advanced_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -26524,7 +26507,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -26532,12 +26515,12 @@
         "compatibility_pair": {
           "bound_name": "_normalize_prompt_studio_wildcard_seed_control",
           "target": "easyuse_anima/prompt/advanced.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_normalize_prompt_studio_wildcard_seed_control",
         "kind": "static_from",
-        "line": 212,
+        "line": 210,
         "name": "_normalize_prompt_studio_wildcard_seed_control",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -26555,7 +26538,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -26563,12 +26546,12 @@
         "compatibility_pair": {
           "bound_name": "_set_naia_field_text",
           "target": "easyuse_anima/prompt/advanced.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_set_naia_field_text",
         "kind": "static_from",
-        "line": 212,
+        "line": 210,
         "name": "_set_naia_field_text",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -26586,7 +26569,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -26594,12 +26577,12 @@
         "compatibility_pair": {
           "bound_name": "_translate_prompt_fields",
           "target": "easyuse_anima/prompt/advanced.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_translate_prompt_fields",
         "kind": "static_from",
-        "line": 212,
+        "line": 210,
         "name": "_translate_prompt_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -26617,7 +26600,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -26625,12 +26608,12 @@
         "compatibility_pair": {
           "bound_name": "_apply_regional_field_inputs",
           "target": "easyuse_anima/prompt/regional.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_apply_regional_field_inputs",
         "kind": "static_from",
-        "line": 247,
+        "line": 245,
         "name": "_apply_regional_field_inputs",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -26648,7 +26631,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -26656,12 +26639,12 @@
         "compatibility_pair": {
           "bound_name": "_build_regional_outputs",
           "target": "easyuse_anima/prompt/regional.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_build_regional_outputs",
         "kind": "static_from",
-        "line": 247,
+        "line": 245,
         "name": "_build_regional_outputs",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -26679,7 +26662,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -26687,12 +26670,12 @@
         "compatibility_pair": {
           "bound_name": "_clone_regional_fields",
           "target": "easyuse_anima/prompt/regional.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_clone_regional_fields",
         "kind": "static_from",
-        "line": 247,
+        "line": 245,
         "name": "_clone_regional_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -26710,7 +26693,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -26718,12 +26701,12 @@
         "compatibility_pair": {
           "bound_name": "_conditioning_set_values",
           "target": "easyuse_anima/prompt/regional.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_conditioning_set_values",
         "kind": "static_from",
-        "line": 247,
+        "line": 245,
         "name": "_conditioning_set_values",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -26741,7 +26724,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -26749,12 +26732,12 @@
         "compatibility_pair": {
           "bound_name": "_normalize_mask_ids",
           "target": "easyuse_anima/prompt/regional.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_normalize_mask_ids",
         "kind": "static_from",
-        "line": 247,
+        "line": 245,
         "name": "_normalize_mask_ids",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -26772,7 +26755,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -26780,12 +26763,12 @@
         "compatibility_pair": {
           "bound_name": "_normalize_regional_config",
           "target": "easyuse_anima/prompt/regional.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_normalize_regional_config",
         "kind": "static_from",
-        "line": 247,
+        "line": 245,
         "name": "_normalize_regional_config",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -26803,7 +26786,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -26811,12 +26794,12 @@
         "compatibility_pair": {
           "bound_name": "_normalize_regional_fields",
           "target": "easyuse_anima/prompt/regional.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_normalize_regional_fields",
         "kind": "static_from",
-        "line": 247,
+        "line": 245,
         "name": "_normalize_regional_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -26834,7 +26817,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -26842,12 +26825,12 @@
         "compatibility_pair": {
           "bound_name": "_parse_json_object",
           "target": "easyuse_anima/prompt/regional.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_parse_json_object",
         "kind": "static_from",
-        "line": 247,
+        "line": 245,
         "name": "_parse_json_object",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -26865,7 +26848,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -26873,12 +26856,12 @@
         "compatibility_pair": {
           "bound_name": "_regional_config_json",
           "target": "easyuse_anima/prompt/regional.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_regional_config_json",
         "kind": "static_from",
-        "line": 247,
+        "line": 245,
         "name": "_regional_config_json",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -26896,7 +26879,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -26904,12 +26887,12 @@
         "compatibility_pair": {
           "bound_name": "_regional_fields_json",
           "target": "easyuse_anima/prompt/regional.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_regional_fields_json",
         "kind": "static_from",
-        "line": 247,
+        "line": 245,
         "name": "_regional_fields_json",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -26927,7 +26910,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -26935,12 +26918,12 @@
         "compatibility_pair": {
           "bound_name": "_regional_mask_bounds_area",
           "target": "easyuse_anima/prompt/regional.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_regional_mask_bounds_area",
         "kind": "static_from",
-        "line": 247,
+        "line": 245,
         "name": "_regional_mask_bounds_area",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -26958,7 +26941,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -26966,12 +26949,12 @@
         "compatibility_pair": {
           "bound_name": "_regional_payload_canvas",
           "target": "easyuse_anima/prompt/regional.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_regional_payload_canvas",
         "kind": "static_from",
-        "line": 247,
+        "line": 245,
         "name": "_regional_payload_canvas",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -26989,7 +26972,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -26997,12 +26980,12 @@
         "compatibility_pair": {
           "bound_name": "_regional_union_mask_for_ids",
           "target": "easyuse_anima/prompt/regional.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_regional_union_mask_for_ids",
         "kind": "static_from",
-        "line": 247,
+        "line": 245,
         "name": "_regional_union_mask_for_ids",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -27020,7 +27003,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -27028,12 +27011,12 @@
         "compatibility_pair": {
           "bound_name": "ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
           "target": "easyuse_anima/prompt/conditioning.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
         "kind": "static_from",
-        "line": 274,
+        "line": 272,
         "name": "ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -27051,7 +27034,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -27059,12 +27042,12 @@
         "compatibility_pair": {
           "bound_name": "ANIMA_MOD_GUIDANCE_MODES",
           "target": "easyuse_anima/prompt/conditioning.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODES",
         "kind": "static_from",
-        "line": 274,
+        "line": 272,
         "name": "ANIMA_MOD_GUIDANCE_MODES",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -27082,7 +27065,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -27090,12 +27073,12 @@
         "compatibility_pair": {
           "bound_name": "ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
           "target": "easyuse_anima/prompt/conditioning.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 274,
+        "line": 272,
         "name": "ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -27113,7 +27096,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -27121,12 +27104,12 @@
         "compatibility_pair": {
           "bound_name": "ANIMA_MOD_GUIDANCE_PROFILE_OFF",
           "target": "easyuse_anima/prompt/conditioning.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_PROFILE_OFF",
         "kind": "static_from",
-        "line": 274,
+        "line": 272,
         "name": "ANIMA_MOD_GUIDANCE_PROFILE_OFF",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -27144,7 +27127,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -27152,12 +27135,12 @@
         "compatibility_pair": {
           "bound_name": "_apply_spectrum_anima_mod_guidance",
           "target": "easyuse_anima/prompt/conditioning.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:_apply_spectrum_anima_mod_guidance",
         "kind": "static_from",
-        "line": 274,
+        "line": 272,
         "name": "_apply_spectrum_anima_mod_guidance",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -27175,7 +27158,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -27183,12 +27166,12 @@
         "compatibility_pair": {
           "bound_name": "_find_spectrum_anima_mod_guidance_class",
           "target": "easyuse_anima/prompt/conditioning.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:_find_spectrum_anima_mod_guidance_class",
         "kind": "static_from",
-        "line": 274,
+        "line": 272,
         "name": "_find_spectrum_anima_mod_guidance_class",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -27206,7 +27189,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -27214,12 +27197,12 @@
         "compatibility_pair": {
           "bound_name": "_normalize_anima_mod_guidance_profile",
           "target": "easyuse_anima/prompt/conditioning.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:_normalize_anima_mod_guidance_profile",
         "kind": "static_from",
-        "line": 274,
+        "line": 272,
         "name": "_normalize_anima_mod_guidance_profile",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -27237,7 +27220,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -27245,12 +27228,12 @@
         "compatibility_pair": {
           "bound_name": "_resolve_anima_mod_guidance_enabled",
           "target": "easyuse_anima/prompt/conditioning.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:_resolve_anima_mod_guidance_enabled",
         "kind": "static_from",
-        "line": 274,
+        "line": 272,
         "name": "_resolve_anima_mod_guidance_enabled",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -27268,7 +27251,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -27276,12 +27259,12 @@
         "compatibility_pair": {
           "bound_name": "ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
           "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
         "kind": "static_from",
-        "line": 289,
+        "line": 287,
         "name": "ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -27299,7 +27282,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -27307,12 +27290,12 @@
         "compatibility_pair": {
           "bound_name": "ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
           "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
         "kind": "static_from",
-        "line": 289,
+        "line": 287,
         "name": "ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -27330,7 +27313,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -27338,12 +27321,12 @@
         "compatibility_pair": {
           "bound_name": "ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
           "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
         "kind": "static_from",
-        "line": 289,
+        "line": 287,
         "name": "ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -27361,7 +27344,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -27369,12 +27352,12 @@
         "compatibility_pair": {
           "bound_name": "ARTIST_MIX_DEFAULT_EXACT_TOP_K",
           "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_EXACT_TOP_K",
         "kind": "static_from",
-        "line": 289,
+        "line": 287,
         "name": "ARTIST_MIX_DEFAULT_EXACT_TOP_K",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -27392,7 +27375,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -27400,12 +27383,12 @@
         "compatibility_pair": {
           "bound_name": "ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
           "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
         "kind": "static_from",
-        "line": 289,
+        "line": 287,
         "name": "ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -27423,7 +27406,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -27431,12 +27414,12 @@
         "compatibility_pair": {
           "bound_name": "ARTIST_MIX_DEFAULT_START_PERCENT",
           "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_START_PERCENT",
         "kind": "static_from",
-        "line": 289,
+        "line": 287,
         "name": "ARTIST_MIX_DEFAULT_START_PERCENT",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -27454,7 +27437,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -27462,12 +27445,12 @@
         "compatibility_pair": {
           "bound_name": "ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
           "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
         "kind": "static_from",
-        "line": 289,
+        "line": 287,
         "name": "ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -27485,7 +27468,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -27493,12 +27476,12 @@
         "compatibility_pair": {
           "bound_name": "ARTIST_MIX_DEFAULT_STYLE_GAIN",
           "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STYLE_GAIN",
         "kind": "static_from",
-        "line": 289,
+        "line": 287,
         "name": "ARTIST_MIX_DEFAULT_STYLE_GAIN",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -27516,7 +27499,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -27524,12 +27507,12 @@
         "compatibility_pair": {
           "bound_name": "ARTIST_MIX_INPUT_MODES",
           "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_INPUT_MODES",
         "kind": "static_from",
-        "line": 289,
+        "line": 287,
         "name": "ARTIST_MIX_INPUT_MODES",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -27547,7 +27530,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -27555,12 +27538,12 @@
         "compatibility_pair": {
           "bound_name": "ARTIST_MIX_MODE_FROM_PROMPT_DATA",
           "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 289,
+        "line": 287,
         "name": "ARTIST_MIX_MODE_FROM_PROMPT_DATA",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -27578,7 +27561,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -27586,12 +27569,12 @@
         "compatibility_pair": {
           "bound_name": "_artist_mix_inline_prompt",
           "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_artist_mix_inline_prompt",
         "kind": "static_from",
-        "line": 289,
+        "line": 287,
         "name": "_artist_mix_inline_prompt",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -27609,7 +27592,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -27617,12 +27600,12 @@
         "compatibility_pair": {
           "bound_name": "_artist_mix_mode_tooltip",
           "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_artist_mix_mode_tooltip",
         "kind": "static_from",
-        "line": 289,
+        "line": 287,
         "name": "_artist_mix_mode_tooltip",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -27640,7 +27623,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -27648,12 +27631,12 @@
         "compatibility_pair": {
           "bound_name": "_artist_prompt_with_position",
           "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_artist_prompt_with_position",
         "kind": "static_from",
-        "line": 289,
+        "line": 287,
         "name": "_artist_prompt_with_position",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -27671,7 +27654,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -27679,12 +27662,12 @@
         "compatibility_pair": {
           "bound_name": "_artist_tags_from_prompt",
           "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_artist_tags_from_prompt",
         "kind": "static_from",
-        "line": 289,
+        "line": 287,
         "name": "_artist_tags_from_prompt",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -27702,7 +27685,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -27710,12 +27693,12 @@
         "compatibility_pair": {
           "bound_name": "_blend_conditionings",
           "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_blend_conditionings",
         "kind": "static_from",
-        "line": 289,
+        "line": 287,
         "name": "_blend_conditionings",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -27733,7 +27716,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -27741,12 +27724,12 @@
         "compatibility_pair": {
           "bound_name": "_bounded_artist_mix_float",
           "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_bounded_artist_mix_float",
         "kind": "static_from",
-        "line": 289,
+        "line": 287,
         "name": "_bounded_artist_mix_float",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -27764,7 +27747,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -27772,12 +27755,12 @@
         "compatibility_pair": {
           "bound_name": "_bounded_artist_mix_int",
           "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_bounded_artist_mix_int",
         "kind": "static_from",
-        "line": 289,
+        "line": 287,
         "name": "_bounded_artist_mix_int",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -27795,7 +27778,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -27803,12 +27786,12 @@
         "compatibility_pair": {
           "bound_name": "_encode_artist_clustered",
           "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_encode_artist_clustered",
         "kind": "static_from",
-        "line": 289,
+        "line": 287,
         "name": "_encode_artist_clustered",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -27826,7 +27809,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -27834,12 +27817,12 @@
         "compatibility_pair": {
           "bound_name": "_encode_artist_delta_rms",
           "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_encode_artist_delta_rms",
         "kind": "static_from",
-        "line": 289,
+        "line": 287,
         "name": "_encode_artist_delta_rms",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -27857,7 +27840,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -27865,12 +27848,12 @@
         "compatibility_pair": {
           "bound_name": "_encode_prompt_data_positive_conditioning",
           "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_encode_prompt_data_positive_conditioning",
         "kind": "static_from",
-        "line": 289,
+        "line": 287,
         "name": "_encode_prompt_data_positive_conditioning",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -27888,7 +27871,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -27896,12 +27879,12 @@
         "compatibility_pair": {
           "bound_name": "_join_artist_mix_source_prompts",
           "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_join_artist_mix_source_prompts",
         "kind": "static_from",
-        "line": 289,
+        "line": 287,
         "name": "_join_artist_mix_source_prompts",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -27919,7 +27902,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -27927,12 +27910,12 @@
         "compatibility_pair": {
           "bound_name": "_normalize_artist_mix_mode",
           "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_normalize_artist_mix_mode",
         "kind": "static_from",
-        "line": 289,
+        "line": 287,
         "name": "_normalize_artist_mix_mode",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -27950,7 +27933,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -27958,12 +27941,12 @@
         "compatibility_pair": {
           "bound_name": "_normalize_artist_tag_position",
           "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_normalize_artist_tag_position",
         "kind": "static_from",
-        "line": 289,
+        "line": 287,
         "name": "_normalize_artist_tag_position",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -27981,7 +27964,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -27989,12 +27972,12 @@
         "compatibility_pair": {
           "bound_name": "_parse_artist_mix_items",
           "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_parse_artist_mix_items",
         "kind": "static_from",
-        "line": 289,
+        "line": 287,
         "name": "_parse_artist_mix_items",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -28012,7 +27995,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -28020,12 +28003,12 @@
         "compatibility_pair": {
           "bound_name": "EasyUseAnimaArtistMixConditioning",
           "target": "easyuse_anima/nodes/prompt_data_nodes.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaArtistMixConditioning",
         "kind": "static_from",
-        "line": 368,
+        "line": 366,
         "name": "EasyUseAnimaArtistMixConditioning",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_data_nodes",
@@ -28043,7 +28026,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -28051,12 +28034,12 @@
         "compatibility_pair": {
           "bound_name": "EasyUseAnimaPromptDataConditioning",
           "target": "easyuse_anima/nodes/prompt_data_nodes.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataConditioning",
         "kind": "static_from",
-        "line": 368,
+        "line": 366,
         "name": "EasyUseAnimaPromptDataConditioning",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_data_nodes",
@@ -28074,7 +28057,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -28082,12 +28065,12 @@
         "compatibility_pair": {
           "bound_name": "EasyUseAnimaPromptDataUnpack",
           "target": "easyuse_anima/nodes/prompt_data_nodes.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataUnpack",
         "kind": "static_from",
-        "line": 368,
+        "line": 366,
         "name": "EasyUseAnimaPromptDataUnpack",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_data_nodes",
@@ -28105,7 +28088,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -28113,12 +28096,12 @@
         "compatibility_pair": {
           "bound_name": "_ANY_TYPE",
           "target": "easyuse_anima/nodes/input_types.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.nodes.input_types:_ANY_TYPE",
         "kind": "static_from",
-        "line": 373,
+        "line": 371,
         "name": "_ANY_TYPE",
         "optional": false,
         "requested": ".easyuse_anima.nodes.input_types",
@@ -28136,7 +28119,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -28144,12 +28127,12 @@
         "compatibility_pair": {
           "bound_name": "_AnyType",
           "target": "easyuse_anima/nodes/input_types.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.nodes.input_types:_AnyType",
         "kind": "static_from",
-        "line": 373,
+        "line": 371,
         "name": "_AnyType",
         "optional": false,
         "requested": ".easyuse_anima.nodes.input_types",
@@ -28167,7 +28150,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -28175,12 +28158,12 @@
         "compatibility_pair": {
           "bound_name": "_FlexibleOptionalInputType",
           "target": "easyuse_anima/nodes/input_types.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.nodes.input_types:_FlexibleOptionalInputType",
         "kind": "static_from",
-        "line": 373,
+        "line": 371,
         "name": "_FlexibleOptionalInputType",
         "optional": false,
         "requested": ".easyuse_anima.nodes.input_types",
@@ -28198,7 +28181,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -28206,12 +28189,12 @@
         "compatibility_pair": {
           "bound_name": "EasyUseAnimaPromptStudioAdvanced",
           "target": "easyuse_anima/nodes/prompt_advanced_nodes.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvanced",
         "kind": "static_from",
-        "line": 378,
+        "line": 376,
         "name": "EasyUseAnimaPromptStudioAdvanced",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_advanced_nodes",
@@ -28229,7 +28212,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -28237,12 +28220,12 @@
         "compatibility_pair": {
           "bound_name": "EasyUseAnimaPromptStudioAdvancedV2",
           "target": "easyuse_anima/nodes/prompt_advanced_nodes.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvancedV2",
         "kind": "static_from",
-        "line": 378,
+        "line": 376,
         "name": "EasyUseAnimaPromptStudioAdvancedV2",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_advanced_nodes",
@@ -28260,7 +28243,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -28268,12 +28251,12 @@
         "compatibility_pair": {
           "bound_name": "EASY_USE_ANIMA_INPUT_TYPE",
           "target": "easyuse_anima/nodes/aio_nodes.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.nodes.aio_nodes:EASY_USE_ANIMA_INPUT_TYPE",
         "kind": "static_from",
-        "line": 383,
+        "line": 381,
         "name": "EASY_USE_ANIMA_INPUT_TYPE",
         "optional": false,
         "requested": ".easyuse_anima.nodes.aio_nodes",
@@ -28291,7 +28274,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -28299,12 +28282,12 @@
         "compatibility_pair": {
           "bound_name": "EasyUseAnimaAIOGenerator",
           "target": "easyuse_anima/nodes/aio_nodes.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.nodes.aio_nodes:EasyUseAnimaAIOGenerator",
         "kind": "static_from",
-        "line": 383,
+        "line": 381,
         "name": "EasyUseAnimaAIOGenerator",
         "optional": false,
         "requested": ".easyuse_anima.nodes.aio_nodes",
@@ -28322,7 +28305,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -28330,12 +28313,12 @@
         "compatibility_pair": {
           "bound_name": "EasyUseAnimaInput",
           "target": "easyuse_anima/nodes/aio_nodes.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.nodes.aio_nodes:EasyUseAnimaInput",
         "kind": "static_from",
-        "line": 383,
+        "line": 381,
         "name": "EasyUseAnimaInput",
         "optional": false,
         "requested": ".easyuse_anima.nodes.aio_nodes",
@@ -28353,7 +28336,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -28361,12 +28344,12 @@
         "compatibility_pair": {
           "bound_name": "_aio_generation_settings_json",
           "target": "easyuse_anima/nodes/aio_nodes.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.nodes.aio_nodes:_aio_generation_settings_json",
         "kind": "static_from",
-        "line": 383,
+        "line": 381,
         "name": "_aio_generation_settings_json",
         "optional": false,
         "requested": ".easyuse_anima.nodes.aio_nodes",
@@ -28384,7 +28367,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -28392,12 +28375,12 @@
         "compatibility_pair": {
           "bound_name": "_aio_input_settings_json",
           "target": "easyuse_anima/nodes/aio_nodes.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.nodes.aio_nodes:_aio_input_settings_json",
         "kind": "static_from",
-        "line": 383,
+        "line": 381,
         "name": "_aio_input_settings_json",
         "optional": false,
         "requested": ".easyuse_anima.nodes.aio_nodes",
@@ -28415,7 +28398,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -28423,12 +28406,12 @@
         "compatibility_pair": {
           "bound_name": "_align_down",
           "target": "easyuse_anima/image/geometry.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.image.geometry:_align_down",
         "kind": "static_from",
-        "line": 390,
+        "line": 388,
         "name": "_align_down",
         "optional": false,
         "requested": ".easyuse_anima.image.geometry",
@@ -28446,7 +28429,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -28454,12 +28437,12 @@
         "compatibility_pair": {
           "bound_name": "_align_nearest",
           "target": "easyuse_anima/image/geometry.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.image.geometry:_align_nearest",
         "kind": "static_from",
-        "line": 390,
+        "line": 388,
         "name": "_align_nearest",
         "optional": false,
         "requested": ".easyuse_anima.image.geometry",
@@ -28477,7 +28460,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -28485,12 +28468,12 @@
         "compatibility_pair": {
           "bound_name": "_image_tensor_size",
           "target": "easyuse_anima/image/geometry.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.image.geometry:_image_tensor_size",
         "kind": "static_from",
-        "line": 390,
+        "line": 388,
         "name": "_image_tensor_size",
         "optional": false,
         "requested": ".easyuse_anima.image.geometry",
@@ -28508,7 +28491,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -28516,12 +28499,12 @@
         "compatibility_pair": {
           "bound_name": "_context_value",
           "target": "easyuse_anima/image/sam3.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.image.sam3:_context_value",
         "kind": "static_from",
-        "line": 401,
+        "line": 399,
         "name": "_context_value",
         "optional": false,
         "requested": ".easyuse_anima.image.sam3",
@@ -28539,7 +28522,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -28547,12 +28530,12 @@
         "compatibility_pair": {
           "bound_name": "_sam3_context",
           "target": "easyuse_anima/image/sam3.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.image.sam3:_sam3_context",
         "kind": "static_from",
-        "line": 401,
+        "line": 399,
         "name": "_sam3_context",
         "optional": false,
         "requested": ".easyuse_anima.image.sam3",
@@ -28570,7 +28553,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -28578,12 +28561,12 @@
         "compatibility_pair": {
           "bound_name": "_segs_has_items",
           "target": "easyuse_anima/image/sam3.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.image.sam3:_segs_has_items",
         "kind": "static_from",
-        "line": 401,
+        "line": 399,
         "name": "_segs_has_items",
         "optional": false,
         "requested": ".easyuse_anima.image.sam3",
@@ -28601,7 +28584,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -28609,12 +28592,12 @@
         "compatibility_pair": {
           "bound_name": "IMAGE_SCALE_MULTIPLES",
           "target": "easyuse_anima/image/scaling.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.image.scaling:IMAGE_SCALE_MULTIPLES",
         "kind": "static_from",
-        "line": 413,
+        "line": 411,
         "name": "IMAGE_SCALE_MULTIPLES",
         "optional": false,
         "requested": ".easyuse_anima.image.scaling",
@@ -28632,7 +28615,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -28640,12 +28623,12 @@
         "compatibility_pair": {
           "bound_name": "IMAGE_UPSCALE_METHODS",
           "target": "easyuse_anima/image/scaling.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.image.scaling:IMAGE_UPSCALE_METHODS",
         "kind": "static_from",
-        "line": 413,
+        "line": 411,
         "name": "IMAGE_UPSCALE_METHODS",
         "optional": false,
         "requested": ".easyuse_anima.image.scaling",
@@ -28663,7 +28646,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -28671,12 +28654,12 @@
         "compatibility_pair": {
           "bound_name": "_comfy_sampler_names",
           "target": "easyuse_anima/infrastructure/comfy/capabilities.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_comfy_sampler_names",
         "kind": "static_from",
-        "line": 421,
+        "line": 419,
         "name": "_comfy_sampler_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -28694,7 +28677,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -28702,12 +28685,12 @@
         "compatibility_pair": {
           "bound_name": "_comfy_scheduler_names",
           "target": "easyuse_anima/infrastructure/comfy/capabilities.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_comfy_scheduler_names",
         "kind": "static_from",
-        "line": 421,
+        "line": 419,
         "name": "_comfy_scheduler_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -28725,7 +28708,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -28733,12 +28716,12 @@
         "compatibility_pair": {
           "bound_name": "_impact_scheduler_names",
           "target": "easyuse_anima/infrastructure/comfy/capabilities.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_impact_scheduler_names",
         "kind": "static_from",
-        "line": 421,
+        "line": 419,
         "name": "_impact_scheduler_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -28756,7 +28739,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -28764,12 +28747,12 @@
         "compatibility_pair": {
           "bound_name": "_call_with_supported_kwargs",
           "target": "easyuse_anima/infrastructure/comfy/invocation.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.invocation:_call_with_supported_kwargs",
         "kind": "static_from",
-        "line": 427,
+        "line": 425,
         "name": "_call_with_supported_kwargs",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.invocation",
@@ -28787,7 +28770,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -28795,12 +28778,12 @@
         "compatibility_pair": {
           "bound_name": "_common_upscale_image",
           "target": "easyuse_anima/infrastructure/comfy/invocation.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.invocation:_common_upscale_image",
         "kind": "static_from",
-        "line": 427,
+        "line": 425,
         "name": "_common_upscale_image",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.invocation",
@@ -28818,7 +28801,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -28826,12 +28809,12 @@
         "compatibility_pair": {
           "bound_name": "_node_output_tuple",
           "target": "easyuse_anima/infrastructure/comfy/invocation.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.invocation:_node_output_tuple",
         "kind": "static_from",
-        "line": 427,
+        "line": 425,
         "name": "_node_output_tuple",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.invocation",
@@ -28849,7 +28832,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -28857,12 +28840,12 @@
         "compatibility_pair": {
           "bound_name": "_adapter_comfy_clip_loader_types",
           "target": "easyuse_anima/infrastructure/comfy/resources.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_comfy_clip_loader_types",
         "kind": "static_from",
-        "line": 432,
+        "line": 430,
         "name": "_comfy_clip_loader_types",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -28880,7 +28863,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -28888,12 +28871,12 @@
         "compatibility_pair": {
           "bound_name": "_adapter_comfy_diffusion_model_names",
           "target": "easyuse_anima/infrastructure/comfy/resources.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_comfy_diffusion_model_names",
         "kind": "static_from",
-        "line": 432,
+        "line": 430,
         "name": "_comfy_diffusion_model_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -28911,7 +28894,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -28919,12 +28902,12 @@
         "compatibility_pair": {
           "bound_name": "_adapter_comfy_text_encoder_names",
           "target": "easyuse_anima/infrastructure/comfy/resources.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_comfy_text_encoder_names",
         "kind": "static_from",
-        "line": 432,
+        "line": 430,
         "name": "_comfy_text_encoder_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -28942,7 +28925,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -28950,12 +28933,12 @@
         "compatibility_pair": {
           "bound_name": "_adapter_comfy_vae_names",
           "target": "easyuse_anima/infrastructure/comfy/resources.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_comfy_vae_names",
         "kind": "static_from",
-        "line": 432,
+        "line": 430,
         "name": "_comfy_vae_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -28973,7 +28956,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -28981,12 +28964,12 @@
         "compatibility_pair": {
           "bound_name": "_folder_path_names",
           "target": "easyuse_anima/infrastructure/comfy/resources.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_folder_path_names",
         "kind": "static_from",
-        "line": 432,
+        "line": 430,
         "name": "_folder_path_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -29004,7 +28987,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -29012,12 +28995,12 @@
         "compatibility_pair": {
           "bound_name": "EasyUseAnimaDetailerAlignHook",
           "target": "easyuse_anima/nodes/image_nodes.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.nodes.image_nodes:EasyUseAnimaDetailerAlignHook",
         "kind": "static_from",
-        "line": 440,
+        "line": 438,
         "name": "EasyUseAnimaDetailerAlignHook",
         "optional": false,
         "requested": ".easyuse_anima.nodes.image_nodes",
@@ -29035,7 +29018,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -29043,12 +29026,12 @@
         "compatibility_pair": {
           "bound_name": "EasyUseAnimaImageScaleByMultiple",
           "target": "easyuse_anima/nodes/image_nodes.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.nodes.image_nodes:EasyUseAnimaImageScaleByMultiple",
         "kind": "static_from",
-        "line": 440,
+        "line": 438,
         "name": "EasyUseAnimaImageScaleByMultiple",
         "optional": false,
         "requested": ".easyuse_anima.nodes.image_nodes",
@@ -29066,7 +29049,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -29074,12 +29057,12 @@
         "compatibility_pair": {
           "bound_name": "EasyUseAnimaSAM3Context",
           "target": "easyuse_anima/nodes/sam3_nodes.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Context",
         "kind": "static_from",
-        "line": 444,
+        "line": 442,
         "name": "EasyUseAnimaSAM3Context",
         "optional": false,
         "requested": ".easyuse_anima.nodes.sam3_nodes",
@@ -29097,7 +29080,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -29105,12 +29088,12 @@
         "compatibility_pair": {
           "bound_name": "EasyUseAnimaSAM3Detailer",
           "target": "easyuse_anima/nodes/sam3_nodes.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Detailer",
         "kind": "static_from",
-        "line": 444,
+        "line": 442,
         "name": "EasyUseAnimaSAM3Detailer",
         "optional": false,
         "requested": ".easyuse_anima.nodes.sam3_nodes",
@@ -29128,7 +29111,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -29136,12 +29119,12 @@
         "compatibility_pair": {
           "bound_name": "EasyUseAnimaPromptBuilder",
           "target": "easyuse_anima/nodes/prompt_nodes.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptBuilder",
         "kind": "static_from",
-        "line": 448,
+        "line": 446,
         "name": "EasyUseAnimaPromptBuilder",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_nodes",
@@ -29159,7 +29142,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -29167,12 +29150,12 @@
         "compatibility_pair": {
           "bound_name": "EasyUseAnimaPromptCorrector",
           "target": "easyuse_anima/nodes/prompt_nodes.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrector",
         "kind": "static_from",
-        "line": 448,
+        "line": 446,
         "name": "EasyUseAnimaPromptCorrector",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_nodes",
@@ -29190,7 +29173,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -29198,12 +29181,12 @@
         "compatibility_pair": {
           "bound_name": "EasyUseAnimaPromptCorrectorSimple",
           "target": "easyuse_anima/nodes/prompt_nodes.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrectorSimple",
         "kind": "static_from",
-        "line": 448,
+        "line": 446,
         "name": "EasyUseAnimaPromptCorrectorSimple",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_nodes",
@@ -29221,7 +29204,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -29229,12 +29212,12 @@
         "compatibility_pair": {
           "bound_name": "EasyUseAnimaPromptStudio",
           "target": "easyuse_anima/nodes/prompt_nodes.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptStudio",
         "kind": "static_from",
-        "line": 448,
+        "line": 446,
         "name": "EasyUseAnimaPromptStudio",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_nodes",
@@ -29252,7 +29235,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -29260,12 +29243,12 @@
         "compatibility_pair": {
           "bound_name": "EasyUseAnimaPromptStudioRegional",
           "target": "easyuse_anima/nodes/regional_nodes.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.nodes.regional_nodes:EasyUseAnimaPromptStudioRegional",
         "kind": "static_from",
-        "line": 454,
+        "line": 452,
         "name": "EasyUseAnimaPromptStudioRegional",
         "optional": false,
         "requested": ".easyuse_anima.nodes.regional_nodes",
@@ -29283,7 +29266,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -29291,12 +29274,12 @@
         "compatibility_pair": {
           "bound_name": "EasyUseAnimaRegionalConditioning",
           "target": "easyuse_anima/nodes/regional_nodes.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.nodes.regional_nodes:EasyUseAnimaRegionalConditioning",
         "kind": "static_from",
-        "line": 454,
+        "line": 452,
         "name": "EasyUseAnimaRegionalConditioning",
         "optional": false,
         "requested": ".easyuse_anima.nodes.regional_nodes",
@@ -29314,7 +29297,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -29322,12 +29305,12 @@
         "compatibility_pair": {
           "bound_name": "LATENT_ALIGN",
           "target": "easyuse_anima/naia/client.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.naia.client:LATENT_ALIGN",
         "kind": "static_from",
-        "line": 458,
+        "line": 456,
         "name": "LATENT_ALIGN",
         "optional": false,
         "requested": ".easyuse_anima.naia.client",
@@ -29345,7 +29328,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -29353,12 +29336,12 @@
         "compatibility_pair": {
           "bound_name": "_parse_random_response",
           "target": "easyuse_anima/naia/client.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.naia.client:_parse_random_response",
         "kind": "static_from",
-        "line": 458,
+        "line": 456,
         "name": "_parse_random_response",
         "optional": false,
         "requested": ".easyuse_anima.naia.client",
@@ -29376,7 +29359,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -29384,12 +29367,12 @@
         "compatibility_pair": {
           "bound_name": "_post_random",
           "target": "easyuse_anima/naia/client.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.naia.client:_post_random",
         "kind": "static_from",
-        "line": 458,
+        "line": 456,
         "name": "_post_random",
         "optional": false,
         "requested": ".easyuse_anima.naia.client",
@@ -29407,7 +29390,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -29415,12 +29398,12 @@
         "compatibility_pair": {
           "bound_name": "_advanced_resolution_from_selection",
           "target": "easyuse_anima/naia/resolution.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_advanced_resolution_from_selection",
         "kind": "static_from",
-        "line": 476,
+        "line": 474,
         "name": "_advanced_resolution_from_selection",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -29438,7 +29421,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -29446,12 +29429,12 @@
         "compatibility_pair": {
           "bound_name": "_normalize_resolution_bucket",
           "target": "easyuse_anima/naia/resolution.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_normalize_resolution_bucket",
         "kind": "static_from",
-        "line": 476,
+        "line": 474,
         "name": "_normalize_resolution_bucket",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -29469,7 +29452,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -29477,12 +29460,12 @@
         "compatibility_pair": {
           "bound_name": "_ratio_label",
           "target": "easyuse_anima/naia/resolution.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_ratio_label",
         "kind": "static_from",
-        "line": 476,
+        "line": 474,
         "name": "_ratio_label",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -29500,7 +29483,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -29508,12 +29491,12 @@
         "compatibility_pair": {
           "bound_name": "_resolution_label",
           "target": "easyuse_anima/naia/resolution.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_resolution_label",
         "kind": "static_from",
-        "line": 476,
+        "line": 474,
         "name": "_resolution_label",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -29531,7 +29514,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -29539,12 +29522,12 @@
         "compatibility_pair": {
           "bound_name": "_resolve_naia_resolution",
           "target": "easyuse_anima/naia/resolution.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_resolve_naia_resolution",
         "kind": "static_from",
-        "line": 476,
+        "line": 474,
         "name": "_resolve_naia_resolution",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -29562,7 +29545,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -29570,12 +29553,12 @@
         "compatibility_pair": {
           "bound_name": "EasyUseAnimaNAIARandomPrompt",
           "target": "easyuse_anima/nodes/naia_nodes.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.nodes.naia_nodes:EasyUseAnimaNAIARandomPrompt",
         "kind": "static_from",
-        "line": 499,
+        "line": 497,
         "name": "EasyUseAnimaNAIARandomPrompt",
         "optional": false,
         "requested": ".easyuse_anima.nodes.naia_nodes",
@@ -29593,7 +29576,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -29601,12 +29584,12 @@
         "compatibility_pair": {
           "bound_name": "EasyUseAnimaWildcard",
           "target": "easyuse_anima/nodes/wildcard_nodes.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.nodes.wildcard_nodes:EasyUseAnimaWildcard",
         "kind": "static_from",
-        "line": 502,
+        "line": 500,
         "name": "EasyUseAnimaWildcard",
         "optional": false,
         "requested": ".easyuse_anima.nodes.wildcard_nodes",
@@ -29624,7 +29607,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -29632,12 +29615,12 @@
         "compatibility_pair": {
           "bound_name": "_apply_lora_syntax_format",
           "target": "easyuse_anima/lora/metadata.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_apply_lora_syntax_format",
         "kind": "static_from",
-        "line": 506,
+        "line": 504,
         "name": "_apply_lora_syntax_format",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -29655,7 +29638,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -29663,12 +29646,12 @@
         "compatibility_pair": {
           "bound_name": "_dedupe_text_values",
           "target": "easyuse_anima/lora/metadata.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_dedupe_text_values",
         "kind": "static_from",
-        "line": 506,
+        "line": 504,
         "name": "_dedupe_text_values",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -29686,7 +29669,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -29694,12 +29677,12 @@
         "compatibility_pair": {
           "bound_name": "_fallback_lora_path",
           "target": "easyuse_anima/lora/metadata.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_fallback_lora_path",
         "kind": "static_from",
-        "line": 506,
+        "line": 504,
         "name": "_fallback_lora_path",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -29717,7 +29700,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -29725,12 +29708,12 @@
         "compatibility_pair": {
           "bound_name": "_get_lora_info",
           "target": "easyuse_anima/lora/metadata.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_get_lora_info",
         "kind": "static_from",
-        "line": 506,
+        "line": 504,
         "name": "_get_lora_info",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -29748,7 +29731,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -29756,12 +29739,12 @@
         "compatibility_pair": {
           "bound_name": "_get_lora_manager_trigger_words",
           "target": "easyuse_anima/lora/metadata.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_get_lora_manager_trigger_words",
         "kind": "static_from",
-        "line": 506,
+        "line": 504,
         "name": "_get_lora_manager_trigger_words",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -29779,7 +29762,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -29787,12 +29770,12 @@
         "compatibility_pair": {
           "bound_name": "_load_lora_manager_metadata",
           "target": "easyuse_anima/lora/metadata.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_load_lora_manager_metadata",
         "kind": "static_from",
-        "line": 506,
+        "line": 504,
         "name": "_load_lora_manager_metadata",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -29810,7 +29793,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -29818,12 +29801,12 @@
         "compatibility_pair": {
           "bound_name": "_lora_combo_values",
           "target": "easyuse_anima/lora/metadata.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_lora_combo_values",
         "kind": "static_from",
-        "line": 506,
+        "line": 504,
         "name": "_lora_combo_values",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -29841,7 +29824,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -29849,12 +29832,12 @@
         "compatibility_pair": {
           "bound_name": "_lora_manager_trigger_words_from_metadata",
           "target": "easyuse_anima/lora/metadata.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_lora_manager_trigger_words_from_metadata",
         "kind": "static_from",
-        "line": 506,
+        "line": 504,
         "name": "_lora_manager_trigger_words_from_metadata",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -29872,7 +29855,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -29880,12 +29863,12 @@
         "compatibility_pair": {
           "bound_name": "_lora_model_exists",
           "target": "easyuse_anima/lora/metadata.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_lora_model_exists",
         "kind": "static_from",
-        "line": 506,
+        "line": 504,
         "name": "_lora_model_exists",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -29903,7 +29886,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -29911,12 +29894,12 @@
         "compatibility_pair": {
           "bound_name": "_lora_stack_name",
           "target": "easyuse_anima/lora/metadata.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_lora_stack_name",
         "kind": "static_from",
-        "line": 506,
+        "line": 504,
         "name": "_lora_stack_name",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -29934,7 +29917,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -29942,12 +29925,12 @@
         "compatibility_pair": {
           "bound_name": "_metadata_json_paths_for_lora",
           "target": "easyuse_anima/lora/metadata.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_metadata_json_paths_for_lora",
         "kind": "static_from",
-        "line": 506,
+        "line": 504,
         "name": "_metadata_json_paths_for_lora",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -29965,7 +29948,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -29973,12 +29956,12 @@
         "compatibility_pair": {
           "bound_name": "_missing_lora_display_name",
           "target": "easyuse_anima/lora/metadata.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_missing_lora_display_name",
         "kind": "static_from",
-        "line": 506,
+        "line": 504,
         "name": "_missing_lora_display_name",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -29996,7 +29979,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -30004,12 +29987,12 @@
         "compatibility_pair": {
           "bound_name": "_raise_missing_loras",
           "target": "easyuse_anima/lora/metadata.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_raise_missing_loras",
         "kind": "static_from",
-        "line": 506,
+        "line": 504,
         "name": "_raise_missing_loras",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -30027,7 +30010,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -30035,12 +30018,12 @@
         "compatibility_pair": {
           "bound_name": "_trigger_words_from_value",
           "target": "easyuse_anima/lora/metadata.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_trigger_words_from_value",
         "kind": "static_from",
-        "line": 506,
+        "line": 504,
         "name": "_trigger_words_from_value",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -30058,7 +30041,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -30066,12 +30049,12 @@
         "compatibility_pair": {
           "bound_name": "_correct_style_prompt",
           "target": "easyuse_anima/lora/preset.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_correct_style_prompt",
         "kind": "static_from",
-        "line": 522,
+        "line": 520,
         "name": "_correct_style_prompt",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -30089,7 +30072,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -30097,12 +30080,12 @@
         "compatibility_pair": {
           "bound_name": "_format_strength",
           "target": "easyuse_anima/lora/preset.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_format_strength",
         "kind": "static_from",
-        "line": 522,
+        "line": 520,
         "name": "_format_strength",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -30120,7 +30103,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -30128,12 +30111,12 @@
         "compatibility_pair": {
           "bound_name": "_get_loras_list",
           "target": "easyuse_anima/lora/preset.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_get_loras_list",
         "kind": "static_from",
-        "line": 522,
+        "line": 520,
         "name": "_get_loras_list",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -30151,7 +30134,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -30159,12 +30142,12 @@
         "compatibility_pair": {
           "bound_name": "_load_profile_data",
           "target": "easyuse_anima/lora/preset.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_load_profile_data",
         "kind": "static_from",
-        "line": 522,
+        "line": 520,
         "name": "_load_profile_data",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -30182,7 +30165,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -30190,12 +30173,12 @@
         "compatibility_pair": {
           "bound_name": "_profile_key",
           "target": "easyuse_anima/lora/preset.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_profile_key",
         "kind": "static_from",
-        "line": 522,
+        "line": 520,
         "name": "_profile_key",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -30213,7 +30196,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -30221,12 +30204,12 @@
         "compatibility_pair": {
           "bound_name": "_select_profile_values",
           "target": "easyuse_anima/lora/preset.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_select_profile_values",
         "kind": "static_from",
-        "line": 522,
+        "line": 520,
         "name": "_select_profile_values",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -30244,7 +30227,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -30252,12 +30235,12 @@
         "compatibility_pair": {
           "bound_name": "_wrap_profile_index",
           "target": "easyuse_anima/lora/preset.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_wrap_profile_index",
         "kind": "static_from",
-        "line": 522,
+        "line": 520,
         "name": "_wrap_profile_index",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -30275,7 +30258,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -30283,12 +30266,12 @@
         "compatibility_pair": {
           "bound_name": "EasyUseAnimaLoraPreset",
           "target": "easyuse_anima/nodes/lora_nodes.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".easyuse_anima.nodes.lora_nodes:EasyUseAnimaLoraPreset",
         "kind": "static_from",
-        "line": 531,
+        "line": 529,
         "name": "EasyUseAnimaLoraPreset",
         "optional": false,
         "requested": ".easyuse_anima.nodes.lora_nodes",
@@ -30306,7 +30289,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -30314,12 +30297,12 @@
         "compatibility_pair": {
           "bound_name": "correct_prompt",
           "target": "anima_prompt/__init__.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".anima_prompt:correct_prompt",
         "kind": "static_from",
-        "line": 534,
+        "line": 532,
         "name": "correct_prompt",
         "optional": false,
         "requested": ".anima_prompt",
@@ -30337,7 +30320,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -30345,12 +30328,12 @@
         "compatibility_pair": {
           "bound_name": "load_knowledge_base",
           "target": "anima_prompt/__init__.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".anima_prompt:load_knowledge_base",
         "kind": "static_from",
-        "line": 534,
+        "line": 532,
         "name": "load_knowledge_base",
         "optional": false,
         "requested": ".anima_prompt",
@@ -30368,7 +30351,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -30376,12 +30359,12 @@
         "compatibility_pair": {
           "bound_name": "parse_prompt",
           "target": "anima_prompt/parser.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".anima_prompt.parser:parse_prompt",
         "kind": "static_from",
-        "line": 535,
+        "line": 533,
         "name": "parse_prompt",
         "optional": false,
         "requested": ".anima_prompt.parser",
@@ -30399,7 +30382,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -30407,12 +30390,12 @@
         "compatibility_pair": {
           "bound_name": "resolve_metadata_filter_words",
           "target": "settings.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".settings:resolve_metadata_filter_words",
         "kind": "static_from",
-        "line": 536,
+        "line": 534,
         "name": "resolve_metadata_filter_words",
         "optional": false,
         "requested": ".settings",
@@ -30430,7 +30413,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -30438,12 +30421,12 @@
         "compatibility_pair": {
           "bound_name": "resolve_naia_settings",
           "target": "settings.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".settings:resolve_naia_settings",
         "kind": "static_from",
-        "line": 536,
+        "line": 534,
         "name": "resolve_naia_settings",
         "optional": false,
         "requested": ".settings",
@@ -30461,7 +30444,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -30469,12 +30452,12 @@
         "compatibility_pair": {
           "bound_name": "resolve_prompt_translation_settings",
           "target": "settings.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".settings:resolve_prompt_translation_settings",
         "kind": "static_from",
-        "line": 536,
+        "line": 534,
         "name": "resolve_prompt_translation_settings",
         "optional": false,
         "requested": ".settings",
@@ -30492,7 +30475,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -30500,12 +30483,12 @@
         "compatibility_pair": {
           "bound_name": "has_prompt_translation_markers",
           "target": "prompt_translation.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".prompt_translation:has_prompt_translation_markers",
         "kind": "static_from",
-        "line": 541,
+        "line": 539,
         "name": "has_prompt_translation_markers",
         "optional": false,
         "requested": ".prompt_translation",
@@ -30523,7 +30506,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -30531,12 +30514,12 @@
         "compatibility_pair": {
           "bound_name": "translate_prompt_markers",
           "target": "prompt_translation.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".prompt_translation:translate_prompt_markers",
         "kind": "static_from",
-        "line": 541,
+        "line": 539,
         "name": "translate_prompt_markers",
         "optional": false,
         "requested": ".prompt_translation",
@@ -30554,7 +30537,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -30562,12 +30545,12 @@
         "compatibility_pair": {
           "bound_name": "MAX_SEED",
           "target": "wildcard_engine.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".wildcard_engine:MAX_SEED",
         "kind": "static_from",
-        "line": 542,
+        "line": 540,
         "name": "MAX_SEED",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -30585,7 +30568,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -30593,12 +30576,12 @@
         "compatibility_pair": {
           "bound_name": "PROMPT_STUDIO_WILDCARD_MODE_LABELS",
           "target": "wildcard_engine.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".wildcard_engine:PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "kind": "static_from",
-        "line": 542,
+        "line": 540,
         "name": "PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -30616,7 +30599,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -30624,12 +30607,12 @@
         "compatibility_pair": {
           "bound_name": "PUBLIC_MAX_SEED",
           "target": "wildcard_engine.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".wildcard_engine:PUBLIC_MAX_SEED",
         "kind": "static_from",
-        "line": 542,
+        "line": 540,
         "name": "PUBLIC_MAX_SEED",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -30647,7 +30630,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -30655,12 +30638,12 @@
         "compatibility_pair": {
           "bound_name": "SEED_CONTROL_DECREMENT",
           "target": "wildcard_engine.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_DECREMENT",
         "kind": "static_from",
-        "line": 542,
+        "line": 540,
         "name": "SEED_CONTROL_DECREMENT",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -30678,7 +30661,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -30686,12 +30669,12 @@
         "compatibility_pair": {
           "bound_name": "SEED_CONTROL_FIXED",
           "target": "wildcard_engine.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_FIXED",
         "kind": "static_from",
-        "line": 542,
+        "line": 540,
         "name": "SEED_CONTROL_FIXED",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -30709,7 +30692,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -30717,12 +30700,12 @@
         "compatibility_pair": {
           "bound_name": "SEED_CONTROL_INCREMENT",
           "target": "wildcard_engine.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_INCREMENT",
         "kind": "static_from",
-        "line": 542,
+        "line": 540,
         "name": "SEED_CONTROL_INCREMENT",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -30740,7 +30723,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -30748,12 +30731,12 @@
         "compatibility_pair": {
           "bound_name": "SEED_CONTROL_MODES",
           "target": "wildcard_engine.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_MODES",
         "kind": "static_from",
-        "line": 542,
+        "line": 540,
         "name": "SEED_CONTROL_MODES",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -30771,7 +30754,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -30779,12 +30762,12 @@
         "compatibility_pair": {
           "bound_name": "SEED_CONTROL_RANDOMIZE",
           "target": "wildcard_engine.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_RANDOMIZE",
         "kind": "static_from",
-        "line": 542,
+        "line": 540,
         "name": "SEED_CONTROL_RANDOMIZE",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -30802,7 +30785,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -30810,12 +30793,12 @@
         "compatibility_pair": {
           "bound_name": "WILDCARD_MODE_FIXED",
           "target": "wildcard_engine.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".wildcard_engine:WILDCARD_MODE_FIXED",
         "kind": "static_from",
-        "line": 542,
+        "line": 540,
         "name": "WILDCARD_MODE_FIXED",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -30833,7 +30816,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -30841,12 +30824,12 @@
         "compatibility_pair": {
           "bound_name": "WILDCARD_MODE_POPULATE",
           "target": "wildcard_engine.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".wildcard_engine:WILDCARD_MODE_POPULATE",
         "kind": "static_from",
-        "line": 542,
+        "line": 540,
         "name": "WILDCARD_MODE_POPULATE",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -30864,7 +30847,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -30872,12 +30855,12 @@
         "compatibility_pair": {
           "bound_name": "WILDCARD_MODE_SEQUENTIAL",
           "target": "wildcard_engine.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".wildcard_engine:WILDCARD_MODE_SEQUENTIAL",
         "kind": "static_from",
-        "line": 542,
+        "line": 540,
         "name": "WILDCARD_MODE_SEQUENTIAL",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -30895,7 +30878,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -30903,12 +30886,12 @@
         "compatibility_pair": {
           "bound_name": "expand_wildcard_texts",
           "target": "wildcard_engine.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".wildcard_engine:expand_wildcard_texts",
         "kind": "static_from",
-        "line": 542,
+        "line": 540,
         "name": "expand_wildcard_texts",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -30926,7 +30909,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -30934,12 +30917,12 @@
         "compatibility_pair": {
           "bound_name": "expand_wildcards",
           "target": "wildcard_engine.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".wildcard_engine:expand_wildcards",
         "kind": "static_from",
-        "line": 542,
+        "line": 540,
         "name": "expand_wildcards",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -30957,7 +30940,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -30965,12 +30948,12 @@
         "compatibility_pair": {
           "bound_name": "has_wildcard_syntax",
           "target": "wildcard_engine.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".wildcard_engine:has_wildcard_syntax",
         "kind": "static_from",
-        "line": 542,
+        "line": 540,
         "name": "has_wildcard_syntax",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -30988,7 +30971,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -30996,12 +30979,12 @@
         "compatibility_pair": {
           "bound_name": "next_seed",
           "target": "wildcard_engine.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".wildcard_engine:next_seed",
         "kind": "static_from",
-        "line": 542,
+        "line": 540,
         "name": "next_seed",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -31019,7 +31002,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -31027,12 +31010,12 @@
         "compatibility_pair": {
           "bound_name": "normalize_prompt_studio_wildcard_mode",
           "target": "wildcard_engine.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".wildcard_engine:normalize_prompt_studio_wildcard_mode",
         "kind": "static_from",
-        "line": 542,
+        "line": 540,
         "name": "normalize_prompt_studio_wildcard_mode",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -31050,7 +31033,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -31058,12 +31041,12 @@
         "compatibility_pair": {
           "bound_name": "normalize_seed",
           "target": "wildcard_engine.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".wildcard_engine:normalize_seed",
         "kind": "static_from",
-        "line": 542,
+        "line": 540,
         "name": "normalize_seed",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -31081,7 +31064,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -31089,12 +31072,12 @@
         "compatibility_pair": {
           "bound_name": "normalize_wildcard_mode",
           "target": "wildcard_engine.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".wildcard_engine:normalize_wildcard_mode",
         "kind": "static_from",
-        "line": 542,
+        "line": 540,
         "name": "normalize_wildcard_mode",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -31112,7 +31095,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "internal",
@@ -31120,12 +31103,12 @@
         "compatibility_pair": {
           "bound_name": "wildcard_sources_signature",
           "target": "wildcard_engine.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": ".wildcard_engine:wildcard_sources_signature",
         "kind": "static_from",
-        "line": 542,
+        "line": 540,
         "name": "wildcard_sources_signature",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -31144,9 +31127,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -31154,12 +31137,12 @@
         "compatibility_pair": {
           "bound_name": "AIO_FIRST_PASS_CACHE_MAX_ENTRIES",
           "target": "easyuse_anima/aio/first_pass_cache.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:AIO_FIRST_PASS_CACHE_MAX_ENTRIES",
         "kind": "static_from",
-        "line": 564,
+        "line": 562,
         "name": "AIO_FIRST_PASS_CACHE_MAX_ENTRIES",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -31178,9 +31161,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -31188,12 +31171,12 @@
         "compatibility_pair": {
           "bound_name": "_AIO_FIRST_PASS_CACHE",
           "target": "easyuse_anima/aio/first_pass_cache.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_AIO_FIRST_PASS_CACHE",
         "kind": "static_from",
-        "line": 564,
+        "line": 562,
         "name": "_AIO_FIRST_PASS_CACHE",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -31212,9 +31195,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -31222,12 +31205,12 @@
         "compatibility_pair": {
           "bound_name": "_AIO_FIRST_PASS_CACHE_ORDER",
           "target": "easyuse_anima/aio/first_pass_cache.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_AIO_FIRST_PASS_CACHE_ORDER",
         "kind": "static_from",
-        "line": 564,
+        "line": 562,
         "name": "_AIO_FIRST_PASS_CACHE_ORDER",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -31246,9 +31229,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -31256,12 +31239,12 @@
         "compatibility_pair": {
           "bound_name": "_aio_first_pass_cache_key",
           "target": "easyuse_anima/aio/first_pass_cache.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_aio_first_pass_cache_key",
         "kind": "static_from",
-        "line": 564,
+        "line": 562,
         "name": "_aio_first_pass_cache_key",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -31280,9 +31263,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -31290,12 +31273,12 @@
         "compatibility_pair": {
           "bound_name": "_clone_aio_cache_value",
           "target": "easyuse_anima/aio/first_pass_cache.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_clone_aio_cache_value",
         "kind": "static_from",
-        "line": 564,
+        "line": 562,
         "name": "_clone_aio_cache_value",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -31314,9 +31297,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -31324,12 +31307,12 @@
         "compatibility_pair": {
           "bound_name": "_get_aio_first_pass_cache",
           "target": "easyuse_anima/aio/first_pass_cache.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_get_aio_first_pass_cache",
         "kind": "static_from",
-        "line": 564,
+        "line": 562,
         "name": "_get_aio_first_pass_cache",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -31348,9 +31331,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -31358,12 +31341,12 @@
         "compatibility_pair": {
           "bound_name": "_put_aio_first_pass_cache",
           "target": "easyuse_anima/aio/first_pass_cache.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_put_aio_first_pass_cache",
         "kind": "static_from",
-        "line": 564,
+        "line": 562,
         "name": "_put_aio_first_pass_cache",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -31382,9 +31365,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -31392,12 +31375,12 @@
         "compatibility_pair": {
           "bound_name": "_run_aio_detailer_stage",
           "target": "easyuse_anima/aio/legacy_generation.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_detailer_stage",
         "kind": "static_from",
-        "line": 574,
+        "line": 572,
         "name": "_run_aio_detailer_stage",
         "optional": false,
         "requested": "easyuse_anima.aio.legacy_generation",
@@ -31416,9 +31399,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -31426,12 +31409,12 @@
         "compatibility_pair": {
           "bound_name": "_run_aio_detailer_target",
           "target": "easyuse_anima/aio/legacy_generation.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_detailer_target",
         "kind": "static_from",
-        "line": 574,
+        "line": 572,
         "name": "_run_aio_detailer_target",
         "optional": false,
         "requested": "easyuse_anima.aio.legacy_generation",
@@ -31450,9 +31433,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -31460,12 +31443,12 @@
         "compatibility_pair": {
           "bound_name": "_run_aio_highres_stage",
           "target": "easyuse_anima/aio/legacy_generation.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_highres_stage",
         "kind": "static_from",
-        "line": 574,
+        "line": 572,
         "name": "_run_aio_highres_stage",
         "optional": false,
         "requested": "easyuse_anima.aio.legacy_generation",
@@ -31484,9 +31467,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -31494,12 +31477,12 @@
         "compatibility_pair": {
           "bound_name": "_run_aio_legacy_generation",
           "target": "easyuse_anima/aio/legacy_generation.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_legacy_generation",
         "kind": "static_from",
-        "line": 574,
+        "line": 572,
         "name": "_run_aio_legacy_generation",
         "optional": false,
         "requested": "easyuse_anima.aio.legacy_generation",
@@ -31518,9 +31501,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -31528,12 +31511,12 @@
         "compatibility_pair": {
           "bound_name": "_run_aio_resshift_upscale_stage",
           "target": "easyuse_anima/aio/legacy_generation.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_resshift_upscale_stage",
         "kind": "static_from",
-        "line": 574,
+        "line": 572,
         "name": "_run_aio_resshift_upscale_stage",
         "optional": false,
         "requested": "easyuse_anima.aio.legacy_generation",
@@ -31552,9 +31535,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -31562,12 +31545,12 @@
         "compatibility_pair": {
           "bound_name": "_run_aio_upscale_stage",
           "target": "easyuse_anima/aio/legacy_generation.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_upscale_stage",
         "kind": "static_from",
-        "line": 574,
+        "line": 572,
         "name": "_run_aio_upscale_stage",
         "optional": false,
         "requested": "easyuse_anima.aio.legacy_generation",
@@ -31586,9 +31569,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -31596,12 +31579,12 @@
         "compatibility_pair": {
           "bound_name": "_run_aio_usdu_upscale_stage",
           "target": "easyuse_anima/aio/legacy_generation.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_usdu_upscale_stage",
         "kind": "static_from",
-        "line": 574,
+        "line": 572,
         "name": "_run_aio_usdu_upscale_stage",
         "optional": false,
         "requested": "easyuse_anima.aio.legacy_generation",
@@ -31620,9 +31603,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -31630,12 +31613,12 @@
         "compatibility_pair": {
           "bound_name": "_AIO_DETAILER_CUSTOM_RE",
           "target": "easyuse_anima/aio/generation_normalization.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_AIO_DETAILER_CUSTOM_RE",
         "kind": "static_from",
-        "line": 583,
+        "line": 581,
         "name": "_AIO_DETAILER_CUSTOM_RE",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -31654,9 +31637,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -31664,12 +31647,12 @@
         "compatibility_pair": {
           "bound_name": "_AIO_DETAILER_RESERVED_KEYS",
           "target": "easyuse_anima/aio/generation_normalization.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_AIO_DETAILER_RESERVED_KEYS",
         "kind": "static_from",
-        "line": 583,
+        "line": 581,
         "name": "_AIO_DETAILER_RESERVED_KEYS",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -31688,9 +31671,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -31698,12 +31681,12 @@
         "compatibility_pair": {
           "bound_name": "_aio_detailer_has_enabled_targets",
           "target": "easyuse_anima/aio/generation_normalization.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_aio_detailer_has_enabled_targets",
         "kind": "static_from",
-        "line": 583,
+        "line": 581,
         "name": "_aio_detailer_has_enabled_targets",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -31722,9 +31705,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -31732,12 +31715,12 @@
         "compatibility_pair": {
           "bound_name": "_aio_detailer_target_defaults",
           "target": "easyuse_anima/aio/generation_normalization.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_aio_detailer_target_defaults",
         "kind": "static_from",
-        "line": 583,
+        "line": 581,
         "name": "_aio_detailer_target_defaults",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -31756,9 +31739,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -31766,12 +31749,12 @@
         "compatibility_pair": {
           "bound_name": "_aio_detailer_target_order",
           "target": "easyuse_anima/aio/generation_normalization.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_aio_detailer_target_order",
         "kind": "static_from",
-        "line": 583,
+        "line": 581,
         "name": "_aio_detailer_target_order",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -31790,9 +31773,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -31800,12 +31783,12 @@
         "compatibility_pair": {
           "bound_name": "_is_aio_detailer_target_name",
           "target": "easyuse_anima/aio/generation_normalization.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_is_aio_detailer_target_name",
         "kind": "static_from",
-        "line": 583,
+        "line": 581,
         "name": "_is_aio_detailer_target_name",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -31824,9 +31807,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -31834,12 +31817,12 @@
         "compatibility_pair": {
           "bound_name": "_merge_versioned_settings",
           "target": "easyuse_anima/aio/generation_normalization.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_merge_versioned_settings",
         "kind": "static_from",
-        "line": 583,
+        "line": 581,
         "name": "_merge_versioned_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -31858,9 +31841,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -31868,12 +31851,12 @@
         "compatibility_pair": {
           "bound_name": "_normalize_aio_dit_corrections_settings",
           "target": "easyuse_anima/aio/generation_normalization.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_dit_corrections_settings",
         "kind": "static_from",
-        "line": 583,
+        "line": 581,
         "name": "_normalize_aio_dit_corrections_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -31892,9 +31875,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -31902,12 +31885,12 @@
         "compatibility_pair": {
           "bound_name": "_normalize_aio_generation_settings",
           "target": "easyuse_anima/aio/generation_normalization.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_generation_settings",
         "kind": "static_from",
-        "line": 583,
+        "line": 581,
         "name": "_normalize_aio_generation_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -31926,9 +31909,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -31936,12 +31919,12 @@
         "compatibility_pair": {
           "bound_name": "_normalize_aio_seed",
           "target": "easyuse_anima/aio/generation_normalization.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_seed",
         "kind": "static_from",
-        "line": 583,
+        "line": 581,
         "name": "_normalize_aio_seed",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -31960,9 +31943,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -31970,12 +31953,12 @@
         "compatibility_pair": {
           "bound_name": "_normalize_aio_spectrum_settings",
           "target": "easyuse_anima/aio/generation_normalization.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_spectrum_settings",
         "kind": "static_from",
-        "line": 583,
+        "line": 581,
         "name": "_normalize_aio_spectrum_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -31994,9 +31977,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -32004,12 +31987,12 @@
         "compatibility_pair": {
           "bound_name": "AIO_FINAL_FIT_MODES",
           "target": "easyuse_anima/aio/generation_defaults.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_FINAL_FIT_MODES",
         "kind": "static_from",
-        "line": 596,
+        "line": 594,
         "name": "AIO_FINAL_FIT_MODES",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_defaults",
@@ -32028,9 +32011,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -32038,12 +32021,12 @@
         "compatibility_pair": {
           "bound_name": "AIO_FINAL_UPSCALE_BACKENDS",
           "target": "easyuse_anima/aio/generation_defaults.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_FINAL_UPSCALE_BACKENDS",
         "kind": "static_from",
-        "line": 596,
+        "line": 594,
         "name": "AIO_FINAL_UPSCALE_BACKENDS",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_defaults",
@@ -32062,9 +32045,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -32072,12 +32055,12 @@
         "compatibility_pair": {
           "bound_name": "AIO_GENERATION_DEFAULT_SETTINGS",
           "target": "easyuse_anima/aio/generation_defaults.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_GENERATION_DEFAULT_SETTINGS",
         "kind": "static_from",
-        "line": 596,
+        "line": 594,
         "name": "AIO_GENERATION_DEFAULT_SETTINGS",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_defaults",
@@ -32096,9 +32079,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -32106,12 +32089,12 @@
         "compatibility_pair": {
           "bound_name": "AIO_GENERATION_SETTINGS_SCHEMA",
           "target": "easyuse_anima/aio/generation_defaults.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_GENERATION_SETTINGS_SCHEMA",
         "kind": "static_from",
-        "line": 596,
+        "line": 594,
         "name": "AIO_GENERATION_SETTINGS_SCHEMA",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_defaults",
@@ -32130,9 +32113,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -32140,12 +32123,12 @@
         "compatibility_pair": {
           "bound_name": "AIO_GENERATION_SETTINGS_VERSION",
           "target": "easyuse_anima/aio/generation_defaults.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_GENERATION_SETTINGS_VERSION",
         "kind": "static_from",
-        "line": 596,
+        "line": 594,
         "name": "AIO_GENERATION_SETTINGS_VERSION",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_defaults",
@@ -32164,9 +32147,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -32174,12 +32157,12 @@
         "compatibility_pair": {
           "bound_name": "AIO_RESHIFT_DTYPES",
           "target": "easyuse_anima/aio/generation_defaults.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_RESHIFT_DTYPES",
         "kind": "static_from",
-        "line": 596,
+        "line": 594,
         "name": "AIO_RESHIFT_DTYPES",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_defaults",
@@ -32198,9 +32181,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -32208,12 +32191,12 @@
         "compatibility_pair": {
           "bound_name": "AIO_RESHIFT_SCALES",
           "target": "easyuse_anima/aio/generation_defaults.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_RESHIFT_SCALES",
         "kind": "static_from",
-        "line": 596,
+        "line": 594,
         "name": "AIO_RESHIFT_SCALES",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_defaults",
@@ -32232,9 +32215,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -32242,12 +32225,12 @@
         "compatibility_pair": {
           "bound_name": "AIO_SPECIAL_SEEDS",
           "target": "easyuse_anima/aio/generation_defaults.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_SPECIAL_SEEDS",
         "kind": "static_from",
-        "line": 596,
+        "line": 594,
         "name": "AIO_SPECIAL_SEEDS",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_defaults",
@@ -32266,9 +32249,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -32276,12 +32259,12 @@
         "compatibility_pair": {
           "bound_name": "AIO_SPECIAL_SEED_DECREMENT",
           "target": "easyuse_anima/aio/generation_defaults.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_SPECIAL_SEED_DECREMENT",
         "kind": "static_from",
-        "line": 596,
+        "line": 594,
         "name": "AIO_SPECIAL_SEED_DECREMENT",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_defaults",
@@ -32300,9 +32283,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -32310,12 +32293,12 @@
         "compatibility_pair": {
           "bound_name": "AIO_SPECIAL_SEED_INCREMENT",
           "target": "easyuse_anima/aio/generation_defaults.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_SPECIAL_SEED_INCREMENT",
         "kind": "static_from",
-        "line": 596,
+        "line": 594,
         "name": "AIO_SPECIAL_SEED_INCREMENT",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_defaults",
@@ -32334,9 +32317,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -32344,12 +32327,12 @@
         "compatibility_pair": {
           "bound_name": "AIO_SPECIAL_SEED_RANDOM",
           "target": "easyuse_anima/aio/generation_defaults.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_SPECIAL_SEED_RANDOM",
         "kind": "static_from",
-        "line": 596,
+        "line": 594,
         "name": "AIO_SPECIAL_SEED_RANDOM",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_defaults",
@@ -32368,9 +32351,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -32378,12 +32361,12 @@
         "compatibility_pair": {
           "bound_name": "AIO_USDU_MODE_TYPES",
           "target": "easyuse_anima/aio/generation_defaults.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_USDU_MODE_TYPES",
         "kind": "static_from",
-        "line": 596,
+        "line": 594,
         "name": "AIO_USDU_MODE_TYPES",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_defaults",
@@ -32402,9 +32385,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -32412,12 +32395,12 @@
         "compatibility_pair": {
           "bound_name": "AIO_USDU_PROMPT_FULL",
           "target": "easyuse_anima/aio/generation_defaults.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_USDU_PROMPT_FULL",
         "kind": "static_from",
-        "line": 596,
+        "line": 594,
         "name": "AIO_USDU_PROMPT_FULL",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_defaults",
@@ -32436,9 +32419,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -32446,12 +32429,12 @@
         "compatibility_pair": {
           "bound_name": "AIO_USDU_PROMPT_MODES",
           "target": "easyuse_anima/aio/generation_defaults.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_USDU_PROMPT_MODES",
         "kind": "static_from",
-        "line": 596,
+        "line": 594,
         "name": "AIO_USDU_PROMPT_MODES",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_defaults",
@@ -32470,9 +32453,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -32480,12 +32463,12 @@
         "compatibility_pair": {
           "bound_name": "AIO_USDU_PROMPT_NO_GENERAL",
           "target": "easyuse_anima/aio/generation_defaults.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_USDU_PROMPT_NO_GENERAL",
         "kind": "static_from",
-        "line": 596,
+        "line": 594,
         "name": "AIO_USDU_PROMPT_NO_GENERAL",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_defaults",
@@ -32504,9 +32487,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -32514,12 +32497,12 @@
         "compatibility_pair": {
           "bound_name": "AIO_USDU_SEAM_FIX_MODES",
           "target": "easyuse_anima/aio/generation_defaults.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_USDU_SEAM_FIX_MODES",
         "kind": "static_from",
-        "line": 596,
+        "line": 594,
         "name": "AIO_USDU_SEAM_FIX_MODES",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_defaults",
@@ -32538,9 +32521,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -32548,12 +32531,12 @@
         "compatibility_pair": {
           "bound_name": "_round_trip_aio_generation_settings",
           "target": "easyuse_anima/aio/generation_settings.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_settings:round_trip_aio_generation_settings",
         "kind": "static_from",
-        "line": 614,
+        "line": 612,
         "name": "round_trip_aio_generation_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_settings",
@@ -32572,9 +32555,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -32582,12 +32565,12 @@
         "compatibility_pair": {
           "bound_name": "AIO_INPUT_DEFAULT_SETTINGS",
           "target": "easyuse_anima/aio/input_defaults.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.input_defaults:AIO_INPUT_DEFAULT_SETTINGS",
         "kind": "static_from",
-        "line": 617,
+        "line": 615,
         "name": "AIO_INPUT_DEFAULT_SETTINGS",
         "optional": false,
         "requested": "easyuse_anima.aio.input_defaults",
@@ -32606,9 +32589,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -32616,12 +32599,12 @@
         "compatibility_pair": {
           "bound_name": "ANIMA_CLIP_DEVICES",
           "target": "easyuse_anima/aio/input_defaults.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.input_defaults:ANIMA_CLIP_DEVICES",
         "kind": "static_from",
-        "line": 617,
+        "line": 615,
         "name": "ANIMA_CLIP_DEVICES",
         "optional": false,
         "requested": "easyuse_anima.aio.input_defaults",
@@ -32640,9 +32623,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -32650,12 +32633,12 @@
         "compatibility_pair": {
           "bound_name": "ANIMA_CLIP_TYPES",
           "target": "easyuse_anima/aio/input_defaults.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.input_defaults:ANIMA_CLIP_TYPES",
         "kind": "static_from",
-        "line": 617,
+        "line": 615,
         "name": "ANIMA_CLIP_TYPES",
         "optional": false,
         "requested": "easyuse_anima.aio.input_defaults",
@@ -32674,9 +32657,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -32684,12 +32667,12 @@
         "compatibility_pair": {
           "bound_name": "ANIMA_DEFAULT_CLIP_CANDIDATES",
           "target": "easyuse_anima/aio/input_defaults.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.input_defaults:ANIMA_DEFAULT_CLIP_CANDIDATES",
         "kind": "static_from",
-        "line": 617,
+        "line": 615,
         "name": "ANIMA_DEFAULT_CLIP_CANDIDATES",
         "optional": false,
         "requested": "easyuse_anima.aio.input_defaults",
@@ -32708,9 +32691,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -32718,12 +32701,12 @@
         "compatibility_pair": {
           "bound_name": "ANIMA_DEFAULT_DIFFUSION_MODEL_CANDIDATES",
           "target": "easyuse_anima/aio/input_defaults.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.input_defaults:ANIMA_DEFAULT_DIFFUSION_MODEL_CANDIDATES",
         "kind": "static_from",
-        "line": 617,
+        "line": 615,
         "name": "ANIMA_DEFAULT_DIFFUSION_MODEL_CANDIDATES",
         "optional": false,
         "requested": "easyuse_anima.aio.input_defaults",
@@ -32742,9 +32725,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -32752,12 +32735,12 @@
         "compatibility_pair": {
           "bound_name": "ANIMA_DEFAULT_VAE_CANDIDATES",
           "target": "easyuse_anima/aio/input_defaults.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.input_defaults:ANIMA_DEFAULT_VAE_CANDIDATES",
         "kind": "static_from",
-        "line": 617,
+        "line": 615,
         "name": "ANIMA_DEFAULT_VAE_CANDIDATES",
         "optional": false,
         "requested": "easyuse_anima.aio.input_defaults",
@@ -32776,9 +32759,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -32786,12 +32769,12 @@
         "compatibility_pair": {
           "bound_name": "ANIMA_UNET_WEIGHT_DTYPES",
           "target": "easyuse_anima/aio/input_defaults.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.input_defaults:ANIMA_UNET_WEIGHT_DTYPES",
         "kind": "static_from",
-        "line": 617,
+        "line": 615,
         "name": "ANIMA_UNET_WEIGHT_DTYPES",
         "optional": false,
         "requested": "easyuse_anima.aio.input_defaults",
@@ -32810,9 +32793,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -32820,12 +32803,12 @@
         "compatibility_pair": {
           "bound_name": "EASY_USE_ANIMA_INPUT_SCHEMA",
           "target": "easyuse_anima/aio/input_defaults.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.input_defaults:EASY_USE_ANIMA_INPUT_SCHEMA",
         "kind": "static_from",
-        "line": 617,
+        "line": 615,
         "name": "EASY_USE_ANIMA_INPUT_SCHEMA",
         "optional": false,
         "requested": "easyuse_anima.aio.input_defaults",
@@ -32844,9 +32827,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -32854,12 +32837,12 @@
         "compatibility_pair": {
           "bound_name": "EASY_USE_ANIMA_INPUT_SETTINGS_VERSION",
           "target": "easyuse_anima/aio/input_defaults.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.input_defaults:EASY_USE_ANIMA_INPUT_SETTINGS_VERSION",
         "kind": "static_from",
-        "line": 617,
+        "line": 615,
         "name": "EASY_USE_ANIMA_INPUT_SETTINGS_VERSION",
         "optional": false,
         "requested": "easyuse_anima.aio.input_defaults",
@@ -32878,9 +32861,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -32888,12 +32871,12 @@
         "compatibility_pair": {
           "bound_name": "_easy_use_anima_input_signature",
           "target": "easyuse_anima/aio/input_context.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.input_context:_easy_use_anima_input_signature",
         "kind": "static_from",
-        "line": 628,
+        "line": 626,
         "name": "_easy_use_anima_input_signature",
         "optional": false,
         "requested": "easyuse_anima.aio.input_context",
@@ -32912,9 +32895,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -32922,12 +32905,12 @@
         "compatibility_pair": {
           "bound_name": "_require_easy_use_anima_input",
           "target": "easyuse_anima/aio/input_context.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.input_context:_require_easy_use_anima_input",
         "kind": "static_from",
-        "line": 628,
+        "line": 626,
         "name": "_require_easy_use_anima_input",
         "optional": false,
         "requested": "easyuse_anima.aio.input_context",
@@ -32946,9 +32929,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -32956,12 +32939,12 @@
         "compatibility_pair": {
           "bound_name": "_aio_usdu_auto_tile_dimension",
           "target": "easyuse_anima/aio/usdu.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.usdu:_aio_usdu_auto_tile_dimension",
         "kind": "static_from",
-        "line": 632,
+        "line": 630,
         "name": "_aio_usdu_auto_tile_dimension",
         "optional": false,
         "requested": "easyuse_anima.aio.usdu",
@@ -32980,9 +32963,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -32990,12 +32973,12 @@
         "compatibility_pair": {
           "bound_name": "_aio_usdu_tile_plan",
           "target": "easyuse_anima/aio/usdu.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.usdu:_aio_usdu_tile_plan",
         "kind": "static_from",
-        "line": 632,
+        "line": 630,
         "name": "_aio_usdu_tile_plan",
         "optional": false,
         "requested": "easyuse_anima.aio.usdu",
@@ -33014,9 +32997,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -33024,12 +33007,12 @@
         "compatibility_pair": {
           "bound_name": "_aio_final_fit_size",
           "target": "easyuse_anima/aio/postprocess.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_aio_final_fit_size",
         "kind": "static_from",
-        "line": 636,
+        "line": 634,
         "name": "_aio_final_fit_size",
         "optional": false,
         "requested": "easyuse_anima.aio.postprocess",
@@ -33048,9 +33031,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -33058,12 +33041,12 @@
         "compatibility_pair": {
           "bound_name": "_apply_aio_final_fit",
           "target": "easyuse_anima/aio/postprocess.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_apply_aio_final_fit",
         "kind": "static_from",
-        "line": 636,
+        "line": 634,
         "name": "_apply_aio_final_fit",
         "optional": false,
         "requested": "easyuse_anima.aio.postprocess",
@@ -33082,9 +33065,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -33092,12 +33075,12 @@
         "compatibility_pair": {
           "bound_name": "_resize_image_to_size_if_needed",
           "target": "easyuse_anima/aio/postprocess.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_resize_image_to_size_if_needed",
         "kind": "static_from",
-        "line": 636,
+        "line": 634,
         "name": "_resize_image_to_size_if_needed",
         "optional": false,
         "requested": "easyuse_anima.aio.postprocess",
@@ -33116,9 +33099,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -33126,12 +33109,12 @@
         "compatibility_pair": {
           "bound_name": "_run_aio_postprocess_stage",
           "target": "easyuse_anima/aio/postprocess.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_run_aio_postprocess_stage",
         "kind": "static_from",
-        "line": 636,
+        "line": 634,
         "name": "_run_aio_postprocess_stage",
         "optional": false,
         "requested": "easyuse_anima.aio.postprocess",
@@ -33150,9 +33133,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -33160,12 +33143,12 @@
         "compatibility_pair": {
           "bound_name": "_aio_prompt_data_fields_for_usdu",
           "target": "easyuse_anima/aio/conditioning.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_prompt_data_fields_for_usdu",
         "kind": "static_from",
-        "line": 642,
+        "line": 640,
         "name": "_aio_prompt_data_fields_for_usdu",
         "optional": false,
         "requested": "easyuse_anima.aio.conditioning",
@@ -33184,9 +33167,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -33194,12 +33177,12 @@
         "compatibility_pair": {
           "bound_name": "_aio_usdu_conditioning",
           "target": "easyuse_anima/aio/conditioning.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_usdu_conditioning",
         "kind": "static_from",
-        "line": 642,
+        "line": 640,
         "name": "_aio_usdu_conditioning",
         "optional": false,
         "requested": "easyuse_anima.aio.conditioning",
@@ -33218,9 +33201,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -33228,12 +33211,12 @@
         "compatibility_pair": {
           "bound_name": "_aio_usdu_prompt_without_general",
           "target": "easyuse_anima/aio/conditioning.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_usdu_prompt_without_general",
         "kind": "static_from",
-        "line": 642,
+        "line": 640,
         "name": "_aio_usdu_prompt_without_general",
         "optional": false,
         "requested": "easyuse_anima.aio.conditioning",
@@ -33252,9 +33235,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -33262,12 +33245,12 @@
         "compatibility_pair": {
           "bound_name": "_aio_lora_stack_signature",
           "target": "easyuse_anima/aio/model_preparation.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_aio_lora_stack_signature",
         "kind": "static_from",
-        "line": 647,
+        "line": 645,
         "name": "_aio_lora_stack_signature",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -33286,9 +33269,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -33296,12 +33279,12 @@
         "compatibility_pair": {
           "bound_name": "_apply_aio_anima_dave_patch",
           "target": "easyuse_anima/aio/model_preparation.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_anima_dave_patch",
         "kind": "static_from",
-        "line": 647,
+        "line": 645,
         "name": "_apply_aio_anima_dave_patch",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -33320,9 +33303,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -33330,12 +33313,12 @@
         "compatibility_pair": {
           "bound_name": "_apply_aio_kj_model_patches",
           "target": "easyuse_anima/aio/model_preparation.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_kj_model_patches",
         "kind": "static_from",
-        "line": 647,
+        "line": 645,
         "name": "_apply_aio_kj_model_patches",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -33354,9 +33337,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -33364,12 +33347,12 @@
         "compatibility_pair": {
           "bound_name": "_apply_aio_lora_stack",
           "target": "easyuse_anima/aio/model_preparation.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_lora_stack",
         "kind": "static_from",
-        "line": 647,
+        "line": 645,
         "name": "_apply_aio_lora_stack",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -33388,9 +33371,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -33398,12 +33381,12 @@
         "compatibility_pair": {
           "bound_name": "_apply_aio_model_patches",
           "target": "easyuse_anima/aio/model_preparation.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_model_patches",
         "kind": "static_from",
-        "line": 647,
+        "line": 645,
         "name": "_apply_aio_model_patches",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -33422,9 +33405,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -33432,12 +33415,12 @@
         "compatibility_pair": {
           "bound_name": "_apply_aio_safe_pag_patch",
           "target": "easyuse_anima/aio/model_preparation.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_safe_pag_patch",
         "kind": "static_from",
-        "line": 647,
+        "line": 645,
         "name": "_apply_aio_safe_pag_patch",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -33456,9 +33439,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -33466,12 +33449,12 @@
         "compatibility_pair": {
           "bound_name": "_apply_aio_spectrum_correction_patch_for_comfy_sampler",
           "target": "easyuse_anima/aio/model_preparation.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_correction_patch_for_comfy_sampler",
         "kind": "static_from",
-        "line": 647,
+        "line": 645,
         "name": "_apply_aio_spectrum_correction_patch_for_comfy_sampler",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -33490,9 +33473,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -33500,12 +33483,12 @@
         "compatibility_pair": {
           "bound_name": "_apply_aio_spectrum_forecast_patch_for_comfy_sampler",
           "target": "easyuse_anima/aio/model_preparation.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_forecast_patch_for_comfy_sampler",
         "kind": "static_from",
-        "line": 647,
+        "line": 645,
         "name": "_apply_aio_spectrum_forecast_patch_for_comfy_sampler",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -33524,9 +33507,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -33534,12 +33517,12 @@
         "compatibility_pair": {
           "bound_name": "_apply_aio_spectrum_model_patches_for_comfy_sampler",
           "target": "easyuse_anima/aio/model_preparation.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_model_patches_for_comfy_sampler",
         "kind": "static_from",
-        "line": 647,
+        "line": 645,
         "name": "_apply_aio_spectrum_model_patches_for_comfy_sampler",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -33558,9 +33541,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -33568,12 +33551,12 @@
         "compatibility_pair": {
           "bound_name": "_cleanup_aio_ephemeral_model",
           "target": "easyuse_anima/aio/model_preparation.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_cleanup_aio_ephemeral_model",
         "kind": "static_from",
-        "line": 647,
+        "line": 645,
         "name": "_cleanup_aio_ephemeral_model",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -33592,9 +33575,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -33602,12 +33585,12 @@
         "compatibility_pair": {
           "bound_name": "_normalize_aio_lora_stack",
           "target": "easyuse_anima/aio/model_preparation.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_normalize_aio_lora_stack",
         "kind": "static_from",
-        "line": 647,
+        "line": 645,
         "name": "_normalize_aio_lora_stack",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -33626,9 +33609,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -33636,12 +33619,12 @@
         "compatibility_pair": {
           "bound_name": "_patch_model_sampling_aura_flow",
           "target": "easyuse_anima/aio/model_preparation.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_patch_model_sampling_aura_flow",
         "kind": "static_from",
-        "line": 647,
+        "line": 645,
         "name": "_patch_model_sampling_aura_flow",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -33660,9 +33643,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -33670,12 +33653,12 @@
         "compatibility_pair": {
           "bound_name": "_aio_highres_effective_backend",
           "target": "easyuse_anima/aio/sampling.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_aio_highres_effective_backend",
         "kind": "static_from",
-        "line": 661,
+        "line": 659,
         "name": "_aio_highres_effective_backend",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -33694,9 +33677,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -33704,12 +33687,12 @@
         "compatibility_pair": {
           "bound_name": "_aio_stage_sampler_settings",
           "target": "easyuse_anima/aio/sampling.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_aio_stage_sampler_settings",
         "kind": "static_from",
-        "line": 661,
+        "line": 659,
         "name": "_aio_stage_sampler_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -33728,9 +33711,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -33738,12 +33721,12 @@
         "compatibility_pair": {
           "bound_name": "_decode_latent_with_comfy",
           "target": "easyuse_anima/aio/sampling.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_decode_latent_with_comfy",
         "kind": "static_from",
-        "line": 661,
+        "line": 659,
         "name": "_decode_latent_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -33762,9 +33745,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -33772,12 +33755,12 @@
         "compatibility_pair": {
           "bound_name": "_encode_image_with_comfy_vae",
           "target": "easyuse_anima/aio/sampling.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_encode_image_with_comfy_vae",
         "kind": "static_from",
-        "line": 661,
+        "line": 659,
         "name": "_encode_image_with_comfy_vae",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -33796,9 +33779,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -33806,12 +33789,12 @@
         "compatibility_pair": {
           "bound_name": "_generate_empty_latent_with_comfy",
           "target": "easyuse_anima/aio/sampling.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_generate_empty_latent_with_comfy",
         "kind": "static_from",
-        "line": 661,
+        "line": 659,
         "name": "_generate_empty_latent_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -33830,9 +33813,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -33840,12 +33823,12 @@
         "compatibility_pair": {
           "bound_name": "_new_aio_random_seed",
           "target": "easyuse_anima/aio/sampling.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_new_aio_random_seed",
         "kind": "static_from",
-        "line": 661,
+        "line": 659,
         "name": "_new_aio_random_seed",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -33864,9 +33847,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -33874,12 +33857,12 @@
         "compatibility_pair": {
           "bound_name": "_resolve_aio_runtime_seed",
           "target": "easyuse_anima/aio/sampling.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_resolve_aio_runtime_seed",
         "kind": "static_from",
-        "line": 661,
+        "line": 659,
         "name": "_resolve_aio_runtime_seed",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -33898,9 +33881,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -33908,12 +33891,12 @@
         "compatibility_pair": {
           "bound_name": "_sample_latent_with_aio_backend",
           "target": "easyuse_anima/aio/sampling.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_aio_backend",
         "kind": "static_from",
-        "line": 661,
+        "line": 659,
         "name": "_sample_latent_with_aio_backend",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -33932,9 +33915,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -33942,12 +33925,12 @@
         "compatibility_pair": {
           "bound_name": "_sample_latent_with_comfy",
           "target": "easyuse_anima/aio/sampling.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_comfy",
         "kind": "static_from",
-        "line": 661,
+        "line": 659,
         "name": "_sample_latent_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -33966,9 +33949,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -33976,12 +33959,12 @@
         "compatibility_pair": {
           "bound_name": "_sample_latent_with_spectrum_mod_guidance_advanced",
           "target": "easyuse_anima/aio/sampling.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_spectrum_mod_guidance_advanced",
         "kind": "static_from",
-        "line": 661,
+        "line": 659,
         "name": "_sample_latent_with_spectrum_mod_guidance_advanced",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -34000,9 +33983,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -34010,12 +33993,12 @@
         "compatibility_pair": {
           "bound_name": "_sample_latent_with_spectrum_spd",
           "target": "easyuse_anima/aio/sampling.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_spectrum_spd",
         "kind": "static_from",
-        "line": 661,
+        "line": 659,
         "name": "_sample_latent_with_spectrum_spd",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -34034,9 +34017,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -34044,12 +34027,12 @@
         "compatibility_pair": {
           "bound_name": "AIO_PREVIEW_CACHE_FORMAT",
           "target": "easyuse_anima/aio/preview.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_CACHE_FORMAT",
         "kind": "static_from",
-        "line": 674,
+        "line": 672,
         "name": "AIO_PREVIEW_CACHE_FORMAT",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -34068,9 +34051,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -34078,12 +34061,12 @@
         "compatibility_pair": {
           "bound_name": "AIO_PREVIEW_CACHE_QUALITY",
           "target": "easyuse_anima/aio/preview.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_CACHE_QUALITY",
         "kind": "static_from",
-        "line": 674,
+        "line": 672,
         "name": "AIO_PREVIEW_CACHE_QUALITY",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -34102,9 +34085,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -34112,12 +34095,12 @@
         "compatibility_pair": {
           "bound_name": "AIO_PREVIEW_EVENT",
           "target": "easyuse_anima/aio/preview.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_EVENT",
         "kind": "static_from",
-        "line": 674,
+        "line": 672,
         "name": "AIO_PREVIEW_EVENT",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -34136,9 +34119,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -34146,12 +34129,12 @@
         "compatibility_pair": {
           "bound_name": "AIO_PREVIEW_STAGE_LABELS",
           "target": "easyuse_anima/aio/preview.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_STAGE_LABELS",
         "kind": "static_from",
-        "line": 674,
+        "line": 672,
         "name": "AIO_PREVIEW_STAGE_LABELS",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -34170,9 +34153,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -34180,12 +34163,12 @@
         "compatibility_pair": {
           "bound_name": "_aio_preview_base_directory",
           "target": "easyuse_anima/aio/preview.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_aio_preview_base_directory",
         "kind": "static_from",
-        "line": 674,
+        "line": 672,
         "name": "_aio_preview_base_directory",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -34204,9 +34187,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -34214,12 +34197,12 @@
         "compatibility_pair": {
           "bound_name": "_aio_preview_file_size_bytes",
           "target": "easyuse_anima/aio/preview.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_aio_preview_file_size_bytes",
         "kind": "static_from",
-        "line": 674,
+        "line": 672,
         "name": "_aio_preview_file_size_bytes",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -34238,9 +34221,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -34248,12 +34231,12 @@
         "compatibility_pair": {
           "bound_name": "_save_aio_temp_preview_image",
           "target": "easyuse_anima/aio/preview.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_save_aio_temp_preview_image",
         "kind": "static_from",
-        "line": 674,
+        "line": 672,
         "name": "_save_aio_temp_preview_image",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -34272,9 +34255,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -34282,12 +34265,12 @@
         "compatibility_pair": {
           "bound_name": "_send_aio_preview_event",
           "target": "easyuse_anima/aio/preview.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_send_aio_preview_event",
         "kind": "static_from",
-        "line": 674,
+        "line": 672,
         "name": "_send_aio_preview_event",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -34306,9 +34289,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -34316,12 +34299,12 @@
         "compatibility_pair": {
           "bound_name": "_tag_aio_preview_images",
           "target": "easyuse_anima/aio/preview.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_tag_aio_preview_images",
         "kind": "static_from",
-        "line": 674,
+        "line": 672,
         "name": "_tag_aio_preview_images",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -34340,9 +34323,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -34350,12 +34333,12 @@
         "compatibility_pair": {
           "bound_name": "_aio_image_saver_additional_hashes",
           "target": "easyuse_anima/aio/output.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_image_saver_additional_hashes",
         "kind": "static_from",
-        "line": 685,
+        "line": 683,
         "name": "_aio_image_saver_additional_hashes",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -34374,9 +34357,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -34384,12 +34367,12 @@
         "compatibility_pair": {
           "bound_name": "_aio_image_saver_civitai_hash_fetcher_entries",
           "target": "easyuse_anima/aio/output.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_image_saver_civitai_hash_fetcher_entries",
         "kind": "static_from",
-        "line": 685,
+        "line": 683,
         "name": "_aio_image_saver_civitai_hash_fetcher_entries",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -34408,9 +34391,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -34418,12 +34401,12 @@
         "compatibility_pair": {
           "bound_name": "_aio_lora_metadata_name",
           "target": "easyuse_anima/aio/output.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_lora_metadata_name",
         "kind": "static_from",
-        "line": 685,
+        "line": 683,
         "name": "_aio_lora_metadata_name",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -34442,9 +34425,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -34452,12 +34435,12 @@
         "compatibility_pair": {
           "bound_name": "_aio_prompt_with_lora_metadata",
           "target": "easyuse_anima/aio/output.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_prompt_with_lora_metadata",
         "kind": "static_from",
-        "line": 685,
+        "line": 683,
         "name": "_aio_prompt_with_lora_metadata",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -34476,9 +34459,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -34486,12 +34469,12 @@
         "compatibility_pair": {
           "bound_name": "_aio_save_filename_prefix",
           "target": "easyuse_anima/aio/output.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_save_filename_prefix",
         "kind": "static_from",
-        "line": 685,
+        "line": 683,
         "name": "_aio_save_filename_prefix",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -34510,9 +34493,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -34520,12 +34503,12 @@
         "compatibility_pair": {
           "bound_name": "_save_image_with_comfy",
           "target": "easyuse_anima/aio/output.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_save_image_with_comfy",
         "kind": "static_from",
-        "line": 685,
+        "line": 683,
         "name": "_save_image_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -34544,9 +34527,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -34554,12 +34537,12 @@
         "compatibility_pair": {
           "bound_name": "_save_image_with_image_saver",
           "target": "easyuse_anima/aio/output.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_save_image_with_image_saver",
         "kind": "static_from",
-        "line": 685,
+        "line": 683,
         "name": "_save_image_with_image_saver",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -34578,9 +34561,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -34588,12 +34571,12 @@
         "compatibility_pair": {
           "bound_name": "_normalize_aio_civitai_hash_fetchers",
           "target": "easyuse_anima/aio/output_settings.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.output_settings:_normalize_aio_civitai_hash_fetchers",
         "kind": "static_from",
-        "line": 694,
+        "line": 692,
         "name": "_normalize_aio_civitai_hash_fetchers",
         "optional": false,
         "requested": "easyuse_anima.aio.output_settings",
@@ -34612,9 +34595,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -34622,12 +34605,12 @@
         "compatibility_pair": {
           "bound_name": "_normalize_aio_hash_bundles",
           "target": "easyuse_anima/aio/output_settings.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.output_settings:_normalize_aio_hash_bundles",
         "kind": "static_from",
-        "line": 694,
+        "line": 692,
         "name": "_normalize_aio_hash_bundles",
         "optional": false,
         "requested": "easyuse_anima.aio.output_settings",
@@ -34646,9 +34629,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -34656,12 +34639,12 @@
         "compatibility_pair": {
           "bound_name": "_comfy_clip_loader_types",
           "target": "easyuse_anima/aio/resources.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_clip_loader_types",
         "kind": "static_from",
-        "line": 698,
+        "line": 696,
         "name": "_comfy_clip_loader_types",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -34680,9 +34663,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -34690,12 +34673,12 @@
         "compatibility_pair": {
           "bound_name": "_comfy_diffusion_model_names",
           "target": "easyuse_anima/aio/resources.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_diffusion_model_names",
         "kind": "static_from",
-        "line": 698,
+        "line": 696,
         "name": "_comfy_diffusion_model_names",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -34714,9 +34697,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -34724,12 +34707,12 @@
         "compatibility_pair": {
           "bound_name": "_comfy_text_encoder_names",
           "target": "easyuse_anima/aio/resources.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_text_encoder_names",
         "kind": "static_from",
-        "line": 698,
+        "line": 696,
         "name": "_comfy_text_encoder_names",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -34748,9 +34731,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -34758,12 +34741,12 @@
         "compatibility_pair": {
           "bound_name": "_comfy_vae_names",
           "target": "easyuse_anima/aio/resources.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_vae_names",
         "kind": "static_from",
-        "line": 698,
+        "line": 696,
         "name": "_comfy_vae_names",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -34782,9 +34765,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -34792,12 +34775,12 @@
         "compatibility_pair": {
           "bound_name": "_load_aio_resources_from_input_context",
           "target": "easyuse_anima/aio/resources.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_aio_resources_from_input_context",
         "kind": "static_from",
-        "line": 698,
+        "line": 696,
         "name": "_load_aio_resources_from_input_context",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -34816,9 +34799,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -34826,12 +34809,12 @@
         "compatibility_pair": {
           "bound_name": "_load_aio_sam3_context",
           "target": "easyuse_anima/aio/resources.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_aio_sam3_context",
         "kind": "static_from",
-        "line": 698,
+        "line": 696,
         "name": "_load_aio_sam3_context",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -34850,9 +34833,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -34860,12 +34843,12 @@
         "compatibility_pair": {
           "bound_name": "_load_checkpoint_with_comfy",
           "target": "easyuse_anima/aio/resources.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_checkpoint_with_comfy",
         "kind": "static_from",
-        "line": 698,
+        "line": 696,
         "name": "_load_checkpoint_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -34884,9 +34867,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -34894,12 +34877,12 @@
         "compatibility_pair": {
           "bound_name": "_load_clip_with_comfy",
           "target": "easyuse_anima/aio/resources.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_clip_with_comfy",
         "kind": "static_from",
-        "line": 698,
+        "line": 696,
         "name": "_load_clip_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -34918,9 +34901,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -34928,12 +34911,12 @@
         "compatibility_pair": {
           "bound_name": "_load_diffusion_model_with_comfy",
           "target": "easyuse_anima/aio/resources.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_diffusion_model_with_comfy",
         "kind": "static_from",
-        "line": 698,
+        "line": 696,
         "name": "_load_diffusion_model_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -34952,9 +34935,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -34962,12 +34945,12 @@
         "compatibility_pair": {
           "bound_name": "_load_upscale_model_with_comfy",
           "target": "easyuse_anima/aio/resources.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_upscale_model_with_comfy",
         "kind": "static_from",
-        "line": 698,
+        "line": 696,
         "name": "_load_upscale_model_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -34986,9 +34969,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -34996,12 +34979,12 @@
         "compatibility_pair": {
           "bound_name": "_load_vae_with_comfy",
           "target": "easyuse_anima/aio/resources.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_vae_with_comfy",
         "kind": "static_from",
-        "line": 698,
+        "line": 696,
         "name": "_load_vae_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -35020,9 +35003,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -35030,12 +35013,12 @@
         "compatibility_pair": {
           "bound_name": "_normalize_aio_input_settings",
           "target": "easyuse_anima/aio/resources.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_normalize_aio_input_settings",
         "kind": "static_from",
-        "line": 698,
+        "line": 696,
         "name": "_normalize_aio_input_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -35054,9 +35037,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -35064,12 +35047,12 @@
         "compatibility_pair": {
           "bound_name": "_preferred_checkpoint_default",
           "target": "easyuse_anima/aio/resources.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_checkpoint_default",
         "kind": "static_from",
-        "line": 698,
+        "line": 696,
         "name": "_preferred_checkpoint_default",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -35088,9 +35071,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -35098,12 +35081,12 @@
         "compatibility_pair": {
           "bound_name": "_preferred_clip_type_default",
           "target": "easyuse_anima/aio/resources.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_clip_type_default",
         "kind": "static_from",
-        "line": 698,
+        "line": 696,
         "name": "_preferred_clip_type_default",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -35122,9 +35105,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -35132,12 +35115,12 @@
         "compatibility_pair": {
           "bound_name": "_preferred_name_default",
           "target": "easyuse_anima/aio/resources.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_name_default",
         "kind": "static_from",
-        "line": 698,
+        "line": 696,
         "name": "_preferred_name_default",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -35156,9 +35139,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -35166,12 +35149,12 @@
         "compatibility_pair": {
           "bound_name": "_json_clone",
           "target": "easyuse_anima/common/serialization.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_json_clone",
         "kind": "static_from",
-        "line": 715,
+        "line": 713,
         "name": "_json_clone",
         "optional": false,
         "requested": "easyuse_anima.common.serialization",
@@ -35190,9 +35173,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -35200,12 +35183,12 @@
         "compatibility_pair": {
           "bound_name": "_json_object",
           "target": "easyuse_anima/common/serialization.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_json_object",
         "kind": "static_from",
-        "line": 715,
+        "line": 713,
         "name": "_json_object",
         "optional": false,
         "requested": "easyuse_anima.common.serialization",
@@ -35224,9 +35207,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -35234,12 +35217,12 @@
         "compatibility_pair": {
           "bound_name": "_stable_change_key",
           "target": "easyuse_anima/common/serialization.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_stable_change_key",
         "kind": "static_from",
-        "line": 715,
+        "line": 713,
         "name": "_stable_change_key",
         "optional": false,
         "requested": "easyuse_anima.common.serialization",
@@ -35258,9 +35241,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -35268,12 +35251,12 @@
         "compatibility_pair": {
           "bound_name": "_as_bool",
           "target": "easyuse_anima/common/values.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_bool",
         "kind": "static_from",
-        "line": 720,
+        "line": 718,
         "name": "_as_bool",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -35292,9 +35275,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -35302,12 +35285,12 @@
         "compatibility_pair": {
           "bound_name": "_as_float",
           "target": "easyuse_anima/common/values.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_float",
         "kind": "static_from",
-        "line": 720,
+        "line": 718,
         "name": "_as_float",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -35326,9 +35309,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -35336,12 +35319,12 @@
         "compatibility_pair": {
           "bound_name": "_as_int",
           "target": "easyuse_anima/common/values.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_int",
         "kind": "static_from",
-        "line": 720,
+        "line": 718,
         "name": "_as_int",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -35360,9 +35343,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -35370,12 +35353,12 @@
         "compatibility_pair": {
           "bound_name": "_choice",
           "target": "easyuse_anima/common/values.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.common.values:_choice",
         "kind": "static_from",
-        "line": 720,
+        "line": 718,
         "name": "_choice",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -35394,9 +35377,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -35404,12 +35387,12 @@
         "compatibility_pair": {
           "bound_name": "_single_value",
           "target": "easyuse_anima/common/values.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.common.values:_single_value",
         "kind": "static_from",
-        "line": 720,
+        "line": 718,
         "name": "_single_value",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -35428,9 +35411,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -35438,12 +35421,12 @@
         "compatibility_pair": {
           "bound_name": "WILDCARD_QUEUE_MAX_SAFE_SEED",
           "target": "easyuse_anima/seed/compatibility.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.seed.compatibility:WILDCARD_QUEUE_MAX_SAFE_SEED",
         "kind": "static_from",
-        "line": 727,
+        "line": 725,
         "name": "WILDCARD_QUEUE_MAX_SAFE_SEED",
         "optional": false,
         "requested": "easyuse_anima.seed.compatibility",
@@ -35462,9 +35445,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -35472,12 +35455,12 @@
         "compatibility_pair": {
           "bound_name": "WILDCARD_RESERVED_NEXT_SEED_INPUT",
           "target": "easyuse_anima/seed/compatibility.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.seed.compatibility:WILDCARD_RESERVED_NEXT_SEED_INPUT",
         "kind": "static_from",
-        "line": 727,
+        "line": 725,
         "name": "WILDCARD_RESERVED_NEXT_SEED_INPUT",
         "optional": false,
         "requested": "easyuse_anima.seed.compatibility",
@@ -35496,9 +35479,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -35506,12 +35489,12 @@
         "compatibility_pair": {
           "bound_name": "_consume_reserved_wildcard_next_seed",
           "target": "easyuse_anima/seed/compatibility.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.seed.compatibility:_consume_reserved_wildcard_next_seed",
         "kind": "static_from",
-        "line": 727,
+        "line": 725,
         "name": "_consume_reserved_wildcard_next_seed",
         "optional": false,
         "requested": "easyuse_anima.seed.compatibility",
@@ -35530,9 +35513,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -35540,12 +35523,12 @@
         "compatibility_pair": {
           "bound_name": "_get_workflow_node",
           "target": "easyuse_anima/workflow.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.workflow:_get_workflow_node",
         "kind": "static_from",
-        "line": 732,
+        "line": 730,
         "name": "_get_workflow_node",
         "optional": false,
         "requested": "easyuse_anima.workflow",
@@ -35564,9 +35547,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -35574,12 +35557,12 @@
         "compatibility_pair": {
           "bound_name": "_prompt_translation_change_key",
           "target": "easyuse_anima/prompt/correction.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_prompt_translation_change_key",
         "kind": "static_from",
-        "line": 733,
+        "line": 731,
         "name": "_prompt_translation_change_key",
         "optional": false,
         "requested": "easyuse_anima.prompt.correction",
@@ -35598,9 +35581,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -35608,12 +35591,12 @@
         "compatibility_pair": {
           "bound_name": "_split_tag_text",
           "target": "easyuse_anima/prompt/correction.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_split_tag_text",
         "kind": "static_from",
-        "line": 733,
+        "line": 731,
         "name": "_split_tag_text",
         "optional": false,
         "requested": "easyuse_anima.prompt.correction",
@@ -35632,9 +35615,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -35642,12 +35625,12 @@
         "compatibility_pair": {
           "bound_name": "_translate_prompt_text",
           "target": "easyuse_anima/prompt/correction.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_translate_prompt_text",
         "kind": "static_from",
-        "line": 733,
+        "line": 731,
         "name": "_translate_prompt_text",
         "optional": false,
         "requested": "easyuse_anima.prompt.correction",
@@ -35666,9 +35649,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -35676,12 +35659,12 @@
         "compatibility_pair": {
           "bound_name": "_HASH_COMMENT_RE",
           "target": "easyuse_anima/prompt/fields.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_HASH_COMMENT_RE",
         "kind": "static_from",
-        "line": 738,
+        "line": 736,
         "name": "_HASH_COMMENT_RE",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -35700,9 +35683,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -35710,12 +35693,12 @@
         "compatibility_pair": {
           "bound_name": "_INLINE_SPACE_RE",
           "target": "easyuse_anima/prompt/fields.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_INLINE_SPACE_RE",
         "kind": "static_from",
-        "line": 738,
+        "line": 736,
         "name": "_INLINE_SPACE_RE",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -35734,9 +35717,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -35744,12 +35727,12 @@
         "compatibility_pair": {
           "bound_name": "_WEIGHTED_TOKEN_RE",
           "target": "easyuse_anima/prompt/fields.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_WEIGHTED_TOKEN_RE",
         "kind": "static_from",
-        "line": 738,
+        "line": 736,
         "name": "_WEIGHTED_TOKEN_RE",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -35768,9 +35751,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -35778,12 +35761,12 @@
         "compatibility_pair": {
           "bound_name": "_correct_builder_prompt",
           "target": "easyuse_anima/prompt/fields.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_correct_builder_prompt",
         "kind": "static_from",
-        "line": 738,
+        "line": 736,
         "name": "_correct_builder_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -35802,9 +35785,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -35812,12 +35795,12 @@
         "compatibility_pair": {
           "bound_name": "_filter_metadata_prompt",
           "target": "easyuse_anima/prompt/fields.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_filter_metadata_prompt",
         "kind": "static_from",
-        "line": 738,
+        "line": 736,
         "name": "_filter_metadata_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -35836,9 +35819,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -35846,12 +35829,12 @@
         "compatibility_pair": {
           "bound_name": "_join_prompt_tokens",
           "target": "easyuse_anima/prompt/fields.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_join_prompt_tokens",
         "kind": "static_from",
-        "line": 738,
+        "line": 736,
         "name": "_join_prompt_tokens",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -35870,9 +35853,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -35880,12 +35863,12 @@
         "compatibility_pair": {
           "bound_name": "_metadata_filter_key",
           "target": "easyuse_anima/prompt/fields.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_metadata_filter_key",
         "kind": "static_from",
-        "line": 738,
+        "line": 736,
         "name": "_metadata_filter_key",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -35904,9 +35887,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -35914,12 +35897,12 @@
         "compatibility_pair": {
           "bound_name": "_metadata_filter_keys",
           "target": "easyuse_anima/prompt/fields.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_metadata_filter_keys",
         "kind": "static_from",
-        "line": 738,
+        "line": 736,
         "name": "_metadata_filter_keys",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -35938,9 +35921,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -35948,12 +35931,12 @@
         "compatibility_pair": {
           "bound_name": "_prompt_tokens",
           "target": "easyuse_anima/prompt/fields.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_prompt_tokens",
         "kind": "static_from",
-        "line": 738,
+        "line": 736,
         "name": "_prompt_tokens",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -35972,9 +35955,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -35982,12 +35965,12 @@
         "compatibility_pair": {
           "bound_name": "PROMPT_DATA_TYPE",
           "target": "easyuse_anima/prompt/data.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:PROMPT_DATA_TYPE",
         "kind": "static_from",
-        "line": 751,
+        "line": 749,
         "name": "PROMPT_DATA_TYPE",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -36006,9 +35989,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -36016,12 +35999,12 @@
         "compatibility_pair": {
           "bound_name": "_advanced_outputs_from_prompt_data",
           "target": "easyuse_anima/prompt/data.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_advanced_outputs_from_prompt_data",
         "kind": "static_from",
-        "line": 751,
+        "line": 749,
         "name": "_advanced_outputs_from_prompt_data",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -36040,9 +36023,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -36050,12 +36033,12 @@
         "compatibility_pair": {
           "bound_name": "_apply_prompt_data_overrides",
           "target": "easyuse_anima/prompt/data.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_apply_prompt_data_overrides",
         "kind": "static_from",
-        "line": 751,
+        "line": 749,
         "name": "_apply_prompt_data_overrides",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -36074,9 +36057,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -36084,12 +36067,12 @@
         "compatibility_pair": {
           "bound_name": "_copy_prompt_data_for_update",
           "target": "easyuse_anima/prompt/data.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_copy_prompt_data_for_update",
         "kind": "static_from",
-        "line": 751,
+        "line": 749,
         "name": "_copy_prompt_data_for_update",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -36108,9 +36091,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -36118,12 +36101,12 @@
         "compatibility_pair": {
           "bound_name": "_normalize_prompt_data",
           "target": "easyuse_anima/prompt/data.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_normalize_prompt_data",
         "kind": "static_from",
-        "line": 751,
+        "line": 749,
         "name": "_normalize_prompt_data",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -36142,9 +36125,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -36152,12 +36135,12 @@
         "compatibility_pair": {
           "bound_name": "_prompt_data_json_safe",
           "target": "easyuse_anima/prompt/data.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_prompt_data_json_safe",
         "kind": "static_from",
-        "line": 751,
+        "line": 749,
         "name": "_prompt_data_json_safe",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -36176,9 +36159,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -36186,12 +36169,12 @@
         "compatibility_pair": {
           "bound_name": "_prompt_data_parameter_snapshot",
           "target": "easyuse_anima/prompt/data.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_prompt_data_parameter_snapshot",
         "kind": "static_from",
-        "line": 751,
+        "line": 749,
         "name": "_prompt_data_parameter_snapshot",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -36210,9 +36193,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -36220,12 +36203,12 @@
         "compatibility_pair": {
           "bound_name": "_advanced_artist_field_prompt",
           "target": "easyuse_anima/prompt/advanced.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_artist_field_prompt",
         "kind": "static_from",
-        "line": 769,
+        "line": 767,
         "name": "_advanced_artist_field_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -36244,9 +36227,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -36254,12 +36237,12 @@
         "compatibility_pair": {
           "bound_name": "_advanced_default_fields",
           "target": "easyuse_anima/prompt/advanced.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_default_fields",
         "kind": "static_from",
-        "line": 769,
+        "line": 767,
         "name": "_advanced_default_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -36278,9 +36261,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -36288,12 +36271,12 @@
         "compatibility_pair": {
           "bound_name": "_advanced_enabled_naia_panes",
           "target": "easyuse_anima/prompt/advanced.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_enabled_naia_panes",
         "kind": "static_from",
-        "line": 769,
+        "line": 767,
         "name": "_advanced_enabled_naia_panes",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -36312,9 +36295,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -36322,12 +36305,12 @@
         "compatibility_pair": {
           "bound_name": "_advanced_enabled_pane_fields",
           "target": "easyuse_anima/prompt/advanced.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_enabled_pane_fields",
         "kind": "static_from",
-        "line": 769,
+        "line": 767,
         "name": "_advanced_enabled_pane_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -36346,9 +36329,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -36356,12 +36339,12 @@
         "compatibility_pair": {
           "bound_name": "_advanced_field_input_values",
           "target": "easyuse_anima/prompt/advanced.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_field_input_values",
         "kind": "static_from",
-        "line": 769,
+        "line": 767,
         "name": "_advanced_field_input_values",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -36380,9 +36363,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -36390,12 +36373,12 @@
         "compatibility_pair": {
           "bound_name": "_advanced_field_socket_name",
           "target": "easyuse_anima/prompt/advanced.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_field_socket_name",
         "kind": "static_from",
-        "line": 769,
+        "line": 767,
         "name": "_advanced_field_socket_name",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -36414,9 +36397,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -36424,12 +36407,12 @@
         "compatibility_pair": {
           "bound_name": "_advanced_fields_json",
           "target": "easyuse_anima/prompt/advanced.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_fields_json",
         "kind": "static_from",
-        "line": 769,
+        "line": 767,
         "name": "_advanced_fields_json",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -36448,9 +36431,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -36458,12 +36441,12 @@
         "compatibility_pair": {
           "bound_name": "_advanced_has_enabled_naia",
           "target": "easyuse_anima/prompt/advanced.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_has_enabled_naia",
         "kind": "static_from",
-        "line": 769,
+        "line": 767,
         "name": "_advanced_has_enabled_naia",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -36482,9 +36465,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -36492,12 +36475,12 @@
         "compatibility_pair": {
           "bound_name": "_advanced_prompt_with_artist_override",
           "target": "easyuse_anima/prompt/advanced.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_prompt_with_artist_override",
         "kind": "static_from",
-        "line": 769,
+        "line": 767,
         "name": "_advanced_prompt_with_artist_override",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -36516,9 +36499,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -36526,12 +36509,12 @@
         "compatibility_pair": {
           "bound_name": "_advanced_uses_naia_resolution",
           "target": "easyuse_anima/prompt/advanced.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_uses_naia_resolution",
         "kind": "static_from",
-        "line": 769,
+        "line": 767,
         "name": "_advanced_uses_naia_resolution",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -36550,9 +36533,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -36560,12 +36543,12 @@
         "compatibility_pair": {
           "bound_name": "_apply_advanced_field_inputs",
           "target": "easyuse_anima/prompt/advanced.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_apply_advanced_field_inputs",
         "kind": "static_from",
-        "line": 769,
+        "line": 767,
         "name": "_apply_advanced_field_inputs",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -36584,9 +36567,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -36594,12 +36577,12 @@
         "compatibility_pair": {
           "bound_name": "_as_advanced_height",
           "target": "easyuse_anima/prompt/advanced.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_as_advanced_height",
         "kind": "static_from",
-        "line": 769,
+        "line": 767,
         "name": "_as_advanced_height",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -36618,9 +36601,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -36628,12 +36611,12 @@
         "compatibility_pair": {
           "bound_name": "_build_advanced_prompt_data",
           "target": "easyuse_anima/prompt/advanced.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_build_advanced_prompt_data",
         "kind": "static_from",
-        "line": 769,
+        "line": 767,
         "name": "_build_advanced_prompt_data",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -36652,9 +36635,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -36662,12 +36645,12 @@
         "compatibility_pair": {
           "bound_name": "_build_advanced_prompts",
           "target": "easyuse_anima/prompt/advanced.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_build_advanced_prompts",
         "kind": "static_from",
-        "line": 769,
+        "line": 767,
         "name": "_build_advanced_prompts",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -36686,9 +36669,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -36696,12 +36679,12 @@
         "compatibility_pair": {
           "bound_name": "_clone_advanced_fields",
           "target": "easyuse_anima/prompt/advanced.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_clone_advanced_fields",
         "kind": "static_from",
-        "line": 769,
+        "line": 767,
         "name": "_clone_advanced_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -36720,9 +36703,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -36730,12 +36713,12 @@
         "compatibility_pair": {
           "bound_name": "_correct_advanced_field_sequence",
           "target": "easyuse_anima/prompt/advanced.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_correct_advanced_field_sequence",
         "kind": "static_from",
-        "line": 769,
+        "line": 767,
         "name": "_correct_advanced_field_sequence",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -36754,9 +36737,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -36764,12 +36747,12 @@
         "compatibility_pair": {
           "bound_name": "_expand_advanced_wildcard_fields",
           "target": "easyuse_anima/prompt/advanced.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_expand_advanced_wildcard_fields",
         "kind": "static_from",
-        "line": 769,
+        "line": 767,
         "name": "_expand_advanced_wildcard_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -36788,9 +36771,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -36798,12 +36781,12 @@
         "compatibility_pair": {
           "bound_name": "_normalize_advanced_fields",
           "target": "easyuse_anima/prompt/advanced.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_normalize_advanced_fields",
         "kind": "static_from",
-        "line": 769,
+        "line": 767,
         "name": "_normalize_advanced_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -36822,9 +36805,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -36832,12 +36815,12 @@
         "compatibility_pair": {
           "bound_name": "_normalize_prompt_studio_wildcard_seed_control",
           "target": "easyuse_anima/prompt/advanced.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_normalize_prompt_studio_wildcard_seed_control",
         "kind": "static_from",
-        "line": 769,
+        "line": 767,
         "name": "_normalize_prompt_studio_wildcard_seed_control",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -36856,9 +36839,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -36866,12 +36849,12 @@
         "compatibility_pair": {
           "bound_name": "_set_naia_field_text",
           "target": "easyuse_anima/prompt/advanced.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_set_naia_field_text",
         "kind": "static_from",
-        "line": 769,
+        "line": 767,
         "name": "_set_naia_field_text",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -36890,9 +36873,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -36900,12 +36883,12 @@
         "compatibility_pair": {
           "bound_name": "_translate_prompt_fields",
           "target": "easyuse_anima/prompt/advanced.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_translate_prompt_fields",
         "kind": "static_from",
-        "line": 769,
+        "line": 767,
         "name": "_translate_prompt_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -36924,9 +36907,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -36934,12 +36917,12 @@
         "compatibility_pair": {
           "bound_name": "_apply_regional_field_inputs",
           "target": "easyuse_anima/prompt/regional.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_apply_regional_field_inputs",
         "kind": "static_from",
-        "line": 804,
+        "line": 802,
         "name": "_apply_regional_field_inputs",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -36958,9 +36941,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -36968,12 +36951,12 @@
         "compatibility_pair": {
           "bound_name": "_build_regional_outputs",
           "target": "easyuse_anima/prompt/regional.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_build_regional_outputs",
         "kind": "static_from",
-        "line": 804,
+        "line": 802,
         "name": "_build_regional_outputs",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -36992,9 +36975,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -37002,12 +36985,12 @@
         "compatibility_pair": {
           "bound_name": "_clone_regional_fields",
           "target": "easyuse_anima/prompt/regional.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_clone_regional_fields",
         "kind": "static_from",
-        "line": 804,
+        "line": 802,
         "name": "_clone_regional_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -37026,9 +37009,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -37036,12 +37019,12 @@
         "compatibility_pair": {
           "bound_name": "_conditioning_set_values",
           "target": "easyuse_anima/prompt/regional.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_conditioning_set_values",
         "kind": "static_from",
-        "line": 804,
+        "line": 802,
         "name": "_conditioning_set_values",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -37060,9 +37043,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -37070,12 +37053,12 @@
         "compatibility_pair": {
           "bound_name": "_normalize_mask_ids",
           "target": "easyuse_anima/prompt/regional.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_mask_ids",
         "kind": "static_from",
-        "line": 804,
+        "line": 802,
         "name": "_normalize_mask_ids",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -37094,9 +37077,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -37104,12 +37087,12 @@
         "compatibility_pair": {
           "bound_name": "_normalize_regional_config",
           "target": "easyuse_anima/prompt/regional.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_regional_config",
         "kind": "static_from",
-        "line": 804,
+        "line": 802,
         "name": "_normalize_regional_config",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -37128,9 +37111,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -37138,12 +37121,12 @@
         "compatibility_pair": {
           "bound_name": "_normalize_regional_fields",
           "target": "easyuse_anima/prompt/regional.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_regional_fields",
         "kind": "static_from",
-        "line": 804,
+        "line": 802,
         "name": "_normalize_regional_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -37162,9 +37145,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -37172,12 +37155,12 @@
         "compatibility_pair": {
           "bound_name": "_parse_json_object",
           "target": "easyuse_anima/prompt/regional.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_parse_json_object",
         "kind": "static_from",
-        "line": 804,
+        "line": 802,
         "name": "_parse_json_object",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -37196,9 +37179,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -37206,12 +37189,12 @@
         "compatibility_pair": {
           "bound_name": "_regional_config_json",
           "target": "easyuse_anima/prompt/regional.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_config_json",
         "kind": "static_from",
-        "line": 804,
+        "line": 802,
         "name": "_regional_config_json",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -37230,9 +37213,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -37240,12 +37223,12 @@
         "compatibility_pair": {
           "bound_name": "_regional_fields_json",
           "target": "easyuse_anima/prompt/regional.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_fields_json",
         "kind": "static_from",
-        "line": 804,
+        "line": 802,
         "name": "_regional_fields_json",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -37264,9 +37247,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -37274,12 +37257,12 @@
         "compatibility_pair": {
           "bound_name": "_regional_mask_bounds_area",
           "target": "easyuse_anima/prompt/regional.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_mask_bounds_area",
         "kind": "static_from",
-        "line": 804,
+        "line": 802,
         "name": "_regional_mask_bounds_area",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -37298,9 +37281,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -37308,12 +37291,12 @@
         "compatibility_pair": {
           "bound_name": "_regional_payload_canvas",
           "target": "easyuse_anima/prompt/regional.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_payload_canvas",
         "kind": "static_from",
-        "line": 804,
+        "line": 802,
         "name": "_regional_payload_canvas",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -37332,9 +37315,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -37342,12 +37325,12 @@
         "compatibility_pair": {
           "bound_name": "_regional_union_mask_for_ids",
           "target": "easyuse_anima/prompt/regional.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_union_mask_for_ids",
         "kind": "static_from",
-        "line": 804,
+        "line": 802,
         "name": "_regional_union_mask_for_ids",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -37366,9 +37349,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -37376,12 +37359,12 @@
         "compatibility_pair": {
           "bound_name": "ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
           "target": "easyuse_anima/prompt/conditioning.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
         "kind": "static_from",
-        "line": 831,
+        "line": 829,
         "name": "ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -37400,9 +37383,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -37410,12 +37393,12 @@
         "compatibility_pair": {
           "bound_name": "ANIMA_MOD_GUIDANCE_MODES",
           "target": "easyuse_anima/prompt/conditioning.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODES",
         "kind": "static_from",
-        "line": 831,
+        "line": 829,
         "name": "ANIMA_MOD_GUIDANCE_MODES",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -37434,9 +37417,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -37444,12 +37427,12 @@
         "compatibility_pair": {
           "bound_name": "ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
           "target": "easyuse_anima/prompt/conditioning.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 831,
+        "line": 829,
         "name": "ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -37468,9 +37451,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -37478,12 +37461,12 @@
         "compatibility_pair": {
           "bound_name": "ANIMA_MOD_GUIDANCE_PROFILE_OFF",
           "target": "easyuse_anima/prompt/conditioning.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_PROFILE_OFF",
         "kind": "static_from",
-        "line": 831,
+        "line": 829,
         "name": "ANIMA_MOD_GUIDANCE_PROFILE_OFF",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -37502,9 +37485,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -37512,12 +37495,12 @@
         "compatibility_pair": {
           "bound_name": "_apply_spectrum_anima_mod_guidance",
           "target": "easyuse_anima/prompt/conditioning.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_apply_spectrum_anima_mod_guidance",
         "kind": "static_from",
-        "line": 831,
+        "line": 829,
         "name": "_apply_spectrum_anima_mod_guidance",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -37536,9 +37519,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -37546,12 +37529,12 @@
         "compatibility_pair": {
           "bound_name": "_find_spectrum_anima_mod_guidance_class",
           "target": "easyuse_anima/prompt/conditioning.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_find_spectrum_anima_mod_guidance_class",
         "kind": "static_from",
-        "line": 831,
+        "line": 829,
         "name": "_find_spectrum_anima_mod_guidance_class",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -37570,9 +37553,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -37580,12 +37563,12 @@
         "compatibility_pair": {
           "bound_name": "_normalize_anima_mod_guidance_profile",
           "target": "easyuse_anima/prompt/conditioning.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_normalize_anima_mod_guidance_profile",
         "kind": "static_from",
-        "line": 831,
+        "line": 829,
         "name": "_normalize_anima_mod_guidance_profile",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -37604,9 +37587,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -37614,12 +37597,12 @@
         "compatibility_pair": {
           "bound_name": "_resolve_anima_mod_guidance_enabled",
           "target": "easyuse_anima/prompt/conditioning.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_resolve_anima_mod_guidance_enabled",
         "kind": "static_from",
-        "line": 831,
+        "line": 829,
         "name": "_resolve_anima_mod_guidance_enabled",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -37638,9 +37621,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -37648,12 +37631,12 @@
         "compatibility_pair": {
           "bound_name": "ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
           "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
         "kind": "static_from",
-        "line": 846,
+        "line": 844,
         "name": "ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -37672,9 +37655,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -37682,12 +37665,12 @@
         "compatibility_pair": {
           "bound_name": "ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
           "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
         "kind": "static_from",
-        "line": 846,
+        "line": 844,
         "name": "ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -37706,9 +37689,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -37716,12 +37699,12 @@
         "compatibility_pair": {
           "bound_name": "ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
           "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
         "kind": "static_from",
-        "line": 846,
+        "line": 844,
         "name": "ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -37740,9 +37723,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -37750,12 +37733,12 @@
         "compatibility_pair": {
           "bound_name": "ARTIST_MIX_DEFAULT_EXACT_TOP_K",
           "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_EXACT_TOP_K",
         "kind": "static_from",
-        "line": 846,
+        "line": 844,
         "name": "ARTIST_MIX_DEFAULT_EXACT_TOP_K",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -37774,9 +37757,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -37784,12 +37767,12 @@
         "compatibility_pair": {
           "bound_name": "ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
           "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
         "kind": "static_from",
-        "line": 846,
+        "line": 844,
         "name": "ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -37808,9 +37791,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -37818,12 +37801,12 @@
         "compatibility_pair": {
           "bound_name": "ARTIST_MIX_DEFAULT_START_PERCENT",
           "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_START_PERCENT",
         "kind": "static_from",
-        "line": 846,
+        "line": 844,
         "name": "ARTIST_MIX_DEFAULT_START_PERCENT",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -37842,9 +37825,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -37852,12 +37835,12 @@
         "compatibility_pair": {
           "bound_name": "ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
           "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
         "kind": "static_from",
-        "line": 846,
+        "line": 844,
         "name": "ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -37876,9 +37859,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -37886,12 +37869,12 @@
         "compatibility_pair": {
           "bound_name": "ARTIST_MIX_DEFAULT_STYLE_GAIN",
           "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STYLE_GAIN",
         "kind": "static_from",
-        "line": 846,
+        "line": 844,
         "name": "ARTIST_MIX_DEFAULT_STYLE_GAIN",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -37910,9 +37893,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -37920,12 +37903,12 @@
         "compatibility_pair": {
           "bound_name": "ARTIST_MIX_INPUT_MODES",
           "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_INPUT_MODES",
         "kind": "static_from",
-        "line": 846,
+        "line": 844,
         "name": "ARTIST_MIX_INPUT_MODES",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -37944,9 +37927,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -37954,12 +37937,12 @@
         "compatibility_pair": {
           "bound_name": "ARTIST_MIX_MODE_FROM_PROMPT_DATA",
           "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 846,
+        "line": 844,
         "name": "ARTIST_MIX_MODE_FROM_PROMPT_DATA",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -37978,9 +37961,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -37988,12 +37971,12 @@
         "compatibility_pair": {
           "bound_name": "_artist_mix_inline_prompt",
           "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_mix_inline_prompt",
         "kind": "static_from",
-        "line": 846,
+        "line": 844,
         "name": "_artist_mix_inline_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -38012,9 +37995,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -38022,12 +38005,12 @@
         "compatibility_pair": {
           "bound_name": "_artist_mix_mode_tooltip",
           "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_mix_mode_tooltip",
         "kind": "static_from",
-        "line": 846,
+        "line": 844,
         "name": "_artist_mix_mode_tooltip",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -38046,9 +38029,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -38056,12 +38039,12 @@
         "compatibility_pair": {
           "bound_name": "_artist_prompt_with_position",
           "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_prompt_with_position",
         "kind": "static_from",
-        "line": 846,
+        "line": 844,
         "name": "_artist_prompt_with_position",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -38080,9 +38063,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -38090,12 +38073,12 @@
         "compatibility_pair": {
           "bound_name": "_artist_tags_from_prompt",
           "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_tags_from_prompt",
         "kind": "static_from",
-        "line": 846,
+        "line": 844,
         "name": "_artist_tags_from_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -38114,9 +38097,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -38124,12 +38107,12 @@
         "compatibility_pair": {
           "bound_name": "_blend_conditionings",
           "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_blend_conditionings",
         "kind": "static_from",
-        "line": 846,
+        "line": 844,
         "name": "_blend_conditionings",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -38148,9 +38131,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -38158,12 +38141,12 @@
         "compatibility_pair": {
           "bound_name": "_bounded_artist_mix_float",
           "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bounded_artist_mix_float",
         "kind": "static_from",
-        "line": 846,
+        "line": 844,
         "name": "_bounded_artist_mix_float",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -38182,9 +38165,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -38192,12 +38175,12 @@
         "compatibility_pair": {
           "bound_name": "_bounded_artist_mix_int",
           "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bounded_artist_mix_int",
         "kind": "static_from",
-        "line": 846,
+        "line": 844,
         "name": "_bounded_artist_mix_int",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -38216,9 +38199,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -38226,12 +38209,12 @@
         "compatibility_pair": {
           "bound_name": "_encode_artist_clustered",
           "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_clustered",
         "kind": "static_from",
-        "line": 846,
+        "line": 844,
         "name": "_encode_artist_clustered",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -38250,9 +38233,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -38260,12 +38243,12 @@
         "compatibility_pair": {
           "bound_name": "_encode_artist_delta_rms",
           "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_delta_rms",
         "kind": "static_from",
-        "line": 846,
+        "line": 844,
         "name": "_encode_artist_delta_rms",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -38284,9 +38267,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -38294,12 +38277,12 @@
         "compatibility_pair": {
           "bound_name": "_encode_prompt_data_positive_conditioning",
           "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_prompt_data_positive_conditioning",
         "kind": "static_from",
-        "line": 846,
+        "line": 844,
         "name": "_encode_prompt_data_positive_conditioning",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -38318,9 +38301,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -38328,12 +38311,12 @@
         "compatibility_pair": {
           "bound_name": "_join_artist_mix_source_prompts",
           "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_join_artist_mix_source_prompts",
         "kind": "static_from",
-        "line": 846,
+        "line": 844,
         "name": "_join_artist_mix_source_prompts",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -38352,9 +38335,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -38362,12 +38345,12 @@
         "compatibility_pair": {
           "bound_name": "_normalize_artist_mix_mode",
           "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_normalize_artist_mix_mode",
         "kind": "static_from",
-        "line": 846,
+        "line": 844,
         "name": "_normalize_artist_mix_mode",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -38386,9 +38369,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -38396,12 +38379,12 @@
         "compatibility_pair": {
           "bound_name": "_normalize_artist_tag_position",
           "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_normalize_artist_tag_position",
         "kind": "static_from",
-        "line": 846,
+        "line": 844,
         "name": "_normalize_artist_tag_position",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -38420,9 +38403,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -38430,12 +38413,12 @@
         "compatibility_pair": {
           "bound_name": "_parse_artist_mix_items",
           "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_parse_artist_mix_items",
         "kind": "static_from",
-        "line": 846,
+        "line": 844,
         "name": "_parse_artist_mix_items",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -38454,9 +38437,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -38464,12 +38447,12 @@
         "compatibility_pair": {
           "bound_name": "EasyUseAnimaArtistMixConditioning",
           "target": "easyuse_anima/nodes/prompt_data_nodes.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaArtistMixConditioning",
         "kind": "static_from",
-        "line": 925,
+        "line": 923,
         "name": "EasyUseAnimaArtistMixConditioning",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_data_nodes",
@@ -38488,9 +38471,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -38498,12 +38481,12 @@
         "compatibility_pair": {
           "bound_name": "EasyUseAnimaPromptDataConditioning",
           "target": "easyuse_anima/nodes/prompt_data_nodes.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataConditioning",
         "kind": "static_from",
-        "line": 925,
+        "line": 923,
         "name": "EasyUseAnimaPromptDataConditioning",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_data_nodes",
@@ -38522,9 +38505,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -38532,12 +38515,12 @@
         "compatibility_pair": {
           "bound_name": "EasyUseAnimaPromptDataUnpack",
           "target": "easyuse_anima/nodes/prompt_data_nodes.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataUnpack",
         "kind": "static_from",
-        "line": 925,
+        "line": 923,
         "name": "EasyUseAnimaPromptDataUnpack",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_data_nodes",
@@ -38556,9 +38539,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -38566,12 +38549,12 @@
         "compatibility_pair": {
           "bound_name": "_ANY_TYPE",
           "target": "easyuse_anima/nodes/input_types.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_ANY_TYPE",
         "kind": "static_from",
-        "line": 930,
+        "line": 928,
         "name": "_ANY_TYPE",
         "optional": false,
         "requested": "easyuse_anima.nodes.input_types",
@@ -38590,9 +38573,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -38600,12 +38583,12 @@
         "compatibility_pair": {
           "bound_name": "_AnyType",
           "target": "easyuse_anima/nodes/input_types.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_AnyType",
         "kind": "static_from",
-        "line": 930,
+        "line": 928,
         "name": "_AnyType",
         "optional": false,
         "requested": "easyuse_anima.nodes.input_types",
@@ -38624,9 +38607,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -38634,12 +38617,12 @@
         "compatibility_pair": {
           "bound_name": "_FlexibleOptionalInputType",
           "target": "easyuse_anima/nodes/input_types.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_FlexibleOptionalInputType",
         "kind": "static_from",
-        "line": 930,
+        "line": 928,
         "name": "_FlexibleOptionalInputType",
         "optional": false,
         "requested": "easyuse_anima.nodes.input_types",
@@ -38658,9 +38641,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -38668,12 +38651,12 @@
         "compatibility_pair": {
           "bound_name": "EasyUseAnimaPromptStudioAdvanced",
           "target": "easyuse_anima/nodes/prompt_advanced_nodes.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvanced",
         "kind": "static_from",
-        "line": 935,
+        "line": 933,
         "name": "EasyUseAnimaPromptStudioAdvanced",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_advanced_nodes",
@@ -38692,9 +38675,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -38702,12 +38685,12 @@
         "compatibility_pair": {
           "bound_name": "EasyUseAnimaPromptStudioAdvancedV2",
           "target": "easyuse_anima/nodes/prompt_advanced_nodes.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvancedV2",
         "kind": "static_from",
-        "line": 935,
+        "line": 933,
         "name": "EasyUseAnimaPromptStudioAdvancedV2",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_advanced_nodes",
@@ -38726,9 +38709,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -38736,12 +38719,12 @@
         "compatibility_pair": {
           "bound_name": "EASY_USE_ANIMA_INPUT_TYPE",
           "target": "easyuse_anima/nodes/aio_nodes.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:EASY_USE_ANIMA_INPUT_TYPE",
         "kind": "static_from",
-        "line": 940,
+        "line": 938,
         "name": "EASY_USE_ANIMA_INPUT_TYPE",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -38760,9 +38743,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -38770,12 +38753,12 @@
         "compatibility_pair": {
           "bound_name": "EasyUseAnimaAIOGenerator",
           "target": "easyuse_anima/nodes/aio_nodes.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:EasyUseAnimaAIOGenerator",
         "kind": "static_from",
-        "line": 940,
+        "line": 938,
         "name": "EasyUseAnimaAIOGenerator",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -38794,9 +38777,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -38804,12 +38787,12 @@
         "compatibility_pair": {
           "bound_name": "EasyUseAnimaInput",
           "target": "easyuse_anima/nodes/aio_nodes.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:EasyUseAnimaInput",
         "kind": "static_from",
-        "line": 940,
+        "line": 938,
         "name": "EasyUseAnimaInput",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -38828,9 +38811,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -38838,12 +38821,12 @@
         "compatibility_pair": {
           "bound_name": "_aio_generation_settings_json",
           "target": "easyuse_anima/nodes/aio_nodes.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_aio_generation_settings_json",
         "kind": "static_from",
-        "line": 940,
+        "line": 938,
         "name": "_aio_generation_settings_json",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -38862,9 +38845,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -38872,12 +38855,12 @@
         "compatibility_pair": {
           "bound_name": "_aio_input_settings_json",
           "target": "easyuse_anima/nodes/aio_nodes.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_aio_input_settings_json",
         "kind": "static_from",
-        "line": 940,
+        "line": 938,
         "name": "_aio_input_settings_json",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -38896,9 +38879,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -38906,12 +38889,12 @@
         "compatibility_pair": {
           "bound_name": "_align_down",
           "target": "easyuse_anima/image/geometry.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_align_down",
         "kind": "static_from",
-        "line": 947,
+        "line": 945,
         "name": "_align_down",
         "optional": false,
         "requested": "easyuse_anima.image.geometry",
@@ -38930,9 +38913,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -38940,12 +38923,12 @@
         "compatibility_pair": {
           "bound_name": "_align_nearest",
           "target": "easyuse_anima/image/geometry.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_align_nearest",
         "kind": "static_from",
-        "line": 947,
+        "line": 945,
         "name": "_align_nearest",
         "optional": false,
         "requested": "easyuse_anima.image.geometry",
@@ -38964,9 +38947,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -38974,12 +38957,12 @@
         "compatibility_pair": {
           "bound_name": "_image_tensor_size",
           "target": "easyuse_anima/image/geometry.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_image_tensor_size",
         "kind": "static_from",
-        "line": 947,
+        "line": 945,
         "name": "_image_tensor_size",
         "optional": false,
         "requested": "easyuse_anima.image.geometry",
@@ -38998,9 +38981,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -39008,12 +38991,12 @@
         "compatibility_pair": {
           "bound_name": "_context_value",
           "target": "easyuse_anima/image/sam3.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_context_value",
         "kind": "static_from",
-        "line": 958,
+        "line": 956,
         "name": "_context_value",
         "optional": false,
         "requested": "easyuse_anima.image.sam3",
@@ -39032,9 +39015,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -39042,12 +39025,12 @@
         "compatibility_pair": {
           "bound_name": "_sam3_context",
           "target": "easyuse_anima/image/sam3.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_sam3_context",
         "kind": "static_from",
-        "line": 958,
+        "line": 956,
         "name": "_sam3_context",
         "optional": false,
         "requested": "easyuse_anima.image.sam3",
@@ -39066,9 +39049,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -39076,12 +39059,12 @@
         "compatibility_pair": {
           "bound_name": "_segs_has_items",
           "target": "easyuse_anima/image/sam3.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_segs_has_items",
         "kind": "static_from",
-        "line": 958,
+        "line": 956,
         "name": "_segs_has_items",
         "optional": false,
         "requested": "easyuse_anima.image.sam3",
@@ -39100,9 +39083,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -39110,12 +39093,12 @@
         "compatibility_pair": {
           "bound_name": "IMAGE_SCALE_MULTIPLES",
           "target": "easyuse_anima/image/scaling.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:IMAGE_SCALE_MULTIPLES",
         "kind": "static_from",
-        "line": 970,
+        "line": 968,
         "name": "IMAGE_SCALE_MULTIPLES",
         "optional": false,
         "requested": "easyuse_anima.image.scaling",
@@ -39134,9 +39117,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -39144,12 +39127,12 @@
         "compatibility_pair": {
           "bound_name": "IMAGE_UPSCALE_METHODS",
           "target": "easyuse_anima/image/scaling.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:IMAGE_UPSCALE_METHODS",
         "kind": "static_from",
-        "line": 970,
+        "line": 968,
         "name": "IMAGE_UPSCALE_METHODS",
         "optional": false,
         "requested": "easyuse_anima.image.scaling",
@@ -39168,9 +39151,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -39178,12 +39161,12 @@
         "compatibility_pair": {
           "bound_name": "_comfy_sampler_names",
           "target": "easyuse_anima/infrastructure/comfy/capabilities.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_sampler_names",
         "kind": "static_from",
-        "line": 978,
+        "line": 976,
         "name": "_comfy_sampler_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -39202,9 +39185,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -39212,12 +39195,12 @@
         "compatibility_pair": {
           "bound_name": "_comfy_scheduler_names",
           "target": "easyuse_anima/infrastructure/comfy/capabilities.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_scheduler_names",
         "kind": "static_from",
-        "line": 978,
+        "line": 976,
         "name": "_comfy_scheduler_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -39236,9 +39219,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -39246,12 +39229,12 @@
         "compatibility_pair": {
           "bound_name": "_impact_scheduler_names",
           "target": "easyuse_anima/infrastructure/comfy/capabilities.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_impact_scheduler_names",
         "kind": "static_from",
-        "line": 978,
+        "line": 976,
         "name": "_impact_scheduler_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -39270,9 +39253,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -39280,12 +39263,12 @@
         "compatibility_pair": {
           "bound_name": "_call_with_supported_kwargs",
           "target": "easyuse_anima/infrastructure/comfy/invocation.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_call_with_supported_kwargs",
         "kind": "static_from",
-        "line": 984,
+        "line": 982,
         "name": "_call_with_supported_kwargs",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.invocation",
@@ -39304,9 +39287,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -39314,12 +39297,12 @@
         "compatibility_pair": {
           "bound_name": "_common_upscale_image",
           "target": "easyuse_anima/infrastructure/comfy/invocation.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_common_upscale_image",
         "kind": "static_from",
-        "line": 984,
+        "line": 982,
         "name": "_common_upscale_image",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.invocation",
@@ -39338,9 +39321,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -39348,12 +39331,12 @@
         "compatibility_pair": {
           "bound_name": "_node_output_tuple",
           "target": "easyuse_anima/infrastructure/comfy/invocation.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_node_output_tuple",
         "kind": "static_from",
-        "line": 984,
+        "line": 982,
         "name": "_node_output_tuple",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.invocation",
@@ -39372,9 +39355,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -39382,12 +39365,12 @@
         "compatibility_pair": {
           "bound_name": "_adapter_comfy_clip_loader_types",
           "target": "easyuse_anima/infrastructure/comfy/resources.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_clip_loader_types",
         "kind": "static_from",
-        "line": 989,
+        "line": 987,
         "name": "_comfy_clip_loader_types",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -39406,9 +39389,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -39416,12 +39399,12 @@
         "compatibility_pair": {
           "bound_name": "_adapter_comfy_diffusion_model_names",
           "target": "easyuse_anima/infrastructure/comfy/resources.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_diffusion_model_names",
         "kind": "static_from",
-        "line": 989,
+        "line": 987,
         "name": "_comfy_diffusion_model_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -39440,9 +39423,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -39450,12 +39433,12 @@
         "compatibility_pair": {
           "bound_name": "_adapter_comfy_text_encoder_names",
           "target": "easyuse_anima/infrastructure/comfy/resources.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_text_encoder_names",
         "kind": "static_from",
-        "line": 989,
+        "line": 987,
         "name": "_comfy_text_encoder_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -39474,9 +39457,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -39484,12 +39467,12 @@
         "compatibility_pair": {
           "bound_name": "_adapter_comfy_vae_names",
           "target": "easyuse_anima/infrastructure/comfy/resources.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_vae_names",
         "kind": "static_from",
-        "line": 989,
+        "line": 987,
         "name": "_comfy_vae_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -39508,9 +39491,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -39518,12 +39501,12 @@
         "compatibility_pair": {
           "bound_name": "_folder_path_names",
           "target": "easyuse_anima/infrastructure/comfy/resources.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_folder_path_names",
         "kind": "static_from",
-        "line": 989,
+        "line": 987,
         "name": "_folder_path_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -39542,9 +39525,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -39552,12 +39535,12 @@
         "compatibility_pair": {
           "bound_name": "EasyUseAnimaDetailerAlignHook",
           "target": "easyuse_anima/nodes/image_nodes.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.nodes.image_nodes:EasyUseAnimaDetailerAlignHook",
         "kind": "static_from",
-        "line": 997,
+        "line": 995,
         "name": "EasyUseAnimaDetailerAlignHook",
         "optional": false,
         "requested": "easyuse_anima.nodes.image_nodes",
@@ -39576,9 +39559,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -39586,12 +39569,12 @@
         "compatibility_pair": {
           "bound_name": "EasyUseAnimaImageScaleByMultiple",
           "target": "easyuse_anima/nodes/image_nodes.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.nodes.image_nodes:EasyUseAnimaImageScaleByMultiple",
         "kind": "static_from",
-        "line": 997,
+        "line": 995,
         "name": "EasyUseAnimaImageScaleByMultiple",
         "optional": false,
         "requested": "easyuse_anima.nodes.image_nodes",
@@ -39610,9 +39593,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -39620,12 +39603,12 @@
         "compatibility_pair": {
           "bound_name": "EasyUseAnimaSAM3Context",
           "target": "easyuse_anima/nodes/sam3_nodes.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Context",
         "kind": "static_from",
-        "line": 1001,
+        "line": 999,
         "name": "EasyUseAnimaSAM3Context",
         "optional": false,
         "requested": "easyuse_anima.nodes.sam3_nodes",
@@ -39644,9 +39627,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -39654,12 +39637,12 @@
         "compatibility_pair": {
           "bound_name": "EasyUseAnimaSAM3Detailer",
           "target": "easyuse_anima/nodes/sam3_nodes.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Detailer",
         "kind": "static_from",
-        "line": 1001,
+        "line": 999,
         "name": "EasyUseAnimaSAM3Detailer",
         "optional": false,
         "requested": "easyuse_anima.nodes.sam3_nodes",
@@ -39678,9 +39661,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -39688,12 +39671,12 @@
         "compatibility_pair": {
           "bound_name": "EasyUseAnimaPromptBuilder",
           "target": "easyuse_anima/nodes/prompt_nodes.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptBuilder",
         "kind": "static_from",
-        "line": 1005,
+        "line": 1003,
         "name": "EasyUseAnimaPromptBuilder",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -39712,9 +39695,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -39722,12 +39705,12 @@
         "compatibility_pair": {
           "bound_name": "EasyUseAnimaPromptCorrector",
           "target": "easyuse_anima/nodes/prompt_nodes.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrector",
         "kind": "static_from",
-        "line": 1005,
+        "line": 1003,
         "name": "EasyUseAnimaPromptCorrector",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -39746,9 +39729,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -39756,12 +39739,12 @@
         "compatibility_pair": {
           "bound_name": "EasyUseAnimaPromptCorrectorSimple",
           "target": "easyuse_anima/nodes/prompt_nodes.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrectorSimple",
         "kind": "static_from",
-        "line": 1005,
+        "line": 1003,
         "name": "EasyUseAnimaPromptCorrectorSimple",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -39780,9 +39763,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -39790,12 +39773,12 @@
         "compatibility_pair": {
           "bound_name": "EasyUseAnimaPromptStudio",
           "target": "easyuse_anima/nodes/prompt_nodes.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptStudio",
         "kind": "static_from",
-        "line": 1005,
+        "line": 1003,
         "name": "EasyUseAnimaPromptStudio",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -39814,9 +39797,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -39824,12 +39807,12 @@
         "compatibility_pair": {
           "bound_name": "EasyUseAnimaPromptStudioRegional",
           "target": "easyuse_anima/nodes/regional_nodes.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:EasyUseAnimaPromptStudioRegional",
         "kind": "static_from",
-        "line": 1011,
+        "line": 1009,
         "name": "EasyUseAnimaPromptStudioRegional",
         "optional": false,
         "requested": "easyuse_anima.nodes.regional_nodes",
@@ -39848,9 +39831,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -39858,12 +39841,12 @@
         "compatibility_pair": {
           "bound_name": "EasyUseAnimaRegionalConditioning",
           "target": "easyuse_anima/nodes/regional_nodes.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:EasyUseAnimaRegionalConditioning",
         "kind": "static_from",
-        "line": 1011,
+        "line": 1009,
         "name": "EasyUseAnimaRegionalConditioning",
         "optional": false,
         "requested": "easyuse_anima.nodes.regional_nodes",
@@ -39882,9 +39865,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -39892,12 +39875,12 @@
         "compatibility_pair": {
           "bound_name": "LATENT_ALIGN",
           "target": "easyuse_anima/naia/client.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.naia.client:LATENT_ALIGN",
         "kind": "static_from",
-        "line": 1015,
+        "line": 1013,
         "name": "LATENT_ALIGN",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -39916,9 +39899,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -39926,12 +39909,12 @@
         "compatibility_pair": {
           "bound_name": "_parse_random_response",
           "target": "easyuse_anima/naia/client.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_parse_random_response",
         "kind": "static_from",
-        "line": 1015,
+        "line": 1013,
         "name": "_parse_random_response",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -39950,9 +39933,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -39960,12 +39943,12 @@
         "compatibility_pair": {
           "bound_name": "_post_random",
           "target": "easyuse_anima/naia/client.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_post_random",
         "kind": "static_from",
-        "line": 1015,
+        "line": 1013,
         "name": "_post_random",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -39984,9 +39967,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -39994,12 +39977,12 @@
         "compatibility_pair": {
           "bound_name": "_advanced_resolution_from_selection",
           "target": "easyuse_anima/naia/resolution.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_advanced_resolution_from_selection",
         "kind": "static_from",
-        "line": 1033,
+        "line": 1031,
         "name": "_advanced_resolution_from_selection",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -40018,9 +40001,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -40028,12 +40011,12 @@
         "compatibility_pair": {
           "bound_name": "_normalize_resolution_bucket",
           "target": "easyuse_anima/naia/resolution.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_normalize_resolution_bucket",
         "kind": "static_from",
-        "line": 1033,
+        "line": 1031,
         "name": "_normalize_resolution_bucket",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -40052,9 +40035,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -40062,12 +40045,12 @@
         "compatibility_pair": {
           "bound_name": "_ratio_label",
           "target": "easyuse_anima/naia/resolution.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_ratio_label",
         "kind": "static_from",
-        "line": 1033,
+        "line": 1031,
         "name": "_ratio_label",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -40086,9 +40069,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -40096,12 +40079,12 @@
         "compatibility_pair": {
           "bound_name": "_resolution_label",
           "target": "easyuse_anima/naia/resolution.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolution_label",
         "kind": "static_from",
-        "line": 1033,
+        "line": 1031,
         "name": "_resolution_label",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -40120,9 +40103,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -40130,12 +40113,12 @@
         "compatibility_pair": {
           "bound_name": "_resolve_naia_resolution",
           "target": "easyuse_anima/naia/resolution.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolve_naia_resolution",
         "kind": "static_from",
-        "line": 1033,
+        "line": 1031,
         "name": "_resolve_naia_resolution",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -40154,9 +40137,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -40164,12 +40147,12 @@
         "compatibility_pair": {
           "bound_name": "EasyUseAnimaNAIARandomPrompt",
           "target": "easyuse_anima/nodes/naia_nodes.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.nodes.naia_nodes:EasyUseAnimaNAIARandomPrompt",
         "kind": "static_from",
-        "line": 1056,
+        "line": 1054,
         "name": "EasyUseAnimaNAIARandomPrompt",
         "optional": false,
         "requested": "easyuse_anima.nodes.naia_nodes",
@@ -40188,9 +40171,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -40198,12 +40181,12 @@
         "compatibility_pair": {
           "bound_name": "EasyUseAnimaWildcard",
           "target": "easyuse_anima/nodes/wildcard_nodes.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.nodes.wildcard_nodes:EasyUseAnimaWildcard",
         "kind": "static_from",
-        "line": 1059,
+        "line": 1057,
         "name": "EasyUseAnimaWildcard",
         "optional": false,
         "requested": "easyuse_anima.nodes.wildcard_nodes",
@@ -40222,9 +40205,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -40232,12 +40215,12 @@
         "compatibility_pair": {
           "bound_name": "_apply_lora_syntax_format",
           "target": "easyuse_anima/lora/metadata.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_apply_lora_syntax_format",
         "kind": "static_from",
-        "line": 1063,
+        "line": 1061,
         "name": "_apply_lora_syntax_format",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -40256,9 +40239,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -40266,12 +40249,12 @@
         "compatibility_pair": {
           "bound_name": "_dedupe_text_values",
           "target": "easyuse_anima/lora/metadata.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_dedupe_text_values",
         "kind": "static_from",
-        "line": 1063,
+        "line": 1061,
         "name": "_dedupe_text_values",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -40290,9 +40273,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -40300,12 +40283,12 @@
         "compatibility_pair": {
           "bound_name": "_fallback_lora_path",
           "target": "easyuse_anima/lora/metadata.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_fallback_lora_path",
         "kind": "static_from",
-        "line": 1063,
+        "line": 1061,
         "name": "_fallback_lora_path",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -40324,9 +40307,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -40334,12 +40317,12 @@
         "compatibility_pair": {
           "bound_name": "_get_lora_info",
           "target": "easyuse_anima/lora/metadata.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_get_lora_info",
         "kind": "static_from",
-        "line": 1063,
+        "line": 1061,
         "name": "_get_lora_info",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -40358,9 +40341,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -40368,12 +40351,12 @@
         "compatibility_pair": {
           "bound_name": "_get_lora_manager_trigger_words",
           "target": "easyuse_anima/lora/metadata.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_get_lora_manager_trigger_words",
         "kind": "static_from",
-        "line": 1063,
+        "line": 1061,
         "name": "_get_lora_manager_trigger_words",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -40392,9 +40375,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -40402,12 +40385,12 @@
         "compatibility_pair": {
           "bound_name": "_load_lora_manager_metadata",
           "target": "easyuse_anima/lora/metadata.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_load_lora_manager_metadata",
         "kind": "static_from",
-        "line": 1063,
+        "line": 1061,
         "name": "_load_lora_manager_metadata",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -40426,9 +40409,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -40436,12 +40419,12 @@
         "compatibility_pair": {
           "bound_name": "_lora_combo_values",
           "target": "easyuse_anima/lora/metadata.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_combo_values",
         "kind": "static_from",
-        "line": 1063,
+        "line": 1061,
         "name": "_lora_combo_values",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -40460,9 +40443,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -40470,12 +40453,12 @@
         "compatibility_pair": {
           "bound_name": "_lora_manager_trigger_words_from_metadata",
           "target": "easyuse_anima/lora/metadata.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_manager_trigger_words_from_metadata",
         "kind": "static_from",
-        "line": 1063,
+        "line": 1061,
         "name": "_lora_manager_trigger_words_from_metadata",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -40494,9 +40477,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -40504,12 +40487,12 @@
         "compatibility_pair": {
           "bound_name": "_lora_model_exists",
           "target": "easyuse_anima/lora/metadata.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_model_exists",
         "kind": "static_from",
-        "line": 1063,
+        "line": 1061,
         "name": "_lora_model_exists",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -40528,9 +40511,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -40538,12 +40521,12 @@
         "compatibility_pair": {
           "bound_name": "_lora_stack_name",
           "target": "easyuse_anima/lora/metadata.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_stack_name",
         "kind": "static_from",
-        "line": 1063,
+        "line": 1061,
         "name": "_lora_stack_name",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -40562,9 +40545,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -40572,12 +40555,12 @@
         "compatibility_pair": {
           "bound_name": "_metadata_json_paths_for_lora",
           "target": "easyuse_anima/lora/metadata.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_metadata_json_paths_for_lora",
         "kind": "static_from",
-        "line": 1063,
+        "line": 1061,
         "name": "_metadata_json_paths_for_lora",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -40596,9 +40579,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -40606,12 +40589,12 @@
         "compatibility_pair": {
           "bound_name": "_missing_lora_display_name",
           "target": "easyuse_anima/lora/metadata.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_missing_lora_display_name",
         "kind": "static_from",
-        "line": 1063,
+        "line": 1061,
         "name": "_missing_lora_display_name",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -40630,9 +40613,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -40640,12 +40623,12 @@
         "compatibility_pair": {
           "bound_name": "_raise_missing_loras",
           "target": "easyuse_anima/lora/metadata.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_raise_missing_loras",
         "kind": "static_from",
-        "line": 1063,
+        "line": 1061,
         "name": "_raise_missing_loras",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -40664,9 +40647,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -40674,12 +40657,12 @@
         "compatibility_pair": {
           "bound_name": "_trigger_words_from_value",
           "target": "easyuse_anima/lora/metadata.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_trigger_words_from_value",
         "kind": "static_from",
-        "line": 1063,
+        "line": 1061,
         "name": "_trigger_words_from_value",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -40698,9 +40681,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -40708,12 +40691,12 @@
         "compatibility_pair": {
           "bound_name": "_correct_style_prompt",
           "target": "easyuse_anima/lora/preset.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_correct_style_prompt",
         "kind": "static_from",
-        "line": 1079,
+        "line": 1077,
         "name": "_correct_style_prompt",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -40732,9 +40715,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -40742,12 +40725,12 @@
         "compatibility_pair": {
           "bound_name": "_format_strength",
           "target": "easyuse_anima/lora/preset.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_format_strength",
         "kind": "static_from",
-        "line": 1079,
+        "line": 1077,
         "name": "_format_strength",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -40766,9 +40749,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -40776,12 +40759,12 @@
         "compatibility_pair": {
           "bound_name": "_get_loras_list",
           "target": "easyuse_anima/lora/preset.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_get_loras_list",
         "kind": "static_from",
-        "line": 1079,
+        "line": 1077,
         "name": "_get_loras_list",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -40800,9 +40783,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -40810,12 +40793,12 @@
         "compatibility_pair": {
           "bound_name": "_load_profile_data",
           "target": "easyuse_anima/lora/preset.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_load_profile_data",
         "kind": "static_from",
-        "line": 1079,
+        "line": 1077,
         "name": "_load_profile_data",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -40834,9 +40817,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -40844,12 +40827,12 @@
         "compatibility_pair": {
           "bound_name": "_profile_key",
           "target": "easyuse_anima/lora/preset.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_profile_key",
         "kind": "static_from",
-        "line": 1079,
+        "line": 1077,
         "name": "_profile_key",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -40868,9 +40851,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -40878,12 +40861,12 @@
         "compatibility_pair": {
           "bound_name": "_select_profile_values",
           "target": "easyuse_anima/lora/preset.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_select_profile_values",
         "kind": "static_from",
-        "line": 1079,
+        "line": 1077,
         "name": "_select_profile_values",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -40902,9 +40885,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -40912,12 +40895,12 @@
         "compatibility_pair": {
           "bound_name": "_wrap_profile_index",
           "target": "easyuse_anima/lora/preset.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_wrap_profile_index",
         "kind": "static_from",
-        "line": 1079,
+        "line": 1077,
         "name": "_wrap_profile_index",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -40936,9 +40919,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -40946,12 +40929,12 @@
         "compatibility_pair": {
           "bound_name": "EasyUseAnimaLoraPreset",
           "target": "easyuse_anima/nodes/lora_nodes.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "easyuse_anima.nodes.lora_nodes:EasyUseAnimaLoraPreset",
         "kind": "static_from",
-        "line": 1088,
+        "line": 1086,
         "name": "EasyUseAnimaLoraPreset",
         "optional": false,
         "requested": "easyuse_anima.nodes.lora_nodes",
@@ -40970,9 +40953,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -40980,12 +40963,12 @@
         "compatibility_pair": {
           "bound_name": "correct_prompt",
           "target": "anima_prompt/__init__.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "anima_prompt:correct_prompt",
         "kind": "static_from",
-        "line": 1091,
+        "line": 1089,
         "name": "correct_prompt",
         "optional": false,
         "requested": "anima_prompt",
@@ -41004,9 +40987,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -41014,12 +40997,12 @@
         "compatibility_pair": {
           "bound_name": "load_knowledge_base",
           "target": "anima_prompt/__init__.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "anima_prompt:load_knowledge_base",
         "kind": "static_from",
-        "line": 1091,
+        "line": 1089,
         "name": "load_knowledge_base",
         "optional": false,
         "requested": "anima_prompt",
@@ -41038,9 +41021,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -41048,12 +41031,12 @@
         "compatibility_pair": {
           "bound_name": "parse_prompt",
           "target": "anima_prompt/parser.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "anima_prompt.parser:parse_prompt",
         "kind": "static_from",
-        "line": 1092,
+        "line": 1090,
         "name": "parse_prompt",
         "optional": false,
         "requested": "anima_prompt.parser",
@@ -41072,9 +41055,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -41082,12 +41065,12 @@
         "compatibility_pair": {
           "bound_name": "resolve_metadata_filter_words",
           "target": "settings.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "settings:resolve_metadata_filter_words",
         "kind": "static_from",
-        "line": 1093,
+        "line": 1091,
         "name": "resolve_metadata_filter_words",
         "optional": false,
         "requested": "settings",
@@ -41106,9 +41089,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -41116,12 +41099,12 @@
         "compatibility_pair": {
           "bound_name": "resolve_naia_settings",
           "target": "settings.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "settings:resolve_naia_settings",
         "kind": "static_from",
-        "line": 1093,
+        "line": 1091,
         "name": "resolve_naia_settings",
         "optional": false,
         "requested": "settings",
@@ -41140,9 +41123,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -41150,12 +41133,12 @@
         "compatibility_pair": {
           "bound_name": "resolve_prompt_translation_settings",
           "target": "settings.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "settings:resolve_prompt_translation_settings",
         "kind": "static_from",
-        "line": 1093,
+        "line": 1091,
         "name": "resolve_prompt_translation_settings",
         "optional": false,
         "requested": "settings",
@@ -41174,9 +41157,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -41184,12 +41167,12 @@
         "compatibility_pair": {
           "bound_name": "has_prompt_translation_markers",
           "target": "prompt_translation.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "prompt_translation:has_prompt_translation_markers",
         "kind": "static_from",
-        "line": 1098,
+        "line": 1096,
         "name": "has_prompt_translation_markers",
         "optional": false,
         "requested": "prompt_translation",
@@ -41208,9 +41191,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -41218,12 +41201,12 @@
         "compatibility_pair": {
           "bound_name": "translate_prompt_markers",
           "target": "prompt_translation.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "prompt_translation:translate_prompt_markers",
         "kind": "static_from",
-        "line": 1098,
+        "line": 1096,
         "name": "translate_prompt_markers",
         "optional": false,
         "requested": "prompt_translation",
@@ -41242,9 +41225,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -41252,12 +41235,12 @@
         "compatibility_pair": {
           "bound_name": "MAX_SEED",
           "target": "wildcard_engine.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "wildcard_engine:MAX_SEED",
         "kind": "static_from",
-        "line": 1099,
+        "line": 1097,
         "name": "MAX_SEED",
         "optional": false,
         "requested": "wildcard_engine",
@@ -41276,9 +41259,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -41286,12 +41269,12 @@
         "compatibility_pair": {
           "bound_name": "PROMPT_STUDIO_WILDCARD_MODE_LABELS",
           "target": "wildcard_engine.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "wildcard_engine:PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "kind": "static_from",
-        "line": 1099,
+        "line": 1097,
         "name": "PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "optional": false,
         "requested": "wildcard_engine",
@@ -41310,9 +41293,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -41320,12 +41303,12 @@
         "compatibility_pair": {
           "bound_name": "PUBLIC_MAX_SEED",
           "target": "wildcard_engine.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "wildcard_engine:PUBLIC_MAX_SEED",
         "kind": "static_from",
-        "line": 1099,
+        "line": 1097,
         "name": "PUBLIC_MAX_SEED",
         "optional": false,
         "requested": "wildcard_engine",
@@ -41344,9 +41327,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -41354,12 +41337,12 @@
         "compatibility_pair": {
           "bound_name": "SEED_CONTROL_DECREMENT",
           "target": "wildcard_engine.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_DECREMENT",
         "kind": "static_from",
-        "line": 1099,
+        "line": 1097,
         "name": "SEED_CONTROL_DECREMENT",
         "optional": false,
         "requested": "wildcard_engine",
@@ -41378,9 +41361,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -41388,12 +41371,12 @@
         "compatibility_pair": {
           "bound_name": "SEED_CONTROL_FIXED",
           "target": "wildcard_engine.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_FIXED",
         "kind": "static_from",
-        "line": 1099,
+        "line": 1097,
         "name": "SEED_CONTROL_FIXED",
         "optional": false,
         "requested": "wildcard_engine",
@@ -41412,9 +41395,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -41422,12 +41405,12 @@
         "compatibility_pair": {
           "bound_name": "SEED_CONTROL_INCREMENT",
           "target": "wildcard_engine.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_INCREMENT",
         "kind": "static_from",
-        "line": 1099,
+        "line": 1097,
         "name": "SEED_CONTROL_INCREMENT",
         "optional": false,
         "requested": "wildcard_engine",
@@ -41446,9 +41429,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -41456,12 +41439,12 @@
         "compatibility_pair": {
           "bound_name": "SEED_CONTROL_MODES",
           "target": "wildcard_engine.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_MODES",
         "kind": "static_from",
-        "line": 1099,
+        "line": 1097,
         "name": "SEED_CONTROL_MODES",
         "optional": false,
         "requested": "wildcard_engine",
@@ -41480,9 +41463,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -41490,12 +41473,12 @@
         "compatibility_pair": {
           "bound_name": "SEED_CONTROL_RANDOMIZE",
           "target": "wildcard_engine.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_RANDOMIZE",
         "kind": "static_from",
-        "line": 1099,
+        "line": 1097,
         "name": "SEED_CONTROL_RANDOMIZE",
         "optional": false,
         "requested": "wildcard_engine",
@@ -41514,9 +41497,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -41524,12 +41507,12 @@
         "compatibility_pair": {
           "bound_name": "WILDCARD_MODE_FIXED",
           "target": "wildcard_engine.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_FIXED",
         "kind": "static_from",
-        "line": 1099,
+        "line": 1097,
         "name": "WILDCARD_MODE_FIXED",
         "optional": false,
         "requested": "wildcard_engine",
@@ -41548,9 +41531,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -41558,12 +41541,12 @@
         "compatibility_pair": {
           "bound_name": "WILDCARD_MODE_POPULATE",
           "target": "wildcard_engine.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_POPULATE",
         "kind": "static_from",
-        "line": 1099,
+        "line": 1097,
         "name": "WILDCARD_MODE_POPULATE",
         "optional": false,
         "requested": "wildcard_engine",
@@ -41582,9 +41565,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -41592,12 +41575,12 @@
         "compatibility_pair": {
           "bound_name": "WILDCARD_MODE_SEQUENTIAL",
           "target": "wildcard_engine.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_SEQUENTIAL",
         "kind": "static_from",
-        "line": 1099,
+        "line": 1097,
         "name": "WILDCARD_MODE_SEQUENTIAL",
         "optional": false,
         "requested": "wildcard_engine",
@@ -41616,9 +41599,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -41626,12 +41609,12 @@
         "compatibility_pair": {
           "bound_name": "expand_wildcard_texts",
           "target": "wildcard_engine.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "wildcard_engine:expand_wildcard_texts",
         "kind": "static_from",
-        "line": 1099,
+        "line": 1097,
         "name": "expand_wildcard_texts",
         "optional": false,
         "requested": "wildcard_engine",
@@ -41650,9 +41633,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -41660,12 +41643,12 @@
         "compatibility_pair": {
           "bound_name": "expand_wildcards",
           "target": "wildcard_engine.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "wildcard_engine:expand_wildcards",
         "kind": "static_from",
-        "line": 1099,
+        "line": 1097,
         "name": "expand_wildcards",
         "optional": false,
         "requested": "wildcard_engine",
@@ -41684,9 +41667,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -41694,12 +41677,12 @@
         "compatibility_pair": {
           "bound_name": "has_wildcard_syntax",
           "target": "wildcard_engine.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "wildcard_engine:has_wildcard_syntax",
         "kind": "static_from",
-        "line": 1099,
+        "line": 1097,
         "name": "has_wildcard_syntax",
         "optional": false,
         "requested": "wildcard_engine",
@@ -41718,9 +41701,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -41728,12 +41711,12 @@
         "compatibility_pair": {
           "bound_name": "next_seed",
           "target": "wildcard_engine.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "wildcard_engine:next_seed",
         "kind": "static_from",
-        "line": 1099,
+        "line": 1097,
         "name": "next_seed",
         "optional": false,
         "requested": "wildcard_engine",
@@ -41752,9 +41735,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -41762,12 +41745,12 @@
         "compatibility_pair": {
           "bound_name": "normalize_prompt_studio_wildcard_mode",
           "target": "wildcard_engine.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "wildcard_engine:normalize_prompt_studio_wildcard_mode",
         "kind": "static_from",
-        "line": 1099,
+        "line": 1097,
         "name": "normalize_prompt_studio_wildcard_mode",
         "optional": false,
         "requested": "wildcard_engine",
@@ -41786,9 +41769,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -41796,12 +41779,12 @@
         "compatibility_pair": {
           "bound_name": "normalize_seed",
           "target": "wildcard_engine.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "wildcard_engine:normalize_seed",
         "kind": "static_from",
-        "line": 1099,
+        "line": 1097,
         "name": "normalize_seed",
         "optional": false,
         "requested": "wildcard_engine",
@@ -41820,9 +41803,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -41830,12 +41813,12 @@
         "compatibility_pair": {
           "bound_name": "normalize_wildcard_mode",
           "target": "wildcard_engine.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "wildcard_engine:normalize_wildcard_mode",
         "kind": "static_from",
-        "line": 1099,
+        "line": 1097,
         "name": "normalize_wildcard_mode",
         "optional": false,
         "requested": "wildcard_engine",
@@ -41854,9 +41837,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
@@ -41864,12 +41847,12 @@
         "compatibility_pair": {
           "bound_name": "wildcard_sources_signature",
           "target": "wildcard_engine.py",
-          "try_line": 6
+          "try_line": 4
         },
         "conditional": true,
         "imported": "wildcard_engine:wildcard_sources_signature",
         "kind": "static_from",
-        "line": 1099,
+        "line": 1097,
         "name": "wildcard_sources_signature",
         "optional": false,
         "requested": "wildcard_engine",
@@ -43358,10 +43341,6 @@
       {
         "from": "__init__.py",
         "to": "easyuse_anima/registration.py"
-      },
-      {
-        "from": "__init__.py",
-        "to": "nodes.py"
       },
       {
         "from": "__init__.py",
@@ -45225,9 +45204,9 @@
     "modules": [
       {
         "is_package": true,
-        "loc": 52,
+        "loc": 50,
         "module": "__root__",
-        "normalized_git_blob_sha1": "12ab225bf2436a2c76323d5b8fcd2fe6bd50cffe",
+        "normalized_git_blob_sha1": "923eac5d9e4cad69f2aad4fbb8b3158f4d7ced9d",
         "path": "__init__.py",
         "top_level": {
           "class_count": 0,
@@ -46281,14 +46260,14 @@
       },
       {
         "is_package": false,
-        "loc": 1123,
+        "loc": 1138,
         "module": "nodes",
-        "normalized_git_blob_sha1": "d91507b0c3836e0964979ddaa735f277d0a5934d",
+        "normalized_git_blob_sha1": "d57d76310253976c1f725974802aba61f456c225",
         "path": "nodes.py",
         "top_level": {
           "class_count": 0,
           "function_count": 0,
-          "global_count": 2
+          "global_count": 1
         }
       },
       {
@@ -46378,155 +46357,155 @@
     "reexports": [
       {
         "declared_in_all": false,
-        "imported": ".nodes:EasyUseAnimaAIOGenerator",
+        "imported": ".easyuse_anima.registration:EasyUseAnimaAIOGenerator",
         "line": 3,
         "name": "EasyUseAnimaAIOGenerator",
-        "source": "nodes.py"
+        "source": "easyuse_anima/registration.py"
       },
       {
         "declared_in_all": false,
-        "imported": ".nodes:EasyUseAnimaArtistMixConditioning",
+        "imported": ".easyuse_anima.registration:EasyUseAnimaArtistMixConditioning",
         "line": 3,
         "name": "EasyUseAnimaArtistMixConditioning",
-        "source": "nodes.py"
+        "source": "easyuse_anima/registration.py"
       },
       {
         "declared_in_all": false,
-        "imported": ".nodes:EasyUseAnimaDetailerAlignHook",
+        "imported": ".easyuse_anima.registration:EasyUseAnimaDetailerAlignHook",
         "line": 3,
         "name": "EasyUseAnimaDetailerAlignHook",
-        "source": "nodes.py"
+        "source": "easyuse_anima/registration.py"
       },
       {
         "declared_in_all": false,
-        "imported": ".nodes:EasyUseAnimaImageScaleByMultiple",
+        "imported": ".easyuse_anima.registration:EasyUseAnimaImageScaleByMultiple",
         "line": 3,
         "name": "EasyUseAnimaImageScaleByMultiple",
-        "source": "nodes.py"
+        "source": "easyuse_anima/registration.py"
       },
       {
         "declared_in_all": false,
-        "imported": ".nodes:EasyUseAnimaInput",
+        "imported": ".easyuse_anima.registration:EasyUseAnimaInput",
         "line": 3,
         "name": "EasyUseAnimaInput",
-        "source": "nodes.py"
+        "source": "easyuse_anima/registration.py"
       },
       {
         "declared_in_all": false,
-        "imported": ".nodes:EasyUseAnimaLoraPreset",
+        "imported": ".easyuse_anima.registration:EasyUseAnimaLoraPreset",
         "line": 3,
         "name": "EasyUseAnimaLoraPreset",
-        "source": "nodes.py"
+        "source": "easyuse_anima/registration.py"
       },
       {
         "declared_in_all": false,
-        "imported": ".nodes:EasyUseAnimaNAIARandomPrompt",
+        "imported": ".easyuse_anima.registration:EasyUseAnimaNAIARandomPrompt",
         "line": 3,
         "name": "EasyUseAnimaNAIARandomPrompt",
-        "source": "nodes.py"
+        "source": "easyuse_anima/registration.py"
       },
       {
         "declared_in_all": false,
-        "imported": ".nodes:EasyUseAnimaPromptBuilder",
+        "imported": ".easyuse_anima.registration:EasyUseAnimaPromptBuilder",
         "line": 3,
         "name": "EasyUseAnimaPromptBuilder",
-        "source": "nodes.py"
+        "source": "easyuse_anima/registration.py"
       },
       {
         "declared_in_all": false,
-        "imported": ".nodes:EasyUseAnimaPromptCorrector",
+        "imported": ".easyuse_anima.registration:EasyUseAnimaPromptCorrector",
         "line": 3,
         "name": "EasyUseAnimaPromptCorrector",
-        "source": "nodes.py"
+        "source": "easyuse_anima/registration.py"
       },
       {
         "declared_in_all": false,
-        "imported": ".nodes:EasyUseAnimaPromptCorrectorSimple",
+        "imported": ".easyuse_anima.registration:EasyUseAnimaPromptCorrectorSimple",
         "line": 3,
         "name": "EasyUseAnimaPromptCorrectorSimple",
-        "source": "nodes.py"
+        "source": "easyuse_anima/registration.py"
       },
       {
         "declared_in_all": false,
-        "imported": ".nodes:EasyUseAnimaPromptDataConditioning",
+        "imported": ".easyuse_anima.registration:EasyUseAnimaPromptDataConditioning",
         "line": 3,
         "name": "EasyUseAnimaPromptDataConditioning",
-        "source": "nodes.py"
+        "source": "easyuse_anima/registration.py"
       },
       {
         "declared_in_all": false,
-        "imported": ".nodes:EasyUseAnimaPromptDataUnpack",
+        "imported": ".easyuse_anima.registration:EasyUseAnimaPromptDataUnpack",
         "line": 3,
         "name": "EasyUseAnimaPromptDataUnpack",
-        "source": "nodes.py"
+        "source": "easyuse_anima/registration.py"
       },
       {
         "declared_in_all": false,
-        "imported": ".nodes:EasyUseAnimaPromptStudio",
+        "imported": ".easyuse_anima.registration:EasyUseAnimaPromptStudio",
         "line": 3,
         "name": "EasyUseAnimaPromptStudio",
-        "source": "nodes.py"
+        "source": "easyuse_anima/registration.py"
       },
       {
         "declared_in_all": false,
-        "imported": ".nodes:EasyUseAnimaPromptStudioAdvanced",
+        "imported": ".easyuse_anima.registration:EasyUseAnimaPromptStudioAdvanced",
         "line": 3,
         "name": "EasyUseAnimaPromptStudioAdvanced",
-        "source": "nodes.py"
+        "source": "easyuse_anima/registration.py"
       },
       {
         "declared_in_all": false,
-        "imported": ".nodes:EasyUseAnimaPromptStudioAdvancedV2",
+        "imported": ".easyuse_anima.registration:EasyUseAnimaPromptStudioAdvancedV2",
         "line": 3,
         "name": "EasyUseAnimaPromptStudioAdvancedV2",
-        "source": "nodes.py"
+        "source": "easyuse_anima/registration.py"
       },
       {
         "declared_in_all": false,
-        "imported": ".nodes:EasyUseAnimaPromptStudioRegional",
+        "imported": ".easyuse_anima.registration:EasyUseAnimaPromptStudioRegional",
         "line": 3,
         "name": "EasyUseAnimaPromptStudioRegional",
-        "source": "nodes.py"
+        "source": "easyuse_anima/registration.py"
       },
       {
         "declared_in_all": false,
-        "imported": ".nodes:EasyUseAnimaRegionalConditioning",
+        "imported": ".easyuse_anima.registration:EasyUseAnimaRegionalConditioning",
         "line": 3,
         "name": "EasyUseAnimaRegionalConditioning",
-        "source": "nodes.py"
+        "source": "easyuse_anima/registration.py"
       },
       {
         "declared_in_all": false,
-        "imported": ".nodes:EasyUseAnimaWildcard",
+        "imported": ".easyuse_anima.registration:EasyUseAnimaWildcard",
         "line": 3,
         "name": "EasyUseAnimaWildcard",
-        "source": "nodes.py"
+        "source": "easyuse_anima/registration.py"
       },
       {
         "declared_in_all": true,
         "imported": ".easyuse_anima.registration:NODE_CLASS_MAPPINGS",
-        "line": 25,
+        "line": 3,
         "name": "NODE_CLASS_MAPPINGS",
         "source": "easyuse_anima/registration.py"
       },
       {
         "declared_in_all": true,
         "imported": ".easyuse_anima.registration:NODE_DISPLAY_NAME_MAPPINGS",
-        "line": 25,
+        "line": 3,
         "name": "NODE_DISPLAY_NAME_MAPPINGS",
         "source": "easyuse_anima/registration.py"
       },
       {
         "declared_in_all": false,
         "imported": ".:api",
-        "line": 23,
+        "line": 25,
         "name": "api",
         "source": "api.py"
       },
       {
         "declared_in_all": false,
         "imported": ".wildcard_engine:ensure_default_wildcard_root",
-        "line": 29,
+        "line": 27,
         "name": "ensure_default_wildcard_root",
         "source": "wildcard_engine.py"
       }
@@ -47854,16 +47833,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:AIO_FIRST_PASS_CACHE_MAX_ENTRIES",
         "kind": "static_from",
-        "line": 564,
+        "line": 562,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47877,16 +47856,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_AIO_FIRST_PASS_CACHE",
         "kind": "static_from",
-        "line": 564,
+        "line": 562,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47900,16 +47879,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_AIO_FIRST_PASS_CACHE_ORDER",
         "kind": "static_from",
-        "line": 564,
+        "line": 562,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47923,16 +47902,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_aio_first_pass_cache_key",
         "kind": "static_from",
-        "line": 564,
+        "line": 562,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47946,16 +47925,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_clone_aio_cache_value",
         "kind": "static_from",
-        "line": 564,
+        "line": 562,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47969,16 +47948,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_get_aio_first_pass_cache",
         "kind": "static_from",
-        "line": 564,
+        "line": 562,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47992,16 +47971,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_put_aio_first_pass_cache",
         "kind": "static_from",
-        "line": 564,
+        "line": 562,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48015,16 +47994,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_detailer_stage",
         "kind": "static_from",
-        "line": 574,
+        "line": 572,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48038,16 +48017,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_detailer_target",
         "kind": "static_from",
-        "line": 574,
+        "line": 572,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48061,16 +48040,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_highres_stage",
         "kind": "static_from",
-        "line": 574,
+        "line": 572,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48084,16 +48063,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_legacy_generation",
         "kind": "static_from",
-        "line": 574,
+        "line": 572,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48107,16 +48086,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_resshift_upscale_stage",
         "kind": "static_from",
-        "line": 574,
+        "line": 572,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48130,16 +48109,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_upscale_stage",
         "kind": "static_from",
-        "line": 574,
+        "line": 572,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48153,16 +48132,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_usdu_upscale_stage",
         "kind": "static_from",
-        "line": 574,
+        "line": 572,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48176,16 +48155,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_AIO_DETAILER_CUSTOM_RE",
         "kind": "static_from",
-        "line": 583,
+        "line": 581,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48199,16 +48178,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_AIO_DETAILER_RESERVED_KEYS",
         "kind": "static_from",
-        "line": 583,
+        "line": 581,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48222,16 +48201,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_aio_detailer_has_enabled_targets",
         "kind": "static_from",
-        "line": 583,
+        "line": 581,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48245,16 +48224,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_aio_detailer_target_defaults",
         "kind": "static_from",
-        "line": 583,
+        "line": 581,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48268,16 +48247,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_aio_detailer_target_order",
         "kind": "static_from",
-        "line": 583,
+        "line": 581,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48291,16 +48270,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_is_aio_detailer_target_name",
         "kind": "static_from",
-        "line": 583,
+        "line": 581,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48314,16 +48293,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_merge_versioned_settings",
         "kind": "static_from",
-        "line": 583,
+        "line": 581,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48337,16 +48316,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_dit_corrections_settings",
         "kind": "static_from",
-        "line": 583,
+        "line": 581,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48360,16 +48339,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_generation_settings",
         "kind": "static_from",
-        "line": 583,
+        "line": 581,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48383,16 +48362,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_seed",
         "kind": "static_from",
-        "line": 583,
+        "line": 581,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48406,16 +48385,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_spectrum_settings",
         "kind": "static_from",
-        "line": 583,
+        "line": 581,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48429,16 +48408,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_FINAL_FIT_MODES",
         "kind": "static_from",
-        "line": 596,
+        "line": 594,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48452,16 +48431,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_FINAL_UPSCALE_BACKENDS",
         "kind": "static_from",
-        "line": 596,
+        "line": 594,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48475,16 +48454,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_GENERATION_DEFAULT_SETTINGS",
         "kind": "static_from",
-        "line": 596,
+        "line": 594,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48498,16 +48477,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_GENERATION_SETTINGS_SCHEMA",
         "kind": "static_from",
-        "line": 596,
+        "line": 594,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48521,16 +48500,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_GENERATION_SETTINGS_VERSION",
         "kind": "static_from",
-        "line": 596,
+        "line": 594,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48544,16 +48523,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_RESHIFT_DTYPES",
         "kind": "static_from",
-        "line": 596,
+        "line": 594,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48567,16 +48546,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_RESHIFT_SCALES",
         "kind": "static_from",
-        "line": 596,
+        "line": 594,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48590,16 +48569,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_SPECIAL_SEEDS",
         "kind": "static_from",
-        "line": 596,
+        "line": 594,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48613,16 +48592,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_SPECIAL_SEED_DECREMENT",
         "kind": "static_from",
-        "line": 596,
+        "line": 594,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48636,16 +48615,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_SPECIAL_SEED_INCREMENT",
         "kind": "static_from",
-        "line": 596,
+        "line": 594,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48659,16 +48638,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_SPECIAL_SEED_RANDOM",
         "kind": "static_from",
-        "line": 596,
+        "line": 594,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48682,16 +48661,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_USDU_MODE_TYPES",
         "kind": "static_from",
-        "line": 596,
+        "line": 594,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48705,16 +48684,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_USDU_PROMPT_FULL",
         "kind": "static_from",
-        "line": 596,
+        "line": 594,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48728,16 +48707,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_USDU_PROMPT_MODES",
         "kind": "static_from",
-        "line": 596,
+        "line": 594,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48751,16 +48730,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_USDU_PROMPT_NO_GENERAL",
         "kind": "static_from",
-        "line": 596,
+        "line": 594,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48774,16 +48753,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_USDU_SEAM_FIX_MODES",
         "kind": "static_from",
-        "line": 596,
+        "line": 594,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48797,16 +48776,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_settings:round_trip_aio_generation_settings",
         "kind": "static_from",
-        "line": 614,
+        "line": 612,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48820,16 +48799,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.input_defaults:AIO_INPUT_DEFAULT_SETTINGS",
         "kind": "static_from",
-        "line": 617,
+        "line": 615,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48843,16 +48822,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.input_defaults:ANIMA_CLIP_DEVICES",
         "kind": "static_from",
-        "line": 617,
+        "line": 615,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48866,16 +48845,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.input_defaults:ANIMA_CLIP_TYPES",
         "kind": "static_from",
-        "line": 617,
+        "line": 615,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48889,16 +48868,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.input_defaults:ANIMA_DEFAULT_CLIP_CANDIDATES",
         "kind": "static_from",
-        "line": 617,
+        "line": 615,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48912,16 +48891,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.input_defaults:ANIMA_DEFAULT_DIFFUSION_MODEL_CANDIDATES",
         "kind": "static_from",
-        "line": 617,
+        "line": 615,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48935,16 +48914,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.input_defaults:ANIMA_DEFAULT_VAE_CANDIDATES",
         "kind": "static_from",
-        "line": 617,
+        "line": 615,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48958,16 +48937,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.input_defaults:ANIMA_UNET_WEIGHT_DTYPES",
         "kind": "static_from",
-        "line": 617,
+        "line": 615,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48981,16 +48960,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.input_defaults:EASY_USE_ANIMA_INPUT_SCHEMA",
         "kind": "static_from",
-        "line": 617,
+        "line": 615,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49004,16 +48983,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.input_defaults:EASY_USE_ANIMA_INPUT_SETTINGS_VERSION",
         "kind": "static_from",
-        "line": 617,
+        "line": 615,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49027,16 +49006,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.input_context:_easy_use_anima_input_signature",
         "kind": "static_from",
-        "line": 628,
+        "line": 626,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49050,16 +49029,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.input_context:_require_easy_use_anima_input",
         "kind": "static_from",
-        "line": 628,
+        "line": 626,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49073,16 +49052,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.usdu:_aio_usdu_auto_tile_dimension",
         "kind": "static_from",
-        "line": 632,
+        "line": 630,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49096,16 +49075,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.usdu:_aio_usdu_tile_plan",
         "kind": "static_from",
-        "line": 632,
+        "line": 630,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49119,16 +49098,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_aio_final_fit_size",
         "kind": "static_from",
-        "line": 636,
+        "line": 634,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49142,16 +49121,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_apply_aio_final_fit",
         "kind": "static_from",
-        "line": 636,
+        "line": 634,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49165,16 +49144,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_resize_image_to_size_if_needed",
         "kind": "static_from",
-        "line": 636,
+        "line": 634,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49188,16 +49167,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_run_aio_postprocess_stage",
         "kind": "static_from",
-        "line": 636,
+        "line": 634,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49211,16 +49190,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_prompt_data_fields_for_usdu",
         "kind": "static_from",
-        "line": 642,
+        "line": 640,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49234,16 +49213,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_usdu_conditioning",
         "kind": "static_from",
-        "line": 642,
+        "line": 640,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49257,16 +49236,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_usdu_prompt_without_general",
         "kind": "static_from",
-        "line": 642,
+        "line": 640,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49280,16 +49259,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_aio_lora_stack_signature",
         "kind": "static_from",
-        "line": 647,
+        "line": 645,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49303,16 +49282,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_anima_dave_patch",
         "kind": "static_from",
-        "line": 647,
+        "line": 645,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49326,16 +49305,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_kj_model_patches",
         "kind": "static_from",
-        "line": 647,
+        "line": 645,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49349,16 +49328,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_lora_stack",
         "kind": "static_from",
-        "line": 647,
+        "line": 645,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49372,16 +49351,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_model_patches",
         "kind": "static_from",
-        "line": 647,
+        "line": 645,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49395,16 +49374,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_safe_pag_patch",
         "kind": "static_from",
-        "line": 647,
+        "line": 645,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49418,16 +49397,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_correction_patch_for_comfy_sampler",
         "kind": "static_from",
-        "line": 647,
+        "line": 645,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49441,16 +49420,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_forecast_patch_for_comfy_sampler",
         "kind": "static_from",
-        "line": 647,
+        "line": 645,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49464,16 +49443,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_model_patches_for_comfy_sampler",
         "kind": "static_from",
-        "line": 647,
+        "line": 645,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49487,16 +49466,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_cleanup_aio_ephemeral_model",
         "kind": "static_from",
-        "line": 647,
+        "line": 645,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49510,16 +49489,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_normalize_aio_lora_stack",
         "kind": "static_from",
-        "line": 647,
+        "line": 645,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49533,16 +49512,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_patch_model_sampling_aura_flow",
         "kind": "static_from",
-        "line": 647,
+        "line": 645,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49556,16 +49535,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_aio_highres_effective_backend",
         "kind": "static_from",
-        "line": 661,
+        "line": 659,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49579,16 +49558,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_aio_stage_sampler_settings",
         "kind": "static_from",
-        "line": 661,
+        "line": 659,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49602,16 +49581,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_decode_latent_with_comfy",
         "kind": "static_from",
-        "line": 661,
+        "line": 659,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49625,16 +49604,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_encode_image_with_comfy_vae",
         "kind": "static_from",
-        "line": 661,
+        "line": 659,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49648,16 +49627,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_generate_empty_latent_with_comfy",
         "kind": "static_from",
-        "line": 661,
+        "line": 659,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49671,16 +49650,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_new_aio_random_seed",
         "kind": "static_from",
-        "line": 661,
+        "line": 659,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49694,16 +49673,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_resolve_aio_runtime_seed",
         "kind": "static_from",
-        "line": 661,
+        "line": 659,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49717,16 +49696,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_aio_backend",
         "kind": "static_from",
-        "line": 661,
+        "line": 659,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49740,16 +49719,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_comfy",
         "kind": "static_from",
-        "line": 661,
+        "line": 659,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49763,16 +49742,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_spectrum_mod_guidance_advanced",
         "kind": "static_from",
-        "line": 661,
+        "line": 659,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49786,16 +49765,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_spectrum_spd",
         "kind": "static_from",
-        "line": 661,
+        "line": 659,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49809,16 +49788,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_CACHE_FORMAT",
         "kind": "static_from",
-        "line": 674,
+        "line": 672,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49832,16 +49811,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_CACHE_QUALITY",
         "kind": "static_from",
-        "line": 674,
+        "line": 672,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49855,16 +49834,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_EVENT",
         "kind": "static_from",
-        "line": 674,
+        "line": 672,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49878,16 +49857,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_STAGE_LABELS",
         "kind": "static_from",
-        "line": 674,
+        "line": 672,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49901,16 +49880,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_aio_preview_base_directory",
         "kind": "static_from",
-        "line": 674,
+        "line": 672,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49924,16 +49903,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_aio_preview_file_size_bytes",
         "kind": "static_from",
-        "line": 674,
+        "line": 672,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49947,16 +49926,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_save_aio_temp_preview_image",
         "kind": "static_from",
-        "line": 674,
+        "line": 672,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49970,16 +49949,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_send_aio_preview_event",
         "kind": "static_from",
-        "line": 674,
+        "line": 672,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49993,16 +49972,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_tag_aio_preview_images",
         "kind": "static_from",
-        "line": 674,
+        "line": 672,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50016,16 +49995,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_image_saver_additional_hashes",
         "kind": "static_from",
-        "line": 685,
+        "line": 683,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50039,16 +50018,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_image_saver_civitai_hash_fetcher_entries",
         "kind": "static_from",
-        "line": 685,
+        "line": 683,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50062,16 +50041,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_lora_metadata_name",
         "kind": "static_from",
-        "line": 685,
+        "line": 683,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50085,16 +50064,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_prompt_with_lora_metadata",
         "kind": "static_from",
-        "line": 685,
+        "line": 683,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50108,16 +50087,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_save_filename_prefix",
         "kind": "static_from",
-        "line": 685,
+        "line": 683,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50131,16 +50110,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_save_image_with_comfy",
         "kind": "static_from",
-        "line": 685,
+        "line": 683,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50154,16 +50133,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_save_image_with_image_saver",
         "kind": "static_from",
-        "line": 685,
+        "line": 683,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50177,16 +50156,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.output_settings:_normalize_aio_civitai_hash_fetchers",
         "kind": "static_from",
-        "line": 694,
+        "line": 692,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50200,16 +50179,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.output_settings:_normalize_aio_hash_bundles",
         "kind": "static_from",
-        "line": 694,
+        "line": 692,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50223,16 +50202,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_clip_loader_types",
         "kind": "static_from",
-        "line": 698,
+        "line": 696,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50246,16 +50225,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_diffusion_model_names",
         "kind": "static_from",
-        "line": 698,
+        "line": 696,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50269,16 +50248,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_text_encoder_names",
         "kind": "static_from",
-        "line": 698,
+        "line": 696,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50292,16 +50271,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_vae_names",
         "kind": "static_from",
-        "line": 698,
+        "line": 696,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50315,16 +50294,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_aio_resources_from_input_context",
         "kind": "static_from",
-        "line": 698,
+        "line": 696,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50338,16 +50317,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_aio_sam3_context",
         "kind": "static_from",
-        "line": 698,
+        "line": 696,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50361,16 +50340,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_checkpoint_with_comfy",
         "kind": "static_from",
-        "line": 698,
+        "line": 696,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50384,16 +50363,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_clip_with_comfy",
         "kind": "static_from",
-        "line": 698,
+        "line": 696,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50407,16 +50386,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_diffusion_model_with_comfy",
         "kind": "static_from",
-        "line": 698,
+        "line": 696,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50430,16 +50409,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_upscale_model_with_comfy",
         "kind": "static_from",
-        "line": 698,
+        "line": 696,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50453,16 +50432,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_vae_with_comfy",
         "kind": "static_from",
-        "line": 698,
+        "line": 696,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50476,16 +50455,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_normalize_aio_input_settings",
         "kind": "static_from",
-        "line": 698,
+        "line": 696,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50499,16 +50478,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_checkpoint_default",
         "kind": "static_from",
-        "line": 698,
+        "line": 696,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50522,16 +50501,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_clip_type_default",
         "kind": "static_from",
-        "line": 698,
+        "line": 696,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50545,16 +50524,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_name_default",
         "kind": "static_from",
-        "line": 698,
+        "line": 696,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50568,16 +50547,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_json_clone",
         "kind": "static_from",
-        "line": 715,
+        "line": 713,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50591,16 +50570,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_json_object",
         "kind": "static_from",
-        "line": 715,
+        "line": 713,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50614,16 +50593,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_stable_change_key",
         "kind": "static_from",
-        "line": 715,
+        "line": 713,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50637,16 +50616,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_bool",
         "kind": "static_from",
-        "line": 720,
+        "line": 718,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50660,16 +50639,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_float",
         "kind": "static_from",
-        "line": 720,
+        "line": 718,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50683,16 +50662,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_int",
         "kind": "static_from",
-        "line": 720,
+        "line": 718,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50706,16 +50685,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.common.values:_choice",
         "kind": "static_from",
-        "line": 720,
+        "line": 718,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50729,16 +50708,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.common.values:_single_value",
         "kind": "static_from",
-        "line": 720,
+        "line": 718,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50752,16 +50731,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.seed.compatibility:WILDCARD_QUEUE_MAX_SAFE_SEED",
         "kind": "static_from",
-        "line": 727,
+        "line": 725,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50775,16 +50754,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.seed.compatibility:WILDCARD_RESERVED_NEXT_SEED_INPUT",
         "kind": "static_from",
-        "line": 727,
+        "line": 725,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50798,16 +50777,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.seed.compatibility:_consume_reserved_wildcard_next_seed",
         "kind": "static_from",
-        "line": 727,
+        "line": 725,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50821,16 +50800,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.workflow:_get_workflow_node",
         "kind": "static_from",
-        "line": 732,
+        "line": 730,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50844,16 +50823,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_prompt_translation_change_key",
         "kind": "static_from",
-        "line": 733,
+        "line": 731,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50867,16 +50846,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_split_tag_text",
         "kind": "static_from",
-        "line": 733,
+        "line": 731,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50890,16 +50869,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_translate_prompt_text",
         "kind": "static_from",
-        "line": 733,
+        "line": 731,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50913,16 +50892,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_HASH_COMMENT_RE",
         "kind": "static_from",
-        "line": 738,
+        "line": 736,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50936,16 +50915,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_INLINE_SPACE_RE",
         "kind": "static_from",
-        "line": 738,
+        "line": 736,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50959,16 +50938,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_WEIGHTED_TOKEN_RE",
         "kind": "static_from",
-        "line": 738,
+        "line": 736,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50982,16 +50961,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_correct_builder_prompt",
         "kind": "static_from",
-        "line": 738,
+        "line": 736,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51005,16 +50984,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_filter_metadata_prompt",
         "kind": "static_from",
-        "line": 738,
+        "line": 736,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51028,16 +51007,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_join_prompt_tokens",
         "kind": "static_from",
-        "line": 738,
+        "line": 736,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51051,16 +51030,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_metadata_filter_key",
         "kind": "static_from",
-        "line": 738,
+        "line": 736,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51074,16 +51053,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_metadata_filter_keys",
         "kind": "static_from",
-        "line": 738,
+        "line": 736,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51097,16 +51076,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_prompt_tokens",
         "kind": "static_from",
-        "line": 738,
+        "line": 736,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51120,16 +51099,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:PROMPT_DATA_TYPE",
         "kind": "static_from",
-        "line": 751,
+        "line": 749,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51143,16 +51122,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_advanced_outputs_from_prompt_data",
         "kind": "static_from",
-        "line": 751,
+        "line": 749,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51166,16 +51145,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_apply_prompt_data_overrides",
         "kind": "static_from",
-        "line": 751,
+        "line": 749,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51189,16 +51168,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_copy_prompt_data_for_update",
         "kind": "static_from",
-        "line": 751,
+        "line": 749,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51212,16 +51191,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_normalize_prompt_data",
         "kind": "static_from",
-        "line": 751,
+        "line": 749,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51235,16 +51214,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_prompt_data_json_safe",
         "kind": "static_from",
-        "line": 751,
+        "line": 749,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51258,16 +51237,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_prompt_data_parameter_snapshot",
         "kind": "static_from",
-        "line": 751,
+        "line": 749,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51281,16 +51260,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_artist_field_prompt",
         "kind": "static_from",
-        "line": 769,
+        "line": 767,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51304,16 +51283,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_default_fields",
         "kind": "static_from",
-        "line": 769,
+        "line": 767,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51327,16 +51306,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_enabled_naia_panes",
         "kind": "static_from",
-        "line": 769,
+        "line": 767,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51350,16 +51329,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_enabled_pane_fields",
         "kind": "static_from",
-        "line": 769,
+        "line": 767,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51373,16 +51352,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_field_input_values",
         "kind": "static_from",
-        "line": 769,
+        "line": 767,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51396,16 +51375,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_field_socket_name",
         "kind": "static_from",
-        "line": 769,
+        "line": 767,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51419,16 +51398,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_fields_json",
         "kind": "static_from",
-        "line": 769,
+        "line": 767,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51442,16 +51421,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_has_enabled_naia",
         "kind": "static_from",
-        "line": 769,
+        "line": 767,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51465,16 +51444,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_prompt_with_artist_override",
         "kind": "static_from",
-        "line": 769,
+        "line": 767,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51488,16 +51467,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_uses_naia_resolution",
         "kind": "static_from",
-        "line": 769,
+        "line": 767,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51511,16 +51490,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_apply_advanced_field_inputs",
         "kind": "static_from",
-        "line": 769,
+        "line": 767,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51534,16 +51513,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_as_advanced_height",
         "kind": "static_from",
-        "line": 769,
+        "line": 767,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51557,16 +51536,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_build_advanced_prompt_data",
         "kind": "static_from",
-        "line": 769,
+        "line": 767,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51580,16 +51559,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_build_advanced_prompts",
         "kind": "static_from",
-        "line": 769,
+        "line": 767,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51603,16 +51582,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_clone_advanced_fields",
         "kind": "static_from",
-        "line": 769,
+        "line": 767,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51626,16 +51605,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_correct_advanced_field_sequence",
         "kind": "static_from",
-        "line": 769,
+        "line": 767,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51649,16 +51628,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_expand_advanced_wildcard_fields",
         "kind": "static_from",
-        "line": 769,
+        "line": 767,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51672,16 +51651,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_normalize_advanced_fields",
         "kind": "static_from",
-        "line": 769,
+        "line": 767,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51695,16 +51674,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_normalize_prompt_studio_wildcard_seed_control",
         "kind": "static_from",
-        "line": 769,
+        "line": 767,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51718,16 +51697,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_set_naia_field_text",
         "kind": "static_from",
-        "line": 769,
+        "line": 767,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51741,16 +51720,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_translate_prompt_fields",
         "kind": "static_from",
-        "line": 769,
+        "line": 767,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51764,16 +51743,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_apply_regional_field_inputs",
         "kind": "static_from",
-        "line": 804,
+        "line": 802,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51787,16 +51766,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_build_regional_outputs",
         "kind": "static_from",
-        "line": 804,
+        "line": 802,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51810,16 +51789,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_clone_regional_fields",
         "kind": "static_from",
-        "line": 804,
+        "line": 802,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51833,16 +51812,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_conditioning_set_values",
         "kind": "static_from",
-        "line": 804,
+        "line": 802,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51856,16 +51835,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_mask_ids",
         "kind": "static_from",
-        "line": 804,
+        "line": 802,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51879,16 +51858,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_regional_config",
         "kind": "static_from",
-        "line": 804,
+        "line": 802,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51902,16 +51881,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_regional_fields",
         "kind": "static_from",
-        "line": 804,
+        "line": 802,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51925,16 +51904,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_parse_json_object",
         "kind": "static_from",
-        "line": 804,
+        "line": 802,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51948,16 +51927,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_config_json",
         "kind": "static_from",
-        "line": 804,
+        "line": 802,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51971,16 +51950,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_fields_json",
         "kind": "static_from",
-        "line": 804,
+        "line": 802,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51994,16 +51973,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_mask_bounds_area",
         "kind": "static_from",
-        "line": 804,
+        "line": 802,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52017,16 +51996,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_payload_canvas",
         "kind": "static_from",
-        "line": 804,
+        "line": 802,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52040,16 +52019,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_union_mask_for_ids",
         "kind": "static_from",
-        "line": 804,
+        "line": 802,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52063,16 +52042,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
         "kind": "static_from",
-        "line": 831,
+        "line": 829,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52086,16 +52065,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODES",
         "kind": "static_from",
-        "line": 831,
+        "line": 829,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52109,16 +52088,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 831,
+        "line": 829,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52132,16 +52111,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_PROFILE_OFF",
         "kind": "static_from",
-        "line": 831,
+        "line": 829,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52155,16 +52134,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_apply_spectrum_anima_mod_guidance",
         "kind": "static_from",
-        "line": 831,
+        "line": 829,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52178,16 +52157,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_find_spectrum_anima_mod_guidance_class",
         "kind": "static_from",
-        "line": 831,
+        "line": 829,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52201,16 +52180,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_normalize_anima_mod_guidance_profile",
         "kind": "static_from",
-        "line": 831,
+        "line": 829,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52224,16 +52203,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_resolve_anima_mod_guidance_enabled",
         "kind": "static_from",
-        "line": 831,
+        "line": 829,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52247,16 +52226,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
         "kind": "static_from",
-        "line": 846,
+        "line": 844,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52270,16 +52249,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
         "kind": "static_from",
-        "line": 846,
+        "line": 844,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52293,16 +52272,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
         "kind": "static_from",
-        "line": 846,
+        "line": 844,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52316,16 +52295,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_EXACT_TOP_K",
         "kind": "static_from",
-        "line": 846,
+        "line": 844,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52339,16 +52318,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
         "kind": "static_from",
-        "line": 846,
+        "line": 844,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52362,16 +52341,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_START_PERCENT",
         "kind": "static_from",
-        "line": 846,
+        "line": 844,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52385,16 +52364,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
         "kind": "static_from",
-        "line": 846,
+        "line": 844,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52408,16 +52387,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STYLE_GAIN",
         "kind": "static_from",
-        "line": 846,
+        "line": 844,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52431,16 +52410,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_INPUT_MODES",
         "kind": "static_from",
-        "line": 846,
+        "line": 844,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52454,16 +52433,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 846,
+        "line": 844,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52477,16 +52456,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_mix_inline_prompt",
         "kind": "static_from",
-        "line": 846,
+        "line": 844,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52500,16 +52479,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_mix_mode_tooltip",
         "kind": "static_from",
-        "line": 846,
+        "line": 844,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52523,16 +52502,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_prompt_with_position",
         "kind": "static_from",
-        "line": 846,
+        "line": 844,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52546,16 +52525,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_tags_from_prompt",
         "kind": "static_from",
-        "line": 846,
+        "line": 844,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52569,16 +52548,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_blend_conditionings",
         "kind": "static_from",
-        "line": 846,
+        "line": 844,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52592,16 +52571,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bounded_artist_mix_float",
         "kind": "static_from",
-        "line": 846,
+        "line": 844,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52615,16 +52594,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bounded_artist_mix_int",
         "kind": "static_from",
-        "line": 846,
+        "line": 844,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52638,16 +52617,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_clustered",
         "kind": "static_from",
-        "line": 846,
+        "line": 844,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52661,16 +52640,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_delta_rms",
         "kind": "static_from",
-        "line": 846,
+        "line": 844,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52684,16 +52663,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_prompt_data_positive_conditioning",
         "kind": "static_from",
-        "line": 846,
+        "line": 844,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52707,16 +52686,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_join_artist_mix_source_prompts",
         "kind": "static_from",
-        "line": 846,
+        "line": 844,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52730,16 +52709,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_normalize_artist_mix_mode",
         "kind": "static_from",
-        "line": 846,
+        "line": 844,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52753,16 +52732,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_normalize_artist_tag_position",
         "kind": "static_from",
-        "line": 846,
+        "line": 844,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52776,16 +52755,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_parse_artist_mix_items",
         "kind": "static_from",
-        "line": 846,
+        "line": 844,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52799,16 +52778,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaArtistMixConditioning",
         "kind": "static_from",
-        "line": 925,
+        "line": 923,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52822,16 +52801,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataConditioning",
         "kind": "static_from",
-        "line": 925,
+        "line": 923,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52845,16 +52824,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataUnpack",
         "kind": "static_from",
-        "line": 925,
+        "line": 923,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52868,16 +52847,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_ANY_TYPE",
         "kind": "static_from",
-        "line": 930,
+        "line": 928,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52891,16 +52870,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_AnyType",
         "kind": "static_from",
-        "line": 930,
+        "line": 928,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52914,16 +52893,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_FlexibleOptionalInputType",
         "kind": "static_from",
-        "line": 930,
+        "line": 928,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52937,16 +52916,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvanced",
         "kind": "static_from",
-        "line": 935,
+        "line": 933,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52960,16 +52939,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvancedV2",
         "kind": "static_from",
-        "line": 935,
+        "line": 933,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52983,16 +52962,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:EASY_USE_ANIMA_INPUT_TYPE",
         "kind": "static_from",
-        "line": 940,
+        "line": 938,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53006,16 +52985,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:EasyUseAnimaAIOGenerator",
         "kind": "static_from",
-        "line": 940,
+        "line": 938,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53029,16 +53008,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:EasyUseAnimaInput",
         "kind": "static_from",
-        "line": 940,
+        "line": 938,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53052,16 +53031,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_aio_generation_settings_json",
         "kind": "static_from",
-        "line": 940,
+        "line": 938,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53075,16 +53054,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_aio_input_settings_json",
         "kind": "static_from",
-        "line": 940,
+        "line": 938,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53098,16 +53077,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_align_down",
         "kind": "static_from",
-        "line": 947,
+        "line": 945,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53121,16 +53100,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_align_nearest",
         "kind": "static_from",
-        "line": 947,
+        "line": 945,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53144,16 +53123,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_image_tensor_size",
         "kind": "static_from",
-        "line": 947,
+        "line": 945,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53167,16 +53146,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_context_value",
         "kind": "static_from",
-        "line": 958,
+        "line": 956,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53190,16 +53169,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_sam3_context",
         "kind": "static_from",
-        "line": 958,
+        "line": 956,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53213,16 +53192,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_segs_has_items",
         "kind": "static_from",
-        "line": 958,
+        "line": 956,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53236,16 +53215,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:IMAGE_SCALE_MULTIPLES",
         "kind": "static_from",
-        "line": 970,
+        "line": 968,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53259,16 +53238,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:IMAGE_UPSCALE_METHODS",
         "kind": "static_from",
-        "line": 970,
+        "line": 968,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53282,16 +53261,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_sampler_names",
         "kind": "static_from",
-        "line": 978,
+        "line": 976,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53305,16 +53284,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_scheduler_names",
         "kind": "static_from",
-        "line": 978,
+        "line": 976,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53328,16 +53307,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_impact_scheduler_names",
         "kind": "static_from",
-        "line": 978,
+        "line": 976,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53351,16 +53330,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_call_with_supported_kwargs",
         "kind": "static_from",
-        "line": 984,
+        "line": 982,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53374,16 +53353,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_common_upscale_image",
         "kind": "static_from",
-        "line": 984,
+        "line": 982,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53397,16 +53376,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_node_output_tuple",
         "kind": "static_from",
-        "line": 984,
+        "line": 982,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53420,16 +53399,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_clip_loader_types",
         "kind": "static_from",
-        "line": 989,
+        "line": 987,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53443,16 +53422,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_diffusion_model_names",
         "kind": "static_from",
-        "line": 989,
+        "line": 987,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53466,16 +53445,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_text_encoder_names",
         "kind": "static_from",
-        "line": 989,
+        "line": 987,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53489,16 +53468,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_vae_names",
         "kind": "static_from",
-        "line": 989,
+        "line": 987,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53512,16 +53491,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_folder_path_names",
         "kind": "static_from",
-        "line": 989,
+        "line": 987,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53535,16 +53514,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.nodes.image_nodes:EasyUseAnimaDetailerAlignHook",
         "kind": "static_from",
-        "line": 997,
+        "line": 995,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53558,16 +53537,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.nodes.image_nodes:EasyUseAnimaImageScaleByMultiple",
         "kind": "static_from",
-        "line": 997,
+        "line": 995,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53581,16 +53560,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Context",
         "kind": "static_from",
-        "line": 1001,
+        "line": 999,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53604,16 +53583,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Detailer",
         "kind": "static_from",
-        "line": 1001,
+        "line": 999,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53627,16 +53606,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptBuilder",
         "kind": "static_from",
-        "line": 1005,
+        "line": 1003,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53650,16 +53629,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrector",
         "kind": "static_from",
-        "line": 1005,
+        "line": 1003,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53673,16 +53652,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrectorSimple",
         "kind": "static_from",
-        "line": 1005,
+        "line": 1003,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53696,16 +53675,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptStudio",
         "kind": "static_from",
-        "line": 1005,
+        "line": 1003,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53719,16 +53698,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:EasyUseAnimaPromptStudioRegional",
         "kind": "static_from",
-        "line": 1011,
+        "line": 1009,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53742,16 +53721,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:EasyUseAnimaRegionalConditioning",
         "kind": "static_from",
-        "line": 1011,
+        "line": 1009,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53765,16 +53744,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.naia.client:LATENT_ALIGN",
         "kind": "static_from",
-        "line": 1015,
+        "line": 1013,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53788,16 +53767,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_parse_random_response",
         "kind": "static_from",
-        "line": 1015,
+        "line": 1013,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53811,16 +53790,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_post_random",
         "kind": "static_from",
-        "line": 1015,
+        "line": 1013,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53834,16 +53813,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_advanced_resolution_from_selection",
         "kind": "static_from",
-        "line": 1033,
+        "line": 1031,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53857,16 +53836,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_normalize_resolution_bucket",
         "kind": "static_from",
-        "line": 1033,
+        "line": 1031,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53880,16 +53859,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_ratio_label",
         "kind": "static_from",
-        "line": 1033,
+        "line": 1031,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53903,16 +53882,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolution_label",
         "kind": "static_from",
-        "line": 1033,
+        "line": 1031,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53926,16 +53905,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolve_naia_resolution",
         "kind": "static_from",
-        "line": 1033,
+        "line": 1031,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53949,16 +53928,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.nodes.naia_nodes:EasyUseAnimaNAIARandomPrompt",
         "kind": "static_from",
-        "line": 1056,
+        "line": 1054,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53972,16 +53951,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.nodes.wildcard_nodes:EasyUseAnimaWildcard",
         "kind": "static_from",
-        "line": 1059,
+        "line": 1057,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53995,16 +53974,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_apply_lora_syntax_format",
         "kind": "static_from",
-        "line": 1063,
+        "line": 1061,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54018,16 +53997,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_dedupe_text_values",
         "kind": "static_from",
-        "line": 1063,
+        "line": 1061,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54041,16 +54020,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_fallback_lora_path",
         "kind": "static_from",
-        "line": 1063,
+        "line": 1061,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54064,16 +54043,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_get_lora_info",
         "kind": "static_from",
-        "line": 1063,
+        "line": 1061,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54087,16 +54066,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_get_lora_manager_trigger_words",
         "kind": "static_from",
-        "line": 1063,
+        "line": 1061,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54110,16 +54089,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_load_lora_manager_metadata",
         "kind": "static_from",
-        "line": 1063,
+        "line": 1061,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54133,16 +54112,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_combo_values",
         "kind": "static_from",
-        "line": 1063,
+        "line": 1061,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54156,16 +54135,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_manager_trigger_words_from_metadata",
         "kind": "static_from",
-        "line": 1063,
+        "line": 1061,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54179,16 +54158,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_model_exists",
         "kind": "static_from",
-        "line": 1063,
+        "line": 1061,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54202,16 +54181,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_stack_name",
         "kind": "static_from",
-        "line": 1063,
+        "line": 1061,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54225,16 +54204,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_metadata_json_paths_for_lora",
         "kind": "static_from",
-        "line": 1063,
+        "line": 1061,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54248,16 +54227,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_missing_lora_display_name",
         "kind": "static_from",
-        "line": 1063,
+        "line": 1061,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54271,16 +54250,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_raise_missing_loras",
         "kind": "static_from",
-        "line": 1063,
+        "line": 1061,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54294,16 +54273,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_trigger_words_from_value",
         "kind": "static_from",
-        "line": 1063,
+        "line": 1061,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54317,16 +54296,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_correct_style_prompt",
         "kind": "static_from",
-        "line": 1079,
+        "line": 1077,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54340,16 +54319,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_format_strength",
         "kind": "static_from",
-        "line": 1079,
+        "line": 1077,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54363,16 +54342,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_get_loras_list",
         "kind": "static_from",
-        "line": 1079,
+        "line": 1077,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54386,16 +54365,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_load_profile_data",
         "kind": "static_from",
-        "line": 1079,
+        "line": 1077,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54409,16 +54388,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_profile_key",
         "kind": "static_from",
-        "line": 1079,
+        "line": 1077,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54432,16 +54411,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_select_profile_values",
         "kind": "static_from",
-        "line": 1079,
+        "line": 1077,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54455,16 +54434,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_wrap_profile_index",
         "kind": "static_from",
-        "line": 1079,
+        "line": 1077,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54478,16 +54457,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.nodes.lora_nodes:EasyUseAnimaLoraPreset",
         "kind": "static_from",
-        "line": 1088,
+        "line": 1086,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54501,16 +54480,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "anima_prompt:correct_prompt",
         "kind": "static_from",
-        "line": 1091,
+        "line": 1089,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54524,16 +54503,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "anima_prompt:load_knowledge_base",
         "kind": "static_from",
-        "line": 1091,
+        "line": 1089,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54547,16 +54526,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "anima_prompt.parser:parse_prompt",
         "kind": "static_from",
-        "line": 1092,
+        "line": 1090,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54570,16 +54549,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "settings:resolve_metadata_filter_words",
         "kind": "static_from",
-        "line": 1093,
+        "line": 1091,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54593,16 +54572,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "settings:resolve_naia_settings",
         "kind": "static_from",
-        "line": 1093,
+        "line": 1091,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54616,16 +54595,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "settings:resolve_prompt_translation_settings",
         "kind": "static_from",
-        "line": 1093,
+        "line": 1091,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54639,16 +54618,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "prompt_translation:has_prompt_translation_markers",
         "kind": "static_from",
-        "line": 1098,
+        "line": 1096,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54662,16 +54641,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "prompt_translation:translate_prompt_markers",
         "kind": "static_from",
-        "line": 1098,
+        "line": 1096,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54685,16 +54664,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "wildcard_engine:MAX_SEED",
         "kind": "static_from",
-        "line": 1099,
+        "line": 1097,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54708,16 +54687,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "wildcard_engine:PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "kind": "static_from",
-        "line": 1099,
+        "line": 1097,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54731,16 +54710,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "wildcard_engine:PUBLIC_MAX_SEED",
         "kind": "static_from",
-        "line": 1099,
+        "line": 1097,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54754,16 +54733,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_DECREMENT",
         "kind": "static_from",
-        "line": 1099,
+        "line": 1097,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54777,16 +54756,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_FIXED",
         "kind": "static_from",
-        "line": 1099,
+        "line": 1097,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54800,16 +54779,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_INCREMENT",
         "kind": "static_from",
-        "line": 1099,
+        "line": 1097,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54823,16 +54802,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_MODES",
         "kind": "static_from",
-        "line": 1099,
+        "line": 1097,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54846,16 +54825,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_RANDOMIZE",
         "kind": "static_from",
-        "line": 1099,
+        "line": 1097,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54869,16 +54848,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_FIXED",
         "kind": "static_from",
-        "line": 1099,
+        "line": 1097,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54892,16 +54871,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_POPULATE",
         "kind": "static_from",
-        "line": 1099,
+        "line": 1097,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54915,16 +54894,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_SEQUENTIAL",
         "kind": "static_from",
-        "line": 1099,
+        "line": 1097,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54938,16 +54917,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "wildcard_engine:expand_wildcard_texts",
         "kind": "static_from",
-        "line": 1099,
+        "line": 1097,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54961,16 +54940,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "wildcard_engine:expand_wildcards",
         "kind": "static_from",
-        "line": 1099,
+        "line": 1097,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54984,16 +54963,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "wildcard_engine:has_wildcard_syntax",
         "kind": "static_from",
-        "line": 1099,
+        "line": 1097,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -55007,16 +54986,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "wildcard_engine:next_seed",
         "kind": "static_from",
-        "line": 1099,
+        "line": 1097,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -55030,16 +55009,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "wildcard_engine:normalize_prompt_studio_wildcard_mode",
         "kind": "static_from",
-        "line": 1099,
+        "line": 1097,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -55053,16 +55032,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "wildcard_engine:normalize_seed",
         "kind": "static_from",
-        "line": 1099,
+        "line": 1097,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -55076,16 +55055,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "wildcard_engine:normalize_wildcard_mode",
         "kind": "static_from",
-        "line": 1099,
+        "line": 1097,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -55099,16 +55078,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 563,
+            "handler_line": 561,
             "kind": "try",
-            "line": 6
+            "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "wildcard_engine:wildcard_sources_signature",
         "kind": "static_from",
-        "line": 1099,
+        "line": 1097,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -55352,7 +55331,8 @@
       }
     ],
     "entry_modules": [
-      "__init__.py"
+      "__init__.py",
+      "nodes.py"
     ],
     "external_imports": [
       {
@@ -55362,14 +55342,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 33
+            "line": 31
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 34,
+        "line": 32,
         "optional": true,
         "role": "optional_dependency",
         "source": "__init__.py"
@@ -58984,17 +58964,6 @@
         "branch_context": [],
         "classification": "external",
         "conditional": false,
-        "imported": "logging",
-        "kind": "static_import",
-        "line": 4,
-        "optional": false,
-        "role": "ordinary",
-        "source": "nodes.py"
-      },
-      {
-        "branch_context": [],
-        "classification": "external",
-        "conditional": false,
         "imported": "__future__:annotations",
         "kind": "static_from",
         "line": 1,
@@ -59538,14 +59507,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 33
+            "line": 31
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 34,
+        "line": 32,
         "optional": true,
         "role": "optional_dependency",
         "source": "__init__.py"
@@ -60670,7 +60639,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 40,
+        "line": 38,
         "module": "__init__.py",
         "scope": "<module>"
       },
@@ -61755,15 +61724,6 @@
         "scope": "<module>"
       },
       {
-        "callee": "logging.getLogger",
-        "column": 9,
-        "context": "assign:logger",
-        "kind": "import_time_call",
-        "line": 1121,
-        "module": "nodes.py",
-        "scope": "<module>"
-      },
-      {
         "callee": "dataclass",
         "column": 1,
         "context": "decorator:PromptTranslationSettings",
@@ -62021,7 +61981,7 @@
     "mutable_globals": [
       {
         "kind": "list",
-        "line": 48,
+        "line": 46,
         "module": "__init__.py",
         "name": "__all__"
       },
@@ -62282,6 +62242,12 @@
         "line": 65,
         "module": "easyuse_anima/seed/reservation.py",
         "name": "_LEGACY_SELECTION_BY_SEED"
+      },
+      {
+        "kind": "list",
+        "line": 1119,
+        "module": "nodes.py",
+        "name": "__all__"
       },
       {
         "kind": "set",

--- a/tests/fixtures/python_compatibility_surface.v1.json
+++ b/tests/fixtures/python_compatibility_surface.v1.json
@@ -82,7 +82,8 @@
       "B-11c30d0b",
       "B-11c30d5",
       "B-11c30d6",
-      "B-11c30e"
+      "B-11c30e",
+      "B-11d"
     ]
   },
   "enums": {
@@ -116,17 +117,38 @@
   },
   "expected_counts": {
     "root_entrypoints": 3,
-    "excluded_preamble_implementation_bindings": 1,
+    "excluded_preamble_implementation_bindings": 0,
     "nodes_canonical_bindings": 289,
     "nodes_legacy_bindings": 27,
+    "nodes_public_exports": 18,
     "mapped_public_classes": 18,
     "unmapped_classes": 2,
     "root_residual_functions": 0,
     "root_residual_classes": 0,
-    "root_residual_globals": 2,
+    "root_residual_globals": 0,
     "runtime_binders": 0,
     "direct_nodes_import_test_files": 21
   },
+  "nodes_public_exports": [
+    "EasyUseAnimaAIOGenerator",
+    "EasyUseAnimaDetailerAlignHook",
+    "EasyUseAnimaArtistMixConditioning",
+    "EasyUseAnimaInput",
+    "EasyUseAnimaImageScaleByMultiple",
+    "EasyUseAnimaLoraPreset",
+    "EasyUseAnimaNAIARandomPrompt",
+    "EasyUseAnimaPromptDataConditioning",
+    "EasyUseAnimaPromptDataUnpack",
+    "EasyUseAnimaPromptBuilder",
+    "EasyUseAnimaPromptCorrector",
+    "EasyUseAnimaPromptCorrectorSimple",
+    "EasyUseAnimaPromptStudio",
+    "EasyUseAnimaPromptStudioAdvanced",
+    "EasyUseAnimaPromptStudioAdvancedV2",
+    "EasyUseAnimaPromptStudioRegional",
+    "EasyUseAnimaRegionalConditioning",
+    "EasyUseAnimaWildcard"
+  ],
   "mapped_public_classes": [
     "EasyUseAnimaAIOGenerator",
     "EasyUseAnimaArtistMixConditioning",
@@ -151,9 +173,7 @@
     "EasyUseAnimaSAM3Context",
     "EasyUseAnimaSAM3Detailer"
   ],
-  "excluded_preamble_implementation_bindings": {
-    "logging": "logging:logging"
-  },
+  "excluded_preamble_implementation_bindings": {},
   "runtime_binders": [],
   "runtime_resolver_consumers": {},
   "runtime_binder_audit": {
@@ -2918,10 +2938,7 @@
       "id": "nodes_root_residuals:globals",
       "surface": "nodes_root_residuals",
       "kind": "globals",
-      "symbols": {
-        "_TRIGGER_WORD_KEYS": "_TRIGGER_WORD_KEYS",
-        "logger": "logger"
-      },
+      "symbols": {},
       "classification": "transitional_private_seam",
       "current_target": "nodes.py",
       "canonical_target": null,

--- a/tests/test_node_contracts.py
+++ b/tests/test_node_contracts.py
@@ -3773,6 +3773,10 @@ class PublicNodeContractTests(unittest.TestCase):
             )
             self.assertEqual(list(runtime_mappings), [node_id for node_id, _ in class_mappings])
             self.assertEqual(package_entrypoint.NODE_DISPLAY_NAME_MAPPINGS, display_mappings)
+            self.assertEqual(
+                package_nodes.__all__,
+                [class_name for _, class_name in class_mappings],
+            )
             for node_id, class_name in class_mappings:
                 with self.subTest(node_id=node_id):
                     mapped_class = runtime_mappings[node_id]

--- a/tests/test_nodes_module_analyzer.py
+++ b/tests/test_nodes_module_analyzer.py
@@ -73,12 +73,12 @@ def load_dynamic():
     def test_current_nodes_module_shape_matches_recorded_baseline(self):
         report = analyzer.analyze_path(ROOT / "nodes.py")
 
-        self.assertEqual(report["git_blob_sha1"], "d91507b0c3836e0964979ddaa735f277d0a5934d")
-        # B-11c30e removes the Wildcard/NAIA callback binder imports and
-        # initialization without changing the public class surface.
+        self.assertEqual(report["git_blob_sha1"], "d57d76310253976c1f725974802aba61f456c225")
+        # B-11d removes the final residual implementation globals and records
+        # the supported mapped class surface in an explicit __all__.
         self.assertEqual(report["top_level"]["function_count"], 0)
         self.assertEqual(report["top_level"]["class_count"], 0)
-        self.assertEqual(report["line_count"], 1_123)
+        self.assertEqual(report["line_count"], 1_138)
         class_names = {item["name"] for item in report["top_level"]["classes"]}
         self.assertNotIn("EasyUseAnimaAIOGenerator", class_names)
         self.assertNotIn("EasyUseAnimaInput", class_names)

--- a/tests/test_python_backend_analyzer.py
+++ b/tests/test_python_backend_analyzer.py
@@ -292,6 +292,14 @@ def comfy_runtime():
             [{"from": "__init__.py", "to": "runtime.py"}],
         )
         self.assertEqual(
+            report["registry"]["entry_modules"],
+            ["__init__.py", "nodes.py"],
+        )
+        self.assertIn(
+            "nodes.py",
+            report["registry"]["runtime_import_closure"],
+        )
+        self.assertEqual(
             report["imports"]["module_graph_policy"]["duplicate_policy"],
             "collapse by source and target path",
         )
@@ -686,6 +694,10 @@ ignored/
         self.assertEqual(report["inventory"]["module_count"], 93)
         self.assertEqual(len(report["registry"]["shipped_python_modules"]), 93)
         self.assertEqual(len(report["registry"]["runtime_import_closure"]), 93)
+        self.assertEqual(
+            report["registry"]["entry_modules"],
+            ["__init__.py", "nodes.py"],
+        )
         self.assertEqual(report["registry"]["missing_internal_imports"], [])
         self.assertEqual(report["registry"]["unreachable_shipped_python_modules"], [])
         self.assertTrue(

--- a/tests/test_python_compatibility_surface.py
+++ b/tests/test_python_compatibility_surface.py
@@ -76,9 +76,7 @@ RUNTIME_LOOKUP_CALLS = {
     "_runtime_proxy",
     "runtime_proxy",
 }
-PREAMBLE_IMPLEMENTATION_BINDINGS = {
-    "logging": "logging:logging",
-}
+PREAMBLE_IMPLEMENTATION_BINDINGS: dict[str, str] = {}
 PROMPT_SERVICE_RUNTIME_BINDERS = (
     "_bind_regional_runtime",
     "_bind_advanced_runtime",
@@ -1471,9 +1469,13 @@ def _root_residuals(tree: ast.Module) -> dict[str, list[str]]:
     for node in tree.body:
         if isinstance(node, ast.Assign):
             for target in node.targets:
-                if isinstance(target, ast.Name):
+                if isinstance(target, ast.Name) and target.id != "__all__":
                     globals_.add(target.id)
-        elif isinstance(node, ast.AnnAssign) and isinstance(node.target, ast.Name):
+        elif (
+            isinstance(node, ast.AnnAssign)
+            and isinstance(node.target, ast.Name)
+            and node.target.id != "__all__"
+        ):
             globals_.add(node.target.id)
     return {
         "functions": functions,
@@ -2128,7 +2130,46 @@ def _build_document() -> dict[str, Any]:
         raise AssertionError("node and display mapping IDs differ")
     if set(node_mappings) != set(node_mappings.values()):
         raise AssertionError("mapped node IDs must retain same-named class bindings")
+    nodes_public_exports = _literal_string_list(
+        _named_assignment(nodes_tree, "__all__")
+    )
+    if nodes_public_exports != list(node_mappings.values()):
+        raise AssertionError(
+            "nodes.py __all__ must exactly match registration class order"
+        )
     mapped_classes = set(node_mappings.values())
+    entrypoint_root_node_imports = [
+        node
+        for node in entrypoint_tree.body
+        if isinstance(node, ast.ImportFrom)
+        and node.level == 1
+        and (
+            node.module == "nodes"
+            or (
+                node.module is None
+                and any(alias.name == "nodes" for alias in node.names)
+            )
+        )
+    ]
+    if entrypoint_root_node_imports:
+        raise AssertionError(
+            "root package entrypoint cannot consume compatibility nodes.py"
+        )
+    entrypoint_registration_names = {
+        alias.asname or alias.name
+        for node in entrypoint_tree.body
+        if isinstance(node, ast.ImportFrom)
+        and node.level == 1
+        and node.module == "easyuse_anima.registration"
+        for alias in node.names
+    }
+    missing_entrypoint_classes = mapped_classes - entrypoint_registration_names
+    if missing_entrypoint_classes:
+        raise AssertionError(
+            "root package entrypoint must source mapped class attributes from "
+            "easyuse_anima.registration: "
+            + ", ".join(sorted(missing_entrypoint_classes))
+        )
     loads = _runtime_loads(nodes_tree, import_try)
     residuals = _root_residuals(nodes_tree)
     available = set(relative) | set(relative_legacy)
@@ -2308,6 +2349,7 @@ def _build_document() -> dict[str, Any]:
                 "B-11c30d5",
                 "B-11c30d6",
                 "B-11c30e",
+                "B-11d",
             ],
         },
         "enums": {
@@ -2319,17 +2361,19 @@ def _build_document() -> dict[str, Any]:
         },
         "expected_counts": {
             "root_entrypoints": 3,
-            "excluded_preamble_implementation_bindings": 1,
+            "excluded_preamble_implementation_bindings": 0,
             "nodes_canonical_bindings": 289,
             "nodes_legacy_bindings": 27,
+            "nodes_public_exports": 18,
             "mapped_public_classes": 18,
             "unmapped_classes": 2,
             "root_residual_functions": 0,
             "root_residual_classes": 0,
-            "root_residual_globals": 2,
+            "root_residual_globals": 0,
             "runtime_binders": 0,
             "direct_nodes_import_test_files": 21,
         },
+        "nodes_public_exports": nodes_public_exports,
         "mapped_public_classes": sorted(mapped_classes),
         "unmapped_classes": unmapped_classes,
         "excluded_preamble_implementation_bindings": preamble_bindings,
@@ -2442,6 +2486,10 @@ class PythonCompatibilitySurfaceTests(unittest.TestCase):
         self.assertEqual(len(canonical), counts["nodes_canonical_bindings"])
         self.assertEqual(len(legacy), counts["nodes_legacy_bindings"])
         self.assertEqual(
+            len(self.document["nodes_public_exports"]),
+            counts["nodes_public_exports"],
+        )
+        self.assertEqual(
             len(self.document["mapped_public_classes"]),
             counts["mapped_public_classes"],
         )
@@ -2457,6 +2505,20 @@ class PythonCompatibilitySurfaceTests(unittest.TestCase):
             for symbol in group["symbols"]
         }
         self.assertEqual(supported, set(self.document["mapped_public_classes"]))
+        registration_order = list(
+            _literal_mapping(
+                _read_tree(REGISTRATION_PATH),
+                "NODE_CLASS_MAPPINGS",
+            ).values()
+        )
+        self.assertEqual(
+            self.document["nodes_public_exports"],
+            registration_order,
+        )
+        self.assertEqual(
+            set(self.document["nodes_public_exports"]),
+            supported,
+        )
         self.assertTrue(
             all(canonical[name].startswith("easyuse_anima.nodes.") for name in supported)
         )
@@ -2469,6 +2531,37 @@ class PythonCompatibilitySurfaceTests(unittest.TestCase):
                 "EasyUseAnimaSAM3Context",
                 "EasyUseAnimaSAM3Detailer",
             ],
+        )
+
+    def test_root_entrypoint_sources_class_attributes_without_the_nodes_shim(self):
+        tree = _read_tree(ENTRYPOINT_PATH)
+        self.assertFalse(
+            [
+                node
+                for node in tree.body
+                if isinstance(node, ast.ImportFrom)
+                and node.level == 1
+                and (
+                    node.module == "nodes"
+                    or (
+                        node.module is None
+                        and any(alias.name == "nodes" for alias in node.names)
+                    )
+                )
+            ]
+        )
+        registration_names = {
+            alias.asname or alias.name
+            for node in tree.body
+            if isinstance(node, ast.ImportFrom)
+            and node.level == 1
+            and node.module == "easyuse_anima.registration"
+            for alias in node.names
+        }
+        self.assertTrue(
+            set(self.document["mapped_public_classes"]).issubset(
+                registration_names
+            )
         )
 
     def test_preamble_implementation_import_exclusion_is_exact(self):

--- a/tools/analyze_python_backend.py
+++ b/tools/analyze_python_backend.py
@@ -30,6 +30,7 @@ from typing import Iterable, Mapping, Sequence
 REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
 ROOT_MODULE = "__root__"
 SCHEMA_VERSION = 2
+REGISTRY_ENTRY_MODULE_CANDIDATES = ("__init__.py", "nodes.py")
 DYNAMIC_IMPORT_CALLEES = frozenset({"__import__", "importlib.import_module"})
 MUTABLE_CONSTRUCTORS = {
     "ChainMap": "dict",
@@ -1286,14 +1287,16 @@ def _package_ancestors(path: str, available_paths: set[str]) -> list[str]:
 def _registry_closure(
     nodes: Sequence[str],
     graph_edges: Sequence[Mapping[str, str]],
+    *,
+    entry_modules: Sequence[str],
 ) -> list[str]:
-    if "__init__.py" not in nodes:
+    if not entry_modules:
         return []
     available = set(nodes)
     adjacency = {node: set() for node in nodes}
     for edge in graph_edges:
         adjacency[edge["from"]].add(edge["to"])
-    pending = deque(["__init__.py"])
+    pending = deque(entry_modules)
     visited = set()
     while pending:
         node = pending.popleft()
@@ -1460,7 +1463,16 @@ def analyze_source_set(
         }
     )
     graph_records = [{"from": source, "to": target} for source, target in graph_edges]
-    closure = _registry_closure(shipped_paths, graph_records)
+    entry_modules = [
+        candidate
+        for candidate in REGISTRY_ENTRY_MODULE_CANDIDATES
+        if candidate in shipped_paths
+    ]
+    closure = _registry_closure(
+        shipped_paths,
+        graph_records,
+        entry_modules=entry_modules,
+    )
     closure_set = set(closure)
     closure_edges = [
         edge for edge in runtime_edges if edge["source"] in closure_set
@@ -1552,7 +1564,7 @@ def analyze_source_set(
             "package_root": ".",
             "ignore_file": ".comfyignore",
             "ignore_file_normalized_git_blob_sha1": _normalized_git_blob_sha1(ignore_bytes),
-            "entry_modules": ["__init__.py"],
+            "entry_modules": entry_modules,
             "shipped_python_modules": shipped_paths,
             "runtime_import_closure": closure,
             "unreachable_shipped_python_modules": sorted(set(shipped_paths) - closure_set),


### PR DESCRIPTION
## 변경 요약

B-11d final root shim을 완료하는 **Move 전용 PR**입니다.

- root `nodes.py`의 마지막 미사용 구현 잔여물만 제거
- 지원되는 mapped class 18개를 `nodes.py.__all__`로 명시
- root package entrypoint가 compatibility `nodes.py`를 소비하지 않고 pure `easyuse_anima.registration`에서 동일 class object를 가져오도록 전환
- Registry 분석기가 독립적인 두 root entry module(`__init__.py`, `nodes.py`)을 추적하도록 보정
- 기존 316개 direct alias binding과 모든 동작/계약은 유지

## 사전 symbol/caller/alias/global-state inventory

- `nodes.py`: 1,123 lines, relative-package/flat-fallback 2개 import branch
- direct bindings: canonical 289 + legacy 27 = 316
- supported mapped class re-export: 18
- unmapped class alias: 2
  - `EasyUseAnimaSAM3Context`: documented transitional compatibility
  - `EasyUseAnimaSAM3Detailer`: unsupported/test-only
- unsupported/test-only symbols: 297
  - ADR-002에 따라 이 PR에서 일괄 제거하거나 public으로 승격하지 않음
- runtime ownership:
  - root functions/classes/binders/resolvers: 모두 0
  - residual globals: `logger`, `_TRIGGER_WORD_KEYS`
  - preamble implementation import: `logging`
- root `__init__.py`가 compatibility shim의 유일한 production consumer
- internal `easyuse_anima` package-to-root import: 0
- repository direct `nodes.py` test import: 21 files; test-only 소비는 public support 근거가 아님

## Allowed boundary

Production:

- `nodes.py`
- `__init__.py`

Supporting:

- Python compatibility 및 nodes/backend analyzer gate/fixture
- public node contract coverage
- architecture 문서 3개

## 구현 결과

- root `logging`/`logger`/`_TRIGGER_WORD_KEYS` 제거
- `nodes.py.__all__`은 registration order의 mapped class 18개와 exact equality
- root residual function/class/global/binder/resolver: 모두 0
- root `__init__.py`는 mapped class attribute를 `easyuse_anima.registration`에서 가져오며 `.nodes`를 import하지 않음
- Registry archive 분석은 root entry module 2개와 shipped/reachable Python module 93개를 기록
- root `nodes.py`: 1,138-line explicit compatibility shim
- 기존 canonical 289 + legacy 27 direct binding과 class identity는 유지

## 검증

Focused/checkpoint:

- compatibility/analyzer/node-contract/package/runtime 6개 module: 139 tests, 138 pass
  - 1건은 entrypoint 전환으로 기존 analyzer가 `nodes.py`를 Registry closure에서 누락한 결정적 gate drift
- analyzer exact closure 수정 후 `tests.test_python_backend_analyzer`: 18 pass
- 변경 Python 파일 `py_compile`: 통과
- `git diff --check`: 통과
- test-instance venv의 별도 Ruff 시도는 Ruff 미설치로 실행 전 종료; 패키지 설치는 하지 않음

Registry/package:

- `comfy node validate`: 통과
- `comfy node pack`: 통과
- archive: 225 entries / 13,092,476 bytes
- expected Python 93 / missing 0 / unexpected 0

Live ComfyUI:

- ComfyUI v0.27.0 Codex test instance: API/module smoke
- mapped node ID 18/18 등록 확인
- `EasyUseAnimaWildcard → ShowText`를 같은 text/seed로 2회 큐 실행
- 두 실행 모두 success, 결과 `blue flower`, same output 확인
- 사용자 인스턴스 및 browser UI smoke는 수행하지 않음
- unrelated optional-node warning: `comfyui-distilled-resshift`의 `omegaconf` 누락 및 Impact Pack SAM2 optional warning

Official full — 이 PR에서 정확히 1회 실행:

- 정상 종료: 50.3초
- Python compile: 통과
- Ruff G-01 report-only: 80 findings, 실행 정상
- Pyright baseline ratchet: 76 files / 14 baseline errors / 통과
- import boundary: 6 groups / 0 violations
- Python unittest: 986 pass
- frontend: 114 JavaScript files / TypeScript 6.0.3 / 통과
- `git diff --check`: 통과

공식 full 이후에는 검증 결과를 기록하는 문서 전용 커밋만 추가했으며 full을 재실행하지 않았습니다.

## 호환성 및 제외 범위

유지:

- 기존 316 direct alias binding과 object identity
- package/flat import parity
- mapping/display order, schemas, workflows, optional-import timing
- seed/Wildcard/NAIA/Prompt/AiO/cache/persistence behavior

제외:

- private/test-only alias 제거 또는 public 승격
- Behavior/Contract/performance/dependency 변경
- Phase D consolidation, #167/#169 Behavior, release

Owner: #184  
Policy: ADR-002
