### PR TITLE
S167-01b: make the seed arithmetic domain explicit

### DIFF
--- a/docs/architecture/python-backend-execution-roadmap.md
+++ b/docs/architecture/python-backend-execution-roadmap.md
@@ -405,7 +405,7 @@ mechanical retirement series.
 | 12 | B-10a machine-readable compatibility audit | COMPLETE on `dev` | Contract/gate | #184/#188 | PR #271 / `3c7b857` |
 | 13 | B-10b private alias reduction | COMPLETE on `dev` through PR #291 / `c6b4680` | Contract/cleanup, split PRs | #184/#188 | Audited alias surface integrated |
 | 14 | B-11 registration/bootstrap/root shim | COMPLETE in PR #356 | Move/Contract, split PRs | #184 | Zero runtime binders/residual implementation; explicit root `__all__`; frozen compatibility audit |
-| 15 | S167 backend seed reservation series | S167-01 Contract COMPLETE in PR #343 and S167-01a consumer Move COMPLETE in PR #344; Behavior and Adapter remain | Contract then Move then Behavior | #167 | Canonical AiO/node seams |
+| 15 | S167 backend seed reservation series | S167-01/01a complete; S167-01b seed-domain Contract is required before Behavior | Contract then Move then Behavior | #167 | Canonical AiO/node seams |
 | 16 | A169 stage pipeline series | READY after #168 and Phase B completion; begin with A169-01 Contract | Contract then Behavior | #169 | Typed config and mechanical AiO move |
 | 17 | A169 first-pass cache policy | BLOCKED by stage/cache ownership seam | Behavior | #169 | Mechanical cache move and benchmark harness |
 | 18 | D-series canonical root consolidation | BLOCKED by relevant C contracts | Move | #186 | Phase B exit; per-feature behavior stable |
@@ -1195,10 +1195,13 @@ Split into at least these rollback units:
 
 1. **S167-01 Contract:** concrete seed payload/service interface and compatibility
    parsing for legacy `-1/-2/-3`; no reservation behavior change.
-2. **S167-02 Behavior:** authoritative, atomic random/increment/decrement
+2. **S167-01b Contract:** make the arithmetic maximum and clamp/wrap policy
+   explicit; the current AiO and Prompt Studio domains differ and must not be
+   inferred from stream IDs.
+3. **S167-02 Behavior:** authoritative, atomic random/increment/decrement
    reservation including concurrent queue, failure, retry, and cancellation
    transitions.
-3. **S167-03 Adapter:** browser queue interceptor becomes a compatibility/display
+4. **S167-03 Adapter:** browser queue interceptor becomes a compatibility/display
    adapter; headless and browser behavior parity is proven.
 
 S167-01 uses
@@ -1211,7 +1214,10 @@ any existing runtime, payload bytes, or reservation behavior. S167-01a uses the
 same document for its exact Move inventory and allowed-file gate. PR #344
 completes that Move while preserving the root aliases and both node-adapter
 binders for B-11c30c2b. PR #345 then retires those two binders without changing
-the seed contract or beginning S167-02 Behavior.
+the seed contract or beginning S167-02 Behavior. The pre-Behavior audit then
+found that version 1 omitted the arithmetic domain: AiO clamps at its editable
+maximum while Prompt Studio wraps at its JavaScript-safe maximum. S167-01b must
+close that Contract gap without adding state or behavior before S167-02 begins.
 
 Do not mix this sequence into B-09 or #169 stages.
 

--- a/docs/architecture/python-backend-execution-roadmap.md
+++ b/docs/architecture/python-backend-execution-roadmap.md
@@ -405,7 +405,7 @@ mechanical retirement series.
 | 12 | B-10a machine-readable compatibility audit | COMPLETE on `dev` | Contract/gate | #184/#188 | PR #271 / `3c7b857` |
 | 13 | B-10b private alias reduction | COMPLETE on `dev` through PR #291 / `c6b4680` | Contract/cleanup, split PRs | #184/#188 | Audited alias surface integrated |
 | 14 | B-11 registration/bootstrap/root shim | COMPLETE in PR #356 | Move/Contract, split PRs | #184 | Zero runtime binders/residual implementation; explicit root `__all__`; frozen compatibility audit |
-| 15 | S167 backend seed reservation series | S167-01/01a complete; S167-01b seed-domain Contract implemented in PR #357 with final gate pending | Contract then Move then Behavior | #167 | Canonical AiO/node seams |
+| 15 | S167 backend seed reservation series | S167-01/01a complete; S167-01b seed-domain Contract COMPLETE in PR #357 | Contract then Move then Behavior | #167 | Canonical AiO/node seams |
 | 16 | A169 stage pipeline series | READY after #168 and Phase B completion; begin with A169-01 Contract | Contract then Behavior | #169 | Typed config and mechanical AiO move |
 | 17 | A169 first-pass cache policy | BLOCKED by stage/cache ownership seam | Behavior | #169 | Mechanical cache move and benchmark harness |
 | 18 | D-series canonical root consolidation | BLOCKED by relevant C contracts | Move | #186 | Phase B exit; per-feature behavior stable |

--- a/docs/architecture/python-backend-execution-roadmap.md
+++ b/docs/architecture/python-backend-execution-roadmap.md
@@ -405,7 +405,7 @@ mechanical retirement series.
 | 12 | B-10a machine-readable compatibility audit | COMPLETE on `dev` | Contract/gate | #184/#188 | PR #271 / `3c7b857` |
 | 13 | B-10b private alias reduction | COMPLETE on `dev` through PR #291 / `c6b4680` | Contract/cleanup, split PRs | #184/#188 | Audited alias surface integrated |
 | 14 | B-11 registration/bootstrap/root shim | COMPLETE in PR #356 | Move/Contract, split PRs | #184 | Zero runtime binders/residual implementation; explicit root `__all__`; frozen compatibility audit |
-| 15 | S167 backend seed reservation series | S167-01/01a complete; S167-01b seed-domain Contract is required before Behavior | Contract then Move then Behavior | #167 | Canonical AiO/node seams |
+| 15 | S167 backend seed reservation series | S167-01/01a complete; S167-01b seed-domain Contract implemented in PR #357 with final gate pending | Contract then Move then Behavior | #167 | Canonical AiO/node seams |
 | 16 | A169 stage pipeline series | READY after #168 and Phase B completion; begin with A169-01 Contract | Contract then Behavior | #169 | Typed config and mechanical AiO move |
 | 17 | A169 first-pass cache policy | BLOCKED by stage/cache ownership seam | Behavior | #169 | Mechanical cache move and benchmark harness |
 | 18 | D-series canonical root consolidation | BLOCKED by relevant C contracts | Move | #186 | Phase B exit; per-feature behavior stable |

--- a/docs/architecture/seed-reservation-contract.md
+++ b/docs/architecture/seed-reservation-contract.md
@@ -231,7 +231,7 @@ Python modules with no missing internal imports.
 
 ## S167-01b seed-domain Contract gate
 
-- State: IMPLEMENTED IN PR #357; final gate pending
+- State: COMPLETE IN PR #357
 - PR type: Contract
 - Baseline: `dev` commit
   `8cde31a9db6968bd71a45c3bfc19c086179caf66`
@@ -297,6 +297,15 @@ S167-03 supplies each adapter's existing reviewed domain explicitly.
   above uint64 fail closed; and
 - no production caller, state owner, RNG, lock, runtime, workflow, node, or
   frontend surface changes in this Contract.
+
+### Validation result
+
+- focused contract/import/analyzer checkpoint: 13 tests passed;
+- additional uint64 result-boundary check: 1 test passed;
+- Python compile and `git diff --check`: passed; and
+- the official full runner passed once in 50.2 seconds: 988 Python tests and
+  frontend checks for 114 JavaScript files, with the Pyright baseline and all
+  six import-boundary groups passing.
 
 ### Allowed-file boundary
 

--- a/docs/architecture/seed-reservation-contract.md
+++ b/docs/architecture/seed-reservation-contract.md
@@ -231,6 +231,7 @@ Python modules with no missing internal imports.
 
 ## S167-01b seed-domain Contract gate
 
+- State: IMPLEMENTED IN PR #357; final gate pending
 - PR type: Contract
 - Baseline: `dev` commit
   `8cde31a9db6968bd71a45c3bfc19c086179caf66`
@@ -282,6 +283,20 @@ Concrete execution seeds remain valid through uint64 maximum. Fixed
 after-generate preserves the concrete execution seed even when it is above the
 arithmetic maximum. S167-02 owns the exact arithmetic and lifecycle tests;
 S167-03 supplies each adapter's existing reviewed domain explicitly.
+
+### Implementation result
+
+- the contract version advances from 1 to 2 before any production consumer is
+  connected;
+- `SeedReservationRequest` requires validated `next_seed_max` and `overflow`;
+- concrete request and result seeds are bounded to uint64, independently from
+  the smaller next-seed arithmetic maximum;
+- both existing domains are representable without feature-name inference:
+  AiO's `2^50` clamp domain and Prompt Studio's JavaScript-safe wrap domain;
+- version 1, missing/invalid domains, booleans, negative bounds, and values
+  above uint64 fail closed; and
+- no production caller, state owner, RNG, lock, runtime, workflow, node, or
+  frontend surface changes in this Contract.
 
 ### Allowed-file boundary
 

--- a/docs/architecture/seed-reservation-contract.md
+++ b/docs/architecture/seed-reservation-contract.md
@@ -228,3 +228,87 @@ The deterministic compatibility audit records 284 canonical root bindings,
 zero residual root functions, 24 residual root globals, and the unchanged 16
 runtime binders. The whole-backend inventory records 89 shipped and reachable
 Python modules with no missing internal imports.
+
+## S167-01b seed-domain Contract gate
+
+- PR type: Contract
+- Baseline: `dev` commit
+  `8cde31a9db6968bd71a45c3bfc19c086179caf66`
+- Production consumers: none; S167-02 and S167-03 have not started
+
+### Blocker found before S167-02
+
+The version-1 request distinguishes selection and after-generate intent but
+does not identify the arithmetic domain. The existing consumers cannot share
+one implicit rule:
+
+- AiO's editable browser domain is `0..1125899906842624` and its current queue
+  arithmetic clamps at both ends;
+- Prompt Studio's editable browser domain is
+  `0..9007199254740991` and its current queue arithmetic wraps at both ends;
+  and
+- Python keeps accepting a concrete legacy seed through
+  `18446744073709551615`. Fixed mode preserves that value, while browser
+  arithmetic cannot safely publish the full uint64 range.
+
+Inferring a policy from `stream_id`, node names, or the current seed would make
+the service feature-aware and would make extension-loaded and headless requests
+diverge. S167-02 therefore remains blocked until the request carries an
+explicit arithmetic maximum and overflow policy.
+
+### Symbol, caller, alias, and state inventory
+
+- `SeedReservationRequest`, `parse_seed_reservation_request`, and
+  `parse_legacy_seed_reservation_request` are the only contract symbols that
+  need the missing domain.
+- No production caller constructs either parser request. Current callers are
+  the contract tests only, so the pre-adapter contract can advance without
+  workflow or payload migration.
+- `SeedReservation`, `SeedReservationService`, and settlement values do not
+  need a signature change.
+- No root compatibility alias exposes the reservation contract.
+- Backend reservation maps, locks, RNG, counters, stream state, and cleanup
+  state are still absent. This Contract must not add them.
+
+### Contract amendment
+
+Advance the contract version and add two required request values:
+
+- `next_seed_max`: the inclusive maximum used only for random selection and
+  increment/decrement arithmetic; and
+- `overflow`: `clamp` or `wrap`.
+
+Concrete execution seeds remain valid through uint64 maximum. Fixed
+after-generate preserves the concrete execution seed even when it is above the
+arithmetic maximum. S167-02 owns the exact arithmetic and lifecycle tests;
+S167-03 supplies each adapter's existing reviewed domain explicitly.
+
+### Allowed-file boundary
+
+S167-01b may change only:
+
+- `easyuse_anima/seed/reservation.py`;
+- `tests/test_seed_reservation_contract.py`;
+- `tests/fixtures/python_backend_baseline.json`;
+- `docs/architecture/seed-reservation-contract.md`; and
+- `docs/architecture/python-backend-execution-roadmap.md`.
+
+The analyzer fixture may change only by the deterministic contract-symbol and
+signature delta in the existing module.
+
+Forbidden:
+
+- reservation maps, locks, RNG, counters, settlement, retry, cancellation, or
+  cleanup behavior;
+- `RuntimeServices`, bootstrap, routes, node adapters, AiO/Prompt execution,
+  root shims, frontend files, workflows, or hidden payload bytes;
+- changing current AiO or Prompt Studio seed bounds/arithmetic; and
+- beginning S167-02 Behavior or S167-03 Adapter work.
+
+Exit:
+
+- the request cannot be constructed without an explicit domain;
+- version-1 requests fail closed before any state exists;
+- uint64 concrete seeds and both reviewed arithmetic domains are represented
+  without JavaScript-unsafe numeric policy inference; and
+- focused contract/import/analyzer gates pass.

--- a/easyuse_anima/seed/reservation.py
+++ b/easyuse_anima/seed/reservation.py
@@ -8,7 +8,8 @@ from dataclasses import dataclass
 from typing import Literal, Protocol, TypeAlias, cast
 
 SEED_RESERVATION_REQUEST_SCHEMA = "easyuse_anima_seed_reservation_request"
-SEED_RESERVATION_CONTRACT_VERSION = 1
+SEED_RESERVATION_CONTRACT_VERSION = 2
+SEED_MAX_UINT64 = 0xFFFFFFFFFFFFFFFF
 
 SEED_SELECTION_CONCRETE = "concrete"
 SEED_SELECTION_RANDOMIZE = "randomize"
@@ -30,6 +31,15 @@ SEED_CONTROLS = frozenset(
         SEED_SELECTION_RANDOMIZE,
         SEED_SELECTION_INCREMENT,
         SEED_SELECTION_DECREMENT,
+    }
+)
+
+SEED_OVERFLOW_CLAMP = "clamp"
+SEED_OVERFLOW_WRAP = "wrap"
+SEED_OVERFLOW_POLICIES = frozenset(
+    {
+        SEED_OVERFLOW_CLAMP,
+        SEED_OVERFLOW_WRAP,
     }
 )
 
@@ -55,6 +65,10 @@ SeedControl: TypeAlias = Literal[
     "randomize",
     "increment",
     "decrement",
+]
+SeedOverflowPolicy: TypeAlias = Literal[
+    "clamp",
+    "wrap",
 ]
 SeedReservationSettlement: TypeAlias = Literal[
     "accepted",
@@ -102,9 +116,14 @@ def _require_choice(
 
 
 def _require_concrete_seed(value: object, label: str) -> int:
-    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+    if (
+        isinstance(value, bool)
+        or not isinstance(value, int)
+        or value < 0
+        or value > SEED_MAX_UINT64
+    ):
         raise SeedReservationContractError(
-            f"{label} must be a non-negative integer"
+            f"{label} must be an unsigned 64-bit integer"
         )
     return value
 
@@ -120,6 +139,8 @@ class SeedReservationRequest:
     selection: SeedSelection
     seed: int | None
     after_generate: SeedControl
+    next_seed_max: int
+    overflow: SeedOverflowPolicy
 
     def __post_init__(self) -> None:
         if self.schema != SEED_RESERVATION_REQUEST_SCHEMA:
@@ -151,6 +172,23 @@ class SeedReservationRequest:
                     self.after_generate,
                     SEED_CONTROLS,
                     "Seed after_generate",
+                ),
+            ),
+        )
+        object.__setattr__(
+            self,
+            "next_seed_max",
+            _require_concrete_seed(self.next_seed_max, "Seed next_seed_max"),
+        )
+        object.__setattr__(
+            self,
+            "overflow",
+            cast(
+                SeedOverflowPolicy,
+                _require_choice(
+                    self.overflow,
+                    SEED_OVERFLOW_POLICIES,
+                    "Seed overflow",
                 ),
             ),
         )
@@ -235,6 +273,8 @@ def parse_seed_reservation_request(
         selection=cast(SeedSelection, payload.get("selection")),
         seed=cast(int | None, payload.get("seed")),
         after_generate=cast(SeedControl, payload.get("after_generate")),
+        next_seed_max=cast(int, payload.get("next_seed_max")),
+        overflow=cast(SeedOverflowPolicy, payload.get("overflow")),
     )
 
 
@@ -244,6 +284,8 @@ def parse_legacy_seed_reservation_request(
     request_id: str,
     normalized_seed: int,
     after_generate: SeedControl,
+    next_seed_max: int,
+    overflow: SeedOverflowPolicy,
 ) -> SeedReservationRequest:
     """Translate an already-normalized legacy AiO seed without choosing a seed."""
 
@@ -271,12 +313,18 @@ def parse_legacy_seed_reservation_request(
         selection=selection,
         seed=concrete_seed,
         after_generate=after_generate,
+        next_seed_max=next_seed_max,
+        overflow=overflow,
     )
 
 
 __all__ = (
     "SEED_CONTROL_FIXED",
     "SEED_CONTROLS",
+    "SEED_MAX_UINT64",
+    "SEED_OVERFLOW_CLAMP",
+    "SEED_OVERFLOW_POLICIES",
+    "SEED_OVERFLOW_WRAP",
     "SEED_RESERVATION_CONTRACT_VERSION",
     "SEED_RESERVATION_REQUEST_SCHEMA",
     "SEED_SELECTION_CONCRETE",
@@ -289,6 +337,7 @@ __all__ = (
     "SEED_SETTLEMENT_REJECTED",
     "SEED_SETTLEMENTS",
     "SeedControl",
+    "SeedOverflowPolicy",
     "SeedReservation",
     "SeedReservationContractError",
     "SeedReservationRequest",

--- a/tests/fixtures/python_backend_baseline.json
+++ b/tests/fixtures/python_backend_baseline.json
@@ -46236,14 +46236,14 @@
       },
       {
         "is_package": false,
-        "loc": 300,
+        "loc": 349,
         "module": "easyuse_anima.seed.reservation",
-        "normalized_git_blob_sha1": "cba158be576da33aec0029813dedf9b06db53660",
+        "normalized_git_blob_sha1": "6b3d2d9a96a3969b26088471c9f0ba1fba45806b",
         "path": "easyuse_anima/seed/reservation.py",
         "top_level": {
           "class_count": 4,
           "function_count": 6,
-          "global_count": 18
+          "global_count": 23
         }
       },
       {
@@ -61683,7 +61683,7 @@
         "column": 18,
         "context": "assign:SEED_SELECTIONS",
         "kind": "import_time_call",
-        "line": 17,
+        "line": 18,
         "module": "easyuse_anima/seed/reservation.py",
         "scope": "<module>"
       },
@@ -61692,7 +61692,16 @@
         "column": 16,
         "context": "assign:SEED_CONTROLS",
         "kind": "import_time_call",
-        "line": 27,
+        "line": 28,
+        "module": "easyuse_anima/seed/reservation.py",
+        "scope": "<module>"
+      },
+      {
+        "callee": "frozenset",
+        "column": 25,
+        "context": "assign:SEED_OVERFLOW_POLICIES",
+        "kind": "import_time_call",
+        "line": 39,
         "module": "easyuse_anima/seed/reservation.py",
         "scope": "<module>"
       },
@@ -61701,7 +61710,7 @@
         "column": 19,
         "context": "assign:SEED_SETTLEMENTS",
         "kind": "import_time_call",
-        "line": 39,
+        "line": 49,
         "module": "easyuse_anima/seed/reservation.py",
         "scope": "<module>"
       },
@@ -61710,7 +61719,7 @@
         "column": 1,
         "context": "decorator:SeedReservationRequest",
         "kind": "import_time_call",
-        "line": 112,
+        "line": 131,
         "module": "easyuse_anima/seed/reservation.py",
         "scope": "<module>"
       },
@@ -61719,7 +61728,7 @@
         "column": 1,
         "context": "decorator:SeedReservation",
         "kind": "import_time_call",
-        "line": 169,
+        "line": 207,
         "module": "easyuse_anima/seed/reservation.py",
         "scope": "<module>"
       },
@@ -62239,7 +62248,7 @@
       },
       {
         "kind": "dict",
-        "line": 65,
+        "line": 79,
         "module": "easyuse_anima/seed/reservation.py",
         "name": "_LEGACY_SELECTION_BY_SEED"
       },

--- a/tests/test_seed_reservation_contract.py
+++ b/tests/test_seed_reservation_contract.py
@@ -22,6 +22,8 @@ def _request_payload(**updates: object) -> dict[str, object]:
         "selection": reservation.SEED_SELECTION_CONCRETE,
         "seed": 123,
         "after_generate": reservation.SEED_CONTROL_FIXED,
+        "next_seed_max": (1 << 50),
+        "overflow": reservation.SEED_OVERFLOW_CLAMP,
     }
     payload.update(updates)
     return payload
@@ -37,12 +39,14 @@ class SeedReservationContractTests(unittest.TestCase):
             parsed,
             reservation.SeedReservationRequest(
                 schema=reservation.SEED_RESERVATION_REQUEST_SCHEMA,
-                version=1,
+                version=2,
                 stream_id="node:42",
                 request_id="queue:abc",
                 selection="concrete",
                 seed=123,
                 after_generate="fixed",
+                next_seed_max=(1 << 50),
+                overflow="clamp",
             ),
         )
         with self.assertRaises(FrozenInstanceError):
@@ -56,6 +60,38 @@ class SeedReservationContractTests(unittest.TestCase):
                 )
                 self.assertEqual(parsed.selection, selection)
                 self.assertIsNone(parsed.seed)
+
+    def test_request_carries_each_reviewed_arithmetic_domain_explicitly(self):
+        cases = (
+            ((1 << 50), "clamp"),
+            (((1 << 53) - 1), "wrap"),
+        )
+
+        for next_seed_max, overflow in cases:
+            with self.subTest(
+                next_seed_max=next_seed_max,
+                overflow=overflow,
+            ):
+                parsed = reservation.parse_seed_reservation_request(
+                    _request_payload(
+                        next_seed_max=next_seed_max,
+                        overflow=overflow,
+                    )
+                )
+                self.assertEqual(parsed.next_seed_max, next_seed_max)
+                self.assertEqual(parsed.overflow, overflow)
+
+    def test_uint64_concrete_seed_is_independent_from_the_arithmetic_domain(self):
+        parsed = reservation.parse_seed_reservation_request(
+            _request_payload(
+                seed=reservation.SEED_MAX_UINT64,
+                next_seed_max=(1 << 50),
+                overflow="clamp",
+            )
+        )
+
+        self.assertEqual(parsed.seed, reservation.SEED_MAX_UINT64)
+        self.assertEqual(parsed.next_seed_max, (1 << 50))
 
     def test_legacy_sentinels_map_to_distinct_selection_intents(self):
         expected = {
@@ -72,6 +108,8 @@ class SeedReservationContractTests(unittest.TestCase):
                     request_id=f"queue:{legacy_seed}",
                     normalized_seed=legacy_seed,
                     after_generate="fixed",
+                    next_seed_max=(1 << 50),
+                    overflow="clamp",
                 )
                 self.assertEqual(parsed.selection, selection)
                 self.assertIsNone(parsed.seed)
@@ -84,6 +122,8 @@ class SeedReservationContractTests(unittest.TestCase):
             request_id="queue:concrete",
             normalized_seed=legacy_uint64_max,
             after_generate="increment",
+            next_seed_max=(1 << 50),
+            overflow="clamp",
         )
 
         self.assertEqual(parsed.selection, "concrete")
@@ -95,7 +135,8 @@ class SeedReservationContractTests(unittest.TestCase):
             [],
             _request_payload(schema="other"),
             _request_payload(version=True),
-            _request_payload(version=2),
+            _request_payload(version=1),
+            _request_payload(version=3),
             _request_payload(stream_id=" "),
             _request_payload(request_id=None),
             _request_payload(selection="random"),
@@ -103,7 +144,15 @@ class SeedReservationContractTests(unittest.TestCase):
             _request_payload(seed=None),
             _request_payload(seed=True),
             _request_payload(seed=-1),
+            _request_payload(seed=reservation.SEED_MAX_UINT64 + 1),
             _request_payload(after_generate="accept"),
+            _request_payload(next_seed_max=None),
+            _request_payload(next_seed_max=True),
+            _request_payload(next_seed_max=-1),
+            _request_payload(
+                next_seed_max=reservation.SEED_MAX_UINT64 + 1,
+            ),
+            _request_payload(overflow="cycle"),
         )
 
         for payload in invalid_payloads:
@@ -122,6 +171,8 @@ class SeedReservationContractTests(unittest.TestCase):
                     request_id="queue:invalid",
                     normalized_seed=seed,
                     after_generate="fixed",
+                    next_seed_max=(1 << 50),
+                    overflow="clamp",
                 )
 
         with self.assertRaises(reservation.SeedReservationContractError):
@@ -130,11 +181,23 @@ class SeedReservationContractTests(unittest.TestCase):
                 request_id="queue:invalid-control",
                 normalized_seed=1,
                 after_generate="unknown",
+                next_seed_max=(1 << 50),
+                overflow="clamp",
+            )
+
+        with self.assertRaises(reservation.SeedReservationContractError):
+            reservation.parse_legacy_seed_reservation_request(
+                stream_id="aio:7",
+                request_id="queue:invalid-domain",
+                normalized_seed=1,
+                after_generate="fixed",
+                next_seed_max=(1 << 50),
+                overflow="unknown",
             )
 
     def test_reservation_result_is_concrete_immutable_and_versioned(self):
         result = reservation.SeedReservation(
-            version=1,
+            version=2,
             reservation_id=" reservation:1 ",
             stream_id=" node:42 ",
             request_id=" queue:abc ",
@@ -149,14 +212,16 @@ class SeedReservationContractTests(unittest.TestCase):
             result.next_seed = 125
 
         for updates in (
-            {"version": 2},
+            {"version": 1},
             {"reservation_id": ""},
             {"execution_seed": -1},
             {"execution_seed": True},
+            {"execution_seed": reservation.SEED_MAX_UINT64 + 1},
             {"next_seed": -1},
+            {"next_seed": reservation.SEED_MAX_UINT64 + 1},
         ):
             values = {
-                "version": 1,
+                "version": 2,
                 "reservation_id": "reservation:1",
                 "stream_id": "node:42",
                 "request_id": "queue:abc",
@@ -180,7 +245,7 @@ class SeedReservationContractTests(unittest.TestCase):
             ) -> reservation.SeedReservation:
                 self.calls.append(("reserve", request))
                 return reservation.SeedReservation(
-                    version=1,
+                    version=2,
                     reservation_id="reservation:1",
                     stream_id=request.stream_id,
                     request_id=request.request_id,


### PR DESCRIPTION
## 목적

S167-02 Behavior 직전 감사에서 발견한 seed-domain 누락을 닫는 **Contract 전용 PR**입니다.

version 1은 selection과 after-generate intent만 전달했지만 현재 두 소비자의 산술 계약이 달라, backend가 명시적 domain 없이 올바르게 예약할 수 없었습니다.

- AiO editable domain: `0..1125899906842624`, clamp
- Prompt Studio editable domain: `0..9007199254740991`, wrap
- Python concrete compatibility: uint64 maximum까지; fixed는 큰 legacy seed도 보존

## 사전 symbol/caller/alias/global-state inventory

- 변경 대상:
  - `SeedReservationRequest`
  - `parse_seed_reservation_request`
  - `parse_legacy_seed_reservation_request`
- 변경 불필요:
  - `SeedReservation`
  - `SeedReservationService`
  - settlement signature
- production caller: 0
  - 현재 parser/request constructor consumer는 contract tests뿐
  - S167-02 service와 S167-03 adapter는 아직 없음
- root compatibility alias: 0
- backend reservation map/lock/RNG/counter/stream/cleanup state: 0

## Allowed-file boundary

- `easyuse_anima/seed/reservation.py`
- `tests/test_seed_reservation_contract.py`
- `tests/fixtures/python_backend_baseline.json`
- `docs/architecture/seed-reservation-contract.md`
- `docs/architecture/python-backend-execution-roadmap.md`

실제 변경은 이 5개 파일뿐입니다. Analyzer fixture는 동일 module의 deterministic symbol/signature delta만 포함합니다.

## 구현 결과

- contract version 1 → 2
- request에 required `next_seed_max` 추가
- request에 required `overflow` (`clamp` / `wrap`) 추가
- request/result concrete seed를 uint64 범위로 명시
- concrete execution seed와 smaller next-seed arithmetic domain을 분리
- version 1, 누락/잘못된 domain, bool/negative/uint64 초과 값을 fail closed
- AiO `2^50 clamp`와 Prompt Studio JS-safe `wrap` domain을 node/stream 이름 추측 없이 표현

## 검증

Focused/checkpoint:

- contract/import/analyzer: 13 tests pass
- 추가 uint64 result boundary: 1 test pass
- changed Python `py_compile`: pass
- `git diff --check`: pass

Official full — 이 PR에서 정확히 1회:

- 정상 종료: 50.2초
- Python compile: pass
- Ruff G-01 report-only: 80 existing findings, 실행 정상
- Pyright baseline ratchet: 76 files / 14 baseline errors / pass
- import boundary: 6 groups / 0 violations
- Python unittest: 988 pass
- frontend: 114 JavaScript files / TypeScript 6.0.3 / pass
- project runner `git diff --check`: pass

full 이후에는 검증 결과를 기록하는 문서 전용 커밋만 추가했고 full을 재실행하지 않았습니다.

## 호환성 및 제외 범위

- production consumer/payload/workflow/node/frontend/runtime 동작 변경 없음
- reservation state/lock/RNG/counter/settlement/retry/cancel/cleanup 없음
- current AiO/Prompt Studio bounds와 arithmetic 변경 없음
- S167-02 Behavior와 S167-03 Adapter는 별도 rollback unit

S167-02는 이제 `stream_id` 기반 추측 없이 request가 제공하는 arithmetic domain만 소비할 수 있습니다.

Owner: #167
