### PR TITLE
refactor: seed 실행 세션 수명주기 추가

### DIFF
--- a/docs/architecture/python-backend-execution-roadmap.md
+++ b/docs/architecture/python-backend-execution-roadmap.md
@@ -405,7 +405,7 @@ mechanical retirement series.
 | 12 | B-10a machine-readable compatibility audit | COMPLETE on `dev` | Contract/gate | #184/#188 | PR #271 / `3c7b857` |
 | 13 | B-10b private alias reduction | COMPLETE on `dev` through PR #291 / `c6b4680` | Contract/cleanup, split PRs | #184/#188 | Audited alias surface integrated |
 | 14 | B-11 registration/bootstrap/root shim | COMPLETE in PR #356 | Move/Contract, split PRs | #184 | Zero runtime binders/residual implementation; explicit root `__all__`; frozen compatibility audit |
-| 15 | S167 backend seed reservation series | S167-01 through S167-03a COMPLETE on `dev`; S167-03b execution identity Contract VALIDATED | Contract then Move then Behavior | #167 | Canonical AiO/node seams |
+| 15 | S167 backend seed reservation series | S167-01 through S167-03b COMPLETE on `dev`; S167-03c execution session Behavior VALIDATED | Contract then Move then Behavior | #167 | Canonical AiO/node seams |
 | 16 | A169 stage pipeline series | READY after #168 and Phase B completion; begin with A169-01 Contract | Contract then Behavior | #169 | Typed config and mechanical AiO move |
 | 17 | A169 first-pass cache policy | BLOCKED by stage/cache ownership seam | Behavior | #169 | Mechanical cache move and benchmark harness |
 | 18 | D-series canonical root consolidation | BLOCKED by relevant C contracts | Move | #186 | Phase B exit; per-feature behavior stable |
@@ -1237,6 +1237,12 @@ reservation caller. It validates Comfy's call-time `prompt_id`, effective
 and stream identities, and uses a fresh request identity with a stable hidden
 `UNIQUE_ID` stream only when execution context is unavailable. The existing
 four-method `ComfyHostProvider` and all feature nodes remain unchanged.
+
+S167-03c wraps one reservation in a shared exception-safe execution session.
+Normal return settles accepted, Comfy's already-loaded
+`InterruptProcessingException` settles cancelled, and every other
+`BaseException` settles rejected before re-raise. The classifier never imports
+the heavy Comfy/Torch host on demand, and no feature caller is added.
 
 Do not mix this sequence into B-09 or #169 stages.
 

--- a/docs/architecture/seed-reservation-contract.md
+++ b/docs/architecture/seed-reservation-contract.md
@@ -739,3 +739,88 @@ Exit:
   behavior is explicit and focused-tested; and
 - S167-03c can own reserve/settle exception behavior without inferring host
   identity rules.
+
+## S167-03c execution session Behavior record
+
+- State: VALIDATED; `dev` merge pending
+- PR type: Behavior
+- Baseline: `dev` commit
+  `dc4b81f3252111bc202bbad730e72aaab32fc56e`
+- Feature reservation callers: zero
+
+### Implemented boundary
+
+`easyuse_anima.seed.execution_session.seed_execution_session()` now owns the
+complete lifetime of one already-normalized reservation request:
+
+- `reserve` occurs before the wrapped body starts;
+- normal body return settles `accepted`;
+- Comfy's `InterruptProcessingException` settles `cancelled`;
+- every other `BaseException` settles `rejected`;
+- the original body exception is re-raised after settlement;
+- a reserve failure never attempts settlement; and
+- interruption-classifier failure cannot mask the body exception and falls
+  back to `rejected`.
+
+The interruption classifier consults only an already-loaded
+`comfy.model_management` module through `sys.modules`. It never imports Comfy,
+Torch, or another host dependency. This is sufficient during a real Comfy
+execution because the raised exception's defining module is already loaded.
+
+### Procedure correction from observed validation
+
+An isolated Comfy v0.27.0 interpreter probe imported
+`comfy.model_management`, printed a successful `True` match, but exceeded the
+10-second watchdog while the heavy Torch host finished initialization. That
+probe is not counted as a passing smoke and was not repeated. The production
+classifier was changed to loaded-module lookup, and final live classification
+ownership remains with S167-03d/03e where Comfy is already running.
+
+### Caller, alias, and state delta
+
+- Production `reserve` and `settle` feature caller counts remain zero.
+- The seed package privately imports the session module only to keep the
+  shipped runtime closure complete.
+- No mutable global, pending session registry, reservation duplicate, or
+  background lifecycle was added.
+- `RuntimeServices`, `ComfyHostProvider`, root aliases, feature nodes, browser
+  hooks, workflow schemas, and cache behavior remain unchanged.
+
+### Validation
+
+- focused session, reservation-service, package-skeleton, analyzer-fixture,
+  and import-boundary checks: 46 tests passed;
+- strict Pyright on the new production module: 0 errors and 0 warnings;
+- Python compile: passed; and
+- official full: intentionally not run because this unit has zero feature
+  callers and S167-03a assigns full ownership to S167-03d/03e.
+
+### Allowed-file boundary
+
+S167-03c may change only:
+
+- `easyuse_anima/seed/__init__.py`;
+- `easyuse_anima/seed/execution_session.py`;
+- `tests/test_seed_execution_session.py`;
+- `tests/test_python_package_skeleton.py`;
+- `tests/test_python_backend_analyzer.py`;
+- `tests/fixtures/python_backend_baseline.json`;
+- `docs/architecture/seed-reservation-contract.md`; and
+- `docs/architecture/python-backend-execution-roadmap.md`.
+
+Forbidden:
+
+- a feature-node or browser reservation caller;
+- workflow, metadata, route, socket, widget, or hidden-input changes;
+- changes to identity, reservation arithmetic, capacity, or cache policy;
+- adding a second state owner or importing Comfy/Torch during package import;
+  and
+- S167-03d/03e cutover, #169, D-12, release, or Registry work.
+
+Exit:
+
+- one shared session owns reserve/settle success, failure, and interruption
+  timing;
+- service retry and duplicate-idempotency behavior remains focused-tested;
+- no heavy host import is needed to classify an active Comfy interruption; and
+- S167-03d can connect Prompt Studio without duplicating lifetime logic.

--- a/easyuse_anima/seed/__init__.py
+++ b/easyuse_anima/seed/__init__.py
@@ -1,6 +1,7 @@
 """Side-effect-free backend seed reservation contracts."""
 
 from . import execution_identity as _execution_identity
+from . import execution_session as _execution_session
 from . import reservation as _reservation
 
 __all__ = ()

--- a/easyuse_anima/seed/execution_session.py
+++ b/easyuse_anima/seed/execution_session.py
@@ -1,0 +1,92 @@
+# pyright: strict
+"""Exception-safe lifetime for one authoritative seed reservation."""
+
+from __future__ import annotations
+
+import sys
+from collections.abc import Callable, Generator
+from contextlib import contextmanager
+from typing import TypeAlias
+
+from .reservation import (
+    SEED_SETTLEMENT_ACCEPTED,
+    SEED_SETTLEMENT_CANCELLED,
+    SEED_SETTLEMENT_REJECTED,
+    SeedReservation,
+    SeedReservationRequest,
+    SeedReservationService,
+    SeedReservationSettlement,
+)
+
+_COMFY_MODEL_MANAGEMENT = "comfy.model_management"
+_COMFY_INTERRUPTION = "InterruptProcessingException"
+
+_HostModuleLoader: TypeAlias = Callable[[str], object | None]
+_InterruptionClassifier: TypeAlias = Callable[[BaseException], bool]
+
+
+def _loaded_host_module(module_name: str) -> object | None:
+    return sys.modules.get(module_name)
+
+
+def is_comfy_processing_interruption(
+    error: BaseException,
+    *,
+    load_module: _HostModuleLoader = _loaded_host_module,
+) -> bool:
+    """Match Comfy's already-loaded execution interruption signal."""
+
+    try:
+        module = load_module(_COMFY_MODEL_MANAGEMENT)
+        interruption_type = getattr(module, _COMFY_INTERRUPTION)
+        if not isinstance(interruption_type, type):
+            return False
+        return isinstance(error, interruption_type)
+    except Exception:
+        return False
+
+
+def _settlement_for_error(
+    error: BaseException,
+    is_interruption: _InterruptionClassifier,
+) -> SeedReservationSettlement:
+    try:
+        interrupted = is_interruption(error)
+    except Exception:
+        interrupted = False
+    return (
+        SEED_SETTLEMENT_CANCELLED
+        if interrupted
+        else SEED_SETTLEMENT_REJECTED
+    )
+
+
+@contextmanager
+def seed_execution_session(
+    service: SeedReservationService,
+    request: SeedReservationRequest,
+    *,
+    is_interruption: _InterruptionClassifier = is_comfy_processing_interruption,
+) -> Generator[SeedReservation, None, None]:
+    """Reserve once and settle from the wrapped execution outcome."""
+
+    reservation = service.reserve(request)
+    try:
+        yield reservation
+    except BaseException as error:
+        service.settle(
+            reservation.reservation_id,
+            _settlement_for_error(error, is_interruption),
+        )
+        raise
+    else:
+        service.settle(
+            reservation.reservation_id,
+            SEED_SETTLEMENT_ACCEPTED,
+        )
+
+
+__all__ = (
+    "is_comfy_processing_interruption",
+    "seed_execution_session",
+)

--- a/tests/fixtures/python_backend_baseline.json
+++ b/tests/fixtures/python_backend_baseline.json
@@ -21070,6 +21070,24 @@
         "target": "easyuse_anima/seed/execution_identity.py"
       },
       {
+        "alias": "_execution_session",
+        "bound_name": "_execution_session",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".:execution_session",
+        "kind": "static_from",
+        "line": 4,
+        "name": "execution_session",
+        "optional": false,
+        "requested": ".",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/seed/__init__.py",
+        "target": "easyuse_anima/seed/execution_session.py"
+      },
+      {
         "alias": "_reservation",
         "bound_name": "_reservation",
         "branch_context": [],
@@ -21078,7 +21096,7 @@
         "conditional": false,
         "imported": ".:reservation",
         "kind": "static_from",
-        "line": 4,
+        "line": 5,
         "name": "reservation",
         "optional": false,
         "requested": ".",
@@ -21339,6 +21357,234 @@
         "role": "ordinary",
         "scope": "<module>",
         "source": "easyuse_anima/seed/execution_identity.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "annotations",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "__future__:annotations",
+        "kind": "static_from",
+        "line": 4,
+        "name": "annotations",
+        "optional": false,
+        "requested": "__future__",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/seed/execution_session.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "sys",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "sys",
+        "kind": "static_import",
+        "line": 6,
+        "name": null,
+        "optional": false,
+        "requested": "sys",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/seed/execution_session.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "Callable",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "collections.abc:Callable",
+        "kind": "static_from",
+        "line": 7,
+        "name": "Callable",
+        "optional": false,
+        "requested": "collections.abc",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/seed/execution_session.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "Generator",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "collections.abc:Generator",
+        "kind": "static_from",
+        "line": 7,
+        "name": "Generator",
+        "optional": false,
+        "requested": "collections.abc",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/seed/execution_session.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "contextmanager",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "contextlib:contextmanager",
+        "kind": "static_from",
+        "line": 8,
+        "name": "contextmanager",
+        "optional": false,
+        "requested": "contextlib",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/seed/execution_session.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "TypeAlias",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "typing:TypeAlias",
+        "kind": "static_from",
+        "line": 9,
+        "name": "TypeAlias",
+        "optional": false,
+        "requested": "typing",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/seed/execution_session.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "SEED_SETTLEMENT_ACCEPTED",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".reservation:SEED_SETTLEMENT_ACCEPTED",
+        "kind": "static_from",
+        "line": 11,
+        "name": "SEED_SETTLEMENT_ACCEPTED",
+        "optional": false,
+        "requested": ".reservation",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/seed/execution_session.py",
+        "target": "easyuse_anima/seed/reservation.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "SEED_SETTLEMENT_CANCELLED",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".reservation:SEED_SETTLEMENT_CANCELLED",
+        "kind": "static_from",
+        "line": 11,
+        "name": "SEED_SETTLEMENT_CANCELLED",
+        "optional": false,
+        "requested": ".reservation",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/seed/execution_session.py",
+        "target": "easyuse_anima/seed/reservation.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "SEED_SETTLEMENT_REJECTED",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".reservation:SEED_SETTLEMENT_REJECTED",
+        "kind": "static_from",
+        "line": 11,
+        "name": "SEED_SETTLEMENT_REJECTED",
+        "optional": false,
+        "requested": ".reservation",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/seed/execution_session.py",
+        "target": "easyuse_anima/seed/reservation.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "SeedReservation",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".reservation:SeedReservation",
+        "kind": "static_from",
+        "line": 11,
+        "name": "SeedReservation",
+        "optional": false,
+        "requested": ".reservation",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/seed/execution_session.py",
+        "target": "easyuse_anima/seed/reservation.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "SeedReservationRequest",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".reservation:SeedReservationRequest",
+        "kind": "static_from",
+        "line": 11,
+        "name": "SeedReservationRequest",
+        "optional": false,
+        "requested": ".reservation",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/seed/execution_session.py",
+        "target": "easyuse_anima/seed/reservation.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "SeedReservationService",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".reservation:SeedReservationService",
+        "kind": "static_from",
+        "line": 11,
+        "name": "SeedReservationService",
+        "optional": false,
+        "requested": ".reservation",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/seed/execution_session.py",
+        "target": "easyuse_anima/seed/reservation.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "SeedReservationSettlement",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".reservation:SeedReservationSettlement",
+        "kind": "static_from",
+        "line": 11,
+        "name": "SeedReservationSettlement",
+        "optional": false,
+        "requested": ".reservation",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/seed/execution_session.py",
+        "target": "easyuse_anima/seed/reservation.py"
       },
       {
         "alias": null,
@@ -45026,6 +45272,10 @@
       },
       {
         "from": "easyuse_anima/seed/__init__.py",
+        "to": "easyuse_anima/seed/execution_session.py"
+      },
+      {
+        "from": "easyuse_anima/seed/__init__.py",
         "to": "easyuse_anima/seed/reservation.py"
       },
       {
@@ -45035,6 +45285,10 @@
       {
         "from": "easyuse_anima/seed/compatibility.py",
         "to": "wildcard_engine.py"
+      },
+      {
+        "from": "easyuse_anima/seed/execution_session.py",
+        "to": "easyuse_anima/seed/reservation.py"
       },
       {
         "from": "easyuse_anima/seed/service.py",
@@ -45810,6 +46064,12 @@
       {
         "cyclic": false,
         "modules": [
+          "easyuse_anima/seed/execution_session.py"
+        ]
+      },
+      {
+        "cyclic": false,
+        "modules": [
           "easyuse_anima/seed/reservation.py"
         ]
       },
@@ -45858,7 +46118,7 @@
     ]
   },
   "inventory": {
-    "module_count": 95,
+    "module_count": 96,
     "modules": [
       {
         "is_package": true,
@@ -46870,9 +47130,9 @@
       },
       {
         "is_package": true,
-        "loc": 6,
+        "loc": 7,
         "module": "easyuse_anima.seed",
-        "normalized_git_blob_sha1": "bcbf1d5f2b745218e803706fb31a23ff944ff13a",
+        "normalized_git_blob_sha1": "e77628c2788025ffd33abd555d289f4ecca9acca",
         "path": "easyuse_anima/seed/__init__.py",
         "top_level": {
           "class_count": 0,
@@ -46902,6 +47162,18 @@
           "class_count": 3,
           "function_count": 8,
           "global_count": 8
+        }
+      },
+      {
+        "is_package": false,
+        "loc": 92,
+        "module": "easyuse_anima.seed.execution_session",
+        "normalized_git_blob_sha1": "acf4da13d00c8ceff567eb7b000f25197b9aa667",
+        "path": "easyuse_anima/seed/execution_session.py",
+        "top_level": {
+          "class_count": 0,
+          "function_count": 4,
+          "global_count": 5
         }
       },
       {
@@ -59640,6 +59912,72 @@
         "line": 4,
         "optional": false,
         "role": "ordinary",
+        "source": "easyuse_anima/seed/execution_session.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "sys",
+        "kind": "static_import",
+        "line": 6,
+        "optional": false,
+        "role": "ordinary",
+        "source": "easyuse_anima/seed/execution_session.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "collections.abc:Callable",
+        "kind": "static_from",
+        "line": 7,
+        "optional": false,
+        "role": "ordinary",
+        "source": "easyuse_anima/seed/execution_session.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "collections.abc:Generator",
+        "kind": "static_from",
+        "line": 7,
+        "optional": false,
+        "role": "ordinary",
+        "source": "easyuse_anima/seed/execution_session.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "contextlib:contextmanager",
+        "kind": "static_from",
+        "line": 8,
+        "optional": false,
+        "role": "ordinary",
+        "source": "easyuse_anima/seed/execution_session.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "typing:TypeAlias",
+        "kind": "static_from",
+        "line": 9,
+        "optional": false,
+        "role": "ordinary",
+        "source": "easyuse_anima/seed/execution_session.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "__future__:annotations",
+        "kind": "static_from",
+        "line": 4,
+        "optional": false,
+        "role": "ordinary",
         "source": "easyuse_anima/seed/reservation.py"
       },
       {
@@ -61407,6 +61745,7 @@
       "easyuse_anima/seed/__init__.py",
       "easyuse_anima/seed/compatibility.py",
       "easyuse_anima/seed/execution_identity.py",
+      "easyuse_anima/seed/execution_session.py",
       "easyuse_anima/seed/reservation.py",
       "easyuse_anima/seed/service.py",
       "easyuse_anima/workflow.py",
@@ -61504,6 +61843,7 @@
       "easyuse_anima/seed/__init__.py",
       "easyuse_anima/seed/compatibility.py",
       "easyuse_anima/seed/execution_identity.py",
+      "easyuse_anima/seed/execution_session.py",
       "easyuse_anima/seed/reservation.py",
       "easyuse_anima/seed/service.py",
       "easyuse_anima/workflow.py",

--- a/tests/test_python_backend_analyzer.py
+++ b/tests/test_python_backend_analyzer.py
@@ -691,9 +691,9 @@ ignored/
 
         self.assertEqual(analyzer.render_json(report), expected_text)
         self.assertEqual(report["schema_version"], 2)
-        self.assertEqual(report["inventory"]["module_count"], 95)
-        self.assertEqual(len(report["registry"]["shipped_python_modules"]), 95)
-        self.assertEqual(len(report["registry"]["runtime_import_closure"]), 95)
+        self.assertEqual(report["inventory"]["module_count"], 96)
+        self.assertEqual(len(report["registry"]["shipped_python_modules"]), 96)
+        self.assertEqual(len(report["registry"]["runtime_import_closure"]), 96)
         self.assertEqual(
             report["registry"]["entry_modules"],
             ["__init__.py", "nodes.py"],
@@ -766,6 +766,7 @@ ignored/
                 "easyuse_anima/seed/__init__.py",
                 "easyuse_anima/seed/compatibility.py",
                 "easyuse_anima/seed/execution_identity.py",
+                "easyuse_anima/seed/execution_session.py",
                 "easyuse_anima/seed/reservation.py",
                 "easyuse_anima/seed/service.py",
                 "easyuse_anima/prompt/__init__.py",
@@ -830,6 +831,7 @@ ignored/
                 "easyuse_anima/profiles/mutation.py",
                 "easyuse_anima/runtime.py",
                 "easyuse_anima/seed/execution_identity.py",
+                "easyuse_anima/seed/execution_session.py",
             }.issubset(report["registry"]["runtime_import_closure"])
         )
         self.assertIn(

--- a/tests/test_python_package_skeleton.py
+++ b/tests/test_python_package_skeleton.py
@@ -59,6 +59,7 @@ PACKAGE_MODULES = (
     "easyuse_anima.profiles.contract",
     "easyuse_anima.profiles.mutation",
     "easyuse_anima.seed.execution_identity",
+    "easyuse_anima.seed.execution_session",
     "easyuse_anima.seed.service",
     "easyuse_anima.prompt",
     "easyuse_anima.prompt.advanced",
@@ -165,6 +166,12 @@ print(json.dumps({{
             "SeedExecutionIdentityError",
             "read_comfy_execution_context",
             "resolve_seed_execution_identity",
+        ]
+        expected_all[
+            PACKAGE_MODULES.index("easyuse_anima.seed.execution_session")
+        ] = [
+            "is_comfy_processing_interruption",
+            "seed_execution_session",
         ]
         self.assertEqual(payload["declared_all"], expected_all)
         self.assertEqual(payload["new_forbidden"], [])

--- a/tests/test_seed_execution_session.py
+++ b/tests/test_seed_execution_session.py
@@ -1,0 +1,286 @@
+from __future__ import annotations
+
+import subprocess
+import sys
+import types
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from easyuse_anima.seed import execution_session
+from easyuse_anima.seed.reservation import (
+    SEED_CONTROL_FIXED,
+    SEED_OVERFLOW_CLAMP,
+    SEED_RESERVATION_CONTRACT_VERSION,
+    SEED_RESERVATION_REQUEST_SCHEMA,
+    SEED_SELECTION_CONCRETE,
+    SEED_SETTLEMENT_ACCEPTED,
+    SEED_SETTLEMENT_CANCELLED,
+    SEED_SETTLEMENT_REJECTED,
+    SeedReservation,
+    SeedReservationRequest,
+    SeedReservationSettlement,
+)
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def make_request(request_id: str = "request:1") -> SeedReservationRequest:
+    return SeedReservationRequest(
+        schema=SEED_RESERVATION_REQUEST_SCHEMA,
+        version=SEED_RESERVATION_CONTRACT_VERSION,
+        stream_id="stream:7",
+        request_id=request_id,
+        selection=SEED_SELECTION_CONCRETE,
+        seed=7,
+        after_generate=SEED_CONTROL_FIXED,
+        next_seed_max=(1 << 50),
+        overflow=SEED_OVERFLOW_CLAMP,
+    )
+
+
+class RecordingService:
+    def __init__(self, *, reserve_error: BaseException | None = None) -> None:
+        self.reserve_error = reserve_error
+        self.calls: list[tuple[str, object]] = []
+        self.reservation = SeedReservation(
+            version=SEED_RESERVATION_CONTRACT_VERSION,
+            reservation_id="reservation:1",
+            stream_id="stream:7",
+            request_id="request:1",
+            execution_seed=7,
+            next_seed=7,
+        )
+
+    def reserve(self, request: SeedReservationRequest) -> SeedReservation:
+        self.calls.append(("reserve", request))
+        if self.reserve_error is not None:
+            raise self.reserve_error
+        return self.reservation
+
+    def settle(
+        self,
+        reservation_id: str,
+        settlement: SeedReservationSettlement,
+    ) -> None:
+        self.calls.append((reservation_id, settlement))
+
+
+class SeedExecutionSessionTests(unittest.TestCase):
+    def test_normal_return_settles_accepted_after_the_body(self):
+        service = RecordingService()
+        observations: list[object] = []
+
+        with execution_session.seed_execution_session(
+            service,
+            make_request(),
+        ) as reservation:
+            observations.append(reservation)
+            observations.append(tuple(service.calls))
+
+        self.assertIs(observations[0], service.reservation)
+        self.assertEqual(
+            observations[1],
+            (("reserve", make_request()),),
+        )
+        self.assertEqual(
+            service.calls,
+            [
+                ("reserve", make_request()),
+                ("reservation:1", SEED_SETTLEMENT_ACCEPTED),
+            ],
+        )
+
+    def test_regular_exception_settles_rejected_and_is_reraised(self):
+        service = RecordingService()
+        original = RuntimeError("generation failed")
+
+        with self.assertRaises(RuntimeError) as captured:
+            with execution_session.seed_execution_session(
+                service,
+                make_request(),
+                is_interruption=lambda _error: False,
+            ):
+                raise original
+
+        self.assertIs(captured.exception, original)
+        self.assertEqual(
+            service.calls[-1],
+            ("reservation:1", SEED_SETTLEMENT_REJECTED),
+        )
+
+    def test_comfy_base_exception_settles_cancelled_and_is_reraised(self):
+        class InterruptProcessingException(BaseException):
+            pass
+
+        module = types.SimpleNamespace(
+            InterruptProcessingException=InterruptProcessingException,
+        )
+        original = InterruptProcessingException()
+        service = RecordingService()
+
+        with self.assertRaises(InterruptProcessingException) as captured:
+            with execution_session.seed_execution_session(
+                service,
+                make_request(),
+                is_interruption=lambda error: (
+                    execution_session.is_comfy_processing_interruption(
+                        error,
+                        load_module=lambda _module_name: module,
+                    )
+                ),
+            ):
+                raise original
+
+        self.assertIs(captured.exception, original)
+        self.assertEqual(
+            service.calls[-1],
+            ("reservation:1", SEED_SETTLEMENT_CANCELLED),
+        )
+        with patch.dict(
+            sys.modules,
+            {"comfy.model_management": module},
+        ):
+            self.assertTrue(
+                execution_session.is_comfy_processing_interruption(original)
+            )
+
+    def test_non_comfy_base_exception_is_rejected(self):
+        service = RecordingService()
+
+        with self.assertRaises(KeyboardInterrupt):
+            with execution_session.seed_execution_session(
+                service,
+                make_request(),
+                is_interruption=lambda _error: False,
+            ):
+                raise KeyboardInterrupt()
+
+        self.assertEqual(
+            service.calls[-1],
+            ("reservation:1", SEED_SETTLEMENT_REJECTED),
+        )
+
+    def test_classifier_failure_does_not_mask_the_execution_error(self):
+        service = RecordingService()
+        original = ValueError("body failed")
+
+        def classifier(_error: BaseException) -> bool:
+            raise LookupError("host classifier failed")
+
+        with self.assertRaises(ValueError) as captured:
+            with execution_session.seed_execution_session(
+                service,
+                make_request(),
+                is_interruption=classifier,
+            ):
+                raise original
+
+        self.assertIs(captured.exception, original)
+        self.assertEqual(
+            service.calls[-1],
+            ("reservation:1", SEED_SETTLEMENT_REJECTED),
+        )
+
+    def test_reserve_failure_does_not_attempt_settlement(self):
+        original = RuntimeError("capacity exhausted")
+        service = RecordingService(reserve_error=original)
+
+        with self.assertRaises(RuntimeError) as captured:
+            with execution_session.seed_execution_session(
+                service,
+                make_request(),
+            ):
+                self.fail("session body must not run")
+
+        self.assertIs(captured.exception, original)
+        self.assertEqual(service.calls, [("reserve", make_request())])
+
+    def test_duplicate_success_session_remains_service_idempotent(self):
+        from easyuse_anima.seed.service import InMemorySeedReservationService
+
+        service = InMemorySeedReservationService(
+            reservation_id_factory=lambda: "reservation:stable",
+        )
+        request = make_request()
+
+        with execution_session.seed_execution_session(
+            service,
+            request,
+        ) as first:
+            self.assertEqual(first.execution_seed, 7)
+        with execution_session.seed_execution_session(
+            service,
+            request,
+        ) as second:
+            self.assertIs(second, first)
+
+    def test_rejected_session_allows_same_request_retry(self):
+        from easyuse_anima.seed.service import InMemorySeedReservationService
+
+        ids = iter(("reservation:1", "reservation:2"))
+        service = InMemorySeedReservationService(
+            reservation_id_factory=lambda: next(ids),
+        )
+        request = make_request()
+
+        with self.assertRaises(ValueError):
+            with execution_session.seed_execution_session(
+                service,
+                request,
+                is_interruption=lambda _error: False,
+            ) as first:
+                raise ValueError(first.reservation_id)
+
+        with execution_session.seed_execution_session(
+            service,
+            request,
+        ) as retried:
+            self.assertEqual(retried.reservation_id, "reservation:2")
+            self.assertEqual(retried.execution_seed, 7)
+
+    def test_host_classifier_handles_absent_or_malformed_modules(self):
+        error = RuntimeError("failed")
+
+        def unavailable(_module_name: str) -> object:
+            raise ImportError("Comfy is unavailable")
+
+        self.assertFalse(
+            execution_session.is_comfy_processing_interruption(
+                error,
+                load_module=unavailable,
+            )
+        )
+        self.assertFalse(
+            execution_session.is_comfy_processing_interruption(
+                error,
+                load_module=lambda _module_name: types.SimpleNamespace(
+                    InterruptProcessingException="not-a-type",
+                ),
+            )
+        )
+
+    def test_contract_import_does_not_import_comfy_in_a_fresh_process(self):
+        script = (
+            f"import sys; sys.path.insert(0, {str(ROOT)!r}); "
+            "import easyuse_anima.seed.execution_session; "
+            "print(int('comfy' in sys.modules))"
+        )
+
+        result = subprocess.run(
+            [sys.executable, "-I", "-B", "-c", script],
+            cwd=ROOT,
+            check=False,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            timeout=10,
+        )
+
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertEqual(result.stdout.strip(), "0")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 요약

#167 S167-03c 범위로 한 reservation의 실행 수명주기를 단일 context manager에 고정합니다. 아직 AiO/Prompt Studio feature caller는 추가하지 않습니다.

- body 시작 전 `reserve`
- 정상 반환 시 `accepted`
- Comfy `InterruptProcessingException` 시 `cancelled`
- 그 외 모든 `BaseException` 시 `rejected`
- settlement 후 원래 body 예외 재전파
- reserve 실패 시 settlement 미실행
- classifier 실패는 원래 오류를 가리지 않고 `rejected`로 후퇴

## 작업 전 inventory

### symbol / caller / alias

- `SeedReservationService.reserve/settle`: authoritative port
- `InMemorySeedReservationService`: process 단일 구현
- `SeedExecutionIdentity`: S167-03b가 확정한 request/stream identity
- Comfy v0.27.0: `comfy.model_management.InterruptProcessingException(BaseException)`
- production feature `reserve`/`settle` caller: 0개
- root compatibility aliases 및 feature helpers: 변경 없음

### global state

- 새 session 모듈은 mutable global, pending registry, duplicated reservation state를 소유하지 않음
- interruption 분류는 이미 로드된 `sys.modules["comfy.model_management"]`만 조회
- Comfy/Torch를 새로 import하거나 cache하지 않음

## 변경 파일

- `easyuse_anima/seed/__init__.py`
- `easyuse_anima/seed/execution_session.py`
- `tests/test_seed_execution_session.py`
- `tests/test_python_package_skeleton.py`
- `tests/test_python_backend_analyzer.py`
- `tests/fixtures/python_backend_baseline.json`
- `docs/architecture/seed-reservation-contract.md`
- `docs/architecture/python-backend-execution-roadmap.md`

## 검증

- focused session/service/package/analyzer/import-boundary: 46 passed (2.451s)
- final analyzer fixture exact-match: 1 passed (1.077s)
- strict Pyright `easyuse_anima/seed/execution_session.py`: 0 errors, 0 warnings
- Python compile: passed
- `git diff --cached --check`: 통과
- official full: 실행하지 않음. feature caller가 0개인 공유 Behavior 단위이며 S167-03a에서 full 소유권을 03d/03e cutover에 배정함

## 관측된 검증 비용 문제와 수정

별도 Comfy v0.27.0 Python 프로세스에서 `comfy.model_management`를 직접 import한 probe는 타입 일치 `True`를 출력했지만 Torch 초기화 때문에 10초 watchdog을 넘겼습니다. 통과한 smoke로 계산하지 않았고 반복하지 않았습니다. 생산 classifier를 on-demand import 대신 이미 로드된 module lookup으로 바꿨으며, 실제 서버 분류는 S167-03d/03e live checkpoint에서 확인합니다.

## 위험 / 미확인

- Prompt Studio/AiO feature wiring, cache forcing, UI publication은 아직 변경하지 않았습니다.
- workflow schema, sockets, hidden inputs, browser hooks, root aliases는 동일합니다.
- 실제 running Comfy interruption 분류는 후속 cutover checkpoint 소유입니다.

Parent: #167