### PR TITLE
refactor: seed 실행 정체성 계약 추가

### DIFF
--- a/docs/architecture/python-backend-execution-roadmap.md
+++ b/docs/architecture/python-backend-execution-roadmap.md
@@ -405,7 +405,7 @@ mechanical retirement series.
 | 12 | B-10a machine-readable compatibility audit | COMPLETE on `dev` | Contract/gate | #184/#188 | PR #271 / `3c7b857` |
 | 13 | B-10b private alias reduction | COMPLETE on `dev` through PR #291 / `c6b4680` | Contract/cleanup, split PRs | #184/#188 | Audited alias surface integrated |
 | 14 | B-11 registration/bootstrap/root shim | COMPLETE in PR #356 | Move/Contract, split PRs | #184 | Zero runtime binders/residual implementation; explicit root `__all__`; frozen compatibility audit |
-| 15 | S167 backend seed reservation series | S167-01 through S167-02 COMPLETE on `dev`; S167-03a adapter Contract/docs gate READY | Contract then Move then Behavior | #167 | Canonical AiO/node seams |
+| 15 | S167 backend seed reservation series | S167-01 through S167-03a COMPLETE on `dev`; S167-03b execution identity Contract VALIDATED | Contract then Move then Behavior | #167 | Canonical AiO/node seams |
 | 16 | A169 stage pipeline series | READY after #168 and Phase B completion; begin with A169-01 Contract | Contract then Behavior | #169 | Typed config and mechanical AiO move |
 | 17 | A169 first-pass cache policy | BLOCKED by stage/cache ownership seam | Behavior | #169 | Mechanical cache move and benchmark harness |
 | 18 | D-series canonical root consolidation | BLOCKED by relevant C contracts | Move | #186 | Phase B exit; per-feature behavior stable |
@@ -1230,6 +1230,13 @@ S167-03a now freezes those decisions plus cache, compatibility, display, split,
 and validation ownership in
 [`seed-reservation-contract.md`](seed-reservation-contract.md) before any
 production adapter is added.
+
+S167-03b implements the frozen execution-identity boundary without creating a
+reservation caller. It validates Comfy's call-time `prompt_id`, effective
+`node_id`, and optional `list_index`, derives collision-safe versioned request
+and stream identities, and uses a fresh request identity with a stable hidden
+`UNIQUE_ID` stream only when execution context is unavailable. The existing
+four-method `ComfyHostProvider` and all feature nodes remain unchanged.
 
 Do not mix this sequence into B-09 or #169 stages.
 

--- a/docs/architecture/seed-reservation-contract.md
+++ b/docs/architecture/seed-reservation-contract.md
@@ -657,3 +657,85 @@ Exit:
   display ownership, rollback units, and validation ownership are explicit;
 - the diff contains only the two allowed Markdown files; and
 - S167-03b can begin without feature-specific inference.
+
+## S167-03b execution identity Contract record
+
+- State: VALIDATED; `dev` merge pending
+- PR type: Contract
+- Baseline: `dev` commit
+  `eedaea110612c4cb0523e5b45fa470e1b786f7b0`
+- Feature reservation callers: zero
+
+### Implemented boundary
+
+`easyuse_anima.seed.execution_identity` now owns:
+
+- immutable validated `SeedExecutionContext` and `SeedExecutionIdentity`
+  values;
+- call-time-only discovery of
+  `comfy_execution.utils.get_executing_context()` with no host import or cache
+  at package import time;
+- context-authoritative request identity from feature, `prompt_id`, effective
+  `node_id`, and optional `list_index`;
+- stream identity from feature and stable effective node ID;
+- stable hidden `UNIQUE_ID` fallback streams with a fresh opaque request ID;
+  and
+- collision-safe, versioned JSON component encoding instead of delimiter
+  concatenation.
+
+Malformed or unavailable host context returns `None` from the host adapter.
+When neither that context nor a usable hidden node ID exists, identity
+resolution also returns `None`; no reservation service can be mutated by this
+Contract alone.
+
+### Caller, alias, and state delta
+
+- `reserve` and `settle` production caller counts remain zero.
+- The seed package privately imports the new module so the shipped runtime
+  closure remains complete; no public package re-export was added.
+- `ComfyHostProvider` remains the frozen four-method E-02a capability port.
+- Root `nodes.py`, feature nodes, browser hooks, workflow schemas, and
+  compatibility aliases are unchanged.
+- The module owns no mutable global, context cache, reservation, or background
+  lifecycle.
+
+### Validation
+
+- focused identity, package-skeleton, analyzer-fixture, and import-boundary
+  checks: 22 tests passed;
+- strict Pyright on the new production module: 0 errors and 0 warnings;
+- Python compile: passed;
+- Comfy v0.27.0 call-time host import smoke outside active execution: safely
+  returned `None`; and
+- official full: intentionally not run because this unit has zero feature
+  callers and S167-03a assigns full ownership to the cutover Behavior units.
+
+### Allowed-file boundary
+
+S167-03b may change only:
+
+- `easyuse_anima/seed/__init__.py`;
+- `easyuse_anima/seed/execution_identity.py`;
+- `tests/test_seed_execution_identity.py`;
+- `tests/test_python_package_skeleton.py`;
+- `tests/test_python_backend_analyzer.py`;
+- `tests/fixtures/python_backend_baseline.json`;
+- `docs/architecture/seed-reservation-contract.md`; and
+- `docs/architecture/python-backend-execution-roadmap.md`.
+
+Forbidden:
+
+- a production `reserve` or `settle` caller;
+- feature-node, browser, workflow, metadata, route, or hidden-input changes;
+- changes to reservation arithmetic, settlement, capacity, or cache policy;
+- expanding `ComfyHostProvider`; and
+- S167-03c session behavior, S167-03d/03e cutover, #169, D-12, release, or
+  Registry work.
+
+Exit:
+
+- one canonical context/identity adapter exists with no mutable state;
+- headless, mapped-call, older-host, malformed-host, and missing-identity
+  behavior is explicit and focused-tested; and
+- S167-03c can own reserve/settle exception behavior without inferring host
+  identity rules.

--- a/easyuse_anima/seed/__init__.py
+++ b/easyuse_anima/seed/__init__.py
@@ -1,5 +1,6 @@
 """Side-effect-free backend seed reservation contracts."""
 
+from . import execution_identity as _execution_identity
 from . import reservation as _reservation
 
 __all__ = ()

--- a/easyuse_anima/seed/execution_identity.py
+++ b/easyuse_anima/seed/execution_identity.py
@@ -1,0 +1,212 @@
+# pyright: strict
+"""Call-time Comfy execution identity for authoritative seed reservations."""
+
+from __future__ import annotations
+
+import importlib
+import json
+import uuid
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import TypeAlias, cast
+
+SEED_EXECUTION_IDENTITY_VERSION = 1
+
+_REQUEST_NAMESPACE = (
+    f"easyuse_anima.seed.request.v{SEED_EXECUTION_IDENTITY_VERSION}"
+)
+_STREAM_NAMESPACE = (
+    f"easyuse_anima.seed.stream.v{SEED_EXECUTION_IDENTITY_VERSION}"
+)
+_COMFY_EXECUTION_UTILS = "comfy_execution.utils"
+
+_HostModuleLoader: TypeAlias = Callable[[str], object]
+_ExecutionContextLoader: TypeAlias = Callable[[], object]
+_RequestIdFactory: TypeAlias = Callable[[], str]
+
+
+class SeedExecutionIdentityError(ValueError):
+    """A seed execution identity component is invalid."""
+
+
+def _require_text(value: object, label: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise SeedExecutionIdentityError(f"{label} must be a non-empty string")
+    return value.strip()
+
+
+def _normalize_node_id(value: object) -> str | None:
+    if isinstance(value, (list, tuple)):
+        if not value:
+            return None
+        value = cast(object, value[0])
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int):
+        return str(value)
+    if isinstance(value, str) and value.strip():
+        return value.strip()
+    return None
+
+
+def _require_list_index(value: object) -> int | None:
+    if value is None:
+        return None
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+        raise SeedExecutionIdentityError(
+            "Comfy execution list_index must be a non-negative integer or None"
+        )
+    return value
+
+
+def _encoded_identity(namespace: str, *components: object) -> str:
+    return (
+        f"{namespace}:"
+        + json.dumps(
+            components,
+            ensure_ascii=False,
+            separators=(",", ":"),
+        )
+    )
+
+
+@dataclass(frozen=True, slots=True)
+class SeedExecutionContext:
+    """Validated host identity for one effective Comfy node invocation."""
+
+    prompt_id: str
+    node_id: str
+    list_index: int | None = None
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self,
+            "prompt_id",
+            _require_text(self.prompt_id, "Comfy execution prompt_id"),
+        )
+        normalized_node_id = _normalize_node_id(self.node_id)
+        if normalized_node_id is None:
+            raise SeedExecutionIdentityError(
+                "Comfy execution node_id must be a non-empty string or integer"
+            )
+        object.__setattr__(self, "node_id", normalized_node_id)
+        object.__setattr__(
+            self,
+            "list_index",
+            _require_list_index(self.list_index),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class SeedExecutionIdentity:
+    """Stable stream and idempotent request identities for one execution."""
+
+    stream_id: str
+    request_id: str
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self,
+            "stream_id",
+            _require_text(self.stream_id, "Seed execution stream_id"),
+        )
+        object.__setattr__(
+            self,
+            "request_id",
+            _require_text(self.request_id, "Seed execution request_id"),
+        )
+
+
+def _import_host_module(module_name: str) -> object:
+    return importlib.import_module(module_name)
+
+
+def read_comfy_execution_context(
+    *,
+    load_module: _HostModuleLoader = _import_host_module,
+) -> SeedExecutionContext | None:
+    """Read and validate current Comfy execution state without caching it."""
+
+    try:
+        module = load_module(_COMFY_EXECUTION_UTILS)
+        get_context = getattr(module, "get_executing_context")
+        raw_context = get_context()
+        if raw_context is None:
+            return None
+        return SeedExecutionContext(
+            prompt_id=getattr(raw_context, "prompt_id"),
+            node_id=getattr(raw_context, "node_id"),
+            list_index=getattr(raw_context, "list_index", None),
+        )
+    except Exception:
+        return None
+
+
+def _new_opaque_request_id() -> str:
+    return uuid.uuid4().hex
+
+
+def resolve_seed_execution_identity(
+    feature: str,
+    *,
+    unique_id: object = None,
+    load_context: _ExecutionContextLoader = read_comfy_execution_context,
+    request_id_factory: _RequestIdFactory = _new_opaque_request_id,
+) -> SeedExecutionIdentity | None:
+    """Resolve the authoritative context identity or a UNIQUE_ID fallback."""
+
+    feature_id = _require_text(feature, "Seed execution feature")
+    context = load_context()
+
+    if context is not None:
+        if not isinstance(context, SeedExecutionContext):
+            raise TypeError(
+                "load_context must return a SeedExecutionContext or None"
+            )
+        return SeedExecutionIdentity(
+            stream_id=_encoded_identity(
+                _STREAM_NAMESPACE,
+                feature_id,
+                context.node_id,
+            ),
+            request_id=_encoded_identity(
+                _REQUEST_NAMESPACE,
+                feature_id,
+                context.prompt_id,
+                context.node_id,
+                context.list_index,
+            ),
+        )
+
+    fallback_node_id = _normalize_node_id(unique_id)
+    if fallback_node_id is None:
+        return None
+
+    opaque_request_id = _require_text(
+        request_id_factory(),
+        "Opaque seed request ID",
+    )
+    return SeedExecutionIdentity(
+        stream_id=_encoded_identity(
+            _STREAM_NAMESPACE,
+            feature_id,
+            fallback_node_id,
+        ),
+        request_id=_encoded_identity(
+            _REQUEST_NAMESPACE,
+            feature_id,
+            fallback_node_id,
+            "fallback",
+            opaque_request_id,
+        ),
+    )
+
+
+__all__ = (
+    "SEED_EXECUTION_IDENTITY_VERSION",
+    "SeedExecutionContext",
+    "SeedExecutionIdentity",
+    "SeedExecutionIdentityError",
+    "read_comfy_execution_context",
+    "resolve_seed_execution_identity",
+)

--- a/tests/fixtures/python_backend_baseline.json
+++ b/tests/fixtures/python_backend_baseline.json
@@ -21052,6 +21052,24 @@
         "target": "easyuse_anima/seed/reservation.py"
       },
       {
+        "alias": "_execution_identity",
+        "bound_name": "_execution_identity",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".:execution_identity",
+        "kind": "static_from",
+        "line": 3,
+        "name": "execution_identity",
+        "optional": false,
+        "requested": ".",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/seed/__init__.py",
+        "target": "easyuse_anima/seed/execution_identity.py"
+      },
+      {
         "alias": "_reservation",
         "bound_name": "_reservation",
         "branch_context": [],
@@ -21060,7 +21078,7 @@
         "conditional": false,
         "imported": ".:reservation",
         "kind": "static_from",
-        "line": 3,
+        "line": 4,
         "name": "reservation",
         "optional": false,
         "requested": ".",
@@ -21185,6 +21203,142 @@
         "scope": "_wildcard_engine_module",
         "source": "easyuse_anima/seed/compatibility.py",
         "target": "wildcard_engine.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "annotations",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "__future__:annotations",
+        "kind": "static_from",
+        "line": 4,
+        "name": "annotations",
+        "optional": false,
+        "requested": "__future__",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/seed/execution_identity.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "importlib",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "importlib",
+        "kind": "static_import",
+        "line": 6,
+        "name": null,
+        "optional": false,
+        "requested": "importlib",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/seed/execution_identity.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "json",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "json",
+        "kind": "static_import",
+        "line": 7,
+        "name": null,
+        "optional": false,
+        "requested": "json",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/seed/execution_identity.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "uuid",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "uuid",
+        "kind": "static_import",
+        "line": 8,
+        "name": null,
+        "optional": false,
+        "requested": "uuid",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/seed/execution_identity.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "Callable",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "collections.abc:Callable",
+        "kind": "static_from",
+        "line": 9,
+        "name": "Callable",
+        "optional": false,
+        "requested": "collections.abc",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/seed/execution_identity.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "dataclass",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "dataclasses:dataclass",
+        "kind": "static_from",
+        "line": 10,
+        "name": "dataclass",
+        "optional": false,
+        "requested": "dataclasses",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/seed/execution_identity.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "TypeAlias",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "typing:TypeAlias",
+        "kind": "static_from",
+        "line": 11,
+        "name": "TypeAlias",
+        "optional": false,
+        "requested": "typing",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/seed/execution_identity.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "cast",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "typing:cast",
+        "kind": "static_from",
+        "line": 11,
+        "name": "cast",
+        "optional": false,
+        "requested": "typing",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/seed/execution_identity.py"
       },
       {
         "alias": null,
@@ -44868,6 +45022,10 @@
       },
       {
         "from": "easyuse_anima/seed/__init__.py",
+        "to": "easyuse_anima/seed/execution_identity.py"
+      },
+      {
+        "from": "easyuse_anima/seed/__init__.py",
         "to": "easyuse_anima/seed/reservation.py"
       },
       {
@@ -45646,6 +45804,12 @@
       {
         "cyclic": false,
         "modules": [
+          "easyuse_anima/seed/execution_identity.py"
+        ]
+      },
+      {
+        "cyclic": false,
+        "modules": [
           "easyuse_anima/seed/reservation.py"
         ]
       },
@@ -45694,7 +45858,7 @@
     ]
   },
   "inventory": {
-    "module_count": 94,
+    "module_count": 95,
     "modules": [
       {
         "is_package": true,
@@ -46706,9 +46870,9 @@
       },
       {
         "is_package": true,
-        "loc": 5,
+        "loc": 6,
         "module": "easyuse_anima.seed",
-        "normalized_git_blob_sha1": "653d1c05aec0ab255562bf631fc9707071b5cc4e",
+        "normalized_git_blob_sha1": "bcbf1d5f2b745218e803706fb31a23ff944ff13a",
         "path": "easyuse_anima/seed/__init__.py",
         "top_level": {
           "class_count": 0,
@@ -46726,6 +46890,18 @@
           "class_count": 0,
           "function_count": 2,
           "global_count": 3
+        }
+      },
+      {
+        "is_package": false,
+        "loc": 212,
+        "module": "easyuse_anima.seed.execution_identity",
+        "normalized_git_blob_sha1": "4f09455dd43382096ea3e87946f793c16bdba870",
+        "path": "easyuse_anima/seed/execution_identity.py",
+        "top_level": {
+          "class_count": 3,
+          "function_count": 8,
+          "global_count": 8
         }
       },
       {
@@ -59376,6 +59552,94 @@
         "line": 4,
         "optional": false,
         "role": "ordinary",
+        "source": "easyuse_anima/seed/execution_identity.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "importlib",
+        "kind": "static_import",
+        "line": 6,
+        "optional": false,
+        "role": "ordinary",
+        "source": "easyuse_anima/seed/execution_identity.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "json",
+        "kind": "static_import",
+        "line": 7,
+        "optional": false,
+        "role": "ordinary",
+        "source": "easyuse_anima/seed/execution_identity.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "uuid",
+        "kind": "static_import",
+        "line": 8,
+        "optional": false,
+        "role": "ordinary",
+        "source": "easyuse_anima/seed/execution_identity.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "collections.abc:Callable",
+        "kind": "static_from",
+        "line": 9,
+        "optional": false,
+        "role": "ordinary",
+        "source": "easyuse_anima/seed/execution_identity.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "dataclasses:dataclass",
+        "kind": "static_from",
+        "line": 10,
+        "optional": false,
+        "role": "ordinary",
+        "source": "easyuse_anima/seed/execution_identity.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "typing:TypeAlias",
+        "kind": "static_from",
+        "line": 11,
+        "optional": false,
+        "role": "ordinary",
+        "source": "easyuse_anima/seed/execution_identity.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "typing:cast",
+        "kind": "static_from",
+        "line": 11,
+        "optional": false,
+        "role": "ordinary",
+        "source": "easyuse_anima/seed/execution_identity.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "__future__:annotations",
+        "kind": "static_from",
+        "line": 4,
+        "optional": false,
+        "role": "ordinary",
         "source": "easyuse_anima/seed/reservation.py"
       },
       {
@@ -61142,6 +61406,7 @@
       "easyuse_anima/runtime.py",
       "easyuse_anima/seed/__init__.py",
       "easyuse_anima/seed/compatibility.py",
+      "easyuse_anima/seed/execution_identity.py",
       "easyuse_anima/seed/reservation.py",
       "easyuse_anima/seed/service.py",
       "easyuse_anima/workflow.py",
@@ -61238,6 +61503,7 @@
       "easyuse_anima/runtime.py",
       "easyuse_anima/seed/__init__.py",
       "easyuse_anima/seed/compatibility.py",
+      "easyuse_anima/seed/execution_identity.py",
       "easyuse_anima/seed/reservation.py",
       "easyuse_anima/seed/service.py",
       "easyuse_anima/workflow.py",
@@ -62294,6 +62560,24 @@
         "kind": "import_time_call",
         "line": 11,
         "module": "easyuse_anima/runtime.py",
+        "scope": "<module>"
+      },
+      {
+        "callee": "dataclass",
+        "column": 1,
+        "context": "decorator:SeedExecutionContext",
+        "kind": "import_time_call",
+        "line": 73,
+        "module": "easyuse_anima/seed/execution_identity.py",
+        "scope": "<module>"
+      },
+      {
+        "callee": "dataclass",
+        "column": 1,
+        "context": "decorator:SeedExecutionIdentity",
+        "kind": "import_time_call",
+        "line": 100,
+        "module": "easyuse_anima/seed/execution_identity.py",
         "scope": "<module>"
       },
       {

--- a/tests/test_python_backend_analyzer.py
+++ b/tests/test_python_backend_analyzer.py
@@ -691,9 +691,9 @@ ignored/
 
         self.assertEqual(analyzer.render_json(report), expected_text)
         self.assertEqual(report["schema_version"], 2)
-        self.assertEqual(report["inventory"]["module_count"], 94)
-        self.assertEqual(len(report["registry"]["shipped_python_modules"]), 94)
-        self.assertEqual(len(report["registry"]["runtime_import_closure"]), 94)
+        self.assertEqual(report["inventory"]["module_count"], 95)
+        self.assertEqual(len(report["registry"]["shipped_python_modules"]), 95)
+        self.assertEqual(len(report["registry"]["runtime_import_closure"]), 95)
         self.assertEqual(
             report["registry"]["entry_modules"],
             ["__init__.py", "nodes.py"],
@@ -765,6 +765,7 @@ ignored/
                 "easyuse_anima/runtime.py",
                 "easyuse_anima/seed/__init__.py",
                 "easyuse_anima/seed/compatibility.py",
+                "easyuse_anima/seed/execution_identity.py",
                 "easyuse_anima/seed/reservation.py",
                 "easyuse_anima/seed/service.py",
                 "easyuse_anima/prompt/__init__.py",
@@ -828,6 +829,7 @@ ignored/
                 "easyuse_anima/profiles/contract.py",
                 "easyuse_anima/profiles/mutation.py",
                 "easyuse_anima/runtime.py",
+                "easyuse_anima/seed/execution_identity.py",
             }.issubset(report["registry"]["runtime_import_closure"])
         )
         self.assertIn(

--- a/tests/test_python_package_skeleton.py
+++ b/tests/test_python_package_skeleton.py
@@ -58,6 +58,7 @@ PACKAGE_MODULES = (
     "easyuse_anima.profiles",
     "easyuse_anima.profiles.contract",
     "easyuse_anima.profiles.mutation",
+    "easyuse_anima.seed.execution_identity",
     "easyuse_anima.seed.service",
     "easyuse_anima.prompt",
     "easyuse_anima.prompt.advanced",
@@ -154,6 +155,16 @@ print(json.dumps({{
             "SeedReservationCapacityError",
             "SeedReservationConflictError",
             "SeedReservationServiceError",
+        ]
+        expected_all[
+            PACKAGE_MODULES.index("easyuse_anima.seed.execution_identity")
+        ] = [
+            "SEED_EXECUTION_IDENTITY_VERSION",
+            "SeedExecutionContext",
+            "SeedExecutionIdentity",
+            "SeedExecutionIdentityError",
+            "read_comfy_execution_context",
+            "resolve_seed_execution_identity",
         ]
         self.assertEqual(payload["declared_all"], expected_all)
         self.assertEqual(payload["new_forbidden"], [])

--- a/tests/test_seed_execution_identity.py
+++ b/tests/test_seed_execution_identity.py
@@ -1,0 +1,257 @@
+from __future__ import annotations
+
+import subprocess
+import sys
+import types
+import unittest
+from dataclasses import FrozenInstanceError
+from pathlib import Path
+
+from easyuse_anima.seed import execution_identity
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+class SeedExecutionIdentityTests(unittest.TestCase):
+    def test_comfy_context_is_loaded_only_when_the_adapter_is_called(self):
+        calls: list[str] = []
+        raw_context = types.SimpleNamespace(
+            prompt_id=" prompt-a ",
+            node_id=" 42 ",
+            list_index=3,
+        )
+        module = types.SimpleNamespace(
+            get_executing_context=lambda: raw_context,
+        )
+
+        context = execution_identity.read_comfy_execution_context(
+            load_module=lambda module_name: (
+                calls.append(module_name) or module
+            ),
+        )
+
+        self.assertEqual(calls, ["comfy_execution.utils"])
+        self.assertEqual(
+            context,
+            execution_identity.SeedExecutionContext(
+                prompt_id="prompt-a",
+                node_id="42",
+                list_index=3,
+            ),
+        )
+
+    def test_context_identity_is_idempotent_and_context_node_wins(self):
+        context = execution_identity.SeedExecutionContext(
+            prompt_id="prompt-a",
+            node_id="context-node",
+            list_index=2,
+        )
+
+        first = execution_identity.resolve_seed_execution_identity(
+            "prompt_studio",
+            unique_id="different-hidden-node",
+            load_context=lambda: context,
+        )
+        second = execution_identity.resolve_seed_execution_identity(
+            "prompt_studio",
+            unique_id="different-hidden-node",
+            load_context=lambda: context,
+        )
+
+        self.assertEqual(first, second)
+        self.assertIsNotNone(first)
+        assert first is not None
+        self.assertIn('"context-node"', first.stream_id)
+        self.assertNotIn("different-hidden-node", first.stream_id)
+        self.assertIn('"prompt-a"', first.request_id)
+        self.assertIn(",2]", first.request_id)
+
+    def test_stream_is_stable_across_prompts_but_request_is_not(self):
+        first = execution_identity.resolve_seed_execution_identity(
+            "aio",
+            load_context=lambda: execution_identity.SeedExecutionContext(
+                prompt_id="prompt-a",
+                node_id="7",
+            ),
+        )
+        second = execution_identity.resolve_seed_execution_identity(
+            "aio",
+            load_context=lambda: execution_identity.SeedExecutionContext(
+                prompt_id="prompt-b",
+                node_id="7",
+            ),
+        )
+
+        self.assertIsNotNone(first)
+        self.assertIsNotNone(second)
+        assert first is not None and second is not None
+        self.assertEqual(first.stream_id, second.stream_id)
+        self.assertNotEqual(first.request_id, second.request_id)
+
+    def test_list_index_distinguishes_mapped_calls(self):
+        identities = [
+            execution_identity.resolve_seed_execution_identity(
+                "aio",
+                load_context=lambda index=index: (
+                    execution_identity.SeedExecutionContext(
+                        prompt_id="prompt-a",
+                        node_id="7",
+                        list_index=index,
+                    )
+                ),
+            )
+            for index in (None, 0, 1)
+        ]
+
+        self.assertEqual(len({item.request_id for item in identities if item}), 3)
+        self.assertEqual(len({item.stream_id for item in identities if item}), 1)
+
+    def test_unique_id_fallback_keeps_stream_and_refreshes_request(self):
+        opaque_ids = iter(("opaque-a", "opaque-b"))
+
+        first = execution_identity.resolve_seed_execution_identity(
+            "aio",
+            unique_id=[42],
+            load_context=lambda: None,
+            request_id_factory=lambda: next(opaque_ids),
+        )
+        second = execution_identity.resolve_seed_execution_identity(
+            "aio",
+            unique_id=(42,),
+            load_context=lambda: None,
+            request_id_factory=lambda: next(opaque_ids),
+        )
+
+        self.assertIsNotNone(first)
+        self.assertIsNotNone(second)
+        assert first is not None and second is not None
+        self.assertEqual(first.stream_id, second.stream_id)
+        self.assertNotEqual(first.request_id, second.request_id)
+        self.assertIn('"fallback","opaque-a"', first.request_id)
+        self.assertIn('"fallback","opaque-b"', second.request_id)
+
+    def test_missing_identity_returns_none_without_allocating_request(self):
+        allocations = 0
+
+        def allocate() -> str:
+            nonlocal allocations
+            allocations += 1
+            return "unused"
+
+        for unique_id in (None, "", "  ", True, [], ()):
+            with self.subTest(unique_id=unique_id):
+                self.assertIsNone(
+                    execution_identity.resolve_seed_execution_identity(
+                        "aio",
+                        unique_id=unique_id,
+                        load_context=lambda: None,
+                        request_id_factory=allocate,
+                    )
+                )
+
+        self.assertEqual(allocations, 0)
+
+    def test_host_absence_and_malformed_context_are_safe(self):
+        def unavailable(_module_name: str) -> object:
+            raise ImportError("host not installed")
+
+        malformed = types.SimpleNamespace(
+            get_executing_context=lambda: types.SimpleNamespace(
+                prompt_id="prompt-a",
+                node_id="",
+                list_index=0,
+            )
+        )
+
+        self.assertIsNone(
+            execution_identity.read_comfy_execution_context(
+                load_module=unavailable
+            )
+        )
+        self.assertIsNone(
+            execution_identity.read_comfy_execution_context(
+                load_module=lambda _module_name: malformed
+            )
+        )
+
+    def test_namespaced_json_encoding_avoids_delimiter_collisions(self):
+        first = execution_identity.resolve_seed_execution_identity(
+            "feature:a",
+            load_context=lambda: execution_identity.SeedExecutionContext(
+                prompt_id="prompt",
+                node_id="b",
+            ),
+        )
+        second = execution_identity.resolve_seed_execution_identity(
+            "feature",
+            load_context=lambda: execution_identity.SeedExecutionContext(
+                prompt_id="prompt",
+                node_id="a:b",
+            ),
+        )
+
+        self.assertNotEqual(first, second)
+
+    def test_contract_values_are_immutable_and_reject_invalid_parts(self):
+        context = execution_identity.SeedExecutionContext(
+            prompt_id="prompt",
+            node_id="7",
+        )
+        with self.assertRaises(FrozenInstanceError):
+            context.node_id = "8"
+
+        for values in (
+            {"prompt_id": "", "node_id": "7", "list_index": None},
+            {"prompt_id": "prompt", "node_id": "", "list_index": None},
+            {"prompt_id": "prompt", "node_id": "7", "list_index": -1},
+            {"prompt_id": "prompt", "node_id": "7", "list_index": True},
+        ):
+            with self.subTest(values=values), self.assertRaises(
+                execution_identity.SeedExecutionIdentityError
+            ):
+                execution_identity.SeedExecutionContext(**values)
+
+        with self.assertRaises(execution_identity.SeedExecutionIdentityError):
+            execution_identity.resolve_seed_execution_identity(
+                "",
+                unique_id="7",
+                load_context=lambda: None,
+            )
+        with self.assertRaises(execution_identity.SeedExecutionIdentityError):
+            execution_identity.resolve_seed_execution_identity(
+                "aio",
+                unique_id="7",
+                load_context=lambda: None,
+                request_id_factory=lambda: "",
+            )
+        with self.assertRaises(TypeError):
+            execution_identity.resolve_seed_execution_identity(
+                "aio",
+                unique_id="7",
+                load_context=lambda: object(),
+            )
+
+    def test_contract_import_does_not_import_comfy_in_a_fresh_process(self):
+        script = (
+            f"import sys; sys.path.insert(0, {str(ROOT)!r}); "
+            "import easyuse_anima.seed.execution_identity; "
+            "print(int('comfy_execution' in sys.modules))"
+        )
+
+        result = subprocess.run(
+            [sys.executable, "-I", "-B", "-c", script],
+            cwd=ROOT,
+            check=False,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            timeout=10,
+        )
+
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertEqual(result.stdout.strip(), "0")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 요약

#167 S167-03b 범위로 authoritative seed reservation에 사용할 실행 정체성 계약을 추가합니다. 아직 feature `reserve`/`settle` caller는 만들지 않습니다.

- Comfy `get_executing_context()`를 호출 시점에만 읽음
- `prompt_id` + effective `node_id` + optional `list_index`로 idempotent request ID 생성
- feature + stable node ID로 stream ID 생성
- context가 없는 구형/test host는 안정적인 `UNIQUE_ID` stream + 매 호출 opaque request ID 사용
- context와 `UNIQUE_ID`가 모두 없으면 `None`을 반환해 service mutation을 차단
- 기존 4-method `ComfyHostProvider`는 변경하지 않음

## 작업 전 inventory

### symbol / caller / alias

- `RuntimeServices.seed_reservations`: 유일한 process service
- production `reserve`/`settle` caller: 0개
- host context: Comfy v0.27.0 `comfy_execution.utils.get_executing_context()`가 `prompt_id`, `node_id`, `list_index` 제공
- feature fallback: AiO/Prompt Studio 모두 hidden `UNIQUE_ID` 보유
- root aliases: `_resolve_aio_runtime_seed`, `_consume_reserved_wildcard_next_seed`, v1 hidden payload 상수 유지; D-12/후속 cutover 소유

### global state

- 새 identity 모듈은 mutable global, context cache, reservation, background lifecycle을 소유하지 않음
- seed package의 private import로 shipped runtime closure만 유지
- 기존 backend/browser reservation state는 변경하지 않음

## 변경 파일

- `easyuse_anima/seed/__init__.py`
- `easyuse_anima/seed/execution_identity.py`
- `tests/test_seed_execution_identity.py`
- `tests/test_python_package_skeleton.py`
- `tests/test_python_backend_analyzer.py`
- `tests/fixtures/python_backend_baseline.json`
- `docs/architecture/seed-reservation-contract.md`
- `docs/architecture/python-backend-execution-roadmap.md`

## 검증

- focused identity/package/analyzer/import-boundary: 22 passed (2.264s)
- final identity/package/analyzer focused: 12 passed (1.575s)
- regenerated analyzer fixture exact-match: 1 passed (1.101s)
- strict Pyright `easyuse_anima/seed/execution_identity.py`: 0 errors, 0 warnings
- Python compile: passed
- Comfy v0.27.0 call-time import smoke outside active execution: `None` 안전 반환
- `git diff --cached --check`: 통과
- official full: 실행하지 않음. feature caller가 0개인 Contract 단위이며 S167-03a에서 full 소유권을 03d/03e Behavior에 배정함

## 위험 / 미확인

- 실제 reserve/settle 예외 수명주기는 S167-03c에서 구현·focused 검증합니다.
- feature cache/UI/browser parity는 각각 S167-03d/03e 소유입니다.
- workflow schema, sockets, hidden inputs, root aliases에는 변화가 없습니다.

Parent: #167