### PR TITLE
feat: add bounded AiO cache metrics

### DIFF
--- a/docs/architecture/aio-first-pass-cache-metrics.md
+++ b/docs/architecture/aio-first-pass-cache-metrics.md
@@ -5,7 +5,7 @@
 - PR type: Behavior
 - Baseline: `dev` commit
   `a34b7c07a07829c9f7bb65c7d0e3a5c4dd0eb46a`
-- State: INVENTORY
+- State: VALIDATED
 
 CACHE-05b adds bounded process-local hit/miss/skip/eviction counters to the
 thread-safe first-pass cache. It does not expose metrics through API, settings,
@@ -118,3 +118,25 @@ Focused validation must prove:
 Use existing bounded test runners only. Run one official full validation after
 focused checks pass; no server, model, browser, or user-instance smoke is
 required.
+
+## Validation result
+
+Validated on the CACHE-05b worktree:
+
+- frozen snapshot/reset independence, exact hit/miss/skip/TTL/capacity deltas,
+  clear/disable preservation, and bounded concurrent exact totals: 29 focused
+  cache tests passed in 0.015 seconds;
+- benchmark metrics-reset isolation and existing clone/mutation contract: 4
+  focused tests passed;
+- unchanged First-pass stage caller: 5 focused tests passed;
+- targeted Ruff 0.15.22: changed production file passed all rules and changed
+  test files passed fatal rules;
+- targeted Pyright 1.1.411: changed production file passed with 0 errors;
+- Python backend analyzer: 18 focused tests passed;
+- Python import-boundary gate: 6 completed package groups, 0 violations; and
+- official full: 1,124 Python tests plus 112 frontend JavaScript files passed,
+  with the reviewed Pyright baseline unchanged at 88 files and 14 errors.
+
+No API/settings/frontend/log/telemetry exposure, latency/histogram label, cache
+decision, key/entry/TTL/lock/budget/clone/storage, caller/root alias, server,
+model, browser, workflow, or user-instance behavior was changed.

--- a/docs/architecture/aio-first-pass-cache-metrics.md
+++ b/docs/architecture/aio-first-pass-cache-metrics.md
@@ -1,0 +1,120 @@
+# AiO first-pass cache process-local metrics
+
+- Owner issue: [#169](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/169)
+- Roadmap unit: A169-CACHE-05b
+- PR type: Behavior
+- Baseline: `dev` commit
+  `a34b7c07a07829c9f7bb65c7d0e3a5c4dd0eb46a`
+- State: INVENTORY
+
+CACHE-05b adds bounded process-local hit/miss/skip/eviction counters to the
+thread-safe first-pass cache. It does not expose metrics through API, settings,
+frontend, logs, or workflow data and does not change cache decisions.
+
+## Symbol, caller, alias, and global-state inventory
+
+### Current cache state and operations
+
+- `easyuse_anima.aio.first_pass_cache` owns mapping/order/enabled/generation
+  state and one reentrant lock.
+- Get linearizes disabled, missing, expired, and hit decisions under the lock,
+  then clones a validated entry outside the lock.
+- Put performs an initial enabled/generation snapshot, estimates/captures
+  outside the lock, and linearizes final skip/store/eviction under the lock.
+- Clear and enabled transitions are lock-protected mutation barriers.
+- There is no metrics state, snapshot, or reset seam.
+
+### Callers and compatibility aliases
+
+- The typed First-pass stage and benchmark use canonical get/put/clear
+  functions without observing counters.
+- Root `nodes.py` retains its existing direct mapping/order/key/get/put aliases.
+- Metrics state, frozen snapshots, and reset/snapshot helpers are new private
+  canonical-owner seams and are not added to root or package exports.
+- No caller, function signature, return value, entry, key, or workflow contract
+  changes in CACHE-05b.
+
+## Target metrics contract
+
+Provide one frozen snapshot with non-negative integer fields:
+
+- `hits`: an enabled get found a non-expired canonical or readable legacy
+  entry and linearized its LRU update. The hit is counted before independent
+  checkout cloning.
+- `misses`: an enabled get found no entry/falsey legacy entry, or expired a
+  canonical entry. Expiration increments both `misses` and `evictions`.
+- `skips`: an operation deliberately bypassed cache work or storage:
+  - get while disabled;
+  - put disabled at its initial check;
+  - put rejected by pre-capture or captured single-entry size;
+  - put rejected at final commit because disabled/generation changed.
+- `evictions`: each entry removed by TTL expiration or count/total-byte budget.
+  Same-key overwrite, explicit clear, disable-clear, and metrics reset are not
+  evictions.
+
+Additional rules:
+
+- Counter mutation, snapshot, and reset use the existing reentrant lock.
+- Snapshot returns a frozen independent value; callers cannot mutate internal
+  counters.
+- Reset zeros counters only and does not clear, enable/disable, reorder, or
+  otherwise mutate cache entries.
+- Clear and enable/disable do not reset accumulated metrics.
+- Successful put/store has no new counter. Timing, latency, byte-volume,
+  histogram, and per-key labels are outside this bounded contract.
+- Counter updates must not add tensor cloning, filesystem access, logging,
+  background work, or failure paths to normal cache operations.
+
+## Allowed-file boundary
+
+CACHE-05b may change only:
+
+- `easyuse_anima/aio/first_pass_cache.py`;
+- `tests/test_aio_first_pass_cache.py`;
+- `tests/test_aio_first_pass_cache_benchmark.py` for explicit metrics reset
+  isolation only;
+- `tests/test_python_backend_analyzer.py` only if analyzer assertions require
+  enrollment;
+- `tests/fixtures/python_backend_baseline.json`, regenerated from source;
+- this document; and
+- `docs/architecture/python-backend-execution-roadmap.md`.
+
+Read-only evidence:
+
+- `easyuse_anima/aio/generation_first_pass.py`;
+- `easyuse_anima/aio/legacy_generation.py`;
+- root `nodes.py`;
+- `tools/benchmark_aio_first_pass_cache.py`;
+- `tests/test_aio_first_pass_stage.py`;
+- `tests/test_python_import_boundaries.py`; and
+- `tests/fixtures/python_compatibility_surface.v1.json`.
+
+Forbidden:
+
+- API route, settings, frontend, log/event/telemetry export, persistence, or
+  workflow/metadata serialization;
+- latency/timing, byte-throughput, per-key/resource labels, histograms, or
+  unbounded metric dimensions;
+- changing cache key/resource revision, entry layout, TTL, lock/generation,
+  count/byte caps, eviction decisions, clone/copy-on-write, or storage;
+- changing caller, stage, root aliases, sampling, seed, preview, Save, cleanup,
+  server startup, model execution, browser, release, Registry, or
+  user-instance work.
+
+## Required validation
+
+Focused validation must prove:
+
+- exact default/reset/snapshot schema and frozen independence;
+- hit, missing, disabled, TTL, oversize, stale-generation, and capacity/byte
+  counter deltas;
+- clear/disable do not count eviction or reset metrics;
+- reset does not mutate cache/enabled/LRU state;
+- exact aggregate counter totals under bounded concurrent operations;
+- existing cache concurrency, lifecycle, key/resource revision, clone/mutation
+  benchmark, stage caller, analyzer, and import boundary contracts remain
+  valid.
+
+Use existing bounded test runners only. Run one official full validation after
+focused checks pass; no server, model, browser, or user-instance smoke is
+required.

--- a/docs/architecture/python-backend-execution-roadmap.md
+++ b/docs/architecture/python-backend-execution-roadmap.md
@@ -407,7 +407,7 @@ mechanical retirement series.
 | 14 | B-11 registration/bootstrap/root shim | COMPLETE in PR #356 | Move/Contract, split PRs | #184 | Zero runtime binders/residual implementation; explicit root `__all__`; frozen compatibility audit |
 | 15 | S167 backend seed reservation series | S167-01 through S167-03d COMPLETE on `dev`; S167-03e AiO cutover VALIDATED with isolated API/module/browser-load parity | Contract then Move then Behavior | #167 | Canonical AiO/node seams |
 | 16 | A169 stage pipeline series | A169-01 through A169-08 MERGED; A169-09 final adapter/integration VALIDATED in PR #372 | Contract then Behavior | #169 | Typed config and mechanical AiO move |
-| 17 | A169 first-pass cache policy | A169-CACHE-01/02/03 and CACHE-04a/04b MERGED; CACHE-05a thread-safe mutation VALIDATED in PR #378; CACHE-05b metrics follows | Contract then Behavior | #169 | Mechanical cache move and stable stage seam |
+| 17 | A169 first-pass cache policy | A169-CACHE-01/02/03, CACHE-04a/04b, and CACHE-05a MERGED; CACHE-05b metrics INVENTORY | Contract then Behavior | #169 | Mechanical cache move and stable stage seam |
 | 18 | D-series canonical root consolidation | BLOCKED by relevant C contracts | Move | #186 | Phase B exit; per-feature behavior stable |
 | 19 | E-series RuntimeServices/lifecycle | BLOCKED by canonical owners | Move/Contract, split PRs | #187 | Relevant D moves |
 | 20 | G-04 through G-06 and H | INCREMENTAL/LATER | Gate/Contract | #188 | Appropriate package and release evidence |

--- a/docs/architecture/python-backend-execution-roadmap.md
+++ b/docs/architecture/python-backend-execution-roadmap.md
@@ -407,7 +407,7 @@ mechanical retirement series.
 | 14 | B-11 registration/bootstrap/root shim | COMPLETE in PR #356 | Move/Contract, split PRs | #184 | Zero runtime binders/residual implementation; explicit root `__all__`; frozen compatibility audit |
 | 15 | S167 backend seed reservation series | S167-01 through S167-03d COMPLETE on `dev`; S167-03e AiO cutover VALIDATED with isolated API/module/browser-load parity | Contract then Move then Behavior | #167 | Canonical AiO/node seams |
 | 16 | A169 stage pipeline series | A169-01 through A169-08 MERGED; A169-09 final adapter/integration VALIDATED in PR #372 | Contract then Behavior | #169 | Typed config and mechanical AiO move |
-| 17 | A169 first-pass cache policy | A169-CACHE-01/02/03, CACHE-04a/04b, and CACHE-05a MERGED; CACHE-05b metrics INVENTORY | Contract then Behavior | #169 | Mechanical cache move and stable stage seam |
+| 17 | A169 first-pass cache policy | A169-CACHE-01/02/03, CACHE-04a/04b, and CACHE-05a MERGED; CACHE-05b metrics VALIDATED in PR #379; CACHE-06 4K/batch evidence follows | Contract then Behavior | #169 | Mechanical cache move and stable stage seam |
 | 18 | D-series canonical root consolidation | BLOCKED by relevant C contracts | Move | #186 | Phase B exit; per-feature behavior stable |
 | 19 | E-series RuntimeServices/lifecycle | BLOCKED by canonical owners | Move/Contract, split PRs | #187 | Relevant D moves |
 | 20 | G-04 through G-06 and H | INCREMENTAL/LATER | Gate/Contract | #188 | Appropriate package and release evidence |

--- a/easyuse_anima/aio/first_pass_cache.py
+++ b/easyuse_anima/aio/first_pass_cache.py
@@ -55,6 +55,14 @@ class _AIOFirstPassCacheEntry:
         )
 
 
+@dataclass(frozen=True, slots=True)
+class _AIOFirstPassCacheMetrics:
+    hits: int
+    misses: int
+    skips: int
+    evictions: int
+
+
 _AIO_FIRST_PASS_CACHE: dict[
     str,
     _AIOFirstPassCacheEntry | dict[str, Any],
@@ -62,6 +70,12 @@ _AIO_FIRST_PASS_CACHE: dict[
 _AIO_FIRST_PASS_CACHE_ORDER: list[str] = []
 _AIO_FIRST_PASS_CACHE_LOCK = RLock()
 _AIO_FIRST_PASS_CACHE_GENERATION = 0
+_AIO_FIRST_PASS_CACHE_METRICS = {
+    "hits": 0,
+    "misses": 0,
+    "skips": 0,
+    "evictions": 0,
+}
 
 
 def _clone_aio_cache_value(value):
@@ -178,6 +192,27 @@ def _aio_first_pass_cache_total_bytes() -> int:
         )
 
 
+def _aio_first_pass_cache_metrics_snapshot() -> _AIOFirstPassCacheMetrics:
+    with _AIO_FIRST_PASS_CACHE_LOCK:
+        return _AIOFirstPassCacheMetrics(
+            hits=_AIO_FIRST_PASS_CACHE_METRICS["hits"],
+            misses=_AIO_FIRST_PASS_CACHE_METRICS["misses"],
+            skips=_AIO_FIRST_PASS_CACHE_METRICS["skips"],
+            evictions=_AIO_FIRST_PASS_CACHE_METRICS["evictions"],
+        )
+
+
+def _reset_aio_first_pass_cache_metrics() -> None:
+    with _AIO_FIRST_PASS_CACHE_LOCK:
+        for name in _AIO_FIRST_PASS_CACHE_METRICS:
+            _AIO_FIRST_PASS_CACHE_METRICS[name] = 0
+
+
+def _record_aio_first_pass_cache_metric(name: str) -> None:
+    with _AIO_FIRST_PASS_CACHE_LOCK:
+        _AIO_FIRST_PASS_CACHE_METRICS[name] += 1
+
+
 def _clear_aio_first_pass_cache() -> None:
     global _AIO_FIRST_PASS_CACHE_GENERATION
 
@@ -289,9 +324,11 @@ def _aio_first_pass_cache_key(
 def _get_aio_first_pass_cache(cache_key: str):
     with _AIO_FIRST_PASS_CACHE_LOCK:
         if not _AIO_FIRST_PASS_CACHE_ENABLED:
+            _AIO_FIRST_PASS_CACHE_METRICS["skips"] += 1
             return None
         entry = _AIO_FIRST_PASS_CACHE.get(cache_key)
         if not entry:
+            _AIO_FIRST_PASS_CACHE_METRICS["misses"] += 1
             return None
         if isinstance(entry, _AIOFirstPassCacheEntry):
             now = _aio_first_pass_cache_now()
@@ -299,12 +336,15 @@ def _get_aio_first_pass_cache(cache_key: str):
                 _AIO_FIRST_PASS_CACHE.pop(cache_key, None)
                 if cache_key in _AIO_FIRST_PASS_CACHE_ORDER:
                     _AIO_FIRST_PASS_CACHE_ORDER.remove(cache_key)
+                _AIO_FIRST_PASS_CACHE_METRICS["misses"] += 1
+                _AIO_FIRST_PASS_CACHE_METRICS["evictions"] += 1
                 return None
             entry = replace(entry, last_access_at=now)
             _AIO_FIRST_PASS_CACHE[cache_key] = entry
         if cache_key in _AIO_FIRST_PASS_CACHE_ORDER:
             _AIO_FIRST_PASS_CACHE_ORDER.remove(cache_key)
         _AIO_FIRST_PASS_CACHE_ORDER.append(cache_key)
+        _AIO_FIRST_PASS_CACHE_METRICS["hits"] += 1
     if isinstance(entry, _AIOFirstPassCacheEntry):
         return entry.checkout()
     return (
@@ -316,12 +356,14 @@ def _get_aio_first_pass_cache(cache_key: str):
 def _put_aio_first_pass_cache(cache_key: str, latent, image) -> None:
     with _AIO_FIRST_PASS_CACHE_LOCK:
         if not _AIO_FIRST_PASS_CACHE_ENABLED:
+            _AIO_FIRST_PASS_CACHE_METRICS["skips"] += 1
             return
         generation = _AIO_FIRST_PASS_CACHE_GENERATION
     if (
         _aio_cache_pair_size_bytes(latent, image)
         > AIO_FIRST_PASS_CACHE_MAX_ENTRY_BYTES
     ):
+        _record_aio_first_pass_cache_metric("skips")
         return
     entry = _AIOFirstPassCacheEntry.capture(
         latent,
@@ -329,12 +371,14 @@ def _put_aio_first_pass_cache(cache_key: str, latent, image) -> None:
         now=_aio_first_pass_cache_now(),
     )
     if entry.size_bytes > AIO_FIRST_PASS_CACHE_MAX_ENTRY_BYTES:
+        _record_aio_first_pass_cache_metric("skips")
         return
     with _AIO_FIRST_PASS_CACHE_LOCK:
         if (
             not _AIO_FIRST_PASS_CACHE_ENABLED
             or generation != _AIO_FIRST_PASS_CACHE_GENERATION
         ):
+            _AIO_FIRST_PASS_CACHE_METRICS["skips"] += 1
             return
         _AIO_FIRST_PASS_CACHE[cache_key] = entry
         if cache_key in _AIO_FIRST_PASS_CACHE_ORDER:
@@ -348,6 +392,7 @@ def _put_aio_first_pass_cache(cache_key: str, latent, image) -> None:
         ):
             old_key = _AIO_FIRST_PASS_CACHE_ORDER.pop(0)
             _AIO_FIRST_PASS_CACHE.pop(old_key, None)
+            _AIO_FIRST_PASS_CACHE_METRICS["evictions"] += 1
 
 
 __all__ = ()

--- a/tests/fixtures/python_backend_baseline.json
+++ b/tests/fixtures/python_backend_baseline.json
@@ -48932,14 +48932,14 @@
       },
       {
         "is_package": false,
-        "loc": 353,
+        "loc": 398,
         "module": "easyuse_anima.aio.first_pass_cache",
-        "normalized_git_blob_sha1": "0f2fa5f9ae38c2443a10b7a8a49395de37cf8e08",
+        "normalized_git_blob_sha1": "98c242f27faf93f7f856b7afadfccc7f27472d6a",
         "path": "easyuse_anima/aio/first_pass_cache.py",
         "top_level": {
-          "class_count": 1,
-          "function_count": 12,
-          "global_count": 10
+          "class_count": 2,
+          "function_count": 15,
+          "global_count": 11
         }
       },
       {
@@ -65924,11 +65924,20 @@
         "scope": "<module>"
       },
       {
+        "callee": "dataclass",
+        "column": 1,
+        "context": "decorator:_AIOFirstPassCacheMetrics",
+        "kind": "import_time_call",
+        "line": 58,
+        "module": "easyuse_anima/aio/first_pass_cache.py",
+        "scope": "<module>"
+      },
+      {
         "callee": "RLock",
         "column": 29,
         "context": "assign:_AIO_FIRST_PASS_CACHE_LOCK",
         "kind": "import_time_call",
-        "line": 63,
+        "line": 71,
         "module": "easyuse_anima/aio/first_pass_cache.py",
         "scope": "<module>"
       },
@@ -67240,13 +67249,19 @@
       },
       {
         "kind": "dict",
-        "line": 58,
+        "line": 66,
         "module": "easyuse_anima/aio/first_pass_cache.py",
         "name": "_AIO_FIRST_PASS_CACHE"
       },
       {
+        "kind": "dict",
+        "line": 73,
+        "module": "easyuse_anima/aio/first_pass_cache.py",
+        "name": "_AIO_FIRST_PASS_CACHE_METRICS"
+      },
+      {
         "kind": "list",
-        "line": 62,
+        "line": 70,
         "module": "easyuse_anima/aio/first_pass_cache.py",
         "name": "_AIO_FIRST_PASS_CACHE_ORDER"
       },
@@ -67619,7 +67634,7 @@
           "mutable_container"
         ],
         "initializer": "Dict",
-        "line": 58,
+        "line": 66,
         "module": "easyuse_anima/aio/first_pass_cache.py",
         "name": "_AIO_FIRST_PASS_CACHE"
       },
@@ -67628,7 +67643,7 @@
           "lock"
         ],
         "initializer": "RLock",
-        "line": 63,
+        "line": 71,
         "module": "easyuse_anima/aio/first_pass_cache.py",
         "name": "_AIO_FIRST_PASS_CACHE_LOCK"
       },
@@ -67637,8 +67652,18 @@
           "cache",
           "mutable_container"
         ],
+        "initializer": "Dict",
+        "line": 73,
+        "module": "easyuse_anima/aio/first_pass_cache.py",
+        "name": "_AIO_FIRST_PASS_CACHE_METRICS"
+      },
+      {
+        "categories": [
+          "cache",
+          "mutable_container"
+        ],
         "initializer": "List",
-        "line": 62,
+        "line": 70,
         "module": "easyuse_anima/aio/first_pass_cache.py",
         "name": "_AIO_FIRST_PASS_CACHE_ORDER"
       },

--- a/tests/test_aio_first_pass_cache.py
+++ b/tests/test_aio_first_pass_cache.py
@@ -56,10 +56,12 @@ class AIOFirstPassCacheMoveTests(unittest.TestCase):
     def setUp(self):
         first_pass_cache._set_aio_first_pass_cache_enabled(True)
         first_pass_cache._clear_aio_first_pass_cache()
+        first_pass_cache._reset_aio_first_pass_cache_metrics()
 
     def tearDown(self):
         first_pass_cache._set_aio_first_pass_cache_enabled(True)
         first_pass_cache._clear_aio_first_pass_cache()
+        first_pass_cache._reset_aio_first_pass_cache_metrics()
 
     def test_default_count_and_byte_policy_are_explicit(self):
         self.assertEqual(first_pass_cache.AIO_FIRST_PASS_CACHE_MAX_ENTRIES, 2)
@@ -258,6 +260,15 @@ class AIOFirstPassCacheMoveTests(unittest.TestCase):
         self.assertFalse(
             hasattr(nodes, "_AIO_FIRST_PASS_CACHE_GENERATION")
         )
+        self.assertFalse(
+            hasattr(nodes, "_AIO_FIRST_PASS_CACHE_METRICS")
+        )
+        self.assertFalse(
+            hasattr(nodes, "_aio_first_pass_cache_metrics_snapshot")
+        )
+        self.assertFalse(
+            hasattr(nodes, "_reset_aio_first_pass_cache_metrics")
+        )
         for name in (
             "AIO_FIRST_PASS_CACHE_MAX_ENTRIES",
             "_AIO_FIRST_PASS_CACHE",
@@ -269,6 +280,201 @@ class AIOFirstPassCacheMoveTests(unittest.TestCase):
         ):
             with self.subTest(name=name):
                 self.assertIs(getattr(nodes, name), getattr(first_pass_cache, name))
+
+    def test_metrics_snapshot_is_frozen_and_reset_preserves_cache_state(self):
+        first_pass_cache._put_aio_first_pass_cache(
+            "entry",
+            b"latent",
+            b"image",
+        )
+        self.assertEqual(
+            first_pass_cache._get_aio_first_pass_cache("entry"),
+            (b"latent", b"image"),
+        )
+        snapshot = first_pass_cache._aio_first_pass_cache_metrics_snapshot()
+        self.assertEqual(
+            (
+                snapshot.hits,
+                snapshot.misses,
+                snapshot.skips,
+                snapshot.evictions,
+            ),
+            (1, 0, 0, 0),
+        )
+        with self.assertRaises(FrozenInstanceError):
+            snapshot.hits = 2
+
+        mapping = first_pass_cache._AIO_FIRST_PASS_CACHE
+        order = first_pass_cache._AIO_FIRST_PASS_CACHE_ORDER
+        entry = mapping["entry"]
+        first_pass_cache._reset_aio_first_pass_cache_metrics()
+
+        self.assertEqual(
+            first_pass_cache._aio_first_pass_cache_metrics_snapshot(),
+            first_pass_cache._AIOFirstPassCacheMetrics(0, 0, 0, 0),
+        )
+        self.assertIs(first_pass_cache._AIO_FIRST_PASS_CACHE, mapping)
+        self.assertIs(first_pass_cache._AIO_FIRST_PASS_CACHE_ORDER, order)
+        self.assertIs(mapping["entry"], entry)
+        self.assertEqual(order, ["entry"])
+        self.assertTrue(first_pass_cache._AIO_FIRST_PASS_CACHE_ENABLED)
+
+    def test_metrics_count_hit_miss_skip_expiration_and_capacity_eviction(self):
+        self.assertIsNone(
+            first_pass_cache._get_aio_first_pass_cache("missing")
+        )
+        first_pass_cache._put_aio_first_pass_cache(
+            "hit",
+            b"latent",
+            b"image",
+        )
+        self.assertEqual(
+            first_pass_cache._get_aio_first_pass_cache("hit"),
+            (b"latent", b"image"),
+        )
+
+        first_pass_cache._clear_aio_first_pass_cache()
+        with patch.object(
+            first_pass_cache,
+            "_aio_first_pass_cache_now",
+            side_effect=[0.0, 301.0],
+        ):
+            first_pass_cache._put_aio_first_pass_cache(
+                "expired",
+                b"latent",
+                b"image",
+            )
+            self.assertIsNone(
+                first_pass_cache._get_aio_first_pass_cache("expired")
+            )
+
+        first_pass_cache._set_aio_first_pass_cache_enabled(False)
+        self.assertIsNone(
+            first_pass_cache._get_aio_first_pass_cache("disabled")
+        )
+        first_pass_cache._put_aio_first_pass_cache(
+            "disabled",
+            b"latent",
+            b"image",
+        )
+        first_pass_cache._set_aio_first_pass_cache_enabled(True)
+
+        with patch.object(
+            first_pass_cache,
+            "AIO_FIRST_PASS_CACHE_MAX_ENTRY_BYTES",
+            1,
+        ):
+            first_pass_cache._put_aio_first_pass_cache(
+                "preflight-oversize",
+                b"xx",
+                b"",
+            )
+            with patch.object(
+                first_pass_cache,
+                "_aio_cache_pair_size_bytes",
+                side_effect=[1, 2],
+            ):
+                first_pass_cache._put_aio_first_pass_cache(
+                    "captured-oversize",
+                    b"a",
+                    b"",
+                )
+
+        def capture(latent, image, *, now):
+            first_pass_cache._clear_aio_first_pass_cache()
+            return first_pass_cache._AIOFirstPassCacheEntry(
+                latent=latent,
+                image=image,
+                size_bytes=1,
+                created_at=now,
+                last_access_at=now,
+            )
+
+        with patch.object(
+            first_pass_cache._AIOFirstPassCacheEntry,
+            "capture",
+            side_effect=capture,
+        ):
+            first_pass_cache._put_aio_first_pass_cache(
+                "stale-generation",
+                b"a",
+                b"",
+            )
+
+        with patch.object(
+            first_pass_cache,
+            "AIO_FIRST_PASS_CACHE_MAX_ENTRIES",
+            1,
+        ):
+            first_pass_cache._put_aio_first_pass_cache(
+                "first",
+                b"a",
+                b"",
+            )
+            first_pass_cache._put_aio_first_pass_cache(
+                "second",
+                b"b",
+                b"",
+            )
+
+        snapshot = first_pass_cache._aio_first_pass_cache_metrics_snapshot()
+        self.assertEqual(
+            (
+                snapshot.hits,
+                snapshot.misses,
+                snapshot.skips,
+                snapshot.evictions,
+            ),
+            (1, 2, 5, 2),
+        )
+
+    def test_clear_and_disable_preserve_accumulated_metrics_without_eviction(self):
+        first_pass_cache._put_aio_first_pass_cache(
+            "entry",
+            b"latent",
+            b"image",
+        )
+        first_pass_cache._get_aio_first_pass_cache("entry")
+        first_pass_cache._clear_aio_first_pass_cache()
+        first_pass_cache._put_aio_first_pass_cache(
+            "second",
+            b"latent",
+            b"image",
+        )
+        first_pass_cache._set_aio_first_pass_cache_enabled(False)
+
+        self.assertEqual(
+            first_pass_cache._aio_first_pass_cache_metrics_snapshot(),
+            first_pass_cache._AIOFirstPassCacheMetrics(1, 0, 0, 0),
+        )
+
+    def test_bounded_concurrent_metrics_have_exact_totals(self):
+        worker_count = 8
+        calls_per_worker = 50
+        first_pass_cache._set_aio_first_pass_cache_enabled(False)
+        first_pass_cache._reset_aio_first_pass_cache_metrics()
+
+        def exercise(_worker_id):
+            for _ in range(calls_per_worker):
+                first_pass_cache._get_aio_first_pass_cache("disabled")
+
+        with ThreadPoolExecutor(max_workers=worker_count) as executor:
+            futures = [
+                executor.submit(exercise, worker_id)
+                for worker_id in range(worker_count)
+            ]
+            for future in futures:
+                future.result(timeout=5.0)
+
+        self.assertEqual(
+            first_pass_cache._aio_first_pass_cache_metrics_snapshot(),
+            first_pass_cache._AIOFirstPassCacheMetrics(
+                0,
+                0,
+                worker_count * calls_per_worker,
+                0,
+            ),
+        )
 
     def test_disable_reenable_during_inflight_capture_prevents_stale_insert(self):
         clone_started = threading.Event()

--- a/tests/test_aio_first_pass_cache_benchmark.py
+++ b/tests/test_aio_first_pass_cache_benchmark.py
@@ -33,10 +33,12 @@ class AIOFirstPassCacheBenchmarkTests(unittest.TestCase):
     def setUp(self):
         first_pass_cache._set_aio_first_pass_cache_enabled(True)
         first_pass_cache._clear_aio_first_pass_cache()
+        first_pass_cache._reset_aio_first_pass_cache_metrics()
 
     def tearDown(self):
         first_pass_cache._set_aio_first_pass_cache_enabled(True)
         first_pass_cache._clear_aio_first_pass_cache()
+        first_pass_cache._reset_aio_first_pass_cache_metrics()
 
     def test_fake_tensor_exposes_deterministic_payload_bytes(self):
         tensor = benchmark.BenchmarkTensor.filled(


### PR DESCRIPTION
## 변경 요약

- first-pass cache에 process-local `hits`, `misses`, `skips`, `evictions` 카운터를 추가했습니다.
- frozen snapshot과 metrics-only reset seam을 추가했습니다.
- 모든 counter mutation/snapshot/reset은 CACHE-05a의 기존 `RLock` 아래에서 수행합니다.
- hit은 validated entry의 LRU linearization 시점, miss는 enabled missing/expiry, skip은 disabled/oversize/stale-generation bypass를 셉니다.
- TTL 또는 count/total-byte budget으로 실제 제거된 entry만 eviction으로 셉니다.
- explicit clear, disable-clear, same-key overwrite, metrics reset은 eviction이 아닙니다.
- clear/disable은 누적 metrics를 보존하며 reset은 cache/enabled/LRU를 변경하지 않습니다.

## Inventory와 경계

- canonical owner: `easyuse_anima.aio.first_pass_cache`
- typed First-pass stage/benchmark caller와 root mapping/order/key/get/put aliases 유지
- metrics state/snapshot/reset은 private이며 root/package export 미추가
- cache key, entry, TTL, lock/generation, budget, eviction decision, clone/storage 변경 없음
- API/settings/frontend/log/workflow/telemetry 노출 없음

## 주요 파일

- `easyuse_anima/aio/first_pass_cache.py`
- `tests/test_aio_first_pass_cache.py`
- `tests/test_aio_first_pass_cache_benchmark.py`
- `tests/fixtures/python_backend_baseline.json`
- `docs/architecture/aio-first-pass-cache-metrics.md`
- `docs/architecture/python-backend-execution-roadmap.md`

## 검증

- cache focused: 29 passed in 0.015s
- benchmark/mutation isolation: 4 passed
- First-pass stage focused: 5 passed
- targeted Ruff 0.15.22: production all rules passed; tests fatal rules passed
- targeted Pyright 1.1.411: changed production file 0 errors
- Python backend analyzer: 18 passed
- import boundary: 6 groups, 0 violations
- official full: Python 1,124 passed, frontend JavaScript 112 files passed
- full Pyright baseline: 88 files, 기존 검토 대상 14 errors 유지
- `git diff --check`: passed

모든 concurrency metric 검증은 bounded executor와 명시적 timeout을 사용했습니다. 서버 기동, 모델 로드/실행, 브라우저 smoke는 실행하지 않았습니다.

## 남은 위험과 후속

- counters는 process-local이며 restart 시 초기화됩니다. 이번 범위에서는 의도된 계약입니다.
- latency, peak allocation, byte throughput, histogram, per-key label은 포함하지 않았습니다.
- 다음 A169-CACHE-06에서 4K/batch allocation과 hit-latency evidence를 별도 gate로 진행합니다.
