### PR TITLE
feat: invalidate AiO cache on resource file revision

### DIFF
--- a/docs/architecture/aio-first-pass-cache-resource-revision.md
+++ b/docs/architecture/aio-first-pass-cache-resource-revision.md
@@ -5,7 +5,7 @@
 - PR type: Behavior
 - Baseline: `dev` commit
   `7de7d604a40627abcb3bfcb38bc6918424d7093f`
-- State: INVENTORY
+- State: VALIDATED
 
 CACHE-04b invalidates first-pass cache entries when a resolved UNET, VAE,
 text-encoder, or LoRA file changes without changing its logical ComfyUI name.
@@ -129,3 +129,26 @@ Focused validation must prove:
 Run one official full validation only after focused checks pass. Server startup,
 model loading/execution, browser smoke, and user-instance reflection are not
 required for this deterministic adapter/key Behavior.
+
+## Validation result
+
+Validated on the CACHE-04b worktree:
+
+- exact category/name forwarding, canonical path/size/`mtime_ns`, legacy
+  resolver support, and safe host/helper/path/stat fallbacks: 4 focused Comfy
+  resource adapter tests passed;
+- version-2 payload, base and ordered LoRA revisions, unchanged-key stability,
+  and path/size/`mtime_ns` invalidation: 21 focused cache tests passed;
+- unchanged First-pass stage hit/miss consumer: 5 focused tests passed;
+- hostless package import: 1 focused test passed;
+- targeted Ruff 0.15.22: changed production files passed all rules and changed
+  test files passed fatal rules;
+- targeted Pyright 1.1.411: changed production files passed with 0 errors;
+- Python backend analyzer: 18 focused tests passed;
+- Python import-boundary gate: 6 completed package groups, 0 violations; and
+- official full: 1,116 Python tests plus 112 frontend JavaScript files passed,
+  with the reviewed Pyright baseline unchanged at 88 files and 14 errors.
+
+No resource loader/context schema, caller/root alias, entry lifecycle, cache
+budget/clone/storage, concurrency, metrics, server, model, browser, frontend,
+workflow, or user-instance behavior was changed.

--- a/docs/architecture/aio-first-pass-cache-resource-revision.md
+++ b/docs/architecture/aio-first-pass-cache-resource-revision.md
@@ -1,0 +1,131 @@
+# AiO first-pass cache resource revision invalidation
+
+- Owner issue: [#169](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/169)
+- Roadmap unit: A169-CACHE-04b
+- PR type: Behavior
+- Baseline: `dev` commit
+  `7de7d604a40627abcb3bfcb38bc6918424d7093f`
+- State: INVENTORY
+
+CACHE-04b invalidates first-pass cache entries when a resolved UNET, VAE,
+text-encoder, or LoRA file changes without changing its logical ComfyUI name.
+It does not change resource loading, entry lifecycle, concurrency, metrics, or
+storage policy.
+
+## Symbol, caller, alias, and global-state inventory
+
+### Cache key owner and caller
+
+- `easyuse_anima.aio.first_pass_cache._aio_first_pass_cache_key` is the
+  canonical key owner. Its version-1 payload already includes logical
+  `resource_info`, normalized input settings, prompt data, LoRA names and
+  strengths, sampler/model-patch settings, prompts, and dimensions.
+- `easyuse_anima.aio.legacy_generation._run_aio_generation_pipeline` is the
+  only production caller. It loads the three base resources, applies LoRAs and
+  model patches, builds conditioning, and then creates one first-pass key
+  before constructing the typed generation request.
+- The First-pass stage consumes only the resulting opaque key through the
+  existing get/put functions. Its signature and hit/miss contract do not need
+  to change.
+
+### Resource identity and host adapter
+
+- `easyuse_anima.nodes.aio_nodes.EasyUseAnimaInput.build` records logical
+  `unet_name`, `vae_name`, `clip_name`, loader mode/type, weight dtype, and
+  clip device. It does not resolve filesystem paths.
+- `easyuse_anima.aio.resources` passes those same logical names to ComfyUI
+  loaders. Changing that context or loader contract is outside this task.
+- `easyuse_anima.infrastructure.comfy.resources` is the canonical lazy host
+  adapter for ComfyUI resource discovery. It imports `folder_paths` only inside
+  call-time functions and currently owns no cache or mutable global state.
+- Required ComfyUI categories are `diffusion_models`, `vae`,
+  `text_encoders`, and `loras`.
+
+### Compatibility aliases and state
+
+- Root `nodes.py` retains the direct `_aio_first_pass_cache_key` alias. The
+  function identity, signature, and root binding remain unchanged.
+- No new root alias or package export is introduced.
+- The new file-revision helper is private to the canonical host adapter and
+  owns no cache, registry, generation counter, or mutable global state.
+- Existing cache mapping/order/enabled state, TTL, byte budgets, clone
+  boundaries, and frozen entry layout remain unchanged.
+
+## Target behavior contract
+
+- Resolve each non-empty logical resource name at key-build time through the
+  lazy ComfyUI host adapter.
+- A resolved regular resource contributes a deterministic descriptor with:
+  - canonical resolved path;
+  - non-negative file size; and
+  - nanosecond modification time (`mtime_ns`).
+- Base roles resolve as UNET → `diffusion_models`, VAE → `vae`, and CLIP →
+  `text_encoders`.
+- Each normalized LoRA signature contributes a `loras` revision in the same
+  order as its existing name/strength signature.
+- Empty names, unavailable host modules/helpers, unresolved files, and stat
+  failures return no revision and do not raise. The existing logical names and
+  settings remain in the key, so hostless/package tests and unsupported
+  resources retain deterministic name-based behavior.
+- The key schema version advances from 1 to 2 and includes one
+  `resource_revision` field. A path, size, or `mtime_ns` change must produce a
+  different key; unchanged descriptors must produce the same key.
+- Revision data is internal to the opaque stable key. It is not added to
+  workflow data, metadata, API responses, logs, or user-visible errors.
+
+## Allowed-file boundary
+
+CACHE-04b may change only:
+
+- `easyuse_anima/infrastructure/comfy/resources.py`;
+- `easyuse_anima/aio/first_pass_cache.py`;
+- `tests/test_comfy_adapters.py`;
+- `tests/test_aio_first_pass_cache.py`;
+- `tests/test_python_backend_analyzer.py` only if analyzer assertions require
+  enrollment;
+- `tests/fixtures/python_backend_baseline.json`, regenerated from source;
+- this document; and
+- `docs/architecture/python-backend-execution-roadmap.md`.
+
+Read-only evidence:
+
+- `easyuse_anima/nodes/aio_nodes.py`;
+- `easyuse_anima/aio/resources.py`;
+- `easyuse_anima/aio/model_preparation.py`;
+- `easyuse_anima/aio/legacy_generation.py`;
+- `easyuse_anima/aio/generation_first_pass.py`;
+- root `nodes.py`;
+- `tests/test_aio_first_pass_stage.py`;
+- `tests/test_aio_legacy_generation.py`;
+- `tests/test_python_import_boundaries.py`; and
+- `tests/test_python_package_skeleton.py`.
+
+Forbidden:
+
+- changing input-context/resource-info schemas or ComfyUI loader behavior;
+- changing the cache-key function signature, caller, root alias, stage
+  signature, or workflow/output serialization;
+- adding resource registries, persistent caches, watchers, threads, locks,
+  metrics, generation counters, or new mutable global state;
+- changing TTL/LRU/clear/disable, clone/copy-on-write, byte/count budgets,
+  CPU/GPU storage, seeds, sampling, conditioning, preview, Save, or cleanup;
+- frontend, release, Registry, server startup, model execution, browser, or
+  user-instance work.
+
+## Required validation
+
+Focused validation must prove:
+
+- exact category/name forwarding and resolved path/size/`mtime_ns` descriptor;
+- modern/legacy host resolver fallback, empty/missing/unresolved/stat-failure
+  no-revision behavior, and no import-time host dependency;
+- unchanged resources produce the same version-2 key;
+- base resource path/size/`mtime_ns` changes each produce a different key;
+- LoRA revision order follows the normalized signature and LoRA file changes
+  produce a different key;
+- the existing key signature/root alias, cache lifecycle, clone/isolation,
+  byte/count policy, stage caller, analyzer, and import boundary stay valid.
+
+Run one official full validation only after focused checks pass. Server startup,
+model loading/execution, browser smoke, and user-instance reflection are not
+required for this deterministic adapter/key Behavior.

--- a/docs/architecture/python-backend-execution-roadmap.md
+++ b/docs/architecture/python-backend-execution-roadmap.md
@@ -407,7 +407,7 @@ mechanical retirement series.
 | 14 | B-11 registration/bootstrap/root shim | COMPLETE in PR #356 | Move/Contract, split PRs | #184 | Zero runtime binders/residual implementation; explicit root `__all__`; frozen compatibility audit |
 | 15 | S167 backend seed reservation series | S167-01 through S167-03d COMPLETE on `dev`; S167-03e AiO cutover VALIDATED with isolated API/module/browser-load parity | Contract then Move then Behavior | #167 | Canonical AiO/node seams |
 | 16 | A169 stage pipeline series | A169-01 through A169-08 MERGED; A169-09 final adapter/integration VALIDATED in PR #372 | Contract then Behavior | #169 | Typed config and mechanical AiO move |
-| 17 | A169 first-pass cache policy | A169-CACHE-01/02/03 and CACHE-04a MERGED; CACHE-04b resource revision INVENTORY | Contract then Behavior | #169 | Mechanical cache move and stable stage seam |
+| 17 | A169 first-pass cache policy | A169-CACHE-01/02/03 and CACHE-04a MERGED; CACHE-04b resource revision VALIDATED in PR #377; CACHE-05 concurrency/metrics follows | Contract then Behavior | #169 | Mechanical cache move and stable stage seam |
 | 18 | D-series canonical root consolidation | BLOCKED by relevant C contracts | Move | #186 | Phase B exit; per-feature behavior stable |
 | 19 | E-series RuntimeServices/lifecycle | BLOCKED by canonical owners | Move/Contract, split PRs | #187 | Relevant D moves |
 | 20 | G-04 through G-06 and H | INCREMENTAL/LATER | Gate/Contract | #188 | Appropriate package and release evidence |

--- a/docs/architecture/python-backend-execution-roadmap.md
+++ b/docs/architecture/python-backend-execution-roadmap.md
@@ -407,7 +407,7 @@ mechanical retirement series.
 | 14 | B-11 registration/bootstrap/root shim | COMPLETE in PR #356 | Move/Contract, split PRs | #184 | Zero runtime binders/residual implementation; explicit root `__all__`; frozen compatibility audit |
 | 15 | S167 backend seed reservation series | S167-01 through S167-03d COMPLETE on `dev`; S167-03e AiO cutover VALIDATED with isolated API/module/browser-load parity | Contract then Move then Behavior | #167 | Canonical AiO/node seams |
 | 16 | A169 stage pipeline series | A169-01 through A169-08 MERGED; A169-09 final adapter/integration VALIDATED in PR #372 | Contract then Behavior | #169 | Typed config and mechanical AiO move |
-| 17 | A169 first-pass cache policy | A169-CACHE-01/02/03 MERGED; CACHE-04a TTL/LRU/clear-disable VALIDATED in PR #376; CACHE-04b resource revision follows | Contract then Behavior | #169 | Mechanical cache move and stable stage seam |
+| 17 | A169 first-pass cache policy | A169-CACHE-01/02/03 and CACHE-04a MERGED; CACHE-04b resource revision INVENTORY | Contract then Behavior | #169 | Mechanical cache move and stable stage seam |
 | 18 | D-series canonical root consolidation | BLOCKED by relevant C contracts | Move | #186 | Phase B exit; per-feature behavior stable |
 | 19 | E-series RuntimeServices/lifecycle | BLOCKED by canonical owners | Move/Contract, split PRs | #187 | Relevant D moves |
 | 20 | G-04 through G-06 and H | INCREMENTAL/LATER | Gate/Contract | #188 | Appropriate package and release evidence |

--- a/easyuse_anima/aio/first_pass_cache.py
+++ b/easyuse_anima/aio/first_pass_cache.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass, replace
 from typing import Any
 
 from ..common.serialization import _stable_change_key
+from ..infrastructure.comfy.resources import _comfy_resource_file_revision
 from ..prompt.data import _prompt_data_json_safe
 from .model_preparation import _aio_lora_stack_signature
 
@@ -190,6 +191,32 @@ def _aio_first_pass_cache_now() -> float:
     return time.monotonic()
 
 
+def _aio_first_pass_resource_revision(
+    resource_info,
+    lora_signature,
+) -> dict[str, Any]:
+    info = resource_info if isinstance(resource_info, dict) else {}
+
+    def revision(folder_name: str, value) -> dict[str, int | str] | None:
+        name = str(value or "").strip()
+        if not name:
+            return None
+        return _comfy_resource_file_revision(folder_name, name)
+
+    lora_revisions = []
+    if isinstance(lora_signature, list):
+        for entry in lora_signature:
+            name = entry.get("name") if isinstance(entry, dict) else ""
+            lora_revisions.append(revision("loras", name))
+
+    return {
+        "unet": revision("diffusion_models", info.get("unet_name")),
+        "vae": revision("vae", info.get("vae_name")),
+        "clip": revision("text_encoders", info.get("clip_name")),
+        "loras": lora_revisions,
+    }
+
+
 def _aio_first_pass_cache_key(
     *,
     cache_scope: str,
@@ -206,19 +233,23 @@ def _aio_first_pass_cache_key(
     width: int,
     height: int,
 ) -> str:
+    resource_info = context.get("resource_info", {})
+    lora_signature = _aio_lora_stack_signature(lora_stack)
     return _stable_change_key({
         "schema": "easyuse_anima_aio_first_pass_cache",
-        "version": 1,
+        "version": 2,
         "scope": str(cache_scope or ""),
         "mode": settings.get("mode"),
-        "resource_info": _prompt_data_json_safe(
-            context.get("resource_info", {})
+        "resource_info": _prompt_data_json_safe(resource_info),
+        "resource_revision": _aio_first_pass_resource_revision(
+            resource_info,
+            lora_signature,
         ),
         "input_settings": _prompt_data_json_safe(
             context.get("input_settings", {})
         ),
         "prompt_data": _prompt_data_json_safe(prompt_data),
-        "lora_stack": _aio_lora_stack_signature(lora_stack),
+        "lora_stack": lora_signature,
         "sampler": _prompt_data_json_safe(
             settings.get("sampler", {})
         ),

--- a/easyuse_anima/infrastructure/comfy/resources.py
+++ b/easyuse_anima/infrastructure/comfy/resources.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Callable, Iterable
+from pathlib import Path
 from typing import Any
 
 
@@ -28,6 +29,52 @@ def _folder_path_names(folder_name: str, fallback: list[str]) -> list[str]:
     except Exception:
         pass
     return list(fallback)
+
+
+def _comfy_resource_file_revision(
+    folder_name: str,
+    filename: str,
+) -> dict[str, int | str] | None:
+    category = str(folder_name or "").strip()
+    name = str(filename or "").strip()
+    if not category or not name:
+        return None
+
+    try:
+        import folder_paths  # type: ignore
+
+        resolve_path = getattr(folder_paths, "get_full_path", None)
+        if not callable(resolve_path):
+            resolve_path = getattr(
+                folder_paths,
+                "get_full_path_or_raise",
+                None,
+            )
+        if not callable(resolve_path):
+            return None
+        raw_path = resolve_path(category, name)
+        if not isinstance(raw_path, (str, Path)) or not raw_path:
+            return None
+        resolved_path = Path(raw_path).resolve(strict=False)
+        stat = resolved_path.stat()
+    except Exception:
+        return None
+
+    size = getattr(stat, "st_size", None)
+    mtime_ns = getattr(stat, "st_mtime_ns", None)
+    if (
+        not isinstance(size, int)
+        or isinstance(size, bool)
+        or size < 0
+        or not isinstance(mtime_ns, int)
+        or isinstance(mtime_ns, bool)
+    ):
+        return None
+    return {
+        "path": str(resolved_path),
+        "size": size,
+        "mtime_ns": mtime_ns,
+    }
 
 
 def _comfy_diffusion_model_names(

--- a/tests/fixtures/python_backend_baseline.json
+++ b/tests/fixtures/python_backend_baseline.json
@@ -4726,6 +4726,24 @@
       },
       {
         "alias": null,
+        "bound_name": "_comfy_resource_file_revision",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": "..infrastructure.comfy.resources:_comfy_resource_file_revision",
+        "kind": "static_from",
+        "line": 10,
+        "name": "_comfy_resource_file_revision",
+        "optional": false,
+        "requested": "..infrastructure.comfy.resources",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/aio/first_pass_cache.py",
+        "target": "easyuse_anima/infrastructure/comfy/resources.py"
+      },
+      {
+        "alias": null,
         "bound_name": "_prompt_data_json_safe",
         "branch_context": [],
         "classification": "internal",
@@ -4733,7 +4751,7 @@
         "conditional": false,
         "imported": "..prompt.data:_prompt_data_json_safe",
         "kind": "static_from",
-        "line": 10,
+        "line": 11,
         "name": "_prompt_data_json_safe",
         "optional": false,
         "requested": "..prompt.data",
@@ -4751,7 +4769,7 @@
         "conditional": false,
         "imported": ".model_preparation:_aio_lora_stack_signature",
         "kind": "static_from",
-        "line": 11,
+        "line": 12,
         "name": "_aio_lora_stack_signature",
         "optional": false,
         "requested": ".model_preparation",
@@ -13503,6 +13521,23 @@
       },
       {
         "alias": null,
+        "bound_name": "Path",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "pathlib:Path",
+        "kind": "static_from",
+        "line": 6,
+        "name": "Path",
+        "optional": false,
+        "requested": "pathlib",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/infrastructure/comfy/resources.py"
+      },
+      {
+        "alias": null,
         "bound_name": "Any",
         "branch_context": [],
         "classification": "external",
@@ -13510,7 +13545,7 @@
         "conditional": false,
         "imported": "typing:Any",
         "kind": "static_from",
-        "line": 6,
+        "line": 7,
         "name": "Any",
         "optional": false,
         "requested": "typing",
@@ -13527,7 +13562,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 10
+            "line": 11
           }
         ],
         "classification": "external",
@@ -13535,7 +13570,7 @@
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 11,
+        "line": 12,
         "name": null,
         "optional": true,
         "requested": "folder_paths",
@@ -13552,7 +13587,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 22
+            "line": 23
           }
         ],
         "classification": "external",
@@ -13560,12 +13595,37 @@
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 23,
+        "line": 24,
         "name": null,
         "optional": true,
         "requested": "folder_paths",
         "role": "optional_dependency",
         "scope": "_folder_path_names",
+        "source": "easyuse_anima/infrastructure/comfy/resources.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "folder_paths",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": false,
+            "kind": "try",
+            "line": 43
+          }
+        ],
+        "classification": "external",
+        "column": 8,
+        "conditional": true,
+        "imported": "folder_paths",
+        "kind": "static_import",
+        "line": 44,
+        "name": null,
+        "optional": true,
+        "requested": "folder_paths",
+        "role": "optional_dependency",
+        "scope": "_comfy_resource_file_revision",
         "source": "easyuse_anima/infrastructure/comfy/resources.py"
       },
       {
@@ -46767,6 +46827,10 @@
       },
       {
         "from": "easyuse_anima/aio/first_pass_cache.py",
+        "to": "easyuse_anima/infrastructure/comfy/resources.py"
+      },
+      {
+        "from": "easyuse_anima/aio/first_pass_cache.py",
         "to": "easyuse_anima/prompt/data.py"
       },
       {
@@ -48851,13 +48915,13 @@
       },
       {
         "is_package": false,
-        "loc": 298,
+        "loc": 329,
         "module": "easyuse_anima.aio.first_pass_cache",
-        "normalized_git_blob_sha1": "2fe838a28380587be4870c8e7f8f3e9e6ea22377",
+        "normalized_git_blob_sha1": "44912cfb910ce201a0f400881fb9251b523e4c1c",
         "path": "easyuse_anima/aio/first_pass_cache.py",
         "top_level": {
           "class_count": 1,
-          "function_count": 11,
+          "function_count": 12,
           "global_count": 8
         }
       },
@@ -49367,13 +49431,13 @@
       },
       {
         "is_package": false,
-        "loc": 80,
+        "loc": 127,
         "module": "easyuse_anima.infrastructure.comfy.resources",
-        "normalized_git_blob_sha1": "ddfdbefea28e0b53e34c48c1301f17a5a32c3bdd",
+        "normalized_git_blob_sha1": "d2459fb9c4408d70eeafbaa26a9a877c8ffa3639",
         "path": "easyuse_anima/infrastructure/comfy/resources.py",
         "top_level": {
           "class_count": 0,
-          "function_count": 6,
+          "function_count": 7,
           "global_count": 1
         }
       },
@@ -61974,9 +62038,20 @@
         "branch_context": [],
         "classification": "external",
         "conditional": false,
-        "imported": "typing:Any",
+        "imported": "pathlib:Path",
         "kind": "static_from",
         "line": 6,
+        "optional": false,
+        "role": "ordinary",
+        "source": "easyuse_anima/infrastructure/comfy/resources.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "typing:Any",
+        "kind": "static_from",
+        "line": 7,
         "optional": false,
         "role": "ordinary",
         "source": "easyuse_anima/infrastructure/comfy/resources.py"
@@ -61988,14 +62063,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 10
+            "line": 11
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 11,
+        "line": 12,
         "optional": true,
         "role": "optional_dependency",
         "source": "easyuse_anima/infrastructure/comfy/resources.py"
@@ -62007,14 +62082,33 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 22
+            "line": 23
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 23,
+        "line": 24,
+        "optional": true,
+        "role": "optional_dependency",
+        "source": "easyuse_anima/infrastructure/comfy/resources.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": false,
+            "kind": "try",
+            "line": 43
+          }
+        ],
+        "classification": "external",
+        "conditional": true,
+        "imported": "folder_paths",
+        "kind": "static_import",
+        "line": 44,
         "optional": true,
         "role": "optional_dependency",
         "source": "easyuse_anima/infrastructure/comfy/resources.py"
@@ -64701,14 +64795,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 10
+            "line": 11
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 11,
+        "line": 12,
         "optional": true,
         "role": "optional_dependency",
         "source": "easyuse_anima/infrastructure/comfy/resources.py"
@@ -64720,14 +64814,33 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 22
+            "line": 23
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 23,
+        "line": 24,
+        "optional": true,
+        "role": "optional_dependency",
+        "source": "easyuse_anima/infrastructure/comfy/resources.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": false,
+            "kind": "try",
+            "line": 43
+          }
+        ],
+        "classification": "external",
+        "conditional": true,
+        "imported": "folder_paths",
+        "kind": "static_import",
+        "line": 44,
         "optional": true,
         "role": "optional_dependency",
         "source": "easyuse_anima/infrastructure/comfy/resources.py"
@@ -65778,7 +65891,7 @@
         "column": 1,
         "context": "decorator:_AIOFirstPassCacheEntry",
         "kind": "import_time_call",
-        "line": 20,
+        "line": 21,
         "module": "easyuse_anima/aio/first_pass_cache.py",
         "scope": "<module>"
       },
@@ -67090,13 +67203,13 @@
       },
       {
         "kind": "dict",
-        "line": 56,
+        "line": 57,
         "module": "easyuse_anima/aio/first_pass_cache.py",
         "name": "_AIO_FIRST_PASS_CACHE"
       },
       {
         "kind": "list",
-        "line": 60,
+        "line": 61,
         "module": "easyuse_anima/aio/first_pass_cache.py",
         "name": "_AIO_FIRST_PASS_CACHE_ORDER"
       },
@@ -67469,7 +67582,7 @@
           "mutable_container"
         ],
         "initializer": "Dict",
-        "line": 56,
+        "line": 57,
         "module": "easyuse_anima/aio/first_pass_cache.py",
         "name": "_AIO_FIRST_PASS_CACHE"
       },
@@ -67479,7 +67592,7 @@
           "mutable_container"
         ],
         "initializer": "List",
-        "line": 60,
+        "line": 61,
         "module": "easyuse_anima/aio/first_pass_cache.py",
         "name": "_AIO_FIRST_PASS_CACHE_ORDER"
       },

--- a/tests/test_aio_first_pass_cache.py
+++ b/tests/test_aio_first_pass_cache.py
@@ -316,6 +316,7 @@ class AIOFirstPassCacheMoveTests(unittest.TestCase):
         captured = []
         json_safe = Mock(side_effect=lambda value: {"safe": value})
         lora_signature = Mock(return_value=[{"name": "lora"}])
+        resource_revision = Mock(return_value={"revision": "files"})
 
         def stable_change_key(payload):
             captured.append(payload)
@@ -346,10 +347,22 @@ class AIOFirstPassCacheMoveTests(unittest.TestCase):
                 "_aio_lora_stack_signature",
                 lora_signature,
             ),
+            patch.object(
+                first_pass_cache,
+                "_aio_first_pass_resource_revision",
+                resource_revision,
+            ),
         ):
             result = first_pass_cache._aio_first_pass_cache_key(
                 cache_scope=0,
-                context={"resource_info": {"model": "a"}, "input_settings": {"loader": "b"}},
+                context={
+                    "resource_info": {
+                        "unet_name": "unet.safetensors",
+                        "vae_name": "vae.safetensors",
+                        "clip_name": "clip.safetensors",
+                    },
+                    "input_settings": {"loader": "b"},
+                },
                 prompt_data={"positive": "p"},
                 lora_stack="loras",
                 settings=settings,
@@ -368,16 +381,18 @@ class AIOFirstPassCacheMoveTests(unittest.TestCase):
         self.assertEqual(
             list(payload),
             [
-                "schema", "version", "scope", "mode", "resource_info", "input_settings",
-                "prompt_data", "lora_stack", "sampler", "model_patches", "mod_guidance",
-                "artist_mix", "positive_prompt", "negative_prompt", "quality_tags",
-                "quality_neg", "use_anima_mod_guidance", "use_negative_anima_mod_guidance",
-                "width", "height",
+                "schema", "version", "scope", "mode", "resource_info",
+                "resource_revision", "input_settings", "prompt_data", "lora_stack", "sampler",
+                "model_patches", "mod_guidance", "artist_mix", "positive_prompt",
+                "negative_prompt", "quality_tags", "quality_neg",
+                "use_anima_mod_guidance", "use_negative_anima_mod_guidance", "width",
+                "height",
             ],
         )
         self.assertEqual(payload["schema"], "easyuse_anima_aio_first_pass_cache")
-        self.assertEqual(payload["version"], 1)
+        self.assertEqual(payload["version"], 2)
         self.assertEqual(payload["scope"], "")
+        self.assertEqual(payload["resource_revision"], {"revision": "files"})
         self.assertEqual(payload["lora_stack"], [{"name": "lora"}])
         self.assertEqual(payload["positive_prompt"], "")
         self.assertEqual(payload["negative_prompt"], "")
@@ -390,11 +405,162 @@ class AIOFirstPassCacheMoveTests(unittest.TestCase):
         self.assertEqual(
             [call.args[0] for call in json_safe.call_args_list],
             [
-                {"model": "a"}, {"loader": "b"}, {"positive": "p"}, {"seed": 42},
-                {"dave": True}, {"mode": "enabled"}, {"mode": "off"},
+                {
+                    "unet_name": "unet.safetensors",
+                    "vae_name": "vae.safetensors",
+                    "clip_name": "clip.safetensors",
+                },
+                {"loader": "b"}, {"positive": "p"}, {"seed": 42}, {"dave": True},
+                {"mode": "enabled"}, {"mode": "off"},
             ],
         )
         lora_signature.assert_called_once_with("loras")
+        resource_revision.assert_called_once_with(
+            {
+                "unet_name": "unet.safetensors",
+                "vae_name": "vae.safetensors",
+                "clip_name": "clip.safetensors",
+            },
+            [{"name": "lora"}],
+        )
+
+    def test_resource_revision_maps_base_resources_and_loras_in_signature_order(self):
+        revisions = Mock(
+            side_effect=lambda folder_name, filename: (
+                f"{folder_name}:{filename}"
+            )
+        )
+        with patch.object(
+            first_pass_cache,
+            "_comfy_resource_file_revision",
+            revisions,
+        ):
+            result = first_pass_cache._aio_first_pass_resource_revision(
+                {
+                    "unet_name": "unet.safetensors",
+                    "vae_name": "vae.safetensors",
+                    "clip_name": "clip.safetensors",
+                },
+                [
+                    {"name": "style/a.safetensors"},
+                    {"name": "style/b.safetensors"},
+                ],
+            )
+
+        self.assertEqual(
+            result,
+            {
+                "unet": "diffusion_models:unet.safetensors",
+                "vae": "vae:vae.safetensors",
+                "clip": "text_encoders:clip.safetensors",
+                "loras": [
+                    "loras:style/a.safetensors",
+                    "loras:style/b.safetensors",
+                ],
+            },
+        )
+        self.assertEqual(
+            [call.args for call in revisions.call_args_list],
+            [
+                ("loras", "style/a.safetensors"),
+                ("loras", "style/b.safetensors"),
+                ("diffusion_models", "unet.safetensors"),
+                ("vae", "vae.safetensors"),
+                ("text_encoders", "clip.safetensors"),
+            ],
+        )
+
+    def test_key_changes_for_base_and_lora_file_revision_but_not_same_descriptor(self):
+        settings = {
+            "mode": "txt2img",
+            "sampler": {"seed": 42},
+            "model_patches": {},
+            "mod_guidance": {},
+            "artist_mix": {},
+        }
+        key_args = {
+            "cache_scope": "node",
+            "context": {
+                "resource_info": {
+                    "unet_name": "unet.safetensors",
+                    "vae_name": "vae.safetensors",
+                    "clip_name": "clip.safetensors",
+                },
+                "input_settings": {},
+            },
+            "prompt_data": {"positive": "prompt"},
+            "lora_stack": [
+                {
+                    "name": "style.safetensors",
+                    "strength_model": 1.0,
+                    "strength_clip": 1.0,
+                }
+            ],
+            "settings": settings,
+            "positive_prompt": "prompt",
+            "negative_prompt": "",
+            "quality_tags": "",
+            "quality_neg": "",
+            "use_anima_mod_guidance": False,
+            "use_negative_anima_mod_guidance": False,
+            "width": 1024,
+            "height": 1024,
+        }
+        baseline = {
+            ("diffusion_models", "unet.safetensors"): {
+                "path": "models/unet.safetensors",
+                "size": 100,
+                "mtime_ns": 1000,
+            },
+            ("vae", "vae.safetensors"): {
+                "path": "models/vae.safetensors",
+                "size": 200,
+                "mtime_ns": 2000,
+            },
+            ("text_encoders", "clip.safetensors"): {
+                "path": "models/clip.safetensors",
+                "size": 300,
+                "mtime_ns": 3000,
+            },
+            ("loras", "style.safetensors"): {
+                "path": "models/style.safetensors",
+                "size": 400,
+                "mtime_ns": 4000,
+            },
+        }
+
+        def key_for(revisions):
+            with patch.object(
+                first_pass_cache,
+                "_comfy_resource_file_revision",
+                side_effect=lambda folder_name, filename: revisions[
+                    (folder_name, filename)
+                ],
+            ):
+                return first_pass_cache._aio_first_pass_cache_key(**key_args)
+
+        first = key_for(baseline)
+        self.assertEqual(key_for(dict(baseline)), first)
+
+        for field, value in (
+            ("path", "models/replaced-unet.safetensors"),
+            ("size", 101),
+            ("mtime_ns", 1001),
+        ):
+            with self.subTest(base_field=field):
+                changed = {
+                    key: dict(revision)
+                    for key, revision in baseline.items()
+                }
+                changed[("diffusion_models", "unet.safetensors")][field] = value
+                self.assertNotEqual(key_for(changed), first)
+
+        changed_lora = {
+            key: dict(revision)
+            for key, revision in baseline.items()
+        }
+        changed_lora[("loras", "style.safetensors")]["mtime_ns"] = 4001
+        self.assertNotEqual(key_for(changed_lora), first)
 
     def test_replacement_state_clear_and_falsey_miss_are_call_time(self):
         cache = {"empty": {}}

--- a/tests/test_comfy_adapters.py
+++ b/tests/test_comfy_adapters.py
@@ -174,6 +174,141 @@ class ComfyCapabilityAdapterTests(unittest.TestCase):
 
 
 class ComfyResourceAdapterTests(unittest.TestCase):
+    def test_resource_file_revision_uses_resolved_path_size_and_mtime(self):
+        calls = []
+        folder_paths = SimpleNamespace(
+            get_full_path=lambda folder_name, filename: (
+                calls.append((folder_name, filename))
+                or "models/runtime.safetensors"
+            ),
+        )
+        resolved_path = Path("canonical/runtime.safetensors")
+        with (
+            patch.dict(sys.modules, {"folder_paths": folder_paths}),
+            patch.object(
+                resources.Path,
+                "resolve",
+                return_value=resolved_path,
+            ) as resolve,
+            patch.object(
+                resources.Path,
+                "stat",
+                return_value=SimpleNamespace(
+                    st_size=1234,
+                    st_mtime_ns=5678,
+                ),
+            ) as stat,
+        ):
+            revision = resources._comfy_resource_file_revision(
+                "diffusion_models",
+                "anima.safetensors",
+            )
+
+        self.assertEqual(
+            revision,
+            {
+                "path": str(resolved_path),
+                "size": 1234,
+                "mtime_ns": 5678,
+            },
+        )
+        self.assertEqual(
+            calls,
+            [("diffusion_models", "anima.safetensors")],
+        )
+        resolve.assert_called_once_with(strict=False)
+        stat.assert_called_once_with()
+
+    def test_resource_file_revision_supports_legacy_resolver_and_safe_fallbacks(self):
+        legacy_calls = []
+        legacy_folder_paths = SimpleNamespace(
+            get_full_path_or_raise=lambda folder_name, filename: (
+                legacy_calls.append((folder_name, filename))
+                or "models/legacy.safetensors"
+            ),
+        )
+        with (
+            patch.dict(sys.modules, {"folder_paths": legacy_folder_paths}),
+            patch.object(
+                resources.Path,
+                "resolve",
+                return_value=Path("canonical/legacy.safetensors"),
+            ),
+            patch.object(
+                resources.Path,
+                "stat",
+                return_value=SimpleNamespace(
+                    st_size=10,
+                    st_mtime_ns=20,
+                ),
+            ),
+        ):
+            self.assertEqual(
+                resources._comfy_resource_file_revision(
+                    "vae",
+                    "legacy.safetensors",
+                ),
+                {
+                    "path": str(Path("canonical/legacy.safetensors")),
+                    "size": 10,
+                    "mtime_ns": 20,
+                },
+            )
+        self.assertEqual(
+            legacy_calls,
+            [("vae", "legacy.safetensors")],
+        )
+
+        self.assertIsNone(
+            resources._comfy_resource_file_revision("", "model")
+        )
+        self.assertIsNone(
+            resources._comfy_resource_file_revision("vae", "")
+        )
+        for folder_paths in (
+            SimpleNamespace(),
+            SimpleNamespace(get_full_path=lambda *_args: None),
+            SimpleNamespace(get_full_path=lambda *_args: object()),
+            SimpleNamespace(
+                get_full_path=lambda *_args: (
+                    _ for _ in ()
+                ).throw(RuntimeError("unavailable"))
+            ),
+        ):
+            with self.subTest(folder_paths=folder_paths), patch.dict(
+                sys.modules,
+                {"folder_paths": folder_paths},
+            ):
+                self.assertIsNone(
+                    resources._comfy_resource_file_revision(
+                        "vae",
+                        "missing.safetensors",
+                    )
+                )
+
+        folder_paths = SimpleNamespace(
+            get_full_path=lambda *_args: "models/broken.safetensors",
+        )
+        with (
+            patch.dict(sys.modules, {"folder_paths": folder_paths}),
+            patch.object(
+                resources.Path,
+                "resolve",
+                return_value=Path("canonical/broken.safetensors"),
+            ),
+            patch.object(
+                resources.Path,
+                "stat",
+                side_effect=OSError("stat failed"),
+            ),
+        ):
+            self.assertIsNone(
+                resources._comfy_resource_file_revision(
+                    "vae",
+                    "broken.safetensors",
+                )
+            )
+
     def test_folder_resources_use_runtime_names_and_preserve_fallbacks(self):
         folder_paths = SimpleNamespace(
             get_filename_list=lambda folder_name: {


### PR DESCRIPTION
## 변경 요약

- first-pass cache key schema를 version 2로 올리고 내부 `resource_revision`을 추가했습니다.
- UNET/VAE/CLIP/LoRA의 ComfyUI logical name을 lazy host adapter에서 실제 파일로 해석합니다.
- key descriptor는 canonical resolved path, file size, `mtime_ns`를 포함합니다.
- 같은 logical name이어도 path/size/`mtime_ns`가 바뀌면 다른 key가 되어 기존 cache entry를 재사용하지 않습니다.
- host module/helper가 없거나 파일 해석/stat이 실패하면 예외 없이 no-revision으로 폴백하며 기존 logical name 기반 key는 유지됩니다.
- revision 정보는 opaque key 내부에만 사용하고 workflow/metadata/API/log에는 추가하지 않았습니다.

## Inventory와 경계

- canonical owner: `easyuse_anima.aio.first_pass_cache._aio_first_pass_cache_key`
- only production caller: `easyuse_anima.aio.legacy_generation._run_aio_generation_pipeline`
- root `_aio_first_pass_cache_key` direct alias/signature/identity 유지
- First-pass stage는 기존 opaque key get/put 계약 유지
- lazy host owner: `easyuse_anima.infrastructure.comfy.resources`
- 새 helper는 root alias/export/cache/registry/generation counter/global mutable state를 만들지 않음
- resource context/loader, TTL/LRU/clear/disable, clone, budgets, storage, concurrency/metrics는 변경하지 않음

## 주요 파일

- `easyuse_anima/infrastructure/comfy/resources.py`
- `easyuse_anima/aio/first_pass_cache.py`
- `tests/test_comfy_adapters.py`
- `tests/test_aio_first_pass_cache.py`
- `tests/fixtures/python_backend_baseline.json`
- `docs/architecture/aio-first-pass-cache-resource-revision.md`
- `docs/architecture/python-backend-execution-roadmap.md`

## 검증

- resource adapter focused: 4 passed
- cache focused: 21 passed
- First-pass stage focused: 5 passed
- hostless package import: 1 passed
- targeted Ruff 0.15.22: production all rules passed; tests fatal rules passed
- targeted Pyright 1.1.411: changed production files 0 errors
- Python backend analyzer: 18 passed
- import boundary: 6 groups, 0 violations
- official full: Python 1,116 passed, frontend JavaScript 112 files passed
- full Pyright baseline: 88 files, 기존 검토 대상 14 errors 유지
- `git diff --check`: passed

서버 기동, 모델 로드/실행, 브라우저 smoke는 이 deterministic adapter/key Behavior에 필요하지 않아 실행하지 않았습니다.

검증 중 새 payload 필드의 테스트 기대 순서 1건과 dynamic host path 반환 타입의 Pyright 오류 1건을 확인해 정확히 수정했으며, 관련 focused/정적 검사와 official full 최종 결과는 모두 통과했습니다.

## 남은 위험과 후속

- 동일 path/size/`mtime_ns`를 유지한 채 파일 내용만 바꾸는 비정상 교체는 감지하지 않습니다. 이 계약은 이슈 #169가 요구한 path/size/`mtime_ns` revision 경계입니다.
- 동시 hit/put/eviction과 metrics는 다음 A169-CACHE-05 단위로 분리합니다.
