### PR TITLE
feat: budget AiO first-pass cache bytes

### DIFF
--- a/docs/architecture/aio-first-pass-cache-byte-budget.md
+++ b/docs/architecture/aio-first-pass-cache-byte-budget.md
@@ -1,0 +1,131 @@
+# AiO first-pass cache byte budget and single-entry cap
+
+- Owner issue: [#169](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/169)
+- Roadmap unit: A169-CACHE-03
+- PR type: Behavior
+- Baseline: `dev` commit
+  `2b54ee0a803dfdf90a5da0c36147258298659d2f`
+- State: INVENTORY
+
+A169-CACHE-03 adds deterministic payload-byte accounting, a total cache
+budget, and a single-entry cap. It leaves time, invalidation, metrics,
+concurrency, and runtime ownership to later units.
+
+## Symbol, caller, alias, and state inventory
+
+### Current state and policy
+
+- `_AIO_FIRST_PASS_CACHE` maps keys to frozen cache-owned entries or a narrow
+  legacy mapping fallback.
+- `_AIO_FIRST_PASS_CACHE_ORDER` records oldest-to-newest access order.
+- `AIO_FIRST_PASS_CACHE_MAX_ENTRIES` remains `2`.
+- Each canonical entry owns latent/image snapshots but has no size metadata.
+- Put captures before insertion, refreshes LRU order, then evicts only by entry
+  count.
+- Get returns an independent checkout copy and refreshes order.
+- Clear mutates the canonical mapping/order objects in place.
+
+### Callers and compatibility aliases
+
+- The canonical pipeline and First-pass stage use only get/put return behavior.
+- Root `nodes.py` aliases the existing count constant, mapping/order objects,
+  clone/key/get/put helpers. Those identities and names remain unchanged.
+- Put returns `None`; an oversized skip must retain that return contract.
+- Existing call-time replacement of mapping/order/count remains valid.
+- No caller currently consumes entry size or total cache bytes.
+
+## Byte-accounting contract
+
+The estimator reports deterministic logical payload bytes, not Python object
+overhead or process RSS:
+
+1. count each object identity at most once per estimate;
+2. recursively traverse dictionaries, lists, and tuples;
+3. count `bytes`, `bytearray`, and `memoryview` length;
+4. prefer callable tensor-style `numel() * element_size()`;
+5. otherwise accept a non-negative integer `nbytes`;
+6. treat unsupported or failing objects as zero bytes.
+
+This intentionally over- or under-approximates some storage-sharing objects;
+it is a stable admission/eviction key, not an RSS claim. CACHE-06 owns real
+4K/batch peak allocation and RSS evidence.
+
+Each frozen canonical entry records `size_bytes` after capture. Legacy mapping
+entries are estimated at read/eviction time.
+
+## Policy decision
+
+- Total logical payload budget: `512 MiB`.
+- Single-entry logical payload cap: `256 MiB`.
+- Existing maximum entry count: `2`.
+
+The total budget matches two maximum-size entries and the current two-entry
+policy. The single cap is intended to admit a typical 4K batch-1 image/latent
+payload while preventing one larger batch from monopolizing CPU cache memory.
+These are explicit private-policy constants, not serialized user settings.
+CACHE-06 may revise them with model-backed 4K/RSS evidence in a separate PR.
+
+Put behavior:
+
+1. capture caller values with the unchanged clone contract;
+2. record deterministic entry bytes;
+3. if entry bytes exceed the single cap, skip insertion without mutating
+   mapping/order or an existing same-key entry;
+4. otherwise insert/replace and refresh LRU order; and
+5. evict oldest entries until both count and total-byte budgets are satisfied.
+
+Get, key, clone, clear, root aliases, return shape, and stage metadata remain
+unchanged.
+
+## Allowed-file boundary
+
+A169-CACHE-03 may change only:
+
+- `easyuse_anima/aio/first_pass_cache.py`;
+- `tests/test_aio_first_pass_cache.py`;
+- `tools/benchmark_aio_first_pass_cache.py` only to expose deterministic fake
+  tensor bytes;
+- `tests/test_aio_first_pass_cache_benchmark.py`;
+- `tests/test_python_backend_analyzer.py`;
+- `tests/fixtures/python_backend_baseline.json`, regenerated from source;
+- this document;
+- `docs/architecture/aio-first-pass-cache-entry-contract.md`; and
+- `docs/architecture/python-backend-execution-roadmap.md`.
+
+Read-only evidence:
+
+- `easyuse_anima/aio/generation_first_pass.py`;
+- `easyuse_anima/aio/legacy_generation.py`;
+- root `nodes.py`;
+- `tests/test_aio_first_pass_stage.py`;
+- `tests/test_aio_legacy_generation.py`;
+- `tests/test_aio_nodes.py`; and
+- `tests/fixtures/python_compatibility_surface.v1.json`.
+
+Forbidden:
+
+- removing or reordering put/get clones;
+- changing key, miss, get, clear, caller, alias, stage, seed, sampling,
+  preview, metadata, Save, workflow, or socket behavior;
+- TTL, clock, explicit enable/disable, resource revision, metrics, lock,
+  concurrency, runtime owner, or serialized configuration;
+- claiming real GPU/CPU allocation, latency, or RSS from logical bytes;
+- module Move, root shim, frontend, release, or Registry work; and
+- ComfyUI server, Torch/model workload, browser, or user-instance changes.
+
+## Required validation
+
+Focused validation must prove:
+
+- byte estimation for nested tensor/bytes values, shared identities, failures,
+  and unsupported values;
+- canonical entry size matches captured payloads;
+- entries over 256 MiB are skipped without mutating mapping/order;
+- total budget and count cap evict oldest entries independently and together;
+- overwrite and legacy mapping fallback participate in byte accounting;
+- clone count, logical copied bytes, mutation isolation, get, key, clear, LRU,
+  root aliases, stage caller, and return contracts remain unchanged; and
+- analyzer/import-boundary/package contracts remain valid.
+
+One official full validation follows focused success. No server, model,
+browser, or user-instance smoke is required.

--- a/docs/architecture/aio-first-pass-cache-byte-budget.md
+++ b/docs/architecture/aio-first-pass-cache-byte-budget.md
@@ -5,7 +5,7 @@
 - PR type: Behavior
 - Baseline: `dev` commit
   `2b54ee0a803dfdf90a5da0c36147258298659d2f`
-- State: INVENTORY
+- State: VALIDATED
 
 A169-CACHE-03 adds deterministic payload-byte accounting, a total cache
 budget, and a single-entry cap. It leaves time, invalidation, metrics,
@@ -67,12 +67,14 @@ CACHE-06 may revise them with model-backed 4K/RSS evidence in a separate PR.
 
 Put behavior:
 
-1. capture caller values with the unchanged clone contract;
-2. record deterministic entry bytes;
-3. if entry bytes exceed the single cap, skip insertion without mutating
-   mapping/order or an existing same-key entry;
-4. otherwise insert/replace and refresh LRU order; and
-5. evict oldest entries until both count and total-byte budgets are satisfied.
+1. preflight caller payload bytes;
+2. if preflight bytes exceed the single cap, skip before cloning without
+   mutating mapping/order or an existing same-key entry;
+3. capture admitted caller values with the unchanged clone contract and record
+   deterministic cache-owned entry bytes;
+4. defensively skip if the captured entry exceeds the cap;
+5. otherwise insert/replace and refresh LRU order; and
+6. evict oldest entries until both count and total-byte budgets are satisfied.
 
 Get, key, clone, clear, root aliases, return shape, and stage metadata remain
 unchanged.
@@ -120,7 +122,7 @@ Focused validation must prove:
 - byte estimation for nested tensor/bytes values, shared identities, failures,
   and unsupported values;
 - canonical entry size matches captured payloads;
-- entries over 256 MiB are skipped without mutating mapping/order;
+- entries over 256 MiB are skipped without cloning or mutating mapping/order;
 - total budget and count cap evict oldest entries independently and together;
 - overwrite and legacy mapping fallback participate in byte accounting;
 - clone count, logical copied bytes, mutation isolation, get, key, clear, LRU,
@@ -129,3 +131,28 @@ Focused validation must prove:
 
 One official full validation follows focused success. No server, model,
 browser, or user-instance smoke is required.
+
+## Validation result
+
+Validated on the A169-CACHE-03 worktree:
+
+- byte estimator, explicit defaults, oversize preflight, total/count eviction,
+  legacy accounting, frozen entry, LRU/cap/clear/root aliases: 14 focused cache
+  tests passed;
+- benchmark byte exposure and clone/mutation contract: 4 focused tests passed;
+- First-pass stage caller: 5 focused tests passed;
+- default bounded benchmark retained 50 clones and 3,276,800 logical copied
+  bytes for both admitted put-overwrite and get-hit, with both isolation checks
+  true;
+- oversized preflight was proven to perform zero clones and preserve an
+  existing same-key entry/order;
+- targeted Ruff 0.15.22 and Pyright 1.1.411: changed production/tool/test files
+  passed, production file with 0 Pyright errors;
+- Python backend analyzer: 18 focused tests passed;
+- Python import-boundary gate: 6 completed package groups, 0 violations; and
+- official full: 1,107 Python tests plus 112 frontend JavaScript files passed,
+  with the reviewed Pyright baseline unchanged at 88 files and 14 errors.
+
+No TTL, clock, disable, resource revision, metrics, concurrency, runtime owner,
+server, model, browser, workflow, frontend, or user-instance behavior was
+changed.

--- a/docs/architecture/python-backend-execution-roadmap.md
+++ b/docs/architecture/python-backend-execution-roadmap.md
@@ -407,7 +407,7 @@ mechanical retirement series.
 | 14 | B-11 registration/bootstrap/root shim | COMPLETE in PR #356 | Move/Contract, split PRs | #184 | Zero runtime binders/residual implementation; explicit root `__all__`; frozen compatibility audit |
 | 15 | S167 backend seed reservation series | S167-01 through S167-03d COMPLETE on `dev`; S167-03e AiO cutover VALIDATED with isolated API/module/browser-load parity | Contract then Move then Behavior | #167 | Canonical AiO/node seams |
 | 16 | A169 stage pipeline series | A169-01 through A169-08 MERGED; A169-09 final adapter/integration VALIDATED in PR #372 | Contract then Behavior | #169 | Typed config and mechanical AiO move |
-| 17 | A169 first-pass cache policy | A169-CACHE-01 MERGED; A169-CACHE-02 immutable entry/copy-on-write contract VALIDATED in PR #374 | Contract then Behavior | #169 | Mechanical cache move and stable stage seam |
+| 17 | A169 first-pass cache policy | A169-CACHE-01/02 MERGED; A169-CACHE-03 byte budget/single-entry cap INVENTORY | Contract then Behavior | #169 | Mechanical cache move and stable stage seam |
 | 18 | D-series canonical root consolidation | BLOCKED by relevant C contracts | Move | #186 | Phase B exit; per-feature behavior stable |
 | 19 | E-series RuntimeServices/lifecycle | BLOCKED by canonical owners | Move/Contract, split PRs | #187 | Relevant D moves |
 | 20 | G-04 through G-06 and H | INCREMENTAL/LATER | Gate/Contract | #188 | Appropriate package and release evidence |

--- a/docs/architecture/python-backend-execution-roadmap.md
+++ b/docs/architecture/python-backend-execution-roadmap.md
@@ -407,7 +407,7 @@ mechanical retirement series.
 | 14 | B-11 registration/bootstrap/root shim | COMPLETE in PR #356 | Move/Contract, split PRs | #184 | Zero runtime binders/residual implementation; explicit root `__all__`; frozen compatibility audit |
 | 15 | S167 backend seed reservation series | S167-01 through S167-03d COMPLETE on `dev`; S167-03e AiO cutover VALIDATED with isolated API/module/browser-load parity | Contract then Move then Behavior | #167 | Canonical AiO/node seams |
 | 16 | A169 stage pipeline series | A169-01 through A169-08 MERGED; A169-09 final adapter/integration VALIDATED in PR #372 | Contract then Behavior | #169 | Typed config and mechanical AiO move |
-| 17 | A169 first-pass cache policy | A169-CACHE-01/02 MERGED; A169-CACHE-03 byte budget/single-entry cap INVENTORY | Contract then Behavior | #169 | Mechanical cache move and stable stage seam |
+| 17 | A169 first-pass cache policy | A169-CACHE-01/02 MERGED; A169-CACHE-03 byte budget/single-entry cap VALIDATED in PR #375 | Contract then Behavior | #169 | Mechanical cache move and stable stage seam |
 | 18 | D-series canonical root consolidation | BLOCKED by relevant C contracts | Move | #186 | Phase B exit; per-feature behavior stable |
 | 19 | E-series RuntimeServices/lifecycle | BLOCKED by canonical owners | Move/Contract, split PRs | #187 | Relevant D moves |
 | 20 | G-04 through G-06 and H | INCREMENTAL/LATER | Gate/Contract | #188 | Appropriate package and release evidence |

--- a/easyuse_anima/aio/first_pass_cache.py
+++ b/easyuse_anima/aio/first_pass_cache.py
@@ -10,18 +10,27 @@ from ..prompt.data import _prompt_data_json_safe
 from .model_preparation import _aio_lora_stack_signature
 
 AIO_FIRST_PASS_CACHE_MAX_ENTRIES = 2
+AIO_FIRST_PASS_CACHE_MAX_BYTES = 512 * 1024 * 1024
+AIO_FIRST_PASS_CACHE_MAX_ENTRY_BYTES = 256 * 1024 * 1024
 
 
 @dataclass(frozen=True, slots=True)
 class _AIOFirstPassCacheEntry:
     latent: Any
     image: Any
+    size_bytes: int
 
     @classmethod
     def capture(cls, latent, image) -> _AIOFirstPassCacheEntry:
+        latent_snapshot = _clone_aio_cache_value(latent)
+        image_snapshot = _clone_aio_cache_value(image)
         return cls(
-            latent=_clone_aio_cache_value(latent),
-            image=_clone_aio_cache_value(image),
+            latent=latent_snapshot,
+            image=image_snapshot,
+            size_bytes=_aio_cache_pair_size_bytes(
+                latent_snapshot,
+                image_snapshot,
+            ),
         )
 
     def checkout(self):
@@ -61,6 +70,94 @@ def _clone_aio_cache_value(value):
                 pass
         return tensor
     return value
+
+
+def _aio_cache_value_size_bytes(
+    value,
+    *,
+    _seen: set[int] | None = None,
+) -> int:
+    seen = set() if _seen is None else _seen
+    identity = id(value)
+    if identity in seen:
+        return 0
+    seen.add(identity)
+
+    if isinstance(value, dict):
+        return sum(
+            _aio_cache_value_size_bytes(item, _seen=seen)
+            for item in value.values()
+        )
+    if isinstance(value, (list, tuple)):
+        return sum(
+            _aio_cache_value_size_bytes(item, _seen=seen)
+            for item in value
+        )
+    if isinstance(value, (bytes, bytearray)):
+        return len(value)
+    if isinstance(value, memoryview):
+        return value.nbytes
+
+    try:
+        numel = getattr(value, "numel", None)
+        element_size = getattr(value, "element_size", None)
+    except Exception:
+        numel = None
+        element_size = None
+    if callable(numel) and callable(element_size):
+        try:
+            count = numel()
+            item_bytes = element_size()
+            if (
+                isinstance(count, int)
+                and not isinstance(count, bool)
+                and isinstance(item_bytes, int)
+                and not isinstance(item_bytes, bool)
+                and count >= 0
+                and item_bytes >= 0
+            ):
+                return count * item_bytes
+        except Exception:
+            pass
+
+    try:
+        nbytes = getattr(value, "nbytes", None)
+    except Exception:
+        nbytes = None
+    if callable(nbytes):
+        try:
+            nbytes = nbytes()
+        except Exception:
+            nbytes = None
+    if isinstance(nbytes, int) and not isinstance(nbytes, bool):
+        return max(0, nbytes)
+    return 0
+
+
+def _aio_cache_pair_size_bytes(latent, image) -> int:
+    seen: set[int] = set()
+    return (
+        _aio_cache_value_size_bytes(latent, _seen=seen)
+        + _aio_cache_value_size_bytes(image, _seen=seen)
+    )
+
+
+def _aio_first_pass_cache_entry_size_bytes(entry) -> int:
+    if isinstance(entry, _AIOFirstPassCacheEntry):
+        return entry.size_bytes
+    if isinstance(entry, dict):
+        return _aio_cache_pair_size_bytes(
+            entry.get("latent"),
+            entry.get("image"),
+        )
+    return 0
+
+
+def _aio_first_pass_cache_total_bytes() -> int:
+    return sum(
+        _aio_first_pass_cache_entry_size_bytes(entry)
+        for entry in _AIO_FIRST_PASS_CACHE.values()
+    )
 
 
 def _clear_aio_first_pass_cache() -> None:
@@ -136,12 +233,22 @@ def _get_aio_first_pass_cache(cache_key: str):
 
 
 def _put_aio_first_pass_cache(cache_key: str, latent, image) -> None:
+    if (
+        _aio_cache_pair_size_bytes(latent, image)
+        > AIO_FIRST_PASS_CACHE_MAX_ENTRY_BYTES
+    ):
+        return
     entry = _AIOFirstPassCacheEntry.capture(latent, image)
+    if entry.size_bytes > AIO_FIRST_PASS_CACHE_MAX_ENTRY_BYTES:
+        return
     _AIO_FIRST_PASS_CACHE[cache_key] = entry
     if cache_key in _AIO_FIRST_PASS_CACHE_ORDER:
         _AIO_FIRST_PASS_CACHE_ORDER.remove(cache_key)
     _AIO_FIRST_PASS_CACHE_ORDER.append(cache_key)
-    while len(_AIO_FIRST_PASS_CACHE_ORDER) > AIO_FIRST_PASS_CACHE_MAX_ENTRIES:
+    while _AIO_FIRST_PASS_CACHE_ORDER and (
+        len(_AIO_FIRST_PASS_CACHE_ORDER) > AIO_FIRST_PASS_CACHE_MAX_ENTRIES
+        or _aio_first_pass_cache_total_bytes() > AIO_FIRST_PASS_CACHE_MAX_BYTES
+    ):
         old_key = _AIO_FIRST_PASS_CACHE_ORDER.pop(0)
         _AIO_FIRST_PASS_CACHE.pop(old_key, None)
 

--- a/tests/fixtures/python_backend_baseline.json
+++ b/tests/fixtures/python_backend_baseline.json
@@ -48817,14 +48817,14 @@
       },
       {
         "is_package": false,
-        "loc": 149,
+        "loc": 256,
         "module": "easyuse_anima.aio.first_pass_cache",
-        "normalized_git_blob_sha1": "c46472b68b24e116d882fbb96ba9c2e1a3ca246b",
+        "normalized_git_blob_sha1": "184b29009ac138dbc1eced33f848cd40097b6352",
         "path": "easyuse_anima/aio/first_pass_cache.py",
         "top_level": {
           "class_count": 1,
-          "function_count": 5,
-          "global_count": 4
+          "function_count": 9,
+          "global_count": 6
         }
       },
       {
@@ -65722,7 +65722,7 @@
         "column": 1,
         "context": "decorator:_AIOFirstPassCacheEntry",
         "kind": "import_time_call",
-        "line": 15,
+        "line": 17,
         "module": "easyuse_anima/aio/first_pass_cache.py",
         "scope": "<module>"
       },
@@ -67034,13 +67034,13 @@
       },
       {
         "kind": "dict",
-        "line": 34,
+        "line": 43,
         "module": "easyuse_anima/aio/first_pass_cache.py",
         "name": "_AIO_FIRST_PASS_CACHE"
       },
       {
         "kind": "list",
-        "line": 38,
+        "line": 47,
         "module": "easyuse_anima/aio/first_pass_cache.py",
         "name": "_AIO_FIRST_PASS_CACHE_ORDER"
       },
@@ -67413,7 +67413,7 @@
           "mutable_container"
         ],
         "initializer": "Dict",
-        "line": 34,
+        "line": 43,
         "module": "easyuse_anima/aio/first_pass_cache.py",
         "name": "_AIO_FIRST_PASS_CACHE"
       },
@@ -67423,7 +67423,7 @@
           "mutable_container"
         ],
         "initializer": "List",
-        "line": 38,
+        "line": 47,
         "module": "easyuse_anima/aio/first_pass_cache.py",
         "name": "_AIO_FIRST_PASS_CACHE_ORDER"
       },

--- a/tests/test_aio_first_pass_cache.py
+++ b/tests/test_aio_first_pass_cache.py
@@ -8,12 +8,65 @@ import nodes
 from easyuse_anima.aio import first_pass_cache
 
 
+class _SizedTensor:
+    def __init__(
+        self,
+        *,
+        count: int,
+        item_bytes: int,
+        fail_numel: bool = False,
+        fallback_nbytes: int | None = None,
+        clone_calls: list[int] | None = None,
+    ):
+        self.count = count
+        self.item_bytes = item_bytes
+        self.fail_numel = fail_numel
+        self.nbytes = fallback_nbytes
+        self.clone_calls = clone_calls
+
+    def detach(self):
+        return self
+
+    def clone(self):
+        if self.clone_calls is not None:
+            self.clone_calls.append(self.count * self.item_bytes)
+        return _SizedTensor(
+            count=self.count,
+            item_bytes=self.item_bytes,
+            fail_numel=self.fail_numel,
+            fallback_nbytes=self.nbytes,
+            clone_calls=self.clone_calls,
+        )
+
+    def cpu(self):
+        return self
+
+    def numel(self):
+        if self.fail_numel:
+            raise RuntimeError("numel unavailable")
+        return self.count
+
+    def element_size(self):
+        return self.item_bytes
+
+
 class AIOFirstPassCacheMoveTests(unittest.TestCase):
     def setUp(self):
         first_pass_cache._clear_aio_first_pass_cache()
 
     def tearDown(self):
         first_pass_cache._clear_aio_first_pass_cache()
+
+    def test_default_count_and_byte_policy_are_explicit(self):
+        self.assertEqual(first_pass_cache.AIO_FIRST_PASS_CACHE_MAX_ENTRIES, 2)
+        self.assertEqual(
+            first_pass_cache.AIO_FIRST_PASS_CACHE_MAX_BYTES,
+            512 * 1024 * 1024,
+        )
+        self.assertEqual(
+            first_pass_cache.AIO_FIRST_PASS_CACHE_MAX_ENTRY_BYTES,
+            256 * 1024 * 1024,
+        )
 
     def test_root_state_and_functions_are_direct_canonical_aliases(self):
         self.assertFalse(
@@ -248,6 +301,151 @@ class AIOFirstPassCacheMoveTests(unittest.TestCase):
             replacement_entry.checkout(),
             ({"samples": [3]}, [4]),
         )
+
+    def test_payload_byte_estimator_is_recursive_deduplicated_and_best_effort(self):
+        tensor = _SizedTensor(count=3, item_bytes=4)
+        fallback = _SizedTensor(
+            count=0,
+            item_bytes=0,
+            fail_numel=True,
+            fallback_nbytes=9,
+        )
+        value = {
+            "tensor": tensor,
+            "shared": [tensor],
+            "bytes": b"abc",
+            "bytearray": bytearray(4),
+            "memoryview": memoryview(b"12345"),
+            "fallback": fallback,
+            "unknown": object(),
+        }
+
+        self.assertEqual(
+            first_pass_cache._aio_cache_value_size_bytes(value),
+            33,
+        )
+        self.assertEqual(
+            first_pass_cache._aio_cache_pair_size_bytes(tensor, tensor),
+            12,
+        )
+        self.assertEqual(
+            first_pass_cache._aio_cache_value_size_bytes(
+                _SizedTensor(
+                    count=0,
+                    item_bytes=0,
+                    fail_numel=True,
+                    fallback_nbytes=-1,
+                )
+            ),
+            0,
+        )
+
+    def test_single_entry_cap_skips_without_mutating_existing_state(self):
+        cache = {}
+        order = []
+        with (
+            patch.object(first_pass_cache, "_AIO_FIRST_PASS_CACHE", cache),
+            patch.object(first_pass_cache, "_AIO_FIRST_PASS_CACHE_ORDER", order),
+            patch.object(
+                first_pass_cache,
+                "AIO_FIRST_PASS_CACHE_MAX_ENTRY_BYTES",
+                8,
+            ),
+        ):
+            first_pass_cache._put_aio_first_pass_cache(
+                "entry",
+                _SizedTensor(count=1, item_bytes=4),
+                _SizedTensor(count=1, item_bytes=4),
+            )
+            existing = cache["entry"]
+            oversize_clone_calls = []
+            first_pass_cache._put_aio_first_pass_cache(
+                "entry",
+                _SizedTensor(
+                    count=2,
+                    item_bytes=4,
+                    clone_calls=oversize_clone_calls,
+                ),
+                _SizedTensor(
+                    count=1,
+                    item_bytes=4,
+                    clone_calls=oversize_clone_calls,
+                ),
+            )
+
+        self.assertIs(cache["entry"], existing)
+        self.assertEqual(order, ["entry"])
+        self.assertEqual(existing.size_bytes, 8)
+        self.assertEqual(oversize_clone_calls, [])
+
+    def test_total_byte_budget_evicts_oldest_independently_of_count_cap(self):
+        cache = {}
+        order = []
+        with (
+            patch.object(first_pass_cache, "_AIO_FIRST_PASS_CACHE", cache),
+            patch.object(first_pass_cache, "_AIO_FIRST_PASS_CACHE_ORDER", order),
+            patch.object(first_pass_cache, "AIO_FIRST_PASS_CACHE_MAX_ENTRIES", 3),
+            patch.object(
+                first_pass_cache,
+                "AIO_FIRST_PASS_CACHE_MAX_ENTRY_BYTES",
+                8,
+            ),
+            patch.object(
+                first_pass_cache,
+                "AIO_FIRST_PASS_CACHE_MAX_BYTES",
+                12,
+            ),
+        ):
+            first_pass_cache._put_aio_first_pass_cache(
+                "a",
+                _SizedTensor(count=1, item_bytes=4),
+                _SizedTensor(count=1, item_bytes=4),
+            )
+            first_pass_cache._put_aio_first_pass_cache(
+                "b",
+                _SizedTensor(count=1, item_bytes=4),
+                _SizedTensor(count=1, item_bytes=4),
+            )
+            total_bytes = first_pass_cache._aio_first_pass_cache_total_bytes()
+
+        self.assertEqual(set(cache), {"b"})
+        self.assertEqual(order, ["b"])
+        self.assertEqual(total_bytes, 8)
+
+    def test_legacy_mapping_bytes_participate_in_oldest_eviction(self):
+        legacy = {
+            "latent": _SizedTensor(count=1, item_bytes=4),
+            "image": _SizedTensor(count=1, item_bytes=4),
+        }
+        cache = {"legacy": legacy}
+        order = ["legacy"]
+        with (
+            patch.object(first_pass_cache, "_AIO_FIRST_PASS_CACHE", cache),
+            patch.object(first_pass_cache, "_AIO_FIRST_PASS_CACHE_ORDER", order),
+            patch.object(first_pass_cache, "AIO_FIRST_PASS_CACHE_MAX_ENTRIES", 3),
+            patch.object(
+                first_pass_cache,
+                "AIO_FIRST_PASS_CACHE_MAX_ENTRY_BYTES",
+                8,
+            ),
+            patch.object(
+                first_pass_cache,
+                "AIO_FIRST_PASS_CACHE_MAX_BYTES",
+                12,
+            ),
+        ):
+            self.assertEqual(
+                first_pass_cache._aio_first_pass_cache_total_bytes(),
+                8,
+            )
+            first_pass_cache._put_aio_first_pass_cache(
+                "new",
+                _SizedTensor(count=1, item_bytes=4),
+                _SizedTensor(count=1, item_bytes=4),
+            )
+
+        self.assertEqual(set(cache), {"new"})
+        self.assertEqual(order, ["new"])
 
     def test_put_get_clone_isolation_lru_refresh_overwrite_and_eviction(self):
         latent = {"samples": [1]}

--- a/tests/test_aio_first_pass_cache_benchmark.py
+++ b/tests/test_aio_first_pass_cache_benchmark.py
@@ -33,6 +33,15 @@ class AIOFirstPassCacheBenchmarkTests(unittest.TestCase):
     def tearDown(self):
         first_pass_cache._clear_aio_first_pass_cache()
 
+    def test_fake_tensor_exposes_deterministic_payload_bytes(self):
+        tensor = benchmark.BenchmarkTensor.filled(
+            32,
+            0x11,
+            benchmark.CloneCounters(),
+        )
+
+        self.assertEqual(tensor.nbytes, 32)
+
     def test_report_freezes_clone_cost_and_bidirectional_isolation(self):
         report = benchmark.run_benchmark(
             payload_bytes=32,

--- a/tools/benchmark_aio_first_pass_cache.py
+++ b/tools/benchmark_aio_first_pass_cache.py
@@ -74,6 +74,10 @@ class BenchmarkTensor:
         self.counters.cpu_calls += 1
         return self
 
+    @property
+    def nbytes(self) -> int:
+        return len(self.payload)
+
     def mutate_first_byte(self) -> None:
         self.payload[0] ^= 0xFF
 


### PR DESCRIPTION
## 변경 요약

- #169 로드맵의 A169-CACHE-03 byte budget/single-entry cap Behavior를 완료합니다.
- deterministic logical payload byte estimator를 추가합니다.
- total budget 512 MiB, single-entry cap 256 MiB, 기존 count cap 2를 명시합니다.
- oversize source는 capture 전에 preflight하여 clone 없이 skip합니다.
- admitted entry는 기존 capture/checkout clone과 mutation isolation을 유지합니다.
- count/total budget을 모두 만족할 때까지 oldest entry를 eviction합니다.

## 주요 파일

- `easyuse_anima/aio/first_pass_cache.py`
- `tests/test_aio_first_pass_cache.py`
- `tools/benchmark_aio_first_pass_cache.py`
- `tests/test_aio_first_pass_cache_benchmark.py`
- `tests/fixtures/python_backend_baseline.json`
- `docs/architecture/aio-first-pass-cache-byte-budget.md`
- `docs/architecture/python-backend-execution-roadmap.md`

## Byte accounting과 호환 경계

- dict/list/tuple 재귀, bytes/bytearray/memoryview, tensor `numel * element_size`, `nbytes` fallback
- shared object identity는 estimate당 1회
- 실패/미지원 object는 0 logical bytes
- logical bytes는 Python overhead/RSS 주장이 아님
- key/miss/get/clear/LRU/order/root aliases/caller/stage/put return 유지
- legacy mapping entry도 total budget에 참여
- oversize same-key skip은 기존 mapping/order를 변경하지 않음

## 검증

- `tests.test_aio_first_pass_cache`: 14 passed
- `tests.test_aio_first_pass_cache_benchmark`: 4 passed
- `tests.test_aio_first_pass_stage`: 5 passed
- `tests.test_python_backend_analyzer`: 18 passed
- oversize preflight: 0 clones, existing same-key entry/order 보존
- default bounded benchmark
  - admitted put-overwrite/get-hit 각각 50 clones
  - 각각 3,276,800 logical copied bytes
  - source-after-put/returned-hit isolation 모두 true
- targeted Ruff 0.15.22: changed production/tool/test files passed
- targeted Pyright 1.1.411: production 1 file, 0 errors
- Python import boundary: 6 groups, 0 violations
- official full
  - Python unittest: 1,107 passed
  - frontend: 112 JavaScript files passed
  - Pyright baseline: 88 files, reviewed 14 errors 유지
  - import boundary와 `git diff --check` passed

## 테스트 표면과 남은 위험

- ComfyUI Codex test environment: repository full validation
- Live ComfyUI/server/Torch model/browser smoke: 실행하지 않음
- 실제 4K/batch peak allocation과 RSS는 CACHE-06 소유
- 다음 CACHE-04가 TTL, LRU, clear/disable, resource-revision invalidation을 별도 소유
