### PR TITLE
refactor: freeze AiO first-pass cache entries

### DIFF
--- a/docs/architecture/aio-first-pass-cache-entry-contract.md
+++ b/docs/architecture/aio-first-pass-cache-entry-contract.md
@@ -1,0 +1,122 @@
+# AiO first-pass cache immutable entry contract
+
+- Owner issue: [#169](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/169)
+- Roadmap unit: A169-CACHE-02
+- PR type: Behavior
+- Baseline: `dev` commit
+  `366c4709edb5da8bcf450891221fbcdd474b29f8`
+- State: INVENTORY
+
+A169-CACHE-02 turns each cache value into a structurally frozen, cache-owned
+snapshot and defines overwrite as whole-entry replacement. It keeps the
+A169-CACHE-01 clone count and bidirectional mutation isolation. It does not
+remove cloning or add eviction/resource policy.
+
+## Symbol, caller, alias, and state inventory
+
+### Current entry and operations
+
+- `_AIO_FIRST_PASS_CACHE` is currently typed as
+  `dict[str, dict[str, Any]]`.
+- Put recursively clones caller-owned latent/image values, stores them in a
+  mutable `{"latent": ..., "image": ...}` dictionary, refreshes order, and
+  evicts oldest keys beyond the fixed cap.
+- Get returns `None` for a missing/falsey patched entry, refreshes order, then
+  recursively clones the stored latent/image values.
+- Overwriting a key replaces its dictionary but no type expresses that the
+  stored values are cache-owned and must not be exposed or mutated in place.
+
+### Callers and compatibility aliases
+
+- `_run_aio_generation_pipeline` injects canonical get/put functions into
+  `FirstPassRuntime`.
+- `AIOFirstPassStage.run` sees only `(latent, image)` or `None`; it does not
+  inspect the entry representation.
+- Root `nodes.py` directly aliases the max-entry constant, canonical mapping,
+  order list, clone/key/get/put helpers. The mapping and order object identities
+  remain unchanged.
+- Existing tests replace the canonical mapping/order/cap at call time and rely
+  on falsey entries being treated as misses.
+- No production caller consumes `entry["latent"]` or `entry["image"]`
+  directly.
+
+### Mutable and global state
+
+- The process-global mapping and order list retain their current lifetime.
+- Clear mutates both canonical containers in place.
+- Stored tensor/container snapshots are mutable objects, but only the cache
+  mapping can reach them until get creates an independent checkout copy.
+- LRU refresh, fixed two-entry cap, key schema, clone helper, and call-time
+  monkeypatch seams remain unchanged.
+
+## Target contract
+
+A private frozen/slots entry value owns two fields: `latent` and `image`.
+
+- Capture clones caller-owned values exactly once per field and stores the
+  resulting cache-owned snapshots.
+- Checkout clones both stored fields exactly once and returns the existing
+  `(latent, image)` tuple.
+- Get never exposes either stored field.
+- Overwrite constructs a new entry and replaces the mapping value; it never
+  mutates an existing entry.
+- Frozen means structural field reassignment is rejected. It does not claim
+  deep immutability of tensor/container objects.
+- A non-empty legacy mapping value remains readable through a narrow fallback
+  so call-time test/compatibility replacement does not become a hidden
+  migration boundary. New puts always create the canonical frozen entry.
+
+This is the copy-on-write boundary for later policy work: cache-owned snapshots
+remain stable, callers mutate only checkout copies, and new results replace
+entries wholesale.
+
+## Allowed-file boundary
+
+A169-CACHE-02 may change only:
+
+- `easyuse_anima/aio/first_pass_cache.py`;
+- `tests/test_aio_first_pass_cache.py`;
+- `tests/test_aio_first_pass_cache_benchmark.py` only if the frozen baseline
+  needs an explicit assertion;
+- `tests/test_python_backend_analyzer.py`;
+- `tests/fixtures/python_backend_baseline.json`, regenerated from source;
+- this document;
+- `docs/architecture/aio-first-pass-cache-benchmark.md`; and
+- `docs/architecture/python-backend-execution-roadmap.md`.
+
+Read-only evidence:
+
+- `easyuse_anima/aio/generation_first_pass.py`;
+- `easyuse_anima/aio/legacy_generation.py`;
+- root `nodes.py`;
+- `tools/benchmark_aio_first_pass_cache.py`;
+- `tests/test_aio_legacy_generation.py`;
+- `tests/test_aio_nodes.py`; and
+- `tests/fixtures/python_compatibility_surface.v1.json`.
+
+Forbidden:
+
+- changing clone helper semantics/order/count or removing put/get cloning;
+- changing key, miss, LRU, cap, clear, caller, alias, stage, seed, sampling,
+  preview, metadata, Save, workflow, or socket behavior;
+- byte budget, single-entry cap, TTL, resource revision, metrics, lock,
+  enabled flag, runtime owner, configuration, or concurrency work;
+- module Move, root shim change, frontend, release, or Registry work; and
+- ComfyUI server, Torch/model workload, browser, or user-instance changes.
+
+## Required validation
+
+Focused validation must prove:
+
+- capture/checkout preserve the A169-CACHE-01 clone count and logical bytes;
+- structural field reassignment fails;
+- source and returned-hit mutations cannot reach the stored snapshot;
+- overwrite replaces entry identity without mutating the previous entry;
+- get preserves a canonical entry identity while returning independent copies;
+- falsey patched entries remain misses and non-empty legacy mapping entries
+  remain readable;
+- exact LRU/cap/clear/root alias behavior remains unchanged; and
+- analyzer/import-boundary/package contracts remain valid.
+
+One official full validation follows focused success. No server, model,
+browser, or user-instance smoke is required.

--- a/docs/architecture/aio-first-pass-cache-entry-contract.md
+++ b/docs/architecture/aio-first-pass-cache-entry-contract.md
@@ -5,7 +5,7 @@
 - PR type: Behavior
 - Baseline: `dev` commit
   `366c4709edb5da8bcf450891221fbcdd474b29f8`
-- State: INVENTORY
+- State: VALIDATED
 
 A169-CACHE-02 turns each cache value into a structurally frozen, cache-owned
 snapshot and defines overwrite as whole-entry replacement. It keeps the
@@ -120,3 +120,23 @@ Focused validation must prove:
 
 One official full validation follows focused success. No server, model,
 browser, or user-instance smoke is required.
+
+## Validation result
+
+Validated on the A169-CACHE-02 worktree:
+
+- frozen entry, legacy mapping fallback, LRU/cap/clear/root aliases: 9 focused
+  cache tests passed;
+- A169-CACHE-01 benchmark/mutation-isolation contract: 3 focused tests passed;
+- First-pass stage caller: 5 focused tests passed;
+- default bounded benchmark retained 50 clones and 3,276,800 logical copied
+  bytes for both put-overwrite and get-hit, with both isolation checks true;
+- targeted Ruff 0.15.22 and Pyright 1.1.411: changed production file passed
+  with 0 errors;
+- Python backend analyzer: 18 focused tests passed;
+- Python import-boundary gate: 6 completed package groups, 0 violations; and
+- official full: 1,101 Python tests plus 112 frontend JavaScript files passed,
+  with the reviewed Pyright baseline unchanged at 88 files and 14 errors.
+
+No clone count, key, miss, LRU, cap, clear, alias, caller, stage, server, model,
+browser, workflow, frontend, or user-instance behavior was changed.

--- a/docs/architecture/python-backend-execution-roadmap.md
+++ b/docs/architecture/python-backend-execution-roadmap.md
@@ -407,7 +407,7 @@ mechanical retirement series.
 | 14 | B-11 registration/bootstrap/root shim | COMPLETE in PR #356 | Move/Contract, split PRs | #184 | Zero runtime binders/residual implementation; explicit root `__all__`; frozen compatibility audit |
 | 15 | S167 backend seed reservation series | S167-01 through S167-03d COMPLETE on `dev`; S167-03e AiO cutover VALIDATED with isolated API/module/browser-load parity | Contract then Move then Behavior | #167 | Canonical AiO/node seams |
 | 16 | A169 stage pipeline series | A169-01 through A169-08 MERGED; A169-09 final adapter/integration VALIDATED in PR #372 | Contract then Behavior | #169 | Typed config and mechanical AiO move |
-| 17 | A169 first-pass cache policy | A169-CACHE-01 MERGED; A169-CACHE-02 immutable entry/copy-on-write contract INVENTORY | Contract then Behavior | #169 | Mechanical cache move and stable stage seam |
+| 17 | A169 first-pass cache policy | A169-CACHE-01 MERGED; A169-CACHE-02 immutable entry/copy-on-write contract VALIDATED in PR #374 | Contract then Behavior | #169 | Mechanical cache move and stable stage seam |
 | 18 | D-series canonical root consolidation | BLOCKED by relevant C contracts | Move | #186 | Phase B exit; per-feature behavior stable |
 | 19 | E-series RuntimeServices/lifecycle | BLOCKED by canonical owners | Move/Contract, split PRs | #187 | Relevant D moves |
 | 20 | G-04 through G-06 and H | INCREMENTAL/LATER | Gate/Contract | #188 | Appropriate package and release evidence |

--- a/docs/architecture/python-backend-execution-roadmap.md
+++ b/docs/architecture/python-backend-execution-roadmap.md
@@ -407,7 +407,7 @@ mechanical retirement series.
 | 14 | B-11 registration/bootstrap/root shim | COMPLETE in PR #356 | Move/Contract, split PRs | #184 | Zero runtime binders/residual implementation; explicit root `__all__`; frozen compatibility audit |
 | 15 | S167 backend seed reservation series | S167-01 through S167-03d COMPLETE on `dev`; S167-03e AiO cutover VALIDATED with isolated API/module/browser-load parity | Contract then Move then Behavior | #167 | Canonical AiO/node seams |
 | 16 | A169 stage pipeline series | A169-01 through A169-08 MERGED; A169-09 final adapter/integration VALIDATED in PR #372 | Contract then Behavior | #169 | Typed config and mechanical AiO move |
-| 17 | A169 first-pass cache policy | A169-CACHE-01 benchmark/mutation-isolation harness VALIDATED in PR #373; policy units wait on its evidence | Contract then Behavior | #169 | Mechanical cache move and stable stage seam |
+| 17 | A169 first-pass cache policy | A169-CACHE-01 MERGED; A169-CACHE-02 immutable entry/copy-on-write contract INVENTORY | Contract then Behavior | #169 | Mechanical cache move and stable stage seam |
 | 18 | D-series canonical root consolidation | BLOCKED by relevant C contracts | Move | #186 | Phase B exit; per-feature behavior stable |
 | 19 | E-series RuntimeServices/lifecycle | BLOCKED by canonical owners | Move/Contract, split PRs | #187 | Relevant D moves |
 | 20 | G-04 through G-06 and H | INCREMENTAL/LATER | Gate/Contract | #188 | Appropriate package and release evidence |

--- a/easyuse_anima/aio/first_pass_cache.py
+++ b/easyuse_anima/aio/first_pass_cache.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from typing import Any
 
 from ..common.serialization import _stable_change_key
@@ -9,7 +10,31 @@ from ..prompt.data import _prompt_data_json_safe
 from .model_preparation import _aio_lora_stack_signature
 
 AIO_FIRST_PASS_CACHE_MAX_ENTRIES = 2
-_AIO_FIRST_PASS_CACHE: dict[str, dict[str, Any]] = {}
+
+
+@dataclass(frozen=True, slots=True)
+class _AIOFirstPassCacheEntry:
+    latent: Any
+    image: Any
+
+    @classmethod
+    def capture(cls, latent, image) -> _AIOFirstPassCacheEntry:
+        return cls(
+            latent=_clone_aio_cache_value(latent),
+            image=_clone_aio_cache_value(image),
+        )
+
+    def checkout(self):
+        return (
+            _clone_aio_cache_value(self.latent),
+            _clone_aio_cache_value(self.image),
+        )
+
+
+_AIO_FIRST_PASS_CACHE: dict[
+    str,
+    _AIOFirstPassCacheEntry | dict[str, Any],
+] = {}
 _AIO_FIRST_PASS_CACHE_ORDER: list[str] = []
 
 
@@ -102,6 +127,8 @@ def _get_aio_first_pass_cache(cache_key: str):
     if cache_key in _AIO_FIRST_PASS_CACHE_ORDER:
         _AIO_FIRST_PASS_CACHE_ORDER.remove(cache_key)
     _AIO_FIRST_PASS_CACHE_ORDER.append(cache_key)
+    if isinstance(entry, _AIOFirstPassCacheEntry):
+        return entry.checkout()
     return (
         _clone_aio_cache_value(entry["latent"]),
         _clone_aio_cache_value(entry["image"]),
@@ -109,10 +136,7 @@ def _get_aio_first_pass_cache(cache_key: str):
 
 
 def _put_aio_first_pass_cache(cache_key: str, latent, image) -> None:
-    entry = {
-        "latent": _clone_aio_cache_value(latent),
-        "image": _clone_aio_cache_value(image),
-    }
+    entry = _AIOFirstPassCacheEntry.capture(latent, image)
     _AIO_FIRST_PASS_CACHE[cache_key] = entry
     if cache_key in _AIO_FIRST_PASS_CACHE_ORDER:
         _AIO_FIRST_PASS_CACHE_ORDER.remove(cache_key)

--- a/tests/fixtures/python_backend_baseline.json
+++ b/tests/fixtures/python_backend_baseline.json
@@ -4640,6 +4640,23 @@
       },
       {
         "alias": null,
+        "bound_name": "dataclass",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "dataclasses:dataclass",
+        "kind": "static_from",
+        "line": 5,
+        "name": "dataclass",
+        "optional": false,
+        "requested": "dataclasses",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/aio/first_pass_cache.py"
+      },
+      {
+        "alias": null,
         "bound_name": "Any",
         "branch_context": [],
         "classification": "external",
@@ -4647,7 +4664,7 @@
         "conditional": false,
         "imported": "typing:Any",
         "kind": "static_from",
-        "line": 5,
+        "line": 6,
         "name": "Any",
         "optional": false,
         "requested": "typing",
@@ -4664,7 +4681,7 @@
         "conditional": false,
         "imported": "..common.serialization:_stable_change_key",
         "kind": "static_from",
-        "line": 7,
+        "line": 8,
         "name": "_stable_change_key",
         "optional": false,
         "requested": "..common.serialization",
@@ -4682,7 +4699,7 @@
         "conditional": false,
         "imported": "..prompt.data:_prompt_data_json_safe",
         "kind": "static_from",
-        "line": 8,
+        "line": 9,
         "name": "_prompt_data_json_safe",
         "optional": false,
         "requested": "..prompt.data",
@@ -4700,7 +4717,7 @@
         "conditional": false,
         "imported": ".model_preparation:_aio_lora_stack_signature",
         "kind": "static_from",
-        "line": 9,
+        "line": 10,
         "name": "_aio_lora_stack_signature",
         "optional": false,
         "requested": ".model_preparation",
@@ -48800,12 +48817,12 @@
       },
       {
         "is_package": false,
-        "loc": 125,
+        "loc": 149,
         "module": "easyuse_anima.aio.first_pass_cache",
-        "normalized_git_blob_sha1": "872fc97c6a338c600cbc141faaaaf9d584d02c4a",
+        "normalized_git_blob_sha1": "c46472b68b24e116d882fbb96ba9c2e1a3ca246b",
         "path": "easyuse_anima/aio/first_pass_cache.py",
         "top_level": {
-          "class_count": 0,
+          "class_count": 1,
           "function_count": 5,
           "global_count": 4
         }
@@ -59684,9 +59701,20 @@
         "branch_context": [],
         "classification": "external",
         "conditional": false,
-        "imported": "typing:Any",
+        "imported": "dataclasses:dataclass",
         "kind": "static_from",
         "line": 5,
+        "optional": false,
+        "role": "ordinary",
+        "source": "easyuse_anima/aio/first_pass_cache.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "typing:Any",
+        "kind": "static_from",
+        "line": 6,
         "optional": false,
         "role": "ordinary",
         "source": "easyuse_anima/aio/first_pass_cache.py"
@@ -65692,6 +65720,15 @@
       {
         "callee": "dataclass",
         "column": 1,
+        "context": "decorator:_AIOFirstPassCacheEntry",
+        "kind": "import_time_call",
+        "line": 15,
+        "module": "easyuse_anima/aio/first_pass_cache.py",
+        "scope": "<module>"
+      },
+      {
+        "callee": "dataclass",
+        "column": 1,
         "context": "decorator:AIOGenerationSAM3Config",
         "kind": "import_time_call",
         "line": 25,
@@ -66997,13 +67034,13 @@
       },
       {
         "kind": "dict",
-        "line": 12,
+        "line": 34,
         "module": "easyuse_anima/aio/first_pass_cache.py",
         "name": "_AIO_FIRST_PASS_CACHE"
       },
       {
         "kind": "list",
-        "line": 13,
+        "line": 38,
         "module": "easyuse_anima/aio/first_pass_cache.py",
         "name": "_AIO_FIRST_PASS_CACHE_ORDER"
       },
@@ -67376,7 +67413,7 @@
           "mutable_container"
         ],
         "initializer": "Dict",
-        "line": 12,
+        "line": 34,
         "module": "easyuse_anima/aio/first_pass_cache.py",
         "name": "_AIO_FIRST_PASS_CACHE"
       },
@@ -67386,7 +67423,7 @@
           "mutable_container"
         ],
         "initializer": "List",
-        "line": 13,
+        "line": 38,
         "module": "easyuse_anima/aio/first_pass_cache.py",
         "name": "_AIO_FIRST_PASS_CACHE_ORDER"
       },

--- a/tests/test_aio_first_pass_cache.py
+++ b/tests/test_aio_first_pass_cache.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import unittest
+from dataclasses import FrozenInstanceError
 from unittest.mock import Mock, patch
 
 import nodes
@@ -178,6 +179,76 @@ class AIOFirstPassCacheMoveTests(unittest.TestCase):
         self.assertEqual(cache, {})
         self.assertEqual(order, [])
 
+    def test_nonempty_legacy_mapping_entry_remains_readable_and_isolated(self):
+        cache = {
+            "legacy": {
+                "latent": {"samples": [1]},
+                "image": [2],
+            }
+        }
+        order = ["legacy"]
+        with (
+            patch.object(first_pass_cache, "_AIO_FIRST_PASS_CACHE", cache),
+            patch.object(first_pass_cache, "_AIO_FIRST_PASS_CACHE_ORDER", order),
+        ):
+            latent, image = first_pass_cache._get_aio_first_pass_cache("legacy")
+            latent["samples"].append(99)
+            image.append(99)
+
+        self.assertEqual(
+            cache,
+            {
+                "legacy": {
+                    "latent": {"samples": [1]},
+                    "image": [2],
+                }
+            },
+        )
+        self.assertEqual(order, ["legacy"])
+
+    def test_frozen_entry_checkout_and_overwrite_are_copy_on_write(self):
+        first_pass_cache._put_aio_first_pass_cache(
+            "entry",
+            {"samples": [1]},
+            [2],
+        )
+        original_entry = first_pass_cache._AIO_FIRST_PASS_CACHE["entry"]
+
+        self.assertIsInstance(
+            original_entry,
+            first_pass_cache._AIOFirstPassCacheEntry,
+        )
+        with self.assertRaises(FrozenInstanceError):
+            setattr(original_entry, "latent", {"samples": [99]})
+
+        latent, image = first_pass_cache._get_aio_first_pass_cache("entry")
+        self.assertIs(
+            first_pass_cache._AIO_FIRST_PASS_CACHE["entry"],
+            original_entry,
+        )
+        latent["samples"].append(88)
+        image.append(88)
+        self.assertEqual(
+            original_entry.checkout(),
+            ({"samples": [1]}, [2]),
+        )
+
+        first_pass_cache._put_aio_first_pass_cache(
+            "entry",
+            {"samples": [3]},
+            [4],
+        )
+        replacement_entry = first_pass_cache._AIO_FIRST_PASS_CACHE["entry"]
+        self.assertIsNot(replacement_entry, original_entry)
+        self.assertEqual(
+            original_entry.checkout(),
+            ({"samples": [1]}, [2]),
+        )
+        self.assertEqual(
+            replacement_entry.checkout(),
+            ({"samples": [3]}, [4]),
+        )
+
     def test_put_get_clone_isolation_lru_refresh_overwrite_and_eviction(self):
         latent = {"samples": [1]}
         image = [2]
@@ -220,7 +291,15 @@ class AIOFirstPassCacheMoveTests(unittest.TestCase):
             first_pass_cache._put_aio_first_pass_cache("a", "latent-a", "image-a")
             first_pass_cache._put_aio_first_pass_cache("b", "latent-b", "image-b")
 
-        self.assertEqual(cache, {"b": {"latent": "latent-b", "image": "image-b"}})
+        entry = cache["b"]
+        self.assertIsInstance(
+            entry,
+            first_pass_cache._AIOFirstPassCacheEntry,
+        )
+        self.assertEqual(
+            (entry.latent, entry.image),
+            ("latent-b", "image-b"),
+        )
         self.assertEqual(order, ["b"])
 
 


### PR DESCRIPTION
## 변경 요약

- #169 로드맵의 A169-CACHE-02 immutable entry/copy-on-write Behavior를 완료합니다.
- cache mapping value를 private frozen/slots entry로 구조화합니다.
- put은 caller-owned 값을 capture하고, get은 cache-owned snapshot에서 독립 checkout copy를 반환합니다.
- overwrite는 기존 entry를 mutate하지 않고 새 entry로 wholesale replacement합니다.
- clone 횟수·논리 복사량·양방향 mutation isolation은 CACHE-01 baseline을 유지합니다.

## 주요 파일

- `easyuse_anima/aio/first_pass_cache.py`
- `tests/test_aio_first_pass_cache.py`
- `tests/fixtures/python_backend_baseline.json`
- `docs/architecture/aio-first-pass-cache-entry-contract.md`
- `docs/architecture/python-backend-execution-roadmap.md`

## 호환 경계

- canonical mapping/order 객체 identity 유지
- root max/mapping/order/clone/key/get/put direct aliases 유지
- key, miss, LRU refresh, fixed cap, clear-in-place 유지
- falsey patched entry는 계속 miss
- non-empty legacy mapping entry는 clone된 tuple로 계속 읽기 가능
- First-pass stage/runtime caller와 반환 shape `(latent, image) | None` 유지
- frozen은 field reassignment만 차단하며 deep tensor immutability는 주장하지 않음

## 검증

- `tests.test_aio_first_pass_cache`: 9 passed
- `tests.test_aio_first_pass_cache_benchmark`: 3 passed
- `tests.test_aio_first_pass_stage`: 5 passed
- `tests.test_python_backend_analyzer`: 18 passed
- default bounded benchmark
  - put-overwrite/get-hit 각각 50 clones
  - 각각 3,276,800 logical copied bytes
  - source-after-put/returned-hit isolation 모두 true
- targeted Ruff 0.15.22: changed production file passed
- targeted Pyright 1.1.411: 1 file, 0 errors
- Python import boundary: 6 groups, 0 violations
- official full
  - Python unittest: 1,101 passed
  - frontend: 112 JavaScript files passed
  - Pyright baseline: 88 files, reviewed 14 errors 유지
  - import boundary와 `git diff --check` passed

## 테스트 표면과 남은 위험

- ComfyUI Codex test environment: repository full validation
- Live ComfyUI/server/model/browser smoke: 실행하지 않음
- clone 제거/최적화는 수행하지 않음
- 다음 CACHE-03 byte budget/single-entry cap이 별도 Behavior로 entry metadata와 eviction policy를 소유
