### PR TITLE
feat: serialize AiO first-pass cache mutation

### DIFF
--- a/docs/architecture/aio-first-pass-cache-concurrency.md
+++ b/docs/architecture/aio-first-pass-cache-concurrency.md
@@ -5,7 +5,7 @@
 - PR type: Behavior
 - Baseline: `dev` commit
   `beade4ff73575c927efd50dc5b125f9de120c392`
-- State: INVENTORY
+- State: VALIDATED
 
 CACHE-05a makes process-local first-pass cache mutation thread-safe without
 changing key, entry, budget, TTL, clone, or hit/miss behavior. CACHE-05b
@@ -45,10 +45,11 @@ review and rollback boundaries.
 
 ## Target concurrency contract
 
-- Add one private module-owned reentrant lock. It is not exported or aliased
-  through root.
+- Add one private module-owned reentrant lock and one private monotonic mutation
+  generation. Neither is exported or aliased through root.
 - Clear and enable/disable transitions linearize under the lock. Disabling sets
-  disabled and clears mapping/order in the same critical section.
+  disabled and clears mapping/order in the same critical section. Explicit
+  clear and enabled-state transitions advance the mutation generation.
 - Total-byte reads observe one locked mapping snapshot.
 - Get linearizes while locked:
   - disabled/missing/expired decisions;
@@ -58,11 +59,12 @@ review and rollback boundaries.
 - Checkout cloning occurs after the lock is released. A hit linearized before a
   later clear/disable may finish its independent checkout; clear/disable does
   not wait for tensor cloning.
-- Put performs an initial locked enabled check, then size estimation and
-  immutable capture outside the lock. It rechecks enabled under the lock before
-  insertion.
-- Disable that completes during an in-flight capture wins: the captured value
-  is discarded and the cache remains empty/disabled.
+- Put performs an initial locked enabled/generation snapshot, then size
+  estimation and immutable capture outside the lock. It rechecks both under the
+  lock before insertion.
+- Clear or disable that completes during an in-flight capture wins: the
+  captured value is discarded. A disable/re-enable cycle cannot admit a stale
+  capture from the prior enabled generation.
 - Insert/overwrite, LRU update, and all count/byte evictions occur in one final
   critical section. Concurrent same-key puts leave at most one key/order entry.
 - Existing disabled zero-work behavior remains: a put that observes disabled at
@@ -111,12 +113,13 @@ Forbidden:
 
 Focused validation must prove:
 
-- lock ownership is private and root aliases stay unchanged;
+- lock/generation ownership is private and root aliases stay unchanged;
 - clear/disable/re-enable and total-byte reads preserve existing results;
 - get/put/eviction maintain mapping/order/count/byte invariants under bounded
   concurrent hit/put activity;
 - checkout and capture cloning do not hold the shared lock;
-- disable completed during in-flight capture prevents the final insert;
+- clear or disable/re-enable completed during in-flight capture prevents the
+  final stale insert;
 - existing TTL/LRU, resource revision, disabled zero-work, clone/mutation
   isolation, benchmark, stage caller, analyzer, and import boundary contracts
   remain valid.
@@ -124,3 +127,25 @@ Focused validation must prove:
 Use bounded events/barriers with explicit timeouts; do not start a server or
 long-running worker. Run one official full validation only after focused checks
 pass.
+
+## Validation result
+
+Validated on the CACHE-05a worktree:
+
+- private lock/generation ownership, clear and disable/re-enable capture
+  barriers, checkout/capture outside-lock behavior, bounded concurrent
+  hit/put/eviction invariants, and all existing cache contracts: 25 focused
+  cache tests passed in 0.009 seconds;
+- existing bounded clone/mutation benchmark: 4 focused tests passed;
+- unchanged First-pass stage caller: 5 focused tests passed;
+- targeted Ruff 0.15.22: changed production file passed all rules and changed
+  test file passed fatal rules;
+- targeted Pyright 1.1.411: changed production file passed with 0 errors;
+- Python backend analyzer: 18 focused tests passed;
+- Python import-boundary gate: 6 completed package groups, 0 violations; and
+- official full: 1,120 Python tests plus 112 frontend JavaScript files passed,
+  with the reviewed Pyright baseline unchanged at 88 files and 14 errors.
+
+No metrics, key/resource revision, entry/TTL/budget/clone/storage, caller/root
+alias, server, model, browser, frontend, workflow, or user-instance behavior
+was changed.

--- a/docs/architecture/aio-first-pass-cache-concurrency.md
+++ b/docs/architecture/aio-first-pass-cache-concurrency.md
@@ -1,0 +1,126 @@
+# AiO first-pass cache thread-safe mutation
+
+- Owner issue: [#169](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/169)
+- Roadmap unit: A169-CACHE-05a
+- PR type: Behavior
+- Baseline: `dev` commit
+  `beade4ff73575c927efd50dc5b125f9de120c392`
+- State: INVENTORY
+
+CACHE-05a makes process-local first-pass cache mutation thread-safe without
+changing key, entry, budget, TTL, clone, or hit/miss behavior. CACHE-05b
+separately owns metrics so lock correctness and observability retain independent
+review and rollback boundaries.
+
+## Symbol, caller, alias, and global-state inventory
+
+### Canonical mutable state
+
+- `easyuse_anima.aio.first_pass_cache` owns one process-local mapping, one LRU
+  order list, and one enabled flag.
+- `_clear_aio_first_pass_cache`, `_set_aio_first_pass_cache_enabled`,
+  `_get_aio_first_pass_cache`, and `_put_aio_first_pass_cache` mutate or
+  coordinate that shared state.
+- `_aio_first_pass_cache_total_bytes` reads the full mapping and is used by put
+  while enforcing count and byte budgets.
+- No lock currently protects multi-step mapping/order/enabled operations.
+
+### Callers and compatibility aliases
+
+- The typed First-pass stage calls get/put through its existing runtime.
+- Root `nodes.py` retains direct aliases for count, mapping/order, clone,
+  key/get/put. The clear and enabled setter are canonical test/internal seams
+  and are not root aliases.
+- Repository benchmark/tests call the canonical owner directly.
+- No caller, function signature, root alias, package export, or workflow
+  contract changes in CACHE-05a.
+
+### Entry and expensive-work boundary
+
+- Canonical entries are frozen and own independent snapshots. Mapping removal
+  or replacement does not mutate an entry already observed by a get.
+- Size estimation, capture cloning, and checkout cloning may be expensive.
+- Key construction and resource revision stat calls happen before cache get/put
+  and do not touch cache mutable state.
+
+## Target concurrency contract
+
+- Add one private module-owned reentrant lock. It is not exported or aliased
+  through root.
+- Clear and enable/disable transitions linearize under the lock. Disabling sets
+  disabled and clears mapping/order in the same critical section.
+- Total-byte reads observe one locked mapping snapshot.
+- Get linearizes while locked:
+  - disabled/missing/expired decisions;
+  - expiration removal;
+  - canonical last-access replacement; and
+  - LRU remove/append.
+- Checkout cloning occurs after the lock is released. A hit linearized before a
+  later clear/disable may finish its independent checkout; clear/disable does
+  not wait for tensor cloning.
+- Put performs an initial locked enabled check, then size estimation and
+  immutable capture outside the lock. It rechecks enabled under the lock before
+  insertion.
+- Disable that completes during an in-flight capture wins: the captured value
+  is discarded and the cache remains empty/disabled.
+- Insert/overwrite, LRU update, and all count/byte evictions occur in one final
+  critical section. Concurrent same-key puts leave at most one key/order entry.
+- Existing disabled zero-work behavior remains: a put that observes disabled at
+  its initial check performs no estimation, clone, or clock work.
+
+These linearization points avoid holding the shared lock across tensor copies
+while preserving deterministic mapping/order/enabled invariants.
+
+## Allowed-file boundary
+
+CACHE-05a may change only:
+
+- `easyuse_anima/aio/first_pass_cache.py`;
+- `tests/test_aio_first_pass_cache.py`;
+- `tests/test_aio_first_pass_cache_benchmark.py` only if concurrent test
+  isolation requires an explicit reset;
+- `tests/test_python_backend_analyzer.py` only if analyzer assertions require
+  enrollment;
+- `tests/fixtures/python_backend_baseline.json`, regenerated from source;
+- this document; and
+- `docs/architecture/python-backend-execution-roadmap.md`.
+
+Read-only evidence:
+
+- `easyuse_anima/aio/generation_first_pass.py`;
+- `easyuse_anima/aio/legacy_generation.py`;
+- `easyuse_anima/infrastructure/comfy/resources.py`;
+- root `nodes.py`;
+- `tools/benchmark_aio_first_pass_cache.py`;
+- `tests/test_aio_first_pass_stage.py`;
+- `tests/test_aio_first_pass_cache_benchmark.py`;
+- `tests/test_python_import_boundaries.py`; and
+- `tests/fixtures/python_compatibility_surface.v1.json`.
+
+Forbidden:
+
+- metrics/counters/snapshots/logging or settings/frontend observability;
+- changing cache key/resource revision, entry layout, TTL, count/byte caps,
+  eviction policy, clone/copy-on-write, CPU/GPU storage, or benchmark budgets;
+- changing caller, stage, root aliases, loader/context, workflow/output,
+  sampling, seed, preview, Save, or cleanup behavior;
+- new worker threads, executors, background tasks, persistent state, server
+  startup, model execution, browser, release, Registry, or user-instance work.
+
+## Required validation
+
+Focused validation must prove:
+
+- lock ownership is private and root aliases stay unchanged;
+- clear/disable/re-enable and total-byte reads preserve existing results;
+- get/put/eviction maintain mapping/order/count/byte invariants under bounded
+  concurrent hit/put activity;
+- checkout and capture cloning do not hold the shared lock;
+- disable completed during in-flight capture prevents the final insert;
+- existing TTL/LRU, resource revision, disabled zero-work, clone/mutation
+  isolation, benchmark, stage caller, analyzer, and import boundary contracts
+  remain valid.
+
+Use bounded events/barriers with explicit timeouts; do not start a server or
+long-running worker. Run one official full validation only after focused checks
+pass.

--- a/docs/architecture/python-backend-execution-roadmap.md
+++ b/docs/architecture/python-backend-execution-roadmap.md
@@ -407,7 +407,7 @@ mechanical retirement series.
 | 14 | B-11 registration/bootstrap/root shim | COMPLETE in PR #356 | Move/Contract, split PRs | #184 | Zero runtime binders/residual implementation; explicit root `__all__`; frozen compatibility audit |
 | 15 | S167 backend seed reservation series | S167-01 through S167-03d COMPLETE on `dev`; S167-03e AiO cutover VALIDATED with isolated API/module/browser-load parity | Contract then Move then Behavior | #167 | Canonical AiO/node seams |
 | 16 | A169 stage pipeline series | A169-01 through A169-08 MERGED; A169-09 final adapter/integration VALIDATED in PR #372 | Contract then Behavior | #169 | Typed config and mechanical AiO move |
-| 17 | A169 first-pass cache policy | A169-CACHE-01/02/03 and CACHE-04a MERGED; CACHE-04b resource revision VALIDATED in PR #377; CACHE-05 concurrency/metrics follows | Contract then Behavior | #169 | Mechanical cache move and stable stage seam |
+| 17 | A169 first-pass cache policy | A169-CACHE-01/02/03 and CACHE-04a/04b MERGED; CACHE-05a thread-safe mutation INVENTORY; CACHE-05b metrics follows | Contract then Behavior | #169 | Mechanical cache move and stable stage seam |
 | 18 | D-series canonical root consolidation | BLOCKED by relevant C contracts | Move | #186 | Phase B exit; per-feature behavior stable |
 | 19 | E-series RuntimeServices/lifecycle | BLOCKED by canonical owners | Move/Contract, split PRs | #187 | Relevant D moves |
 | 20 | G-04 through G-06 and H | INCREMENTAL/LATER | Gate/Contract | #188 | Appropriate package and release evidence |

--- a/docs/architecture/python-backend-execution-roadmap.md
+++ b/docs/architecture/python-backend-execution-roadmap.md
@@ -407,7 +407,7 @@ mechanical retirement series.
 | 14 | B-11 registration/bootstrap/root shim | COMPLETE in PR #356 | Move/Contract, split PRs | #184 | Zero runtime binders/residual implementation; explicit root `__all__`; frozen compatibility audit |
 | 15 | S167 backend seed reservation series | S167-01 through S167-03d COMPLETE on `dev`; S167-03e AiO cutover VALIDATED with isolated API/module/browser-load parity | Contract then Move then Behavior | #167 | Canonical AiO/node seams |
 | 16 | A169 stage pipeline series | A169-01 through A169-08 MERGED; A169-09 final adapter/integration VALIDATED in PR #372 | Contract then Behavior | #169 | Typed config and mechanical AiO move |
-| 17 | A169 first-pass cache policy | A169-CACHE-01/02/03 and CACHE-04a/04b MERGED; CACHE-05a thread-safe mutation INVENTORY; CACHE-05b metrics follows | Contract then Behavior | #169 | Mechanical cache move and stable stage seam |
+| 17 | A169 first-pass cache policy | A169-CACHE-01/02/03 and CACHE-04a/04b MERGED; CACHE-05a thread-safe mutation VALIDATED in PR #378; CACHE-05b metrics follows | Contract then Behavior | #169 | Mechanical cache move and stable stage seam |
 | 18 | D-series canonical root consolidation | BLOCKED by relevant C contracts | Move | #186 | Phase B exit; per-feature behavior stable |
 | 19 | E-series RuntimeServices/lifecycle | BLOCKED by canonical owners | Move/Contract, split PRs | #187 | Relevant D moves |
 | 20 | G-04 through G-06 and H | INCREMENTAL/LATER | Gate/Contract | #188 | Appropriate package and release evidence |

--- a/easyuse_anima/aio/first_pass_cache.py
+++ b/easyuse_anima/aio/first_pass_cache.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import time
 from dataclasses import dataclass, replace
+from threading import RLock
 from typing import Any
 
 from ..common.serialization import _stable_change_key
@@ -59,6 +60,8 @@ _AIO_FIRST_PASS_CACHE: dict[
     _AIOFirstPassCacheEntry | dict[str, Any],
 ] = {}
 _AIO_FIRST_PASS_CACHE_ORDER: list[str] = []
+_AIO_FIRST_PASS_CACHE_LOCK = RLock()
+_AIO_FIRST_PASS_CACHE_GENERATION = 0
 
 
 def _clone_aio_cache_value(value):
@@ -168,23 +171,33 @@ def _aio_first_pass_cache_entry_size_bytes(entry) -> int:
 
 
 def _aio_first_pass_cache_total_bytes() -> int:
-    return sum(
-        _aio_first_pass_cache_entry_size_bytes(entry)
-        for entry in _AIO_FIRST_PASS_CACHE.values()
-    )
+    with _AIO_FIRST_PASS_CACHE_LOCK:
+        return sum(
+            _aio_first_pass_cache_entry_size_bytes(entry)
+            for entry in _AIO_FIRST_PASS_CACHE.values()
+        )
 
 
 def _clear_aio_first_pass_cache() -> None:
-    _AIO_FIRST_PASS_CACHE.clear()
-    _AIO_FIRST_PASS_CACHE_ORDER.clear()
+    global _AIO_FIRST_PASS_CACHE_GENERATION
+
+    with _AIO_FIRST_PASS_CACHE_LOCK:
+        _AIO_FIRST_PASS_CACHE_GENERATION += 1
+        _AIO_FIRST_PASS_CACHE.clear()
+        _AIO_FIRST_PASS_CACHE_ORDER.clear()
 
 
 def _set_aio_first_pass_cache_enabled(enabled: bool) -> None:
-    global _AIO_FIRST_PASS_CACHE_ENABLED
+    global _AIO_FIRST_PASS_CACHE_ENABLED, _AIO_FIRST_PASS_CACHE_GENERATION
 
-    _AIO_FIRST_PASS_CACHE_ENABLED = bool(enabled)
-    if not _AIO_FIRST_PASS_CACHE_ENABLED:
-        _clear_aio_first_pass_cache()
+    next_enabled = bool(enabled)
+    with _AIO_FIRST_PASS_CACHE_LOCK:
+        if next_enabled != _AIO_FIRST_PASS_CACHE_ENABLED:
+            _AIO_FIRST_PASS_CACHE_GENERATION += 1
+        _AIO_FIRST_PASS_CACHE_ENABLED = next_enabled
+        if not _AIO_FIRST_PASS_CACHE_ENABLED:
+            _AIO_FIRST_PASS_CACHE.clear()
+            _AIO_FIRST_PASS_CACHE_ORDER.clear()
 
 
 def _aio_first_pass_cache_now() -> float:
@@ -274,23 +287,24 @@ def _aio_first_pass_cache_key(
 
 
 def _get_aio_first_pass_cache(cache_key: str):
-    if not _AIO_FIRST_PASS_CACHE_ENABLED:
-        return None
-    entry = _AIO_FIRST_PASS_CACHE.get(cache_key)
-    if not entry:
-        return None
-    if isinstance(entry, _AIOFirstPassCacheEntry):
-        now = _aio_first_pass_cache_now()
-        if now - entry.created_at >= AIO_FIRST_PASS_CACHE_TTL_SECONDS:
-            _AIO_FIRST_PASS_CACHE.pop(cache_key, None)
-            if cache_key in _AIO_FIRST_PASS_CACHE_ORDER:
-                _AIO_FIRST_PASS_CACHE_ORDER.remove(cache_key)
+    with _AIO_FIRST_PASS_CACHE_LOCK:
+        if not _AIO_FIRST_PASS_CACHE_ENABLED:
             return None
-        entry = replace(entry, last_access_at=now)
-        _AIO_FIRST_PASS_CACHE[cache_key] = entry
-    if cache_key in _AIO_FIRST_PASS_CACHE_ORDER:
-        _AIO_FIRST_PASS_CACHE_ORDER.remove(cache_key)
-    _AIO_FIRST_PASS_CACHE_ORDER.append(cache_key)
+        entry = _AIO_FIRST_PASS_CACHE.get(cache_key)
+        if not entry:
+            return None
+        if isinstance(entry, _AIOFirstPassCacheEntry):
+            now = _aio_first_pass_cache_now()
+            if now - entry.created_at >= AIO_FIRST_PASS_CACHE_TTL_SECONDS:
+                _AIO_FIRST_PASS_CACHE.pop(cache_key, None)
+                if cache_key in _AIO_FIRST_PASS_CACHE_ORDER:
+                    _AIO_FIRST_PASS_CACHE_ORDER.remove(cache_key)
+                return None
+            entry = replace(entry, last_access_at=now)
+            _AIO_FIRST_PASS_CACHE[cache_key] = entry
+        if cache_key in _AIO_FIRST_PASS_CACHE_ORDER:
+            _AIO_FIRST_PASS_CACHE_ORDER.remove(cache_key)
+        _AIO_FIRST_PASS_CACHE_ORDER.append(cache_key)
     if isinstance(entry, _AIOFirstPassCacheEntry):
         return entry.checkout()
     return (
@@ -300,8 +314,10 @@ def _get_aio_first_pass_cache(cache_key: str):
 
 
 def _put_aio_first_pass_cache(cache_key: str, latent, image) -> None:
-    if not _AIO_FIRST_PASS_CACHE_ENABLED:
-        return
+    with _AIO_FIRST_PASS_CACHE_LOCK:
+        if not _AIO_FIRST_PASS_CACHE_ENABLED:
+            return
+        generation = _AIO_FIRST_PASS_CACHE_GENERATION
     if (
         _aio_cache_pair_size_bytes(latent, image)
         > AIO_FIRST_PASS_CACHE_MAX_ENTRY_BYTES
@@ -314,16 +330,24 @@ def _put_aio_first_pass_cache(cache_key: str, latent, image) -> None:
     )
     if entry.size_bytes > AIO_FIRST_PASS_CACHE_MAX_ENTRY_BYTES:
         return
-    _AIO_FIRST_PASS_CACHE[cache_key] = entry
-    if cache_key in _AIO_FIRST_PASS_CACHE_ORDER:
-        _AIO_FIRST_PASS_CACHE_ORDER.remove(cache_key)
-    _AIO_FIRST_PASS_CACHE_ORDER.append(cache_key)
-    while _AIO_FIRST_PASS_CACHE_ORDER and (
-        len(_AIO_FIRST_PASS_CACHE_ORDER) > AIO_FIRST_PASS_CACHE_MAX_ENTRIES
-        or _aio_first_pass_cache_total_bytes() > AIO_FIRST_PASS_CACHE_MAX_BYTES
-    ):
-        old_key = _AIO_FIRST_PASS_CACHE_ORDER.pop(0)
-        _AIO_FIRST_PASS_CACHE.pop(old_key, None)
+    with _AIO_FIRST_PASS_CACHE_LOCK:
+        if (
+            not _AIO_FIRST_PASS_CACHE_ENABLED
+            or generation != _AIO_FIRST_PASS_CACHE_GENERATION
+        ):
+            return
+        _AIO_FIRST_PASS_CACHE[cache_key] = entry
+        if cache_key in _AIO_FIRST_PASS_CACHE_ORDER:
+            _AIO_FIRST_PASS_CACHE_ORDER.remove(cache_key)
+        _AIO_FIRST_PASS_CACHE_ORDER.append(cache_key)
+        while _AIO_FIRST_PASS_CACHE_ORDER and (
+            len(_AIO_FIRST_PASS_CACHE_ORDER)
+            > AIO_FIRST_PASS_CACHE_MAX_ENTRIES
+            or _aio_first_pass_cache_total_bytes()
+            > AIO_FIRST_PASS_CACHE_MAX_BYTES
+        ):
+            old_key = _AIO_FIRST_PASS_CACHE_ORDER.pop(0)
+            _AIO_FIRST_PASS_CACHE.pop(old_key, None)
 
 
 __all__ = ()

--- a/tests/fixtures/python_backend_baseline.json
+++ b/tests/fixtures/python_backend_baseline.json
@@ -4691,6 +4691,23 @@
       },
       {
         "alias": null,
+        "bound_name": "RLock",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "threading:RLock",
+        "kind": "static_from",
+        "line": 7,
+        "name": "RLock",
+        "optional": false,
+        "requested": "threading",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/aio/first_pass_cache.py"
+      },
+      {
+        "alias": null,
         "bound_name": "Any",
         "branch_context": [],
         "classification": "external",
@@ -4698,7 +4715,7 @@
         "conditional": false,
         "imported": "typing:Any",
         "kind": "static_from",
-        "line": 7,
+        "line": 8,
         "name": "Any",
         "optional": false,
         "requested": "typing",
@@ -4715,7 +4732,7 @@
         "conditional": false,
         "imported": "..common.serialization:_stable_change_key",
         "kind": "static_from",
-        "line": 9,
+        "line": 10,
         "name": "_stable_change_key",
         "optional": false,
         "requested": "..common.serialization",
@@ -4733,7 +4750,7 @@
         "conditional": false,
         "imported": "..infrastructure.comfy.resources:_comfy_resource_file_revision",
         "kind": "static_from",
-        "line": 10,
+        "line": 11,
         "name": "_comfy_resource_file_revision",
         "optional": false,
         "requested": "..infrastructure.comfy.resources",
@@ -4751,7 +4768,7 @@
         "conditional": false,
         "imported": "..prompt.data:_prompt_data_json_safe",
         "kind": "static_from",
-        "line": 11,
+        "line": 12,
         "name": "_prompt_data_json_safe",
         "optional": false,
         "requested": "..prompt.data",
@@ -4769,7 +4786,7 @@
         "conditional": false,
         "imported": ".model_preparation:_aio_lora_stack_signature",
         "kind": "static_from",
-        "line": 12,
+        "line": 13,
         "name": "_aio_lora_stack_signature",
         "optional": false,
         "requested": ".model_preparation",
@@ -48915,14 +48932,14 @@
       },
       {
         "is_package": false,
-        "loc": 329,
+        "loc": 353,
         "module": "easyuse_anima.aio.first_pass_cache",
-        "normalized_git_blob_sha1": "44912cfb910ce201a0f400881fb9251b523e4c1c",
+        "normalized_git_blob_sha1": "0f2fa5f9ae38c2443a10b7a8a49395de37cf8e08",
         "path": "easyuse_anima/aio/first_pass_cache.py",
         "top_level": {
           "class_count": 1,
           "function_count": 12,
-          "global_count": 8
+          "global_count": 10
         }
       },
       {
@@ -59832,9 +59849,20 @@
         "branch_context": [],
         "classification": "external",
         "conditional": false,
-        "imported": "typing:Any",
+        "imported": "threading:RLock",
         "kind": "static_from",
         "line": 7,
+        "optional": false,
+        "role": "ordinary",
+        "source": "easyuse_anima/aio/first_pass_cache.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "typing:Any",
+        "kind": "static_from",
+        "line": 8,
         "optional": false,
         "role": "ordinary",
         "source": "easyuse_anima/aio/first_pass_cache.py"
@@ -65891,7 +65919,16 @@
         "column": 1,
         "context": "decorator:_AIOFirstPassCacheEntry",
         "kind": "import_time_call",
-        "line": 21,
+        "line": 22,
+        "module": "easyuse_anima/aio/first_pass_cache.py",
+        "scope": "<module>"
+      },
+      {
+        "callee": "RLock",
+        "column": 29,
+        "context": "assign:_AIO_FIRST_PASS_CACHE_LOCK",
+        "kind": "import_time_call",
+        "line": 63,
         "module": "easyuse_anima/aio/first_pass_cache.py",
         "scope": "<module>"
       },
@@ -67203,13 +67240,13 @@
       },
       {
         "kind": "dict",
-        "line": 57,
+        "line": 58,
         "module": "easyuse_anima/aio/first_pass_cache.py",
         "name": "_AIO_FIRST_PASS_CACHE"
       },
       {
         "kind": "list",
-        "line": 61,
+        "line": 62,
         "module": "easyuse_anima/aio/first_pass_cache.py",
         "name": "_AIO_FIRST_PASS_CACHE_ORDER"
       },
@@ -67582,9 +67619,18 @@
           "mutable_container"
         ],
         "initializer": "Dict",
-        "line": 57,
+        "line": 58,
         "module": "easyuse_anima/aio/first_pass_cache.py",
         "name": "_AIO_FIRST_PASS_CACHE"
+      },
+      {
+        "categories": [
+          "lock"
+        ],
+        "initializer": "RLock",
+        "line": 63,
+        "module": "easyuse_anima/aio/first_pass_cache.py",
+        "name": "_AIO_FIRST_PASS_CACHE_LOCK"
       },
       {
         "categories": [
@@ -67592,7 +67638,7 @@
           "mutable_container"
         ],
         "initializer": "List",
-        "line": 61,
+        "line": 62,
         "module": "easyuse_anima/aio/first_pass_cache.py",
         "name": "_AIO_FIRST_PASS_CACHE_ORDER"
       },

--- a/tests/test_aio_first_pass_cache.py
+++ b/tests/test_aio_first_pass_cache.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+import threading
 import unittest
+from concurrent.futures import ThreadPoolExecutor
 from dataclasses import FrozenInstanceError
 from unittest.mock import Mock, patch
 
@@ -250,6 +252,12 @@ class AIOFirstPassCacheMoveTests(unittest.TestCase):
         self.assertFalse(
             hasattr(first_pass_cache, "_bind_aio_first_pass_cache_runtime")
         )
+        self.assertFalse(
+            hasattr(nodes, "_AIO_FIRST_PASS_CACHE_LOCK")
+        )
+        self.assertFalse(
+            hasattr(nodes, "_AIO_FIRST_PASS_CACHE_GENERATION")
+        )
         for name in (
             "AIO_FIRST_PASS_CACHE_MAX_ENTRIES",
             "_AIO_FIRST_PASS_CACHE",
@@ -261,6 +269,221 @@ class AIOFirstPassCacheMoveTests(unittest.TestCase):
         ):
             with self.subTest(name=name):
                 self.assertIs(getattr(nodes, name), getattr(first_pass_cache, name))
+
+    def test_disable_reenable_during_inflight_capture_prevents_stale_insert(self):
+        clone_started = threading.Event()
+        release_clone = threading.Event()
+        disable_done = threading.Event()
+        errors = []
+
+        class BlockingTensor:
+            def detach(self):
+                return self
+
+            def clone(self):
+                clone_started.set()
+                if not release_clone.wait(2.0):
+                    raise AssertionError("capture clone release timed out")
+                return _SizedTensor(count=1, item_bytes=1)
+
+            def cpu(self):
+                return self
+
+            def numel(self):
+                return 1
+
+            def element_size(self):
+                return 1
+
+        def put():
+            try:
+                first_pass_cache._put_aio_first_pass_cache(
+                    "inflight",
+                    BlockingTensor(),
+                    b"image",
+                )
+            except BaseException as exc:
+                errors.append(exc)
+
+        def disable_reenable():
+            try:
+                first_pass_cache._set_aio_first_pass_cache_enabled(False)
+                first_pass_cache._set_aio_first_pass_cache_enabled(True)
+            except BaseException as exc:
+                errors.append(exc)
+            finally:
+                disable_done.set()
+
+        put_thread = threading.Thread(target=put, daemon=True)
+        disable_thread = threading.Thread(
+            target=disable_reenable,
+            daemon=True,
+        )
+        put_thread.start()
+        self.assertTrue(
+            clone_started.wait(2.0),
+            "capture clone did not start",
+        )
+        try:
+            disable_thread.start()
+            self.assertTrue(
+                disable_done.wait(2.0),
+                "disable was blocked by capture cloning",
+            )
+        finally:
+            release_clone.set()
+            put_thread.join(2.0)
+            disable_thread.join(2.0)
+
+        self.assertFalse(put_thread.is_alive())
+        self.assertFalse(disable_thread.is_alive())
+        self.assertEqual(errors, [])
+        self.assertTrue(first_pass_cache._AIO_FIRST_PASS_CACHE_ENABLED)
+        self.assertEqual(first_pass_cache._AIO_FIRST_PASS_CACHE, {})
+        self.assertEqual(first_pass_cache._AIO_FIRST_PASS_CACHE_ORDER, [])
+
+    def test_clear_during_capture_generation_prevents_stale_insert(self):
+        def capture(latent, image, *, now):
+            first_pass_cache._clear_aio_first_pass_cache()
+            return first_pass_cache._AIOFirstPassCacheEntry(
+                latent=latent,
+                image=image,
+                size_bytes=2,
+                created_at=now,
+                last_access_at=now,
+            )
+
+        with patch.object(
+            first_pass_cache._AIOFirstPassCacheEntry,
+            "capture",
+            side_effect=capture,
+        ) as capture_entry:
+            first_pass_cache._put_aio_first_pass_cache(
+                "stale-after-clear",
+                b"a",
+                b"b",
+            )
+
+        capture_entry.assert_called_once()
+        self.assertTrue(first_pass_cache._AIO_FIRST_PASS_CACHE_ENABLED)
+        self.assertEqual(first_pass_cache._AIO_FIRST_PASS_CACHE, {})
+        self.assertEqual(first_pass_cache._AIO_FIRST_PASS_CACHE_ORDER, [])
+
+    def test_clear_does_not_wait_for_inflight_checkout_clone(self):
+        clone_started = threading.Event()
+        release_clone = threading.Event()
+        clear_done = threading.Event()
+        results = []
+        errors = []
+
+        class BlockingTensor:
+            def detach(self):
+                return self
+
+            def clone(self):
+                clone_started.set()
+                if not release_clone.wait(2.0):
+                    raise AssertionError("checkout clone release timed out")
+                return _SizedTensor(count=1, item_bytes=1)
+
+            def cpu(self):
+                return self
+
+        first_pass_cache._AIO_FIRST_PASS_CACHE["hit"] = (
+            first_pass_cache._AIOFirstPassCacheEntry(
+                latent=BlockingTensor(),
+                image=b"image",
+                size_bytes=1,
+                created_at=0.0,
+                last_access_at=0.0,
+            )
+        )
+        first_pass_cache._AIO_FIRST_PASS_CACHE_ORDER.append("hit")
+
+        def get():
+            try:
+                results.append(
+                    first_pass_cache._get_aio_first_pass_cache("hit")
+                )
+            except BaseException as exc:
+                errors.append(exc)
+
+        def clear():
+            try:
+                first_pass_cache._clear_aio_first_pass_cache()
+            except BaseException as exc:
+                errors.append(exc)
+            finally:
+                clear_done.set()
+
+        with patch.object(
+            first_pass_cache,
+            "_aio_first_pass_cache_now",
+            return_value=1.0,
+        ):
+            get_thread = threading.Thread(target=get, daemon=True)
+            clear_thread = threading.Thread(target=clear, daemon=True)
+            get_thread.start()
+            self.assertTrue(
+                clone_started.wait(2.0),
+                "checkout clone did not start",
+            )
+            try:
+                clear_thread.start()
+                self.assertTrue(
+                    clear_done.wait(2.0),
+                    "clear was blocked by checkout cloning",
+                )
+            finally:
+                release_clone.set()
+                get_thread.join(2.0)
+                clear_thread.join(2.0)
+
+        self.assertFalse(get_thread.is_alive())
+        self.assertFalse(clear_thread.is_alive())
+        self.assertEqual(errors, [])
+        self.assertEqual(len(results), 1)
+        self.assertIsInstance(results[0][0], _SizedTensor)
+        self.assertEqual(results[0][1], b"image")
+        self.assertEqual(first_pass_cache._AIO_FIRST_PASS_CACHE, {})
+        self.assertEqual(first_pass_cache._AIO_FIRST_PASS_CACHE_ORDER, [])
+
+    def test_bounded_concurrent_hit_put_eviction_preserves_invariants(self):
+        worker_count = 8
+        barrier = threading.Barrier(worker_count)
+
+        def exercise(worker_id):
+            barrier.wait(timeout=2.0)
+            for offset in range(40):
+                key = f"entry-{(worker_id + offset) % 4}"
+                payload = bytes((worker_id, offset % 256))
+                first_pass_cache._put_aio_first_pass_cache(
+                    key,
+                    payload,
+                    payload,
+                )
+                first_pass_cache._get_aio_first_pass_cache(key)
+
+        with ThreadPoolExecutor(max_workers=worker_count) as executor:
+            futures = [
+                executor.submit(exercise, worker_id)
+                for worker_id in range(worker_count)
+            ]
+            for future in futures:
+                future.result(timeout=5.0)
+
+        mapping = first_pass_cache._AIO_FIRST_PASS_CACHE
+        order = first_pass_cache._AIO_FIRST_PASS_CACHE_ORDER
+        self.assertLessEqual(
+            len(mapping),
+            first_pass_cache.AIO_FIRST_PASS_CACHE_MAX_ENTRIES,
+        )
+        self.assertEqual(len(order), len(set(order)))
+        self.assertEqual(set(order), set(mapping))
+        self.assertLessEqual(
+            first_pass_cache._aio_first_pass_cache_total_bytes(),
+            first_pass_cache.AIO_FIRST_PASS_CACHE_MAX_BYTES,
+        )
 
     def test_clone_preserves_nested_shape_tensor_clone_and_cpu_failure(self):
         calls = []


### PR DESCRIPTION
## 변경 요약

- first-pass cache mapping/order/enabled mutation을 private module-owned `RLock`으로 직렬화했습니다.
- explicit clear와 enabled-state transition에 private mutation generation을 추가했습니다.
- get의 miss/TTL expiry/last-access replacement/LRU 갱신을 한 critical section에서 처리합니다.
- put은 initial enabled/generation snapshot과 final insert/overwrite/LRU/eviction만 lock 안에서 처리합니다.
- size estimation과 immutable capture, checkout clone은 lock 밖에서 수행해 tensor copy가 clear/disable을 막지 않습니다.
- capture 도중 clear 또는 disable/re-enable가 완료되면 generation mismatch로 stale insert를 폐기합니다.
- concurrent same-key/multi-key hit/put/eviction 후 mapping/order/count/byte invariant를 유지합니다.

## Inventory와 경계

- canonical state owner: `easyuse_anima.aio.first_pass_cache`
- existing clear, enable/disable, get, put, total-byte functions만 동기화
- typed First-pass stage runtime과 root mapping/order/key/get/put aliases 유지
- lock/generation은 root alias/package export가 없는 private state
- key/resource revision, entry layout, TTL, budgets, clone/storage, caller/stage는 변경하지 않음
- metrics는 다음 CACHE-05b로 분리

## 주요 파일

- `easyuse_anima/aio/first_pass_cache.py`
- `tests/test_aio_first_pass_cache.py`
- `tests/fixtures/python_backend_baseline.json`
- `docs/architecture/aio-first-pass-cache-concurrency.md`
- `docs/architecture/python-backend-execution-roadmap.md`

## 검증

- cache focused: 25 passed in 0.009s
- bounded benchmark/mutation isolation: 4 passed
- First-pass stage focused: 5 passed
- targeted Ruff 0.15.22: production all rules passed; test fatal rules passed
- targeted Pyright 1.1.411: changed production file 0 errors
- Python backend analyzer: 18 passed
- import boundary: 6 groups, 0 violations
- official full: Python 1,120 passed, frontend JavaScript 112 files passed
- full Pyright baseline: 88 files, 기존 검토 대상 14 errors 유지
- `git diff --check`: passed

동시성 테스트는 bounded event/barrier와 명시적 2~5초 timeout만 사용했습니다. 서버 기동, 모델 로드/실행, 브라우저 smoke는 실행하지 않았습니다.

## 구현 중 확인한 경계

lock만 추가하면 `capture → disable/clear → re-enable → final insert` ABA로 이전 generation의 entry가 다시 들어갈 수 있습니다. expensive capture를 lock 밖에 유지하면서 이 stale insert를 막기 위해 private mutation generation을 함께 적용했습니다.

## 남은 위험과 후속

- 직접 mutable mapping/order alias를 외부 코드가 lock 없이 수정하는 동작은 지원 계약이 아닙니다. 기존 root identity는 호환을 위해 유지했습니다.
- hit/miss/skip/eviction metrics는 lock 정확성과 섞지 않고 A169-CACHE-05b에서 진행합니다.
