### PR TITLE
refactor: finalize AiO pipeline adapter contract

### DIFF
--- a/docs/architecture/aio-final-adapter-integration.md
+++ b/docs/architecture/aio-final-adapter-integration.md
@@ -5,7 +5,7 @@
 - PR type: Contract/cleanup
 - Baseline: `dev` commit
   `3524b3789baae00d73512fc875a3ecfeb981f63d`
-- State: INVENTORY
+- State: VALIDATED
 
 A169-09 gives the completed stage pipeline one canonical internal entry name,
 keeps both legacy adapters intact, and records the integration matrix for the
@@ -19,20 +19,22 @@ change generation behavior.
 - `EasyUseAnimaAIOGenerator.generate` is the canonical production node caller.
   It validates input, normalizes settings, opens the backend seed execution
   session, writes the concrete execution seed, calls
-  `_run_aio_normalized_legacy_generation`, then publishes the accepted
+  `_run_aio_generation_pipeline`, then publishes the accepted
   execution/next-seed display.
 - `_run_aio_legacy_generation` is the root compatibility adapter. It validates
   input, normalizes settings, resolves the legacy runtime seed, and delegates
   to `_run_aio_normalized_legacy_generation`.
-- `_run_aio_normalized_legacy_generation` now owns the fully connected
-  request/state/six-stage pipeline and is also a direct test seam.
+- `_run_aio_normalized_legacy_generation` is the exact-signature compatibility
+  and direct-test adapter for `_run_aio_generation_pipeline`.
+- `_run_aio_generation_pipeline` owns the fully connected
+  request/state/six-stage pipeline.
 - Root `nodes.py` and package entry modes expose only
   `_run_aio_legacy_generation` plus the existing leaf helpers. The normalized
   entry is not a root compatibility export.
 
 ### Final adapter topology
 
-A169-09 introduces `_run_aio_generation_pipeline` in the existing
+A169-09 provides `_run_aio_generation_pipeline` in the existing
 `legacy_generation.py` module:
 
 1. the current normalized implementation body remains in place under the
@@ -137,3 +139,20 @@ This Contract/cleanup PR receives one official full validation after focused
 tests pass. The full suite is not repeated after deterministic component
 failures; failed components are resumed directly. No server/model/browser smoke
 is required because the production body and frontend do not change.
+
+## Validation result
+
+Validated on the A169-09 worktree:
+
+- normalized legacy adapter and exact execution trace: 26 focused tests passed;
+- backend seed cutover: 1 focused test passed;
+- six-stage pipeline contract: 6 focused tests passed;
+- integration matrix and read-only JSON evidence: 4 focused tests passed;
+- Python backend analyzer: 18 focused tests passed;
+- targeted Ruff 0.15.22 and Pyright 1.1.411: 2 production files, 0 errors;
+- Python import-boundary gate: 6 completed package groups, 0 violations; and
+- official full: 1,096 Python tests plus 112 frontend JavaScript files passed,
+  with the reviewed Pyright baseline unchanged at 88 files and 14 errors.
+
+No ComfyUI server, model-backed generation, browser smoke, fixture rewrite, or
+frontend runtime change was performed or required.

--- a/docs/architecture/aio-final-adapter-integration.md
+++ b/docs/architecture/aio-final-adapter-integration.md
@@ -1,0 +1,139 @@
+# AiO final adapter and integration matrix
+
+- Owner issue: [#169](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/169)
+- Roadmap unit: A169-09
+- PR type: Contract/cleanup
+- Baseline: `dev` commit
+  `3524b3789baae00d73512fc875a3ecfeb981f63d`
+- State: INVENTORY
+
+A169-09 gives the completed stage pipeline one canonical internal entry name,
+keeps both legacy adapters intact, and records the integration matrix for the
+stage-pipeline series. It does not move the implementation to another module or
+change generation behavior.
+
+## Symbol, caller, alias, and state inventory
+
+### Current callers
+
+- `EasyUseAnimaAIOGenerator.generate` is the canonical production node caller.
+  It validates input, normalizes settings, opens the backend seed execution
+  session, writes the concrete execution seed, calls
+  `_run_aio_normalized_legacy_generation`, then publishes the accepted
+  execution/next-seed display.
+- `_run_aio_legacy_generation` is the root compatibility adapter. It validates
+  input, normalizes settings, resolves the legacy runtime seed, and delegates
+  to `_run_aio_normalized_legacy_generation`.
+- `_run_aio_normalized_legacy_generation` now owns the fully connected
+  request/state/six-stage pipeline and is also a direct test seam.
+- Root `nodes.py` and package entry modes expose only
+  `_run_aio_legacy_generation` plus the existing leaf helpers. The normalized
+  entry is not a root compatibility export.
+
+### Final adapter topology
+
+A169-09 introduces `_run_aio_generation_pipeline` in the existing
+`legacy_generation.py` module:
+
+1. the current normalized implementation body remains in place under the
+   canonical name;
+2. `EasyUseAnimaAIOGenerator.generate` imports and calls the canonical name;
+3. `_run_aio_normalized_legacy_generation` remains an exact-signature adapter
+   that delegates to the canonical name;
+4. `_run_aio_legacy_generation` keeps its current normalization/seed behavior
+   and continues through the normalized compatibility seam; and
+5. root/package aliases, leaf helper identities, request/state/stage/lifecycle
+   objects, Save output, and seed publication remain unchanged.
+
+This is not a module Move. Canonical module ownership remains
+`easyuse_anima.aio.legacy_generation` until its separate #184/D-series owner
+changes it.
+
+### Mutable and global state
+
+- The canonical pipeline keeps all current request-local state:
+  `GenerationState`, lifecycle owners, stage instances, preview records, run
+  ID, metadata, and final output.
+- The node adapter keeps the backend seed execution session and accepted seed
+  display.
+- The legacy adapter keeps its direct runtime-seed resolution.
+- First-pass cache, Python random state, helper/module globals, Comfy host
+  state, filesystem side effects, and optional dependency lookup do not
+  change.
+- No new registry, singleton, hook, queue, cache, lock, or background task is
+  introduced.
+
+## Read-only integration matrix
+
+| Surface | Canonical evidence | A169-09 gate |
+| --- | --- | --- |
+| Stage order and result | `aio_legacy_execution_trace.v1.json` | exact two-case trace/output remains byte-unchanged |
+| Node adapter and seed | `test_aio_legacy_generation`, `test_aio_seed_cutover` | canonical call plus unchanged seed session/display |
+| Six stages and lifecycle | stage/pipeline/lifecycle focused tests | all owners remain connected only inside the canonical pipeline |
+| 0.5.2 saved settings | `aio_generation_settings_0_5_2.json` | normalization and typed round-trip remain exact |
+| Public node contract | `node_contracts_0_5_2.json` | class mapping, inputs, three outputs, workflow snapshot remain exact |
+| Representative workflow | `EasyUse_Anima_AiO_generator_release_ko.json` | JSON, node type, keyed settings, links, metadata, and package list remain valid |
+| Package/import safety | package skeleton, analyzer, import-boundary, bootstrap | no new unreachable module, host import, import-time side effect, or baseline drift |
+| Frontend Legacy/Node 2.0 | unchanged frontend plus existing 0.5.4 matrix | no repeat browser run for a backend-only adapter rename |
+| Model-backed queue | parent #169 final close gate | deferred until the separate A169-CACHE series is integrated; not claimed by this PR |
+| Import time/RSS comparison | parent #169 final close gate | deferred until cache policy is integrated so the final measurement is not immediately invalidated |
+
+The two deferred rows are parent-issue completion gates, not evidence claimed
+by A169-09. A169-CACHE remains a separate Behavior series and must not be mixed
+into this adapter cleanup.
+
+## Allowed-file boundary
+
+A169-09 may change only:
+
+- `easyuse_anima/aio/legacy_generation.py`;
+- `easyuse_anima/nodes/aio_nodes.py`;
+- `tests/test_aio_legacy_generation.py`;
+- `tests/test_aio_seed_cutover.py`;
+- `tests/test_aio_stage_pipeline_contract.py`;
+- `tests/test_aio_stage_integration_matrix.py`;
+- `tests/test_python_backend_analyzer.py`;
+- `tests/fixtures/python_backend_baseline.json`, regenerated from source;
+- this document;
+- `docs/architecture/aio-stage-pipeline-contract.md`; and
+- `docs/architecture/python-backend-execution-roadmap.md`.
+
+Read-only evidence:
+
+- `tests/fixtures/aio_legacy_execution_trace.v1.json`;
+- `tests/fixtures/aio_generation_settings_0_5_2.json`;
+- `tests/fixtures/node_contracts_0_5_2.json`;
+- `tests/fixtures/python_compatibility_surface.v1.json`;
+- `tests/fixtures/comfy_host_compatibility.v1.json`; and
+- `docs/example_workflows/EasyUse_Anima_AiO_generator_release_ko.json`.
+
+Forbidden:
+
+- moving the pipeline body or any helper to another module;
+- changing either legacy adapter signature, root/package alias, leaf helper,
+  stage, lifecycle owner, request/state/Protocol, or monkeypatch seam;
+- changing normalization, migration, seed reservation, runtime seed, stage
+  order, validation, cache, sampling, cleanup, preview, Save, metadata, UI, or
+  socket behavior;
+- modifying any read-only fixture or example workflow;
+- A169-CACHE, D-series, settings/defaults/migrations, workflow/schema,
+  frontend, release, or Registry changes; and
+- starting a server or model-backed generation merely for the adapter rename.
+
+## Required validation
+
+Focused tests must prove:
+
+- the public node imports/calls only `_run_aio_generation_pipeline`;
+- both legacy adapters preserve signatures, argument order, normalization/seed
+  behavior, and direct compatibility seams;
+- the canonical function owns all six stages plus lifecycle owners;
+- exact legacy trace/output, 0.5.2 settings round-trip, node contract, and
+  representative workflow evidence remain unchanged;
+- package/analyzer/import-boundary/bootstrap contracts remain valid; and
+- frontend source and read-only compatibility fixtures are untouched.
+
+This Contract/cleanup PR receives one official full validation after focused
+tests pass. The full suite is not repeated after deterministic component
+failures; failed components are resumed directly. No server/model/browser smoke
+is required because the production body and frontend do not change.

--- a/docs/architecture/aio-stage-pipeline-contract.md
+++ b/docs/architecture/aio-stage-pipeline-contract.md
@@ -163,3 +163,23 @@ Validated on the A169-01 worktree:
 - Ruff 0.15.22 import ordering: passed for `generation_pipeline.py`;
 - Python import-boundary gate: 6 package groups, 0 violations; and
 - no ComfyUI server, model generation or browser smoke was run or required.
+
+## Final connected state after A169-09
+
+A169-02 through A169-08 connected the six stages and request-local lifecycle
+owners without changing their order or behavior. A169-09 names that existing
+owner `_run_aio_generation_pipeline`:
+
+- `EasyUseAnimaAIOGenerator.generate` calls the canonical pipeline directly
+  after input normalization and backend seed reservation;
+- `_run_aio_normalized_legacy_generation` remains an exact-signature adapter
+  and test seam;
+- `_run_aio_legacy_generation` remains the root compatibility adapter and
+  preserves its normalization and runtime-seed behavior;
+- root/package aliases and leaf helper identities remain unchanged; and
+- the canonical pipeline retains all six stages plus
+  `EphemeralModelRegistry`, `ModelVariantResolver`, and `PreviewCollector`.
+
+The final adapter is a Contract/cleanup boundary, not a module Move. Cache
+policy remains owned by the separate A169-CACHE Behavior series, and canonical
+module consolidation remains owned by the D-series.

--- a/docs/architecture/python-backend-execution-roadmap.md
+++ b/docs/architecture/python-backend-execution-roadmap.md
@@ -406,7 +406,7 @@ mechanical retirement series.
 | 13 | B-10b private alias reduction | COMPLETE on `dev` through PR #291 / `c6b4680` | Contract/cleanup, split PRs | #184/#188 | Audited alias surface integrated |
 | 14 | B-11 registration/bootstrap/root shim | COMPLETE in PR #356 | Move/Contract, split PRs | #184 | Zero runtime binders/residual implementation; explicit root `__all__`; frozen compatibility audit |
 | 15 | S167 backend seed reservation series | S167-01 through S167-03d COMPLETE on `dev`; S167-03e AiO cutover VALIDATED with isolated API/module/browser-load parity | Contract then Move then Behavior | #167 | Canonical AiO/node seams |
-| 16 | A169 stage pipeline series | A169-01 through A169-07 MERGED; A169-08 lifecycle ownership VALIDATED in `aio-lifecycle-ownership.md` | Contract then Behavior | #169 | Typed config and mechanical AiO move |
+| 16 | A169 stage pipeline series | A169-01 through A169-08 MERGED; A169-09 final adapter/integration INVENTORY in `aio-final-adapter-integration.md` | Contract then Behavior | #169 | Typed config and mechanical AiO move |
 | 17 | A169 first-pass cache policy | BLOCKED by stage/cache ownership seam | Behavior | #169 | Mechanical cache move and benchmark harness |
 | 18 | D-series canonical root consolidation | BLOCKED by relevant C contracts | Move | #186 | Phase B exit; per-feature behavior stable |
 | 19 | E-series RuntimeServices/lifecycle | BLOCKED by canonical owners | Move/Contract, split PRs | #187 | Relevant D moves |

--- a/docs/architecture/python-backend-execution-roadmap.md
+++ b/docs/architecture/python-backend-execution-roadmap.md
@@ -406,7 +406,7 @@ mechanical retirement series.
 | 13 | B-10b private alias reduction | COMPLETE on `dev` through PR #291 / `c6b4680` | Contract/cleanup, split PRs | #184/#188 | Audited alias surface integrated |
 | 14 | B-11 registration/bootstrap/root shim | COMPLETE in PR #356 | Move/Contract, split PRs | #184 | Zero runtime binders/residual implementation; explicit root `__all__`; frozen compatibility audit |
 | 15 | S167 backend seed reservation series | S167-01 through S167-03d COMPLETE on `dev`; S167-03e AiO cutover VALIDATED with isolated API/module/browser-load parity | Contract then Move then Behavior | #167 | Canonical AiO/node seams |
-| 16 | A169 stage pipeline series | A169-01 through A169-08 MERGED; A169-09 final adapter/integration INVENTORY in `aio-final-adapter-integration.md` | Contract then Behavior | #169 | Typed config and mechanical AiO move |
+| 16 | A169 stage pipeline series | A169-01 through A169-08 MERGED; A169-09 final adapter/integration VALIDATED in PR #372 | Contract then Behavior | #169 | Typed config and mechanical AiO move |
 | 17 | A169 first-pass cache policy | BLOCKED by stage/cache ownership seam | Behavior | #169 | Mechanical cache move and benchmark harness |
 | 18 | D-series canonical root consolidation | BLOCKED by relevant C contracts | Move | #186 | Phase B exit; per-feature behavior stable |
 | 19 | E-series RuntimeServices/lifecycle | BLOCKED by canonical owners | Move/Contract, split PRs | #187 | Relevant D moves |

--- a/easyuse_anima/aio/legacy_generation.py
+++ b/easyuse_anima/aio/legacy_generation.py
@@ -681,6 +681,26 @@ def _run_aio_normalized_legacy_generation(
     extra_pnginfo=None,
     unique_id=None,
 ):
+    return _run_aio_generation_pipeline(
+        generator,
+        context,
+        settings,
+        lora_stack,
+        workflow_prompt,
+        extra_pnginfo,
+        unique_id,
+    )
+
+
+def _run_aio_generation_pipeline(
+    generator,
+    context: dict[str, Any],
+    settings: dict[str, Any],
+    lora_stack=None,
+    workflow_prompt=None,
+    extra_pnginfo=None,
+    unique_id=None,
+):
     if settings["mode"] != "txt2img":
         raise RuntimeError("[EasyUseAnima] AiO Generator draft currently supports txt2img only.")
     generation_config = _aio_generation_config_from_dict(settings)

--- a/easyuse_anima/nodes/aio_nodes.py
+++ b/easyuse_anima/nodes/aio_nodes.py
@@ -23,7 +23,7 @@ from ..aio.input_defaults import (
     EASY_USE_ANIMA_INPUT_SCHEMA,
     EASY_USE_ANIMA_INPUT_SETTINGS_VERSION,
 )
-from ..aio.legacy_generation import _run_aio_normalized_legacy_generation
+from ..aio.legacy_generation import _run_aio_generation_pipeline
 from ..aio.model_preparation import _aio_lora_stack_signature
 from ..aio.resources import (
     _comfy_clip_loader_types,
@@ -298,7 +298,7 @@ class EasyUseAnimaAIOGenerator:
             ),
         ) as seed_execution:
             sampler["seed"] = seed_execution.execution_seed
-            output = _run_aio_normalized_legacy_generation(
+            output = _run_aio_generation_pipeline(
                 self,
                 context,
                 settings,

--- a/tests/fixtures/python_backend_baseline.json
+++ b/tests/fixtures/python_backend_baseline.json
@@ -14430,15 +14430,15 @@
       },
       {
         "alias": null,
-        "bound_name": "_run_aio_normalized_legacy_generation",
+        "bound_name": "_run_aio_generation_pipeline",
         "branch_context": [],
         "classification": "internal",
         "column": 0,
         "conditional": false,
-        "imported": "..aio.legacy_generation:_run_aio_normalized_legacy_generation",
+        "imported": "..aio.legacy_generation:_run_aio_generation_pipeline",
         "kind": "static_from",
         "line": 26,
-        "name": "_run_aio_normalized_legacy_generation",
+        "name": "_run_aio_generation_pipeline",
         "optional": false,
         "requested": "..aio.legacy_generation",
         "role": "ordinary",
@@ -49040,13 +49040,13 @@
       },
       {
         "is_package": false,
-        "loc": 985,
+        "loc": 1005,
         "module": "easyuse_anima.aio.legacy_generation",
-        "normalized_git_blob_sha1": "d4d9dcd3f002a06b387567d10128a921d71b3396",
+        "normalized_git_blob_sha1": "cc345da63a722bde41a48ff64c4779c0c6443660",
         "path": "easyuse_anima/aio/legacy_generation.py",
         "top_level": {
           "class_count": 0,
-          "function_count": 11,
+          "function_count": 12,
           "global_count": 2
         }
       },
@@ -49426,7 +49426,7 @@
         "is_package": false,
         "loc": 317,
         "module": "easyuse_anima.nodes.aio_nodes",
-        "normalized_git_blob_sha1": "064ed7be76f7380be3b8b008e8f2d4354aa5c407",
+        "normalized_git_blob_sha1": "9e7e9aab3af2ec1f757c21c407b370df394676e1",
         "path": "easyuse_anima/nodes/aio_nodes.py",
         "top_level": {
           "class_count": 2,

--- a/tests/test_aio_legacy_generation.py
+++ b/tests/test_aio_legacy_generation.py
@@ -26,6 +26,38 @@ class _Token:
 
 
 class AIOGeneratorLegacyMoveTests(unittest.TestCase):
+    def test_normalized_legacy_adapter_forwards_exactly_to_canonical_pipeline(self):
+        expected = object()
+        generator = object()
+        context = {"prompt_data": {}}
+        settings = {"mode": "txt2img"}
+
+        with patch.object(
+            legacy_generation,
+            "_run_aio_generation_pipeline",
+            return_value=expected,
+        ) as run:
+            actual = legacy_generation._run_aio_normalized_legacy_generation(
+                generator,
+                context,
+                settings,
+                "lora",
+                "workflow",
+                "pnginfo",
+                "node-id",
+            )
+
+        self.assertIs(actual, expected)
+        run.assert_called_once_with(
+            generator,
+            context,
+            settings,
+            "lora",
+            "workflow",
+            "pnginfo",
+            "node-id",
+        )
+
     def test_current_normalized_settings_enter_typed_stage_boundary_before_resources(self):
         settings = nodes._normalize_aio_generation_settings("{}")
 
@@ -1839,7 +1871,7 @@ class AIOGeneratorLegacyMoveTests(unittest.TestCase):
             ),
             patch.object(
                 aio_nodes,
-                "_run_aio_normalized_legacy_generation",
+                "_run_aio_generation_pipeline",
                 return_value=forwarded,
             ) as run,
         ):

--- a/tests/test_aio_seed_cutover.py
+++ b/tests/test_aio_seed_cutover.py
@@ -55,7 +55,7 @@ class AioSeedCutoverTests(unittest.TestCase):
             ),
             patch.object(
                 aio_nodes,
-                "_run_aio_normalized_legacy_generation",
+                "_run_aio_generation_pipeline",
                 return_value=legacy_output,
             ) as legacy_generation,
         ):

--- a/tests/test_aio_stage_integration_matrix.py
+++ b/tests/test_aio_stage_integration_matrix.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+import inspect
+import json
+import unittest
+from pathlib import Path
+
+from easyuse_anima.aio import legacy_generation
+from easyuse_anima.nodes import aio_nodes
+
+ROOT = Path(__file__).resolve().parents[1]
+READ_ONLY_JSON_EVIDENCE = (
+    ROOT / "tests" / "fixtures" / "aio_legacy_execution_trace.v1.json",
+    ROOT / "tests" / "fixtures" / "aio_generation_settings_0_5_2.json",
+    ROOT / "tests" / "fixtures" / "node_contracts_0_5_2.json",
+    ROOT / "tests" / "fixtures" / "python_compatibility_surface.v1.json",
+    ROOT / "tests" / "fixtures" / "comfy_host_compatibility.v1.json",
+    ROOT
+    / "docs"
+    / "example_workflows"
+    / "EasyUse_Anima_AiO_generator_release_ko.json",
+)
+
+
+class AIOStageIntegrationMatrixTests(unittest.TestCase):
+    def test_node_and_legacy_adapters_converge_on_canonical_pipeline(self):
+        node_source = inspect.getsource(aio_nodes.EasyUseAnimaAIOGenerator.generate)
+        normalized_adapter_source = inspect.getsource(
+            legacy_generation._run_aio_normalized_legacy_generation
+        )
+        legacy_adapter_source = inspect.getsource(
+            legacy_generation._run_aio_legacy_generation
+        )
+
+        self.assertIn("_run_aio_generation_pipeline", node_source)
+        self.assertNotIn("_run_aio_normalized_legacy_generation", node_source)
+        self.assertIn("_run_aio_generation_pipeline", normalized_adapter_source)
+        self.assertIn(
+            "_run_aio_normalized_legacy_generation",
+            legacy_adapter_source,
+        )
+
+    def test_canonical_pipeline_owns_all_stage_and_lifecycle_connections(self):
+        pipeline_source = inspect.getsource(
+            legacy_generation._run_aio_generation_pipeline
+        )
+        normalized_adapter_source = inspect.getsource(
+            legacy_generation._run_aio_normalized_legacy_generation
+        )
+
+        for owner in (
+            "AIOFirstPassStage",
+            "AIOHighresStage",
+            "AIODetailerStage",
+            "AIOUpscaleStage",
+            "AIOPostprocessStage",
+            "AIOSaveOutputStage",
+            "EphemeralModelRegistry",
+            "ModelVariantResolver",
+            "PreviewCollector",
+        ):
+            self.assertIn(owner, pipeline_source)
+            self.assertNotIn(owner, normalized_adapter_source)
+
+    def test_read_only_integration_evidence_is_valid_json(self):
+        for path in READ_ONLY_JSON_EVIDENCE:
+            with self.subTest(path=path.relative_to(ROOT)):
+                self.assertTrue(path.is_file())
+                parsed = json.loads(path.read_text(encoding="utf-8"))
+                self.assertIsInstance(parsed, dict)
+                self.assertTrue(parsed)
+
+    def test_representative_workflow_contains_aio_generator_and_package_metadata(self):
+        workflow = json.loads(
+            READ_ONLY_JSON_EVIDENCE[-1].read_text(encoding="utf-8")
+        )
+        aio_nodes_in_workflow = [
+            node
+            for node in workflow["nodes"]
+            if node.get("type") == "EasyUseAnimaAIOGenerator"
+        ]
+
+        self.assertEqual(len(aio_nodes_in_workflow), 1)
+        workflow_metadata = workflow["extra"]["easyuse_anima_workflow"]
+        required_node_packs = workflow_metadata["required_node_packs"]
+        self.assertIn(
+            "ComfyUI-EasyUseAnima",
+            {node_pack["name"] for node_pack in required_node_packs},
+        )
+        self.assertEqual(workflow_metadata["package"], "comfyui-easyuse-anima")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_aio_stage_pipeline_contract.py
+++ b/tests/test_aio_stage_pipeline_contract.py
@@ -272,6 +272,11 @@ class AIOStagePipelineContractTests(unittest.TestCase):
         self.assertIn("AIOSaveOutputStage", legacy_source)
         self.assertIn("GenerationRequest", save_output_source)
         self.assertIn("GenerationState", save_output_source)
+        self.assertIn("_run_aio_generation_pipeline", canonical_node_source)
+        self.assertNotIn(
+            "_run_aio_normalized_legacy_generation",
+            canonical_node_source,
+        )
         self.assertNotIn("generation_first_pass", canonical_node_source)
         self.assertNotIn("generation_first_pass", root_source)
         self.assertNotIn("generation_highres", canonical_node_source)


### PR DESCRIPTION
## 변경 요약

- #169 로드맵의 A169-09 final adapter/integration matrix Contract/cleanup을 완료합니다.
- 기존 six-stage 구현 본문은 같은 모듈의 `_run_aio_generation_pipeline` canonical 진입점이 소유합니다.
- `EasyUseAnimaAIOGenerator.generate`는 canonical 진입점을 직접 호출합니다.
- `_run_aio_normalized_legacy_generation`과 `_run_aio_legacy_generation`의 시그니처·호환 seam·seed 동작·root alias는 유지합니다.
- read-only integration evidence와 대표 workflow를 묶는 focused matrix를 추가합니다.

## 주요 파일

- `easyuse_anima/aio/legacy_generation.py`
- `easyuse_anima/nodes/aio_nodes.py`
- `tests/test_aio_stage_integration_matrix.py`
- `tests/test_aio_legacy_generation.py`
- `tests/test_aio_seed_cutover.py`
- `tests/test_aio_stage_pipeline_contract.py`
- `tests/fixtures/python_backend_baseline.json`
- `docs/architecture/aio-final-adapter-integration.md`
- `docs/architecture/aio-stage-pipeline-contract.md`
- `docs/architecture/python-backend-execution-roadmap.md`

## Inventory와 호환 경계

- canonical production caller: `EasyUseAnimaAIOGenerator.generate`
- canonical pipeline owner: `_run_aio_generation_pipeline`
- normalized compatibility/test adapter: `_run_aio_normalized_legacy_generation`
- root compatibility adapter: `_run_aio_legacy_generation`
- root/package alias와 leaf helper identity 유지
- six stages, request/state, lifecycle owners, seed session, Save/output 순서 유지
- 새 global registry, hook, queue, cache, lock, background task 없음
- pipeline/helper/stage/lifecycle module Move와 A169-CACHE Behavior는 포함하지 않음

읽기 전용 trace/settings/node-contract/Python/Comfy compatibility fixture와 대표
AiO workflow는 수정하지 않았습니다. Model-backed queue와 import/RSS comparison은
별도 A169-CACHE 통합 뒤 parent #169 close gate로 유지합니다.

## 검증

- focused unittest
  - `tests.test_aio_legacy_generation`: 26 passed
  - `tests.test_aio_seed_cutover`: 1 passed
  - `tests.test_aio_stage_pipeline_contract`: 6 passed
  - `tests.test_aio_stage_integration_matrix`: 4 passed
  - `tests.test_python_backend_analyzer`: 18 passed
- targeted Ruff 0.15.22: 변경 production 2 files passed
- targeted Pyright 1.1.411: 2 files, 0 errors
- Python import boundary: 6 groups, 0 violations
- official full
  - Python unittest: 1,096 passed
  - frontend: 112 JavaScript files passed
  - Pyright baseline: 88 files, reviewed 14 errors 유지
  - import boundary와 `git diff --check` passed

## 테스트 표면과 남은 위험

- ComfyUI Codex test environment: repository full validation
- Live ComfyUI/server/model/browser smoke: 실행하지 않음
- production body와 frontend를 바꾸지 않는 adapter Contract이므로 live smoke는 요구하지 않음
- A169-CACHE 정책과 parent #169 최종 model-backed/import-RSS gate는 후속 작업
