### PR TITLE
[A169-01] AiO stage request/state protocol 계약

### DIFF
--- a/docs/architecture/aio-stage-pipeline-contract.md
+++ b/docs/architecture/aio-stage-pipeline-contract.md
@@ -3,6 +3,7 @@
 - Owner issue: [#169](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/169)
 - Roadmap unit: A169-01
 - PR type: Contract/gate
+- State: VALIDATED
 - Baseline: `dev` commit
   `89aa20fbde744ce4877f3123eec2061d3193df4d`
 - Production stage callers after this unit: zero
@@ -98,7 +99,10 @@ MODEL/CLIP/VAE/tensor objects or nested mappings are deeply immutable. Mutation
 and cleanup ownership remains with the current legacy function until the
 corresponding Behavior unit migrates it.
 
-No production module imports or instantiates these contracts in A169-01.
+No production module imports or instantiates these contracts in A169-01. The
+backend analyzer therefore allows exactly this one shipped module to remain
+outside the runtime import closure. A169-02 must remove that temporary
+zero-caller allowance when it connects the first stage.
 
 ## Allowed-file boundary
 
@@ -142,3 +146,13 @@ This zero-caller Contract does not require a model-backed generation or browser
 smoke. Reverting the unit removes only unused types, their tests and this
 record; runtime behavior and serialized contracts remain byte-for-byte owned by
 the existing implementation.
+
+Validated on the A169-01 worktree:
+
+- stage contract: 5 focused tests passed;
+- direct package import: 1 focused test passed;
+- analyzer fixture and tracked Registry surface: focused assertions passed;
+- Pyright 1.1.411: 0 errors for `generation_pipeline.py`;
+- Ruff 0.15.22 import ordering: passed for `generation_pipeline.py`;
+- Python import-boundary gate: 6 package groups, 0 violations; and
+- no ComfyUI server, model generation or browser smoke was run or required.

--- a/docs/architecture/aio-stage-pipeline-contract.md
+++ b/docs/architecture/aio-stage-pipeline-contract.md
@@ -1,0 +1,144 @@
+# AiO stage pipeline contract
+
+- Owner issue: [#169](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/169)
+- Roadmap unit: A169-01
+- PR type: Contract/gate
+- Baseline: `dev` commit
+  `89aa20fbde744ce4877f3123eec2061d3193df4d`
+- Production stage callers after this unit: zero
+
+This gate freezes the current orchestration order and the request/state/stage
+types before any generation behavior is moved. It does not call a stage,
+replace legacy orchestration, alter validation timing, or change output.
+
+## Symbol, caller, alias, and global-state inventory
+
+### Current owner and callers
+
+- `EasyUseAnimaAIOGenerator.generate` validates the AiO input, normalizes
+  settings, reserves one backend execution seed, then calls
+  `_run_aio_normalized_legacy_generation`.
+- `_run_aio_legacy_generation` remains the root compatibility entry point. It
+  performs input/settings/legacy-seed normalization and delegates to the same
+  normalized owner.
+- `_run_aio_normalized_legacy_generation` is the sole production orchestrator.
+  It prepares resources, prompt data and conditioning; executes first pass,
+  Highres, Detailer, Upscale and Postprocess; cleans ephemeral model variants;
+  saves the final image; then assembles metadata, previews, UI and three result
+  sockets.
+- `_run_aio_highres_stage`, `_run_aio_detailer_stage`,
+  `_run_aio_upscale_stage`, and `_run_aio_postprocess_stage` are direct
+  orchestration callees. First pass and save/output remain inline.
+
+### Current ordered boundary
+
+The stable high-level order is:
+
+1. validate and normalize at the node/compatibility adapter;
+2. load base resources, apply LoRA and model patches;
+3. normalize prompts and build positive/negative conditioning;
+4. resolve stage enablement, sampler backends and lazy Mod Guidance ownership;
+5. calculate preview/run and first-pass cache identities;
+6. first-pass cache lookup or sample/decode, resize, cache publication and
+   optional preview;
+7. Highres;
+8. Detailer;
+9. Upscale and latent refresh;
+10. Postprocess and conditional latent refresh;
+11. cleanup unique ephemeral model variants in a `finally` block;
+12. save/output, final-preview reconciliation, metadata and result assembly.
+
+`tests/fixtures/aio_legacy_execution_trace.v1.json` already freezes two exact
+execution traces and output payloads: base txt2img and Upscale with intermediate
+previews. A169-01 reuses that fixture rather than introducing a second golden
+source.
+
+### Compatibility aliases
+
+- Root `nodes.py` retains direct aliases for the legacy entry point and
+  Highres/Detailer/Upscale/Postprocess helpers.
+- `easyuse_anima.nodes.aio_nodes` calls the canonical normalized legacy owner
+  directly.
+- A169-01 adds no root alias and changes no existing alias identity or
+  signature. Later stage Behavior units continue to preserve the root
+  compatibility registry until its D-series owner retires it.
+
+### Mutable and process state
+
+- `easyuse_anima.aio.first_pass_cache` owns the current process-global cache
+  mapping and order list. A169-01 and all stage Moves leave its behavior
+  unchanged; the separate A169-CACHE series owns policy changes.
+- `legacy_generation` owns request-local `stage_metadata`, preview lists,
+  generated run ID, first-pass hit flag, lazy Mod Guidance model and the set
+  used to deduplicate cleanup.
+- Backend seed reservation is already owned by #167 outside the stage
+  orchestrator. A169 does not reinterpret or reserve seeds.
+- No stage registry, singleton pipeline, hook, route, queue interceptor or new
+  mutable global is allowed in A169-01.
+
+## Frozen zero-caller contract
+
+`easyuse_anima.aio.generation_pipeline` will be a pure, side-effect-free module
+containing:
+
+- `AIO_GENERATION_STAGE_ORDER`, fixed to `first_pass`, `highres`, `detailer`,
+  `upscale`, `postprocess`, `save_output`;
+- frozen `PromptExecutionData`, `ResourceBundle`, `ConditioningBundle` and
+  `WorkflowContext` ownership records matching values already assembled by the
+  legacy owner;
+- frozen `GenerationRequest`, containing the typed `AIOGenerationConfig` plus
+  those four records;
+- mutable request-local `GenerationState`, containing image, latent, width,
+  height, stage metadata and preview records; and
+- `GenerationStage`, a structural `validate(request, capabilities)` /
+  `run(request, state)` Protocol.
+
+The outer request records are frozen. This does not claim that Comfy
+MODEL/CLIP/VAE/tensor objects or nested mappings are deeply immutable. Mutation
+and cleanup ownership remains with the current legacy function until the
+corresponding Behavior unit migrates it.
+
+No production module imports or instantiates these contracts in A169-01.
+
+## Allowed-file boundary
+
+A169-01 may change only:
+
+- `easyuse_anima/aio/generation_pipeline.py`;
+- `tests/test_aio_stage_pipeline_contract.py`;
+- `tests/test_python_package_skeleton.py`;
+- `tests/test_python_backend_analyzer.py` only when analyzer enrollment needs
+  an explicit assertion;
+- `tests/fixtures/python_backend_baseline.json`, regenerated only from the
+  implemented source;
+- this document; and
+- `docs/architecture/python-backend-execution-roadmap.md`.
+
+The existing legacy trace fixture is read-only in this unit.
+
+Forbidden:
+
+- edits to `legacy_generation.py`, `aio_nodes.py`, root `nodes.py`, settings,
+  defaults, migration, cache, preview, save, stage helpers or frontend code;
+- any production caller, orchestrator, stage instance, registry or mutable
+  global;
+- changing stage order, validation timing, sampling, cache, cleanup, metadata,
+  preview, UI, socket, workflow or seed behavior; and
+- A169-02 or later stage Behavior, A169-CACHE, D-series, release or Registry
+  work.
+
+## Validation and rollback
+
+Focused validation must prove:
+
+- the exact stage order and dataclass/Protocol surface;
+- frozen request records and isolated mutable state containers;
+- no production caller or root alias;
+- both existing trace cases contain the ordered stage/cleanup/save checkpoints;
+- direct package import remains side-effect-free and avoids Comfy/Torch; and
+- analyzer/import closure matches the source.
+
+This zero-caller Contract does not require a model-backed generation or browser
+smoke. Reverting the unit removes only unused types, their tests and this
+record; runtime behavior and serialized contracts remain byte-for-byte owned by
+the existing implementation.

--- a/docs/architecture/python-backend-execution-roadmap.md
+++ b/docs/architecture/python-backend-execution-roadmap.md
@@ -406,7 +406,7 @@ mechanical retirement series.
 | 13 | B-10b private alias reduction | COMPLETE on `dev` through PR #291 / `c6b4680` | Contract/cleanup, split PRs | #184/#188 | Audited alias surface integrated |
 | 14 | B-11 registration/bootstrap/root shim | COMPLETE in PR #356 | Move/Contract, split PRs | #184 | Zero runtime binders/residual implementation; explicit root `__all__`; frozen compatibility audit |
 | 15 | S167 backend seed reservation series | S167-01 through S167-03d COMPLETE on `dev`; S167-03e AiO cutover VALIDATED with isolated API/module/browser-load parity | Contract then Move then Behavior | #167 | Canonical AiO/node seams |
-| 16 | A169 stage pipeline series | A169-01 Contract IN PROGRESS; zero-caller boundary recorded in `aio-stage-pipeline-contract.md` | Contract then Behavior | #169 | Typed config and mechanical AiO move |
+| 16 | A169 stage pipeline series | A169-01 Contract VALIDATED; zero-caller boundary recorded in `aio-stage-pipeline-contract.md` | Contract then Behavior | #169 | Typed config and mechanical AiO move |
 | 17 | A169 first-pass cache policy | BLOCKED by stage/cache ownership seam | Behavior | #169 | Mechanical cache move and benchmark harness |
 | 18 | D-series canonical root consolidation | BLOCKED by relevant C contracts | Move | #186 | Phase B exit; per-feature behavior stable |
 | 19 | E-series RuntimeServices/lifecycle | BLOCKED by canonical owners | Move/Contract, split PRs | #187 | Relevant D moves |

--- a/docs/architecture/python-backend-execution-roadmap.md
+++ b/docs/architecture/python-backend-execution-roadmap.md
@@ -406,7 +406,7 @@ mechanical retirement series.
 | 13 | B-10b private alias reduction | COMPLETE on `dev` through PR #291 / `c6b4680` | Contract/cleanup, split PRs | #184/#188 | Audited alias surface integrated |
 | 14 | B-11 registration/bootstrap/root shim | COMPLETE in PR #356 | Move/Contract, split PRs | #184 | Zero runtime binders/residual implementation; explicit root `__all__`; frozen compatibility audit |
 | 15 | S167 backend seed reservation series | S167-01 through S167-03d COMPLETE on `dev`; S167-03e AiO cutover VALIDATED with isolated API/module/browser-load parity | Contract then Move then Behavior | #167 | Canonical AiO/node seams |
-| 16 | A169 stage pipeline series | READY after #168 and Phase B completion; begin with A169-01 Contract | Contract then Behavior | #169 | Typed config and mechanical AiO move |
+| 16 | A169 stage pipeline series | A169-01 Contract IN PROGRESS; zero-caller boundary recorded in `aio-stage-pipeline-contract.md` | Contract then Behavior | #169 | Typed config and mechanical AiO move |
 | 17 | A169 first-pass cache policy | BLOCKED by stage/cache ownership seam | Behavior | #169 | Mechanical cache move and benchmark harness |
 | 18 | D-series canonical root consolidation | BLOCKED by relevant C contracts | Move | #186 | Phase B exit; per-feature behavior stable |
 | 19 | E-series RuntimeServices/lifecycle | BLOCKED by canonical owners | Move/Contract, split PRs | #187 | Relevant D moves |

--- a/easyuse_anima/aio/generation_pipeline.py
+++ b/easyuse_anima/aio/generation_pipeline.py
@@ -1,0 +1,116 @@
+# pyright: strict
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from typing import Protocol, TypeAlias
+
+from .generation_settings import AIOGenerationConfig
+
+AIO_GENERATION_STAGE_ORDER = (
+    "first_pass",
+    "highres",
+    "detailer",
+    "upscale",
+    "postprocess",
+    "save_output",
+)
+
+
+def _new_metadata() -> dict[str, object]:
+    return {}
+
+
+def _new_previews() -> list[dict[str, object]]:
+    return []
+
+
+@dataclass(frozen=True, slots=True)
+class PromptExecutionData:
+    prompt_data: Mapping[str, object]
+    positive_prompt: str
+    negative_prompt: str
+    quality_tags: str
+    quality_negative: str
+    metadata_positive_prompt: str
+    metadata_negative_prompt: str
+    use_anima_mod_guidance: bool
+    use_negative_anima_mod_guidance: bool
+
+
+@dataclass(frozen=True, slots=True)
+class ResourceBundle:
+    base_model: object
+    base_clip: object
+    model_with_lora: object
+    model: object
+    clip: object
+    vae: object
+    applied_loras: tuple[Mapping[str, object], ...]
+
+
+@dataclass(frozen=True, slots=True)
+class ConditioningBundle:
+    positive: object
+    negative: object
+
+
+@dataclass(frozen=True, slots=True)
+class WorkflowContext:
+    input_context: Mapping[str, object]
+    lora_stack: object | None
+    workflow_prompt: object | None
+    extra_pnginfo: object | None
+    unique_id: object | None
+    cache_scope: str
+
+
+@dataclass(frozen=True, slots=True)
+class GenerationRequest:
+    config: AIOGenerationConfig
+    prompts: PromptExecutionData
+    resources: ResourceBundle
+    conditioning: ConditioningBundle
+    workflow: WorkflowContext
+
+
+@dataclass(slots=True)
+class GenerationState:
+    latent: object | None
+    image: object | None
+    width: int
+    height: int
+    metadata: dict[str, object] = field(default_factory=_new_metadata)
+    previews: list[dict[str, object]] = field(default_factory=_new_previews)
+
+
+GenerationCapabilities: TypeAlias = Mapping[str, object]
+
+
+class GenerationStage(Protocol):
+    name: str
+
+    def validate(
+        self,
+        request: GenerationRequest,
+        capabilities: GenerationCapabilities,
+    ) -> None: ...
+
+    def run(
+        self,
+        request: GenerationRequest,
+        state: GenerationState,
+    ) -> None: ...
+
+
+__all__ = (
+    "AIO_GENERATION_STAGE_ORDER",
+    "ConditioningBundle",
+    "GenerationCapabilities",
+    "GenerationRequest",
+    "GenerationStage",
+    "GenerationState",
+    "PromptExecutionData",
+    "ResourceBundle",
+    "WorkflowContext",
+)

--- a/tests/fixtures/python_backend_baseline.json
+++ b/tests/fixtures/python_backend_baseline.json
@@ -6758,6 +6758,126 @@
         "requested": "__future__",
         "role": "ordinary",
         "scope": "<module>",
+        "source": "easyuse_anima/aio/generation_pipeline.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "Mapping",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "collections.abc:Mapping",
+        "kind": "static_from",
+        "line": 4,
+        "name": "Mapping",
+        "optional": false,
+        "requested": "collections.abc",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/aio/generation_pipeline.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "dataclass",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "dataclasses:dataclass",
+        "kind": "static_from",
+        "line": 5,
+        "name": "dataclass",
+        "optional": false,
+        "requested": "dataclasses",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/aio/generation_pipeline.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "field",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "dataclasses:field",
+        "kind": "static_from",
+        "line": 5,
+        "name": "field",
+        "optional": false,
+        "requested": "dataclasses",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/aio/generation_pipeline.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "Protocol",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "typing:Protocol",
+        "kind": "static_from",
+        "line": 6,
+        "name": "Protocol",
+        "optional": false,
+        "requested": "typing",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/aio/generation_pipeline.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "TypeAlias",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "typing:TypeAlias",
+        "kind": "static_from",
+        "line": 6,
+        "name": "TypeAlias",
+        "optional": false,
+        "requested": "typing",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/aio/generation_pipeline.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "AIOGenerationConfig",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".generation_settings:AIOGenerationConfig",
+        "kind": "static_from",
+        "line": 8,
+        "name": "AIOGenerationConfig",
+        "optional": false,
+        "requested": ".generation_settings",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/aio/generation_pipeline.py",
+        "target": "easyuse_anima/aio/generation_settings.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "annotations",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "__future__:annotations",
+        "kind": "static_from",
+        "line": 2,
+        "name": "annotations",
+        "optional": false,
+        "requested": "__future__",
+        "role": "ordinary",
+        "scope": "<module>",
         "source": "easyuse_anima/aio/generation_sampling.py"
       },
       {
@@ -45013,6 +45133,10 @@
         "to": "easyuse_anima/aio/generation_values.py"
       },
       {
+        "from": "easyuse_anima/aio/generation_pipeline.py",
+        "to": "easyuse_anima/aio/generation_settings.py"
+      },
+      {
         "from": "easyuse_anima/aio/generation_sampling.py",
         "to": "easyuse_anima/aio/generation_values.py"
       },
@@ -46710,7 +46834,7 @@
     ]
   },
   "inventory": {
-    "module_count": 97,
+    "module_count": 98,
     "modules": [
       {
         "is_package": true,
@@ -46974,6 +47098,18 @@
           "class_count": 4,
           "function_count": 0,
           "global_count": 1
+        }
+      },
+      {
+        "is_package": false,
+        "loc": 116,
+        "module": "easyuse_anima.aio.generation_pipeline",
+        "normalized_git_blob_sha1": "0e7e7bc124447e7b183adc52e91ee63d20da89c4",
+        "path": "easyuse_anima/aio/generation_pipeline.py",
+        "top_level": {
+          "class_count": 7,
+          "function_count": 2,
+          "global_count": 3
         }
       },
       {
@@ -62471,6 +62607,7 @@
       "easyuse_anima/aio/generation_migrations.py",
       "easyuse_anima/aio/generation_normalization.py",
       "easyuse_anima/aio/generation_output.py",
+      "easyuse_anima/aio/generation_pipeline.py",
       "easyuse_anima/aio/generation_sampling.py",
       "easyuse_anima/aio/generation_settings.py",
       "easyuse_anima/aio/generation_values.py",
@@ -62547,7 +62684,9 @@
       "storage.py",
       "wildcard_engine.py"
     ],
-    "unreachable_shipped_python_modules": []
+    "unreachable_shipped_python_modules": [
+      "easyuse_anima/aio/generation_pipeline.py"
+    ]
   },
   "schema_version": 2,
   "side_effects": {
@@ -63253,6 +63392,78 @@
         "line": 163,
         "module": "easyuse_anima/aio/generation_output.py",
         "scope": "<module>"
+      },
+      {
+        "callee": "dataclass",
+        "column": 1,
+        "context": "decorator:PromptExecutionData",
+        "kind": "import_time_call",
+        "line": 28,
+        "module": "easyuse_anima/aio/generation_pipeline.py",
+        "scope": "<module>"
+      },
+      {
+        "callee": "dataclass",
+        "column": 1,
+        "context": "decorator:ResourceBundle",
+        "kind": "import_time_call",
+        "line": 41,
+        "module": "easyuse_anima/aio/generation_pipeline.py",
+        "scope": "<module>"
+      },
+      {
+        "callee": "dataclass",
+        "column": 1,
+        "context": "decorator:ConditioningBundle",
+        "kind": "import_time_call",
+        "line": 52,
+        "module": "easyuse_anima/aio/generation_pipeline.py",
+        "scope": "<module>"
+      },
+      {
+        "callee": "dataclass",
+        "column": 1,
+        "context": "decorator:WorkflowContext",
+        "kind": "import_time_call",
+        "line": 58,
+        "module": "easyuse_anima/aio/generation_pipeline.py",
+        "scope": "<module>"
+      },
+      {
+        "callee": "dataclass",
+        "column": 1,
+        "context": "decorator:GenerationRequest",
+        "kind": "import_time_call",
+        "line": 68,
+        "module": "easyuse_anima/aio/generation_pipeline.py",
+        "scope": "<module>"
+      },
+      {
+        "callee": "dataclass",
+        "column": 1,
+        "context": "decorator:GenerationState",
+        "kind": "import_time_call",
+        "line": 77,
+        "module": "easyuse_anima/aio/generation_pipeline.py",
+        "scope": "<module>"
+      },
+      {
+        "callee": "field",
+        "column": 34,
+        "context": "assign:metadata",
+        "kind": "import_time_call",
+        "line": 83,
+        "module": "easyuse_anima/aio/generation_pipeline.py",
+        "scope": "GenerationState"
+      },
+      {
+        "callee": "field",
+        "column": 40,
+        "context": "assign:previews",
+        "kind": "import_time_call",
+        "line": 84,
+        "module": "easyuse_anima/aio/generation_pipeline.py",
+        "scope": "GenerationState"
       },
       {
         "callee": "dataclass",

--- a/tests/test_aio_stage_pipeline_contract.py
+++ b/tests/test_aio_stage_pipeline_contract.py
@@ -1,0 +1,248 @@
+from __future__ import annotations
+
+import json
+import unittest
+from dataclasses import FrozenInstanceError
+from pathlib import Path
+from typing import cast
+
+from easyuse_anima.aio.generation_pipeline import (
+    AIO_GENERATION_STAGE_ORDER,
+    ConditioningBundle,
+    GenerationCapabilities,
+    GenerationRequest,
+    GenerationStage,
+    GenerationState,
+    PromptExecutionData,
+    ResourceBundle,
+    WorkflowContext,
+)
+from easyuse_anima.aio.generation_settings import AIOGenerationConfig
+
+
+ROOT = Path(__file__).resolve().parents[1]
+TRACE_FIXTURE = ROOT / "tests" / "fixtures" / "aio_legacy_execution_trace.v1.json"
+EXPECTED_ALL = (
+    "AIO_GENERATION_STAGE_ORDER",
+    "ConditioningBundle",
+    "GenerationCapabilities",
+    "GenerationRequest",
+    "GenerationStage",
+    "GenerationState",
+    "PromptExecutionData",
+    "ResourceBundle",
+    "WorkflowContext",
+)
+
+
+def _request() -> GenerationRequest:
+    return GenerationRequest(
+        config=cast(AIOGenerationConfig, object()),
+        prompts=PromptExecutionData(
+            prompt_data={"positive_prompt": "prompt"},
+            positive_prompt="prompt",
+            negative_prompt="negative",
+            quality_tags="quality",
+            quality_negative="quality negative",
+            metadata_positive_prompt="metadata prompt",
+            metadata_negative_prompt="metadata negative",
+            use_anima_mod_guidance=True,
+            use_negative_anima_mod_guidance=False,
+        ),
+        resources=ResourceBundle(
+            base_model=object(),
+            base_clip=object(),
+            model_with_lora=object(),
+            model=object(),
+            clip=object(),
+            vae=object(),
+            applied_loras=({"name": "style.safetensors"},),
+        ),
+        conditioning=ConditioningBundle(
+            positive=object(),
+            negative=object(),
+        ),
+        workflow=WorkflowContext(
+            input_context={"schema": "input-settings"},
+            lora_stack=(),
+            workflow_prompt=None,
+            extra_pnginfo=None,
+            unique_id="node-7",
+            cache_scope="node-7",
+        ),
+    )
+
+
+def _assert_ordered_subsequence(
+    test: unittest.TestCase,
+    actual: list[str],
+    expected: tuple[str, ...],
+) -> None:
+    position = -1
+    for checkpoint in expected:
+        position = actual.index(checkpoint, position + 1)
+    test.assertGreaterEqual(position, 0)
+
+
+class AIOStagePipelineContractTests(unittest.TestCase):
+    def test_stage_order_and_public_surface_are_exact(self):
+        from easyuse_anima.aio import generation_pipeline
+
+        self.assertEqual(
+            AIO_GENERATION_STAGE_ORDER,
+            (
+                "first_pass",
+                "highres",
+                "detailer",
+                "upscale",
+                "postprocess",
+                "save_output",
+            ),
+        )
+        self.assertEqual(generation_pipeline.__all__, EXPECTED_ALL)
+
+    def test_request_records_are_frozen_and_state_is_request_local(self):
+        request = _request()
+        with self.assertRaises(FrozenInstanceError):
+            request.workflow = WorkflowContext(  # type: ignore[misc]
+                input_context={},
+                lora_stack=None,
+                workflow_prompt=None,
+                extra_pnginfo=None,
+                unique_id=None,
+                cache_scope="replacement",
+            )
+        with self.assertRaises(FrozenInstanceError):
+            request.prompts.positive_prompt = "replacement"  # type: ignore[misc]
+
+        first = GenerationState(latent=None, image=None, width=64, height=96)
+        second = GenerationState(latent=None, image=None, width=64, height=96)
+        first.metadata["first_pass"] = {"cache_hit": False}
+        first.previews.append({"stage": "first_pass"})
+        first.width = 128
+
+        self.assertEqual(first.width, 128)
+        self.assertEqual(second.width, 64)
+        self.assertEqual(second.metadata, {})
+        self.assertEqual(second.previews, [])
+
+    def test_stage_protocol_is_structural_and_mutates_only_explicit_state(self):
+        events: list[str] = []
+
+        class FirstPassStage:
+            name = "first_pass"
+
+            def validate(
+                self,
+                request: GenerationRequest,
+                capabilities: GenerationCapabilities,
+            ) -> None:
+                events.append(f"validate:{request.workflow.cache_scope}")
+                events.append(f"capability:{capabilities['sampler']}")
+
+            def run(
+                self,
+                request: GenerationRequest,
+                state: GenerationState,
+            ) -> None:
+                events.append(f"run:{request.prompts.positive_prompt}")
+                state.latent = "sampled-latent"
+                state.metadata[self.name] = {"cache_hit": False}
+
+        stage: GenerationStage = FirstPassStage()
+        request = _request()
+        state = GenerationState(latent=None, image=None, width=64, height=96)
+
+        stage.validate(request, {"sampler": "comfy_ksampler"})
+        stage.run(request, state)
+
+        self.assertEqual(
+            events,
+            [
+                "validate:node-7",
+                "capability:comfy_ksampler",
+                "run:prompt",
+            ],
+        )
+        self.assertEqual(state.latent, "sampled-latent")
+        self.assertEqual(state.metadata, {"first_pass": {"cache_hit": False}})
+
+    def test_legacy_traces_preserve_stage_cleanup_and_save_order(self):
+        fixture = json.loads(TRACE_FIXTURE.read_text(encoding="utf-8"))
+        cases = fixture["cases"]
+        checkpoints = (
+            "load_resources",
+            "apply_lora",
+            "apply_model_patches",
+            "encode_positive",
+            "encode_negative",
+            "get_cache",
+            "sample",
+            "decode",
+            "run_highres",
+            "run_detailer",
+            "run_upscale",
+            "run_postprocess",
+            "cleanup:sample",
+            "cleanup:model",
+            "cleanup:lora",
+            "save_comfy",
+            "tag:final",
+        )
+        expected_metadata_stages = [
+            "first_pass",
+            "highres",
+            "detailer",
+            "upscale",
+            "postprocess",
+        ]
+
+        self.assertEqual(
+            sorted(cases),
+            ["base_txt2img", "upscale_with_intermediate_preview"],
+        )
+        for name, case in cases.items():
+            with self.subTest(case=name):
+                _assert_ordered_subsequence(self, case["trace"], checkpoints)
+                self.assertEqual(
+                    list(case["result"]["metadata"]["stages"]),
+                    expected_metadata_stages,
+                )
+
+        _assert_ordered_subsequence(
+            self,
+            cases["upscale_with_intermediate_preview"]["trace"],
+            (
+                "put_cache",
+                "temp_preview:first_pass",
+                "send_preview:first_pass",
+                "run_highres",
+                "run_detailer",
+                "run_upscale",
+                "temp_preview:upscale",
+                "send_preview:upscale",
+                "run_postprocess",
+            ),
+        )
+
+    def test_contract_has_no_production_caller_or_root_alias(self):
+        sources = {
+            "legacy owner": ROOT / "easyuse_anima" / "aio" / "legacy_generation.py",
+            "canonical node": ROOT / "easyuse_anima" / "nodes" / "aio_nodes.py",
+            "root facade": ROOT / "nodes.py",
+        }
+        forbidden = (
+            "generation_pipeline",
+            "GenerationRequest",
+            "GenerationStage",
+            "GenerationState",
+        )
+        for label, path in sources.items():
+            source = path.read_text(encoding="utf-8")
+            with self.subTest(source=label):
+                for token in forbidden:
+                    self.assertNotIn(token, source)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_python_backend_analyzer.py
+++ b/tests/test_python_backend_analyzer.py
@@ -691,15 +691,18 @@ ignored/
 
         self.assertEqual(analyzer.render_json(report), expected_text)
         self.assertEqual(report["schema_version"], 2)
-        self.assertEqual(report["inventory"]["module_count"], 97)
-        self.assertEqual(len(report["registry"]["shipped_python_modules"]), 97)
+        self.assertEqual(report["inventory"]["module_count"], 98)
+        self.assertEqual(len(report["registry"]["shipped_python_modules"]), 98)
         self.assertEqual(len(report["registry"]["runtime_import_closure"]), 97)
         self.assertEqual(
             report["registry"]["entry_modules"],
             ["__init__.py", "nodes.py"],
         )
         self.assertEqual(report["registry"]["missing_internal_imports"], [])
-        self.assertEqual(report["registry"]["unreachable_shipped_python_modules"], [])
+        self.assertEqual(
+            report["registry"]["unreachable_shipped_python_modules"],
+            ["easyuse_anima/aio/generation_pipeline.py"],
+        )
         self.assertTrue(
             {
                 "easyuse_anima/__init__.py",
@@ -707,6 +710,7 @@ ignored/
                 "easyuse_anima/aio/conditioning.py",
                 "easyuse_anima/aio/first_pass_cache.py",
                 "easyuse_anima/aio/legacy_generation.py",
+                "easyuse_anima/aio/generation_pipeline.py",
                 "easyuse_anima/aio/generation_values.py",
                 "easyuse_anima/aio/generation_sampling.py",
                 "easyuse_anima/aio/generation_features.py",

--- a/tests/test_python_package_skeleton.py
+++ b/tests/test_python_package_skeleton.py
@@ -16,6 +16,7 @@ PACKAGE_MODULES = (
     "easyuse_anima.aio.conditioning",
     "easyuse_anima.aio.first_pass_cache",
     "easyuse_anima.aio.legacy_generation",
+    "easyuse_anima.aio.generation_pipeline",
     "easyuse_anima.aio.generation_normalization",
     "easyuse_anima.aio.generation_values",
     "easyuse_anima.aio.model_preparation",
@@ -147,6 +148,19 @@ print(json.dumps({{
         self.assertEqual(payload["modules"], list(PACKAGE_MODULES))
         expected_all = [[] for _ in PACKAGE_MODULES]
         expected_all[PACKAGE_MODULES.index("easyuse_anima.bootstrap")] = ["initialize"]
+        expected_all[
+            PACKAGE_MODULES.index("easyuse_anima.aio.generation_pipeline")
+        ] = [
+            "AIO_GENERATION_STAGE_ORDER",
+            "ConditioningBundle",
+            "GenerationCapabilities",
+            "GenerationRequest",
+            "GenerationStage",
+            "GenerationState",
+            "PromptExecutionData",
+            "ResourceBundle",
+            "WorkflowContext",
+        ]
         expected_all[PACKAGE_MODULES.index("easyuse_anima.nodes.aio_nodes")] = [
             "EasyUseAnimaInput",
             "EasyUseAnimaAIOGenerator",


### PR DESCRIPTION
## 상태

A169-01 Contract/gate 구현과 focused 검증을 완료했습니다. Production caller와 runtime behavior는 변경하지 않았습니다.

## 사전 inventory

### Symbol / caller

- node adapter: `EasyUseAnimaAIOGenerator.generate`
- root compatibility entry: `_run_aio_legacy_generation`
- canonical sole orchestrator: `_run_aio_normalized_legacy_generation`
- direct stage callees: `_run_aio_highres_stage`, `_run_aio_detailer_stage`, `_run_aio_upscale_stage`, `_run_aio_postprocess_stage`
- first pass와 save/output은 현재 orchestrator에 inline 상태

### Current order

1. adapter validation/settings/seed
2. resource load → LoRA → model patches
3. prompt normalization → positive/negative conditioning
4. stage enablement/backend/Mod Guidance resolution
5. preview/run/cache identity
6. first pass cache-or-sample/decode/resize/cache/preview
7. Highres
8. Detailer
9. Upscale + latent refresh
10. Postprocess + conditional latent refresh
11. unique ephemeral model cleanup in `finally`
12. save/output → final preview → metadata/UI/result assembly

기존 `aio_legacy_execution_trace.v1.json`의 base txt2img와 Upscale/intermediate-preview exact trace를 단일 golden source로 재사용합니다.

### Alias / compatibility

- root stage/legacy alias identity와 signature는 유지합니다.
- normalized owner는 canonical adapter가 직접 호출합니다.
- A169-01은 root alias를 추가하지 않습니다.

### Global state

- current process-global mutable owner는 `first_pass_cache`의 mapping/order입니다. 별도 A169-CACHE 전까지 변경하지 않습니다.
- request-local state는 stage metadata, preview list/run ID, cache hit, lazy Mod Guidance model, cleanup dedup set입니다.
- #167 backend seed reservation은 stage pipeline 외부 owner이며 재해석하지 않습니다.
- 신규 stage registry/singleton/hook/mutable global은 추가하지 않았습니다.

## 변경 요약

- `easyuse_anima.aio.generation_pipeline` pure module 추가
- exact `AIO_GENERATION_STAGE_ORDER` 고정
- frozen prompt/resource/conditioning/workflow ownership records와 `GenerationRequest` 추가
- mutable request-local `GenerationState` 추가
- structural `GenerationStage.validate/run` Protocol 추가
- package/analyzer Registry surface와 deterministic analyzer fixture 갱신
- 현재 trace, zero-caller, alias/global-state 경계를 문서와 테스트로 고정

A169-01에서는 production import/instance/caller가 0개입니다. 따라서 analyzer는 `generation_pipeline.py` 하나만 runtime import closure 밖에 있도록 정확히 허용합니다. A169-02에서 first-pass 연결 시 이 임시 allowance를 제거해야 합니다.

## 주요 파일

- `easyuse_anima/aio/generation_pipeline.py`
- `tests/test_aio_stage_pipeline_contract.py`
- `tests/test_python_package_skeleton.py`
- `tests/test_python_backend_analyzer.py`
- `tests/fixtures/python_backend_baseline.json`
- `docs/architecture/aio-stage-pipeline-contract.md`
- `docs/architecture/python-backend-execution-roadmap.md`

legacy orchestrator/node/root/settings/cache/preview/save/frontend 파일은 변경하지 않았습니다.

## 검증

- stage contract focused unittest: 5 passed
- direct package import focused unittest: 1 passed
- analyzer module: 최초 18개 중 17개 통과, 신규 파일이 아직 Git index 밖이라 tracked-surface assertion 1개 실패
- 신규 파일 index 등록 후 실패 method 재검증: 1 passed
- 최종 source analyzer fixture 일치 method: 1 passed
- Pyright 1.1.411 targeted `generation_pipeline.py`: 0 errors
- Ruff 0.15.22 targeted import ordering: passed
- Python import-boundary gate: 6 package groups, 0 violations
- `git diff --check`: passed

전체 quality driver는 최초 Pyright unknown-type 2건에서 중단됐습니다. typed default factory로 수정한 뒤 실패 구성요소를 targeted Pyright와 import-boundary gate로 재개했으며 전체 driver는 반복하지 않았습니다.

ComfyUI server, 모델 생성, 브라우저 smoke는 이 zero-caller Contract에 필요하지 않아 실행하지 않았습니다.

## 위험 및 후속

- runtime behavior는 기존 orchestrator가 전부 소유하므로 이 PR 단독 runtime 영향은 없습니다.
- zero-caller analyzer allowance는 의도적이고 정확히 한 파일로 제한됩니다.
- 다음 lane A169-02는 first pass만 연결하고 Highres/Detailer/Upscale/Postprocess/Save 및 cache policy 변경을 섞지 않습니다.

## Rollback

이 PR을 되돌리면 사용되지 않는 pure types/tests/docs만 제거됩니다. Runtime behavior와 serialized contract는 기존 owner에 그대로 남습니다.