### PR TITLE
test: add AiO first-pass cache benchmark gate

### DIFF
--- a/docs/architecture/aio-first-pass-cache-benchmark.md
+++ b/docs/architecture/aio-first-pass-cache-benchmark.md
@@ -5,7 +5,7 @@
 - PR type: Contract/docs/gate
 - Baseline: `dev` commit
   `f067d12ff9662f9463c6b6c5bd2754805db4042e`
-- State: INVENTORY
+- State: VALIDATED
 - Production changes: forbidden
 
 A169-CACHE-01 records the current first-pass cache cost and proves its mutation
@@ -122,3 +122,22 @@ Focused validation must prove:
 
 One official full validation follows focused success. No server, model,
 browser, or user-instance smoke is required.
+
+## Validation result
+
+Validated on the A169-CACHE-01 worktree:
+
+- benchmark/mutation-isolation harness: 3 focused tests passed in 0.082 seconds;
+- existing first-pass cache contract: 7 focused tests passed;
+- Python backend analyzer: 18 focused tests passed;
+- targeted Ruff 0.15.22 and Python compile: passed for the new tool/test;
+- Python import-boundary gate: 6 completed package groups, 0 violations;
+- default bounded run: 64 KiB per tensor, 25 operations, 50 clones and
+  3,276,800 logical copied bytes for both put-overwrite and get-hit, with both
+  isolation checks true; and
+- official full: 1,099 Python tests plus 112 frontend JavaScript files passed,
+  with the reviewed Pyright baseline unchanged at 88 files and 14 errors.
+
+Elapsed and peak traced-byte fields were observed but are intentionally not
+committed as pass/fail thresholds. No production/read-only file, ComfyUI
+server, Torch/model workload, browser, or user instance was changed or used.

--- a/docs/architecture/aio-first-pass-cache-benchmark.md
+++ b/docs/architecture/aio-first-pass-cache-benchmark.md
@@ -1,0 +1,124 @@
+# AiO first-pass cache benchmark and mutation-isolation gate
+
+- Owner issue: [#169](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/169)
+- Roadmap unit: A169-CACHE-01
+- PR type: Contract/docs/gate
+- Baseline: `dev` commit
+  `f067d12ff9662f9463c6b6c5bd2754805db4042e`
+- State: INVENTORY
+- Production changes: forbidden
+
+A169-CACHE-01 records the current first-pass cache cost and proves its mutation
+isolation before any cache Behavior changes. It adds a deterministic,
+timeboxed, fake-tensor harness. It does not optimize cloning or change cache
+policy.
+
+## Symbol, caller, alias, and state inventory
+
+### Canonical symbols
+
+`easyuse_anima.aio.first_pass_cache` owns:
+
+- `AIO_FIRST_PASS_CACHE_MAX_ENTRIES`, currently `2`;
+- `_AIO_FIRST_PASS_CACHE`, the process-global entry mapping;
+- `_AIO_FIRST_PASS_CACHE_ORDER`, the process-global oldest-to-newest key list;
+- `_clone_aio_cache_value`, the recursive container/tensor clone helper;
+- `_clear_aio_first_pass_cache`;
+- `_aio_first_pass_cache_key`;
+- `_get_aio_first_pass_cache`; and
+- `_put_aio_first_pass_cache`.
+
+The current implementation clones tensor-like leaves on both put and hit:
+`detach()`, `clone()`, then best-effort `cpu()`. Dictionaries, lists, and tuples
+are recursively rebuilt. Non-container, non-tensor values retain identity.
+
+### Callers and compatibility aliases
+
+- `_run_aio_generation_pipeline` injects canonical get/put functions into
+  `FirstPassRuntime`.
+- `AIOFirstPassStage.run` gets before sampling, puts after a miss, and puts a
+  resized result again when its latent/image shape changes.
+- Root `nodes.py` retains direct aliases for the max-entry constant, mapping,
+  order list, clone/key/get/put helpers. The private clear helper is not a root
+  alias.
+- Existing tests patch the canonical mapping, order, max-entry constant, and
+  stage runtime callables at call time. A169-CACHE-01 preserves every seam and
+  identity.
+
+### Mutable and global state
+
+- Entries and LRU order live for the Python process lifetime.
+- Clear mutates the canonical containers in place.
+- Put clones caller-owned values before storage.
+- Get refreshes LRU order and clones stored values before returning them.
+- The current cache has no byte budget, TTL, resource revision, metrics, lock,
+  explicit enabled flag, or runtime owner.
+- The fixed two-entry cap and list-based LRU behavior are unchanged by this
+  unit.
+
+## Harness contract
+
+The harness uses an in-memory fake tensor with `detach`, `clone`, `cpu`, a
+mutable byte payload, and deterministic clone counters. It exercises the real
+canonical put/get/clear functions without importing Torch or starting ComfyUI.
+
+One run reports:
+
+- schema/version and input payload/iteration counts;
+- per-operation detach/clone/cpu counts;
+- logical payload bytes copied by tensor clones;
+- elapsed nanoseconds and peak traced Python bytes as informational
+  measurements; and
+- source-after-put and returned-hit mutation-isolation results.
+
+Tests assert schema, deterministic operation/count/byte math, and isolation.
+They do not gate on wall-clock duration or `tracemalloc` peak values because
+those vary by host and interpreter. The CLI receives bounded positive inputs,
+and focused execution remains under the repository's 45-second unittest
+watchdog.
+
+## Allowed-file boundary
+
+A169-CACHE-01 may change only:
+
+- `tools/benchmark_aio_first_pass_cache.py`;
+- `tests/test_aio_first_pass_cache_benchmark.py`;
+- this document; and
+- `docs/architecture/python-backend-execution-roadmap.md`.
+
+Read-only evidence:
+
+- `easyuse_anima/aio/first_pass_cache.py`;
+- `easyuse_anima/aio/generation_first_pass.py`;
+- `easyuse_anima/aio/legacy_generation.py`;
+- root `nodes.py`;
+- `tests/test_aio_first_pass_cache.py`;
+- `tests/test_aio_legacy_generation.py`;
+- `tests/test_aio_nodes.py`; and
+- `tests/fixtures/python_compatibility_surface.v1.json`.
+
+Forbidden:
+
+- any production Python or frontend change;
+- changing clone, key, get, put, clear, LRU, cap, alias, stage, seed, sampling,
+  preview, metadata, Save, workflow, or socket behavior;
+- adding a cache owner, lock, policy, TTL, budget, metrics, invalidation, or
+  configuration;
+- committing host-specific latency/peak-allocation thresholds;
+- Torch/model-backed allocation, ComfyUI server, browser, release, or Registry
+  work; and
+- A169-CACHE-02 or later Behavior.
+
+## Required validation
+
+Focused validation must prove:
+
+- current put/get clone counts and logical bytes for bounded fake payloads;
+- source mutation after put cannot change the stored entry;
+- mutation of one returned hit cannot change the next hit;
+- CLI output is deterministic in schema/count fields and valid JSON;
+- production/read-only files are untouched; and
+- package/analyzer/import-boundary contracts remain unchanged.
+
+One official full validation follows focused success. No server, model,
+browser, or user-instance smoke is required.

--- a/docs/architecture/python-backend-execution-roadmap.md
+++ b/docs/architecture/python-backend-execution-roadmap.md
@@ -407,7 +407,7 @@ mechanical retirement series.
 | 14 | B-11 registration/bootstrap/root shim | COMPLETE in PR #356 | Move/Contract, split PRs | #184 | Zero runtime binders/residual implementation; explicit root `__all__`; frozen compatibility audit |
 | 15 | S167 backend seed reservation series | S167-01 through S167-03d COMPLETE on `dev`; S167-03e AiO cutover VALIDATED with isolated API/module/browser-load parity | Contract then Move then Behavior | #167 | Canonical AiO/node seams |
 | 16 | A169 stage pipeline series | A169-01 through A169-08 MERGED; A169-09 final adapter/integration VALIDATED in PR #372 | Contract then Behavior | #169 | Typed config and mechanical AiO move |
-| 17 | A169 first-pass cache policy | A169-CACHE-01 benchmark/mutation-isolation harness INVENTORY; policy units wait on its evidence | Contract then Behavior | #169 | Mechanical cache move and stable stage seam |
+| 17 | A169 first-pass cache policy | A169-CACHE-01 benchmark/mutation-isolation harness VALIDATED in PR #373; policy units wait on its evidence | Contract then Behavior | #169 | Mechanical cache move and stable stage seam |
 | 18 | D-series canonical root consolidation | BLOCKED by relevant C contracts | Move | #186 | Phase B exit; per-feature behavior stable |
 | 19 | E-series RuntimeServices/lifecycle | BLOCKED by canonical owners | Move/Contract, split PRs | #187 | Relevant D moves |
 | 20 | G-04 through G-06 and H | INCREMENTAL/LATER | Gate/Contract | #188 | Appropriate package and release evidence |

--- a/docs/architecture/python-backend-execution-roadmap.md
+++ b/docs/architecture/python-backend-execution-roadmap.md
@@ -407,7 +407,7 @@ mechanical retirement series.
 | 14 | B-11 registration/bootstrap/root shim | COMPLETE in PR #356 | Move/Contract, split PRs | #184 | Zero runtime binders/residual implementation; explicit root `__all__`; frozen compatibility audit |
 | 15 | S167 backend seed reservation series | S167-01 through S167-03d COMPLETE on `dev`; S167-03e AiO cutover VALIDATED with isolated API/module/browser-load parity | Contract then Move then Behavior | #167 | Canonical AiO/node seams |
 | 16 | A169 stage pipeline series | A169-01 through A169-08 MERGED; A169-09 final adapter/integration VALIDATED in PR #372 | Contract then Behavior | #169 | Typed config and mechanical AiO move |
-| 17 | A169 first-pass cache policy | BLOCKED by stage/cache ownership seam | Behavior | #169 | Mechanical cache move and benchmark harness |
+| 17 | A169 first-pass cache policy | A169-CACHE-01 benchmark/mutation-isolation harness INVENTORY; policy units wait on its evidence | Contract then Behavior | #169 | Mechanical cache move and stable stage seam |
 | 18 | D-series canonical root consolidation | BLOCKED by relevant C contracts | Move | #186 | Phase B exit; per-feature behavior stable |
 | 19 | E-series RuntimeServices/lifecycle | BLOCKED by canonical owners | Move/Contract, split PRs | #187 | Relevant D moves |
 | 20 | G-04 through G-06 and H | INCREMENTAL/LATER | Gate/Contract | #188 | Appropriate package and release evidence |

--- a/tests/test_aio_first_pass_cache_benchmark.py
+++ b/tests/test_aio_first_pass_cache_benchmark.py
@@ -1,0 +1,135 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+
+from easyuse_anima.aio import first_pass_cache
+
+ROOT = Path(__file__).resolve().parents[1]
+BENCHMARK_PATH = ROOT / "tools" / "benchmark_aio_first_pass_cache.py"
+
+
+def _load_benchmark_module():
+    spec = importlib.util.spec_from_file_location(
+        "easyuse_anima_aio_first_pass_cache_benchmark",
+        BENCHMARK_PATH,
+    )
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Could not load benchmark: {BENCHMARK_PATH.name}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+benchmark = _load_benchmark_module()
+
+
+class AIOFirstPassCacheBenchmarkTests(unittest.TestCase):
+    def tearDown(self):
+        first_pass_cache._clear_aio_first_pass_cache()
+
+    def test_report_freezes_clone_cost_and_bidirectional_isolation(self):
+        report = benchmark.run_benchmark(
+            payload_bytes=32,
+            iterations=3,
+        )
+
+        self.assertEqual(
+            (report["schema"], report["version"]),
+            (
+                "easyuse_anima_aio_first_pass_cache_benchmark",
+                1,
+            ),
+        )
+        self.assertEqual(
+            report["config"],
+            {
+                "payload_bytes": 32,
+                "iterations": 3,
+                "tensors_per_entry": 2,
+                "max_logical_bytes_per_operation": 64 * 1024 * 1024,
+            },
+        )
+        for operation_name in ("put_overwrite", "get_hit"):
+            with self.subTest(operation=operation_name):
+                operation = report["operations"][operation_name]
+                self.assertEqual(operation["operation_count"], 3)
+                self.assertEqual(operation["detach_calls"], 6)
+                self.assertEqual(operation["clone_calls"], 6)
+                self.assertEqual(operation["cpu_calls"], 6)
+                self.assertEqual(operation["logical_bytes_copied"], 192)
+                self.assertGreaterEqual(operation["elapsed_ns"], 0)
+                self.assertGreaterEqual(operation["average_ns"], 0)
+                self.assertGreaterEqual(operation["peak_traced_bytes"], 0)
+
+        self.assertEqual(
+            report["isolation"],
+            {
+                "source_after_put": True,
+                "returned_hit": True,
+            },
+        )
+        self.assertEqual(first_pass_cache._AIO_FIRST_PASS_CACHE, {})
+        self.assertEqual(first_pass_cache._AIO_FIRST_PASS_CACHE_ORDER, [])
+
+    def test_workload_guard_bounds_each_axis_and_total_copy_volume(self):
+        invalid_workloads = (
+            (0, 1),
+            (benchmark.MAX_PAYLOAD_BYTES + 1, 1),
+            (1, 0),
+            (1, benchmark.MAX_ITERATIONS + 1),
+            (benchmark.MAX_PAYLOAD_BYTES, benchmark.MAX_ITERATIONS),
+        )
+
+        for payload_bytes, iterations in invalid_workloads:
+            with (
+                self.subTest(
+                    payload_bytes=payload_bytes,
+                    iterations=iterations,
+                ),
+                self.assertRaises(ValueError),
+            ):
+                benchmark.run_benchmark(
+                    payload_bytes=payload_bytes,
+                    iterations=iterations,
+                )
+
+    def test_cli_emits_valid_json_with_deterministic_contract_fields(self):
+        result = subprocess.run(
+            [
+                sys.executable,
+                str(BENCHMARK_PATH),
+                "--payload-bytes",
+                "16",
+                "--iterations",
+                "2",
+            ],
+            cwd=ROOT,
+            check=True,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            timeout=10,
+        )
+
+        report = json.loads(result.stdout)
+        self.assertEqual(report["config"]["payload_bytes"], 16)
+        self.assertEqual(report["config"]["iterations"], 2)
+        self.assertEqual(
+            report["operations"]["put_overwrite"]["clone_calls"],
+            4,
+        )
+        self.assertEqual(
+            report["operations"]["get_hit"]["logical_bytes_copied"],
+            64,
+        )
+        self.assertTrue(all(report["isolation"].values()))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/benchmark_aio_first_pass_cache.py
+++ b/tools/benchmark_aio_first_pass_cache.py
@@ -1,0 +1,281 @@
+#!/usr/bin/env python3
+"""Measure the current AiO first-pass cache clone and isolation contract."""
+
+from __future__ import annotations
+
+import argparse
+import importlib
+import json
+import sys
+import time
+import tracemalloc
+from collections.abc import Callable
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+first_pass_cache = importlib.import_module(
+    "easyuse_anima.aio.first_pass_cache"
+)
+
+SCHEMA = "easyuse_anima_aio_first_pass_cache_benchmark"
+SCHEMA_VERSION = 1
+TENSORS_PER_ENTRY = 2
+DEFAULT_PAYLOAD_BYTES = 64 * 1024
+DEFAULT_ITERATIONS = 25
+MAX_PAYLOAD_BYTES = 4 * 1024 * 1024
+MAX_ITERATIONS = 100
+MAX_LOGICAL_BYTES_PER_OPERATION = 64 * 1024 * 1024
+
+
+@dataclass
+class CloneCounters:
+    detach_calls: int = 0
+    clone_calls: int = 0
+    cpu_calls: int = 0
+    logical_bytes_copied: int = 0
+
+    def reset(self) -> None:
+        self.detach_calls = 0
+        self.clone_calls = 0
+        self.cpu_calls = 0
+        self.logical_bytes_copied = 0
+
+
+class BenchmarkTensor:
+    """Small mutable tensor stand-in for exercising the canonical clone path."""
+
+    def __init__(self, payload: bytearray, counters: CloneCounters):
+        self.payload = payload
+        self.counters = counters
+
+    @classmethod
+    def filled(
+        cls,
+        payload_bytes: int,
+        fill: int,
+        counters: CloneCounters,
+    ) -> BenchmarkTensor:
+        return cls(bytearray([fill]) * payload_bytes, counters)
+
+    def detach(self) -> BenchmarkTensor:
+        self.counters.detach_calls += 1
+        return self
+
+    def clone(self) -> BenchmarkTensor:
+        self.counters.clone_calls += 1
+        self.counters.logical_bytes_copied += len(self.payload)
+        return BenchmarkTensor(bytearray(self.payload), self.counters)
+
+    def cpu(self) -> BenchmarkTensor:
+        self.counters.cpu_calls += 1
+        return self
+
+    def mutate_first_byte(self) -> None:
+        self.payload[0] ^= 0xFF
+
+    def snapshot(self) -> bytes:
+        return bytes(self.payload)
+
+
+def _validate_workload(payload_bytes: int, iterations: int) -> None:
+    if not 1 <= payload_bytes <= MAX_PAYLOAD_BYTES:
+        raise ValueError(
+            f"payload_bytes must be between 1 and {MAX_PAYLOAD_BYTES}"
+        )
+    if not 1 <= iterations <= MAX_ITERATIONS:
+        raise ValueError(
+            f"iterations must be between 1 and {MAX_ITERATIONS}"
+        )
+    logical_bytes = payload_bytes * iterations * TENSORS_PER_ENTRY
+    if logical_bytes > MAX_LOGICAL_BYTES_PER_OPERATION:
+        raise ValueError(
+            "payload_bytes * iterations * tensors_per_entry must not exceed "
+            f"{MAX_LOGICAL_BYTES_PER_OPERATION}"
+        )
+
+
+def _entry(
+    payload_bytes: int,
+    counters: CloneCounters,
+) -> tuple[dict[str, Any], BenchmarkTensor]:
+    latent = {
+        "samples": BenchmarkTensor.filled(
+            payload_bytes,
+            0x11,
+            counters,
+        )
+    }
+    image = BenchmarkTensor.filled(payload_bytes, 0x22, counters)
+    return latent, image
+
+
+def _measure(
+    operation: Callable[[], object],
+    counters: CloneCounters,
+    iterations: int,
+) -> dict[str, int]:
+    counters.reset()
+    tracemalloc.start()
+    started_ns = time.perf_counter_ns()
+    try:
+        for _ in range(iterations):
+            operation()
+        elapsed_ns = time.perf_counter_ns() - started_ns
+        _, peak_traced_bytes = tracemalloc.get_traced_memory()
+    finally:
+        tracemalloc.stop()
+
+    result = asdict(counters)
+    result.update(
+        {
+            "operation_count": iterations,
+            "elapsed_ns": elapsed_ns,
+            "average_ns": elapsed_ns // iterations,
+            "peak_traced_bytes": peak_traced_bytes,
+        }
+    )
+    return result
+
+
+def _measure_put(
+    payload_bytes: int,
+    iterations: int,
+) -> dict[str, int]:
+    counters = CloneCounters()
+    latent, image = _entry(payload_bytes, counters)
+    return _measure(
+        lambda: first_pass_cache._put_aio_first_pass_cache(
+            "benchmark",
+            latent,
+            image,
+        ),
+        counters,
+        iterations,
+    )
+
+
+def _measure_get_hit(
+    payload_bytes: int,
+    iterations: int,
+) -> dict[str, int]:
+    counters = CloneCounters()
+    latent, image = _entry(payload_bytes, counters)
+    first_pass_cache._put_aio_first_pass_cache(
+        "benchmark",
+        latent,
+        image,
+    )
+    return _measure(
+        lambda: first_pass_cache._get_aio_first_pass_cache("benchmark"),
+        counters,
+        iterations,
+    )
+
+
+def _measure_mutation_isolation(payload_bytes: int) -> dict[str, bool]:
+    counters = CloneCounters()
+    latent, image = _entry(payload_bytes, counters)
+    latent_tensor = latent["samples"]
+    latent_before = latent_tensor.snapshot()
+    image_before = image.snapshot()
+
+    first_pass_cache._put_aio_first_pass_cache(
+        "isolation",
+        latent,
+        image,
+    )
+    latent_tensor.mutate_first_byte()
+    image.mutate_first_byte()
+
+    first_latent, first_image = first_pass_cache._get_aio_first_pass_cache(
+        "isolation"
+    )
+    source_after_put = (
+        first_latent["samples"].snapshot() == latent_before
+        and first_image.snapshot() == image_before
+    )
+
+    first_latent["samples"].mutate_first_byte()
+    first_image.mutate_first_byte()
+    second_latent, second_image = first_pass_cache._get_aio_first_pass_cache(
+        "isolation"
+    )
+    returned_hit = (
+        second_latent["samples"].snapshot() == latent_before
+        and second_image.snapshot() == image_before
+    )
+    return {
+        "source_after_put": source_after_put,
+        "returned_hit": returned_hit,
+    }
+
+
+def run_benchmark(
+    *,
+    payload_bytes: int = DEFAULT_PAYLOAD_BYTES,
+    iterations: int = DEFAULT_ITERATIONS,
+) -> dict[str, object]:
+    _validate_workload(payload_bytes, iterations)
+    first_pass_cache._clear_aio_first_pass_cache()
+    try:
+        put_overwrite = _measure_put(payload_bytes, iterations)
+        first_pass_cache._clear_aio_first_pass_cache()
+        get_hit = _measure_get_hit(payload_bytes, iterations)
+        first_pass_cache._clear_aio_first_pass_cache()
+        isolation = _measure_mutation_isolation(payload_bytes)
+    finally:
+        first_pass_cache._clear_aio_first_pass_cache()
+
+    return {
+        "schema": SCHEMA,
+        "version": SCHEMA_VERSION,
+        "config": {
+            "payload_bytes": payload_bytes,
+            "iterations": iterations,
+            "tensors_per_entry": TENSORS_PER_ENTRY,
+            "max_logical_bytes_per_operation": (
+                MAX_LOGICAL_BYTES_PER_OPERATION
+            ),
+        },
+        "operations": {
+            "put_overwrite": put_overwrite,
+            "get_hit": get_hit,
+        },
+        "isolation": isolation,
+    }
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--payload-bytes",
+        type=int,
+        default=DEFAULT_PAYLOAD_BYTES,
+    )
+    parser.add_argument(
+        "--iterations",
+        type=int,
+        default=DEFAULT_ITERATIONS,
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    try:
+        report = run_benchmark(
+            payload_bytes=args.payload_bytes,
+            iterations=args.iterations,
+        )
+    except ValueError as exc:
+        raise SystemExit(str(exc)) from exc
+    print(json.dumps(report, ensure_ascii=False, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## 변경 요약

- #169 로드맵의 A169-CACHE-01 benchmark/mutation-isolation Contract/docs/gate를 완료합니다.
- 실제 canonical cache put/get/clear 함수를 사용하는 bounded fake-tensor benchmark CLI를 추가합니다.
- clone 횟수·논리 복사량과 양방향 mutation isolation을 결정론적으로 검증합니다.
- elapsed/peak traced bytes는 매 실행의 참고값으로 출력하지만 pass/fail 임계값으로 사용하지 않습니다.
- Production Python/frontend는 변경하지 않습니다.

## 주요 파일

- `tools/benchmark_aio_first_pass_cache.py`
- `tests/test_aio_first_pass_cache_benchmark.py`
- `docs/architecture/aio-first-pass-cache-benchmark.md`
- `docs/architecture/python-backend-execution-roadmap.md`

## Inventory와 계약 경계

- canonical owner: `easyuse_anima.aio.first_pass_cache`
- global state: entry mapping과 oldest-to-newest order list
- current behavior: 최대 2 entries, put/get 양쪽 recursive clone
- tensor-like leaf: `detach()` → `clone()` → best-effort `cpu()`
- pipeline/stage caller와 root direct aliases 유지
- byte budget, TTL, revision invalidation, metrics, lock, enabled flag, runtime owner는 후속 Behavior 소유

Harness는 payload, iteration, 총 logical-copy volume을 모두 제한합니다. 기본
workload는 tensor당 64 KiB, 25 operations이며 put-overwrite와 get-hit 각각
50 clones/3,276,800 logical copied bytes를 기록하고 두 isolation check가
true임을 확인했습니다.

## 검증

- `tests.test_aio_first_pass_cache_benchmark`: 3 passed
- `tests.test_aio_first_pass_cache`: 7 passed
- `tests.test_python_backend_analyzer`: 18 passed
- targeted Ruff 0.15.22: new tool/test passed
- Python compile: new tool/test passed
- Python import boundary: 6 groups, 0 violations
- official full
  - Python unittest: 1,099 passed
  - frontend: 112 JavaScript files passed
  - Pyright baseline: 88 files, reviewed 14 errors 유지
  - import boundary와 `git diff --check` passed

## 테스트 표면과 남은 위험

- ComfyUI Codex test environment: repository full validation
- Live ComfyUI/server/model/browser smoke: 실행하지 않음
- production/read-only 파일: 변경 없음
- 이 fake-tensor baseline은 실제 Torch 4K/batch allocation을 주장하지 않음
- 다음 A169-CACHE-02가 immutable entry/copy-on-write Behavior를 별도 소유
