### PR TITLE
feat: add AiO cache TTL lifecycle

### DIFF
--- a/docs/architecture/aio-first-pass-cache-lifecycle-policy.md
+++ b/docs/architecture/aio-first-pass-cache-lifecycle-policy.md
@@ -5,7 +5,7 @@
 - PR type: Behavior
 - Baseline: `dev` commit
   `fcab2fa92dad164812c2c4961c4f580c77f54acc`
-- State: INVENTORY
+- State: VALIDATED
 
 CACHE-04a adds an explicit process-local enable lifecycle and absolute TTL. It
 does not change resource keys; CACHE-04b separately owns resolved resource
@@ -111,3 +111,23 @@ Focused validation must prove:
 
 One official full validation follows focused success. No server, model,
 browser, or user-instance smoke is required.
+
+## Validation result
+
+Validated on the CACHE-04a worktree:
+
+- exact defaults, clock reads, before/at/after TTL, absolute non-sliding
+  expiration, last-access replacement, disable/clear/re-enable, legacy
+  fallback, byte/count/LRU/root aliases: 19 focused cache tests passed;
+- benchmark clone/mutation and enabled-state isolation: 4 focused tests passed;
+- First-pass stage caller: 5 focused tests passed;
+- disabled get/put were proven to call neither estimator, clone, nor clock;
+- targeted Ruff 0.15.22 and Pyright 1.1.411: changed production/test files
+  passed, production file with 0 Pyright errors;
+- Python backend analyzer: 18 focused tests passed;
+- Python import-boundary gate: 6 completed package groups, 0 violations; and
+- official full: 1,112 Python tests plus 112 frontend JavaScript files passed,
+  with the reviewed Pyright baseline unchanged at 88 files and 14 errors.
+
+No resource revision/key, metrics, concurrency, runtime owner, server, model,
+browser, workflow, frontend, or user-instance behavior was changed.

--- a/docs/architecture/aio-first-pass-cache-lifecycle-policy.md
+++ b/docs/architecture/aio-first-pass-cache-lifecycle-policy.md
@@ -1,0 +1,113 @@
+# AiO first-pass cache TTL and enable lifecycle
+
+- Owner issue: [#169](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/169)
+- Roadmap unit: A169-CACHE-04a
+- PR type: Behavior
+- Baseline: `dev` commit
+  `fcab2fa92dad164812c2c4961c4f580c77f54acc`
+- State: INVENTORY
+
+CACHE-04a adds an explicit process-local enable lifecycle and absolute TTL. It
+does not change resource keys; CACHE-04b separately owns resolved resource
+revision invalidation.
+
+## Symbol, caller, alias, and state inventory
+
+### Current entry and cache state
+
+- Each frozen entry owns latent/image snapshots and deterministic
+  `size_bytes`.
+- The canonical mapping and LRU order list have process lifetime.
+- Get refreshes LRU order but entries have no timestamps.
+- Put enforces single-entry, total-byte, and count limits.
+- `_clear_aio_first_pass_cache` clears mapping/order in place.
+- There is no enabled flag, setter, clock seam, TTL, or expiration path.
+
+### Callers and compatibility aliases
+
+- The canonical pipeline and First-pass stage use get/put only.
+- Root `nodes.py` retains its current direct aliases for count, mapping/order,
+  clone/key/get/put. No new root alias is added.
+- Existing mapping/order/count/byte-cap monkeypatch seams remain call-time.
+- Get stays `(latent, image) | None`; put and clear stay `None`.
+- Disabled and expired entries must look like ordinary misses to the stage.
+
+## Target lifecycle contract
+
+- Default enabled: `True`.
+- Absolute TTL: `300.0` seconds from `created_at`.
+- Clock: private call-time monotonic function seam.
+- Canonical entries record `created_at` and `last_access_at`.
+- Put reads the clock once for an admitted capture and sets both timestamps.
+- Get reads the clock once for a canonical entry:
+  - if `now - created_at >= TTL`, remove the key from mapping/order and return
+    `None`;
+  - otherwise replace the frozen entry with the same snapshot metadata and an
+    updated `last_access_at`, refresh LRU order, then return an independent
+    checkout copy.
+- Legacy mapping fallback remains readable and has no synthetic TTL metadata.
+- Disabling clears mapping/order in place. While disabled, get is a miss and
+  put skips before size estimation/cloning.
+- Re-enabling starts empty and permits normal put/get.
+- Explicit clear remains idempotent and does not change enabled state.
+
+Absolute rather than sliding TTL prevents frequently accessed entries from
+living forever. `last_access_at` is recorded for later metrics/diagnostics but
+does not extend the TTL.
+
+## Decomposition boundary
+
+CACHE-04a owns only time and enable lifecycle. CACHE-04b separately changes the
+cache-key resource revision. This avoids mixing resource filesystem semantics
+with entry expiration and preserves an independent rollback point.
+
+## Allowed-file boundary
+
+CACHE-04a may change only:
+
+- `easyuse_anima/aio/first_pass_cache.py`;
+- `tests/test_aio_first_pass_cache.py`;
+- `tests/test_aio_first_pass_cache_benchmark.py` only if lifecycle isolation
+  needs an explicit assertion;
+- `tests/test_python_backend_analyzer.py`;
+- `tests/fixtures/python_backend_baseline.json`, regenerated from source;
+- this document;
+- `docs/architecture/aio-first-pass-cache-byte-budget.md`; and
+- `docs/architecture/python-backend-execution-roadmap.md`.
+
+Read-only evidence:
+
+- `easyuse_anima/aio/generation_first_pass.py`;
+- `easyuse_anima/aio/legacy_generation.py`;
+- root `nodes.py`;
+- `tools/benchmark_aio_first_pass_cache.py`;
+- `tests/test_aio_first_pass_stage.py`;
+- `tests/test_aio_legacy_generation.py`; and
+- `tests/fixtures/python_compatibility_surface.v1.json`.
+
+Forbidden:
+
+- changing resource_info/resource paths, cache key, resource revision, mtime,
+  size, registry generation, or resolved resource lookup;
+- changing clone, byte estimation, budgets, cap, caller, root alias, stage,
+  seed, sampling, preview, metadata, Save, workflow, or socket behavior;
+- metrics, lock, concurrency, runtime owner, serialized settings, or frontend;
+- module Move, release, Registry, server, Torch/model, browser, or
+  user-instance work.
+
+## Required validation
+
+Focused validation must prove:
+
+- exact default enabled/TTL policy and one clock read per canonical put/get;
+- hit before TTL, miss/removal at and after TTL, and no sliding extension;
+- last-access replacement plus LRU refresh without snapshot mutation;
+- disabled get miss and put clone/estimation zero work;
+- disable clear, re-enable, explicit clear idempotence, and enabled-state
+  preservation;
+- legacy mapping fallback remains readable;
+- byte/count policy, clone/mutation baseline, root aliases, stage caller,
+  analyzer, and import-boundary contracts remain valid.
+
+One official full validation follows focused success. No server, model,
+browser, or user-instance smoke is required.

--- a/docs/architecture/python-backend-execution-roadmap.md
+++ b/docs/architecture/python-backend-execution-roadmap.md
@@ -407,7 +407,7 @@ mechanical retirement series.
 | 14 | B-11 registration/bootstrap/root shim | COMPLETE in PR #356 | Move/Contract, split PRs | #184 | Zero runtime binders/residual implementation; explicit root `__all__`; frozen compatibility audit |
 | 15 | S167 backend seed reservation series | S167-01 through S167-03d COMPLETE on `dev`; S167-03e AiO cutover VALIDATED with isolated API/module/browser-load parity | Contract then Move then Behavior | #167 | Canonical AiO/node seams |
 | 16 | A169 stage pipeline series | A169-01 through A169-08 MERGED; A169-09 final adapter/integration VALIDATED in PR #372 | Contract then Behavior | #169 | Typed config and mechanical AiO move |
-| 17 | A169 first-pass cache policy | A169-CACHE-01/02/03 MERGED; CACHE-04a TTL/LRU/clear-disable INVENTORY; CACHE-04b resource revision follows | Contract then Behavior | #169 | Mechanical cache move and stable stage seam |
+| 17 | A169 first-pass cache policy | A169-CACHE-01/02/03 MERGED; CACHE-04a TTL/LRU/clear-disable VALIDATED in PR #376; CACHE-04b resource revision follows | Contract then Behavior | #169 | Mechanical cache move and stable stage seam |
 | 18 | D-series canonical root consolidation | BLOCKED by relevant C contracts | Move | #186 | Phase B exit; per-feature behavior stable |
 | 19 | E-series RuntimeServices/lifecycle | BLOCKED by canonical owners | Move/Contract, split PRs | #187 | Relevant D moves |
 | 20 | G-04 through G-06 and H | INCREMENTAL/LATER | Gate/Contract | #188 | Appropriate package and release evidence |

--- a/docs/architecture/python-backend-execution-roadmap.md
+++ b/docs/architecture/python-backend-execution-roadmap.md
@@ -407,7 +407,7 @@ mechanical retirement series.
 | 14 | B-11 registration/bootstrap/root shim | COMPLETE in PR #356 | Move/Contract, split PRs | #184 | Zero runtime binders/residual implementation; explicit root `__all__`; frozen compatibility audit |
 | 15 | S167 backend seed reservation series | S167-01 through S167-03d COMPLETE on `dev`; S167-03e AiO cutover VALIDATED with isolated API/module/browser-load parity | Contract then Move then Behavior | #167 | Canonical AiO/node seams |
 | 16 | A169 stage pipeline series | A169-01 through A169-08 MERGED; A169-09 final adapter/integration VALIDATED in PR #372 | Contract then Behavior | #169 | Typed config and mechanical AiO move |
-| 17 | A169 first-pass cache policy | A169-CACHE-01/02 MERGED; A169-CACHE-03 byte budget/single-entry cap VALIDATED in PR #375 | Contract then Behavior | #169 | Mechanical cache move and stable stage seam |
+| 17 | A169 first-pass cache policy | A169-CACHE-01/02/03 MERGED; CACHE-04a TTL/LRU/clear-disable INVENTORY; CACHE-04b resource revision follows | Contract then Behavior | #169 | Mechanical cache move and stable stage seam |
 | 18 | D-series canonical root consolidation | BLOCKED by relevant C contracts | Move | #186 | Phase B exit; per-feature behavior stable |
 | 19 | E-series RuntimeServices/lifecycle | BLOCKED by canonical owners | Move/Contract, split PRs | #187 | Relevant D moves |
 | 20 | G-04 through G-06 and H | INCREMENTAL/LATER | Gate/Contract | #188 | Appropriate package and release evidence |

--- a/easyuse_anima/aio/first_pass_cache.py
+++ b/easyuse_anima/aio/first_pass_cache.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+import time
+from dataclasses import dataclass, replace
 from typing import Any
 
 from ..common.serialization import _stable_change_key
@@ -12,6 +13,8 @@ from .model_preparation import _aio_lora_stack_signature
 AIO_FIRST_PASS_CACHE_MAX_ENTRIES = 2
 AIO_FIRST_PASS_CACHE_MAX_BYTES = 512 * 1024 * 1024
 AIO_FIRST_PASS_CACHE_MAX_ENTRY_BYTES = 256 * 1024 * 1024
+AIO_FIRST_PASS_CACHE_TTL_SECONDS = 300.0
+_AIO_FIRST_PASS_CACHE_ENABLED = True
 
 
 @dataclass(frozen=True, slots=True)
@@ -19,9 +22,17 @@ class _AIOFirstPassCacheEntry:
     latent: Any
     image: Any
     size_bytes: int
+    created_at: float
+    last_access_at: float
 
     @classmethod
-    def capture(cls, latent, image) -> _AIOFirstPassCacheEntry:
+    def capture(
+        cls,
+        latent,
+        image,
+        *,
+        now: float,
+    ) -> _AIOFirstPassCacheEntry:
         latent_snapshot = _clone_aio_cache_value(latent)
         image_snapshot = _clone_aio_cache_value(image)
         return cls(
@@ -31,6 +42,8 @@ class _AIOFirstPassCacheEntry:
                 latent_snapshot,
                 image_snapshot,
             ),
+            created_at=now,
+            last_access_at=now,
         )
 
     def checkout(self):
@@ -165,6 +178,18 @@ def _clear_aio_first_pass_cache() -> None:
     _AIO_FIRST_PASS_CACHE_ORDER.clear()
 
 
+def _set_aio_first_pass_cache_enabled(enabled: bool) -> None:
+    global _AIO_FIRST_PASS_CACHE_ENABLED
+
+    _AIO_FIRST_PASS_CACHE_ENABLED = bool(enabled)
+    if not _AIO_FIRST_PASS_CACHE_ENABLED:
+        _clear_aio_first_pass_cache()
+
+
+def _aio_first_pass_cache_now() -> float:
+    return time.monotonic()
+
+
 def _aio_first_pass_cache_key(
     *,
     cache_scope: str,
@@ -218,9 +243,20 @@ def _aio_first_pass_cache_key(
 
 
 def _get_aio_first_pass_cache(cache_key: str):
+    if not _AIO_FIRST_PASS_CACHE_ENABLED:
+        return None
     entry = _AIO_FIRST_PASS_CACHE.get(cache_key)
     if not entry:
         return None
+    if isinstance(entry, _AIOFirstPassCacheEntry):
+        now = _aio_first_pass_cache_now()
+        if now - entry.created_at >= AIO_FIRST_PASS_CACHE_TTL_SECONDS:
+            _AIO_FIRST_PASS_CACHE.pop(cache_key, None)
+            if cache_key in _AIO_FIRST_PASS_CACHE_ORDER:
+                _AIO_FIRST_PASS_CACHE_ORDER.remove(cache_key)
+            return None
+        entry = replace(entry, last_access_at=now)
+        _AIO_FIRST_PASS_CACHE[cache_key] = entry
     if cache_key in _AIO_FIRST_PASS_CACHE_ORDER:
         _AIO_FIRST_PASS_CACHE_ORDER.remove(cache_key)
     _AIO_FIRST_PASS_CACHE_ORDER.append(cache_key)
@@ -233,12 +269,18 @@ def _get_aio_first_pass_cache(cache_key: str):
 
 
 def _put_aio_first_pass_cache(cache_key: str, latent, image) -> None:
+    if not _AIO_FIRST_PASS_CACHE_ENABLED:
+        return
     if (
         _aio_cache_pair_size_bytes(latent, image)
         > AIO_FIRST_PASS_CACHE_MAX_ENTRY_BYTES
     ):
         return
-    entry = _AIOFirstPassCacheEntry.capture(latent, image)
+    entry = _AIOFirstPassCacheEntry.capture(
+        latent,
+        image,
+        now=_aio_first_pass_cache_now(),
+    )
     if entry.size_bytes > AIO_FIRST_PASS_CACHE_MAX_ENTRY_BYTES:
         return
     _AIO_FIRST_PASS_CACHE[cache_key] = entry

--- a/tests/fixtures/python_backend_baseline.json
+++ b/tests/fixtures/python_backend_baseline.json
@@ -4640,6 +4640,23 @@
       },
       {
         "alias": null,
+        "bound_name": "time",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "time",
+        "kind": "static_import",
+        "line": 5,
+        "name": null,
+        "optional": false,
+        "requested": "time",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/aio/first_pass_cache.py"
+      },
+      {
+        "alias": null,
         "bound_name": "dataclass",
         "branch_context": [],
         "classification": "external",
@@ -4647,8 +4664,25 @@
         "conditional": false,
         "imported": "dataclasses:dataclass",
         "kind": "static_from",
-        "line": 5,
+        "line": 6,
         "name": "dataclass",
+        "optional": false,
+        "requested": "dataclasses",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/aio/first_pass_cache.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "replace",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "dataclasses:replace",
+        "kind": "static_from",
+        "line": 6,
+        "name": "replace",
         "optional": false,
         "requested": "dataclasses",
         "role": "ordinary",
@@ -4664,7 +4698,7 @@
         "conditional": false,
         "imported": "typing:Any",
         "kind": "static_from",
-        "line": 6,
+        "line": 7,
         "name": "Any",
         "optional": false,
         "requested": "typing",
@@ -4681,7 +4715,7 @@
         "conditional": false,
         "imported": "..common.serialization:_stable_change_key",
         "kind": "static_from",
-        "line": 8,
+        "line": 9,
         "name": "_stable_change_key",
         "optional": false,
         "requested": "..common.serialization",
@@ -4699,7 +4733,7 @@
         "conditional": false,
         "imported": "..prompt.data:_prompt_data_json_safe",
         "kind": "static_from",
-        "line": 9,
+        "line": 10,
         "name": "_prompt_data_json_safe",
         "optional": false,
         "requested": "..prompt.data",
@@ -4717,7 +4751,7 @@
         "conditional": false,
         "imported": ".model_preparation:_aio_lora_stack_signature",
         "kind": "static_from",
-        "line": 10,
+        "line": 11,
         "name": "_aio_lora_stack_signature",
         "optional": false,
         "requested": ".model_preparation",
@@ -48817,14 +48851,14 @@
       },
       {
         "is_package": false,
-        "loc": 256,
+        "loc": 298,
         "module": "easyuse_anima.aio.first_pass_cache",
-        "normalized_git_blob_sha1": "184b29009ac138dbc1eced33f848cd40097b6352",
+        "normalized_git_blob_sha1": "2fe838a28380587be4870c8e7f8f3e9e6ea22377",
         "path": "easyuse_anima/aio/first_pass_cache.py",
         "top_level": {
           "class_count": 1,
-          "function_count": 9,
-          "global_count": 6
+          "function_count": 11,
+          "global_count": 8
         }
       },
       {
@@ -59701,9 +59735,31 @@
         "branch_context": [],
         "classification": "external",
         "conditional": false,
+        "imported": "time",
+        "kind": "static_import",
+        "line": 5,
+        "optional": false,
+        "role": "ordinary",
+        "source": "easyuse_anima/aio/first_pass_cache.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
         "imported": "dataclasses:dataclass",
         "kind": "static_from",
-        "line": 5,
+        "line": 6,
+        "optional": false,
+        "role": "ordinary",
+        "source": "easyuse_anima/aio/first_pass_cache.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "dataclasses:replace",
+        "kind": "static_from",
+        "line": 6,
         "optional": false,
         "role": "ordinary",
         "source": "easyuse_anima/aio/first_pass_cache.py"
@@ -59714,7 +59770,7 @@
         "conditional": false,
         "imported": "typing:Any",
         "kind": "static_from",
-        "line": 6,
+        "line": 7,
         "optional": false,
         "role": "ordinary",
         "source": "easyuse_anima/aio/first_pass_cache.py"
@@ -65722,7 +65778,7 @@
         "column": 1,
         "context": "decorator:_AIOFirstPassCacheEntry",
         "kind": "import_time_call",
-        "line": 17,
+        "line": 20,
         "module": "easyuse_anima/aio/first_pass_cache.py",
         "scope": "<module>"
       },
@@ -67034,13 +67090,13 @@
       },
       {
         "kind": "dict",
-        "line": 43,
+        "line": 56,
         "module": "easyuse_anima/aio/first_pass_cache.py",
         "name": "_AIO_FIRST_PASS_CACHE"
       },
       {
         "kind": "list",
-        "line": 47,
+        "line": 60,
         "module": "easyuse_anima/aio/first_pass_cache.py",
         "name": "_AIO_FIRST_PASS_CACHE_ORDER"
       },
@@ -67413,7 +67469,7 @@
           "mutable_container"
         ],
         "initializer": "Dict",
-        "line": 43,
+        "line": 56,
         "module": "easyuse_anima/aio/first_pass_cache.py",
         "name": "_AIO_FIRST_PASS_CACHE"
       },
@@ -67423,7 +67479,7 @@
           "mutable_container"
         ],
         "initializer": "List",
-        "line": 47,
+        "line": 60,
         "module": "easyuse_anima/aio/first_pass_cache.py",
         "name": "_AIO_FIRST_PASS_CACHE_ORDER"
       },

--- a/tests/test_aio_first_pass_cache.py
+++ b/tests/test_aio_first_pass_cache.py
@@ -52,9 +52,11 @@ class _SizedTensor:
 
 class AIOFirstPassCacheMoveTests(unittest.TestCase):
     def setUp(self):
+        first_pass_cache._set_aio_first_pass_cache_enabled(True)
         first_pass_cache._clear_aio_first_pass_cache()
 
     def tearDown(self):
+        first_pass_cache._set_aio_first_pass_cache_enabled(True)
         first_pass_cache._clear_aio_first_pass_cache()
 
     def test_default_count_and_byte_policy_are_explicit(self):
@@ -67,6 +69,182 @@ class AIOFirstPassCacheMoveTests(unittest.TestCase):
             first_pass_cache.AIO_FIRST_PASS_CACHE_MAX_ENTRY_BYTES,
             256 * 1024 * 1024,
         )
+        self.assertEqual(
+            first_pass_cache.AIO_FIRST_PASS_CACHE_TTL_SECONDS,
+            300.0,
+        )
+        self.assertTrue(first_pass_cache._AIO_FIRST_PASS_CACHE_ENABLED)
+
+    def test_put_and_get_read_clock_once_and_replace_last_access(self):
+        clock = Mock(side_effect=[10.0, 20.0])
+        with patch.object(
+            first_pass_cache,
+            "_aio_first_pass_cache_now",
+            clock,
+        ):
+            first_pass_cache._put_aio_first_pass_cache(
+                "entry",
+                {"samples": [1]},
+                [2],
+            )
+            captured = first_pass_cache._AIO_FIRST_PASS_CACHE["entry"]
+            self.assertEqual(
+                (captured.created_at, captured.last_access_at),
+                (10.0, 10.0),
+            )
+
+            self.assertEqual(
+                first_pass_cache._get_aio_first_pass_cache("entry"),
+                ({"samples": [1]}, [2]),
+            )
+
+        accessed = first_pass_cache._AIO_FIRST_PASS_CACHE["entry"]
+        self.assertIsNot(accessed, captured)
+        self.assertEqual(
+            (accessed.created_at, accessed.last_access_at),
+            (10.0, 20.0),
+        )
+        self.assertEqual(clock.call_count, 2)
+
+    def test_absolute_ttl_hits_before_and_expires_at_or_after_boundary(self):
+        for elapsed, expected_hit in (
+            (299.999, True),
+            (300.0, False),
+            (301.0, False),
+        ):
+            with self.subTest(elapsed=elapsed):
+                first_pass_cache._clear_aio_first_pass_cache()
+                clock = Mock(side_effect=[100.0, 100.0 + elapsed])
+                with patch.object(
+                    first_pass_cache,
+                    "_aio_first_pass_cache_now",
+                    clock,
+                ):
+                    first_pass_cache._put_aio_first_pass_cache(
+                        "entry",
+                        "latent",
+                        "image",
+                    )
+                    result = first_pass_cache._get_aio_first_pass_cache(
+                        "entry"
+                    )
+
+                self.assertEqual(result is not None, expected_hit)
+                self.assertEqual(clock.call_count, 2)
+                if expected_hit:
+                    self.assertIn(
+                        "entry",
+                        first_pass_cache._AIO_FIRST_PASS_CACHE,
+                    )
+                    self.assertEqual(
+                        first_pass_cache._AIO_FIRST_PASS_CACHE_ORDER,
+                        ["entry"],
+                    )
+                else:
+                    self.assertNotIn(
+                        "entry",
+                        first_pass_cache._AIO_FIRST_PASS_CACHE,
+                    )
+                    self.assertEqual(
+                        first_pass_cache._AIO_FIRST_PASS_CACHE_ORDER,
+                        [],
+                    )
+
+    def test_last_access_does_not_extend_absolute_ttl(self):
+        clock = Mock(side_effect=[0.0, 200.0, 301.0])
+        with patch.object(
+            first_pass_cache,
+            "_aio_first_pass_cache_now",
+            clock,
+        ):
+            first_pass_cache._put_aio_first_pass_cache(
+                "entry",
+                "latent",
+                "image",
+            )
+            self.assertEqual(
+                first_pass_cache._get_aio_first_pass_cache("entry"),
+                ("latent", "image"),
+            )
+            self.assertIsNone(
+                first_pass_cache._get_aio_first_pass_cache("entry")
+            )
+
+        self.assertEqual(clock.call_count, 3)
+        self.assertEqual(first_pass_cache._AIO_FIRST_PASS_CACHE, {})
+        self.assertEqual(first_pass_cache._AIO_FIRST_PASS_CACHE_ORDER, [])
+
+    def test_disable_clears_and_skips_get_put_work_until_reenabled(self):
+        first_pass_cache._put_aio_first_pass_cache(
+            "entry",
+            "latent",
+            "image",
+        )
+        mapping = first_pass_cache._AIO_FIRST_PASS_CACHE
+        order = first_pass_cache._AIO_FIRST_PASS_CACHE_ORDER
+        first_pass_cache._set_aio_first_pass_cache_enabled(False)
+
+        self.assertIs(first_pass_cache._AIO_FIRST_PASS_CACHE, mapping)
+        self.assertIs(first_pass_cache._AIO_FIRST_PASS_CACHE_ORDER, order)
+        self.assertEqual(mapping, {})
+        self.assertEqual(order, [])
+        self.assertFalse(first_pass_cache._AIO_FIRST_PASS_CACHE_ENABLED)
+
+        estimator = Mock(side_effect=AssertionError("estimator called"))
+        clone = Mock(side_effect=AssertionError("clone called"))
+        clock = Mock(side_effect=AssertionError("clock called"))
+        with (
+            patch.object(
+                first_pass_cache,
+                "_aio_cache_pair_size_bytes",
+                estimator,
+            ),
+            patch.object(
+                first_pass_cache,
+                "_clone_aio_cache_value",
+                clone,
+            ),
+            patch.object(
+                first_pass_cache,
+                "_aio_first_pass_cache_now",
+                clock,
+            ),
+        ):
+            self.assertIsNone(
+                first_pass_cache._get_aio_first_pass_cache("entry")
+            )
+            first_pass_cache._put_aio_first_pass_cache(
+                "entry",
+                "latent",
+                "image",
+            )
+
+        estimator.assert_not_called()
+        clone.assert_not_called()
+        clock.assert_not_called()
+        self.assertEqual(mapping, {})
+        self.assertEqual(order, [])
+
+        first_pass_cache._set_aio_first_pass_cache_enabled(True)
+        first_pass_cache._put_aio_first_pass_cache(
+            "entry",
+            "latent",
+            "image",
+        )
+        self.assertEqual(
+            first_pass_cache._get_aio_first_pass_cache("entry"),
+            ("latent", "image"),
+        )
+
+    def test_explicit_clear_is_idempotent_and_preserves_enabled_state(self):
+        first_pass_cache._clear_aio_first_pass_cache()
+        first_pass_cache._clear_aio_first_pass_cache()
+        self.assertTrue(first_pass_cache._AIO_FIRST_PASS_CACHE_ENABLED)
+
+        first_pass_cache._set_aio_first_pass_cache_enabled(False)
+        first_pass_cache._clear_aio_first_pass_cache()
+        first_pass_cache._clear_aio_first_pass_cache()
+        self.assertFalse(first_pass_cache._AIO_FIRST_PASS_CACHE_ENABLED)
 
     def test_root_state_and_functions_are_direct_canonical_aliases(self):
         self.assertFalse(
@@ -243,6 +421,11 @@ class AIOFirstPassCacheMoveTests(unittest.TestCase):
         with (
             patch.object(first_pass_cache, "_AIO_FIRST_PASS_CACHE", cache),
             patch.object(first_pass_cache, "_AIO_FIRST_PASS_CACHE_ORDER", order),
+            patch.object(
+                first_pass_cache,
+                "_aio_first_pass_cache_now",
+                side_effect=AssertionError("legacy entry read clock"),
+            ),
         ):
             latent, image = first_pass_cache._get_aio_first_pass_cache("legacy")
             latent["samples"].append(99)
@@ -275,9 +458,15 @@ class AIOFirstPassCacheMoveTests(unittest.TestCase):
             setattr(original_entry, "latent", {"samples": [99]})
 
         latent, image = first_pass_cache._get_aio_first_pass_cache("entry")
-        self.assertIs(
-            first_pass_cache._AIO_FIRST_PASS_CACHE["entry"],
-            original_entry,
+        accessed_entry = first_pass_cache._AIO_FIRST_PASS_CACHE["entry"]
+        self.assertIsNot(accessed_entry, original_entry)
+        self.assertEqual(
+            (accessed_entry.created_at, accessed_entry.size_bytes),
+            (original_entry.created_at, original_entry.size_bytes),
+        )
+        self.assertGreaterEqual(
+            accessed_entry.last_access_at,
+            original_entry.last_access_at,
         )
         latent["samples"].append(88)
         image.append(88)

--- a/tests/test_aio_first_pass_cache_benchmark.py
+++ b/tests/test_aio_first_pass_cache_benchmark.py
@@ -30,7 +30,12 @@ benchmark = _load_benchmark_module()
 
 
 class AIOFirstPassCacheBenchmarkTests(unittest.TestCase):
+    def setUp(self):
+        first_pass_cache._set_aio_first_pass_cache_enabled(True)
+        first_pass_cache._clear_aio_first_pass_cache()
+
     def tearDown(self):
+        first_pass_cache._set_aio_first_pass_cache_enabled(True)
         first_pass_cache._clear_aio_first_pass_cache()
 
     def test_fake_tensor_exposes_deterministic_payload_bytes(self):


### PR DESCRIPTION
## 변경 요약

- 첫 패스 캐시에 300초 절대 TTL을 추가했습니다.
- `time.monotonic()` 기준 생성·최근 접근 시각을 불변 엔트리에 기록하고, 조회 시 LRU 순서를 갱신합니다.
- 캐시 비활성화 시 기존 엔트리를 즉시 제자리에서 비우고, 이후 조회·저장은 크기 계산·복제·시계 조회 없이 종료합니다.
- 명시적 clear는 활성화 상태를 바꾸지 않으며, 재활성화 후 정상 저장·조회가 가능합니다.
- 레거시 dict 엔트리는 기존 호환 읽기 경계를 유지하며 합성 TTL을 적용하지 않습니다.

## Inventory와 경계

- Symbol: `easyuse_anima.aio.first_pass_cache`의 전용 캐시 엔트리, 조회/저장/clear와 테스트 전용 활성화 seam
- Caller: 기존 `_cache_first_pass_artifacts()` / `_get_cached_first_pass()` 호출 계약은 변경하지 않았습니다.
- Alias/global state: 기존 mapping과 LRU order 객체의 identity를 유지하며 disable 시 제자리 clear합니다.
- 허용 파일: 캐시 모듈, 캐시/벤치마크 테스트, analyzer fixture, lifecycle/roadmap 문서
- 제외: resource revision/key, metrics, concurrency/lock, runtime owner, frontend/settings, 모듈 이동

## 주요 파일

- `easyuse_anima/aio/first_pass_cache.py`
- `tests/test_aio_first_pass_cache.py`
- `tests/test_aio_first_pass_cache_benchmark.py`
- `tests/fixtures/python_backend_baseline.json`
- `docs/architecture/aio-first-pass-cache-lifecycle-policy.md`
- `docs/architecture/python-backend-execution-roadmap.md`

## 검증

- focused cache unittest: 19 passed
- focused benchmark contract: 4 passed
- focused first-pass stage: 5 passed
- targeted Ruff: passed
- targeted Pyright: 0 errors
- backend analyzer: 18 passed
- import boundary: 6 groups, 0 violations
- official full: Python 1,112 passed, frontend JavaScript 112 files passed
- full Pyright baseline: 88 files, 기존 검토 대상 14 errors 유지
- `git diff --check`: passed

서버 기동, 모델 로드, 브라우저 smoke는 이 캐시 정책 변경에 필요하지 않아 실행하지 않았습니다.

## 남은 위험과 후속

- TTL은 최근 접근으로 연장되지 않는 절대 TTL입니다.
- 레거시 mapping에는 생성 시각이 없어 기존 호환 읽기만 유지합니다.
- 리소스 파일 변경 무효화는 key/caller 경계를 건드리므로 별도 `A169-CACHE-04b` Behavior 작업으로 진행합니다.
