### PR TITLE
refactor: move translation to canonical package

### DIFF
--- a/api.py
+++ b/api.py
@@ -36,11 +36,13 @@ from .autocomplete_dataset import (
     search_autocomplete,
 )
 from .wildcard_engine import list_wildcards, resolve_wildcard_roots
-from .prompt_translation import (
+from .easyuse_anima.translation.contracts import (
     PromptTranslationError,
     TranslationBusyError,
     TranslationCancelledError,
     TranslationTimeoutError,
+)
+from .easyuse_anima.translation.service import (
     translate_prompt_markers,
 )
 from .api_contract import (

--- a/autocomplete_dataset.py
+++ b/autocomplete_dataset.py
@@ -25,7 +25,9 @@ try:
     from .anima_prompt.models import TagSection
     from .anima_prompt.ordering import builtin_tag_section
     from .anima_prompt.parser import parse_prompt
-    from .prompt_translation import iter_prompt_translation_markers
+    from .easyuse_anima.translation.markers import (
+        iter_prompt_translation_markers,
+    )
     from .storage import PACKAGE_DATA_DIR as STORAGE_PACKAGE_DATA_DIR
     from .storage import USER_DATA_DIR
 except ImportError:
@@ -39,7 +41,9 @@ except ImportError:
     from anima_prompt.models import TagSection
     from anima_prompt.ordering import builtin_tag_section
     from anima_prompt.parser import parse_prompt
-    from prompt_translation import iter_prompt_translation_markers
+    from easyuse_anima.translation.markers import (
+        iter_prompt_translation_markers,
+    )
     from storage import PACKAGE_DATA_DIR as STORAGE_PACKAGE_DATA_DIR
     from storage import USER_DATA_DIR
 

--- a/docs/architecture/python-backend-execution-roadmap.md
+++ b/docs/architecture/python-backend-execution-roadmap.md
@@ -408,7 +408,7 @@ mechanical retirement series.
 | 15 | S167 backend seed reservation series | S167-01 through S167-03d COMPLETE on `dev`; S167-03e AiO cutover VALIDATED with isolated API/module/browser-load parity | Contract then Move then Behavior | #167 | Canonical AiO/node seams |
 | 16 | A169 stage pipeline series | A169-01 through A169-08 MERGED; A169-09 final adapter/integration VALIDATED in PR #372 | Contract then Behavior | #169 | Typed config and mechanical AiO move |
 | 17 | A169 first-pass cache policy | COMPLETE through CACHE-06; 4K/batch evidence VALIDATED in PR #380 | Contract then Behavior | #169 | Mechanical cache move and stable stage seam |
-| 18 | D-series canonical root consolidation | D-01 translation INVENTORY; behavior prerequisite #164 complete | Move | #186 | Phase B exit; per-feature behavior stable |
+| 18 | D-series canonical root consolidation | D-01 translation VALIDATED in PR #381; behavior prerequisite #164 complete | Move | #186 | Phase B exit; per-feature behavior stable |
 | 19 | E-series RuntimeServices/lifecycle | BLOCKED by canonical owners | Move/Contract, split PRs | #187 | Relevant D moves |
 | 20 | G-04 through G-06 and H | INCREMENTAL/LATER | Gate/Contract | #188 | Appropriate package and release evidence |
 
@@ -548,7 +548,8 @@ relax or block the package-migration rules above.
 - Existing root loader compatibility may remain baseline debt until B-11/D-14;
   the gate must not be weakened to accommodate new canonical violations.
 - The first blocking ledger contains exactly six reviewed prefixes:
-  `common`, `image`, `infrastructure/comfy`, `lora`, `naia`, and `profiles`.
+  `common`, `image`, `infrastructure/comfy`, `lora`, `naia`, `profiles`, and
+  `translation`.
   Group id, owner issue, prefix, role, ordering, uniqueness, and the exact group
   set are validated so deleting or broadening an entry cannot silently weaken
   the gate. New Python files beneath an enrolled prefix are covered

--- a/docs/architecture/python-backend-execution-roadmap.md
+++ b/docs/architecture/python-backend-execution-roadmap.md
@@ -408,7 +408,7 @@ mechanical retirement series.
 | 15 | S167 backend seed reservation series | S167-01 through S167-03d COMPLETE on `dev`; S167-03e AiO cutover VALIDATED with isolated API/module/browser-load parity | Contract then Move then Behavior | #167 | Canonical AiO/node seams |
 | 16 | A169 stage pipeline series | A169-01 through A169-08 MERGED; A169-09 final adapter/integration VALIDATED in PR #372 | Contract then Behavior | #169 | Typed config and mechanical AiO move |
 | 17 | A169 first-pass cache policy | COMPLETE through CACHE-06; 4K/batch evidence VALIDATED in PR #380 | Contract then Behavior | #169 | Mechanical cache move and stable stage seam |
-| 18 | D-series canonical root consolidation | BLOCKED by relevant C contracts | Move | #186 | Phase B exit; per-feature behavior stable |
+| 18 | D-series canonical root consolidation | D-01 translation INVENTORY; behavior prerequisite #164 complete | Move | #186 | Phase B exit; per-feature behavior stable |
 | 19 | E-series RuntimeServices/lifecycle | BLOCKED by canonical owners | Move/Contract, split PRs | #187 | Relevant D moves |
 | 20 | G-04 through G-06 and H | INCREMENTAL/LATER | Gate/Contract | #188 | Appropriate package and release evidence |
 

--- a/docs/architecture/python-compatibility-shims.md
+++ b/docs/architecture/python-compatibility-shims.md
@@ -64,7 +64,7 @@ import them.
 | `storage.py` | Current implementation; planned filesystem shim | `easyuse_anima.infrastructure.filesystem.*` | #163, #186 D-08 | Existing 0.5.2 surface; convert in D-08/D-14 | `api.py`, `settings.py`, `wildcard_engine.py`, storage/profile tests | Unscheduled; N+1 gate and last-known-good/atomic-write parity |
 | `autocomplete_dataset.py` | Current implementation; planned autocomplete shim | `easyuse_anima.autocomplete.*` | #162, #186 D-11 | Existing 0.5.2 surface; convert in D-11/D-14 | `api.py`, autocomplete/frontend API tests | Unscheduled; N+1 gate and result/ranking/API parity |
 | `wildcard_engine.py` | Current implementation; planned wildcard shim | `easyuse_anima.wildcard.*` | #184, #186 D-12 | Existing 0.5.2 surface; convert in D-12/D-14 | root entrypoint, `nodes.py`, `api.py`, wildcard/workflow tests | Unscheduled; N+1 gate and seed/expansion/workflow parity |
-| `prompt_translation.py` | Current implementation; planned translation shim | `easyuse_anima.translation.*` | #164, #186 D-01 | Existing 0.5.2 surface; convert in D-01/D-14 | `settings.py`, `nodes.py`, `api.py`, `autocomplete_dataset.py`, translation tests | Unscheduled; N+1 gate and provider-off/API parity |
+| `prompt_translation.py` | Explicit direct re-export shim (D-01) | `easyuse_anima.translation.*` | #164, #186 D-01 | Existing 0.5.2 supported module-owned public surface; exact `__all__` and identity fixture | External/legacy imports and translation compatibility tests; production callers use canonical modules | Unscheduled; first canonical+shim release N not yet recorded, then N+1 gate and provider-off/API parity |
 | `anima_prompt/` package | Current implementation; planned package shim | `easyuse_anima.prompt.anima.*` | #184, #186 D-13 | Existing 0.5.2 surface; convert in D-13/D-14 | `nodes.py`, `autocomplete_dataset.py`, prompt tests | Unscheduled; N+1 gate and prompt correction/parser parity |
 
 ## Entry details
@@ -1419,6 +1419,14 @@ EasyUseAnimaWildcard
   parsing, translation execution, and the translation error classes.
 - Canonical target: `easyuse_anima.translation.contracts`, `markers`, `service`,
   and `providers.google` after #164 behavior is stable.
+- D-01 moves the implementation to those canonical owners. The root module
+  lists only the reviewed module-owned public symbols in `__all__` and binds
+  each as the identical canonical object. Private provider registries, locks,
+  cache sentinels, flight state, and the default service are unsupported
+  test-only seams and are not re-exported.
+- Internal production imports use the canonical modules directly. The root shim
+  remains shipped for external/legacy imports through the ADR-002 support
+  window; release N has not yet been recorded.
 - Removal gate: provider-off imports create no client or optional dependency,
   timeout/cache/error/API parity passes, internal imports are canonical, and
   both paths are present in the actual release archive through the support

--- a/docs/architecture/translation-canonical-move.md
+++ b/docs/architecture/translation-canonical-move.md
@@ -1,0 +1,158 @@
+# Translation canonical package move
+
+- Owner issue: [#186](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/186)
+- Prerequisite behavior owner:
+  [#164](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/164) — complete
+- Roadmap unit: D-01
+- PR type: Move
+- Baseline: `dev@d002a9bea1b268d7a79d7c5bbd7c73f2a62f2d77`
+- State: INVENTORY
+- Behavior changes: forbidden
+
+## Responsibility boundary
+
+The root `prompt_translation.py` currently combines four cohesive translation
+responsibilities:
+
+1. settings, provider, error, and limit contracts;
+2. `%{...}` marker parsing;
+3. the lazy Google provider adapter; and
+4. provider reuse, bounded cache/single-flight state, and translation service.
+
+D-01 moves that one feature surface under `easyuse_anima.translation` while
+separating those responsibilities into `contracts`, `markers`, `providers.google`,
+and `service`. This is one behavior-preserving Move, not a translation behavior,
+async, cache, API, or dependency-policy change.
+
+## Symbol inventory
+
+Supported root compatibility symbols are the module-owned public constants,
+types, classes, and functions:
+
+- provider/default/marker constants:
+  `PROMPT_TRANSLATION_PROVIDER_OFF`,
+  `PROMPT_TRANSLATION_PROVIDER_GOOGLE`, `PROMPT_TRANSLATION_PROVIDERS`,
+  `DEFAULT_PROMPT_TRANSLATION_SOURCE`, `DEFAULT_PROMPT_TRANSLATION_TARGET`,
+  and `PROMPT_TRANSLATION_MARKER_LABEL`;
+- service/provider limits:
+  `MAX_PROMPT_TRANSLATION_MARKERS`,
+  `MAX_PROMPT_TRANSLATION_MARKER_CHARACTERS`,
+  `MAX_PROMPT_TRANSLATION_TOTAL_CHARACTERS`,
+  `PROMPT_TRANSLATION_CACHE_MAX_ENTRIES`,
+  `PROMPT_TRANSLATION_CACHE_TTL_SECONDS`, and
+  `PROMPT_TRANSLATION_PROVIDER_TIMEOUT_SECONDS`;
+- contracts and errors:
+  `PromptTranslationSettings`, `PromptTranslationError`,
+  `PromptTranslationLimitError`, `TranslationMarkerCountError`,
+  `TranslationMarkerSizeError`, `TranslationTotalSizeError`,
+  `TranslationProviderUnavailableError`, `TranslationTimeoutError`,
+  `TranslationCancelledError`, `TranslationBusyError`,
+  `TranslationUpstreamError`, `TranslationProvider`, and
+  `TranslationCacheKey`;
+- provider/service classes:
+  `GoogleTranslationProvider`, `BoundedTranslationCache`, and
+  `PromptTranslationService`; and
+- functions:
+  `normalize_prompt_translation_provider`,
+  `normalize_prompt_translation_language`,
+  `iter_prompt_translation_markers`,
+  `has_prompt_translation_markers`, `get_translation_provider`,
+  `google_translate_text`, `strip_prompt_translation_markers`, and
+  `translate_prompt_markers`.
+
+The root shim must list these names explicitly in `__all__` and bind each name
+as the identical canonical object. It must not wrap, proxy, subclass, or use
+`import *`.
+
+Unsupported private/test-only seams are `_is_escaped`, `_looks_like_timeout`,
+`_TRANSLATION_PROVIDER_FACTORIES`, `_TRANSLATION_PROVIDER_INSTANCES`,
+`_TRANSLATION_PROVIDER_LOCK`, `_CACHE_MISS`, `_TranslationFlight`,
+`_translate_segment`, and `_DEFAULT_TRANSLATION_SERVICE`. Canonical tests may
+patch the owning canonical module; these private names are not added to the
+root compatibility surface.
+
+## Caller and alias inventory
+
+Production consumers:
+
+- `api.py`: public translation errors and `translate_prompt_markers`;
+- `settings.py`: provider/default constants, settings type, and normalizers;
+- `autocomplete_dataset.py`: `iter_prompt_translation_markers`;
+- root `nodes.py`: marker detection and translation execution;
+- `easyuse_anima.prompt.correction`: marker detection/execution; and
+- `easyuse_anima.prompt.advanced`: marker detection.
+
+D-01 changes these internal imports to precise canonical modules. Root
+compatibility imports remain only for external/legacy consumers and direct
+identity tests.
+
+Test consumers:
+
+- `tests/test_prompt_translation.py` currently imports the root module and
+  patches root private/provider seams. It will become the canonical service and
+  provider test, with a separate direct root/canonical identity assertion.
+- `tests/test_prompt_translation_api.py` discovers the owner module through
+  `translate_prompt_markers.__module__`; it must continue to observe the
+  canonical service owner without changing route behavior.
+- package, analyzer, import-boundary, and compatibility fixtures must reflect
+  the new shipped modules and direct shim.
+
+## Global state and lifecycle inventory
+
+- Provider factories, provider instances, and their `RLock` are process-local
+  service state. Provider construction remains lazy and one instance is reused
+  per provider name.
+- `GoogleTranslationProvider` owns one lazy client and one per-instance
+  `RLock`; importing the module must not import `googletrans` or create a
+  client.
+- `BoundedTranslationCache` owns its ordered entries and lock.
+- `PromptTranslationService` owns per-key single-flight entries and lock.
+- The default service remains one process-local instance with the same bounded
+  cache and single-flight behavior.
+- No new initialize/shutdown policy is introduced in this Move; lifecycle
+  ownership remains an E-04 follow-up.
+
+## Allowed-file boundary
+
+Production:
+
+- `prompt_translation.py`;
+- new modules under `easyuse_anima/translation/`;
+- `api.py`, `settings.py`, `autocomplete_dataset.py`, and `nodes.py`, import
+  lines only; and
+- `easyuse_anima/prompt/correction.py` and
+  `easyuse_anima/prompt/advanced.py`, import lines only.
+
+Supporting:
+
+- translation focused/identity tests;
+- Python package skeleton, import-boundary, backend analyzer, and their exact
+  fixtures;
+- `docs/architecture/python-compatibility-shims.md`;
+- this document; and
+- `docs/architecture/python-backend-execution-roadmap.md`.
+
+## Forbidden changes
+
+- marker syntax, escaping, normalization, limit values, provider selection,
+  timeout detection, error types/status/messages, HTML unescape, cache key,
+  TTL/LRU, single-flight, deduplication, call order, or output text;
+- API route, worker, response, request ID, cancellation, busy, timeout, or
+  executor behavior;
+- settings keys/defaults, node/workflow contracts, frontend, dependency
+  metadata, Registry, release, or instance files;
+- eager optional dependency import, client creation at import time, server,
+  browser, model, or external translation calls; and
+- D-02 or E-04 behavior/lifecycle work.
+
+## Validation and exit
+
+- focused translation service, API, package skeleton, compatibility identity,
+  import-boundary, and backend analyzer tests;
+- root/canonical identity for every supported `__all__` symbol;
+- provider-off package import with no `googletrans` import/client creation;
+- package/archive closure through the repository-owned gates;
+- official full runner once at the PR checkpoint; and
+- root `prompt_translation.py` contains only explicit direct re-exports,
+  internal production translation imports are canonical, and all behavior
+  fixtures remain unchanged.

--- a/docs/architecture/translation-canonical-move.md
+++ b/docs/architecture/translation-canonical-move.md
@@ -6,7 +6,7 @@
 - Roadmap unit: D-01
 - PR type: Move
 - Baseline: `dev@d002a9bea1b268d7a79d7c5bbd7c73f2a62f2d77`
-- State: INVENTORY
+- State: VALIDATED in PR #381
 - Behavior changes: forbidden
 
 ## Responsibility boundary
@@ -156,3 +156,16 @@ Supporting:
 - root `prompt_translation.py` contains only explicit direct re-exports,
   internal production translation imports are canonical, and all behavior
   fixtures remain unchanged.
+
+## Validation result
+
+- Focused translation service, API, package skeleton, import-boundary,
+  corrector integration, nodes analyzer, and compatibility-surface checks
+  passed.
+- Focused Pyright passed with 0 errors for the new contracts and Google
+  provider modules.
+- The final official full runner passed: Pyright baseline ratchet, seven
+  completed import-boundary groups, 1,129 Python tests, 112 frontend
+  JavaScript files with TypeScript 6.0.3, and `git diff --check`.
+- No server, browser, model, optional provider client, or external translation
+  request was started.

--- a/easyuse_anima/prompt/advanced.py
+++ b/easyuse_anima/prompt/advanced.py
@@ -12,6 +12,7 @@ from ..naia.resolution import (
     NAIA_ADVANCED_RESOLUTION_BUCKET,
     _normalize_resolution_bucket,
 )
+from ..translation.markers import has_prompt_translation_markers
 from .artist_mix import (
     ARTIST_MIX_DEFAULT_CLUSTER_COUNT,
     ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION,
@@ -42,10 +43,8 @@ from .fields import (
 )
 
 try:
-    from ...prompt_translation import has_prompt_translation_markers
     from ...settings import resolve_metadata_filter_words
 except ImportError:
-    from prompt_translation import has_prompt_translation_markers
     from settings import resolve_metadata_filter_words
 
 ADVANCED_FIELD_TYPES = {"quality", "artist", "trigger", "general", "naia"}

--- a/easyuse_anima/prompt/correction.py
+++ b/easyuse_anima/prompt/correction.py
@@ -2,11 +2,12 @@
 
 from __future__ import annotations
 
+from ..translation.markers import has_prompt_translation_markers
+from ..translation.service import translate_prompt_markers
+
 try:
-    from ...prompt_translation import has_prompt_translation_markers, translate_prompt_markers
     from ...settings import resolve_prompt_translation_settings
 except ImportError:
-    from prompt_translation import has_prompt_translation_markers, translate_prompt_markers
     from settings import resolve_prompt_translation_settings
 
 

--- a/easyuse_anima/translation/__init__.py
+++ b/easyuse_anima/translation/__init__.py
@@ -1,0 +1,3 @@
+"""Canonical prompt translation feature package."""
+
+__all__ = ()

--- a/easyuse_anima/translation/contracts.py
+++ b/easyuse_anima/translation/contracts.py
@@ -1,0 +1,135 @@
+"""Prompt translation settings, limits, and error contracts."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Protocol
+
+PROMPT_TRANSLATION_PROVIDER_OFF = "off"
+PROMPT_TRANSLATION_PROVIDER_GOOGLE = "google"
+PROMPT_TRANSLATION_PROVIDERS = {
+    PROMPT_TRANSLATION_PROVIDER_OFF,
+    PROMPT_TRANSLATION_PROVIDER_GOOGLE,
+}
+DEFAULT_PROMPT_TRANSLATION_SOURCE = "auto"
+DEFAULT_PROMPT_TRANSLATION_TARGET = "en"
+
+MAX_PROMPT_TRANSLATION_MARKERS = 64
+MAX_PROMPT_TRANSLATION_MARKER_CHARACTERS = 1024
+MAX_PROMPT_TRANSLATION_TOTAL_CHARACTERS = 4096
+PROMPT_TRANSLATION_CACHE_MAX_ENTRIES = 256
+PROMPT_TRANSLATION_CACHE_TTL_SECONDS = 300.0
+PROMPT_TRANSLATION_PROVIDER_TIMEOUT_SECONDS = 10.0
+
+TranslationCacheKey = tuple[str, str, str, str]
+
+
+@dataclass(frozen=True)
+class PromptTranslationSettings:
+    provider: str = PROMPT_TRANSLATION_PROVIDER_OFF
+    source: str = DEFAULT_PROMPT_TRANSLATION_SOURCE
+    target: str = DEFAULT_PROMPT_TRANSLATION_TARGET
+
+
+class PromptTranslationError(RuntimeError):
+    code = "translation_error"
+    status = 500
+    default_message = "Prompt translation failed."
+
+    def __init__(self, message: str | None = None):
+        super().__init__(message or self.default_message)
+        self.message = message or self.default_message
+
+
+class PromptTranslationLimitError(PromptTranslationError):
+    status = 413
+
+
+class TranslationMarkerCountError(PromptTranslationLimitError):
+    code = "translation_marker_count_exceeded"
+
+
+class TranslationMarkerSizeError(PromptTranslationLimitError):
+    code = "translation_marker_too_long"
+
+
+class TranslationTotalSizeError(PromptTranslationLimitError):
+    code = "translation_marker_characters_exceeded"
+
+
+class TranslationProviderUnavailableError(PromptTranslationError):
+    code = "translation_provider_unavailable"
+    status = 503
+    default_message = "The selected translation provider is unavailable."
+
+
+class TranslationTimeoutError(PromptTranslationError):
+    code = "translation_timeout"
+    status = 504
+    default_message = "The translation provider timed out."
+
+
+class TranslationCancelledError(PromptTranslationError):
+    code = "translation_cancelled"
+    status = 499
+    default_message = "The translation request was cancelled."
+
+
+class TranslationBusyError(PromptTranslationError):
+    code = "translation_busy"
+    status = 503
+    default_message = "A prompt translation request is already in progress."
+
+
+class TranslationUpstreamError(PromptTranslationError):
+    code = "translation_upstream_error"
+    status = 502
+    default_message = "The translation provider request failed."
+
+
+class TranslationProvider(Protocol):
+    def translate(self, text: str, source: str, target: str) -> str:
+        """Translate one marker value and return plain text."""
+        ...
+
+
+def normalize_prompt_translation_provider(value) -> str:
+    provider = str(value or PROMPT_TRANSLATION_PROVIDER_OFF).strip().lower()
+    if provider in PROMPT_TRANSLATION_PROVIDERS:
+        return provider
+    return PROMPT_TRANSLATION_PROVIDER_OFF
+
+
+def normalize_prompt_translation_language(value, default: str) -> str:
+    text = str(value or default).strip().lower()
+    return text[:16] or default
+
+
+__all__ = (
+    "DEFAULT_PROMPT_TRANSLATION_SOURCE",
+    "DEFAULT_PROMPT_TRANSLATION_TARGET",
+    "MAX_PROMPT_TRANSLATION_MARKER_CHARACTERS",
+    "MAX_PROMPT_TRANSLATION_MARKERS",
+    "MAX_PROMPT_TRANSLATION_TOTAL_CHARACTERS",
+    "PROMPT_TRANSLATION_CACHE_MAX_ENTRIES",
+    "PROMPT_TRANSLATION_CACHE_TTL_SECONDS",
+    "PROMPT_TRANSLATION_PROVIDER_GOOGLE",
+    "PROMPT_TRANSLATION_PROVIDER_OFF",
+    "PROMPT_TRANSLATION_PROVIDER_TIMEOUT_SECONDS",
+    "PROMPT_TRANSLATION_PROVIDERS",
+    "PromptTranslationError",
+    "PromptTranslationLimitError",
+    "PromptTranslationSettings",
+    "TranslationBusyError",
+    "TranslationCacheKey",
+    "TranslationCancelledError",
+    "TranslationMarkerCountError",
+    "TranslationMarkerSizeError",
+    "TranslationProvider",
+    "TranslationProviderUnavailableError",
+    "TranslationTimeoutError",
+    "TranslationTotalSizeError",
+    "TranslationUpstreamError",
+    "normalize_prompt_translation_language",
+    "normalize_prompt_translation_provider",
+)

--- a/easyuse_anima/translation/markers.py
+++ b/easyuse_anima/translation/markers.py
@@ -1,0 +1,48 @@
+"""Prompt translation marker parsing."""
+
+from __future__ import annotations
+
+PROMPT_TRANSLATION_MARKER_LABEL = "translation"
+
+
+def _is_escaped(value: str, index: int) -> bool:
+    count = 0
+    for cursor in range(index - 1, -1, -1):
+        if value[cursor] != "\\":
+            break
+        count += 1
+    return count % 2 == 1
+
+
+def iter_prompt_translation_markers(text: str):
+    value = str(text or "")
+    cursor = 0
+    while cursor < len(value):
+        start = value.find("%{", cursor)
+        if start < 0:
+            break
+        if _is_escaped(value, start):
+            cursor = start + 2
+            continue
+        end = -1
+        scan = start + 2
+        while scan < len(value):
+            if value[scan] == "}" and not _is_escaped(value, scan):
+                end = scan + 1
+                break
+            scan += 1
+        if end < 0:
+            break
+        yield start, end, value[start + 2 : end - 1]
+        cursor = end
+
+
+def has_prompt_translation_markers(text: str) -> bool:
+    return next(iter_prompt_translation_markers(text), None) is not None
+
+
+__all__ = (
+    "PROMPT_TRANSLATION_MARKER_LABEL",
+    "has_prompt_translation_markers",
+    "iter_prompt_translation_markers",
+)

--- a/easyuse_anima/translation/providers/__init__.py
+++ b/easyuse_anima/translation/providers/__init__.py
@@ -1,0 +1,3 @@
+"""Prompt translation provider adapters."""
+
+__all__ = ()

--- a/easyuse_anima/translation/providers/google.py
+++ b/easyuse_anima/translation/providers/google.py
@@ -1,0 +1,79 @@
+"""Lazy Google prompt translation provider adapter."""
+
+from __future__ import annotations
+
+import html
+import threading
+from collections.abc import Callable
+from typing import Protocol
+
+from ..contracts import (
+    DEFAULT_PROMPT_TRANSLATION_SOURCE,
+    DEFAULT_PROMPT_TRANSLATION_TARGET,
+    PROMPT_TRANSLATION_PROVIDER_TIMEOUT_SECONDS,
+    PromptTranslationError,
+    TranslationProviderUnavailableError,
+    TranslationTimeoutError,
+    TranslationUpstreamError,
+)
+
+
+class _TranslatorClient(Protocol):
+    def translate(self, text: str, *, src: str, dest: str) -> object: ...
+
+
+def _looks_like_timeout(exc: Exception) -> bool:
+    if isinstance(exc, TimeoutError):
+        return True
+    return any("timeout" in cls.__name__.lower() for cls in type(exc).__mro__)
+
+
+class GoogleTranslationProvider:
+    """Lazy, reusable wrapper around the optional googletrans-py client."""
+
+    def __init__(
+        self,
+        translator_factory: Callable[[], _TranslatorClient] | None = None,
+        *,
+        timeout_seconds: float = PROMPT_TRANSLATION_PROVIDER_TIMEOUT_SECONDS,
+    ):
+        self._translator_factory = translator_factory
+        self._timeout_seconds = max(0.001, float(timeout_seconds))
+        self._translator: _TranslatorClient | None = None
+        self._lock = threading.RLock()
+
+    def _create_translator(self) -> _TranslatorClient:
+        if self._translator_factory is not None:
+            return self._translator_factory()
+        try:
+            from googletrans import Translator  # type: ignore
+        except ImportError as exc:
+            raise TranslationProviderUnavailableError() from exc
+        # googletrans-py forwards this value to its httpx.Client transport.
+        return Translator(timeout=self._timeout_seconds)
+
+    def translate(self, text: str, source: str, target: str) -> str:
+        value = str(text or "")
+        if not value.strip():
+            return value
+        try:
+            with self._lock:
+                if self._translator is None:
+                    self._translator = self._create_translator()
+                translated = self._translator.translate(
+                    value,
+                    src=source or DEFAULT_PROMPT_TRANSLATION_SOURCE,
+                    dest=target or DEFAULT_PROMPT_TRANSLATION_TARGET,
+                )
+        except PromptTranslationError:
+            raise
+        except ImportError as exc:
+            raise TranslationProviderUnavailableError() from exc
+        except Exception as exc:
+            if _looks_like_timeout(exc):
+                raise TranslationTimeoutError() from exc
+            raise TranslationUpstreamError() from exc
+        return html.unescape(str(getattr(translated, "text", "") or ""))
+
+
+__all__ = ("GoogleTranslationProvider",)

--- a/easyuse_anima/translation/service.py
+++ b/easyuse_anima/translation/service.py
@@ -1,0 +1,349 @@
+"""Prompt translation provider reuse, cache, and service ownership."""
+
+from __future__ import annotations
+
+import threading
+import time
+from collections import OrderedDict
+from collections.abc import Callable
+from contextlib import contextmanager
+from dataclasses import dataclass
+
+from .contracts import (
+    DEFAULT_PROMPT_TRANSLATION_SOURCE,
+    DEFAULT_PROMPT_TRANSLATION_TARGET,
+    MAX_PROMPT_TRANSLATION_MARKER_CHARACTERS,
+    MAX_PROMPT_TRANSLATION_MARKERS,
+    MAX_PROMPT_TRANSLATION_TOTAL_CHARACTERS,
+    PROMPT_TRANSLATION_CACHE_MAX_ENTRIES,
+    PROMPT_TRANSLATION_CACHE_TTL_SECONDS,
+    PROMPT_TRANSLATION_PROVIDER_GOOGLE,
+    PROMPT_TRANSLATION_PROVIDER_OFF,
+    PromptTranslationError,
+    PromptTranslationSettings,
+    TranslationCacheKey,
+    TranslationMarkerCountError,
+    TranslationMarkerSizeError,
+    TranslationProvider,
+    TranslationProviderUnavailableError,
+    TranslationTotalSizeError,
+    normalize_prompt_translation_language,
+    normalize_prompt_translation_provider,
+)
+from .markers import iter_prompt_translation_markers
+from .providers.google import GoogleTranslationProvider
+
+_TRANSLATION_PROVIDER_FACTORIES: dict[
+    str,
+    Callable[[], TranslationProvider],
+] = {
+    PROMPT_TRANSLATION_PROVIDER_GOOGLE: GoogleTranslationProvider,
+}
+_TRANSLATION_PROVIDER_INSTANCES: dict[str, TranslationProvider] = {}
+_TRANSLATION_PROVIDER_LOCK = threading.RLock()
+
+
+def get_translation_provider(provider: str) -> TranslationProvider:
+    name = str(provider or "").strip().lower()
+    with _TRANSLATION_PROVIDER_LOCK:
+        instance = _TRANSLATION_PROVIDER_INSTANCES.get(name)
+        if instance is not None:
+            return instance
+        factory = _TRANSLATION_PROVIDER_FACTORIES.get(name)
+        if factory is None:
+            raise TranslationProviderUnavailableError()
+        try:
+            instance = factory()
+        except PromptTranslationError:
+            raise
+        except Exception as exc:
+            raise TranslationProviderUnavailableError() from exc
+        _TRANSLATION_PROVIDER_INSTANCES[name] = instance
+        return instance
+
+
+def google_translate_text(
+    text: str,
+    source: str = "auto",
+    target: str = "en",
+) -> str:
+    value = str(text or "")
+    if not value.strip():
+        return value
+    source = normalize_prompt_translation_language(
+        source,
+        DEFAULT_PROMPT_TRANSLATION_SOURCE,
+    )
+    target = normalize_prompt_translation_language(
+        target,
+        DEFAULT_PROMPT_TRANSLATION_TARGET,
+    )
+    # External translation is opt-in through the provider setting. The optional
+    # dependency is imported only after this function is reached.
+    return get_translation_provider(
+        PROMPT_TRANSLATION_PROVIDER_GOOGLE
+    ).translate(
+        value,
+        source,
+        target,
+    )
+
+
+def _translate_segment(
+    segment: str,
+    settings: PromptTranslationSettings,
+) -> str:
+    if settings.provider == PROMPT_TRANSLATION_PROVIDER_OFF:
+        return str(segment or "")
+    if settings.provider == PROMPT_TRANSLATION_PROVIDER_GOOGLE:
+        return google_translate_text(
+            segment,
+            settings.source,
+            settings.target,
+        )
+    return str(segment or "")
+
+
+_CACHE_MISS = object()
+
+
+@dataclass
+class _TranslationFlight:
+    lock: threading.Lock
+    users: int = 0
+
+
+class BoundedTranslationCache:
+    def __init__(
+        self,
+        max_entries: int = PROMPT_TRANSLATION_CACHE_MAX_ENTRIES,
+        ttl_seconds: float = PROMPT_TRANSLATION_CACHE_TTL_SECONDS,
+        time_func: Callable[[], float] = time.monotonic,
+    ):
+        self.max_entries = max(0, int(max_entries))
+        self.ttl_seconds = max(0.0, float(ttl_seconds))
+        self._time_func = time_func
+        self._entries: OrderedDict[
+            TranslationCacheKey,
+            tuple[float, str],
+        ] = OrderedDict()
+        self._lock = threading.RLock()
+
+    def get(self, key: TranslationCacheKey):
+        with self._lock:
+            entry = self._entries.get(key)
+            if entry is None:
+                return _CACHE_MISS
+            expires_at, value = entry
+            if expires_at <= self._time_func():
+                self._entries.pop(key, None)
+                return _CACHE_MISS
+            self._entries.move_to_end(key)
+            return value
+
+    def put(self, key: TranslationCacheKey, value: str) -> None:
+        if self.max_entries == 0 or self.ttl_seconds == 0:
+            return
+        with self._lock:
+            self._entries[key] = (
+                self._time_func() + self.ttl_seconds,
+                str(value),
+            )
+            self._entries.move_to_end(key)
+            while len(self._entries) > self.max_entries:
+                self._entries.popitem(last=False)
+
+    def clear(self) -> None:
+        with self._lock:
+            self._entries.clear()
+
+    def __len__(self) -> int:
+        with self._lock:
+            return len(self._entries)
+
+
+class PromptTranslationService:
+    def __init__(
+        self,
+        *,
+        cache: BoundedTranslationCache | None = None,
+        max_markers: int = MAX_PROMPT_TRANSLATION_MARKERS,
+        max_marker_characters: int = (
+            MAX_PROMPT_TRANSLATION_MARKER_CHARACTERS
+        ),
+        max_total_characters: int = (
+            MAX_PROMPT_TRANSLATION_TOTAL_CHARACTERS
+        ),
+    ):
+        self.cache = (
+            cache
+            if cache is not None
+            else BoundedTranslationCache()
+        )
+        self.max_markers = max(1, int(max_markers))
+        self.max_marker_characters = max(
+            1,
+            int(max_marker_characters),
+        )
+        self.max_total_characters = max(
+            1,
+            int(max_total_characters),
+        )
+        self._flights: dict[
+            TranslationCacheKey,
+            _TranslationFlight,
+        ] = {}
+        self._flights_lock = threading.RLock()
+
+    @contextmanager
+    def _single_flight(self, key: TranslationCacheKey):
+        with self._flights_lock:
+            flight = self._flights.get(key)
+            if flight is None:
+                flight = _TranslationFlight(lock=threading.Lock())
+                self._flights[key] = flight
+            flight.users += 1
+        try:
+            with flight.lock:
+                yield
+        finally:
+            with self._flights_lock:
+                flight.users -= 1
+                if (
+                    flight.users == 0
+                    and self._flights.get(key) is flight
+                ):
+                    self._flights.pop(key, None)
+
+    def _validate_markers(
+        self,
+        markers: list[tuple[int, int, str]],
+    ) -> None:
+        if len(markers) > self.max_markers:
+            raise TranslationMarkerCountError(
+                "Prompt translation supports at most "
+                f"{self.max_markers} markers per request."
+            )
+        for _start, _end, segment in markers:
+            if len(segment) > self.max_marker_characters:
+                raise TranslationMarkerSizeError(
+                    "Prompt translation supports at most "
+                    f"{self.max_marker_characters} characters "
+                    "in one marker."
+                )
+        total_characters = sum(
+            len(segment)
+            for _start, _end, segment in markers
+        )
+        if total_characters > self.max_total_characters:
+            raise TranslationTotalSizeError(
+                "Prompt translation supports at most "
+                f"{self.max_total_characters} marker characters "
+                "per request."
+            )
+
+    def _translate_cached(
+        self,
+        text: str,
+        settings: PromptTranslationSettings,
+    ) -> str:
+        key = (
+            settings.provider,
+            settings.source,
+            settings.target,
+            text,
+        )
+        cached = self.cache.get(key)
+        if cached is not _CACHE_MISS:
+            return str(cached)
+        with self._single_flight(key):
+            cached = self.cache.get(key)
+            if cached is not _CACHE_MISS:
+                return str(cached)
+            translated = _translate_segment(text, settings)
+            self.cache.put(key, translated)
+            return translated
+
+    def translate_prompt(
+        self,
+        text: str,
+        settings: PromptTranslationSettings | None = None,
+    ) -> str:
+        value = str(text or "")
+        markers = list(iter_prompt_translation_markers(value))
+        if not markers:
+            return value
+        settings = settings or PromptTranslationSettings()
+        settings = PromptTranslationSettings(
+            provider=normalize_prompt_translation_provider(
+                settings.provider
+            ),
+            source=normalize_prompt_translation_language(
+                settings.source,
+                DEFAULT_PROMPT_TRANSLATION_SOURCE,
+            ),
+            target=normalize_prompt_translation_language(
+                settings.target,
+                DEFAULT_PROMPT_TRANSLATION_TARGET,
+            ),
+        )
+
+        if settings.provider == PROMPT_TRANSLATION_PROVIDER_OFF:
+            translated_segments = {
+                segment.strip(): segment.strip()
+                for _, _, segment in markers
+            }
+        else:
+            self._validate_markers(markers)
+            translated_segments: dict[str, str] = {}
+            for _start, _end, segment in markers:
+                marker_text = segment.strip()
+                if marker_text not in translated_segments:
+                    translated_segments[marker_text] = (
+                        self._translate_cached(
+                            marker_text,
+                            settings,
+                        )
+                        if marker_text
+                        else ""
+                    )
+
+        output: list[str] = []
+        cursor = 0
+        for start, end, segment in markers:
+            output.append(value[cursor:start])
+            output.append(translated_segments[segment.strip()])
+            cursor = end
+        output.append(value[cursor:])
+        return "".join(output)
+
+
+_DEFAULT_TRANSLATION_SERVICE = PromptTranslationService()
+
+
+def strip_prompt_translation_markers(text: str) -> str:
+    return translate_prompt_markers(
+        text,
+        PromptTranslationSettings(
+            provider=PROMPT_TRANSLATION_PROVIDER_OFF
+        ),
+    )
+
+
+def translate_prompt_markers(
+    text: str,
+    settings: PromptTranslationSettings | None = None,
+) -> str:
+    """Compatibility facade used by synchronous ComfyUI node execution."""
+
+    return _DEFAULT_TRANSLATION_SERVICE.translate_prompt(text, settings)
+
+
+__all__ = (
+    "BoundedTranslationCache",
+    "PromptTranslationService",
+    "get_translation_provider",
+    "google_translate_text",
+    "strip_prompt_translation_markers",
+    "translate_prompt_markers",
+)

--- a/nodes.py
+++ b/nodes.py
@@ -536,7 +536,12 @@ try:
         resolve_naia_settings,
         resolve_prompt_translation_settings,
     )
-    from .prompt_translation import has_prompt_translation_markers, translate_prompt_markers
+    from .easyuse_anima.translation.markers import (
+        has_prompt_translation_markers,
+    )
+    from .easyuse_anima.translation.service import (
+        translate_prompt_markers,
+    )
     from .wildcard_engine import (
         MAX_SEED,
         PUBLIC_MAX_SEED,
@@ -1093,7 +1098,12 @@ except ImportError:  # allows simple local import tests outside ComfyUI's packag
         resolve_naia_settings,
         resolve_prompt_translation_settings,
     )
-    from prompt_translation import has_prompt_translation_markers, translate_prompt_markers
+    from easyuse_anima.translation.markers import (
+        has_prompt_translation_markers,
+    )
+    from easyuse_anima.translation.service import (
+        translate_prompt_markers,
+    )
     from wildcard_engine import (
         MAX_SEED,
         PUBLIC_MAX_SEED,

--- a/prompt_translation.py
+++ b/prompt_translation.py
@@ -1,423 +1,134 @@
+"""Compatibility shim for the canonical prompt translation feature."""
+
 from __future__ import annotations
 
-import html
-import threading
-import time
-from collections import OrderedDict
-from contextlib import contextmanager
-from dataclasses import dataclass
-from typing import Callable, Protocol
-
-
-PROMPT_TRANSLATION_PROVIDER_OFF = "off"
-PROMPT_TRANSLATION_PROVIDER_GOOGLE = "google"
-PROMPT_TRANSLATION_PROVIDERS = {
-    PROMPT_TRANSLATION_PROVIDER_OFF,
-    PROMPT_TRANSLATION_PROVIDER_GOOGLE,
-}
-DEFAULT_PROMPT_TRANSLATION_SOURCE = "auto"
-DEFAULT_PROMPT_TRANSLATION_TARGET = "en"
-PROMPT_TRANSLATION_MARKER_LABEL = "translation"
-
-MAX_PROMPT_TRANSLATION_MARKERS = 64
-MAX_PROMPT_TRANSLATION_MARKER_CHARACTERS = 1024
-MAX_PROMPT_TRANSLATION_TOTAL_CHARACTERS = 4096
-PROMPT_TRANSLATION_CACHE_MAX_ENTRIES = 256
-PROMPT_TRANSLATION_CACHE_TTL_SECONDS = 300.0
-PROMPT_TRANSLATION_PROVIDER_TIMEOUT_SECONDS = 10.0
-
-
-@dataclass(frozen=True)
-class PromptTranslationSettings:
-    provider: str = PROMPT_TRANSLATION_PROVIDER_OFF
-    source: str = DEFAULT_PROMPT_TRANSLATION_SOURCE
-    target: str = DEFAULT_PROMPT_TRANSLATION_TARGET
-
-
-class PromptTranslationError(RuntimeError):
-    code = "translation_error"
-    status = 500
-    default_message = "Prompt translation failed."
-
-    def __init__(self, message: str | None = None):
-        super().__init__(message or self.default_message)
-        self.message = message or self.default_message
-
-
-class PromptTranslationLimitError(PromptTranslationError):
-    status = 413
-
-
-class TranslationMarkerCountError(PromptTranslationLimitError):
-    code = "translation_marker_count_exceeded"
-
-
-class TranslationMarkerSizeError(PromptTranslationLimitError):
-    code = "translation_marker_too_long"
-
-
-class TranslationTotalSizeError(PromptTranslationLimitError):
-    code = "translation_marker_characters_exceeded"
-
-
-class TranslationProviderUnavailableError(PromptTranslationError):
-    code = "translation_provider_unavailable"
-    status = 503
-    default_message = "The selected translation provider is unavailable."
-
-
-class TranslationTimeoutError(PromptTranslationError):
-    code = "translation_timeout"
-    status = 504
-    default_message = "The translation provider timed out."
-
-
-class TranslationCancelledError(PromptTranslationError):
-    code = "translation_cancelled"
-    status = 499
-    default_message = "The translation request was cancelled."
-
-
-class TranslationBusyError(PromptTranslationError):
-    code = "translation_busy"
-    status = 503
-    default_message = "A prompt translation request is already in progress."
-
-
-class TranslationUpstreamError(PromptTranslationError):
-    code = "translation_upstream_error"
-    status = 502
-    default_message = "The translation provider request failed."
-
-
-class TranslationProvider(Protocol):
-    def translate(self, text: str, source: str, target: str) -> str:
-        """Translate one marker value and return plain text."""
-
-
-def normalize_prompt_translation_provider(value) -> str:
-    provider = str(value or PROMPT_TRANSLATION_PROVIDER_OFF).strip().lower()
-    if provider in PROMPT_TRANSLATION_PROVIDERS:
-        return provider
-    return PROMPT_TRANSLATION_PROVIDER_OFF
-
-
-def normalize_prompt_translation_language(value, default: str) -> str:
-    text = str(value or default).strip().lower()
-    return text[:16] or default
-
-
-def _is_escaped(value: str, index: int) -> bool:
-    count = 0
-    for cursor in range(index - 1, -1, -1):
-        if value[cursor] != "\\":
-            break
-        count += 1
-    return count % 2 == 1
-
-
-def iter_prompt_translation_markers(text: str):
-    value = str(text or "")
-    cursor = 0
-    while cursor < len(value):
-        start = value.find("%{", cursor)
-        if start < 0:
-            break
-        if _is_escaped(value, start):
-            cursor = start + 2
-            continue
-        end = -1
-        scan = start + 2
-        while scan < len(value):
-            if value[scan] == "}" and not _is_escaped(value, scan):
-                end = scan + 1
-                break
-            scan += 1
-        if end < 0:
-            break
-        yield start, end, value[start + 2 : end - 1]
-        cursor = end
-
-
-def has_prompt_translation_markers(text: str) -> bool:
-    return next(iter_prompt_translation_markers(text), None) is not None
-
-
-def _looks_like_timeout(exc: Exception) -> bool:
-    if isinstance(exc, TimeoutError):
-        return True
-    return any("timeout" in cls.__name__.lower() for cls in type(exc).__mro__)
-
-
-class GoogleTranslationProvider:
-    """Lazy, reusable wrapper around the optional googletrans-py client."""
-
-    def __init__(
-        self,
-        translator_factory: Callable[[], object] | None = None,
-        *,
-        timeout_seconds: float = PROMPT_TRANSLATION_PROVIDER_TIMEOUT_SECONDS,
-    ):
-        self._translator_factory = translator_factory
-        self._timeout_seconds = max(0.001, float(timeout_seconds))
-        self._translator = None
-        self._lock = threading.RLock()
-
-    def _create_translator(self):
-        if self._translator_factory is not None:
-            return self._translator_factory()
-        try:
-            from googletrans import Translator  # type: ignore
-        except ImportError as exc:
-            raise TranslationProviderUnavailableError() from exc
-        # googletrans-py forwards this value to its httpx.Client transport.
-        return Translator(timeout=self._timeout_seconds)
-
-    def translate(self, text: str, source: str, target: str) -> str:
-        value = str(text or "")
-        if not value.strip():
-            return value
-        try:
-            with self._lock:
-                if self._translator is None:
-                    self._translator = self._create_translator()
-                translated = self._translator.translate(
-                    value,
-                    src=source or DEFAULT_PROMPT_TRANSLATION_SOURCE,
-                    dest=target or DEFAULT_PROMPT_TRANSLATION_TARGET,
-                )
-        except PromptTranslationError:
-            raise
-        except ImportError as exc:
-            raise TranslationProviderUnavailableError() from exc
-        except Exception as exc:
-            if _looks_like_timeout(exc):
-                raise TranslationTimeoutError() from exc
-            raise TranslationUpstreamError() from exc
-        return html.unescape(str(getattr(translated, "text", "") or ""))
-
-
-_TRANSLATION_PROVIDER_FACTORIES: dict[str, Callable[[], TranslationProvider]] = {
-    PROMPT_TRANSLATION_PROVIDER_GOOGLE: GoogleTranslationProvider,
-}
-_TRANSLATION_PROVIDER_INSTANCES: dict[str, TranslationProvider] = {}
-_TRANSLATION_PROVIDER_LOCK = threading.RLock()
-
-
-def get_translation_provider(provider: str) -> TranslationProvider:
-    name = str(provider or "").strip().lower()
-    with _TRANSLATION_PROVIDER_LOCK:
-        instance = _TRANSLATION_PROVIDER_INSTANCES.get(name)
-        if instance is not None:
-            return instance
-        factory = _TRANSLATION_PROVIDER_FACTORIES.get(name)
-        if factory is None:
-            raise TranslationProviderUnavailableError()
-        try:
-            instance = factory()
-        except PromptTranslationError:
-            raise
-        except Exception as exc:
-            raise TranslationProviderUnavailableError() from exc
-        _TRANSLATION_PROVIDER_INSTANCES[name] = instance
-        return instance
-
-
-def google_translate_text(text: str, source: str = "auto", target: str = "en") -> str:
-    value = str(text or "")
-    if not value.strip():
-        return value
-    source = normalize_prompt_translation_language(source, DEFAULT_PROMPT_TRANSLATION_SOURCE)
-    target = normalize_prompt_translation_language(target, DEFAULT_PROMPT_TRANSLATION_TARGET)
-    # External translation is opt-in through the provider setting. The optional
-    # dependency is imported only after this function is reached.
-    return get_translation_provider(PROMPT_TRANSLATION_PROVIDER_GOOGLE).translate(
-        value,
-        source,
-        target,
+try:
+    from .easyuse_anima.translation.contracts import (
+        DEFAULT_PROMPT_TRANSLATION_SOURCE,
+        DEFAULT_PROMPT_TRANSLATION_TARGET,
+        MAX_PROMPT_TRANSLATION_MARKER_CHARACTERS,
+        MAX_PROMPT_TRANSLATION_MARKERS,
+        MAX_PROMPT_TRANSLATION_TOTAL_CHARACTERS,
+        PROMPT_TRANSLATION_CACHE_MAX_ENTRIES,
+        PROMPT_TRANSLATION_CACHE_TTL_SECONDS,
+        PROMPT_TRANSLATION_PROVIDER_GOOGLE,
+        PROMPT_TRANSLATION_PROVIDER_OFF,
+        PROMPT_TRANSLATION_PROVIDER_TIMEOUT_SECONDS,
+        PROMPT_TRANSLATION_PROVIDERS,
+        PromptTranslationError,
+        PromptTranslationLimitError,
+        PromptTranslationSettings,
+        TranslationBusyError,
+        TranslationCacheKey,
+        TranslationCancelledError,
+        TranslationMarkerCountError,
+        TranslationMarkerSizeError,
+        TranslationProvider,
+        TranslationProviderUnavailableError,
+        TranslationTimeoutError,
+        TranslationTotalSizeError,
+        TranslationUpstreamError,
+        normalize_prompt_translation_language,
+        normalize_prompt_translation_provider,
+    )
+    from .easyuse_anima.translation.markers import (
+        PROMPT_TRANSLATION_MARKER_LABEL,
+        has_prompt_translation_markers,
+        iter_prompt_translation_markers,
+    )
+    from .easyuse_anima.translation.providers.google import (
+        GoogleTranslationProvider,
+    )
+    from .easyuse_anima.translation.service import (
+        BoundedTranslationCache,
+        PromptTranslationService,
+        get_translation_provider,
+        google_translate_text,
+        strip_prompt_translation_markers,
+        translate_prompt_markers,
+    )
+except ImportError:
+    from easyuse_anima.translation.contracts import (
+        DEFAULT_PROMPT_TRANSLATION_SOURCE,
+        DEFAULT_PROMPT_TRANSLATION_TARGET,
+        MAX_PROMPT_TRANSLATION_MARKER_CHARACTERS,
+        MAX_PROMPT_TRANSLATION_MARKERS,
+        MAX_PROMPT_TRANSLATION_TOTAL_CHARACTERS,
+        PROMPT_TRANSLATION_CACHE_MAX_ENTRIES,
+        PROMPT_TRANSLATION_CACHE_TTL_SECONDS,
+        PROMPT_TRANSLATION_PROVIDER_GOOGLE,
+        PROMPT_TRANSLATION_PROVIDER_OFF,
+        PROMPT_TRANSLATION_PROVIDER_TIMEOUT_SECONDS,
+        PROMPT_TRANSLATION_PROVIDERS,
+        PromptTranslationError,
+        PromptTranslationLimitError,
+        PromptTranslationSettings,
+        TranslationBusyError,
+        TranslationCacheKey,
+        TranslationCancelledError,
+        TranslationMarkerCountError,
+        TranslationMarkerSizeError,
+        TranslationProvider,
+        TranslationProviderUnavailableError,
+        TranslationTimeoutError,
+        TranslationTotalSizeError,
+        TranslationUpstreamError,
+        normalize_prompt_translation_language,
+        normalize_prompt_translation_provider,
+    )
+    from easyuse_anima.translation.markers import (
+        PROMPT_TRANSLATION_MARKER_LABEL,
+        has_prompt_translation_markers,
+        iter_prompt_translation_markers,
+    )
+    from easyuse_anima.translation.providers.google import (
+        GoogleTranslationProvider,
+    )
+    from easyuse_anima.translation.service import (
+        BoundedTranslationCache,
+        PromptTranslationService,
+        get_translation_provider,
+        google_translate_text,
+        strip_prompt_translation_markers,
+        translate_prompt_markers,
     )
 
 
-def _translate_segment(segment: str, settings: PromptTranslationSettings) -> str:
-    if settings.provider == PROMPT_TRANSLATION_PROVIDER_OFF:
-        return str(segment or "")
-    if settings.provider == PROMPT_TRANSLATION_PROVIDER_GOOGLE:
-        return google_translate_text(segment, settings.source, settings.target)
-    return str(segment or "")
-
-
-_CACHE_MISS = object()
-TranslationCacheKey = tuple[str, str, str, str]
-
-
-@dataclass
-class _TranslationFlight:
-    lock: threading.Lock
-    users: int = 0
-
-
-class BoundedTranslationCache:
-    def __init__(
-        self,
-        max_entries: int = PROMPT_TRANSLATION_CACHE_MAX_ENTRIES,
-        ttl_seconds: float = PROMPT_TRANSLATION_CACHE_TTL_SECONDS,
-        time_func: Callable[[], float] = time.monotonic,
-    ):
-        self.max_entries = max(0, int(max_entries))
-        self.ttl_seconds = max(0.0, float(ttl_seconds))
-        self._time_func = time_func
-        self._entries: OrderedDict[TranslationCacheKey, tuple[float, str]] = OrderedDict()
-        self._lock = threading.RLock()
-
-    def get(self, key: TranslationCacheKey):
-        with self._lock:
-            entry = self._entries.get(key)
-            if entry is None:
-                return _CACHE_MISS
-            expires_at, value = entry
-            if expires_at <= self._time_func():
-                self._entries.pop(key, None)
-                return _CACHE_MISS
-            self._entries.move_to_end(key)
-            return value
-
-    def put(self, key: TranslationCacheKey, value: str) -> None:
-        if self.max_entries == 0 or self.ttl_seconds == 0:
-            return
-        with self._lock:
-            self._entries[key] = (self._time_func() + self.ttl_seconds, str(value))
-            self._entries.move_to_end(key)
-            while len(self._entries) > self.max_entries:
-                self._entries.popitem(last=False)
-
-    def clear(self) -> None:
-        with self._lock:
-            self._entries.clear()
-
-    def __len__(self) -> int:
-        with self._lock:
-            return len(self._entries)
-
-
-class PromptTranslationService:
-    def __init__(
-        self,
-        *,
-        cache: BoundedTranslationCache | None = None,
-        max_markers: int = MAX_PROMPT_TRANSLATION_MARKERS,
-        max_marker_characters: int = MAX_PROMPT_TRANSLATION_MARKER_CHARACTERS,
-        max_total_characters: int = MAX_PROMPT_TRANSLATION_TOTAL_CHARACTERS,
-    ):
-        self.cache = cache if cache is not None else BoundedTranslationCache()
-        self.max_markers = max(1, int(max_markers))
-        self.max_marker_characters = max(1, int(max_marker_characters))
-        self.max_total_characters = max(1, int(max_total_characters))
-        self._flights: dict[TranslationCacheKey, _TranslationFlight] = {}
-        self._flights_lock = threading.RLock()
-
-    @contextmanager
-    def _single_flight(self, key: TranslationCacheKey):
-        with self._flights_lock:
-            flight = self._flights.get(key)
-            if flight is None:
-                flight = _TranslationFlight(lock=threading.Lock())
-                self._flights[key] = flight
-            flight.users += 1
-        try:
-            with flight.lock:
-                yield
-        finally:
-            with self._flights_lock:
-                flight.users -= 1
-                if flight.users == 0 and self._flights.get(key) is flight:
-                    self._flights.pop(key, None)
-
-    def _validate_markers(self, markers: list[tuple[int, int, str]]) -> None:
-        if len(markers) > self.max_markers:
-            raise TranslationMarkerCountError(
-                f"Prompt translation supports at most {self.max_markers} markers per request."
-            )
-        for _start, _end, segment in markers:
-            if len(segment) > self.max_marker_characters:
-                raise TranslationMarkerSizeError(
-                    "Prompt translation supports at most "
-                    f"{self.max_marker_characters} characters in one marker."
-                )
-        total_characters = sum(len(segment) for _start, _end, segment in markers)
-        if total_characters > self.max_total_characters:
-            raise TranslationTotalSizeError(
-                "Prompt translation supports at most "
-                f"{self.max_total_characters} marker characters per request."
-            )
-
-    def _translate_cached(self, text: str, settings: PromptTranslationSettings) -> str:
-        key = (settings.provider, settings.source, settings.target, text)
-        cached = self.cache.get(key)
-        if cached is not _CACHE_MISS:
-            return str(cached)
-        with self._single_flight(key):
-            cached = self.cache.get(key)
-            if cached is not _CACHE_MISS:
-                return str(cached)
-            translated = _translate_segment(text, settings)
-            self.cache.put(key, translated)
-            return translated
-
-    def translate_prompt(
-        self,
-        text: str,
-        settings: PromptTranslationSettings | None = None,
-    ) -> str:
-        value = str(text or "")
-        markers = list(iter_prompt_translation_markers(value))
-        if not markers:
-            return value
-        settings = settings or PromptTranslationSettings()
-        settings = PromptTranslationSettings(
-            provider=normalize_prompt_translation_provider(settings.provider),
-            source=normalize_prompt_translation_language(
-                settings.source,
-                DEFAULT_PROMPT_TRANSLATION_SOURCE,
-            ),
-            target=normalize_prompt_translation_language(
-                settings.target,
-                DEFAULT_PROMPT_TRANSLATION_TARGET,
-            ),
-        )
-
-        if settings.provider == PROMPT_TRANSLATION_PROVIDER_OFF:
-            translated_segments = {segment.strip(): segment.strip() for _, _, segment in markers}
-        else:
-            self._validate_markers(markers)
-            translated_segments: dict[str, str] = {}
-            for _start, _end, segment in markers:
-                marker_text = segment.strip()
-                if marker_text not in translated_segments:
-                    translated_segments[marker_text] = (
-                        self._translate_cached(marker_text, settings) if marker_text else ""
-                    )
-
-        output: list[str] = []
-        cursor = 0
-        for start, end, segment in markers:
-            output.append(value[cursor:start])
-            output.append(translated_segments[segment.strip()])
-            cursor = end
-        output.append(value[cursor:])
-        return "".join(output)
-
-
-_DEFAULT_TRANSLATION_SERVICE = PromptTranslationService()
-
-
-def strip_prompt_translation_markers(text: str) -> str:
-    return translate_prompt_markers(
-        text,
-        PromptTranslationSettings(provider=PROMPT_TRANSLATION_PROVIDER_OFF),
-    )
-
-
-def translate_prompt_markers(text: str, settings: PromptTranslationSettings | None = None) -> str:
-    """Compatibility facade used by synchronous ComfyUI node execution."""
-
-    return _DEFAULT_TRANSLATION_SERVICE.translate_prompt(text, settings)
+__all__ = (
+    "BoundedTranslationCache",
+    "DEFAULT_PROMPT_TRANSLATION_SOURCE",
+    "DEFAULT_PROMPT_TRANSLATION_TARGET",
+    "GoogleTranslationProvider",
+    "MAX_PROMPT_TRANSLATION_MARKER_CHARACTERS",
+    "MAX_PROMPT_TRANSLATION_MARKERS",
+    "MAX_PROMPT_TRANSLATION_TOTAL_CHARACTERS",
+    "PROMPT_TRANSLATION_CACHE_MAX_ENTRIES",
+    "PROMPT_TRANSLATION_CACHE_TTL_SECONDS",
+    "PROMPT_TRANSLATION_MARKER_LABEL",
+    "PROMPT_TRANSLATION_PROVIDER_GOOGLE",
+    "PROMPT_TRANSLATION_PROVIDER_OFF",
+    "PROMPT_TRANSLATION_PROVIDER_TIMEOUT_SECONDS",
+    "PROMPT_TRANSLATION_PROVIDERS",
+    "PromptTranslationError",
+    "PromptTranslationLimitError",
+    "PromptTranslationService",
+    "PromptTranslationSettings",
+    "TranslationBusyError",
+    "TranslationCacheKey",
+    "TranslationCancelledError",
+    "TranslationMarkerCountError",
+    "TranslationMarkerSizeError",
+    "TranslationProvider",
+    "TranslationProviderUnavailableError",
+    "TranslationTimeoutError",
+    "TranslationTotalSizeError",
+    "TranslationUpstreamError",
+    "get_translation_provider",
+    "google_translate_text",
+    "has_prompt_translation_markers",
+    "iter_prompt_translation_markers",
+    "normalize_prompt_translation_language",
+    "normalize_prompt_translation_provider",
+    "strip_prompt_translation_markers",
+    "translate_prompt_markers",
+)

--- a/settings.py
+++ b/settings.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 try:
     from .storage import AtomicJsonStore, USER_DATA_DIR
-    from .prompt_translation import (
+    from .easyuse_anima.translation.contracts import (
         DEFAULT_PROMPT_TRANSLATION_SOURCE,
         DEFAULT_PROMPT_TRANSLATION_TARGET,
         PROMPT_TRANSLATION_PROVIDER_OFF,
@@ -15,7 +15,7 @@ try:
     )
 except ImportError:
     from storage import AtomicJsonStore, USER_DATA_DIR
-    from prompt_translation import (
+    from easyuse_anima.translation.contracts import (
         DEFAULT_PROMPT_TRANSLATION_SOURCE,
         DEFAULT_PROMPT_TRANSLATION_TARGET,
         PROMPT_TRANSLATION_PROVIDER_OFF,

--- a/tests/fixtures/python_backend_baseline.json
+++ b/tests/fixtures/python_backend_baseline.json
@@ -1738,16 +1738,16 @@
         "classification": "internal",
         "column": 0,
         "conditional": false,
-        "imported": ".prompt_translation:PromptTranslationError",
+        "imported": ".easyuse_anima.translation.contracts:PromptTranslationError",
         "kind": "static_from",
         "line": 39,
         "name": "PromptTranslationError",
         "optional": false,
-        "requested": ".prompt_translation",
+        "requested": ".easyuse_anima.translation.contracts",
         "role": "ordinary",
         "scope": "<module>",
         "source": "api.py",
-        "target": "prompt_translation.py"
+        "target": "easyuse_anima/translation/contracts.py"
       },
       {
         "alias": null,
@@ -1756,16 +1756,16 @@
         "classification": "internal",
         "column": 0,
         "conditional": false,
-        "imported": ".prompt_translation:TranslationBusyError",
+        "imported": ".easyuse_anima.translation.contracts:TranslationBusyError",
         "kind": "static_from",
         "line": 39,
         "name": "TranslationBusyError",
         "optional": false,
-        "requested": ".prompt_translation",
+        "requested": ".easyuse_anima.translation.contracts",
         "role": "ordinary",
         "scope": "<module>",
         "source": "api.py",
-        "target": "prompt_translation.py"
+        "target": "easyuse_anima/translation/contracts.py"
       },
       {
         "alias": null,
@@ -1774,16 +1774,16 @@
         "classification": "internal",
         "column": 0,
         "conditional": false,
-        "imported": ".prompt_translation:TranslationCancelledError",
+        "imported": ".easyuse_anima.translation.contracts:TranslationCancelledError",
         "kind": "static_from",
         "line": 39,
         "name": "TranslationCancelledError",
         "optional": false,
-        "requested": ".prompt_translation",
+        "requested": ".easyuse_anima.translation.contracts",
         "role": "ordinary",
         "scope": "<module>",
         "source": "api.py",
-        "target": "prompt_translation.py"
+        "target": "easyuse_anima/translation/contracts.py"
       },
       {
         "alias": null,
@@ -1792,16 +1792,16 @@
         "classification": "internal",
         "column": 0,
         "conditional": false,
-        "imported": ".prompt_translation:TranslationTimeoutError",
+        "imported": ".easyuse_anima.translation.contracts:TranslationTimeoutError",
         "kind": "static_from",
         "line": 39,
         "name": "TranslationTimeoutError",
         "optional": false,
-        "requested": ".prompt_translation",
+        "requested": ".easyuse_anima.translation.contracts",
         "role": "ordinary",
         "scope": "<module>",
         "source": "api.py",
-        "target": "prompt_translation.py"
+        "target": "easyuse_anima/translation/contracts.py"
       },
       {
         "alias": null,
@@ -1810,16 +1810,16 @@
         "classification": "internal",
         "column": 0,
         "conditional": false,
-        "imported": ".prompt_translation:translate_prompt_markers",
+        "imported": ".easyuse_anima.translation.service:translate_prompt_markers",
         "kind": "static_from",
-        "line": 39,
+        "line": 45,
         "name": "translate_prompt_markers",
         "optional": false,
-        "requested": ".prompt_translation",
+        "requested": ".easyuse_anima.translation.service",
         "role": "ordinary",
         "scope": "<module>",
         "source": "api.py",
-        "target": "prompt_translation.py"
+        "target": "easyuse_anima/translation/service.py"
       },
       {
         "alias": null,
@@ -1830,7 +1830,7 @@
         "conditional": false,
         "imported": ".api_contract:ApiContractError",
         "kind": "static_from",
-        "line": 46,
+        "line": 48,
         "name": "ApiContractError",
         "optional": false,
         "requested": ".api_contract",
@@ -1848,7 +1848,7 @@
         "conditional": false,
         "imported": ".api_contract:attach_request_id_header",
         "kind": "static_from",
-        "line": 46,
+        "line": 48,
         "name": "attach_request_id_header",
         "optional": false,
         "requested": ".api_contract",
@@ -1866,7 +1866,7 @@
         "conditional": false,
         "imported": ".api_contract:correlate_response",
         "kind": "static_from",
-        "line": 46,
+        "line": 48,
         "name": "correlate_response",
         "optional": false,
         "requested": ".api_contract",
@@ -1884,7 +1884,7 @@
         "conditional": false,
         "imported": ".api_contract:create_request_id",
         "kind": "static_from",
-        "line": 46,
+        "line": 48,
         "name": "create_request_id",
         "optional": false,
         "requested": ".api_contract",
@@ -1902,7 +1902,7 @@
         "conditional": false,
         "imported": ".api_contract:error_payload",
         "kind": "static_from",
-        "line": 46,
+        "line": 48,
         "name": "error_payload",
         "optional": false,
         "requested": ".api_contract",
@@ -1920,7 +1920,7 @@
         "conditional": false,
         "imported": ".api_contract:json_boolean",
         "kind": "static_from",
-        "line": 46,
+        "line": 48,
         "name": "json_boolean",
         "optional": false,
         "requested": ".api_contract",
@@ -1938,7 +1938,7 @@
         "conditional": false,
         "imported": ".api_contract:json_integer",
         "kind": "static_from",
-        "line": 46,
+        "line": 48,
         "name": "json_integer",
         "optional": false,
         "requested": ".api_contract",
@@ -1956,7 +1956,7 @@
         "conditional": false,
         "imported": ".api_contract:json_object",
         "kind": "static_from",
-        "line": 46,
+        "line": 48,
         "name": "json_object",
         "optional": false,
         "requested": ".api_contract",
@@ -1974,7 +1974,7 @@
         "conditional": false,
         "imported": ".api_contract:json_string",
         "kind": "static_from",
-        "line": 46,
+        "line": 48,
         "name": "json_string",
         "optional": false,
         "requested": ".api_contract",
@@ -1992,7 +1992,7 @@
         "conditional": false,
         "imported": ".api_contract:json_uuid_string",
         "kind": "static_from",
-        "line": 46,
+        "line": 48,
         "name": "json_uuid_string",
         "optional": false,
         "requested": ".api_contract",
@@ -2010,7 +2010,7 @@
         "conditional": false,
         "imported": ".api_contract:parse_json_object",
         "kind": "static_from",
-        "line": 46,
+        "line": 48,
         "name": "parse_json_object",
         "optional": false,
         "requested": ".api_contract",
@@ -2028,7 +2028,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 59
+            "line": 61
           }
         ],
         "classification": "internal",
@@ -2036,12 +2036,12 @@
         "compatibility_pair": {
           "bound_name": "PROFILE_KIND_AIO",
           "target": "easyuse_anima/profiles/contract.py",
-          "try_line": 59
+          "try_line": 61
         },
         "conditional": true,
         "imported": ".easyuse_anima.profiles.contract:PROFILE_KIND_AIO",
         "kind": "static_from",
-        "line": 60,
+        "line": 62,
         "name": "PROFILE_KIND_AIO",
         "optional": false,
         "requested": ".easyuse_anima.profiles.contract",
@@ -2059,7 +2059,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 59
+            "line": 61
           }
         ],
         "classification": "internal",
@@ -2067,12 +2067,12 @@
         "compatibility_pair": {
           "bound_name": "PROFILE_KIND_LORA",
           "target": "easyuse_anima/profiles/contract.py",
-          "try_line": 59
+          "try_line": 61
         },
         "conditional": true,
         "imported": ".easyuse_anima.profiles.contract:PROFILE_KIND_LORA",
         "kind": "static_from",
-        "line": 60,
+        "line": 62,
         "name": "PROFILE_KIND_LORA",
         "optional": false,
         "requested": ".easyuse_anima.profiles.contract",
@@ -2090,7 +2090,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 59
+            "line": 61
           }
         ],
         "classification": "internal",
@@ -2098,12 +2098,12 @@
         "compatibility_pair": {
           "bound_name": "ProfileContractError",
           "target": "easyuse_anima/profiles/contract.py",
-          "try_line": 59
+          "try_line": 61
         },
         "conditional": true,
         "imported": ".easyuse_anima.profiles.contract:ProfileContractError",
         "kind": "static_from",
-        "line": 60,
+        "line": 62,
         "name": "ProfileContractError",
         "optional": false,
         "requested": ".easyuse_anima.profiles.contract",
@@ -2121,7 +2121,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 59
+            "line": 61
           }
         ],
         "classification": "internal",
@@ -2129,12 +2129,12 @@
         "compatibility_pair": {
           "bound_name": "build_profile_document",
           "target": "easyuse_anima/profiles/contract.py",
-          "try_line": 59
+          "try_line": 61
         },
         "conditional": true,
         "imported": ".easyuse_anima.profiles.contract:build_profile_document",
         "kind": "static_from",
-        "line": 60,
+        "line": 62,
         "name": "build_profile_document",
         "optional": false,
         "requested": ".easyuse_anima.profiles.contract",
@@ -2152,7 +2152,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 59
+            "line": 61
           }
         ],
         "classification": "internal",
@@ -2160,12 +2160,12 @@
         "compatibility_pair": {
           "bound_name": "create_profile_document",
           "target": "easyuse_anima/profiles/contract.py",
-          "try_line": 59
+          "try_line": 61
         },
         "conditional": true,
         "imported": ".easyuse_anima.profiles.contract:create_profile_document",
         "kind": "static_from",
-        "line": 60,
+        "line": 62,
         "name": "create_profile_document",
         "optional": false,
         "requested": ".easyuse_anima.profiles.contract",
@@ -2183,7 +2183,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 59
+            "line": 61
           }
         ],
         "classification": "internal",
@@ -2191,12 +2191,12 @@
         "compatibility_pair": {
           "bound_name": "interpret_profile_document",
           "target": "easyuse_anima/profiles/contract.py",
-          "try_line": 59
+          "try_line": 61
         },
         "conditional": true,
         "imported": ".easyuse_anima.profiles.contract:interpret_profile_document",
         "kind": "static_from",
-        "line": 60,
+        "line": 62,
         "name": "interpret_profile_document",
         "optional": false,
         "requested": ".easyuse_anima.profiles.contract",
@@ -2214,7 +2214,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 59
+            "line": 61
           }
         ],
         "classification": "internal",
@@ -2222,12 +2222,12 @@
         "compatibility_pair": {
           "bound_name": "legacy_profile_id",
           "target": "easyuse_anima/profiles/contract.py",
-          "try_line": 59
+          "try_line": 61
         },
         "conditional": true,
         "imported": ".easyuse_anima.profiles.contract:legacy_profile_id",
         "kind": "static_from",
-        "line": 60,
+        "line": 62,
         "name": "legacy_profile_id",
         "optional": false,
         "requested": ".easyuse_anima.profiles.contract",
@@ -2245,7 +2245,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 59
+            "line": 61
           }
         ],
         "classification": "internal",
@@ -2253,12 +2253,12 @@
         "compatibility_pair": {
           "bound_name": "normalize_profile_filename_identity",
           "target": "easyuse_anima/profiles/contract.py",
-          "try_line": 59
+          "try_line": 61
         },
         "conditional": true,
         "imported": ".easyuse_anima.profiles.contract:normalize_profile_filename_identity",
         "kind": "static_from",
-        "line": 60,
+        "line": 62,
         "name": "normalize_profile_filename_identity",
         "optional": false,
         "requested": ".easyuse_anima.profiles.contract",
@@ -2276,7 +2276,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 59
+            "line": 61
           }
         ],
         "classification": "internal",
@@ -2284,12 +2284,12 @@
         "compatibility_pair": {
           "bound_name": "rename_profile_document",
           "target": "easyuse_anima/profiles/contract.py",
-          "try_line": 59
+          "try_line": 61
         },
         "conditional": true,
         "imported": ".easyuse_anima.profiles.contract:rename_profile_document",
         "kind": "static_from",
-        "line": 60,
+        "line": 62,
         "name": "rename_profile_document",
         "optional": false,
         "requested": ".easyuse_anima.profiles.contract",
@@ -2307,7 +2307,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 59
+            "line": 61
           }
         ],
         "classification": "internal",
@@ -2315,12 +2315,12 @@
         "compatibility_pair": {
           "bound_name": "update_profile_document",
           "target": "easyuse_anima/profiles/contract.py",
-          "try_line": 59
+          "try_line": 61
         },
         "conditional": true,
         "imported": ".easyuse_anima.profiles.contract:update_profile_document",
         "kind": "static_from",
-        "line": 60,
+        "line": 62,
         "name": "update_profile_document",
         "optional": false,
         "requested": ".easyuse_anima.profiles.contract",
@@ -2338,7 +2338,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 59
+            "line": 61
           }
         ],
         "classification": "internal",
@@ -2346,12 +2346,12 @@
         "compatibility_pair": {
           "bound_name": "PROFILE_MUTATION_COORDINATOR",
           "target": "easyuse_anima/profiles/mutation.py",
-          "try_line": 59
+          "try_line": 61
         },
         "conditional": true,
         "imported": ".easyuse_anima.profiles.mutation:PROFILE_MUTATION_COORDINATOR",
         "kind": "static_from",
-        "line": 72,
+        "line": 74,
         "name": "PROFILE_MUTATION_COORDINATOR",
         "optional": false,
         "requested": ".easyuse_anima.profiles.mutation",
@@ -2369,7 +2369,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 59
+            "line": 61
           }
         ],
         "classification": "internal",
@@ -2377,12 +2377,12 @@
         "compatibility_pair": {
           "bound_name": "ProfileMutationError",
           "target": "easyuse_anima/profiles/mutation.py",
-          "try_line": 59
+          "try_line": 61
         },
         "conditional": true,
         "imported": ".easyuse_anima.profiles.mutation:ProfileMutationError",
         "kind": "static_from",
-        "line": 72,
+        "line": 74,
         "name": "ProfileMutationError",
         "optional": false,
         "requested": ".easyuse_anima.profiles.mutation",
@@ -2400,7 +2400,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 59
+            "line": 61
           }
         ],
         "classification": "internal",
@@ -2408,12 +2408,12 @@
         "compatibility_pair": {
           "bound_name": "ProfileRevisionConflictError",
           "target": "easyuse_anima/profiles/mutation.py",
-          "try_line": 59
+          "try_line": 61
         },
         "conditional": true,
         "imported": ".easyuse_anima.profiles.mutation:ProfileRevisionConflictError",
         "kind": "static_from",
-        "line": 72,
+        "line": 74,
         "name": "ProfileRevisionConflictError",
         "optional": false,
         "requested": ".easyuse_anima.profiles.mutation",
@@ -2431,7 +2431,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 59
+            "line": 61
           }
         ],
         "classification": "internal",
@@ -2439,12 +2439,12 @@
         "compatibility_pair": {
           "bound_name": "require_profile_precondition",
           "target": "easyuse_anima/profiles/mutation.py",
-          "try_line": 59
+          "try_line": 61
         },
         "conditional": true,
         "imported": ".easyuse_anima.profiles.mutation:require_profile_precondition",
         "kind": "static_from",
-        "line": 72,
+        "line": 74,
         "name": "require_profile_precondition",
         "optional": false,
         "requested": ".easyuse_anima.profiles.mutation",
@@ -2462,7 +2462,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 59
+            "line": 61
           }
         ],
         "classification": "internal",
@@ -2470,12 +2470,12 @@
         "compatibility_pair": {
           "bound_name": "verify_profile_precondition",
           "target": "easyuse_anima/profiles/mutation.py",
-          "try_line": 59
+          "try_line": 61
         },
         "conditional": true,
         "imported": ".easyuse_anima.profiles.mutation:verify_profile_precondition",
         "kind": "static_from",
-        "line": 72,
+        "line": 74,
         "name": "verify_profile_precondition",
         "optional": false,
         "requested": ".easyuse_anima.profiles.mutation",
@@ -2494,9 +2494,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 79,
+            "handler_line": 81,
             "kind": "try",
-            "line": 59
+            "line": 61
           }
         ],
         "classification": "compatibility_fallback",
@@ -2504,12 +2504,12 @@
         "compatibility_pair": {
           "bound_name": "PROFILE_KIND_AIO",
           "target": "easyuse_anima/profiles/contract.py",
-          "try_line": 59
+          "try_line": 61
         },
         "conditional": true,
         "imported": "easyuse_anima.profiles.contract:PROFILE_KIND_AIO",
         "kind": "static_from",
-        "line": 80,
+        "line": 82,
         "name": "PROFILE_KIND_AIO",
         "optional": false,
         "requested": "easyuse_anima.profiles.contract",
@@ -2528,9 +2528,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 79,
+            "handler_line": 81,
             "kind": "try",
-            "line": 59
+            "line": 61
           }
         ],
         "classification": "compatibility_fallback",
@@ -2538,12 +2538,12 @@
         "compatibility_pair": {
           "bound_name": "PROFILE_KIND_LORA",
           "target": "easyuse_anima/profiles/contract.py",
-          "try_line": 59
+          "try_line": 61
         },
         "conditional": true,
         "imported": "easyuse_anima.profiles.contract:PROFILE_KIND_LORA",
         "kind": "static_from",
-        "line": 80,
+        "line": 82,
         "name": "PROFILE_KIND_LORA",
         "optional": false,
         "requested": "easyuse_anima.profiles.contract",
@@ -2562,9 +2562,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 79,
+            "handler_line": 81,
             "kind": "try",
-            "line": 59
+            "line": 61
           }
         ],
         "classification": "compatibility_fallback",
@@ -2572,12 +2572,12 @@
         "compatibility_pair": {
           "bound_name": "ProfileContractError",
           "target": "easyuse_anima/profiles/contract.py",
-          "try_line": 59
+          "try_line": 61
         },
         "conditional": true,
         "imported": "easyuse_anima.profiles.contract:ProfileContractError",
         "kind": "static_from",
-        "line": 80,
+        "line": 82,
         "name": "ProfileContractError",
         "optional": false,
         "requested": "easyuse_anima.profiles.contract",
@@ -2596,9 +2596,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 79,
+            "handler_line": 81,
             "kind": "try",
-            "line": 59
+            "line": 61
           }
         ],
         "classification": "compatibility_fallback",
@@ -2606,12 +2606,12 @@
         "compatibility_pair": {
           "bound_name": "build_profile_document",
           "target": "easyuse_anima/profiles/contract.py",
-          "try_line": 59
+          "try_line": 61
         },
         "conditional": true,
         "imported": "easyuse_anima.profiles.contract:build_profile_document",
         "kind": "static_from",
-        "line": 80,
+        "line": 82,
         "name": "build_profile_document",
         "optional": false,
         "requested": "easyuse_anima.profiles.contract",
@@ -2630,9 +2630,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 79,
+            "handler_line": 81,
             "kind": "try",
-            "line": 59
+            "line": 61
           }
         ],
         "classification": "compatibility_fallback",
@@ -2640,12 +2640,12 @@
         "compatibility_pair": {
           "bound_name": "create_profile_document",
           "target": "easyuse_anima/profiles/contract.py",
-          "try_line": 59
+          "try_line": 61
         },
         "conditional": true,
         "imported": "easyuse_anima.profiles.contract:create_profile_document",
         "kind": "static_from",
-        "line": 80,
+        "line": 82,
         "name": "create_profile_document",
         "optional": false,
         "requested": "easyuse_anima.profiles.contract",
@@ -2664,9 +2664,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 79,
+            "handler_line": 81,
             "kind": "try",
-            "line": 59
+            "line": 61
           }
         ],
         "classification": "compatibility_fallback",
@@ -2674,12 +2674,12 @@
         "compatibility_pair": {
           "bound_name": "interpret_profile_document",
           "target": "easyuse_anima/profiles/contract.py",
-          "try_line": 59
+          "try_line": 61
         },
         "conditional": true,
         "imported": "easyuse_anima.profiles.contract:interpret_profile_document",
         "kind": "static_from",
-        "line": 80,
+        "line": 82,
         "name": "interpret_profile_document",
         "optional": false,
         "requested": "easyuse_anima.profiles.contract",
@@ -2698,9 +2698,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 79,
+            "handler_line": 81,
             "kind": "try",
-            "line": 59
+            "line": 61
           }
         ],
         "classification": "compatibility_fallback",
@@ -2708,12 +2708,12 @@
         "compatibility_pair": {
           "bound_name": "legacy_profile_id",
           "target": "easyuse_anima/profiles/contract.py",
-          "try_line": 59
+          "try_line": 61
         },
         "conditional": true,
         "imported": "easyuse_anima.profiles.contract:legacy_profile_id",
         "kind": "static_from",
-        "line": 80,
+        "line": 82,
         "name": "legacy_profile_id",
         "optional": false,
         "requested": "easyuse_anima.profiles.contract",
@@ -2732,9 +2732,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 79,
+            "handler_line": 81,
             "kind": "try",
-            "line": 59
+            "line": 61
           }
         ],
         "classification": "compatibility_fallback",
@@ -2742,12 +2742,12 @@
         "compatibility_pair": {
           "bound_name": "normalize_profile_filename_identity",
           "target": "easyuse_anima/profiles/contract.py",
-          "try_line": 59
+          "try_line": 61
         },
         "conditional": true,
         "imported": "easyuse_anima.profiles.contract:normalize_profile_filename_identity",
         "kind": "static_from",
-        "line": 80,
+        "line": 82,
         "name": "normalize_profile_filename_identity",
         "optional": false,
         "requested": "easyuse_anima.profiles.contract",
@@ -2766,9 +2766,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 79,
+            "handler_line": 81,
             "kind": "try",
-            "line": 59
+            "line": 61
           }
         ],
         "classification": "compatibility_fallback",
@@ -2776,12 +2776,12 @@
         "compatibility_pair": {
           "bound_name": "rename_profile_document",
           "target": "easyuse_anima/profiles/contract.py",
-          "try_line": 59
+          "try_line": 61
         },
         "conditional": true,
         "imported": "easyuse_anima.profiles.contract:rename_profile_document",
         "kind": "static_from",
-        "line": 80,
+        "line": 82,
         "name": "rename_profile_document",
         "optional": false,
         "requested": "easyuse_anima.profiles.contract",
@@ -2800,9 +2800,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 79,
+            "handler_line": 81,
             "kind": "try",
-            "line": 59
+            "line": 61
           }
         ],
         "classification": "compatibility_fallback",
@@ -2810,12 +2810,12 @@
         "compatibility_pair": {
           "bound_name": "update_profile_document",
           "target": "easyuse_anima/profiles/contract.py",
-          "try_line": 59
+          "try_line": 61
         },
         "conditional": true,
         "imported": "easyuse_anima.profiles.contract:update_profile_document",
         "kind": "static_from",
-        "line": 80,
+        "line": 82,
         "name": "update_profile_document",
         "optional": false,
         "requested": "easyuse_anima.profiles.contract",
@@ -2834,9 +2834,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 79,
+            "handler_line": 81,
             "kind": "try",
-            "line": 59
+            "line": 61
           }
         ],
         "classification": "compatibility_fallback",
@@ -2844,12 +2844,12 @@
         "compatibility_pair": {
           "bound_name": "PROFILE_MUTATION_COORDINATOR",
           "target": "easyuse_anima/profiles/mutation.py",
-          "try_line": 59
+          "try_line": 61
         },
         "conditional": true,
         "imported": "easyuse_anima.profiles.mutation:PROFILE_MUTATION_COORDINATOR",
         "kind": "static_from",
-        "line": 92,
+        "line": 94,
         "name": "PROFILE_MUTATION_COORDINATOR",
         "optional": false,
         "requested": "easyuse_anima.profiles.mutation",
@@ -2868,9 +2868,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 79,
+            "handler_line": 81,
             "kind": "try",
-            "line": 59
+            "line": 61
           }
         ],
         "classification": "compatibility_fallback",
@@ -2878,12 +2878,12 @@
         "compatibility_pair": {
           "bound_name": "ProfileMutationError",
           "target": "easyuse_anima/profiles/mutation.py",
-          "try_line": 59
+          "try_line": 61
         },
         "conditional": true,
         "imported": "easyuse_anima.profiles.mutation:ProfileMutationError",
         "kind": "static_from",
-        "line": 92,
+        "line": 94,
         "name": "ProfileMutationError",
         "optional": false,
         "requested": "easyuse_anima.profiles.mutation",
@@ -2902,9 +2902,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 79,
+            "handler_line": 81,
             "kind": "try",
-            "line": 59
+            "line": 61
           }
         ],
         "classification": "compatibility_fallback",
@@ -2912,12 +2912,12 @@
         "compatibility_pair": {
           "bound_name": "ProfileRevisionConflictError",
           "target": "easyuse_anima/profiles/mutation.py",
-          "try_line": 59
+          "try_line": 61
         },
         "conditional": true,
         "imported": "easyuse_anima.profiles.mutation:ProfileRevisionConflictError",
         "kind": "static_from",
-        "line": 92,
+        "line": 94,
         "name": "ProfileRevisionConflictError",
         "optional": false,
         "requested": "easyuse_anima.profiles.mutation",
@@ -2936,9 +2936,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 79,
+            "handler_line": 81,
             "kind": "try",
-            "line": 59
+            "line": 61
           }
         ],
         "classification": "compatibility_fallback",
@@ -2946,12 +2946,12 @@
         "compatibility_pair": {
           "bound_name": "require_profile_precondition",
           "target": "easyuse_anima/profiles/mutation.py",
-          "try_line": 59
+          "try_line": 61
         },
         "conditional": true,
         "imported": "easyuse_anima.profiles.mutation:require_profile_precondition",
         "kind": "static_from",
-        "line": 92,
+        "line": 94,
         "name": "require_profile_precondition",
         "optional": false,
         "requested": "easyuse_anima.profiles.mutation",
@@ -2970,9 +2970,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 79,
+            "handler_line": 81,
             "kind": "try",
-            "line": 59
+            "line": 61
           }
         ],
         "classification": "compatibility_fallback",
@@ -2980,12 +2980,12 @@
         "compatibility_pair": {
           "bound_name": "verify_profile_precondition",
           "target": "easyuse_anima/profiles/mutation.py",
-          "try_line": 59
+          "try_line": 61
         },
         "conditional": true,
         "imported": "easyuse_anima.profiles.mutation:verify_profile_precondition",
         "kind": "static_from",
-        "line": 92,
+        "line": 94,
         "name": "verify_profile_precondition",
         "optional": false,
         "requested": "easyuse_anima.profiles.mutation",
@@ -3003,7 +3003,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 99
+            "line": 101
           }
         ],
         "classification": "internal",
@@ -3011,12 +3011,12 @@
         "compatibility_pair": {
           "bound_name": "AtomicJsonStore",
           "target": "storage.py",
-          "try_line": 99
+          "try_line": 101
         },
         "conditional": true,
         "imported": ".storage:AtomicJsonStore",
         "kind": "static_from",
-        "line": 100,
+        "line": 102,
         "name": "AtomicJsonStore",
         "optional": false,
         "requested": ".storage",
@@ -3034,7 +3034,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 99
+            "line": 101
           }
         ],
         "classification": "internal",
@@ -3042,12 +3042,12 @@
         "compatibility_pair": {
           "bound_name": "USER_DATA_DIR",
           "target": "storage.py",
-          "try_line": 99
+          "try_line": 101
         },
         "conditional": true,
         "imported": ".storage:USER_DATA_DIR",
         "kind": "static_from",
-        "line": 100,
+        "line": 102,
         "name": "USER_DATA_DIR",
         "optional": false,
         "requested": ".storage",
@@ -3066,9 +3066,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 101,
+            "handler_line": 103,
             "kind": "try",
-            "line": 99
+            "line": 101
           }
         ],
         "classification": "compatibility_fallback",
@@ -3076,12 +3076,12 @@
         "compatibility_pair": {
           "bound_name": "AtomicJsonStore",
           "target": "storage.py",
-          "try_line": 99
+          "try_line": 101
         },
         "conditional": true,
         "imported": "storage:AtomicJsonStore",
         "kind": "static_from",
-        "line": 102,
+        "line": 104,
         "name": "AtomicJsonStore",
         "optional": false,
         "requested": "storage",
@@ -3100,9 +3100,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 101,
+            "handler_line": 103,
             "kind": "try",
-            "line": 99
+            "line": 101
           }
         ],
         "classification": "compatibility_fallback",
@@ -3110,12 +3110,12 @@
         "compatibility_pair": {
           "bound_name": "USER_DATA_DIR",
           "target": "storage.py",
-          "try_line": 99
+          "try_line": 101
         },
         "conditional": true,
         "imported": "storage:USER_DATA_DIR",
         "kind": "static_from",
-        "line": 102,
+        "line": 104,
         "name": "USER_DATA_DIR",
         "optional": false,
         "requested": "storage",
@@ -3133,7 +3133,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 438
+            "line": 440
           }
         ],
         "classification": "external",
@@ -3141,7 +3141,7 @@
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 439,
+        "line": 441,
         "name": null,
         "optional": true,
         "requested": "folder_paths",
@@ -3158,7 +3158,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 464
+            "line": 466
           }
         ],
         "classification": "external",
@@ -3166,7 +3166,7 @@
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 465,
+        "line": 467,
         "name": null,
         "optional": true,
         "requested": "folder_paths",
@@ -3183,7 +3183,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1005
+            "line": 1007
           }
         ],
         "classification": "external",
@@ -3191,7 +3191,7 @@
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 1006,
+        "line": 1008,
         "name": null,
         "optional": true,
         "requested": "folder_paths",
@@ -3786,20 +3786,20 @@
         "column": 4,
         "compatibility_pair": {
           "bound_name": "iter_prompt_translation_markers",
-          "target": "prompt_translation.py",
+          "target": "easyuse_anima/translation/markers.py",
           "try_line": 17
         },
         "conditional": true,
-        "imported": ".prompt_translation:iter_prompt_translation_markers",
+        "imported": ".easyuse_anima.translation.markers:iter_prompt_translation_markers",
         "kind": "static_from",
         "line": 28,
         "name": "iter_prompt_translation_markers",
         "optional": false,
-        "requested": ".prompt_translation",
+        "requested": ".easyuse_anima.translation.markers",
         "role": "compatibility_primary",
         "scope": "<module>",
         "source": "autocomplete_dataset.py",
-        "target": "prompt_translation.py"
+        "target": "easyuse_anima/translation/markers.py"
       },
       {
         "alias": "STORAGE_PACKAGE_DATA_DIR",
@@ -3823,7 +3823,7 @@
         "conditional": true,
         "imported": ".storage:PACKAGE_DATA_DIR",
         "kind": "static_from",
-        "line": 29,
+        "line": 31,
         "name": "PACKAGE_DATA_DIR",
         "optional": false,
         "requested": ".storage",
@@ -3854,7 +3854,7 @@
         "conditional": true,
         "imported": ".storage:USER_DATA_DIR",
         "kind": "static_from",
-        "line": 30,
+        "line": 32,
         "name": "USER_DATA_DIR",
         "optional": false,
         "requested": ".storage",
@@ -3873,7 +3873,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 31,
+            "handler_line": 33,
             "kind": "try",
             "line": 17
           }
@@ -3888,7 +3888,7 @@
         "conditional": true,
         "imported": "autocomplete_index:AutocompleteIndexDiagnostics",
         "kind": "static_from",
-        "line": 32,
+        "line": 34,
         "name": "AutocompleteIndexDiagnostics",
         "optional": false,
         "requested": "autocomplete_index",
@@ -3907,7 +3907,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 31,
+            "handler_line": 33,
             "kind": "try",
             "line": 17
           }
@@ -3922,7 +3922,7 @@
         "conditional": true,
         "imported": "autocomplete_index:AutocompleteIndexSource",
         "kind": "static_from",
-        "line": 32,
+        "line": 34,
         "name": "AutocompleteIndexSource",
         "optional": false,
         "requested": "autocomplete_index",
@@ -3941,7 +3941,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 31,
+            "handler_line": 33,
             "kind": "try",
             "line": 17
           }
@@ -3956,7 +3956,7 @@
         "conditional": true,
         "imported": "autocomplete_index:AutocompleteIndexUnavailable",
         "kind": "static_from",
-        "line": 32,
+        "line": 34,
         "name": "AutocompleteIndexUnavailable",
         "optional": false,
         "requested": "autocomplete_index",
@@ -3975,7 +3975,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 31,
+            "handler_line": 33,
             "kind": "try",
             "line": 17
           }
@@ -3990,7 +3990,7 @@
         "conditional": true,
         "imported": "autocomplete_index:search_autocomplete_index",
         "kind": "static_from",
-        "line": 32,
+        "line": 34,
         "name": "search_autocomplete_index",
         "optional": false,
         "requested": "autocomplete_index",
@@ -4009,7 +4009,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 31,
+            "handler_line": 33,
             "kind": "try",
             "line": 17
           }
@@ -4024,7 +4024,7 @@
         "conditional": true,
         "imported": "anima_prompt.knowledge:PACKAGE_DATA_DIR",
         "kind": "static_from",
-        "line": 38,
+        "line": 40,
         "name": "PACKAGE_DATA_DIR",
         "optional": false,
         "requested": "anima_prompt.knowledge",
@@ -4043,7 +4043,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 31,
+            "handler_line": 33,
             "kind": "try",
             "line": 17
           }
@@ -4058,7 +4058,7 @@
         "conditional": true,
         "imported": "anima_prompt.models:TagSection",
         "kind": "static_from",
-        "line": 39,
+        "line": 41,
         "name": "TagSection",
         "optional": false,
         "requested": "anima_prompt.models",
@@ -4077,7 +4077,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 31,
+            "handler_line": 33,
             "kind": "try",
             "line": 17
           }
@@ -4092,7 +4092,7 @@
         "conditional": true,
         "imported": "anima_prompt.ordering:builtin_tag_section",
         "kind": "static_from",
-        "line": 40,
+        "line": 42,
         "name": "builtin_tag_section",
         "optional": false,
         "requested": "anima_prompt.ordering",
@@ -4111,7 +4111,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 31,
+            "handler_line": 33,
             "kind": "try",
             "line": 17
           }
@@ -4126,7 +4126,7 @@
         "conditional": true,
         "imported": "anima_prompt.parser:parse_prompt",
         "kind": "static_from",
-        "line": 41,
+        "line": 43,
         "name": "parse_prompt",
         "optional": false,
         "requested": "anima_prompt.parser",
@@ -4145,7 +4145,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 31,
+            "handler_line": 33,
             "kind": "try",
             "line": 17
           }
@@ -4154,20 +4154,20 @@
         "column": 4,
         "compatibility_pair": {
           "bound_name": "iter_prompt_translation_markers",
-          "target": "prompt_translation.py",
+          "target": "easyuse_anima/translation/markers.py",
           "try_line": 17
         },
         "conditional": true,
-        "imported": "prompt_translation:iter_prompt_translation_markers",
+        "imported": "easyuse_anima.translation.markers:iter_prompt_translation_markers",
         "kind": "static_from",
-        "line": 42,
+        "line": 44,
         "name": "iter_prompt_translation_markers",
         "optional": false,
-        "requested": "prompt_translation",
+        "requested": "easyuse_anima.translation.markers",
         "role": "compatibility_fallback",
         "scope": "<module>",
         "source": "autocomplete_dataset.py",
-        "target": "prompt_translation.py"
+        "target": "easyuse_anima/translation/markers.py"
       },
       {
         "alias": "STORAGE_PACKAGE_DATA_DIR",
@@ -4179,7 +4179,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 31,
+            "handler_line": 33,
             "kind": "try",
             "line": 17
           }
@@ -4194,7 +4194,7 @@
         "conditional": true,
         "imported": "storage:PACKAGE_DATA_DIR",
         "kind": "static_from",
-        "line": 43,
+        "line": 47,
         "name": "PACKAGE_DATA_DIR",
         "optional": false,
         "requested": "storage",
@@ -4213,7 +4213,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 31,
+            "handler_line": 33,
             "kind": "try",
             "line": 17
           }
@@ -4228,7 +4228,7 @@
         "conditional": true,
         "imported": "storage:USER_DATA_DIR",
         "kind": "static_from",
-        "line": 44,
+        "line": 48,
         "name": "USER_DATA_DIR",
         "optional": false,
         "requested": "storage",
@@ -21045,6 +21045,24 @@
       },
       {
         "alias": null,
+        "bound_name": "has_prompt_translation_markers",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": "..translation.markers:has_prompt_translation_markers",
+        "kind": "static_from",
+        "line": 15,
+        "name": "has_prompt_translation_markers",
+        "optional": false,
+        "requested": "..translation.markers",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/prompt/advanced.py",
+        "target": "easyuse_anima/translation/markers.py"
+      },
+      {
+        "alias": null,
         "bound_name": "ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
         "branch_context": [],
         "classification": "internal",
@@ -21052,7 +21070,7 @@
         "conditional": false,
         "imported": ".artist_mix:ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
         "kind": "static_from",
-        "line": 15,
+        "line": 16,
         "name": "ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
         "optional": false,
         "requested": ".artist_mix",
@@ -21070,7 +21088,7 @@
         "conditional": false,
         "imported": ".artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
         "kind": "static_from",
-        "line": 15,
+        "line": 16,
         "name": "ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
         "optional": false,
         "requested": ".artist_mix",
@@ -21088,7 +21106,7 @@
         "conditional": false,
         "imported": ".artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
         "kind": "static_from",
-        "line": 15,
+        "line": 16,
         "name": "ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
         "optional": false,
         "requested": ".artist_mix",
@@ -21106,7 +21124,7 @@
         "conditional": false,
         "imported": ".artist_mix:ARTIST_MIX_DEFAULT_EXACT_TOP_K",
         "kind": "static_from",
-        "line": 15,
+        "line": 16,
         "name": "ARTIST_MIX_DEFAULT_EXACT_TOP_K",
         "optional": false,
         "requested": ".artist_mix",
@@ -21124,7 +21142,7 @@
         "conditional": false,
         "imported": ".artist_mix:ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
         "kind": "static_from",
-        "line": 15,
+        "line": 16,
         "name": "ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
         "optional": false,
         "requested": ".artist_mix",
@@ -21142,7 +21160,7 @@
         "conditional": false,
         "imported": ".artist_mix:ARTIST_MIX_DEFAULT_START_PERCENT",
         "kind": "static_from",
-        "line": 15,
+        "line": 16,
         "name": "ARTIST_MIX_DEFAULT_START_PERCENT",
         "optional": false,
         "requested": ".artist_mix",
@@ -21160,7 +21178,7 @@
         "conditional": false,
         "imported": ".artist_mix:ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
         "kind": "static_from",
-        "line": 15,
+        "line": 16,
         "name": "ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
         "optional": false,
         "requested": ".artist_mix",
@@ -21178,7 +21196,7 @@
         "conditional": false,
         "imported": ".artist_mix:ARTIST_MIX_DEFAULT_STYLE_GAIN",
         "kind": "static_from",
-        "line": 15,
+        "line": 16,
         "name": "ARTIST_MIX_DEFAULT_STYLE_GAIN",
         "optional": false,
         "requested": ".artist_mix",
@@ -21196,7 +21214,7 @@
         "conditional": false,
         "imported": ".artist_mix:ARTIST_MIX_MODE_OFF",
         "kind": "static_from",
-        "line": 15,
+        "line": 16,
         "name": "ARTIST_MIX_MODE_OFF",
         "optional": false,
         "requested": ".artist_mix",
@@ -21214,7 +21232,7 @@
         "conditional": false,
         "imported": ".artist_mix:ARTIST_MIX_MODE_PROMPT",
         "kind": "static_from",
-        "line": 15,
+        "line": 16,
         "name": "ARTIST_MIX_MODE_PROMPT",
         "optional": false,
         "requested": ".artist_mix",
@@ -21232,7 +21250,7 @@
         "conditional": false,
         "imported": ".artist_mix:_artist_mix_inline_prompt",
         "kind": "static_from",
-        "line": 15,
+        "line": 16,
         "name": "_artist_mix_inline_prompt",
         "optional": false,
         "requested": ".artist_mix",
@@ -21250,7 +21268,7 @@
         "conditional": false,
         "imported": ".artist_mix:_artist_tags_from_prompt",
         "kind": "static_from",
-        "line": 15,
+        "line": 16,
         "name": "_artist_tags_from_prompt",
         "optional": false,
         "requested": ".artist_mix",
@@ -21268,7 +21286,7 @@
         "conditional": false,
         "imported": ".artist_mix:_bounded_artist_mix_float",
         "kind": "static_from",
-        "line": 15,
+        "line": 16,
         "name": "_bounded_artist_mix_float",
         "optional": false,
         "requested": ".artist_mix",
@@ -21286,7 +21304,7 @@
         "conditional": false,
         "imported": ".artist_mix:_bounded_artist_mix_int",
         "kind": "static_from",
-        "line": 15,
+        "line": 16,
         "name": "_bounded_artist_mix_int",
         "optional": false,
         "requested": ".artist_mix",
@@ -21304,7 +21322,7 @@
         "conditional": false,
         "imported": ".artist_mix:_join_artist_mix_source_prompts",
         "kind": "static_from",
-        "line": 15,
+        "line": 16,
         "name": "_join_artist_mix_source_prompts",
         "optional": false,
         "requested": ".artist_mix",
@@ -21322,7 +21340,7 @@
         "conditional": false,
         "imported": ".artist_mix:_normalize_artist_mix_mode",
         "kind": "static_from",
-        "line": 15,
+        "line": 16,
         "name": "_normalize_artist_mix_mode",
         "optional": false,
         "requested": ".artist_mix",
@@ -21340,7 +21358,7 @@
         "conditional": false,
         "imported": ".artist_mix:_parse_artist_mix_items",
         "kind": "static_from",
-        "line": 15,
+        "line": 16,
         "name": "_parse_artist_mix_items",
         "optional": false,
         "requested": ".artist_mix",
@@ -21358,7 +21376,7 @@
         "conditional": false,
         "imported": ".correction:_translate_prompt_text",
         "kind": "static_from",
-        "line": 34,
+        "line": 35,
         "name": "_translate_prompt_text",
         "optional": false,
         "requested": ".correction",
@@ -21376,7 +21394,7 @@
         "conditional": false,
         "imported": ".data:PROMPT_DATA_SCHEMA",
         "kind": "static_from",
-        "line": 35,
+        "line": 36,
         "name": "PROMPT_DATA_SCHEMA",
         "optional": false,
         "requested": ".data",
@@ -21394,7 +21412,7 @@
         "conditional": false,
         "imported": ".data:PROMPT_DATA_TYPE",
         "kind": "static_from",
-        "line": 35,
+        "line": 36,
         "name": "PROMPT_DATA_TYPE",
         "optional": false,
         "requested": ".data",
@@ -21412,7 +21430,7 @@
         "conditional": false,
         "imported": ".data:PROMPT_DATA_VERSION",
         "kind": "static_from",
-        "line": 35,
+        "line": 36,
         "name": "PROMPT_DATA_VERSION",
         "optional": false,
         "requested": ".data",
@@ -21430,7 +21448,7 @@
         "conditional": false,
         "imported": ".fields:DEFAULT_QUALITY_TAGS",
         "kind": "static_from",
-        "line": 36,
+        "line": 37,
         "name": "DEFAULT_QUALITY_TAGS",
         "optional": false,
         "requested": ".fields",
@@ -21448,7 +21466,7 @@
         "conditional": false,
         "imported": ".fields:DEFAULT_TRAILING_QUALITY_TAGS",
         "kind": "static_from",
-        "line": 36,
+        "line": 37,
         "name": "DEFAULT_TRAILING_QUALITY_TAGS",
         "optional": false,
         "requested": ".fields",
@@ -21466,7 +21484,7 @@
         "conditional": false,
         "imported": ".fields:_correct_builder_prompt",
         "kind": "static_from",
-        "line": 36,
+        "line": 37,
         "name": "_correct_builder_prompt",
         "optional": false,
         "requested": ".fields",
@@ -21484,7 +21502,7 @@
         "conditional": false,
         "imported": ".fields:_filter_metadata_prompt",
         "kind": "static_from",
-        "line": 36,
+        "line": 37,
         "name": "_filter_metadata_prompt",
         "optional": false,
         "requested": ".fields",
@@ -21502,7 +21520,7 @@
         "conditional": false,
         "imported": ".fields:_join_prompt_tokens",
         "kind": "static_from",
-        "line": 36,
+        "line": 37,
         "name": "_join_prompt_tokens",
         "optional": false,
         "requested": ".fields",
@@ -21513,37 +21531,6 @@
       },
       {
         "alias": null,
-        "bound_name": "has_prompt_translation_markers",
-        "branch_context": [
-          {
-            "branch": "body",
-            "handles_import_failure": true,
-            "has_import_fallback_handler": true,
-            "kind": "try",
-            "line": 44
-          }
-        ],
-        "classification": "internal",
-        "column": 4,
-        "compatibility_pair": {
-          "bound_name": "has_prompt_translation_markers",
-          "target": "prompt_translation.py",
-          "try_line": 44
-        },
-        "conditional": true,
-        "imported": "...prompt_translation:has_prompt_translation_markers",
-        "kind": "static_from",
-        "line": 45,
-        "name": "has_prompt_translation_markers",
-        "optional": false,
-        "requested": "...prompt_translation",
-        "role": "compatibility_primary",
-        "scope": "<module>",
-        "source": "easyuse_anima/prompt/advanced.py",
-        "target": "prompt_translation.py"
-      },
-      {
-        "alias": null,
         "bound_name": "resolve_metadata_filter_words",
         "branch_context": [
           {
@@ -21551,7 +21538,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 44
+            "line": 45
           }
         ],
         "classification": "internal",
@@ -21559,7 +21546,7 @@
         "compatibility_pair": {
           "bound_name": "resolve_metadata_filter_words",
           "target": "settings.py",
-          "try_line": 44
+          "try_line": 45
         },
         "conditional": true,
         "imported": "...settings:resolve_metadata_filter_words",
@@ -21575,40 +21562,6 @@
       },
       {
         "alias": null,
-        "bound_name": "has_prompt_translation_markers",
-        "branch_context": [
-          {
-            "branch": "except",
-            "catches_import_error": true,
-            "exceptions": [
-              "ImportError"
-            ],
-            "handler_line": 47,
-            "kind": "try",
-            "line": 44
-          }
-        ],
-        "classification": "compatibility_fallback",
-        "column": 4,
-        "compatibility_pair": {
-          "bound_name": "has_prompt_translation_markers",
-          "target": "prompt_translation.py",
-          "try_line": 44
-        },
-        "conditional": true,
-        "imported": "prompt_translation:has_prompt_translation_markers",
-        "kind": "static_from",
-        "line": 48,
-        "name": "has_prompt_translation_markers",
-        "optional": false,
-        "requested": "prompt_translation",
-        "role": "compatibility_fallback",
-        "scope": "<module>",
-        "source": "easyuse_anima/prompt/advanced.py",
-        "target": "prompt_translation.py"
-      },
-      {
-        "alias": null,
         "bound_name": "resolve_metadata_filter_words",
         "branch_context": [
           {
@@ -21619,7 +21572,7 @@
             ],
             "handler_line": 47,
             "kind": "try",
-            "line": 44
+            "line": 45
           }
         ],
         "classification": "compatibility_fallback",
@@ -21627,12 +21580,12 @@
         "compatibility_pair": {
           "bound_name": "resolve_metadata_filter_words",
           "target": "settings.py",
-          "try_line": 44
+          "try_line": 45
         },
         "conditional": true,
         "imported": "settings:resolve_metadata_filter_words",
         "kind": "static_from",
-        "line": 49,
+        "line": 48,
         "name": "resolve_metadata_filter_words",
         "optional": false,
         "requested": "settings",
@@ -21650,7 +21603,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 136
+            "line": 135
           }
         ],
         "classification": "internal",
@@ -21658,12 +21611,12 @@
         "compatibility_pair": {
           "bound_name": "module",
           "target": "wildcard_engine.py",
-          "try_line": 136
+          "try_line": 135
         },
         "conditional": true,
         "imported": "...:wildcard_engine",
         "kind": "static_from",
-        "line": 137,
+        "line": 136,
         "name": "wildcard_engine",
         "optional": false,
         "requested": "...",
@@ -21682,9 +21635,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 138,
+            "handler_line": 137,
             "kind": "try",
-            "line": 136
+            "line": 135
           }
         ],
         "classification": "compatibility_fallback",
@@ -21692,12 +21645,12 @@
         "compatibility_pair": {
           "bound_name": "module",
           "target": "wildcard_engine.py",
-          "try_line": 136
+          "try_line": 135
         },
         "conditional": true,
         "imported": "wildcard_engine",
         "kind": "static_import",
-        "line": 139,
+        "line": 138,
         "name": null,
         "optional": false,
         "requested": "wildcard_engine",
@@ -22222,64 +22175,38 @@
       {
         "alias": null,
         "bound_name": "has_prompt_translation_markers",
-        "branch_context": [
-          {
-            "branch": "body",
-            "handles_import_failure": true,
-            "has_import_fallback_handler": true,
-            "kind": "try",
-            "line": 5
-          }
-        ],
+        "branch_context": [],
         "classification": "internal",
-        "column": 4,
-        "compatibility_pair": {
-          "bound_name": "has_prompt_translation_markers",
-          "target": "prompt_translation.py",
-          "try_line": 5
-        },
-        "conditional": true,
-        "imported": "...prompt_translation:has_prompt_translation_markers",
+        "column": 0,
+        "conditional": false,
+        "imported": "..translation.markers:has_prompt_translation_markers",
         "kind": "static_from",
-        "line": 6,
+        "line": 5,
         "name": "has_prompt_translation_markers",
         "optional": false,
-        "requested": "...prompt_translation",
-        "role": "compatibility_primary",
+        "requested": "..translation.markers",
+        "role": "ordinary",
         "scope": "<module>",
         "source": "easyuse_anima/prompt/correction.py",
-        "target": "prompt_translation.py"
+        "target": "easyuse_anima/translation/markers.py"
       },
       {
         "alias": null,
         "bound_name": "translate_prompt_markers",
-        "branch_context": [
-          {
-            "branch": "body",
-            "handles_import_failure": true,
-            "has_import_fallback_handler": true,
-            "kind": "try",
-            "line": 5
-          }
-        ],
+        "branch_context": [],
         "classification": "internal",
-        "column": 4,
-        "compatibility_pair": {
-          "bound_name": "translate_prompt_markers",
-          "target": "prompt_translation.py",
-          "try_line": 5
-        },
-        "conditional": true,
-        "imported": "...prompt_translation:translate_prompt_markers",
+        "column": 0,
+        "conditional": false,
+        "imported": "..translation.service:translate_prompt_markers",
         "kind": "static_from",
         "line": 6,
         "name": "translate_prompt_markers",
         "optional": false,
-        "requested": "...prompt_translation",
-        "role": "compatibility_primary",
+        "requested": "..translation.service",
+        "role": "ordinary",
         "scope": "<module>",
         "source": "easyuse_anima/prompt/correction.py",
-        "target": "prompt_translation.py"
+        "target": "easyuse_anima/translation/service.py"
       },
       {
         "alias": null,
@@ -22290,7 +22217,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 5
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -22298,12 +22225,12 @@
         "compatibility_pair": {
           "bound_name": "resolve_prompt_translation_settings",
           "target": "settings.py",
-          "try_line": 5
+          "try_line": 8
         },
         "conditional": true,
         "imported": "...settings:resolve_prompt_translation_settings",
         "kind": "static_from",
-        "line": 7,
+        "line": 9,
         "name": "resolve_prompt_translation_settings",
         "optional": false,
         "requested": "...settings",
@@ -22314,74 +22241,6 @@
       },
       {
         "alias": null,
-        "bound_name": "has_prompt_translation_markers",
-        "branch_context": [
-          {
-            "branch": "except",
-            "catches_import_error": true,
-            "exceptions": [
-              "ImportError"
-            ],
-            "handler_line": 8,
-            "kind": "try",
-            "line": 5
-          }
-        ],
-        "classification": "compatibility_fallback",
-        "column": 4,
-        "compatibility_pair": {
-          "bound_name": "has_prompt_translation_markers",
-          "target": "prompt_translation.py",
-          "try_line": 5
-        },
-        "conditional": true,
-        "imported": "prompt_translation:has_prompt_translation_markers",
-        "kind": "static_from",
-        "line": 9,
-        "name": "has_prompt_translation_markers",
-        "optional": false,
-        "requested": "prompt_translation",
-        "role": "compatibility_fallback",
-        "scope": "<module>",
-        "source": "easyuse_anima/prompt/correction.py",
-        "target": "prompt_translation.py"
-      },
-      {
-        "alias": null,
-        "bound_name": "translate_prompt_markers",
-        "branch_context": [
-          {
-            "branch": "except",
-            "catches_import_error": true,
-            "exceptions": [
-              "ImportError"
-            ],
-            "handler_line": 8,
-            "kind": "try",
-            "line": 5
-          }
-        ],
-        "classification": "compatibility_fallback",
-        "column": 4,
-        "compatibility_pair": {
-          "bound_name": "translate_prompt_markers",
-          "target": "prompt_translation.py",
-          "try_line": 5
-        },
-        "conditional": true,
-        "imported": "prompt_translation:translate_prompt_markers",
-        "kind": "static_from",
-        "line": 9,
-        "name": "translate_prompt_markers",
-        "optional": false,
-        "requested": "prompt_translation",
-        "role": "compatibility_fallback",
-        "scope": "<module>",
-        "source": "easyuse_anima/prompt/correction.py",
-        "target": "prompt_translation.py"
-      },
-      {
-        "alias": null,
         "bound_name": "resolve_prompt_translation_settings",
         "branch_context": [
           {
@@ -22390,9 +22249,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 8,
+            "handler_line": 10,
             "kind": "try",
-            "line": 5
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -22400,12 +22259,12 @@
         "compatibility_pair": {
           "bound_name": "resolve_prompt_translation_settings",
           "target": "settings.py",
-          "try_line": 5
+          "try_line": 8
         },
         "conditional": true,
         "imported": "settings:resolve_prompt_translation_settings",
         "kind": "static_from",
-        "line": 10,
+        "line": 11,
         "name": "resolve_prompt_translation_settings",
         "optional": false,
         "requested": "settings",
@@ -24616,6 +24475,807 @@
         "scope": "<module>",
         "source": "easyuse_anima/seed/service.py",
         "target": "easyuse_anima/seed/reservation.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "annotations",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "__future__:annotations",
+        "kind": "static_from",
+        "line": 3,
+        "name": "annotations",
+        "optional": false,
+        "requested": "__future__",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/translation/contracts.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "dataclass",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "dataclasses:dataclass",
+        "kind": "static_from",
+        "line": 5,
+        "name": "dataclass",
+        "optional": false,
+        "requested": "dataclasses",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/translation/contracts.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "Protocol",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "typing:Protocol",
+        "kind": "static_from",
+        "line": 6,
+        "name": "Protocol",
+        "optional": false,
+        "requested": "typing",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/translation/contracts.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "annotations",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "__future__:annotations",
+        "kind": "static_from",
+        "line": 3,
+        "name": "annotations",
+        "optional": false,
+        "requested": "__future__",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/translation/markers.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "annotations",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "__future__:annotations",
+        "kind": "static_from",
+        "line": 3,
+        "name": "annotations",
+        "optional": false,
+        "requested": "__future__",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/translation/providers/google.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "html",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "html",
+        "kind": "static_import",
+        "line": 5,
+        "name": null,
+        "optional": false,
+        "requested": "html",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/translation/providers/google.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "threading",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "threading",
+        "kind": "static_import",
+        "line": 6,
+        "name": null,
+        "optional": false,
+        "requested": "threading",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/translation/providers/google.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "Callable",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "collections.abc:Callable",
+        "kind": "static_from",
+        "line": 7,
+        "name": "Callable",
+        "optional": false,
+        "requested": "collections.abc",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/translation/providers/google.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "Protocol",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "typing:Protocol",
+        "kind": "static_from",
+        "line": 8,
+        "name": "Protocol",
+        "optional": false,
+        "requested": "typing",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/translation/providers/google.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "DEFAULT_PROMPT_TRANSLATION_SOURCE",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": "..contracts:DEFAULT_PROMPT_TRANSLATION_SOURCE",
+        "kind": "static_from",
+        "line": 10,
+        "name": "DEFAULT_PROMPT_TRANSLATION_SOURCE",
+        "optional": false,
+        "requested": "..contracts",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/translation/providers/google.py",
+        "target": "easyuse_anima/translation/contracts.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "DEFAULT_PROMPT_TRANSLATION_TARGET",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": "..contracts:DEFAULT_PROMPT_TRANSLATION_TARGET",
+        "kind": "static_from",
+        "line": 10,
+        "name": "DEFAULT_PROMPT_TRANSLATION_TARGET",
+        "optional": false,
+        "requested": "..contracts",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/translation/providers/google.py",
+        "target": "easyuse_anima/translation/contracts.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "PROMPT_TRANSLATION_PROVIDER_TIMEOUT_SECONDS",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": "..contracts:PROMPT_TRANSLATION_PROVIDER_TIMEOUT_SECONDS",
+        "kind": "static_from",
+        "line": 10,
+        "name": "PROMPT_TRANSLATION_PROVIDER_TIMEOUT_SECONDS",
+        "optional": false,
+        "requested": "..contracts",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/translation/providers/google.py",
+        "target": "easyuse_anima/translation/contracts.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "PromptTranslationError",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": "..contracts:PromptTranslationError",
+        "kind": "static_from",
+        "line": 10,
+        "name": "PromptTranslationError",
+        "optional": false,
+        "requested": "..contracts",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/translation/providers/google.py",
+        "target": "easyuse_anima/translation/contracts.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "TranslationProviderUnavailableError",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": "..contracts:TranslationProviderUnavailableError",
+        "kind": "static_from",
+        "line": 10,
+        "name": "TranslationProviderUnavailableError",
+        "optional": false,
+        "requested": "..contracts",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/translation/providers/google.py",
+        "target": "easyuse_anima/translation/contracts.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "TranslationTimeoutError",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": "..contracts:TranslationTimeoutError",
+        "kind": "static_from",
+        "line": 10,
+        "name": "TranslationTimeoutError",
+        "optional": false,
+        "requested": "..contracts",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/translation/providers/google.py",
+        "target": "easyuse_anima/translation/contracts.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "TranslationUpstreamError",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": "..contracts:TranslationUpstreamError",
+        "kind": "static_from",
+        "line": 10,
+        "name": "TranslationUpstreamError",
+        "optional": false,
+        "requested": "..contracts",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/translation/providers/google.py",
+        "target": "easyuse_anima/translation/contracts.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "Translator",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 48
+          }
+        ],
+        "classification": "external",
+        "column": 12,
+        "conditional": true,
+        "imported": "googletrans:Translator",
+        "kind": "static_from",
+        "line": 49,
+        "name": "Translator",
+        "optional": true,
+        "requested": "googletrans",
+        "role": "optional_dependency",
+        "scope": "GoogleTranslationProvider._create_translator",
+        "source": "easyuse_anima/translation/providers/google.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "annotations",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "__future__:annotations",
+        "kind": "static_from",
+        "line": 3,
+        "name": "annotations",
+        "optional": false,
+        "requested": "__future__",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/translation/service.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "threading",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "threading",
+        "kind": "static_import",
+        "line": 5,
+        "name": null,
+        "optional": false,
+        "requested": "threading",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/translation/service.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "time",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "time",
+        "kind": "static_import",
+        "line": 6,
+        "name": null,
+        "optional": false,
+        "requested": "time",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/translation/service.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "OrderedDict",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "collections:OrderedDict",
+        "kind": "static_from",
+        "line": 7,
+        "name": "OrderedDict",
+        "optional": false,
+        "requested": "collections",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/translation/service.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "Callable",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "collections.abc:Callable",
+        "kind": "static_from",
+        "line": 8,
+        "name": "Callable",
+        "optional": false,
+        "requested": "collections.abc",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/translation/service.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "contextmanager",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "contextlib:contextmanager",
+        "kind": "static_from",
+        "line": 9,
+        "name": "contextmanager",
+        "optional": false,
+        "requested": "contextlib",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/translation/service.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "dataclass",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "dataclasses:dataclass",
+        "kind": "static_from",
+        "line": 10,
+        "name": "dataclass",
+        "optional": false,
+        "requested": "dataclasses",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/translation/service.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "DEFAULT_PROMPT_TRANSLATION_SOURCE",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".contracts:DEFAULT_PROMPT_TRANSLATION_SOURCE",
+        "kind": "static_from",
+        "line": 12,
+        "name": "DEFAULT_PROMPT_TRANSLATION_SOURCE",
+        "optional": false,
+        "requested": ".contracts",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/translation/service.py",
+        "target": "easyuse_anima/translation/contracts.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "DEFAULT_PROMPT_TRANSLATION_TARGET",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".contracts:DEFAULT_PROMPT_TRANSLATION_TARGET",
+        "kind": "static_from",
+        "line": 12,
+        "name": "DEFAULT_PROMPT_TRANSLATION_TARGET",
+        "optional": false,
+        "requested": ".contracts",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/translation/service.py",
+        "target": "easyuse_anima/translation/contracts.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "MAX_PROMPT_TRANSLATION_MARKERS",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".contracts:MAX_PROMPT_TRANSLATION_MARKERS",
+        "kind": "static_from",
+        "line": 12,
+        "name": "MAX_PROMPT_TRANSLATION_MARKERS",
+        "optional": false,
+        "requested": ".contracts",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/translation/service.py",
+        "target": "easyuse_anima/translation/contracts.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "MAX_PROMPT_TRANSLATION_MARKER_CHARACTERS",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".contracts:MAX_PROMPT_TRANSLATION_MARKER_CHARACTERS",
+        "kind": "static_from",
+        "line": 12,
+        "name": "MAX_PROMPT_TRANSLATION_MARKER_CHARACTERS",
+        "optional": false,
+        "requested": ".contracts",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/translation/service.py",
+        "target": "easyuse_anima/translation/contracts.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "MAX_PROMPT_TRANSLATION_TOTAL_CHARACTERS",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".contracts:MAX_PROMPT_TRANSLATION_TOTAL_CHARACTERS",
+        "kind": "static_from",
+        "line": 12,
+        "name": "MAX_PROMPT_TRANSLATION_TOTAL_CHARACTERS",
+        "optional": false,
+        "requested": ".contracts",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/translation/service.py",
+        "target": "easyuse_anima/translation/contracts.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "PROMPT_TRANSLATION_CACHE_MAX_ENTRIES",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".contracts:PROMPT_TRANSLATION_CACHE_MAX_ENTRIES",
+        "kind": "static_from",
+        "line": 12,
+        "name": "PROMPT_TRANSLATION_CACHE_MAX_ENTRIES",
+        "optional": false,
+        "requested": ".contracts",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/translation/service.py",
+        "target": "easyuse_anima/translation/contracts.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "PROMPT_TRANSLATION_CACHE_TTL_SECONDS",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".contracts:PROMPT_TRANSLATION_CACHE_TTL_SECONDS",
+        "kind": "static_from",
+        "line": 12,
+        "name": "PROMPT_TRANSLATION_CACHE_TTL_SECONDS",
+        "optional": false,
+        "requested": ".contracts",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/translation/service.py",
+        "target": "easyuse_anima/translation/contracts.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "PROMPT_TRANSLATION_PROVIDER_GOOGLE",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".contracts:PROMPT_TRANSLATION_PROVIDER_GOOGLE",
+        "kind": "static_from",
+        "line": 12,
+        "name": "PROMPT_TRANSLATION_PROVIDER_GOOGLE",
+        "optional": false,
+        "requested": ".contracts",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/translation/service.py",
+        "target": "easyuse_anima/translation/contracts.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "PROMPT_TRANSLATION_PROVIDER_OFF",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".contracts:PROMPT_TRANSLATION_PROVIDER_OFF",
+        "kind": "static_from",
+        "line": 12,
+        "name": "PROMPT_TRANSLATION_PROVIDER_OFF",
+        "optional": false,
+        "requested": ".contracts",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/translation/service.py",
+        "target": "easyuse_anima/translation/contracts.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "PromptTranslationError",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".contracts:PromptTranslationError",
+        "kind": "static_from",
+        "line": 12,
+        "name": "PromptTranslationError",
+        "optional": false,
+        "requested": ".contracts",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/translation/service.py",
+        "target": "easyuse_anima/translation/contracts.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "PromptTranslationSettings",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".contracts:PromptTranslationSettings",
+        "kind": "static_from",
+        "line": 12,
+        "name": "PromptTranslationSettings",
+        "optional": false,
+        "requested": ".contracts",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/translation/service.py",
+        "target": "easyuse_anima/translation/contracts.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "TranslationCacheKey",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".contracts:TranslationCacheKey",
+        "kind": "static_from",
+        "line": 12,
+        "name": "TranslationCacheKey",
+        "optional": false,
+        "requested": ".contracts",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/translation/service.py",
+        "target": "easyuse_anima/translation/contracts.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "TranslationMarkerCountError",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".contracts:TranslationMarkerCountError",
+        "kind": "static_from",
+        "line": 12,
+        "name": "TranslationMarkerCountError",
+        "optional": false,
+        "requested": ".contracts",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/translation/service.py",
+        "target": "easyuse_anima/translation/contracts.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "TranslationMarkerSizeError",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".contracts:TranslationMarkerSizeError",
+        "kind": "static_from",
+        "line": 12,
+        "name": "TranslationMarkerSizeError",
+        "optional": false,
+        "requested": ".contracts",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/translation/service.py",
+        "target": "easyuse_anima/translation/contracts.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "TranslationProvider",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".contracts:TranslationProvider",
+        "kind": "static_from",
+        "line": 12,
+        "name": "TranslationProvider",
+        "optional": false,
+        "requested": ".contracts",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/translation/service.py",
+        "target": "easyuse_anima/translation/contracts.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "TranslationProviderUnavailableError",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".contracts:TranslationProviderUnavailableError",
+        "kind": "static_from",
+        "line": 12,
+        "name": "TranslationProviderUnavailableError",
+        "optional": false,
+        "requested": ".contracts",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/translation/service.py",
+        "target": "easyuse_anima/translation/contracts.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "TranslationTotalSizeError",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".contracts:TranslationTotalSizeError",
+        "kind": "static_from",
+        "line": 12,
+        "name": "TranslationTotalSizeError",
+        "optional": false,
+        "requested": ".contracts",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/translation/service.py",
+        "target": "easyuse_anima/translation/contracts.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "normalize_prompt_translation_language",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".contracts:normalize_prompt_translation_language",
+        "kind": "static_from",
+        "line": 12,
+        "name": "normalize_prompt_translation_language",
+        "optional": false,
+        "requested": ".contracts",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/translation/service.py",
+        "target": "easyuse_anima/translation/contracts.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "normalize_prompt_translation_provider",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".contracts:normalize_prompt_translation_provider",
+        "kind": "static_from",
+        "line": 12,
+        "name": "normalize_prompt_translation_provider",
+        "optional": false,
+        "requested": ".contracts",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/translation/service.py",
+        "target": "easyuse_anima/translation/contracts.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "iter_prompt_translation_markers",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".markers:iter_prompt_translation_markers",
+        "kind": "static_from",
+        "line": 33,
+        "name": "iter_prompt_translation_markers",
+        "optional": false,
+        "requested": ".markers",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/translation/service.py",
+        "target": "easyuse_anima/translation/markers.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "GoogleTranslationProvider",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".providers.google:GoogleTranslationProvider",
+        "kind": "static_from",
+        "line": 34,
+        "name": "GoogleTranslationProvider",
+        "optional": false,
+        "requested": ".providers.google",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/translation/service.py",
+        "target": "easyuse_anima/translation/providers/google.py"
       },
       {
         "alias": null,
@@ -33830,20 +34490,20 @@
         "column": 4,
         "compatibility_pair": {
           "bound_name": "has_prompt_translation_markers",
-          "target": "prompt_translation.py",
+          "target": "easyuse_anima/translation/markers.py",
           "try_line": 4
         },
         "conditional": true,
-        "imported": ".prompt_translation:has_prompt_translation_markers",
+        "imported": ".easyuse_anima.translation.markers:has_prompt_translation_markers",
         "kind": "static_from",
         "line": 539,
         "name": "has_prompt_translation_markers",
         "optional": false,
-        "requested": ".prompt_translation",
+        "requested": ".easyuse_anima.translation.markers",
         "role": "compatibility_primary",
         "scope": "<module>",
         "source": "nodes.py",
-        "target": "prompt_translation.py"
+        "target": "easyuse_anima/translation/markers.py"
       },
       {
         "alias": null,
@@ -33861,20 +34521,20 @@
         "column": 4,
         "compatibility_pair": {
           "bound_name": "translate_prompt_markers",
-          "target": "prompt_translation.py",
+          "target": "easyuse_anima/translation/service.py",
           "try_line": 4
         },
         "conditional": true,
-        "imported": ".prompt_translation:translate_prompt_markers",
+        "imported": ".easyuse_anima.translation.service:translate_prompt_markers",
         "kind": "static_from",
-        "line": 539,
+        "line": 542,
         "name": "translate_prompt_markers",
         "optional": false,
-        "requested": ".prompt_translation",
+        "requested": ".easyuse_anima.translation.service",
         "role": "compatibility_primary",
         "scope": "<module>",
         "source": "nodes.py",
-        "target": "prompt_translation.py"
+        "target": "easyuse_anima/translation/service.py"
       },
       {
         "alias": null,
@@ -33898,7 +34558,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:MAX_SEED",
         "kind": "static_from",
-        "line": 540,
+        "line": 545,
         "name": "MAX_SEED",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -33929,7 +34589,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "kind": "static_from",
-        "line": 540,
+        "line": 545,
         "name": "PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -33960,7 +34620,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:PUBLIC_MAX_SEED",
         "kind": "static_from",
-        "line": 540,
+        "line": 545,
         "name": "PUBLIC_MAX_SEED",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -33991,7 +34651,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_DECREMENT",
         "kind": "static_from",
-        "line": 540,
+        "line": 545,
         "name": "SEED_CONTROL_DECREMENT",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -34022,7 +34682,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_FIXED",
         "kind": "static_from",
-        "line": 540,
+        "line": 545,
         "name": "SEED_CONTROL_FIXED",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -34053,7 +34713,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_INCREMENT",
         "kind": "static_from",
-        "line": 540,
+        "line": 545,
         "name": "SEED_CONTROL_INCREMENT",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -34084,7 +34744,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_MODES",
         "kind": "static_from",
-        "line": 540,
+        "line": 545,
         "name": "SEED_CONTROL_MODES",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -34115,7 +34775,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_RANDOMIZE",
         "kind": "static_from",
-        "line": 540,
+        "line": 545,
         "name": "SEED_CONTROL_RANDOMIZE",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -34146,7 +34806,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:WILDCARD_MODE_FIXED",
         "kind": "static_from",
-        "line": 540,
+        "line": 545,
         "name": "WILDCARD_MODE_FIXED",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -34177,7 +34837,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:WILDCARD_MODE_POPULATE",
         "kind": "static_from",
-        "line": 540,
+        "line": 545,
         "name": "WILDCARD_MODE_POPULATE",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -34208,7 +34868,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:WILDCARD_MODE_SEQUENTIAL",
         "kind": "static_from",
-        "line": 540,
+        "line": 545,
         "name": "WILDCARD_MODE_SEQUENTIAL",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -34239,7 +34899,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:expand_wildcard_texts",
         "kind": "static_from",
-        "line": 540,
+        "line": 545,
         "name": "expand_wildcard_texts",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -34270,7 +34930,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:expand_wildcards",
         "kind": "static_from",
-        "line": 540,
+        "line": 545,
         "name": "expand_wildcards",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -34301,7 +34961,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:has_wildcard_syntax",
         "kind": "static_from",
-        "line": 540,
+        "line": 545,
         "name": "has_wildcard_syntax",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -34332,7 +34992,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:next_seed",
         "kind": "static_from",
-        "line": 540,
+        "line": 545,
         "name": "next_seed",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -34363,7 +35023,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:normalize_prompt_studio_wildcard_mode",
         "kind": "static_from",
-        "line": 540,
+        "line": 545,
         "name": "normalize_prompt_studio_wildcard_mode",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -34394,7 +35054,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:normalize_seed",
         "kind": "static_from",
-        "line": 540,
+        "line": 545,
         "name": "normalize_seed",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -34425,7 +35085,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:normalize_wildcard_mode",
         "kind": "static_from",
-        "line": 540,
+        "line": 545,
         "name": "normalize_wildcard_mode",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -34456,7 +35116,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:wildcard_sources_signature",
         "kind": "static_from",
-        "line": 540,
+        "line": 545,
         "name": "wildcard_sources_signature",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -34475,7 +35135,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -34490,7 +35150,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:AIO_FIRST_PASS_CACHE_MAX_ENTRIES",
         "kind": "static_from",
-        "line": 562,
+        "line": 567,
         "name": "AIO_FIRST_PASS_CACHE_MAX_ENTRIES",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -34509,7 +35169,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -34524,7 +35184,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_AIO_FIRST_PASS_CACHE",
         "kind": "static_from",
-        "line": 562,
+        "line": 567,
         "name": "_AIO_FIRST_PASS_CACHE",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -34543,7 +35203,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -34558,7 +35218,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_AIO_FIRST_PASS_CACHE_ORDER",
         "kind": "static_from",
-        "line": 562,
+        "line": 567,
         "name": "_AIO_FIRST_PASS_CACHE_ORDER",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -34577,7 +35237,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -34592,7 +35252,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_aio_first_pass_cache_key",
         "kind": "static_from",
-        "line": 562,
+        "line": 567,
         "name": "_aio_first_pass_cache_key",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -34611,7 +35271,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -34626,7 +35286,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_clone_aio_cache_value",
         "kind": "static_from",
-        "line": 562,
+        "line": 567,
         "name": "_clone_aio_cache_value",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -34645,7 +35305,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -34660,7 +35320,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_get_aio_first_pass_cache",
         "kind": "static_from",
-        "line": 562,
+        "line": 567,
         "name": "_get_aio_first_pass_cache",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -34679,7 +35339,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -34694,7 +35354,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_put_aio_first_pass_cache",
         "kind": "static_from",
-        "line": 562,
+        "line": 567,
         "name": "_put_aio_first_pass_cache",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -34713,7 +35373,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -34728,7 +35388,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_detailer_stage",
         "kind": "static_from",
-        "line": 572,
+        "line": 577,
         "name": "_run_aio_detailer_stage",
         "optional": false,
         "requested": "easyuse_anima.aio.legacy_generation",
@@ -34747,7 +35407,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -34762,7 +35422,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_detailer_target",
         "kind": "static_from",
-        "line": 572,
+        "line": 577,
         "name": "_run_aio_detailer_target",
         "optional": false,
         "requested": "easyuse_anima.aio.legacy_generation",
@@ -34781,7 +35441,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -34796,7 +35456,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_highres_stage",
         "kind": "static_from",
-        "line": 572,
+        "line": 577,
         "name": "_run_aio_highres_stage",
         "optional": false,
         "requested": "easyuse_anima.aio.legacy_generation",
@@ -34815,7 +35475,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -34830,7 +35490,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_legacy_generation",
         "kind": "static_from",
-        "line": 572,
+        "line": 577,
         "name": "_run_aio_legacy_generation",
         "optional": false,
         "requested": "easyuse_anima.aio.legacy_generation",
@@ -34849,7 +35509,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -34864,7 +35524,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_resshift_upscale_stage",
         "kind": "static_from",
-        "line": 572,
+        "line": 577,
         "name": "_run_aio_resshift_upscale_stage",
         "optional": false,
         "requested": "easyuse_anima.aio.legacy_generation",
@@ -34883,7 +35543,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -34898,7 +35558,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_upscale_stage",
         "kind": "static_from",
-        "line": 572,
+        "line": 577,
         "name": "_run_aio_upscale_stage",
         "optional": false,
         "requested": "easyuse_anima.aio.legacy_generation",
@@ -34917,7 +35577,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -34932,7 +35592,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_usdu_upscale_stage",
         "kind": "static_from",
-        "line": 572,
+        "line": 577,
         "name": "_run_aio_usdu_upscale_stage",
         "optional": false,
         "requested": "easyuse_anima.aio.legacy_generation",
@@ -34951,7 +35611,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -34966,7 +35626,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_AIO_DETAILER_CUSTOM_RE",
         "kind": "static_from",
-        "line": 581,
+        "line": 586,
         "name": "_AIO_DETAILER_CUSTOM_RE",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -34985,7 +35645,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -35000,7 +35660,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_AIO_DETAILER_RESERVED_KEYS",
         "kind": "static_from",
-        "line": 581,
+        "line": 586,
         "name": "_AIO_DETAILER_RESERVED_KEYS",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -35019,7 +35679,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -35034,7 +35694,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_aio_detailer_has_enabled_targets",
         "kind": "static_from",
-        "line": 581,
+        "line": 586,
         "name": "_aio_detailer_has_enabled_targets",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -35053,7 +35713,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -35068,7 +35728,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_aio_detailer_target_defaults",
         "kind": "static_from",
-        "line": 581,
+        "line": 586,
         "name": "_aio_detailer_target_defaults",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -35087,7 +35747,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -35102,7 +35762,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_aio_detailer_target_order",
         "kind": "static_from",
-        "line": 581,
+        "line": 586,
         "name": "_aio_detailer_target_order",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -35121,7 +35781,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -35136,7 +35796,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_is_aio_detailer_target_name",
         "kind": "static_from",
-        "line": 581,
+        "line": 586,
         "name": "_is_aio_detailer_target_name",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -35155,7 +35815,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -35170,7 +35830,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_merge_versioned_settings",
         "kind": "static_from",
-        "line": 581,
+        "line": 586,
         "name": "_merge_versioned_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -35189,7 +35849,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -35204,7 +35864,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_dit_corrections_settings",
         "kind": "static_from",
-        "line": 581,
+        "line": 586,
         "name": "_normalize_aio_dit_corrections_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -35223,7 +35883,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -35238,7 +35898,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_generation_settings",
         "kind": "static_from",
-        "line": 581,
+        "line": 586,
         "name": "_normalize_aio_generation_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -35257,7 +35917,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -35272,7 +35932,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_seed",
         "kind": "static_from",
-        "line": 581,
+        "line": 586,
         "name": "_normalize_aio_seed",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -35291,7 +35951,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -35306,7 +35966,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_spectrum_settings",
         "kind": "static_from",
-        "line": 581,
+        "line": 586,
         "name": "_normalize_aio_spectrum_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -35325,7 +35985,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -35340,7 +36000,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_FINAL_FIT_MODES",
         "kind": "static_from",
-        "line": 594,
+        "line": 599,
         "name": "AIO_FINAL_FIT_MODES",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_defaults",
@@ -35359,7 +36019,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -35374,7 +36034,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_FINAL_UPSCALE_BACKENDS",
         "kind": "static_from",
-        "line": 594,
+        "line": 599,
         "name": "AIO_FINAL_UPSCALE_BACKENDS",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_defaults",
@@ -35393,7 +36053,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -35408,7 +36068,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_GENERATION_DEFAULT_SETTINGS",
         "kind": "static_from",
-        "line": 594,
+        "line": 599,
         "name": "AIO_GENERATION_DEFAULT_SETTINGS",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_defaults",
@@ -35427,7 +36087,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -35442,7 +36102,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_GENERATION_SETTINGS_SCHEMA",
         "kind": "static_from",
-        "line": 594,
+        "line": 599,
         "name": "AIO_GENERATION_SETTINGS_SCHEMA",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_defaults",
@@ -35461,7 +36121,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -35476,7 +36136,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_GENERATION_SETTINGS_VERSION",
         "kind": "static_from",
-        "line": 594,
+        "line": 599,
         "name": "AIO_GENERATION_SETTINGS_VERSION",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_defaults",
@@ -35495,7 +36155,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -35510,7 +36170,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_RESHIFT_DTYPES",
         "kind": "static_from",
-        "line": 594,
+        "line": 599,
         "name": "AIO_RESHIFT_DTYPES",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_defaults",
@@ -35529,7 +36189,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -35544,7 +36204,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_RESHIFT_SCALES",
         "kind": "static_from",
-        "line": 594,
+        "line": 599,
         "name": "AIO_RESHIFT_SCALES",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_defaults",
@@ -35563,7 +36223,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -35578,7 +36238,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_SPECIAL_SEEDS",
         "kind": "static_from",
-        "line": 594,
+        "line": 599,
         "name": "AIO_SPECIAL_SEEDS",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_defaults",
@@ -35597,7 +36257,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -35612,7 +36272,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_SPECIAL_SEED_DECREMENT",
         "kind": "static_from",
-        "line": 594,
+        "line": 599,
         "name": "AIO_SPECIAL_SEED_DECREMENT",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_defaults",
@@ -35631,7 +36291,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -35646,7 +36306,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_SPECIAL_SEED_INCREMENT",
         "kind": "static_from",
-        "line": 594,
+        "line": 599,
         "name": "AIO_SPECIAL_SEED_INCREMENT",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_defaults",
@@ -35665,7 +36325,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -35680,7 +36340,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_SPECIAL_SEED_RANDOM",
         "kind": "static_from",
-        "line": 594,
+        "line": 599,
         "name": "AIO_SPECIAL_SEED_RANDOM",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_defaults",
@@ -35699,7 +36359,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -35714,7 +36374,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_USDU_MODE_TYPES",
         "kind": "static_from",
-        "line": 594,
+        "line": 599,
         "name": "AIO_USDU_MODE_TYPES",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_defaults",
@@ -35733,7 +36393,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -35748,7 +36408,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_USDU_PROMPT_FULL",
         "kind": "static_from",
-        "line": 594,
+        "line": 599,
         "name": "AIO_USDU_PROMPT_FULL",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_defaults",
@@ -35767,7 +36427,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -35782,7 +36442,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_USDU_PROMPT_MODES",
         "kind": "static_from",
-        "line": 594,
+        "line": 599,
         "name": "AIO_USDU_PROMPT_MODES",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_defaults",
@@ -35801,7 +36461,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -35816,7 +36476,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_USDU_PROMPT_NO_GENERAL",
         "kind": "static_from",
-        "line": 594,
+        "line": 599,
         "name": "AIO_USDU_PROMPT_NO_GENERAL",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_defaults",
@@ -35835,7 +36495,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -35850,7 +36510,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_USDU_SEAM_FIX_MODES",
         "kind": "static_from",
-        "line": 594,
+        "line": 599,
         "name": "AIO_USDU_SEAM_FIX_MODES",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_defaults",
@@ -35869,7 +36529,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -35884,7 +36544,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_settings:round_trip_aio_generation_settings",
         "kind": "static_from",
-        "line": 612,
+        "line": 617,
         "name": "round_trip_aio_generation_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_settings",
@@ -35903,7 +36563,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -35918,7 +36578,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.input_defaults:AIO_INPUT_DEFAULT_SETTINGS",
         "kind": "static_from",
-        "line": 615,
+        "line": 620,
         "name": "AIO_INPUT_DEFAULT_SETTINGS",
         "optional": false,
         "requested": "easyuse_anima.aio.input_defaults",
@@ -35937,7 +36597,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -35952,7 +36612,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.input_defaults:ANIMA_CLIP_DEVICES",
         "kind": "static_from",
-        "line": 615,
+        "line": 620,
         "name": "ANIMA_CLIP_DEVICES",
         "optional": false,
         "requested": "easyuse_anima.aio.input_defaults",
@@ -35971,7 +36631,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -35986,7 +36646,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.input_defaults:ANIMA_CLIP_TYPES",
         "kind": "static_from",
-        "line": 615,
+        "line": 620,
         "name": "ANIMA_CLIP_TYPES",
         "optional": false,
         "requested": "easyuse_anima.aio.input_defaults",
@@ -36005,7 +36665,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -36020,7 +36680,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.input_defaults:ANIMA_DEFAULT_CLIP_CANDIDATES",
         "kind": "static_from",
-        "line": 615,
+        "line": 620,
         "name": "ANIMA_DEFAULT_CLIP_CANDIDATES",
         "optional": false,
         "requested": "easyuse_anima.aio.input_defaults",
@@ -36039,7 +36699,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -36054,7 +36714,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.input_defaults:ANIMA_DEFAULT_DIFFUSION_MODEL_CANDIDATES",
         "kind": "static_from",
-        "line": 615,
+        "line": 620,
         "name": "ANIMA_DEFAULT_DIFFUSION_MODEL_CANDIDATES",
         "optional": false,
         "requested": "easyuse_anima.aio.input_defaults",
@@ -36073,7 +36733,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -36088,7 +36748,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.input_defaults:ANIMA_DEFAULT_VAE_CANDIDATES",
         "kind": "static_from",
-        "line": 615,
+        "line": 620,
         "name": "ANIMA_DEFAULT_VAE_CANDIDATES",
         "optional": false,
         "requested": "easyuse_anima.aio.input_defaults",
@@ -36107,7 +36767,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -36122,7 +36782,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.input_defaults:ANIMA_UNET_WEIGHT_DTYPES",
         "kind": "static_from",
-        "line": 615,
+        "line": 620,
         "name": "ANIMA_UNET_WEIGHT_DTYPES",
         "optional": false,
         "requested": "easyuse_anima.aio.input_defaults",
@@ -36141,7 +36801,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -36156,7 +36816,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.input_defaults:EASY_USE_ANIMA_INPUT_SCHEMA",
         "kind": "static_from",
-        "line": 615,
+        "line": 620,
         "name": "EASY_USE_ANIMA_INPUT_SCHEMA",
         "optional": false,
         "requested": "easyuse_anima.aio.input_defaults",
@@ -36175,7 +36835,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -36190,7 +36850,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.input_defaults:EASY_USE_ANIMA_INPUT_SETTINGS_VERSION",
         "kind": "static_from",
-        "line": 615,
+        "line": 620,
         "name": "EASY_USE_ANIMA_INPUT_SETTINGS_VERSION",
         "optional": false,
         "requested": "easyuse_anima.aio.input_defaults",
@@ -36209,7 +36869,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -36224,7 +36884,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.input_context:_easy_use_anima_input_signature",
         "kind": "static_from",
-        "line": 626,
+        "line": 631,
         "name": "_easy_use_anima_input_signature",
         "optional": false,
         "requested": "easyuse_anima.aio.input_context",
@@ -36243,7 +36903,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -36258,7 +36918,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.input_context:_require_easy_use_anima_input",
         "kind": "static_from",
-        "line": 626,
+        "line": 631,
         "name": "_require_easy_use_anima_input",
         "optional": false,
         "requested": "easyuse_anima.aio.input_context",
@@ -36277,7 +36937,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -36292,7 +36952,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.usdu:_aio_usdu_auto_tile_dimension",
         "kind": "static_from",
-        "line": 630,
+        "line": 635,
         "name": "_aio_usdu_auto_tile_dimension",
         "optional": false,
         "requested": "easyuse_anima.aio.usdu",
@@ -36311,7 +36971,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -36326,7 +36986,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.usdu:_aio_usdu_tile_plan",
         "kind": "static_from",
-        "line": 630,
+        "line": 635,
         "name": "_aio_usdu_tile_plan",
         "optional": false,
         "requested": "easyuse_anima.aio.usdu",
@@ -36345,7 +37005,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -36360,7 +37020,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_aio_final_fit_size",
         "kind": "static_from",
-        "line": 634,
+        "line": 639,
         "name": "_aio_final_fit_size",
         "optional": false,
         "requested": "easyuse_anima.aio.postprocess",
@@ -36379,7 +37039,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -36394,7 +37054,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_apply_aio_final_fit",
         "kind": "static_from",
-        "line": 634,
+        "line": 639,
         "name": "_apply_aio_final_fit",
         "optional": false,
         "requested": "easyuse_anima.aio.postprocess",
@@ -36413,7 +37073,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -36428,7 +37088,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_resize_image_to_size_if_needed",
         "kind": "static_from",
-        "line": 634,
+        "line": 639,
         "name": "_resize_image_to_size_if_needed",
         "optional": false,
         "requested": "easyuse_anima.aio.postprocess",
@@ -36447,7 +37107,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -36462,7 +37122,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_run_aio_postprocess_stage",
         "kind": "static_from",
-        "line": 634,
+        "line": 639,
         "name": "_run_aio_postprocess_stage",
         "optional": false,
         "requested": "easyuse_anima.aio.postprocess",
@@ -36481,7 +37141,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -36496,7 +37156,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_prompt_data_fields_for_usdu",
         "kind": "static_from",
-        "line": 640,
+        "line": 645,
         "name": "_aio_prompt_data_fields_for_usdu",
         "optional": false,
         "requested": "easyuse_anima.aio.conditioning",
@@ -36515,7 +37175,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -36530,7 +37190,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_usdu_conditioning",
         "kind": "static_from",
-        "line": 640,
+        "line": 645,
         "name": "_aio_usdu_conditioning",
         "optional": false,
         "requested": "easyuse_anima.aio.conditioning",
@@ -36549,7 +37209,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -36564,7 +37224,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_usdu_prompt_without_general",
         "kind": "static_from",
-        "line": 640,
+        "line": 645,
         "name": "_aio_usdu_prompt_without_general",
         "optional": false,
         "requested": "easyuse_anima.aio.conditioning",
@@ -36583,7 +37243,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -36598,7 +37258,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_aio_lora_stack_signature",
         "kind": "static_from",
-        "line": 645,
+        "line": 650,
         "name": "_aio_lora_stack_signature",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -36617,7 +37277,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -36632,7 +37292,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_anima_dave_patch",
         "kind": "static_from",
-        "line": 645,
+        "line": 650,
         "name": "_apply_aio_anima_dave_patch",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -36651,7 +37311,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -36666,7 +37326,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_kj_model_patches",
         "kind": "static_from",
-        "line": 645,
+        "line": 650,
         "name": "_apply_aio_kj_model_patches",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -36685,7 +37345,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -36700,7 +37360,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_lora_stack",
         "kind": "static_from",
-        "line": 645,
+        "line": 650,
         "name": "_apply_aio_lora_stack",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -36719,7 +37379,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -36734,7 +37394,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_model_patches",
         "kind": "static_from",
-        "line": 645,
+        "line": 650,
         "name": "_apply_aio_model_patches",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -36753,7 +37413,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -36768,7 +37428,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_safe_pag_patch",
         "kind": "static_from",
-        "line": 645,
+        "line": 650,
         "name": "_apply_aio_safe_pag_patch",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -36787,7 +37447,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -36802,7 +37462,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_correction_patch_for_comfy_sampler",
         "kind": "static_from",
-        "line": 645,
+        "line": 650,
         "name": "_apply_aio_spectrum_correction_patch_for_comfy_sampler",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -36821,7 +37481,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -36836,7 +37496,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_forecast_patch_for_comfy_sampler",
         "kind": "static_from",
-        "line": 645,
+        "line": 650,
         "name": "_apply_aio_spectrum_forecast_patch_for_comfy_sampler",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -36855,7 +37515,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -36870,7 +37530,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_model_patches_for_comfy_sampler",
         "kind": "static_from",
-        "line": 645,
+        "line": 650,
         "name": "_apply_aio_spectrum_model_patches_for_comfy_sampler",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -36889,7 +37549,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -36904,7 +37564,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_cleanup_aio_ephemeral_model",
         "kind": "static_from",
-        "line": 645,
+        "line": 650,
         "name": "_cleanup_aio_ephemeral_model",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -36923,7 +37583,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -36938,7 +37598,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_normalize_aio_lora_stack",
         "kind": "static_from",
-        "line": 645,
+        "line": 650,
         "name": "_normalize_aio_lora_stack",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -36957,7 +37617,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -36972,7 +37632,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_patch_model_sampling_aura_flow",
         "kind": "static_from",
-        "line": 645,
+        "line": 650,
         "name": "_patch_model_sampling_aura_flow",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -36991,7 +37651,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -37006,7 +37666,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_aio_highres_effective_backend",
         "kind": "static_from",
-        "line": 659,
+        "line": 664,
         "name": "_aio_highres_effective_backend",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -37025,7 +37685,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -37040,7 +37700,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_aio_stage_sampler_settings",
         "kind": "static_from",
-        "line": 659,
+        "line": 664,
         "name": "_aio_stage_sampler_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -37059,7 +37719,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -37074,7 +37734,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_decode_latent_with_comfy",
         "kind": "static_from",
-        "line": 659,
+        "line": 664,
         "name": "_decode_latent_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -37093,7 +37753,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -37108,7 +37768,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_encode_image_with_comfy_vae",
         "kind": "static_from",
-        "line": 659,
+        "line": 664,
         "name": "_encode_image_with_comfy_vae",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -37127,7 +37787,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -37142,7 +37802,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_generate_empty_latent_with_comfy",
         "kind": "static_from",
-        "line": 659,
+        "line": 664,
         "name": "_generate_empty_latent_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -37161,7 +37821,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -37176,7 +37836,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_new_aio_random_seed",
         "kind": "static_from",
-        "line": 659,
+        "line": 664,
         "name": "_new_aio_random_seed",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -37195,7 +37855,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -37210,7 +37870,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_resolve_aio_runtime_seed",
         "kind": "static_from",
-        "line": 659,
+        "line": 664,
         "name": "_resolve_aio_runtime_seed",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -37229,7 +37889,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -37244,7 +37904,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_aio_backend",
         "kind": "static_from",
-        "line": 659,
+        "line": 664,
         "name": "_sample_latent_with_aio_backend",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -37263,7 +37923,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -37278,7 +37938,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_comfy",
         "kind": "static_from",
-        "line": 659,
+        "line": 664,
         "name": "_sample_latent_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -37297,7 +37957,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -37312,7 +37972,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_spectrum_mod_guidance_advanced",
         "kind": "static_from",
-        "line": 659,
+        "line": 664,
         "name": "_sample_latent_with_spectrum_mod_guidance_advanced",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -37331,7 +37991,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -37346,7 +38006,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_spectrum_spd",
         "kind": "static_from",
-        "line": 659,
+        "line": 664,
         "name": "_sample_latent_with_spectrum_spd",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -37365,7 +38025,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -37380,7 +38040,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_CACHE_FORMAT",
         "kind": "static_from",
-        "line": 672,
+        "line": 677,
         "name": "AIO_PREVIEW_CACHE_FORMAT",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -37399,7 +38059,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -37414,7 +38074,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_CACHE_QUALITY",
         "kind": "static_from",
-        "line": 672,
+        "line": 677,
         "name": "AIO_PREVIEW_CACHE_QUALITY",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -37433,7 +38093,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -37448,7 +38108,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_EVENT",
         "kind": "static_from",
-        "line": 672,
+        "line": 677,
         "name": "AIO_PREVIEW_EVENT",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -37467,7 +38127,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -37482,7 +38142,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_STAGE_LABELS",
         "kind": "static_from",
-        "line": 672,
+        "line": 677,
         "name": "AIO_PREVIEW_STAGE_LABELS",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -37501,7 +38161,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -37516,7 +38176,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_aio_preview_base_directory",
         "kind": "static_from",
-        "line": 672,
+        "line": 677,
         "name": "_aio_preview_base_directory",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -37535,7 +38195,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -37550,7 +38210,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_aio_preview_file_size_bytes",
         "kind": "static_from",
-        "line": 672,
+        "line": 677,
         "name": "_aio_preview_file_size_bytes",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -37569,7 +38229,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -37584,7 +38244,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_save_aio_temp_preview_image",
         "kind": "static_from",
-        "line": 672,
+        "line": 677,
         "name": "_save_aio_temp_preview_image",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -37603,7 +38263,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -37618,7 +38278,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_send_aio_preview_event",
         "kind": "static_from",
-        "line": 672,
+        "line": 677,
         "name": "_send_aio_preview_event",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -37637,7 +38297,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -37652,7 +38312,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_tag_aio_preview_images",
         "kind": "static_from",
-        "line": 672,
+        "line": 677,
         "name": "_tag_aio_preview_images",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -37671,7 +38331,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -37686,7 +38346,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_image_saver_additional_hashes",
         "kind": "static_from",
-        "line": 683,
+        "line": 688,
         "name": "_aio_image_saver_additional_hashes",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -37705,7 +38365,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -37720,7 +38380,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_image_saver_civitai_hash_fetcher_entries",
         "kind": "static_from",
-        "line": 683,
+        "line": 688,
         "name": "_aio_image_saver_civitai_hash_fetcher_entries",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -37739,7 +38399,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -37754,7 +38414,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_lora_metadata_name",
         "kind": "static_from",
-        "line": 683,
+        "line": 688,
         "name": "_aio_lora_metadata_name",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -37773,7 +38433,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -37788,7 +38448,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_prompt_with_lora_metadata",
         "kind": "static_from",
-        "line": 683,
+        "line": 688,
         "name": "_aio_prompt_with_lora_metadata",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -37807,7 +38467,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -37822,7 +38482,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_save_filename_prefix",
         "kind": "static_from",
-        "line": 683,
+        "line": 688,
         "name": "_aio_save_filename_prefix",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -37841,7 +38501,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -37856,7 +38516,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_save_image_with_comfy",
         "kind": "static_from",
-        "line": 683,
+        "line": 688,
         "name": "_save_image_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -37875,7 +38535,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -37890,7 +38550,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_save_image_with_image_saver",
         "kind": "static_from",
-        "line": 683,
+        "line": 688,
         "name": "_save_image_with_image_saver",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -37909,7 +38569,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -37924,7 +38584,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output_settings:_normalize_aio_civitai_hash_fetchers",
         "kind": "static_from",
-        "line": 692,
+        "line": 697,
         "name": "_normalize_aio_civitai_hash_fetchers",
         "optional": false,
         "requested": "easyuse_anima.aio.output_settings",
@@ -37943,7 +38603,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -37958,7 +38618,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output_settings:_normalize_aio_hash_bundles",
         "kind": "static_from",
-        "line": 692,
+        "line": 697,
         "name": "_normalize_aio_hash_bundles",
         "optional": false,
         "requested": "easyuse_anima.aio.output_settings",
@@ -37977,7 +38637,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -37992,7 +38652,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_clip_loader_types",
         "kind": "static_from",
-        "line": 696,
+        "line": 701,
         "name": "_comfy_clip_loader_types",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -38011,7 +38671,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -38026,7 +38686,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_diffusion_model_names",
         "kind": "static_from",
-        "line": 696,
+        "line": 701,
         "name": "_comfy_diffusion_model_names",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -38045,7 +38705,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -38060,7 +38720,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_text_encoder_names",
         "kind": "static_from",
-        "line": 696,
+        "line": 701,
         "name": "_comfy_text_encoder_names",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -38079,7 +38739,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -38094,7 +38754,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_vae_names",
         "kind": "static_from",
-        "line": 696,
+        "line": 701,
         "name": "_comfy_vae_names",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -38113,7 +38773,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -38128,7 +38788,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_aio_resources_from_input_context",
         "kind": "static_from",
-        "line": 696,
+        "line": 701,
         "name": "_load_aio_resources_from_input_context",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -38147,7 +38807,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -38162,7 +38822,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_aio_sam3_context",
         "kind": "static_from",
-        "line": 696,
+        "line": 701,
         "name": "_load_aio_sam3_context",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -38181,7 +38841,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -38196,7 +38856,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_checkpoint_with_comfy",
         "kind": "static_from",
-        "line": 696,
+        "line": 701,
         "name": "_load_checkpoint_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -38215,7 +38875,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -38230,7 +38890,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_clip_with_comfy",
         "kind": "static_from",
-        "line": 696,
+        "line": 701,
         "name": "_load_clip_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -38249,7 +38909,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -38264,7 +38924,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_diffusion_model_with_comfy",
         "kind": "static_from",
-        "line": 696,
+        "line": 701,
         "name": "_load_diffusion_model_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -38283,7 +38943,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -38298,7 +38958,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_upscale_model_with_comfy",
         "kind": "static_from",
-        "line": 696,
+        "line": 701,
         "name": "_load_upscale_model_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -38317,7 +38977,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -38332,7 +38992,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_vae_with_comfy",
         "kind": "static_from",
-        "line": 696,
+        "line": 701,
         "name": "_load_vae_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -38351,7 +39011,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -38366,7 +39026,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_normalize_aio_input_settings",
         "kind": "static_from",
-        "line": 696,
+        "line": 701,
         "name": "_normalize_aio_input_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -38385,7 +39045,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -38400,7 +39060,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_checkpoint_default",
         "kind": "static_from",
-        "line": 696,
+        "line": 701,
         "name": "_preferred_checkpoint_default",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -38419,7 +39079,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -38434,7 +39094,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_clip_type_default",
         "kind": "static_from",
-        "line": 696,
+        "line": 701,
         "name": "_preferred_clip_type_default",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -38453,7 +39113,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -38468,7 +39128,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_name_default",
         "kind": "static_from",
-        "line": 696,
+        "line": 701,
         "name": "_preferred_name_default",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -38487,7 +39147,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -38502,7 +39162,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_json_clone",
         "kind": "static_from",
-        "line": 713,
+        "line": 718,
         "name": "_json_clone",
         "optional": false,
         "requested": "easyuse_anima.common.serialization",
@@ -38521,7 +39181,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -38536,7 +39196,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_json_object",
         "kind": "static_from",
-        "line": 713,
+        "line": 718,
         "name": "_json_object",
         "optional": false,
         "requested": "easyuse_anima.common.serialization",
@@ -38555,7 +39215,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -38570,7 +39230,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_stable_change_key",
         "kind": "static_from",
-        "line": 713,
+        "line": 718,
         "name": "_stable_change_key",
         "optional": false,
         "requested": "easyuse_anima.common.serialization",
@@ -38589,7 +39249,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -38604,7 +39264,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_bool",
         "kind": "static_from",
-        "line": 718,
+        "line": 723,
         "name": "_as_bool",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -38623,7 +39283,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -38638,7 +39298,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_float",
         "kind": "static_from",
-        "line": 718,
+        "line": 723,
         "name": "_as_float",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -38657,7 +39317,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -38672,7 +39332,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_int",
         "kind": "static_from",
-        "line": 718,
+        "line": 723,
         "name": "_as_int",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -38691,7 +39351,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -38706,7 +39366,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_choice",
         "kind": "static_from",
-        "line": 718,
+        "line": 723,
         "name": "_choice",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -38725,7 +39385,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -38740,7 +39400,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_single_value",
         "kind": "static_from",
-        "line": 718,
+        "line": 723,
         "name": "_single_value",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -38759,7 +39419,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -38774,7 +39434,7 @@
         "conditional": true,
         "imported": "easyuse_anima.seed.compatibility:WILDCARD_QUEUE_MAX_SAFE_SEED",
         "kind": "static_from",
-        "line": 725,
+        "line": 730,
         "name": "WILDCARD_QUEUE_MAX_SAFE_SEED",
         "optional": false,
         "requested": "easyuse_anima.seed.compatibility",
@@ -38793,7 +39453,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -38808,7 +39468,7 @@
         "conditional": true,
         "imported": "easyuse_anima.seed.compatibility:WILDCARD_RESERVED_NEXT_SEED_INPUT",
         "kind": "static_from",
-        "line": 725,
+        "line": 730,
         "name": "WILDCARD_RESERVED_NEXT_SEED_INPUT",
         "optional": false,
         "requested": "easyuse_anima.seed.compatibility",
@@ -38827,7 +39487,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -38842,7 +39502,7 @@
         "conditional": true,
         "imported": "easyuse_anima.seed.compatibility:_consume_reserved_wildcard_next_seed",
         "kind": "static_from",
-        "line": 725,
+        "line": 730,
         "name": "_consume_reserved_wildcard_next_seed",
         "optional": false,
         "requested": "easyuse_anima.seed.compatibility",
@@ -38861,7 +39521,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -38876,7 +39536,7 @@
         "conditional": true,
         "imported": "easyuse_anima.workflow:_get_workflow_node",
         "kind": "static_from",
-        "line": 730,
+        "line": 735,
         "name": "_get_workflow_node",
         "optional": false,
         "requested": "easyuse_anima.workflow",
@@ -38895,7 +39555,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -38910,7 +39570,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_prompt_translation_change_key",
         "kind": "static_from",
-        "line": 731,
+        "line": 736,
         "name": "_prompt_translation_change_key",
         "optional": false,
         "requested": "easyuse_anima.prompt.correction",
@@ -38929,7 +39589,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -38944,7 +39604,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_split_tag_text",
         "kind": "static_from",
-        "line": 731,
+        "line": 736,
         "name": "_split_tag_text",
         "optional": false,
         "requested": "easyuse_anima.prompt.correction",
@@ -38963,7 +39623,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -38978,7 +39638,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_translate_prompt_text",
         "kind": "static_from",
-        "line": 731,
+        "line": 736,
         "name": "_translate_prompt_text",
         "optional": false,
         "requested": "easyuse_anima.prompt.correction",
@@ -38997,7 +39657,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -39012,7 +39672,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_HASH_COMMENT_RE",
         "kind": "static_from",
-        "line": 736,
+        "line": 741,
         "name": "_HASH_COMMENT_RE",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -39031,7 +39691,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -39046,7 +39706,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_INLINE_SPACE_RE",
         "kind": "static_from",
-        "line": 736,
+        "line": 741,
         "name": "_INLINE_SPACE_RE",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -39065,7 +39725,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -39080,7 +39740,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_WEIGHTED_TOKEN_RE",
         "kind": "static_from",
-        "line": 736,
+        "line": 741,
         "name": "_WEIGHTED_TOKEN_RE",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -39099,7 +39759,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -39114,7 +39774,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_correct_builder_prompt",
         "kind": "static_from",
-        "line": 736,
+        "line": 741,
         "name": "_correct_builder_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -39133,7 +39793,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -39148,7 +39808,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_filter_metadata_prompt",
         "kind": "static_from",
-        "line": 736,
+        "line": 741,
         "name": "_filter_metadata_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -39167,7 +39827,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -39182,7 +39842,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_join_prompt_tokens",
         "kind": "static_from",
-        "line": 736,
+        "line": 741,
         "name": "_join_prompt_tokens",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -39201,7 +39861,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -39216,7 +39876,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_metadata_filter_key",
         "kind": "static_from",
-        "line": 736,
+        "line": 741,
         "name": "_metadata_filter_key",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -39235,7 +39895,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -39250,7 +39910,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_metadata_filter_keys",
         "kind": "static_from",
-        "line": 736,
+        "line": 741,
         "name": "_metadata_filter_keys",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -39269,7 +39929,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -39284,7 +39944,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_prompt_tokens",
         "kind": "static_from",
-        "line": 736,
+        "line": 741,
         "name": "_prompt_tokens",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -39303,7 +39963,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -39318,7 +39978,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:PROMPT_DATA_TYPE",
         "kind": "static_from",
-        "line": 749,
+        "line": 754,
         "name": "PROMPT_DATA_TYPE",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -39337,7 +39997,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -39352,7 +40012,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_advanced_outputs_from_prompt_data",
         "kind": "static_from",
-        "line": 749,
+        "line": 754,
         "name": "_advanced_outputs_from_prompt_data",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -39371,7 +40031,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -39386,7 +40046,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_apply_prompt_data_overrides",
         "kind": "static_from",
-        "line": 749,
+        "line": 754,
         "name": "_apply_prompt_data_overrides",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -39405,7 +40065,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -39420,7 +40080,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_copy_prompt_data_for_update",
         "kind": "static_from",
-        "line": 749,
+        "line": 754,
         "name": "_copy_prompt_data_for_update",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -39439,7 +40099,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -39454,7 +40114,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_normalize_prompt_data",
         "kind": "static_from",
-        "line": 749,
+        "line": 754,
         "name": "_normalize_prompt_data",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -39473,7 +40133,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -39488,7 +40148,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_prompt_data_json_safe",
         "kind": "static_from",
-        "line": 749,
+        "line": 754,
         "name": "_prompt_data_json_safe",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -39507,7 +40167,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -39522,7 +40182,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_prompt_data_parameter_snapshot",
         "kind": "static_from",
-        "line": 749,
+        "line": 754,
         "name": "_prompt_data_parameter_snapshot",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -39541,7 +40201,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -39556,7 +40216,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_artist_field_prompt",
         "kind": "static_from",
-        "line": 767,
+        "line": 772,
         "name": "_advanced_artist_field_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -39575,7 +40235,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -39590,7 +40250,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_default_fields",
         "kind": "static_from",
-        "line": 767,
+        "line": 772,
         "name": "_advanced_default_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -39609,7 +40269,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -39624,7 +40284,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_enabled_naia_panes",
         "kind": "static_from",
-        "line": 767,
+        "line": 772,
         "name": "_advanced_enabled_naia_panes",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -39643,7 +40303,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -39658,7 +40318,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_enabled_pane_fields",
         "kind": "static_from",
-        "line": 767,
+        "line": 772,
         "name": "_advanced_enabled_pane_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -39677,7 +40337,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -39692,7 +40352,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_field_input_values",
         "kind": "static_from",
-        "line": 767,
+        "line": 772,
         "name": "_advanced_field_input_values",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -39711,7 +40371,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -39726,7 +40386,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_field_socket_name",
         "kind": "static_from",
-        "line": 767,
+        "line": 772,
         "name": "_advanced_field_socket_name",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -39745,7 +40405,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -39760,7 +40420,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_fields_json",
         "kind": "static_from",
-        "line": 767,
+        "line": 772,
         "name": "_advanced_fields_json",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -39779,7 +40439,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -39794,7 +40454,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_has_enabled_naia",
         "kind": "static_from",
-        "line": 767,
+        "line": 772,
         "name": "_advanced_has_enabled_naia",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -39813,7 +40473,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -39828,7 +40488,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_prompt_with_artist_override",
         "kind": "static_from",
-        "line": 767,
+        "line": 772,
         "name": "_advanced_prompt_with_artist_override",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -39847,7 +40507,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -39862,7 +40522,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_uses_naia_resolution",
         "kind": "static_from",
-        "line": 767,
+        "line": 772,
         "name": "_advanced_uses_naia_resolution",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -39881,7 +40541,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -39896,7 +40556,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_apply_advanced_field_inputs",
         "kind": "static_from",
-        "line": 767,
+        "line": 772,
         "name": "_apply_advanced_field_inputs",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -39915,7 +40575,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -39930,7 +40590,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_as_advanced_height",
         "kind": "static_from",
-        "line": 767,
+        "line": 772,
         "name": "_as_advanced_height",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -39949,7 +40609,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -39964,7 +40624,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_build_advanced_prompt_data",
         "kind": "static_from",
-        "line": 767,
+        "line": 772,
         "name": "_build_advanced_prompt_data",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -39983,7 +40643,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -39998,7 +40658,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_build_advanced_prompts",
         "kind": "static_from",
-        "line": 767,
+        "line": 772,
         "name": "_build_advanced_prompts",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -40017,7 +40677,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -40032,7 +40692,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_clone_advanced_fields",
         "kind": "static_from",
-        "line": 767,
+        "line": 772,
         "name": "_clone_advanced_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -40051,7 +40711,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -40066,7 +40726,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_correct_advanced_field_sequence",
         "kind": "static_from",
-        "line": 767,
+        "line": 772,
         "name": "_correct_advanced_field_sequence",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -40085,7 +40745,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -40100,7 +40760,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_expand_advanced_wildcard_fields",
         "kind": "static_from",
-        "line": 767,
+        "line": 772,
         "name": "_expand_advanced_wildcard_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -40119,7 +40779,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -40134,7 +40794,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_normalize_advanced_fields",
         "kind": "static_from",
-        "line": 767,
+        "line": 772,
         "name": "_normalize_advanced_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -40153,7 +40813,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -40168,7 +40828,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_normalize_prompt_studio_wildcard_seed_control",
         "kind": "static_from",
-        "line": 767,
+        "line": 772,
         "name": "_normalize_prompt_studio_wildcard_seed_control",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -40187,7 +40847,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -40202,7 +40862,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_set_naia_field_text",
         "kind": "static_from",
-        "line": 767,
+        "line": 772,
         "name": "_set_naia_field_text",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -40221,7 +40881,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -40236,7 +40896,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_translate_prompt_fields",
         "kind": "static_from",
-        "line": 767,
+        "line": 772,
         "name": "_translate_prompt_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -40255,7 +40915,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -40270,7 +40930,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_apply_regional_field_inputs",
         "kind": "static_from",
-        "line": 802,
+        "line": 807,
         "name": "_apply_regional_field_inputs",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -40289,7 +40949,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -40304,7 +40964,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_build_regional_outputs",
         "kind": "static_from",
-        "line": 802,
+        "line": 807,
         "name": "_build_regional_outputs",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -40323,7 +40983,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -40338,7 +40998,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_clone_regional_fields",
         "kind": "static_from",
-        "line": 802,
+        "line": 807,
         "name": "_clone_regional_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -40357,7 +41017,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -40372,7 +41032,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_conditioning_set_values",
         "kind": "static_from",
-        "line": 802,
+        "line": 807,
         "name": "_conditioning_set_values",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -40391,7 +41051,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -40406,7 +41066,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_mask_ids",
         "kind": "static_from",
-        "line": 802,
+        "line": 807,
         "name": "_normalize_mask_ids",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -40425,7 +41085,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -40440,7 +41100,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_regional_config",
         "kind": "static_from",
-        "line": 802,
+        "line": 807,
         "name": "_normalize_regional_config",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -40459,7 +41119,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -40474,7 +41134,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_regional_fields",
         "kind": "static_from",
-        "line": 802,
+        "line": 807,
         "name": "_normalize_regional_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -40493,7 +41153,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -40508,7 +41168,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_parse_json_object",
         "kind": "static_from",
-        "line": 802,
+        "line": 807,
         "name": "_parse_json_object",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -40527,7 +41187,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -40542,7 +41202,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_config_json",
         "kind": "static_from",
-        "line": 802,
+        "line": 807,
         "name": "_regional_config_json",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -40561,7 +41221,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -40576,7 +41236,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_fields_json",
         "kind": "static_from",
-        "line": 802,
+        "line": 807,
         "name": "_regional_fields_json",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -40595,7 +41255,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -40610,7 +41270,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_mask_bounds_area",
         "kind": "static_from",
-        "line": 802,
+        "line": 807,
         "name": "_regional_mask_bounds_area",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -40629,7 +41289,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -40644,7 +41304,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_payload_canvas",
         "kind": "static_from",
-        "line": 802,
+        "line": 807,
         "name": "_regional_payload_canvas",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -40663,7 +41323,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -40678,7 +41338,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_union_mask_for_ids",
         "kind": "static_from",
-        "line": 802,
+        "line": 807,
         "name": "_regional_union_mask_for_ids",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -40697,7 +41357,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -40712,7 +41372,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
         "kind": "static_from",
-        "line": 829,
+        "line": 834,
         "name": "ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -40731,7 +41391,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -40746,7 +41406,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODES",
         "kind": "static_from",
-        "line": 829,
+        "line": 834,
         "name": "ANIMA_MOD_GUIDANCE_MODES",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -40765,7 +41425,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -40780,7 +41440,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 829,
+        "line": 834,
         "name": "ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -40799,7 +41459,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -40814,7 +41474,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_PROFILE_OFF",
         "kind": "static_from",
-        "line": 829,
+        "line": 834,
         "name": "ANIMA_MOD_GUIDANCE_PROFILE_OFF",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -40833,7 +41493,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -40848,7 +41508,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_apply_spectrum_anima_mod_guidance",
         "kind": "static_from",
-        "line": 829,
+        "line": 834,
         "name": "_apply_spectrum_anima_mod_guidance",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -40867,7 +41527,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -40882,7 +41542,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_find_spectrum_anima_mod_guidance_class",
         "kind": "static_from",
-        "line": 829,
+        "line": 834,
         "name": "_find_spectrum_anima_mod_guidance_class",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -40901,7 +41561,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -40916,7 +41576,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_normalize_anima_mod_guidance_profile",
         "kind": "static_from",
-        "line": 829,
+        "line": 834,
         "name": "_normalize_anima_mod_guidance_profile",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -40935,7 +41595,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -40950,7 +41610,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_resolve_anima_mod_guidance_enabled",
         "kind": "static_from",
-        "line": 829,
+        "line": 834,
         "name": "_resolve_anima_mod_guidance_enabled",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -40969,7 +41629,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -40984,7 +41644,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
         "kind": "static_from",
-        "line": 844,
+        "line": 849,
         "name": "ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -41003,7 +41663,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -41018,7 +41678,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
         "kind": "static_from",
-        "line": 844,
+        "line": 849,
         "name": "ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -41037,7 +41697,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -41052,7 +41712,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
         "kind": "static_from",
-        "line": 844,
+        "line": 849,
         "name": "ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -41071,7 +41731,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -41086,7 +41746,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_EXACT_TOP_K",
         "kind": "static_from",
-        "line": 844,
+        "line": 849,
         "name": "ARTIST_MIX_DEFAULT_EXACT_TOP_K",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -41105,7 +41765,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -41120,7 +41780,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
         "kind": "static_from",
-        "line": 844,
+        "line": 849,
         "name": "ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -41139,7 +41799,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -41154,7 +41814,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_START_PERCENT",
         "kind": "static_from",
-        "line": 844,
+        "line": 849,
         "name": "ARTIST_MIX_DEFAULT_START_PERCENT",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -41173,7 +41833,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -41188,7 +41848,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
         "kind": "static_from",
-        "line": 844,
+        "line": 849,
         "name": "ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -41207,7 +41867,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -41222,7 +41882,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STYLE_GAIN",
         "kind": "static_from",
-        "line": 844,
+        "line": 849,
         "name": "ARTIST_MIX_DEFAULT_STYLE_GAIN",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -41241,7 +41901,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -41256,7 +41916,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_INPUT_MODES",
         "kind": "static_from",
-        "line": 844,
+        "line": 849,
         "name": "ARTIST_MIX_INPUT_MODES",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -41275,7 +41935,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -41290,7 +41950,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 844,
+        "line": 849,
         "name": "ARTIST_MIX_MODE_FROM_PROMPT_DATA",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -41309,7 +41969,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -41324,7 +41984,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_mix_inline_prompt",
         "kind": "static_from",
-        "line": 844,
+        "line": 849,
         "name": "_artist_mix_inline_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -41343,7 +42003,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -41358,7 +42018,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_mix_mode_tooltip",
         "kind": "static_from",
-        "line": 844,
+        "line": 849,
         "name": "_artist_mix_mode_tooltip",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -41377,7 +42037,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -41392,7 +42052,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_prompt_with_position",
         "kind": "static_from",
-        "line": 844,
+        "line": 849,
         "name": "_artist_prompt_with_position",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -41411,7 +42071,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -41426,7 +42086,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_tags_from_prompt",
         "kind": "static_from",
-        "line": 844,
+        "line": 849,
         "name": "_artist_tags_from_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -41445,7 +42105,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -41460,7 +42120,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_blend_conditionings",
         "kind": "static_from",
-        "line": 844,
+        "line": 849,
         "name": "_blend_conditionings",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -41479,7 +42139,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -41494,7 +42154,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bounded_artist_mix_float",
         "kind": "static_from",
-        "line": 844,
+        "line": 849,
         "name": "_bounded_artist_mix_float",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -41513,7 +42173,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -41528,7 +42188,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bounded_artist_mix_int",
         "kind": "static_from",
-        "line": 844,
+        "line": 849,
         "name": "_bounded_artist_mix_int",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -41547,7 +42207,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -41562,7 +42222,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_clustered",
         "kind": "static_from",
-        "line": 844,
+        "line": 849,
         "name": "_encode_artist_clustered",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -41581,7 +42241,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -41596,7 +42256,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_delta_rms",
         "kind": "static_from",
-        "line": 844,
+        "line": 849,
         "name": "_encode_artist_delta_rms",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -41615,7 +42275,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -41630,7 +42290,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_prompt_data_positive_conditioning",
         "kind": "static_from",
-        "line": 844,
+        "line": 849,
         "name": "_encode_prompt_data_positive_conditioning",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -41649,7 +42309,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -41664,7 +42324,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_join_artist_mix_source_prompts",
         "kind": "static_from",
-        "line": 844,
+        "line": 849,
         "name": "_join_artist_mix_source_prompts",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -41683,7 +42343,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -41698,7 +42358,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_normalize_artist_mix_mode",
         "kind": "static_from",
-        "line": 844,
+        "line": 849,
         "name": "_normalize_artist_mix_mode",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -41717,7 +42377,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -41732,7 +42392,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_normalize_artist_tag_position",
         "kind": "static_from",
-        "line": 844,
+        "line": 849,
         "name": "_normalize_artist_tag_position",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -41751,7 +42411,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -41766,7 +42426,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_parse_artist_mix_items",
         "kind": "static_from",
-        "line": 844,
+        "line": 849,
         "name": "_parse_artist_mix_items",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -41785,7 +42445,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -41800,7 +42460,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaArtistMixConditioning",
         "kind": "static_from",
-        "line": 923,
+        "line": 928,
         "name": "EasyUseAnimaArtistMixConditioning",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_data_nodes",
@@ -41819,7 +42479,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -41834,7 +42494,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataConditioning",
         "kind": "static_from",
-        "line": 923,
+        "line": 928,
         "name": "EasyUseAnimaPromptDataConditioning",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_data_nodes",
@@ -41853,7 +42513,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -41868,7 +42528,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataUnpack",
         "kind": "static_from",
-        "line": 923,
+        "line": 928,
         "name": "EasyUseAnimaPromptDataUnpack",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_data_nodes",
@@ -41887,7 +42547,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -41902,7 +42562,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_ANY_TYPE",
         "kind": "static_from",
-        "line": 928,
+        "line": 933,
         "name": "_ANY_TYPE",
         "optional": false,
         "requested": "easyuse_anima.nodes.input_types",
@@ -41921,7 +42581,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -41936,7 +42596,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_AnyType",
         "kind": "static_from",
-        "line": 928,
+        "line": 933,
         "name": "_AnyType",
         "optional": false,
         "requested": "easyuse_anima.nodes.input_types",
@@ -41955,7 +42615,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -41970,7 +42630,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_FlexibleOptionalInputType",
         "kind": "static_from",
-        "line": 928,
+        "line": 933,
         "name": "_FlexibleOptionalInputType",
         "optional": false,
         "requested": "easyuse_anima.nodes.input_types",
@@ -41989,7 +42649,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -42004,7 +42664,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvanced",
         "kind": "static_from",
-        "line": 933,
+        "line": 938,
         "name": "EasyUseAnimaPromptStudioAdvanced",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_advanced_nodes",
@@ -42023,7 +42683,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -42038,7 +42698,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvancedV2",
         "kind": "static_from",
-        "line": 933,
+        "line": 938,
         "name": "EasyUseAnimaPromptStudioAdvancedV2",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_advanced_nodes",
@@ -42057,7 +42717,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -42072,7 +42732,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:EASY_USE_ANIMA_INPUT_TYPE",
         "kind": "static_from",
-        "line": 938,
+        "line": 943,
         "name": "EASY_USE_ANIMA_INPUT_TYPE",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -42091,7 +42751,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -42106,7 +42766,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:EasyUseAnimaAIOGenerator",
         "kind": "static_from",
-        "line": 938,
+        "line": 943,
         "name": "EasyUseAnimaAIOGenerator",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -42125,7 +42785,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -42140,7 +42800,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:EasyUseAnimaInput",
         "kind": "static_from",
-        "line": 938,
+        "line": 943,
         "name": "EasyUseAnimaInput",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -42159,7 +42819,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -42174,7 +42834,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_aio_generation_settings_json",
         "kind": "static_from",
-        "line": 938,
+        "line": 943,
         "name": "_aio_generation_settings_json",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -42193,7 +42853,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -42208,7 +42868,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_aio_input_settings_json",
         "kind": "static_from",
-        "line": 938,
+        "line": 943,
         "name": "_aio_input_settings_json",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -42227,7 +42887,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -42242,7 +42902,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_align_down",
         "kind": "static_from",
-        "line": 945,
+        "line": 950,
         "name": "_align_down",
         "optional": false,
         "requested": "easyuse_anima.image.geometry",
@@ -42261,7 +42921,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -42276,7 +42936,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_align_nearest",
         "kind": "static_from",
-        "line": 945,
+        "line": 950,
         "name": "_align_nearest",
         "optional": false,
         "requested": "easyuse_anima.image.geometry",
@@ -42295,7 +42955,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -42310,7 +42970,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_image_tensor_size",
         "kind": "static_from",
-        "line": 945,
+        "line": 950,
         "name": "_image_tensor_size",
         "optional": false,
         "requested": "easyuse_anima.image.geometry",
@@ -42329,7 +42989,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -42344,7 +43004,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_context_value",
         "kind": "static_from",
-        "line": 956,
+        "line": 961,
         "name": "_context_value",
         "optional": false,
         "requested": "easyuse_anima.image.sam3",
@@ -42363,7 +43023,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -42378,7 +43038,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_sam3_context",
         "kind": "static_from",
-        "line": 956,
+        "line": 961,
         "name": "_sam3_context",
         "optional": false,
         "requested": "easyuse_anima.image.sam3",
@@ -42397,7 +43057,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -42412,7 +43072,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_segs_has_items",
         "kind": "static_from",
-        "line": 956,
+        "line": 961,
         "name": "_segs_has_items",
         "optional": false,
         "requested": "easyuse_anima.image.sam3",
@@ -42431,7 +43091,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -42446,7 +43106,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:IMAGE_SCALE_MULTIPLES",
         "kind": "static_from",
-        "line": 968,
+        "line": 973,
         "name": "IMAGE_SCALE_MULTIPLES",
         "optional": false,
         "requested": "easyuse_anima.image.scaling",
@@ -42465,7 +43125,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -42480,7 +43140,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:IMAGE_UPSCALE_METHODS",
         "kind": "static_from",
-        "line": 968,
+        "line": 973,
         "name": "IMAGE_UPSCALE_METHODS",
         "optional": false,
         "requested": "easyuse_anima.image.scaling",
@@ -42499,7 +43159,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -42514,7 +43174,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_sampler_names",
         "kind": "static_from",
-        "line": 976,
+        "line": 981,
         "name": "_comfy_sampler_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -42533,7 +43193,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -42548,7 +43208,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_scheduler_names",
         "kind": "static_from",
-        "line": 976,
+        "line": 981,
         "name": "_comfy_scheduler_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -42567,7 +43227,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -42582,7 +43242,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_impact_scheduler_names",
         "kind": "static_from",
-        "line": 976,
+        "line": 981,
         "name": "_impact_scheduler_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -42601,7 +43261,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -42616,7 +43276,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_call_with_supported_kwargs",
         "kind": "static_from",
-        "line": 982,
+        "line": 987,
         "name": "_call_with_supported_kwargs",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.invocation",
@@ -42635,7 +43295,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -42650,7 +43310,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_common_upscale_image",
         "kind": "static_from",
-        "line": 982,
+        "line": 987,
         "name": "_common_upscale_image",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.invocation",
@@ -42669,7 +43329,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -42684,7 +43344,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_node_output_tuple",
         "kind": "static_from",
-        "line": 982,
+        "line": 987,
         "name": "_node_output_tuple",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.invocation",
@@ -42703,7 +43363,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -42718,7 +43378,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_clip_loader_types",
         "kind": "static_from",
-        "line": 987,
+        "line": 992,
         "name": "_comfy_clip_loader_types",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -42737,7 +43397,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -42752,7 +43412,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_diffusion_model_names",
         "kind": "static_from",
-        "line": 987,
+        "line": 992,
         "name": "_comfy_diffusion_model_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -42771,7 +43431,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -42786,7 +43446,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_text_encoder_names",
         "kind": "static_from",
-        "line": 987,
+        "line": 992,
         "name": "_comfy_text_encoder_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -42805,7 +43465,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -42820,7 +43480,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_vae_names",
         "kind": "static_from",
-        "line": 987,
+        "line": 992,
         "name": "_comfy_vae_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -42839,7 +43499,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -42854,7 +43514,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_folder_path_names",
         "kind": "static_from",
-        "line": 987,
+        "line": 992,
         "name": "_folder_path_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -42873,7 +43533,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -42888,7 +43548,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.image_nodes:EasyUseAnimaDetailerAlignHook",
         "kind": "static_from",
-        "line": 995,
+        "line": 1000,
         "name": "EasyUseAnimaDetailerAlignHook",
         "optional": false,
         "requested": "easyuse_anima.nodes.image_nodes",
@@ -42907,7 +43567,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -42922,7 +43582,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.image_nodes:EasyUseAnimaImageScaleByMultiple",
         "kind": "static_from",
-        "line": 995,
+        "line": 1000,
         "name": "EasyUseAnimaImageScaleByMultiple",
         "optional": false,
         "requested": "easyuse_anima.nodes.image_nodes",
@@ -42941,7 +43601,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -42956,7 +43616,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Context",
         "kind": "static_from",
-        "line": 999,
+        "line": 1004,
         "name": "EasyUseAnimaSAM3Context",
         "optional": false,
         "requested": "easyuse_anima.nodes.sam3_nodes",
@@ -42975,7 +43635,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -42990,7 +43650,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Detailer",
         "kind": "static_from",
-        "line": 999,
+        "line": 1004,
         "name": "EasyUseAnimaSAM3Detailer",
         "optional": false,
         "requested": "easyuse_anima.nodes.sam3_nodes",
@@ -43009,7 +43669,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -43024,7 +43684,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptBuilder",
         "kind": "static_from",
-        "line": 1003,
+        "line": 1008,
         "name": "EasyUseAnimaPromptBuilder",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -43043,7 +43703,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -43058,7 +43718,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrector",
         "kind": "static_from",
-        "line": 1003,
+        "line": 1008,
         "name": "EasyUseAnimaPromptCorrector",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -43077,7 +43737,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -43092,7 +43752,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrectorSimple",
         "kind": "static_from",
-        "line": 1003,
+        "line": 1008,
         "name": "EasyUseAnimaPromptCorrectorSimple",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -43111,7 +43771,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -43126,7 +43786,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptStudio",
         "kind": "static_from",
-        "line": 1003,
+        "line": 1008,
         "name": "EasyUseAnimaPromptStudio",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -43145,7 +43805,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -43160,7 +43820,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:EasyUseAnimaPromptStudioRegional",
         "kind": "static_from",
-        "line": 1009,
+        "line": 1014,
         "name": "EasyUseAnimaPromptStudioRegional",
         "optional": false,
         "requested": "easyuse_anima.nodes.regional_nodes",
@@ -43179,7 +43839,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -43194,7 +43854,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:EasyUseAnimaRegionalConditioning",
         "kind": "static_from",
-        "line": 1009,
+        "line": 1014,
         "name": "EasyUseAnimaRegionalConditioning",
         "optional": false,
         "requested": "easyuse_anima.nodes.regional_nodes",
@@ -43213,7 +43873,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -43228,7 +43888,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:LATENT_ALIGN",
         "kind": "static_from",
-        "line": 1013,
+        "line": 1018,
         "name": "LATENT_ALIGN",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -43247,7 +43907,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -43262,7 +43922,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_parse_random_response",
         "kind": "static_from",
-        "line": 1013,
+        "line": 1018,
         "name": "_parse_random_response",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -43281,7 +43941,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -43296,7 +43956,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_post_random",
         "kind": "static_from",
-        "line": 1013,
+        "line": 1018,
         "name": "_post_random",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -43315,7 +43975,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -43330,7 +43990,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_advanced_resolution_from_selection",
         "kind": "static_from",
-        "line": 1031,
+        "line": 1036,
         "name": "_advanced_resolution_from_selection",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -43349,7 +44009,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -43364,7 +44024,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_normalize_resolution_bucket",
         "kind": "static_from",
-        "line": 1031,
+        "line": 1036,
         "name": "_normalize_resolution_bucket",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -43383,7 +44043,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -43398,7 +44058,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_ratio_label",
         "kind": "static_from",
-        "line": 1031,
+        "line": 1036,
         "name": "_ratio_label",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -43417,7 +44077,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -43432,7 +44092,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolution_label",
         "kind": "static_from",
-        "line": 1031,
+        "line": 1036,
         "name": "_resolution_label",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -43451,7 +44111,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -43466,7 +44126,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolve_naia_resolution",
         "kind": "static_from",
-        "line": 1031,
+        "line": 1036,
         "name": "_resolve_naia_resolution",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -43485,7 +44145,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -43500,7 +44160,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.naia_nodes:EasyUseAnimaNAIARandomPrompt",
         "kind": "static_from",
-        "line": 1054,
+        "line": 1059,
         "name": "EasyUseAnimaNAIARandomPrompt",
         "optional": false,
         "requested": "easyuse_anima.nodes.naia_nodes",
@@ -43519,7 +44179,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -43534,7 +44194,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.wildcard_nodes:EasyUseAnimaWildcard",
         "kind": "static_from",
-        "line": 1057,
+        "line": 1062,
         "name": "EasyUseAnimaWildcard",
         "optional": false,
         "requested": "easyuse_anima.nodes.wildcard_nodes",
@@ -43553,7 +44213,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -43568,7 +44228,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_apply_lora_syntax_format",
         "kind": "static_from",
-        "line": 1061,
+        "line": 1066,
         "name": "_apply_lora_syntax_format",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -43587,7 +44247,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -43602,7 +44262,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_dedupe_text_values",
         "kind": "static_from",
-        "line": 1061,
+        "line": 1066,
         "name": "_dedupe_text_values",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -43621,7 +44281,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -43636,7 +44296,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_fallback_lora_path",
         "kind": "static_from",
-        "line": 1061,
+        "line": 1066,
         "name": "_fallback_lora_path",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -43655,7 +44315,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -43670,7 +44330,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_get_lora_info",
         "kind": "static_from",
-        "line": 1061,
+        "line": 1066,
         "name": "_get_lora_info",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -43689,7 +44349,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -43704,7 +44364,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_get_lora_manager_trigger_words",
         "kind": "static_from",
-        "line": 1061,
+        "line": 1066,
         "name": "_get_lora_manager_trigger_words",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -43723,7 +44383,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -43738,7 +44398,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_load_lora_manager_metadata",
         "kind": "static_from",
-        "line": 1061,
+        "line": 1066,
         "name": "_load_lora_manager_metadata",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -43757,7 +44417,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -43772,7 +44432,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_combo_values",
         "kind": "static_from",
-        "line": 1061,
+        "line": 1066,
         "name": "_lora_combo_values",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -43791,7 +44451,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -43806,7 +44466,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_manager_trigger_words_from_metadata",
         "kind": "static_from",
-        "line": 1061,
+        "line": 1066,
         "name": "_lora_manager_trigger_words_from_metadata",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -43825,7 +44485,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -43840,7 +44500,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_model_exists",
         "kind": "static_from",
-        "line": 1061,
+        "line": 1066,
         "name": "_lora_model_exists",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -43859,7 +44519,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -43874,7 +44534,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_stack_name",
         "kind": "static_from",
-        "line": 1061,
+        "line": 1066,
         "name": "_lora_stack_name",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -43893,7 +44553,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -43908,7 +44568,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_metadata_json_paths_for_lora",
         "kind": "static_from",
-        "line": 1061,
+        "line": 1066,
         "name": "_metadata_json_paths_for_lora",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -43927,7 +44587,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -43942,7 +44602,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_missing_lora_display_name",
         "kind": "static_from",
-        "line": 1061,
+        "line": 1066,
         "name": "_missing_lora_display_name",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -43961,7 +44621,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -43976,7 +44636,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_raise_missing_loras",
         "kind": "static_from",
-        "line": 1061,
+        "line": 1066,
         "name": "_raise_missing_loras",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -43995,7 +44655,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -44010,7 +44670,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_trigger_words_from_value",
         "kind": "static_from",
-        "line": 1061,
+        "line": 1066,
         "name": "_trigger_words_from_value",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -44029,7 +44689,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -44044,7 +44704,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_correct_style_prompt",
         "kind": "static_from",
-        "line": 1077,
+        "line": 1082,
         "name": "_correct_style_prompt",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -44063,7 +44723,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -44078,7 +44738,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_format_strength",
         "kind": "static_from",
-        "line": 1077,
+        "line": 1082,
         "name": "_format_strength",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -44097,7 +44757,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -44112,7 +44772,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_get_loras_list",
         "kind": "static_from",
-        "line": 1077,
+        "line": 1082,
         "name": "_get_loras_list",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -44131,7 +44791,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -44146,7 +44806,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_load_profile_data",
         "kind": "static_from",
-        "line": 1077,
+        "line": 1082,
         "name": "_load_profile_data",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -44165,7 +44825,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -44180,7 +44840,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_profile_key",
         "kind": "static_from",
-        "line": 1077,
+        "line": 1082,
         "name": "_profile_key",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -44199,7 +44859,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -44214,7 +44874,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_select_profile_values",
         "kind": "static_from",
-        "line": 1077,
+        "line": 1082,
         "name": "_select_profile_values",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -44233,7 +44893,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -44248,7 +44908,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_wrap_profile_index",
         "kind": "static_from",
-        "line": 1077,
+        "line": 1082,
         "name": "_wrap_profile_index",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -44267,7 +44927,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -44282,7 +44942,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.lora_nodes:EasyUseAnimaLoraPreset",
         "kind": "static_from",
-        "line": 1086,
+        "line": 1091,
         "name": "EasyUseAnimaLoraPreset",
         "optional": false,
         "requested": "easyuse_anima.nodes.lora_nodes",
@@ -44301,7 +44961,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -44316,7 +44976,7 @@
         "conditional": true,
         "imported": "anima_prompt:correct_prompt",
         "kind": "static_from",
-        "line": 1089,
+        "line": 1094,
         "name": "correct_prompt",
         "optional": false,
         "requested": "anima_prompt",
@@ -44335,7 +44995,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -44350,7 +45010,7 @@
         "conditional": true,
         "imported": "anima_prompt:load_knowledge_base",
         "kind": "static_from",
-        "line": 1089,
+        "line": 1094,
         "name": "load_knowledge_base",
         "optional": false,
         "requested": "anima_prompt",
@@ -44369,7 +45029,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -44384,7 +45044,7 @@
         "conditional": true,
         "imported": "anima_prompt.parser:parse_prompt",
         "kind": "static_from",
-        "line": 1090,
+        "line": 1095,
         "name": "parse_prompt",
         "optional": false,
         "requested": "anima_prompt.parser",
@@ -44403,7 +45063,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -44418,7 +45078,7 @@
         "conditional": true,
         "imported": "settings:resolve_metadata_filter_words",
         "kind": "static_from",
-        "line": 1091,
+        "line": 1096,
         "name": "resolve_metadata_filter_words",
         "optional": false,
         "requested": "settings",
@@ -44437,7 +45097,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -44452,7 +45112,7 @@
         "conditional": true,
         "imported": "settings:resolve_naia_settings",
         "kind": "static_from",
-        "line": 1091,
+        "line": 1096,
         "name": "resolve_naia_settings",
         "optional": false,
         "requested": "settings",
@@ -44471,7 +45131,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -44486,7 +45146,7 @@
         "conditional": true,
         "imported": "settings:resolve_prompt_translation_settings",
         "kind": "static_from",
-        "line": 1091,
+        "line": 1096,
         "name": "resolve_prompt_translation_settings",
         "optional": false,
         "requested": "settings",
@@ -44505,7 +45165,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -44514,20 +45174,20 @@
         "column": 4,
         "compatibility_pair": {
           "bound_name": "has_prompt_translation_markers",
-          "target": "prompt_translation.py",
+          "target": "easyuse_anima/translation/markers.py",
           "try_line": 4
         },
         "conditional": true,
-        "imported": "prompt_translation:has_prompt_translation_markers",
+        "imported": "easyuse_anima.translation.markers:has_prompt_translation_markers",
         "kind": "static_from",
-        "line": 1096,
+        "line": 1101,
         "name": "has_prompt_translation_markers",
         "optional": false,
-        "requested": "prompt_translation",
+        "requested": "easyuse_anima.translation.markers",
         "role": "compatibility_fallback",
         "scope": "<module>",
         "source": "nodes.py",
-        "target": "prompt_translation.py"
+        "target": "easyuse_anima/translation/markers.py"
       },
       {
         "alias": null,
@@ -44539,7 +45199,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -44548,20 +45208,20 @@
         "column": 4,
         "compatibility_pair": {
           "bound_name": "translate_prompt_markers",
-          "target": "prompt_translation.py",
+          "target": "easyuse_anima/translation/service.py",
           "try_line": 4
         },
         "conditional": true,
-        "imported": "prompt_translation:translate_prompt_markers",
+        "imported": "easyuse_anima.translation.service:translate_prompt_markers",
         "kind": "static_from",
-        "line": 1096,
+        "line": 1104,
         "name": "translate_prompt_markers",
         "optional": false,
-        "requested": "prompt_translation",
+        "requested": "easyuse_anima.translation.service",
         "role": "compatibility_fallback",
         "scope": "<module>",
         "source": "nodes.py",
-        "target": "prompt_translation.py"
+        "target": "easyuse_anima/translation/service.py"
       },
       {
         "alias": null,
@@ -44573,7 +45233,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -44588,7 +45248,7 @@
         "conditional": true,
         "imported": "wildcard_engine:MAX_SEED",
         "kind": "static_from",
-        "line": 1097,
+        "line": 1107,
         "name": "MAX_SEED",
         "optional": false,
         "requested": "wildcard_engine",
@@ -44607,7 +45267,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -44622,7 +45282,7 @@
         "conditional": true,
         "imported": "wildcard_engine:PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "kind": "static_from",
-        "line": 1097,
+        "line": 1107,
         "name": "PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "optional": false,
         "requested": "wildcard_engine",
@@ -44641,7 +45301,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -44656,7 +45316,7 @@
         "conditional": true,
         "imported": "wildcard_engine:PUBLIC_MAX_SEED",
         "kind": "static_from",
-        "line": 1097,
+        "line": 1107,
         "name": "PUBLIC_MAX_SEED",
         "optional": false,
         "requested": "wildcard_engine",
@@ -44675,7 +45335,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -44690,7 +45350,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_DECREMENT",
         "kind": "static_from",
-        "line": 1097,
+        "line": 1107,
         "name": "SEED_CONTROL_DECREMENT",
         "optional": false,
         "requested": "wildcard_engine",
@@ -44709,7 +45369,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -44724,7 +45384,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_FIXED",
         "kind": "static_from",
-        "line": 1097,
+        "line": 1107,
         "name": "SEED_CONTROL_FIXED",
         "optional": false,
         "requested": "wildcard_engine",
@@ -44743,7 +45403,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -44758,7 +45418,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_INCREMENT",
         "kind": "static_from",
-        "line": 1097,
+        "line": 1107,
         "name": "SEED_CONTROL_INCREMENT",
         "optional": false,
         "requested": "wildcard_engine",
@@ -44777,7 +45437,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -44792,7 +45452,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_MODES",
         "kind": "static_from",
-        "line": 1097,
+        "line": 1107,
         "name": "SEED_CONTROL_MODES",
         "optional": false,
         "requested": "wildcard_engine",
@@ -44811,7 +45471,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -44826,7 +45486,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_RANDOMIZE",
         "kind": "static_from",
-        "line": 1097,
+        "line": 1107,
         "name": "SEED_CONTROL_RANDOMIZE",
         "optional": false,
         "requested": "wildcard_engine",
@@ -44845,7 +45505,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -44860,7 +45520,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_FIXED",
         "kind": "static_from",
-        "line": 1097,
+        "line": 1107,
         "name": "WILDCARD_MODE_FIXED",
         "optional": false,
         "requested": "wildcard_engine",
@@ -44879,7 +45539,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -44894,7 +45554,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_POPULATE",
         "kind": "static_from",
-        "line": 1097,
+        "line": 1107,
         "name": "WILDCARD_MODE_POPULATE",
         "optional": false,
         "requested": "wildcard_engine",
@@ -44913,7 +45573,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -44928,7 +45588,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_SEQUENTIAL",
         "kind": "static_from",
-        "line": 1097,
+        "line": 1107,
         "name": "WILDCARD_MODE_SEQUENTIAL",
         "optional": false,
         "requested": "wildcard_engine",
@@ -44947,7 +45607,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -44962,7 +45622,7 @@
         "conditional": true,
         "imported": "wildcard_engine:expand_wildcard_texts",
         "kind": "static_from",
-        "line": 1097,
+        "line": 1107,
         "name": "expand_wildcard_texts",
         "optional": false,
         "requested": "wildcard_engine",
@@ -44981,7 +45641,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -44996,7 +45656,7 @@
         "conditional": true,
         "imported": "wildcard_engine:expand_wildcards",
         "kind": "static_from",
-        "line": 1097,
+        "line": 1107,
         "name": "expand_wildcards",
         "optional": false,
         "requested": "wildcard_engine",
@@ -45015,7 +45675,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -45030,7 +45690,7 @@
         "conditional": true,
         "imported": "wildcard_engine:has_wildcard_syntax",
         "kind": "static_from",
-        "line": 1097,
+        "line": 1107,
         "name": "has_wildcard_syntax",
         "optional": false,
         "requested": "wildcard_engine",
@@ -45049,7 +45709,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -45064,7 +45724,7 @@
         "conditional": true,
         "imported": "wildcard_engine:next_seed",
         "kind": "static_from",
-        "line": 1097,
+        "line": 1107,
         "name": "next_seed",
         "optional": false,
         "requested": "wildcard_engine",
@@ -45083,7 +45743,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -45098,7 +45758,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_prompt_studio_wildcard_mode",
         "kind": "static_from",
-        "line": 1097,
+        "line": 1107,
         "name": "normalize_prompt_studio_wildcard_mode",
         "optional": false,
         "requested": "wildcard_engine",
@@ -45117,7 +45777,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -45132,7 +45792,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_seed",
         "kind": "static_from",
-        "line": 1097,
+        "line": 1107,
         "name": "normalize_seed",
         "optional": false,
         "requested": "wildcard_engine",
@@ -45151,7 +45811,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -45166,7 +45826,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_wildcard_mode",
         "kind": "static_from",
-        "line": 1097,
+        "line": 1107,
         "name": "normalize_wildcard_mode",
         "optional": false,
         "requested": "wildcard_engine",
@@ -45185,7 +45845,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -45200,7 +45860,7 @@
         "conditional": true,
         "imported": "wildcard_engine:wildcard_sources_signature",
         "kind": "static_from",
-        "line": 1097,
+        "line": 1107,
         "name": "wildcard_sources_signature",
         "optional": false,
         "requested": "wildcard_engine",
@@ -45218,7 +45878,7 @@
         "conditional": false,
         "imported": "__future__:annotations",
         "kind": "static_from",
-        "line": 1,
+        "line": 3,
         "name": "annotations",
         "optional": false,
         "requested": "__future__",
@@ -45228,164 +45888,2343 @@
       },
       {
         "alias": null,
-        "bound_name": "html",
-        "branch_context": [],
-        "classification": "external",
-        "column": 0,
-        "conditional": false,
-        "imported": "html",
-        "kind": "static_import",
-        "line": 3,
-        "name": null,
-        "optional": false,
-        "requested": "html",
-        "role": "ordinary",
-        "scope": "<module>",
-        "source": "prompt_translation.py"
-      },
-      {
-        "alias": null,
-        "bound_name": "threading",
-        "branch_context": [],
-        "classification": "external",
-        "column": 0,
-        "conditional": false,
-        "imported": "threading",
-        "kind": "static_import",
-        "line": 4,
-        "name": null,
-        "optional": false,
-        "requested": "threading",
-        "role": "ordinary",
-        "scope": "<module>",
-        "source": "prompt_translation.py"
-      },
-      {
-        "alias": null,
-        "bound_name": "time",
-        "branch_context": [],
-        "classification": "external",
-        "column": 0,
-        "conditional": false,
-        "imported": "time",
-        "kind": "static_import",
-        "line": 5,
-        "name": null,
-        "optional": false,
-        "requested": "time",
-        "role": "ordinary",
-        "scope": "<module>",
-        "source": "prompt_translation.py"
-      },
-      {
-        "alias": null,
-        "bound_name": "OrderedDict",
-        "branch_context": [],
-        "classification": "external",
-        "column": 0,
-        "conditional": false,
-        "imported": "collections:OrderedDict",
-        "kind": "static_from",
-        "line": 6,
-        "name": "OrderedDict",
-        "optional": false,
-        "requested": "collections",
-        "role": "ordinary",
-        "scope": "<module>",
-        "source": "prompt_translation.py"
-      },
-      {
-        "alias": null,
-        "bound_name": "contextmanager",
-        "branch_context": [],
-        "classification": "external",
-        "column": 0,
-        "conditional": false,
-        "imported": "contextlib:contextmanager",
-        "kind": "static_from",
-        "line": 7,
-        "name": "contextmanager",
-        "optional": false,
-        "requested": "contextlib",
-        "role": "ordinary",
-        "scope": "<module>",
-        "source": "prompt_translation.py"
-      },
-      {
-        "alias": null,
-        "bound_name": "dataclass",
-        "branch_context": [],
-        "classification": "external",
-        "column": 0,
-        "conditional": false,
-        "imported": "dataclasses:dataclass",
-        "kind": "static_from",
-        "line": 8,
-        "name": "dataclass",
-        "optional": false,
-        "requested": "dataclasses",
-        "role": "ordinary",
-        "scope": "<module>",
-        "source": "prompt_translation.py"
-      },
-      {
-        "alias": null,
-        "bound_name": "Callable",
-        "branch_context": [],
-        "classification": "external",
-        "column": 0,
-        "conditional": false,
-        "imported": "typing:Callable",
-        "kind": "static_from",
-        "line": 9,
-        "name": "Callable",
-        "optional": false,
-        "requested": "typing",
-        "role": "ordinary",
-        "scope": "<module>",
-        "source": "prompt_translation.py"
-      },
-      {
-        "alias": null,
-        "bound_name": "Protocol",
-        "branch_context": [],
-        "classification": "external",
-        "column": 0,
-        "conditional": false,
-        "imported": "typing:Protocol",
-        "kind": "static_from",
-        "line": 9,
-        "name": "Protocol",
-        "optional": false,
-        "requested": "typing",
-        "role": "ordinary",
-        "scope": "<module>",
-        "source": "prompt_translation.py"
-      },
-      {
-        "alias": null,
-        "bound_name": "Translator",
+        "bound_name": "DEFAULT_PROMPT_TRANSLATION_SOURCE",
         "branch_context": [
           {
             "branch": "body",
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 169
+            "line": 5
           }
         ],
-        "classification": "external",
-        "column": 12,
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "DEFAULT_PROMPT_TRANSLATION_SOURCE",
+          "target": "easyuse_anima/translation/contracts.py",
+          "try_line": 5
+        },
         "conditional": true,
-        "imported": "googletrans:Translator",
+        "imported": ".easyuse_anima.translation.contracts:DEFAULT_PROMPT_TRANSLATION_SOURCE",
         "kind": "static_from",
-        "line": 170,
-        "name": "Translator",
-        "optional": true,
-        "requested": "googletrans",
-        "role": "optional_dependency",
-        "scope": "GoogleTranslationProvider._create_translator",
-        "source": "prompt_translation.py"
+        "line": 6,
+        "name": "DEFAULT_PROMPT_TRANSLATION_SOURCE",
+        "optional": false,
+        "requested": ".easyuse_anima.translation.contracts",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "prompt_translation.py",
+        "target": "easyuse_anima/translation/contracts.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "DEFAULT_PROMPT_TRANSLATION_TARGET",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 5
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "DEFAULT_PROMPT_TRANSLATION_TARGET",
+          "target": "easyuse_anima/translation/contracts.py",
+          "try_line": 5
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.translation.contracts:DEFAULT_PROMPT_TRANSLATION_TARGET",
+        "kind": "static_from",
+        "line": 6,
+        "name": "DEFAULT_PROMPT_TRANSLATION_TARGET",
+        "optional": false,
+        "requested": ".easyuse_anima.translation.contracts",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "prompt_translation.py",
+        "target": "easyuse_anima/translation/contracts.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "MAX_PROMPT_TRANSLATION_MARKERS",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 5
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "MAX_PROMPT_TRANSLATION_MARKERS",
+          "target": "easyuse_anima/translation/contracts.py",
+          "try_line": 5
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.translation.contracts:MAX_PROMPT_TRANSLATION_MARKERS",
+        "kind": "static_from",
+        "line": 6,
+        "name": "MAX_PROMPT_TRANSLATION_MARKERS",
+        "optional": false,
+        "requested": ".easyuse_anima.translation.contracts",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "prompt_translation.py",
+        "target": "easyuse_anima/translation/contracts.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "MAX_PROMPT_TRANSLATION_MARKER_CHARACTERS",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 5
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "MAX_PROMPT_TRANSLATION_MARKER_CHARACTERS",
+          "target": "easyuse_anima/translation/contracts.py",
+          "try_line": 5
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.translation.contracts:MAX_PROMPT_TRANSLATION_MARKER_CHARACTERS",
+        "kind": "static_from",
+        "line": 6,
+        "name": "MAX_PROMPT_TRANSLATION_MARKER_CHARACTERS",
+        "optional": false,
+        "requested": ".easyuse_anima.translation.contracts",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "prompt_translation.py",
+        "target": "easyuse_anima/translation/contracts.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "MAX_PROMPT_TRANSLATION_TOTAL_CHARACTERS",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 5
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "MAX_PROMPT_TRANSLATION_TOTAL_CHARACTERS",
+          "target": "easyuse_anima/translation/contracts.py",
+          "try_line": 5
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.translation.contracts:MAX_PROMPT_TRANSLATION_TOTAL_CHARACTERS",
+        "kind": "static_from",
+        "line": 6,
+        "name": "MAX_PROMPT_TRANSLATION_TOTAL_CHARACTERS",
+        "optional": false,
+        "requested": ".easyuse_anima.translation.contracts",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "prompt_translation.py",
+        "target": "easyuse_anima/translation/contracts.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "PROMPT_TRANSLATION_CACHE_MAX_ENTRIES",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 5
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "PROMPT_TRANSLATION_CACHE_MAX_ENTRIES",
+          "target": "easyuse_anima/translation/contracts.py",
+          "try_line": 5
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.translation.contracts:PROMPT_TRANSLATION_CACHE_MAX_ENTRIES",
+        "kind": "static_from",
+        "line": 6,
+        "name": "PROMPT_TRANSLATION_CACHE_MAX_ENTRIES",
+        "optional": false,
+        "requested": ".easyuse_anima.translation.contracts",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "prompt_translation.py",
+        "target": "easyuse_anima/translation/contracts.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "PROMPT_TRANSLATION_CACHE_TTL_SECONDS",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 5
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "PROMPT_TRANSLATION_CACHE_TTL_SECONDS",
+          "target": "easyuse_anima/translation/contracts.py",
+          "try_line": 5
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.translation.contracts:PROMPT_TRANSLATION_CACHE_TTL_SECONDS",
+        "kind": "static_from",
+        "line": 6,
+        "name": "PROMPT_TRANSLATION_CACHE_TTL_SECONDS",
+        "optional": false,
+        "requested": ".easyuse_anima.translation.contracts",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "prompt_translation.py",
+        "target": "easyuse_anima/translation/contracts.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "PROMPT_TRANSLATION_PROVIDERS",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 5
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "PROMPT_TRANSLATION_PROVIDERS",
+          "target": "easyuse_anima/translation/contracts.py",
+          "try_line": 5
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.translation.contracts:PROMPT_TRANSLATION_PROVIDERS",
+        "kind": "static_from",
+        "line": 6,
+        "name": "PROMPT_TRANSLATION_PROVIDERS",
+        "optional": false,
+        "requested": ".easyuse_anima.translation.contracts",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "prompt_translation.py",
+        "target": "easyuse_anima/translation/contracts.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "PROMPT_TRANSLATION_PROVIDER_GOOGLE",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 5
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "PROMPT_TRANSLATION_PROVIDER_GOOGLE",
+          "target": "easyuse_anima/translation/contracts.py",
+          "try_line": 5
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.translation.contracts:PROMPT_TRANSLATION_PROVIDER_GOOGLE",
+        "kind": "static_from",
+        "line": 6,
+        "name": "PROMPT_TRANSLATION_PROVIDER_GOOGLE",
+        "optional": false,
+        "requested": ".easyuse_anima.translation.contracts",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "prompt_translation.py",
+        "target": "easyuse_anima/translation/contracts.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "PROMPT_TRANSLATION_PROVIDER_OFF",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 5
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "PROMPT_TRANSLATION_PROVIDER_OFF",
+          "target": "easyuse_anima/translation/contracts.py",
+          "try_line": 5
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.translation.contracts:PROMPT_TRANSLATION_PROVIDER_OFF",
+        "kind": "static_from",
+        "line": 6,
+        "name": "PROMPT_TRANSLATION_PROVIDER_OFF",
+        "optional": false,
+        "requested": ".easyuse_anima.translation.contracts",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "prompt_translation.py",
+        "target": "easyuse_anima/translation/contracts.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "PROMPT_TRANSLATION_PROVIDER_TIMEOUT_SECONDS",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 5
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "PROMPT_TRANSLATION_PROVIDER_TIMEOUT_SECONDS",
+          "target": "easyuse_anima/translation/contracts.py",
+          "try_line": 5
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.translation.contracts:PROMPT_TRANSLATION_PROVIDER_TIMEOUT_SECONDS",
+        "kind": "static_from",
+        "line": 6,
+        "name": "PROMPT_TRANSLATION_PROVIDER_TIMEOUT_SECONDS",
+        "optional": false,
+        "requested": ".easyuse_anima.translation.contracts",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "prompt_translation.py",
+        "target": "easyuse_anima/translation/contracts.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "PromptTranslationError",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 5
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "PromptTranslationError",
+          "target": "easyuse_anima/translation/contracts.py",
+          "try_line": 5
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.translation.contracts:PromptTranslationError",
+        "kind": "static_from",
+        "line": 6,
+        "name": "PromptTranslationError",
+        "optional": false,
+        "requested": ".easyuse_anima.translation.contracts",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "prompt_translation.py",
+        "target": "easyuse_anima/translation/contracts.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "PromptTranslationLimitError",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 5
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "PromptTranslationLimitError",
+          "target": "easyuse_anima/translation/contracts.py",
+          "try_line": 5
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.translation.contracts:PromptTranslationLimitError",
+        "kind": "static_from",
+        "line": 6,
+        "name": "PromptTranslationLimitError",
+        "optional": false,
+        "requested": ".easyuse_anima.translation.contracts",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "prompt_translation.py",
+        "target": "easyuse_anima/translation/contracts.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "PromptTranslationSettings",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 5
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "PromptTranslationSettings",
+          "target": "easyuse_anima/translation/contracts.py",
+          "try_line": 5
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.translation.contracts:PromptTranslationSettings",
+        "kind": "static_from",
+        "line": 6,
+        "name": "PromptTranslationSettings",
+        "optional": false,
+        "requested": ".easyuse_anima.translation.contracts",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "prompt_translation.py",
+        "target": "easyuse_anima/translation/contracts.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "TranslationBusyError",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 5
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "TranslationBusyError",
+          "target": "easyuse_anima/translation/contracts.py",
+          "try_line": 5
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.translation.contracts:TranslationBusyError",
+        "kind": "static_from",
+        "line": 6,
+        "name": "TranslationBusyError",
+        "optional": false,
+        "requested": ".easyuse_anima.translation.contracts",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "prompt_translation.py",
+        "target": "easyuse_anima/translation/contracts.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "TranslationCacheKey",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 5
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "TranslationCacheKey",
+          "target": "easyuse_anima/translation/contracts.py",
+          "try_line": 5
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.translation.contracts:TranslationCacheKey",
+        "kind": "static_from",
+        "line": 6,
+        "name": "TranslationCacheKey",
+        "optional": false,
+        "requested": ".easyuse_anima.translation.contracts",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "prompt_translation.py",
+        "target": "easyuse_anima/translation/contracts.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "TranslationCancelledError",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 5
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "TranslationCancelledError",
+          "target": "easyuse_anima/translation/contracts.py",
+          "try_line": 5
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.translation.contracts:TranslationCancelledError",
+        "kind": "static_from",
+        "line": 6,
+        "name": "TranslationCancelledError",
+        "optional": false,
+        "requested": ".easyuse_anima.translation.contracts",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "prompt_translation.py",
+        "target": "easyuse_anima/translation/contracts.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "TranslationMarkerCountError",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 5
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "TranslationMarkerCountError",
+          "target": "easyuse_anima/translation/contracts.py",
+          "try_line": 5
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.translation.contracts:TranslationMarkerCountError",
+        "kind": "static_from",
+        "line": 6,
+        "name": "TranslationMarkerCountError",
+        "optional": false,
+        "requested": ".easyuse_anima.translation.contracts",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "prompt_translation.py",
+        "target": "easyuse_anima/translation/contracts.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "TranslationMarkerSizeError",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 5
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "TranslationMarkerSizeError",
+          "target": "easyuse_anima/translation/contracts.py",
+          "try_line": 5
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.translation.contracts:TranslationMarkerSizeError",
+        "kind": "static_from",
+        "line": 6,
+        "name": "TranslationMarkerSizeError",
+        "optional": false,
+        "requested": ".easyuse_anima.translation.contracts",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "prompt_translation.py",
+        "target": "easyuse_anima/translation/contracts.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "TranslationProvider",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 5
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "TranslationProvider",
+          "target": "easyuse_anima/translation/contracts.py",
+          "try_line": 5
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.translation.contracts:TranslationProvider",
+        "kind": "static_from",
+        "line": 6,
+        "name": "TranslationProvider",
+        "optional": false,
+        "requested": ".easyuse_anima.translation.contracts",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "prompt_translation.py",
+        "target": "easyuse_anima/translation/contracts.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "TranslationProviderUnavailableError",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 5
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "TranslationProviderUnavailableError",
+          "target": "easyuse_anima/translation/contracts.py",
+          "try_line": 5
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.translation.contracts:TranslationProviderUnavailableError",
+        "kind": "static_from",
+        "line": 6,
+        "name": "TranslationProviderUnavailableError",
+        "optional": false,
+        "requested": ".easyuse_anima.translation.contracts",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "prompt_translation.py",
+        "target": "easyuse_anima/translation/contracts.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "TranslationTimeoutError",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 5
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "TranslationTimeoutError",
+          "target": "easyuse_anima/translation/contracts.py",
+          "try_line": 5
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.translation.contracts:TranslationTimeoutError",
+        "kind": "static_from",
+        "line": 6,
+        "name": "TranslationTimeoutError",
+        "optional": false,
+        "requested": ".easyuse_anima.translation.contracts",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "prompt_translation.py",
+        "target": "easyuse_anima/translation/contracts.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "TranslationTotalSizeError",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 5
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "TranslationTotalSizeError",
+          "target": "easyuse_anima/translation/contracts.py",
+          "try_line": 5
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.translation.contracts:TranslationTotalSizeError",
+        "kind": "static_from",
+        "line": 6,
+        "name": "TranslationTotalSizeError",
+        "optional": false,
+        "requested": ".easyuse_anima.translation.contracts",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "prompt_translation.py",
+        "target": "easyuse_anima/translation/contracts.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "TranslationUpstreamError",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 5
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "TranslationUpstreamError",
+          "target": "easyuse_anima/translation/contracts.py",
+          "try_line": 5
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.translation.contracts:TranslationUpstreamError",
+        "kind": "static_from",
+        "line": 6,
+        "name": "TranslationUpstreamError",
+        "optional": false,
+        "requested": ".easyuse_anima.translation.contracts",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "prompt_translation.py",
+        "target": "easyuse_anima/translation/contracts.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "normalize_prompt_translation_language",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 5
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "normalize_prompt_translation_language",
+          "target": "easyuse_anima/translation/contracts.py",
+          "try_line": 5
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.translation.contracts:normalize_prompt_translation_language",
+        "kind": "static_from",
+        "line": 6,
+        "name": "normalize_prompt_translation_language",
+        "optional": false,
+        "requested": ".easyuse_anima.translation.contracts",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "prompt_translation.py",
+        "target": "easyuse_anima/translation/contracts.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "normalize_prompt_translation_provider",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 5
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "normalize_prompt_translation_provider",
+          "target": "easyuse_anima/translation/contracts.py",
+          "try_line": 5
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.translation.contracts:normalize_prompt_translation_provider",
+        "kind": "static_from",
+        "line": 6,
+        "name": "normalize_prompt_translation_provider",
+        "optional": false,
+        "requested": ".easyuse_anima.translation.contracts",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "prompt_translation.py",
+        "target": "easyuse_anima/translation/contracts.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "PROMPT_TRANSLATION_MARKER_LABEL",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 5
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "PROMPT_TRANSLATION_MARKER_LABEL",
+          "target": "easyuse_anima/translation/markers.py",
+          "try_line": 5
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.translation.markers:PROMPT_TRANSLATION_MARKER_LABEL",
+        "kind": "static_from",
+        "line": 34,
+        "name": "PROMPT_TRANSLATION_MARKER_LABEL",
+        "optional": false,
+        "requested": ".easyuse_anima.translation.markers",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "prompt_translation.py",
+        "target": "easyuse_anima/translation/markers.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "has_prompt_translation_markers",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 5
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "has_prompt_translation_markers",
+          "target": "easyuse_anima/translation/markers.py",
+          "try_line": 5
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.translation.markers:has_prompt_translation_markers",
+        "kind": "static_from",
+        "line": 34,
+        "name": "has_prompt_translation_markers",
+        "optional": false,
+        "requested": ".easyuse_anima.translation.markers",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "prompt_translation.py",
+        "target": "easyuse_anima/translation/markers.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "iter_prompt_translation_markers",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 5
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "iter_prompt_translation_markers",
+          "target": "easyuse_anima/translation/markers.py",
+          "try_line": 5
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.translation.markers:iter_prompt_translation_markers",
+        "kind": "static_from",
+        "line": 34,
+        "name": "iter_prompt_translation_markers",
+        "optional": false,
+        "requested": ".easyuse_anima.translation.markers",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "prompt_translation.py",
+        "target": "easyuse_anima/translation/markers.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "GoogleTranslationProvider",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 5
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "GoogleTranslationProvider",
+          "target": "easyuse_anima/translation/providers/google.py",
+          "try_line": 5
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.translation.providers.google:GoogleTranslationProvider",
+        "kind": "static_from",
+        "line": 39,
+        "name": "GoogleTranslationProvider",
+        "optional": false,
+        "requested": ".easyuse_anima.translation.providers.google",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "prompt_translation.py",
+        "target": "easyuse_anima/translation/providers/google.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "BoundedTranslationCache",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 5
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "BoundedTranslationCache",
+          "target": "easyuse_anima/translation/service.py",
+          "try_line": 5
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.translation.service:BoundedTranslationCache",
+        "kind": "static_from",
+        "line": 42,
+        "name": "BoundedTranslationCache",
+        "optional": false,
+        "requested": ".easyuse_anima.translation.service",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "prompt_translation.py",
+        "target": "easyuse_anima/translation/service.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "PromptTranslationService",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 5
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "PromptTranslationService",
+          "target": "easyuse_anima/translation/service.py",
+          "try_line": 5
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.translation.service:PromptTranslationService",
+        "kind": "static_from",
+        "line": 42,
+        "name": "PromptTranslationService",
+        "optional": false,
+        "requested": ".easyuse_anima.translation.service",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "prompt_translation.py",
+        "target": "easyuse_anima/translation/service.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "get_translation_provider",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 5
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "get_translation_provider",
+          "target": "easyuse_anima/translation/service.py",
+          "try_line": 5
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.translation.service:get_translation_provider",
+        "kind": "static_from",
+        "line": 42,
+        "name": "get_translation_provider",
+        "optional": false,
+        "requested": ".easyuse_anima.translation.service",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "prompt_translation.py",
+        "target": "easyuse_anima/translation/service.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "google_translate_text",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 5
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "google_translate_text",
+          "target": "easyuse_anima/translation/service.py",
+          "try_line": 5
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.translation.service:google_translate_text",
+        "kind": "static_from",
+        "line": 42,
+        "name": "google_translate_text",
+        "optional": false,
+        "requested": ".easyuse_anima.translation.service",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "prompt_translation.py",
+        "target": "easyuse_anima/translation/service.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "strip_prompt_translation_markers",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 5
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "strip_prompt_translation_markers",
+          "target": "easyuse_anima/translation/service.py",
+          "try_line": 5
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.translation.service:strip_prompt_translation_markers",
+        "kind": "static_from",
+        "line": 42,
+        "name": "strip_prompt_translation_markers",
+        "optional": false,
+        "requested": ".easyuse_anima.translation.service",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "prompt_translation.py",
+        "target": "easyuse_anima/translation/service.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "translate_prompt_markers",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 5
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "translate_prompt_markers",
+          "target": "easyuse_anima/translation/service.py",
+          "try_line": 5
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.translation.service:translate_prompt_markers",
+        "kind": "static_from",
+        "line": 42,
+        "name": "translate_prompt_markers",
+        "optional": false,
+        "requested": ".easyuse_anima.translation.service",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "prompt_translation.py",
+        "target": "easyuse_anima/translation/service.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "DEFAULT_PROMPT_TRANSLATION_SOURCE",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 50,
+            "kind": "try",
+            "line": 5
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "DEFAULT_PROMPT_TRANSLATION_SOURCE",
+          "target": "easyuse_anima/translation/contracts.py",
+          "try_line": 5
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.translation.contracts:DEFAULT_PROMPT_TRANSLATION_SOURCE",
+        "kind": "static_from",
+        "line": 51,
+        "name": "DEFAULT_PROMPT_TRANSLATION_SOURCE",
+        "optional": false,
+        "requested": "easyuse_anima.translation.contracts",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "prompt_translation.py",
+        "target": "easyuse_anima/translation/contracts.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "DEFAULT_PROMPT_TRANSLATION_TARGET",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 50,
+            "kind": "try",
+            "line": 5
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "DEFAULT_PROMPT_TRANSLATION_TARGET",
+          "target": "easyuse_anima/translation/contracts.py",
+          "try_line": 5
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.translation.contracts:DEFAULT_PROMPT_TRANSLATION_TARGET",
+        "kind": "static_from",
+        "line": 51,
+        "name": "DEFAULT_PROMPT_TRANSLATION_TARGET",
+        "optional": false,
+        "requested": "easyuse_anima.translation.contracts",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "prompt_translation.py",
+        "target": "easyuse_anima/translation/contracts.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "MAX_PROMPT_TRANSLATION_MARKERS",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 50,
+            "kind": "try",
+            "line": 5
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "MAX_PROMPT_TRANSLATION_MARKERS",
+          "target": "easyuse_anima/translation/contracts.py",
+          "try_line": 5
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.translation.contracts:MAX_PROMPT_TRANSLATION_MARKERS",
+        "kind": "static_from",
+        "line": 51,
+        "name": "MAX_PROMPT_TRANSLATION_MARKERS",
+        "optional": false,
+        "requested": "easyuse_anima.translation.contracts",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "prompt_translation.py",
+        "target": "easyuse_anima/translation/contracts.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "MAX_PROMPT_TRANSLATION_MARKER_CHARACTERS",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 50,
+            "kind": "try",
+            "line": 5
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "MAX_PROMPT_TRANSLATION_MARKER_CHARACTERS",
+          "target": "easyuse_anima/translation/contracts.py",
+          "try_line": 5
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.translation.contracts:MAX_PROMPT_TRANSLATION_MARKER_CHARACTERS",
+        "kind": "static_from",
+        "line": 51,
+        "name": "MAX_PROMPT_TRANSLATION_MARKER_CHARACTERS",
+        "optional": false,
+        "requested": "easyuse_anima.translation.contracts",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "prompt_translation.py",
+        "target": "easyuse_anima/translation/contracts.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "MAX_PROMPT_TRANSLATION_TOTAL_CHARACTERS",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 50,
+            "kind": "try",
+            "line": 5
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "MAX_PROMPT_TRANSLATION_TOTAL_CHARACTERS",
+          "target": "easyuse_anima/translation/contracts.py",
+          "try_line": 5
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.translation.contracts:MAX_PROMPT_TRANSLATION_TOTAL_CHARACTERS",
+        "kind": "static_from",
+        "line": 51,
+        "name": "MAX_PROMPT_TRANSLATION_TOTAL_CHARACTERS",
+        "optional": false,
+        "requested": "easyuse_anima.translation.contracts",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "prompt_translation.py",
+        "target": "easyuse_anima/translation/contracts.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "PROMPT_TRANSLATION_CACHE_MAX_ENTRIES",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 50,
+            "kind": "try",
+            "line": 5
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "PROMPT_TRANSLATION_CACHE_MAX_ENTRIES",
+          "target": "easyuse_anima/translation/contracts.py",
+          "try_line": 5
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.translation.contracts:PROMPT_TRANSLATION_CACHE_MAX_ENTRIES",
+        "kind": "static_from",
+        "line": 51,
+        "name": "PROMPT_TRANSLATION_CACHE_MAX_ENTRIES",
+        "optional": false,
+        "requested": "easyuse_anima.translation.contracts",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "prompt_translation.py",
+        "target": "easyuse_anima/translation/contracts.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "PROMPT_TRANSLATION_CACHE_TTL_SECONDS",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 50,
+            "kind": "try",
+            "line": 5
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "PROMPT_TRANSLATION_CACHE_TTL_SECONDS",
+          "target": "easyuse_anima/translation/contracts.py",
+          "try_line": 5
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.translation.contracts:PROMPT_TRANSLATION_CACHE_TTL_SECONDS",
+        "kind": "static_from",
+        "line": 51,
+        "name": "PROMPT_TRANSLATION_CACHE_TTL_SECONDS",
+        "optional": false,
+        "requested": "easyuse_anima.translation.contracts",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "prompt_translation.py",
+        "target": "easyuse_anima/translation/contracts.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "PROMPT_TRANSLATION_PROVIDERS",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 50,
+            "kind": "try",
+            "line": 5
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "PROMPT_TRANSLATION_PROVIDERS",
+          "target": "easyuse_anima/translation/contracts.py",
+          "try_line": 5
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.translation.contracts:PROMPT_TRANSLATION_PROVIDERS",
+        "kind": "static_from",
+        "line": 51,
+        "name": "PROMPT_TRANSLATION_PROVIDERS",
+        "optional": false,
+        "requested": "easyuse_anima.translation.contracts",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "prompt_translation.py",
+        "target": "easyuse_anima/translation/contracts.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "PROMPT_TRANSLATION_PROVIDER_GOOGLE",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 50,
+            "kind": "try",
+            "line": 5
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "PROMPT_TRANSLATION_PROVIDER_GOOGLE",
+          "target": "easyuse_anima/translation/contracts.py",
+          "try_line": 5
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.translation.contracts:PROMPT_TRANSLATION_PROVIDER_GOOGLE",
+        "kind": "static_from",
+        "line": 51,
+        "name": "PROMPT_TRANSLATION_PROVIDER_GOOGLE",
+        "optional": false,
+        "requested": "easyuse_anima.translation.contracts",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "prompt_translation.py",
+        "target": "easyuse_anima/translation/contracts.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "PROMPT_TRANSLATION_PROVIDER_OFF",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 50,
+            "kind": "try",
+            "line": 5
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "PROMPT_TRANSLATION_PROVIDER_OFF",
+          "target": "easyuse_anima/translation/contracts.py",
+          "try_line": 5
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.translation.contracts:PROMPT_TRANSLATION_PROVIDER_OFF",
+        "kind": "static_from",
+        "line": 51,
+        "name": "PROMPT_TRANSLATION_PROVIDER_OFF",
+        "optional": false,
+        "requested": "easyuse_anima.translation.contracts",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "prompt_translation.py",
+        "target": "easyuse_anima/translation/contracts.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "PROMPT_TRANSLATION_PROVIDER_TIMEOUT_SECONDS",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 50,
+            "kind": "try",
+            "line": 5
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "PROMPT_TRANSLATION_PROVIDER_TIMEOUT_SECONDS",
+          "target": "easyuse_anima/translation/contracts.py",
+          "try_line": 5
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.translation.contracts:PROMPT_TRANSLATION_PROVIDER_TIMEOUT_SECONDS",
+        "kind": "static_from",
+        "line": 51,
+        "name": "PROMPT_TRANSLATION_PROVIDER_TIMEOUT_SECONDS",
+        "optional": false,
+        "requested": "easyuse_anima.translation.contracts",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "prompt_translation.py",
+        "target": "easyuse_anima/translation/contracts.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "PromptTranslationError",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 50,
+            "kind": "try",
+            "line": 5
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "PromptTranslationError",
+          "target": "easyuse_anima/translation/contracts.py",
+          "try_line": 5
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.translation.contracts:PromptTranslationError",
+        "kind": "static_from",
+        "line": 51,
+        "name": "PromptTranslationError",
+        "optional": false,
+        "requested": "easyuse_anima.translation.contracts",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "prompt_translation.py",
+        "target": "easyuse_anima/translation/contracts.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "PromptTranslationLimitError",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 50,
+            "kind": "try",
+            "line": 5
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "PromptTranslationLimitError",
+          "target": "easyuse_anima/translation/contracts.py",
+          "try_line": 5
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.translation.contracts:PromptTranslationLimitError",
+        "kind": "static_from",
+        "line": 51,
+        "name": "PromptTranslationLimitError",
+        "optional": false,
+        "requested": "easyuse_anima.translation.contracts",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "prompt_translation.py",
+        "target": "easyuse_anima/translation/contracts.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "PromptTranslationSettings",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 50,
+            "kind": "try",
+            "line": 5
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "PromptTranslationSettings",
+          "target": "easyuse_anima/translation/contracts.py",
+          "try_line": 5
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.translation.contracts:PromptTranslationSettings",
+        "kind": "static_from",
+        "line": 51,
+        "name": "PromptTranslationSettings",
+        "optional": false,
+        "requested": "easyuse_anima.translation.contracts",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "prompt_translation.py",
+        "target": "easyuse_anima/translation/contracts.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "TranslationBusyError",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 50,
+            "kind": "try",
+            "line": 5
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "TranslationBusyError",
+          "target": "easyuse_anima/translation/contracts.py",
+          "try_line": 5
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.translation.contracts:TranslationBusyError",
+        "kind": "static_from",
+        "line": 51,
+        "name": "TranslationBusyError",
+        "optional": false,
+        "requested": "easyuse_anima.translation.contracts",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "prompt_translation.py",
+        "target": "easyuse_anima/translation/contracts.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "TranslationCacheKey",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 50,
+            "kind": "try",
+            "line": 5
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "TranslationCacheKey",
+          "target": "easyuse_anima/translation/contracts.py",
+          "try_line": 5
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.translation.contracts:TranslationCacheKey",
+        "kind": "static_from",
+        "line": 51,
+        "name": "TranslationCacheKey",
+        "optional": false,
+        "requested": "easyuse_anima.translation.contracts",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "prompt_translation.py",
+        "target": "easyuse_anima/translation/contracts.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "TranslationCancelledError",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 50,
+            "kind": "try",
+            "line": 5
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "TranslationCancelledError",
+          "target": "easyuse_anima/translation/contracts.py",
+          "try_line": 5
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.translation.contracts:TranslationCancelledError",
+        "kind": "static_from",
+        "line": 51,
+        "name": "TranslationCancelledError",
+        "optional": false,
+        "requested": "easyuse_anima.translation.contracts",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "prompt_translation.py",
+        "target": "easyuse_anima/translation/contracts.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "TranslationMarkerCountError",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 50,
+            "kind": "try",
+            "line": 5
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "TranslationMarkerCountError",
+          "target": "easyuse_anima/translation/contracts.py",
+          "try_line": 5
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.translation.contracts:TranslationMarkerCountError",
+        "kind": "static_from",
+        "line": 51,
+        "name": "TranslationMarkerCountError",
+        "optional": false,
+        "requested": "easyuse_anima.translation.contracts",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "prompt_translation.py",
+        "target": "easyuse_anima/translation/contracts.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "TranslationMarkerSizeError",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 50,
+            "kind": "try",
+            "line": 5
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "TranslationMarkerSizeError",
+          "target": "easyuse_anima/translation/contracts.py",
+          "try_line": 5
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.translation.contracts:TranslationMarkerSizeError",
+        "kind": "static_from",
+        "line": 51,
+        "name": "TranslationMarkerSizeError",
+        "optional": false,
+        "requested": "easyuse_anima.translation.contracts",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "prompt_translation.py",
+        "target": "easyuse_anima/translation/contracts.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "TranslationProvider",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 50,
+            "kind": "try",
+            "line": 5
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "TranslationProvider",
+          "target": "easyuse_anima/translation/contracts.py",
+          "try_line": 5
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.translation.contracts:TranslationProvider",
+        "kind": "static_from",
+        "line": 51,
+        "name": "TranslationProvider",
+        "optional": false,
+        "requested": "easyuse_anima.translation.contracts",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "prompt_translation.py",
+        "target": "easyuse_anima/translation/contracts.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "TranslationProviderUnavailableError",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 50,
+            "kind": "try",
+            "line": 5
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "TranslationProviderUnavailableError",
+          "target": "easyuse_anima/translation/contracts.py",
+          "try_line": 5
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.translation.contracts:TranslationProviderUnavailableError",
+        "kind": "static_from",
+        "line": 51,
+        "name": "TranslationProviderUnavailableError",
+        "optional": false,
+        "requested": "easyuse_anima.translation.contracts",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "prompt_translation.py",
+        "target": "easyuse_anima/translation/contracts.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "TranslationTimeoutError",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 50,
+            "kind": "try",
+            "line": 5
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "TranslationTimeoutError",
+          "target": "easyuse_anima/translation/contracts.py",
+          "try_line": 5
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.translation.contracts:TranslationTimeoutError",
+        "kind": "static_from",
+        "line": 51,
+        "name": "TranslationTimeoutError",
+        "optional": false,
+        "requested": "easyuse_anima.translation.contracts",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "prompt_translation.py",
+        "target": "easyuse_anima/translation/contracts.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "TranslationTotalSizeError",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 50,
+            "kind": "try",
+            "line": 5
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "TranslationTotalSizeError",
+          "target": "easyuse_anima/translation/contracts.py",
+          "try_line": 5
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.translation.contracts:TranslationTotalSizeError",
+        "kind": "static_from",
+        "line": 51,
+        "name": "TranslationTotalSizeError",
+        "optional": false,
+        "requested": "easyuse_anima.translation.contracts",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "prompt_translation.py",
+        "target": "easyuse_anima/translation/contracts.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "TranslationUpstreamError",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 50,
+            "kind": "try",
+            "line": 5
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "TranslationUpstreamError",
+          "target": "easyuse_anima/translation/contracts.py",
+          "try_line": 5
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.translation.contracts:TranslationUpstreamError",
+        "kind": "static_from",
+        "line": 51,
+        "name": "TranslationUpstreamError",
+        "optional": false,
+        "requested": "easyuse_anima.translation.contracts",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "prompt_translation.py",
+        "target": "easyuse_anima/translation/contracts.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "normalize_prompt_translation_language",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 50,
+            "kind": "try",
+            "line": 5
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "normalize_prompt_translation_language",
+          "target": "easyuse_anima/translation/contracts.py",
+          "try_line": 5
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.translation.contracts:normalize_prompt_translation_language",
+        "kind": "static_from",
+        "line": 51,
+        "name": "normalize_prompt_translation_language",
+        "optional": false,
+        "requested": "easyuse_anima.translation.contracts",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "prompt_translation.py",
+        "target": "easyuse_anima/translation/contracts.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "normalize_prompt_translation_provider",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 50,
+            "kind": "try",
+            "line": 5
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "normalize_prompt_translation_provider",
+          "target": "easyuse_anima/translation/contracts.py",
+          "try_line": 5
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.translation.contracts:normalize_prompt_translation_provider",
+        "kind": "static_from",
+        "line": 51,
+        "name": "normalize_prompt_translation_provider",
+        "optional": false,
+        "requested": "easyuse_anima.translation.contracts",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "prompt_translation.py",
+        "target": "easyuse_anima/translation/contracts.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "PROMPT_TRANSLATION_MARKER_LABEL",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 50,
+            "kind": "try",
+            "line": 5
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "PROMPT_TRANSLATION_MARKER_LABEL",
+          "target": "easyuse_anima/translation/markers.py",
+          "try_line": 5
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.translation.markers:PROMPT_TRANSLATION_MARKER_LABEL",
+        "kind": "static_from",
+        "line": 79,
+        "name": "PROMPT_TRANSLATION_MARKER_LABEL",
+        "optional": false,
+        "requested": "easyuse_anima.translation.markers",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "prompt_translation.py",
+        "target": "easyuse_anima/translation/markers.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "has_prompt_translation_markers",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 50,
+            "kind": "try",
+            "line": 5
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "has_prompt_translation_markers",
+          "target": "easyuse_anima/translation/markers.py",
+          "try_line": 5
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.translation.markers:has_prompt_translation_markers",
+        "kind": "static_from",
+        "line": 79,
+        "name": "has_prompt_translation_markers",
+        "optional": false,
+        "requested": "easyuse_anima.translation.markers",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "prompt_translation.py",
+        "target": "easyuse_anima/translation/markers.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "iter_prompt_translation_markers",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 50,
+            "kind": "try",
+            "line": 5
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "iter_prompt_translation_markers",
+          "target": "easyuse_anima/translation/markers.py",
+          "try_line": 5
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.translation.markers:iter_prompt_translation_markers",
+        "kind": "static_from",
+        "line": 79,
+        "name": "iter_prompt_translation_markers",
+        "optional": false,
+        "requested": "easyuse_anima.translation.markers",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "prompt_translation.py",
+        "target": "easyuse_anima/translation/markers.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "GoogleTranslationProvider",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 50,
+            "kind": "try",
+            "line": 5
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "GoogleTranslationProvider",
+          "target": "easyuse_anima/translation/providers/google.py",
+          "try_line": 5
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.translation.providers.google:GoogleTranslationProvider",
+        "kind": "static_from",
+        "line": 84,
+        "name": "GoogleTranslationProvider",
+        "optional": false,
+        "requested": "easyuse_anima.translation.providers.google",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "prompt_translation.py",
+        "target": "easyuse_anima/translation/providers/google.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "BoundedTranslationCache",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 50,
+            "kind": "try",
+            "line": 5
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "BoundedTranslationCache",
+          "target": "easyuse_anima/translation/service.py",
+          "try_line": 5
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.translation.service:BoundedTranslationCache",
+        "kind": "static_from",
+        "line": 87,
+        "name": "BoundedTranslationCache",
+        "optional": false,
+        "requested": "easyuse_anima.translation.service",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "prompt_translation.py",
+        "target": "easyuse_anima/translation/service.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "PromptTranslationService",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 50,
+            "kind": "try",
+            "line": 5
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "PromptTranslationService",
+          "target": "easyuse_anima/translation/service.py",
+          "try_line": 5
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.translation.service:PromptTranslationService",
+        "kind": "static_from",
+        "line": 87,
+        "name": "PromptTranslationService",
+        "optional": false,
+        "requested": "easyuse_anima.translation.service",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "prompt_translation.py",
+        "target": "easyuse_anima/translation/service.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "get_translation_provider",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 50,
+            "kind": "try",
+            "line": 5
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "get_translation_provider",
+          "target": "easyuse_anima/translation/service.py",
+          "try_line": 5
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.translation.service:get_translation_provider",
+        "kind": "static_from",
+        "line": 87,
+        "name": "get_translation_provider",
+        "optional": false,
+        "requested": "easyuse_anima.translation.service",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "prompt_translation.py",
+        "target": "easyuse_anima/translation/service.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "google_translate_text",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 50,
+            "kind": "try",
+            "line": 5
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "google_translate_text",
+          "target": "easyuse_anima/translation/service.py",
+          "try_line": 5
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.translation.service:google_translate_text",
+        "kind": "static_from",
+        "line": 87,
+        "name": "google_translate_text",
+        "optional": false,
+        "requested": "easyuse_anima.translation.service",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "prompt_translation.py",
+        "target": "easyuse_anima/translation/service.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "strip_prompt_translation_markers",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 50,
+            "kind": "try",
+            "line": 5
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "strip_prompt_translation_markers",
+          "target": "easyuse_anima/translation/service.py",
+          "try_line": 5
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.translation.service:strip_prompt_translation_markers",
+        "kind": "static_from",
+        "line": 87,
+        "name": "strip_prompt_translation_markers",
+        "optional": false,
+        "requested": "easyuse_anima.translation.service",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "prompt_translation.py",
+        "target": "easyuse_anima/translation/service.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "translate_prompt_markers",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 50,
+            "kind": "try",
+            "line": 5
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "translate_prompt_markers",
+          "target": "easyuse_anima/translation/service.py",
+          "try_line": 5
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.translation.service:translate_prompt_markers",
+        "kind": "static_from",
+        "line": 87,
+        "name": "translate_prompt_markers",
+        "optional": false,
+        "requested": "easyuse_anima.translation.service",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "prompt_translation.py",
+        "target": "easyuse_anima/translation/service.py"
       },
       {
         "alias": null,
@@ -45516,20 +48355,20 @@
         "column": 4,
         "compatibility_pair": {
           "bound_name": "DEFAULT_PROMPT_TRANSLATION_SOURCE",
-          "target": "prompt_translation.py",
+          "target": "easyuse_anima/translation/contracts.py",
           "try_line": 6
         },
         "conditional": true,
-        "imported": ".prompt_translation:DEFAULT_PROMPT_TRANSLATION_SOURCE",
+        "imported": ".easyuse_anima.translation.contracts:DEFAULT_PROMPT_TRANSLATION_SOURCE",
         "kind": "static_from",
         "line": 8,
         "name": "DEFAULT_PROMPT_TRANSLATION_SOURCE",
         "optional": false,
-        "requested": ".prompt_translation",
+        "requested": ".easyuse_anima.translation.contracts",
         "role": "compatibility_primary",
         "scope": "<module>",
         "source": "settings.py",
-        "target": "prompt_translation.py"
+        "target": "easyuse_anima/translation/contracts.py"
       },
       {
         "alias": null,
@@ -45547,20 +48386,20 @@
         "column": 4,
         "compatibility_pair": {
           "bound_name": "DEFAULT_PROMPT_TRANSLATION_TARGET",
-          "target": "prompt_translation.py",
+          "target": "easyuse_anima/translation/contracts.py",
           "try_line": 6
         },
         "conditional": true,
-        "imported": ".prompt_translation:DEFAULT_PROMPT_TRANSLATION_TARGET",
+        "imported": ".easyuse_anima.translation.contracts:DEFAULT_PROMPT_TRANSLATION_TARGET",
         "kind": "static_from",
         "line": 8,
         "name": "DEFAULT_PROMPT_TRANSLATION_TARGET",
         "optional": false,
-        "requested": ".prompt_translation",
+        "requested": ".easyuse_anima.translation.contracts",
         "role": "compatibility_primary",
         "scope": "<module>",
         "source": "settings.py",
-        "target": "prompt_translation.py"
+        "target": "easyuse_anima/translation/contracts.py"
       },
       {
         "alias": null,
@@ -45578,20 +48417,20 @@
         "column": 4,
         "compatibility_pair": {
           "bound_name": "PROMPT_TRANSLATION_PROVIDER_OFF",
-          "target": "prompt_translation.py",
+          "target": "easyuse_anima/translation/contracts.py",
           "try_line": 6
         },
         "conditional": true,
-        "imported": ".prompt_translation:PROMPT_TRANSLATION_PROVIDER_OFF",
+        "imported": ".easyuse_anima.translation.contracts:PROMPT_TRANSLATION_PROVIDER_OFF",
         "kind": "static_from",
         "line": 8,
         "name": "PROMPT_TRANSLATION_PROVIDER_OFF",
         "optional": false,
-        "requested": ".prompt_translation",
+        "requested": ".easyuse_anima.translation.contracts",
         "role": "compatibility_primary",
         "scope": "<module>",
         "source": "settings.py",
-        "target": "prompt_translation.py"
+        "target": "easyuse_anima/translation/contracts.py"
       },
       {
         "alias": null,
@@ -45609,20 +48448,20 @@
         "column": 4,
         "compatibility_pair": {
           "bound_name": "PromptTranslationSettings",
-          "target": "prompt_translation.py",
+          "target": "easyuse_anima/translation/contracts.py",
           "try_line": 6
         },
         "conditional": true,
-        "imported": ".prompt_translation:PromptTranslationSettings",
+        "imported": ".easyuse_anima.translation.contracts:PromptTranslationSettings",
         "kind": "static_from",
         "line": 8,
         "name": "PromptTranslationSettings",
         "optional": false,
-        "requested": ".prompt_translation",
+        "requested": ".easyuse_anima.translation.contracts",
         "role": "compatibility_primary",
         "scope": "<module>",
         "source": "settings.py",
-        "target": "prompt_translation.py"
+        "target": "easyuse_anima/translation/contracts.py"
       },
       {
         "alias": null,
@@ -45640,20 +48479,20 @@
         "column": 4,
         "compatibility_pair": {
           "bound_name": "normalize_prompt_translation_language",
-          "target": "prompt_translation.py",
+          "target": "easyuse_anima/translation/contracts.py",
           "try_line": 6
         },
         "conditional": true,
-        "imported": ".prompt_translation:normalize_prompt_translation_language",
+        "imported": ".easyuse_anima.translation.contracts:normalize_prompt_translation_language",
         "kind": "static_from",
         "line": 8,
         "name": "normalize_prompt_translation_language",
         "optional": false,
-        "requested": ".prompt_translation",
+        "requested": ".easyuse_anima.translation.contracts",
         "role": "compatibility_primary",
         "scope": "<module>",
         "source": "settings.py",
-        "target": "prompt_translation.py"
+        "target": "easyuse_anima/translation/contracts.py"
       },
       {
         "alias": null,
@@ -45671,20 +48510,20 @@
         "column": 4,
         "compatibility_pair": {
           "bound_name": "normalize_prompt_translation_provider",
-          "target": "prompt_translation.py",
+          "target": "easyuse_anima/translation/contracts.py",
           "try_line": 6
         },
         "conditional": true,
-        "imported": ".prompt_translation:normalize_prompt_translation_provider",
+        "imported": ".easyuse_anima.translation.contracts:normalize_prompt_translation_provider",
         "kind": "static_from",
         "line": 8,
         "name": "normalize_prompt_translation_provider",
         "optional": false,
-        "requested": ".prompt_translation",
+        "requested": ".easyuse_anima.translation.contracts",
         "role": "compatibility_primary",
         "scope": "<module>",
         "source": "settings.py",
-        "target": "prompt_translation.py"
+        "target": "easyuse_anima/translation/contracts.py"
       },
       {
         "alias": null,
@@ -45773,20 +48612,20 @@
         "column": 4,
         "compatibility_pair": {
           "bound_name": "DEFAULT_PROMPT_TRANSLATION_SOURCE",
-          "target": "prompt_translation.py",
+          "target": "easyuse_anima/translation/contracts.py",
           "try_line": 6
         },
         "conditional": true,
-        "imported": "prompt_translation:DEFAULT_PROMPT_TRANSLATION_SOURCE",
+        "imported": "easyuse_anima.translation.contracts:DEFAULT_PROMPT_TRANSLATION_SOURCE",
         "kind": "static_from",
         "line": 18,
         "name": "DEFAULT_PROMPT_TRANSLATION_SOURCE",
         "optional": false,
-        "requested": "prompt_translation",
+        "requested": "easyuse_anima.translation.contracts",
         "role": "compatibility_fallback",
         "scope": "<module>",
         "source": "settings.py",
-        "target": "prompt_translation.py"
+        "target": "easyuse_anima/translation/contracts.py"
       },
       {
         "alias": null,
@@ -45807,20 +48646,20 @@
         "column": 4,
         "compatibility_pair": {
           "bound_name": "DEFAULT_PROMPT_TRANSLATION_TARGET",
-          "target": "prompt_translation.py",
+          "target": "easyuse_anima/translation/contracts.py",
           "try_line": 6
         },
         "conditional": true,
-        "imported": "prompt_translation:DEFAULT_PROMPT_TRANSLATION_TARGET",
+        "imported": "easyuse_anima.translation.contracts:DEFAULT_PROMPT_TRANSLATION_TARGET",
         "kind": "static_from",
         "line": 18,
         "name": "DEFAULT_PROMPT_TRANSLATION_TARGET",
         "optional": false,
-        "requested": "prompt_translation",
+        "requested": "easyuse_anima.translation.contracts",
         "role": "compatibility_fallback",
         "scope": "<module>",
         "source": "settings.py",
-        "target": "prompt_translation.py"
+        "target": "easyuse_anima/translation/contracts.py"
       },
       {
         "alias": null,
@@ -45841,20 +48680,20 @@
         "column": 4,
         "compatibility_pair": {
           "bound_name": "PROMPT_TRANSLATION_PROVIDER_OFF",
-          "target": "prompt_translation.py",
+          "target": "easyuse_anima/translation/contracts.py",
           "try_line": 6
         },
         "conditional": true,
-        "imported": "prompt_translation:PROMPT_TRANSLATION_PROVIDER_OFF",
+        "imported": "easyuse_anima.translation.contracts:PROMPT_TRANSLATION_PROVIDER_OFF",
         "kind": "static_from",
         "line": 18,
         "name": "PROMPT_TRANSLATION_PROVIDER_OFF",
         "optional": false,
-        "requested": "prompt_translation",
+        "requested": "easyuse_anima.translation.contracts",
         "role": "compatibility_fallback",
         "scope": "<module>",
         "source": "settings.py",
-        "target": "prompt_translation.py"
+        "target": "easyuse_anima/translation/contracts.py"
       },
       {
         "alias": null,
@@ -45875,20 +48714,20 @@
         "column": 4,
         "compatibility_pair": {
           "bound_name": "PromptTranslationSettings",
-          "target": "prompt_translation.py",
+          "target": "easyuse_anima/translation/contracts.py",
           "try_line": 6
         },
         "conditional": true,
-        "imported": "prompt_translation:PromptTranslationSettings",
+        "imported": "easyuse_anima.translation.contracts:PromptTranslationSettings",
         "kind": "static_from",
         "line": 18,
         "name": "PromptTranslationSettings",
         "optional": false,
-        "requested": "prompt_translation",
+        "requested": "easyuse_anima.translation.contracts",
         "role": "compatibility_fallback",
         "scope": "<module>",
         "source": "settings.py",
-        "target": "prompt_translation.py"
+        "target": "easyuse_anima/translation/contracts.py"
       },
       {
         "alias": null,
@@ -45909,20 +48748,20 @@
         "column": 4,
         "compatibility_pair": {
           "bound_name": "normalize_prompt_translation_language",
-          "target": "prompt_translation.py",
+          "target": "easyuse_anima/translation/contracts.py",
           "try_line": 6
         },
         "conditional": true,
-        "imported": "prompt_translation:normalize_prompt_translation_language",
+        "imported": "easyuse_anima.translation.contracts:normalize_prompt_translation_language",
         "kind": "static_from",
         "line": 18,
         "name": "normalize_prompt_translation_language",
         "optional": false,
-        "requested": "prompt_translation",
+        "requested": "easyuse_anima.translation.contracts",
         "role": "compatibility_fallback",
         "scope": "<module>",
         "source": "settings.py",
-        "target": "prompt_translation.py"
+        "target": "easyuse_anima/translation/contracts.py"
       },
       {
         "alias": null,
@@ -45943,20 +48782,20 @@
         "column": 4,
         "compatibility_pair": {
           "bound_name": "normalize_prompt_translation_provider",
-          "target": "prompt_translation.py",
+          "target": "easyuse_anima/translation/contracts.py",
           "try_line": 6
         },
         "conditional": true,
-        "imported": "prompt_translation:normalize_prompt_translation_provider",
+        "imported": "easyuse_anima.translation.contracts:normalize_prompt_translation_provider",
         "kind": "static_from",
         "line": 18,
         "name": "normalize_prompt_translation_provider",
         "optional": false,
-        "requested": "prompt_translation",
+        "requested": "easyuse_anima.translation.contracts",
         "role": "compatibility_fallback",
         "scope": "<module>",
         "source": "settings.py",
-        "target": "prompt_translation.py"
+        "target": "easyuse_anima/translation/contracts.py"
       },
       {
         "alias": null,
@@ -46768,7 +49607,11 @@
       },
       {
         "from": "api.py",
-        "to": "prompt_translation.py"
+        "to": "easyuse_anima/translation/contracts.py"
+      },
+      {
+        "from": "api.py",
+        "to": "easyuse_anima/translation/service.py"
       },
       {
         "from": "api.py",
@@ -46804,7 +49647,7 @@
       },
       {
         "from": "autocomplete_dataset.py",
-        "to": "prompt_translation.py"
+        "to": "easyuse_anima/translation/markers.py"
       },
       {
         "from": "autocomplete_dataset.py",
@@ -47720,7 +50563,7 @@
       },
       {
         "from": "easyuse_anima/prompt/advanced.py",
-        "to": "prompt_translation.py"
+        "to": "easyuse_anima/translation/markers.py"
       },
       {
         "from": "easyuse_anima/prompt/advanced.py",
@@ -47760,7 +50603,11 @@
       },
       {
         "from": "easyuse_anima/prompt/correction.py",
-        "to": "prompt_translation.py"
+        "to": "easyuse_anima/translation/markers.py"
+      },
+      {
+        "from": "easyuse_anima/prompt/correction.py",
+        "to": "easyuse_anima/translation/service.py"
       },
       {
         "from": "easyuse_anima/prompt/correction.py",
@@ -47869,6 +50716,22 @@
       {
         "from": "easyuse_anima/seed/service.py",
         "to": "easyuse_anima/seed/reservation.py"
+      },
+      {
+        "from": "easyuse_anima/translation/providers/google.py",
+        "to": "easyuse_anima/translation/contracts.py"
+      },
+      {
+        "from": "easyuse_anima/translation/service.py",
+        "to": "easyuse_anima/translation/contracts.py"
+      },
+      {
+        "from": "easyuse_anima/translation/service.py",
+        "to": "easyuse_anima/translation/markers.py"
+      },
+      {
+        "from": "easyuse_anima/translation/service.py",
+        "to": "easyuse_anima/translation/providers/google.py"
       },
       {
         "from": "easyuse_anima/workflow.py",
@@ -48072,11 +50935,15 @@
       },
       {
         "from": "nodes.py",
-        "to": "easyuse_anima/workflow.py"
+        "to": "easyuse_anima/translation/markers.py"
       },
       {
         "from": "nodes.py",
-        "to": "prompt_translation.py"
+        "to": "easyuse_anima/translation/service.py"
+      },
+      {
+        "from": "nodes.py",
+        "to": "easyuse_anima/workflow.py"
       },
       {
         "from": "nodes.py",
@@ -48087,8 +50954,24 @@
         "to": "wildcard_engine.py"
       },
       {
+        "from": "prompt_translation.py",
+        "to": "easyuse_anima/translation/contracts.py"
+      },
+      {
+        "from": "prompt_translation.py",
+        "to": "easyuse_anima/translation/markers.py"
+      },
+      {
+        "from": "prompt_translation.py",
+        "to": "easyuse_anima/translation/providers/google.py"
+      },
+      {
+        "from": "prompt_translation.py",
+        "to": "easyuse_anima/translation/service.py"
+      },
+      {
         "from": "settings.py",
-        "to": "prompt_translation.py"
+        "to": "easyuse_anima/translation/contracts.py"
       },
       {
         "from": "settings.py",
@@ -48712,6 +51595,42 @@
       {
         "cyclic": false,
         "modules": [
+          "easyuse_anima/translation/__init__.py"
+        ]
+      },
+      {
+        "cyclic": false,
+        "modules": [
+          "easyuse_anima/translation/contracts.py"
+        ]
+      },
+      {
+        "cyclic": false,
+        "modules": [
+          "easyuse_anima/translation/markers.py"
+        ]
+      },
+      {
+        "cyclic": false,
+        "modules": [
+          "easyuse_anima/translation/providers/__init__.py"
+        ]
+      },
+      {
+        "cyclic": false,
+        "modules": [
+          "easyuse_anima/translation/providers/google.py"
+        ]
+      },
+      {
+        "cyclic": false,
+        "modules": [
+          "easyuse_anima/translation/service.py"
+        ]
+      },
+      {
+        "cyclic": false,
+        "modules": [
           "easyuse_anima/workflow.py"
         ]
       },
@@ -48748,7 +51667,7 @@
     ]
   },
   "inventory": {
-    "module_count": 105,
+    "module_count": 111,
     "modules": [
       {
         "is_package": true,
@@ -48848,9 +51767,9 @@
       },
       {
         "is_package": false,
-        "loc": 1556,
+        "loc": 1558,
         "module": "api",
-        "normalized_git_blob_sha1": "019e5c9ed53f2647ecefd412d1d208a145da31c5",
+        "normalized_git_blob_sha1": "c04abd601d62bd61ba15e8849a550ba37ed7cb05",
         "path": "api.py",
         "top_level": {
           "class_count": 2,
@@ -48872,9 +51791,9 @@
       },
       {
         "is_package": false,
-        "loc": 979,
+        "loc": 983,
         "module": "autocomplete_dataset",
-        "normalized_git_blob_sha1": "518a25f783a0e95197feba4af7468456d0fcbf1d",
+        "normalized_git_blob_sha1": "d7ceb9e0b6b527b5ff4cd81080fd4c5c88286cf1",
         "path": "autocomplete_dataset.py",
         "top_level": {
           "class_count": 4,
@@ -49760,9 +52679,9 @@
       },
       {
         "is_package": false,
-        "loc": 874,
+        "loc": 873,
         "module": "easyuse_anima.prompt.advanced",
-        "normalized_git_blob_sha1": "8b547c9bc6630fd4f3602b5c687596f75907813f",
+        "normalized_git_blob_sha1": "21a2be2fb3f5444d9757ee230e844250d902507e",
         "path": "easyuse_anima/prompt/advanced.py",
         "top_level": {
           "class_count": 0,
@@ -49796,9 +52715,9 @@
       },
       {
         "is_package": false,
-        "loc": 38,
+        "loc": 39,
         "module": "easyuse_anima.prompt.correction",
-        "normalized_git_blob_sha1": "9547635b9ec0f45c809a325fff88812564b62776",
+        "normalized_git_blob_sha1": "8e6ccb0ce130474ea3d7bbd18135e63afb1bb1b3",
         "path": "easyuse_anima/prompt/correction.py",
         "top_level": {
           "class_count": 0,
@@ -49939,6 +52858,78 @@
         }
       },
       {
+        "is_package": true,
+        "loc": 3,
+        "module": "easyuse_anima.translation",
+        "normalized_git_blob_sha1": "9587cf5674043a4222fd4aca32ff15608bca1e36",
+        "path": "easyuse_anima/translation/__init__.py",
+        "top_level": {
+          "class_count": 0,
+          "function_count": 0,
+          "global_count": 1
+        }
+      },
+      {
+        "is_package": false,
+        "loc": 135,
+        "module": "easyuse_anima.translation.contracts",
+        "normalized_git_blob_sha1": "4655be5fb22056d89fef34216a30067eccacad12",
+        "path": "easyuse_anima/translation/contracts.py",
+        "top_level": {
+          "class_count": 12,
+          "function_count": 2,
+          "global_count": 13
+        }
+      },
+      {
+        "is_package": false,
+        "loc": 48,
+        "module": "easyuse_anima.translation.markers",
+        "normalized_git_blob_sha1": "df19b4b3614dc2ac58ac3c12df6cb87683c39a55",
+        "path": "easyuse_anima/translation/markers.py",
+        "top_level": {
+          "class_count": 0,
+          "function_count": 3,
+          "global_count": 2
+        }
+      },
+      {
+        "is_package": true,
+        "loc": 3,
+        "module": "easyuse_anima.translation.providers",
+        "normalized_git_blob_sha1": "124c940141cc07494639e7d4526f4d60cf2c4979",
+        "path": "easyuse_anima/translation/providers/__init__.py",
+        "top_level": {
+          "class_count": 0,
+          "function_count": 0,
+          "global_count": 1
+        }
+      },
+      {
+        "is_package": false,
+        "loc": 79,
+        "module": "easyuse_anima.translation.providers.google",
+        "normalized_git_blob_sha1": "bc1ae0ae71ae672770437e1e6048294c5b18af1a",
+        "path": "easyuse_anima/translation/providers/google.py",
+        "top_level": {
+          "class_count": 2,
+          "function_count": 1,
+          "global_count": 1
+        }
+      },
+      {
+        "is_package": false,
+        "loc": 349,
+        "module": "easyuse_anima.translation.service",
+        "normalized_git_blob_sha1": "d8cf6fb4450540acb156ae516995e50b571e40fc",
+        "path": "easyuse_anima/translation/service.py",
+        "top_level": {
+          "class_count": 3,
+          "function_count": 5,
+          "global_count": 6
+        }
+      },
+      {
         "is_package": false,
         "loc": 50,
         "module": "easyuse_anima.workflow",
@@ -49952,9 +52943,9 @@
       },
       {
         "is_package": false,
-        "loc": 1138,
+        "loc": 1148,
         "module": "nodes",
-        "normalized_git_blob_sha1": "d57d76310253976c1f725974802aba61f456c225",
+        "normalized_git_blob_sha1": "a1503e8f532e717667138686fd6881627eb86814",
         "path": "nodes.py",
         "top_level": {
           "class_count": 0,
@@ -49964,21 +52955,21 @@
       },
       {
         "is_package": false,
-        "loc": 423,
+        "loc": 134,
         "module": "prompt_translation",
-        "normalized_git_blob_sha1": "efd8064a08414064071990575cc6a9631c829c23",
+        "normalized_git_blob_sha1": "3121f69a6d48cd79cc3cec31e725acd962d669ab",
         "path": "prompt_translation.py",
         "top_level": {
-          "class_count": 16,
-          "function_count": 11,
-          "global_count": 18
+          "class_count": 0,
+          "function_count": 0,
+          "global_count": 1
         }
       },
       {
         "is_package": false,
         "loc": 700,
         "module": "settings",
-        "normalized_git_blob_sha1": "681fe2bc4edb324c04ed7f4405dfa84d6412a1dc",
+        "normalized_git_blob_sha1": "89e045fe3df4e9ab8a2b2b49039d8ca933648570",
         "path": "settings.py",
         "top_level": {
           "class_count": 0,
@@ -50214,16 +53205,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 79,
+            "handler_line": 81,
             "kind": "try",
-            "line": 59
+            "line": 61
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.profiles.contract:PROFILE_KIND_AIO",
         "kind": "static_from",
-        "line": 80,
+        "line": 82,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "api.py",
@@ -50237,16 +53228,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 79,
+            "handler_line": 81,
             "kind": "try",
-            "line": 59
+            "line": 61
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.profiles.contract:PROFILE_KIND_LORA",
         "kind": "static_from",
-        "line": 80,
+        "line": 82,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "api.py",
@@ -50260,16 +53251,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 79,
+            "handler_line": 81,
             "kind": "try",
-            "line": 59
+            "line": 61
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.profiles.contract:ProfileContractError",
         "kind": "static_from",
-        "line": 80,
+        "line": 82,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "api.py",
@@ -50283,16 +53274,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 79,
+            "handler_line": 81,
             "kind": "try",
-            "line": 59
+            "line": 61
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.profiles.contract:build_profile_document",
         "kind": "static_from",
-        "line": 80,
+        "line": 82,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "api.py",
@@ -50306,16 +53297,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 79,
+            "handler_line": 81,
             "kind": "try",
-            "line": 59
+            "line": 61
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.profiles.contract:create_profile_document",
         "kind": "static_from",
-        "line": 80,
+        "line": 82,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "api.py",
@@ -50329,16 +53320,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 79,
+            "handler_line": 81,
             "kind": "try",
-            "line": 59
+            "line": 61
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.profiles.contract:interpret_profile_document",
         "kind": "static_from",
-        "line": 80,
+        "line": 82,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "api.py",
@@ -50352,16 +53343,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 79,
+            "handler_line": 81,
             "kind": "try",
-            "line": 59
+            "line": 61
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.profiles.contract:legacy_profile_id",
         "kind": "static_from",
-        "line": 80,
+        "line": 82,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "api.py",
@@ -50375,16 +53366,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 79,
+            "handler_line": 81,
             "kind": "try",
-            "line": 59
+            "line": 61
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.profiles.contract:normalize_profile_filename_identity",
         "kind": "static_from",
-        "line": 80,
+        "line": 82,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "api.py",
@@ -50398,16 +53389,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 79,
+            "handler_line": 81,
             "kind": "try",
-            "line": 59
+            "line": 61
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.profiles.contract:rename_profile_document",
         "kind": "static_from",
-        "line": 80,
+        "line": 82,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "api.py",
@@ -50421,16 +53412,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 79,
+            "handler_line": 81,
             "kind": "try",
-            "line": 59
+            "line": 61
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.profiles.contract:update_profile_document",
         "kind": "static_from",
-        "line": 80,
+        "line": 82,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "api.py",
@@ -50444,16 +53435,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 79,
+            "handler_line": 81,
             "kind": "try",
-            "line": 59
+            "line": 61
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.profiles.mutation:PROFILE_MUTATION_COORDINATOR",
         "kind": "static_from",
-        "line": 92,
+        "line": 94,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "api.py",
@@ -50467,16 +53458,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 79,
+            "handler_line": 81,
             "kind": "try",
-            "line": 59
+            "line": 61
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.profiles.mutation:ProfileMutationError",
         "kind": "static_from",
-        "line": 92,
+        "line": 94,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "api.py",
@@ -50490,16 +53481,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 79,
+            "handler_line": 81,
             "kind": "try",
-            "line": 59
+            "line": 61
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.profiles.mutation:ProfileRevisionConflictError",
         "kind": "static_from",
-        "line": 92,
+        "line": 94,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "api.py",
@@ -50513,16 +53504,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 79,
+            "handler_line": 81,
             "kind": "try",
-            "line": 59
+            "line": 61
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.profiles.mutation:require_profile_precondition",
         "kind": "static_from",
-        "line": 92,
+        "line": 94,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "api.py",
@@ -50536,16 +53527,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 79,
+            "handler_line": 81,
             "kind": "try",
-            "line": 59
+            "line": 61
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.profiles.mutation:verify_profile_precondition",
         "kind": "static_from",
-        "line": 92,
+        "line": 94,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "api.py",
@@ -50559,16 +53550,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 101,
+            "handler_line": 103,
             "kind": "try",
-            "line": 99
+            "line": 101
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "storage:AtomicJsonStore",
         "kind": "static_from",
-        "line": 102,
+        "line": 104,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "api.py",
@@ -50582,16 +53573,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 101,
+            "handler_line": 103,
             "kind": "try",
-            "line": 99
+            "line": 101
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "storage:USER_DATA_DIR",
         "kind": "static_from",
-        "line": 102,
+        "line": 104,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "api.py",
@@ -50605,7 +53596,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 31,
+            "handler_line": 33,
             "kind": "try",
             "line": 17
           }
@@ -50614,7 +53605,7 @@
         "conditional": true,
         "imported": "autocomplete_index:AutocompleteIndexDiagnostics",
         "kind": "static_from",
-        "line": 32,
+        "line": 34,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "autocomplete_dataset.py",
@@ -50628,7 +53619,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 31,
+            "handler_line": 33,
             "kind": "try",
             "line": 17
           }
@@ -50637,7 +53628,7 @@
         "conditional": true,
         "imported": "autocomplete_index:AutocompleteIndexSource",
         "kind": "static_from",
-        "line": 32,
+        "line": 34,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "autocomplete_dataset.py",
@@ -50651,7 +53642,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 31,
+            "handler_line": 33,
             "kind": "try",
             "line": 17
           }
@@ -50660,7 +53651,7 @@
         "conditional": true,
         "imported": "autocomplete_index:AutocompleteIndexUnavailable",
         "kind": "static_from",
-        "line": 32,
+        "line": 34,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "autocomplete_dataset.py",
@@ -50674,7 +53665,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 31,
+            "handler_line": 33,
             "kind": "try",
             "line": 17
           }
@@ -50683,7 +53674,7 @@
         "conditional": true,
         "imported": "autocomplete_index:search_autocomplete_index",
         "kind": "static_from",
-        "line": 32,
+        "line": 34,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "autocomplete_dataset.py",
@@ -50697,7 +53688,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 31,
+            "handler_line": 33,
             "kind": "try",
             "line": 17
           }
@@ -50706,7 +53697,7 @@
         "conditional": true,
         "imported": "anima_prompt.knowledge:PACKAGE_DATA_DIR",
         "kind": "static_from",
-        "line": 38,
+        "line": 40,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "autocomplete_dataset.py",
@@ -50720,7 +53711,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 31,
+            "handler_line": 33,
             "kind": "try",
             "line": 17
           }
@@ -50729,7 +53720,7 @@
         "conditional": true,
         "imported": "anima_prompt.models:TagSection",
         "kind": "static_from",
-        "line": 39,
+        "line": 41,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "autocomplete_dataset.py",
@@ -50743,7 +53734,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 31,
+            "handler_line": 33,
             "kind": "try",
             "line": 17
           }
@@ -50752,7 +53743,7 @@
         "conditional": true,
         "imported": "anima_prompt.ordering:builtin_tag_section",
         "kind": "static_from",
-        "line": 40,
+        "line": 42,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "autocomplete_dataset.py",
@@ -50766,7 +53757,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 31,
+            "handler_line": 33,
             "kind": "try",
             "line": 17
           }
@@ -50775,7 +53766,7 @@
         "conditional": true,
         "imported": "anima_prompt.parser:parse_prompt",
         "kind": "static_from",
-        "line": 41,
+        "line": 43,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "autocomplete_dataset.py",
@@ -50789,20 +53780,20 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 31,
+            "handler_line": 33,
             "kind": "try",
             "line": 17
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
-        "imported": "prompt_translation:iter_prompt_translation_markers",
+        "imported": "easyuse_anima.translation.markers:iter_prompt_translation_markers",
         "kind": "static_from",
-        "line": 42,
+        "line": 44,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "autocomplete_dataset.py",
-        "target": "prompt_translation.py"
+        "target": "easyuse_anima/translation/markers.py"
       },
       {
         "branch_context": [
@@ -50812,7 +53803,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 31,
+            "handler_line": 33,
             "kind": "try",
             "line": 17
           }
@@ -50821,7 +53812,7 @@
         "conditional": true,
         "imported": "storage:PACKAGE_DATA_DIR",
         "kind": "static_from",
-        "line": 43,
+        "line": 47,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "autocomplete_dataset.py",
@@ -50835,7 +53826,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 31,
+            "handler_line": 33,
             "kind": "try",
             "line": 17
           }
@@ -50844,7 +53835,7 @@
         "conditional": true,
         "imported": "storage:USER_DATA_DIR",
         "kind": "static_from",
-        "line": 44,
+        "line": 48,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "autocomplete_dataset.py",
@@ -51274,37 +54265,14 @@
             ],
             "handler_line": 47,
             "kind": "try",
-            "line": 44
-          }
-        ],
-        "classification": "compatibility_fallback",
-        "conditional": true,
-        "imported": "prompt_translation:has_prompt_translation_markers",
-        "kind": "static_from",
-        "line": 48,
-        "optional": false,
-        "role": "compatibility_fallback",
-        "source": "easyuse_anima/prompt/advanced.py",
-        "target": "prompt_translation.py"
-      },
-      {
-        "branch_context": [
-          {
-            "branch": "except",
-            "catches_import_error": true,
-            "exceptions": [
-              "ImportError"
-            ],
-            "handler_line": 47,
-            "kind": "try",
-            "line": 44
+            "line": 45
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "settings:resolve_metadata_filter_words",
         "kind": "static_from",
-        "line": 49,
+        "line": 48,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "easyuse_anima/prompt/advanced.py",
@@ -51318,16 +54286,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 138,
+            "handler_line": 137,
             "kind": "try",
-            "line": 136
+            "line": 135
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "wildcard_engine",
         "kind": "static_import",
-        "line": 139,
+        "line": 138,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "easyuse_anima/prompt/advanced.py",
@@ -51341,62 +54309,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 8,
+            "handler_line": 10,
             "kind": "try",
-            "line": 5
-          }
-        ],
-        "classification": "compatibility_fallback",
-        "conditional": true,
-        "imported": "prompt_translation:has_prompt_translation_markers",
-        "kind": "static_from",
-        "line": 9,
-        "optional": false,
-        "role": "compatibility_fallback",
-        "source": "easyuse_anima/prompt/correction.py",
-        "target": "prompt_translation.py"
-      },
-      {
-        "branch_context": [
-          {
-            "branch": "except",
-            "catches_import_error": true,
-            "exceptions": [
-              "ImportError"
-            ],
-            "handler_line": 8,
-            "kind": "try",
-            "line": 5
-          }
-        ],
-        "classification": "compatibility_fallback",
-        "conditional": true,
-        "imported": "prompt_translation:translate_prompt_markers",
-        "kind": "static_from",
-        "line": 9,
-        "optional": false,
-        "role": "compatibility_fallback",
-        "source": "easyuse_anima/prompt/correction.py",
-        "target": "prompt_translation.py"
-      },
-      {
-        "branch_context": [
-          {
-            "branch": "except",
-            "catches_import_error": true,
-            "exceptions": [
-              "ImportError"
-            ],
-            "handler_line": 8,
-            "kind": "try",
-            "line": 5
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "settings:resolve_prompt_translation_settings",
         "kind": "static_from",
-        "line": 10,
+        "line": 11,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "easyuse_anima/prompt/correction.py",
@@ -51525,7 +54447,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -51534,7 +54456,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:AIO_FIRST_PASS_CACHE_MAX_ENTRIES",
         "kind": "static_from",
-        "line": 562,
+        "line": 567,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51548,7 +54470,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -51557,7 +54479,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_AIO_FIRST_PASS_CACHE",
         "kind": "static_from",
-        "line": 562,
+        "line": 567,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51571,7 +54493,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -51580,7 +54502,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_AIO_FIRST_PASS_CACHE_ORDER",
         "kind": "static_from",
-        "line": 562,
+        "line": 567,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51594,7 +54516,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -51603,7 +54525,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_aio_first_pass_cache_key",
         "kind": "static_from",
-        "line": 562,
+        "line": 567,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51617,7 +54539,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -51626,7 +54548,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_clone_aio_cache_value",
         "kind": "static_from",
-        "line": 562,
+        "line": 567,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51640,7 +54562,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -51649,7 +54571,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_get_aio_first_pass_cache",
         "kind": "static_from",
-        "line": 562,
+        "line": 567,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51663,7 +54585,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -51672,7 +54594,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_put_aio_first_pass_cache",
         "kind": "static_from",
-        "line": 562,
+        "line": 567,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51686,7 +54608,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -51695,7 +54617,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_detailer_stage",
         "kind": "static_from",
-        "line": 572,
+        "line": 577,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51709,7 +54631,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -51718,7 +54640,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_detailer_target",
         "kind": "static_from",
-        "line": 572,
+        "line": 577,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51732,7 +54654,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -51741,7 +54663,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_highres_stage",
         "kind": "static_from",
-        "line": 572,
+        "line": 577,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51755,7 +54677,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -51764,7 +54686,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_legacy_generation",
         "kind": "static_from",
-        "line": 572,
+        "line": 577,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51778,7 +54700,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -51787,7 +54709,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_resshift_upscale_stage",
         "kind": "static_from",
-        "line": 572,
+        "line": 577,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51801,7 +54723,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -51810,7 +54732,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_upscale_stage",
         "kind": "static_from",
-        "line": 572,
+        "line": 577,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51824,7 +54746,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -51833,7 +54755,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_usdu_upscale_stage",
         "kind": "static_from",
-        "line": 572,
+        "line": 577,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51847,7 +54769,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -51856,7 +54778,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_AIO_DETAILER_CUSTOM_RE",
         "kind": "static_from",
-        "line": 581,
+        "line": 586,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51870,7 +54792,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -51879,7 +54801,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_AIO_DETAILER_RESERVED_KEYS",
         "kind": "static_from",
-        "line": 581,
+        "line": 586,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51893,7 +54815,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -51902,7 +54824,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_aio_detailer_has_enabled_targets",
         "kind": "static_from",
-        "line": 581,
+        "line": 586,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51916,7 +54838,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -51925,7 +54847,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_aio_detailer_target_defaults",
         "kind": "static_from",
-        "line": 581,
+        "line": 586,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51939,7 +54861,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -51948,7 +54870,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_aio_detailer_target_order",
         "kind": "static_from",
-        "line": 581,
+        "line": 586,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51962,7 +54884,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -51971,7 +54893,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_is_aio_detailer_target_name",
         "kind": "static_from",
-        "line": 581,
+        "line": 586,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51985,7 +54907,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -51994,7 +54916,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_merge_versioned_settings",
         "kind": "static_from",
-        "line": 581,
+        "line": 586,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52008,7 +54930,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -52017,7 +54939,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_dit_corrections_settings",
         "kind": "static_from",
-        "line": 581,
+        "line": 586,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52031,7 +54953,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -52040,7 +54962,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_generation_settings",
         "kind": "static_from",
-        "line": 581,
+        "line": 586,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52054,7 +54976,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -52063,7 +54985,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_seed",
         "kind": "static_from",
-        "line": 581,
+        "line": 586,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52077,7 +54999,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -52086,7 +55008,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_spectrum_settings",
         "kind": "static_from",
-        "line": 581,
+        "line": 586,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52100,7 +55022,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -52109,7 +55031,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_FINAL_FIT_MODES",
         "kind": "static_from",
-        "line": 594,
+        "line": 599,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52123,7 +55045,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -52132,7 +55054,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_FINAL_UPSCALE_BACKENDS",
         "kind": "static_from",
-        "line": 594,
+        "line": 599,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52146,7 +55068,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -52155,7 +55077,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_GENERATION_DEFAULT_SETTINGS",
         "kind": "static_from",
-        "line": 594,
+        "line": 599,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52169,7 +55091,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -52178,7 +55100,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_GENERATION_SETTINGS_SCHEMA",
         "kind": "static_from",
-        "line": 594,
+        "line": 599,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52192,7 +55114,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -52201,7 +55123,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_GENERATION_SETTINGS_VERSION",
         "kind": "static_from",
-        "line": 594,
+        "line": 599,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52215,7 +55137,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -52224,7 +55146,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_RESHIFT_DTYPES",
         "kind": "static_from",
-        "line": 594,
+        "line": 599,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52238,7 +55160,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -52247,7 +55169,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_RESHIFT_SCALES",
         "kind": "static_from",
-        "line": 594,
+        "line": 599,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52261,7 +55183,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -52270,7 +55192,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_SPECIAL_SEEDS",
         "kind": "static_from",
-        "line": 594,
+        "line": 599,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52284,7 +55206,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -52293,7 +55215,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_SPECIAL_SEED_DECREMENT",
         "kind": "static_from",
-        "line": 594,
+        "line": 599,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52307,7 +55229,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -52316,7 +55238,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_SPECIAL_SEED_INCREMENT",
         "kind": "static_from",
-        "line": 594,
+        "line": 599,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52330,7 +55252,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -52339,7 +55261,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_SPECIAL_SEED_RANDOM",
         "kind": "static_from",
-        "line": 594,
+        "line": 599,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52353,7 +55275,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -52362,7 +55284,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_USDU_MODE_TYPES",
         "kind": "static_from",
-        "line": 594,
+        "line": 599,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52376,7 +55298,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -52385,7 +55307,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_USDU_PROMPT_FULL",
         "kind": "static_from",
-        "line": 594,
+        "line": 599,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52399,7 +55321,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -52408,7 +55330,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_USDU_PROMPT_MODES",
         "kind": "static_from",
-        "line": 594,
+        "line": 599,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52422,7 +55344,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -52431,7 +55353,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_USDU_PROMPT_NO_GENERAL",
         "kind": "static_from",
-        "line": 594,
+        "line": 599,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52445,7 +55367,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -52454,7 +55376,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_defaults:AIO_USDU_SEAM_FIX_MODES",
         "kind": "static_from",
-        "line": 594,
+        "line": 599,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52468,7 +55390,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -52477,7 +55399,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_settings:round_trip_aio_generation_settings",
         "kind": "static_from",
-        "line": 612,
+        "line": 617,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52491,7 +55413,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -52500,7 +55422,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.input_defaults:AIO_INPUT_DEFAULT_SETTINGS",
         "kind": "static_from",
-        "line": 615,
+        "line": 620,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52514,7 +55436,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -52523,7 +55445,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.input_defaults:ANIMA_CLIP_DEVICES",
         "kind": "static_from",
-        "line": 615,
+        "line": 620,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52537,7 +55459,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -52546,7 +55468,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.input_defaults:ANIMA_CLIP_TYPES",
         "kind": "static_from",
-        "line": 615,
+        "line": 620,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52560,7 +55482,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -52569,7 +55491,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.input_defaults:ANIMA_DEFAULT_CLIP_CANDIDATES",
         "kind": "static_from",
-        "line": 615,
+        "line": 620,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52583,7 +55505,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -52592,7 +55514,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.input_defaults:ANIMA_DEFAULT_DIFFUSION_MODEL_CANDIDATES",
         "kind": "static_from",
-        "line": 615,
+        "line": 620,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52606,7 +55528,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -52615,7 +55537,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.input_defaults:ANIMA_DEFAULT_VAE_CANDIDATES",
         "kind": "static_from",
-        "line": 615,
+        "line": 620,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52629,7 +55551,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -52638,7 +55560,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.input_defaults:ANIMA_UNET_WEIGHT_DTYPES",
         "kind": "static_from",
-        "line": 615,
+        "line": 620,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52652,7 +55574,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -52661,7 +55583,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.input_defaults:EASY_USE_ANIMA_INPUT_SCHEMA",
         "kind": "static_from",
-        "line": 615,
+        "line": 620,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52675,7 +55597,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -52684,7 +55606,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.input_defaults:EASY_USE_ANIMA_INPUT_SETTINGS_VERSION",
         "kind": "static_from",
-        "line": 615,
+        "line": 620,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52698,7 +55620,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -52707,7 +55629,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.input_context:_easy_use_anima_input_signature",
         "kind": "static_from",
-        "line": 626,
+        "line": 631,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52721,7 +55643,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -52730,7 +55652,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.input_context:_require_easy_use_anima_input",
         "kind": "static_from",
-        "line": 626,
+        "line": 631,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52744,7 +55666,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -52753,7 +55675,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.usdu:_aio_usdu_auto_tile_dimension",
         "kind": "static_from",
-        "line": 630,
+        "line": 635,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52767,7 +55689,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -52776,7 +55698,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.usdu:_aio_usdu_tile_plan",
         "kind": "static_from",
-        "line": 630,
+        "line": 635,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52790,7 +55712,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -52799,7 +55721,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_aio_final_fit_size",
         "kind": "static_from",
-        "line": 634,
+        "line": 639,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52813,7 +55735,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -52822,7 +55744,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_apply_aio_final_fit",
         "kind": "static_from",
-        "line": 634,
+        "line": 639,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52836,7 +55758,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -52845,7 +55767,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_resize_image_to_size_if_needed",
         "kind": "static_from",
-        "line": 634,
+        "line": 639,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52859,7 +55781,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -52868,7 +55790,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_run_aio_postprocess_stage",
         "kind": "static_from",
-        "line": 634,
+        "line": 639,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52882,7 +55804,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -52891,7 +55813,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_prompt_data_fields_for_usdu",
         "kind": "static_from",
-        "line": 640,
+        "line": 645,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52905,7 +55827,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -52914,7 +55836,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_usdu_conditioning",
         "kind": "static_from",
-        "line": 640,
+        "line": 645,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52928,7 +55850,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -52937,7 +55859,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_usdu_prompt_without_general",
         "kind": "static_from",
-        "line": 640,
+        "line": 645,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52951,7 +55873,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -52960,7 +55882,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_aio_lora_stack_signature",
         "kind": "static_from",
-        "line": 645,
+        "line": 650,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52974,7 +55896,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -52983,7 +55905,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_anima_dave_patch",
         "kind": "static_from",
-        "line": 645,
+        "line": 650,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52997,7 +55919,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -53006,7 +55928,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_kj_model_patches",
         "kind": "static_from",
-        "line": 645,
+        "line": 650,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53020,7 +55942,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -53029,7 +55951,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_lora_stack",
         "kind": "static_from",
-        "line": 645,
+        "line": 650,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53043,7 +55965,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -53052,7 +55974,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_model_patches",
         "kind": "static_from",
-        "line": 645,
+        "line": 650,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53066,7 +55988,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -53075,7 +55997,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_safe_pag_patch",
         "kind": "static_from",
-        "line": 645,
+        "line": 650,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53089,7 +56011,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -53098,7 +56020,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_correction_patch_for_comfy_sampler",
         "kind": "static_from",
-        "line": 645,
+        "line": 650,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53112,7 +56034,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -53121,7 +56043,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_forecast_patch_for_comfy_sampler",
         "kind": "static_from",
-        "line": 645,
+        "line": 650,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53135,7 +56057,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -53144,7 +56066,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_model_patches_for_comfy_sampler",
         "kind": "static_from",
-        "line": 645,
+        "line": 650,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53158,7 +56080,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -53167,7 +56089,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_cleanup_aio_ephemeral_model",
         "kind": "static_from",
-        "line": 645,
+        "line": 650,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53181,7 +56103,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -53190,7 +56112,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_normalize_aio_lora_stack",
         "kind": "static_from",
-        "line": 645,
+        "line": 650,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53204,7 +56126,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -53213,7 +56135,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_patch_model_sampling_aura_flow",
         "kind": "static_from",
-        "line": 645,
+        "line": 650,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53227,7 +56149,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -53236,7 +56158,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_aio_highres_effective_backend",
         "kind": "static_from",
-        "line": 659,
+        "line": 664,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53250,7 +56172,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -53259,7 +56181,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_aio_stage_sampler_settings",
         "kind": "static_from",
-        "line": 659,
+        "line": 664,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53273,7 +56195,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -53282,7 +56204,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_decode_latent_with_comfy",
         "kind": "static_from",
-        "line": 659,
+        "line": 664,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53296,7 +56218,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -53305,7 +56227,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_encode_image_with_comfy_vae",
         "kind": "static_from",
-        "line": 659,
+        "line": 664,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53319,7 +56241,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -53328,7 +56250,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_generate_empty_latent_with_comfy",
         "kind": "static_from",
-        "line": 659,
+        "line": 664,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53342,7 +56264,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -53351,7 +56273,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_new_aio_random_seed",
         "kind": "static_from",
-        "line": 659,
+        "line": 664,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53365,7 +56287,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -53374,7 +56296,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_resolve_aio_runtime_seed",
         "kind": "static_from",
-        "line": 659,
+        "line": 664,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53388,7 +56310,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -53397,7 +56319,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_aio_backend",
         "kind": "static_from",
-        "line": 659,
+        "line": 664,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53411,7 +56333,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -53420,7 +56342,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_comfy",
         "kind": "static_from",
-        "line": 659,
+        "line": 664,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53434,7 +56356,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -53443,7 +56365,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_spectrum_mod_guidance_advanced",
         "kind": "static_from",
-        "line": 659,
+        "line": 664,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53457,7 +56379,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -53466,7 +56388,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_spectrum_spd",
         "kind": "static_from",
-        "line": 659,
+        "line": 664,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53480,7 +56402,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -53489,7 +56411,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_CACHE_FORMAT",
         "kind": "static_from",
-        "line": 672,
+        "line": 677,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53503,7 +56425,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -53512,7 +56434,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_CACHE_QUALITY",
         "kind": "static_from",
-        "line": 672,
+        "line": 677,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53526,7 +56448,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -53535,7 +56457,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_EVENT",
         "kind": "static_from",
-        "line": 672,
+        "line": 677,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53549,7 +56471,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -53558,7 +56480,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_STAGE_LABELS",
         "kind": "static_from",
-        "line": 672,
+        "line": 677,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53572,7 +56494,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -53581,7 +56503,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_aio_preview_base_directory",
         "kind": "static_from",
-        "line": 672,
+        "line": 677,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53595,7 +56517,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -53604,7 +56526,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_aio_preview_file_size_bytes",
         "kind": "static_from",
-        "line": 672,
+        "line": 677,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53618,7 +56540,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -53627,7 +56549,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_save_aio_temp_preview_image",
         "kind": "static_from",
-        "line": 672,
+        "line": 677,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53641,7 +56563,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -53650,7 +56572,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_send_aio_preview_event",
         "kind": "static_from",
-        "line": 672,
+        "line": 677,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53664,7 +56586,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -53673,7 +56595,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_tag_aio_preview_images",
         "kind": "static_from",
-        "line": 672,
+        "line": 677,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53687,7 +56609,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -53696,7 +56618,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_image_saver_additional_hashes",
         "kind": "static_from",
-        "line": 683,
+        "line": 688,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53710,7 +56632,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -53719,7 +56641,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_image_saver_civitai_hash_fetcher_entries",
         "kind": "static_from",
-        "line": 683,
+        "line": 688,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53733,7 +56655,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -53742,7 +56664,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_lora_metadata_name",
         "kind": "static_from",
-        "line": 683,
+        "line": 688,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53756,7 +56678,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -53765,7 +56687,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_prompt_with_lora_metadata",
         "kind": "static_from",
-        "line": 683,
+        "line": 688,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53779,7 +56701,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -53788,7 +56710,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_save_filename_prefix",
         "kind": "static_from",
-        "line": 683,
+        "line": 688,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53802,7 +56724,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -53811,7 +56733,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_save_image_with_comfy",
         "kind": "static_from",
-        "line": 683,
+        "line": 688,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53825,7 +56747,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -53834,7 +56756,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_save_image_with_image_saver",
         "kind": "static_from",
-        "line": 683,
+        "line": 688,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53848,7 +56770,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -53857,7 +56779,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output_settings:_normalize_aio_civitai_hash_fetchers",
         "kind": "static_from",
-        "line": 692,
+        "line": 697,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53871,7 +56793,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -53880,7 +56802,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output_settings:_normalize_aio_hash_bundles",
         "kind": "static_from",
-        "line": 692,
+        "line": 697,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53894,7 +56816,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -53903,7 +56825,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_clip_loader_types",
         "kind": "static_from",
-        "line": 696,
+        "line": 701,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53917,7 +56839,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -53926,7 +56848,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_diffusion_model_names",
         "kind": "static_from",
-        "line": 696,
+        "line": 701,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53940,7 +56862,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -53949,7 +56871,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_text_encoder_names",
         "kind": "static_from",
-        "line": 696,
+        "line": 701,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53963,7 +56885,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -53972,7 +56894,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_vae_names",
         "kind": "static_from",
-        "line": 696,
+        "line": 701,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53986,7 +56908,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -53995,7 +56917,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_aio_resources_from_input_context",
         "kind": "static_from",
-        "line": 696,
+        "line": 701,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54009,7 +56931,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -54018,7 +56940,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_aio_sam3_context",
         "kind": "static_from",
-        "line": 696,
+        "line": 701,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54032,7 +56954,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -54041,7 +56963,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_checkpoint_with_comfy",
         "kind": "static_from",
-        "line": 696,
+        "line": 701,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54055,7 +56977,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -54064,7 +56986,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_clip_with_comfy",
         "kind": "static_from",
-        "line": 696,
+        "line": 701,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54078,7 +57000,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -54087,7 +57009,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_diffusion_model_with_comfy",
         "kind": "static_from",
-        "line": 696,
+        "line": 701,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54101,7 +57023,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -54110,7 +57032,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_upscale_model_with_comfy",
         "kind": "static_from",
-        "line": 696,
+        "line": 701,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54124,7 +57046,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -54133,7 +57055,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_vae_with_comfy",
         "kind": "static_from",
-        "line": 696,
+        "line": 701,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54147,7 +57069,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -54156,7 +57078,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_normalize_aio_input_settings",
         "kind": "static_from",
-        "line": 696,
+        "line": 701,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54170,7 +57092,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -54179,7 +57101,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_checkpoint_default",
         "kind": "static_from",
-        "line": 696,
+        "line": 701,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54193,7 +57115,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -54202,7 +57124,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_clip_type_default",
         "kind": "static_from",
-        "line": 696,
+        "line": 701,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54216,7 +57138,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -54225,7 +57147,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_name_default",
         "kind": "static_from",
-        "line": 696,
+        "line": 701,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54239,7 +57161,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -54248,7 +57170,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_json_clone",
         "kind": "static_from",
-        "line": 713,
+        "line": 718,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54262,7 +57184,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -54271,7 +57193,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_json_object",
         "kind": "static_from",
-        "line": 713,
+        "line": 718,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54285,7 +57207,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -54294,7 +57216,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_stable_change_key",
         "kind": "static_from",
-        "line": 713,
+        "line": 718,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54308,7 +57230,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -54317,7 +57239,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_bool",
         "kind": "static_from",
-        "line": 718,
+        "line": 723,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54331,7 +57253,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -54340,7 +57262,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_float",
         "kind": "static_from",
-        "line": 718,
+        "line": 723,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54354,7 +57276,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -54363,7 +57285,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_int",
         "kind": "static_from",
-        "line": 718,
+        "line": 723,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54377,7 +57299,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -54386,7 +57308,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_choice",
         "kind": "static_from",
-        "line": 718,
+        "line": 723,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54400,7 +57322,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -54409,7 +57331,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_single_value",
         "kind": "static_from",
-        "line": 718,
+        "line": 723,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54423,7 +57345,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -54432,7 +57354,7 @@
         "conditional": true,
         "imported": "easyuse_anima.seed.compatibility:WILDCARD_QUEUE_MAX_SAFE_SEED",
         "kind": "static_from",
-        "line": 725,
+        "line": 730,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54446,7 +57368,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -54455,7 +57377,7 @@
         "conditional": true,
         "imported": "easyuse_anima.seed.compatibility:WILDCARD_RESERVED_NEXT_SEED_INPUT",
         "kind": "static_from",
-        "line": 725,
+        "line": 730,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54469,7 +57391,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -54478,7 +57400,7 @@
         "conditional": true,
         "imported": "easyuse_anima.seed.compatibility:_consume_reserved_wildcard_next_seed",
         "kind": "static_from",
-        "line": 725,
+        "line": 730,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54492,7 +57414,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -54501,7 +57423,7 @@
         "conditional": true,
         "imported": "easyuse_anima.workflow:_get_workflow_node",
         "kind": "static_from",
-        "line": 730,
+        "line": 735,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54515,7 +57437,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -54524,7 +57446,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_prompt_translation_change_key",
         "kind": "static_from",
-        "line": 731,
+        "line": 736,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54538,7 +57460,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -54547,7 +57469,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_split_tag_text",
         "kind": "static_from",
-        "line": 731,
+        "line": 736,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54561,7 +57483,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -54570,7 +57492,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_translate_prompt_text",
         "kind": "static_from",
-        "line": 731,
+        "line": 736,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54584,7 +57506,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -54593,7 +57515,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_HASH_COMMENT_RE",
         "kind": "static_from",
-        "line": 736,
+        "line": 741,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54607,7 +57529,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -54616,7 +57538,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_INLINE_SPACE_RE",
         "kind": "static_from",
-        "line": 736,
+        "line": 741,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54630,7 +57552,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -54639,7 +57561,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_WEIGHTED_TOKEN_RE",
         "kind": "static_from",
-        "line": 736,
+        "line": 741,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54653,7 +57575,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -54662,7 +57584,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_correct_builder_prompt",
         "kind": "static_from",
-        "line": 736,
+        "line": 741,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54676,7 +57598,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -54685,7 +57607,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_filter_metadata_prompt",
         "kind": "static_from",
-        "line": 736,
+        "line": 741,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54699,7 +57621,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -54708,7 +57630,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_join_prompt_tokens",
         "kind": "static_from",
-        "line": 736,
+        "line": 741,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54722,7 +57644,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -54731,7 +57653,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_metadata_filter_key",
         "kind": "static_from",
-        "line": 736,
+        "line": 741,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54745,7 +57667,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -54754,7 +57676,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_metadata_filter_keys",
         "kind": "static_from",
-        "line": 736,
+        "line": 741,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54768,7 +57690,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -54777,7 +57699,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_prompt_tokens",
         "kind": "static_from",
-        "line": 736,
+        "line": 741,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54791,7 +57713,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -54800,7 +57722,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:PROMPT_DATA_TYPE",
         "kind": "static_from",
-        "line": 749,
+        "line": 754,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54814,7 +57736,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -54823,7 +57745,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_advanced_outputs_from_prompt_data",
         "kind": "static_from",
-        "line": 749,
+        "line": 754,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54837,7 +57759,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -54846,7 +57768,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_apply_prompt_data_overrides",
         "kind": "static_from",
-        "line": 749,
+        "line": 754,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54860,7 +57782,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -54869,7 +57791,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_copy_prompt_data_for_update",
         "kind": "static_from",
-        "line": 749,
+        "line": 754,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54883,7 +57805,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -54892,7 +57814,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_normalize_prompt_data",
         "kind": "static_from",
-        "line": 749,
+        "line": 754,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54906,7 +57828,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -54915,7 +57837,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_prompt_data_json_safe",
         "kind": "static_from",
-        "line": 749,
+        "line": 754,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54929,7 +57851,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -54938,7 +57860,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_prompt_data_parameter_snapshot",
         "kind": "static_from",
-        "line": 749,
+        "line": 754,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54952,7 +57874,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -54961,7 +57883,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_artist_field_prompt",
         "kind": "static_from",
-        "line": 767,
+        "line": 772,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54975,7 +57897,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -54984,7 +57906,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_default_fields",
         "kind": "static_from",
-        "line": 767,
+        "line": 772,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54998,7 +57920,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -55007,7 +57929,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_enabled_naia_panes",
         "kind": "static_from",
-        "line": 767,
+        "line": 772,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -55021,7 +57943,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -55030,7 +57952,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_enabled_pane_fields",
         "kind": "static_from",
-        "line": 767,
+        "line": 772,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -55044,7 +57966,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -55053,7 +57975,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_field_input_values",
         "kind": "static_from",
-        "line": 767,
+        "line": 772,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -55067,7 +57989,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -55076,7 +57998,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_field_socket_name",
         "kind": "static_from",
-        "line": 767,
+        "line": 772,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -55090,7 +58012,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -55099,7 +58021,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_fields_json",
         "kind": "static_from",
-        "line": 767,
+        "line": 772,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -55113,7 +58035,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -55122,7 +58044,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_has_enabled_naia",
         "kind": "static_from",
-        "line": 767,
+        "line": 772,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -55136,7 +58058,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -55145,7 +58067,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_prompt_with_artist_override",
         "kind": "static_from",
-        "line": 767,
+        "line": 772,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -55159,7 +58081,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -55168,7 +58090,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_uses_naia_resolution",
         "kind": "static_from",
-        "line": 767,
+        "line": 772,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -55182,7 +58104,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -55191,7 +58113,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_apply_advanced_field_inputs",
         "kind": "static_from",
-        "line": 767,
+        "line": 772,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -55205,7 +58127,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -55214,7 +58136,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_as_advanced_height",
         "kind": "static_from",
-        "line": 767,
+        "line": 772,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -55228,7 +58150,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -55237,7 +58159,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_build_advanced_prompt_data",
         "kind": "static_from",
-        "line": 767,
+        "line": 772,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -55251,7 +58173,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -55260,7 +58182,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_build_advanced_prompts",
         "kind": "static_from",
-        "line": 767,
+        "line": 772,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -55274,7 +58196,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -55283,7 +58205,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_clone_advanced_fields",
         "kind": "static_from",
-        "line": 767,
+        "line": 772,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -55297,7 +58219,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -55306,7 +58228,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_correct_advanced_field_sequence",
         "kind": "static_from",
-        "line": 767,
+        "line": 772,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -55320,7 +58242,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -55329,7 +58251,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_expand_advanced_wildcard_fields",
         "kind": "static_from",
-        "line": 767,
+        "line": 772,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -55343,7 +58265,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -55352,7 +58274,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_normalize_advanced_fields",
         "kind": "static_from",
-        "line": 767,
+        "line": 772,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -55366,7 +58288,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -55375,7 +58297,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_normalize_prompt_studio_wildcard_seed_control",
         "kind": "static_from",
-        "line": 767,
+        "line": 772,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -55389,7 +58311,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -55398,7 +58320,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_set_naia_field_text",
         "kind": "static_from",
-        "line": 767,
+        "line": 772,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -55412,7 +58334,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -55421,7 +58343,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_translate_prompt_fields",
         "kind": "static_from",
-        "line": 767,
+        "line": 772,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -55435,7 +58357,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -55444,7 +58366,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_apply_regional_field_inputs",
         "kind": "static_from",
-        "line": 802,
+        "line": 807,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -55458,7 +58380,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -55467,7 +58389,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_build_regional_outputs",
         "kind": "static_from",
-        "line": 802,
+        "line": 807,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -55481,7 +58403,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -55490,7 +58412,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_clone_regional_fields",
         "kind": "static_from",
-        "line": 802,
+        "line": 807,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -55504,7 +58426,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -55513,7 +58435,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_conditioning_set_values",
         "kind": "static_from",
-        "line": 802,
+        "line": 807,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -55527,7 +58449,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -55536,7 +58458,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_mask_ids",
         "kind": "static_from",
-        "line": 802,
+        "line": 807,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -55550,7 +58472,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -55559,7 +58481,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_regional_config",
         "kind": "static_from",
-        "line": 802,
+        "line": 807,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -55573,7 +58495,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -55582,7 +58504,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_regional_fields",
         "kind": "static_from",
-        "line": 802,
+        "line": 807,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -55596,7 +58518,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -55605,7 +58527,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_parse_json_object",
         "kind": "static_from",
-        "line": 802,
+        "line": 807,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -55619,7 +58541,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -55628,7 +58550,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_config_json",
         "kind": "static_from",
-        "line": 802,
+        "line": 807,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -55642,7 +58564,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -55651,7 +58573,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_fields_json",
         "kind": "static_from",
-        "line": 802,
+        "line": 807,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -55665,7 +58587,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -55674,7 +58596,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_mask_bounds_area",
         "kind": "static_from",
-        "line": 802,
+        "line": 807,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -55688,7 +58610,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -55697,7 +58619,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_payload_canvas",
         "kind": "static_from",
-        "line": 802,
+        "line": 807,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -55711,7 +58633,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -55720,7 +58642,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_union_mask_for_ids",
         "kind": "static_from",
-        "line": 802,
+        "line": 807,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -55734,7 +58656,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -55743,7 +58665,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
         "kind": "static_from",
-        "line": 829,
+        "line": 834,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -55757,7 +58679,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -55766,7 +58688,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODES",
         "kind": "static_from",
-        "line": 829,
+        "line": 834,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -55780,7 +58702,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -55789,7 +58711,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 829,
+        "line": 834,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -55803,7 +58725,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -55812,7 +58734,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_PROFILE_OFF",
         "kind": "static_from",
-        "line": 829,
+        "line": 834,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -55826,7 +58748,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -55835,7 +58757,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_apply_spectrum_anima_mod_guidance",
         "kind": "static_from",
-        "line": 829,
+        "line": 834,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -55849,7 +58771,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -55858,7 +58780,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_find_spectrum_anima_mod_guidance_class",
         "kind": "static_from",
-        "line": 829,
+        "line": 834,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -55872,7 +58794,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -55881,7 +58803,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_normalize_anima_mod_guidance_profile",
         "kind": "static_from",
-        "line": 829,
+        "line": 834,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -55895,7 +58817,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -55904,7 +58826,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_resolve_anima_mod_guidance_enabled",
         "kind": "static_from",
-        "line": 829,
+        "line": 834,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -55918,7 +58840,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -55927,7 +58849,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
         "kind": "static_from",
-        "line": 844,
+        "line": 849,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -55941,7 +58863,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -55950,7 +58872,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
         "kind": "static_from",
-        "line": 844,
+        "line": 849,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -55964,7 +58886,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -55973,7 +58895,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
         "kind": "static_from",
-        "line": 844,
+        "line": 849,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -55987,7 +58909,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -55996,7 +58918,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_EXACT_TOP_K",
         "kind": "static_from",
-        "line": 844,
+        "line": 849,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -56010,7 +58932,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -56019,7 +58941,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
         "kind": "static_from",
-        "line": 844,
+        "line": 849,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -56033,7 +58955,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -56042,7 +58964,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_START_PERCENT",
         "kind": "static_from",
-        "line": 844,
+        "line": 849,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -56056,7 +58978,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -56065,7 +58987,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
         "kind": "static_from",
-        "line": 844,
+        "line": 849,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -56079,7 +59001,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -56088,7 +59010,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STYLE_GAIN",
         "kind": "static_from",
-        "line": 844,
+        "line": 849,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -56102,7 +59024,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -56111,7 +59033,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_INPUT_MODES",
         "kind": "static_from",
-        "line": 844,
+        "line": 849,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -56125,7 +59047,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -56134,7 +59056,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 844,
+        "line": 849,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -56148,7 +59070,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -56157,7 +59079,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_mix_inline_prompt",
         "kind": "static_from",
-        "line": 844,
+        "line": 849,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -56171,7 +59093,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -56180,7 +59102,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_mix_mode_tooltip",
         "kind": "static_from",
-        "line": 844,
+        "line": 849,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -56194,7 +59116,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -56203,7 +59125,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_prompt_with_position",
         "kind": "static_from",
-        "line": 844,
+        "line": 849,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -56217,7 +59139,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -56226,7 +59148,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_tags_from_prompt",
         "kind": "static_from",
-        "line": 844,
+        "line": 849,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -56240,7 +59162,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -56249,7 +59171,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_blend_conditionings",
         "kind": "static_from",
-        "line": 844,
+        "line": 849,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -56263,7 +59185,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -56272,7 +59194,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bounded_artist_mix_float",
         "kind": "static_from",
-        "line": 844,
+        "line": 849,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -56286,7 +59208,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -56295,7 +59217,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bounded_artist_mix_int",
         "kind": "static_from",
-        "line": 844,
+        "line": 849,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -56309,7 +59231,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -56318,7 +59240,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_clustered",
         "kind": "static_from",
-        "line": 844,
+        "line": 849,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -56332,7 +59254,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -56341,7 +59263,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_delta_rms",
         "kind": "static_from",
-        "line": 844,
+        "line": 849,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -56355,7 +59277,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -56364,7 +59286,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_prompt_data_positive_conditioning",
         "kind": "static_from",
-        "line": 844,
+        "line": 849,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -56378,7 +59300,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -56387,7 +59309,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_join_artist_mix_source_prompts",
         "kind": "static_from",
-        "line": 844,
+        "line": 849,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -56401,7 +59323,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -56410,7 +59332,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_normalize_artist_mix_mode",
         "kind": "static_from",
-        "line": 844,
+        "line": 849,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -56424,7 +59346,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -56433,7 +59355,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_normalize_artist_tag_position",
         "kind": "static_from",
-        "line": 844,
+        "line": 849,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -56447,7 +59369,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -56456,7 +59378,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_parse_artist_mix_items",
         "kind": "static_from",
-        "line": 844,
+        "line": 849,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -56470,7 +59392,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -56479,7 +59401,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaArtistMixConditioning",
         "kind": "static_from",
-        "line": 923,
+        "line": 928,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -56493,7 +59415,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -56502,7 +59424,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataConditioning",
         "kind": "static_from",
-        "line": 923,
+        "line": 928,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -56516,7 +59438,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -56525,7 +59447,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataUnpack",
         "kind": "static_from",
-        "line": 923,
+        "line": 928,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -56539,7 +59461,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -56548,7 +59470,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_ANY_TYPE",
         "kind": "static_from",
-        "line": 928,
+        "line": 933,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -56562,7 +59484,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -56571,7 +59493,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_AnyType",
         "kind": "static_from",
-        "line": 928,
+        "line": 933,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -56585,7 +59507,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -56594,7 +59516,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_FlexibleOptionalInputType",
         "kind": "static_from",
-        "line": 928,
+        "line": 933,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -56608,7 +59530,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -56617,7 +59539,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvanced",
         "kind": "static_from",
-        "line": 933,
+        "line": 938,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -56631,7 +59553,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -56640,7 +59562,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvancedV2",
         "kind": "static_from",
-        "line": 933,
+        "line": 938,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -56654,7 +59576,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -56663,7 +59585,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:EASY_USE_ANIMA_INPUT_TYPE",
         "kind": "static_from",
-        "line": 938,
+        "line": 943,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -56677,7 +59599,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -56686,7 +59608,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:EasyUseAnimaAIOGenerator",
         "kind": "static_from",
-        "line": 938,
+        "line": 943,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -56700,7 +59622,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -56709,7 +59631,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:EasyUseAnimaInput",
         "kind": "static_from",
-        "line": 938,
+        "line": 943,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -56723,7 +59645,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -56732,7 +59654,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_aio_generation_settings_json",
         "kind": "static_from",
-        "line": 938,
+        "line": 943,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -56746,7 +59668,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -56755,7 +59677,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_aio_input_settings_json",
         "kind": "static_from",
-        "line": 938,
+        "line": 943,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -56769,7 +59691,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -56778,7 +59700,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_align_down",
         "kind": "static_from",
-        "line": 945,
+        "line": 950,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -56792,7 +59714,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -56801,7 +59723,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_align_nearest",
         "kind": "static_from",
-        "line": 945,
+        "line": 950,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -56815,7 +59737,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -56824,7 +59746,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_image_tensor_size",
         "kind": "static_from",
-        "line": 945,
+        "line": 950,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -56838,7 +59760,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -56847,7 +59769,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_context_value",
         "kind": "static_from",
-        "line": 956,
+        "line": 961,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -56861,7 +59783,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -56870,7 +59792,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_sam3_context",
         "kind": "static_from",
-        "line": 956,
+        "line": 961,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -56884,7 +59806,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -56893,7 +59815,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_segs_has_items",
         "kind": "static_from",
-        "line": 956,
+        "line": 961,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -56907,7 +59829,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -56916,7 +59838,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:IMAGE_SCALE_MULTIPLES",
         "kind": "static_from",
-        "line": 968,
+        "line": 973,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -56930,7 +59852,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -56939,7 +59861,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:IMAGE_UPSCALE_METHODS",
         "kind": "static_from",
-        "line": 968,
+        "line": 973,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -56953,7 +59875,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -56962,7 +59884,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_sampler_names",
         "kind": "static_from",
-        "line": 976,
+        "line": 981,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -56976,7 +59898,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -56985,7 +59907,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_scheduler_names",
         "kind": "static_from",
-        "line": 976,
+        "line": 981,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -56999,7 +59921,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -57008,7 +59930,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_impact_scheduler_names",
         "kind": "static_from",
-        "line": 976,
+        "line": 981,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -57022,7 +59944,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -57031,7 +59953,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_call_with_supported_kwargs",
         "kind": "static_from",
-        "line": 982,
+        "line": 987,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -57045,7 +59967,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -57054,7 +59976,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_common_upscale_image",
         "kind": "static_from",
-        "line": 982,
+        "line": 987,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -57068,7 +59990,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -57077,7 +59999,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_node_output_tuple",
         "kind": "static_from",
-        "line": 982,
+        "line": 987,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -57091,7 +60013,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -57100,7 +60022,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_clip_loader_types",
         "kind": "static_from",
-        "line": 987,
+        "line": 992,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -57114,7 +60036,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -57123,7 +60045,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_diffusion_model_names",
         "kind": "static_from",
-        "line": 987,
+        "line": 992,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -57137,7 +60059,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -57146,7 +60068,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_text_encoder_names",
         "kind": "static_from",
-        "line": 987,
+        "line": 992,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -57160,7 +60082,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -57169,7 +60091,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_vae_names",
         "kind": "static_from",
-        "line": 987,
+        "line": 992,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -57183,7 +60105,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -57192,7 +60114,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_folder_path_names",
         "kind": "static_from",
-        "line": 987,
+        "line": 992,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -57206,7 +60128,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -57215,7 +60137,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.image_nodes:EasyUseAnimaDetailerAlignHook",
         "kind": "static_from",
-        "line": 995,
+        "line": 1000,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -57229,7 +60151,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -57238,7 +60160,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.image_nodes:EasyUseAnimaImageScaleByMultiple",
         "kind": "static_from",
-        "line": 995,
+        "line": 1000,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -57252,7 +60174,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -57261,7 +60183,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Context",
         "kind": "static_from",
-        "line": 999,
+        "line": 1004,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -57275,7 +60197,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -57284,7 +60206,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Detailer",
         "kind": "static_from",
-        "line": 999,
+        "line": 1004,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -57298,7 +60220,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -57307,7 +60229,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptBuilder",
         "kind": "static_from",
-        "line": 1003,
+        "line": 1008,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -57321,7 +60243,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -57330,7 +60252,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrector",
         "kind": "static_from",
-        "line": 1003,
+        "line": 1008,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -57344,7 +60266,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -57353,7 +60275,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrectorSimple",
         "kind": "static_from",
-        "line": 1003,
+        "line": 1008,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -57367,7 +60289,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -57376,7 +60298,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptStudio",
         "kind": "static_from",
-        "line": 1003,
+        "line": 1008,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -57390,7 +60312,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -57399,7 +60321,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:EasyUseAnimaPromptStudioRegional",
         "kind": "static_from",
-        "line": 1009,
+        "line": 1014,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -57413,7 +60335,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -57422,7 +60344,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:EasyUseAnimaRegionalConditioning",
         "kind": "static_from",
-        "line": 1009,
+        "line": 1014,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -57436,7 +60358,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -57445,7 +60367,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:LATENT_ALIGN",
         "kind": "static_from",
-        "line": 1013,
+        "line": 1018,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -57459,7 +60381,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -57468,7 +60390,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_parse_random_response",
         "kind": "static_from",
-        "line": 1013,
+        "line": 1018,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -57482,7 +60404,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -57491,7 +60413,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_post_random",
         "kind": "static_from",
-        "line": 1013,
+        "line": 1018,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -57505,7 +60427,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -57514,7 +60436,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_advanced_resolution_from_selection",
         "kind": "static_from",
-        "line": 1031,
+        "line": 1036,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -57528,7 +60450,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -57537,7 +60459,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_normalize_resolution_bucket",
         "kind": "static_from",
-        "line": 1031,
+        "line": 1036,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -57551,7 +60473,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -57560,7 +60482,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_ratio_label",
         "kind": "static_from",
-        "line": 1031,
+        "line": 1036,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -57574,7 +60496,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -57583,7 +60505,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolution_label",
         "kind": "static_from",
-        "line": 1031,
+        "line": 1036,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -57597,7 +60519,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -57606,7 +60528,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolve_naia_resolution",
         "kind": "static_from",
-        "line": 1031,
+        "line": 1036,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -57620,7 +60542,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -57629,7 +60551,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.naia_nodes:EasyUseAnimaNAIARandomPrompt",
         "kind": "static_from",
-        "line": 1054,
+        "line": 1059,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -57643,7 +60565,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -57652,7 +60574,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.wildcard_nodes:EasyUseAnimaWildcard",
         "kind": "static_from",
-        "line": 1057,
+        "line": 1062,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -57666,7 +60588,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -57675,7 +60597,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_apply_lora_syntax_format",
         "kind": "static_from",
-        "line": 1061,
+        "line": 1066,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -57689,7 +60611,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -57698,7 +60620,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_dedupe_text_values",
         "kind": "static_from",
-        "line": 1061,
+        "line": 1066,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -57712,7 +60634,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -57721,7 +60643,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_fallback_lora_path",
         "kind": "static_from",
-        "line": 1061,
+        "line": 1066,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -57735,7 +60657,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -57744,7 +60666,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_get_lora_info",
         "kind": "static_from",
-        "line": 1061,
+        "line": 1066,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -57758,7 +60680,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -57767,7 +60689,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_get_lora_manager_trigger_words",
         "kind": "static_from",
-        "line": 1061,
+        "line": 1066,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -57781,7 +60703,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -57790,7 +60712,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_load_lora_manager_metadata",
         "kind": "static_from",
-        "line": 1061,
+        "line": 1066,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -57804,7 +60726,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -57813,7 +60735,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_combo_values",
         "kind": "static_from",
-        "line": 1061,
+        "line": 1066,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -57827,7 +60749,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -57836,7 +60758,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_manager_trigger_words_from_metadata",
         "kind": "static_from",
-        "line": 1061,
+        "line": 1066,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -57850,7 +60772,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -57859,7 +60781,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_model_exists",
         "kind": "static_from",
-        "line": 1061,
+        "line": 1066,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -57873,7 +60795,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -57882,7 +60804,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_stack_name",
         "kind": "static_from",
-        "line": 1061,
+        "line": 1066,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -57896,7 +60818,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -57905,7 +60827,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_metadata_json_paths_for_lora",
         "kind": "static_from",
-        "line": 1061,
+        "line": 1066,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -57919,7 +60841,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -57928,7 +60850,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_missing_lora_display_name",
         "kind": "static_from",
-        "line": 1061,
+        "line": 1066,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -57942,7 +60864,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -57951,7 +60873,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_raise_missing_loras",
         "kind": "static_from",
-        "line": 1061,
+        "line": 1066,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -57965,7 +60887,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -57974,7 +60896,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_trigger_words_from_value",
         "kind": "static_from",
-        "line": 1061,
+        "line": 1066,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -57988,7 +60910,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -57997,7 +60919,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_correct_style_prompt",
         "kind": "static_from",
-        "line": 1077,
+        "line": 1082,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -58011,7 +60933,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -58020,7 +60942,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_format_strength",
         "kind": "static_from",
-        "line": 1077,
+        "line": 1082,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -58034,7 +60956,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -58043,7 +60965,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_get_loras_list",
         "kind": "static_from",
-        "line": 1077,
+        "line": 1082,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -58057,7 +60979,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -58066,7 +60988,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_load_profile_data",
         "kind": "static_from",
-        "line": 1077,
+        "line": 1082,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -58080,7 +61002,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -58089,7 +61011,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_profile_key",
         "kind": "static_from",
-        "line": 1077,
+        "line": 1082,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -58103,7 +61025,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -58112,7 +61034,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_select_profile_values",
         "kind": "static_from",
-        "line": 1077,
+        "line": 1082,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -58126,7 +61048,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -58135,7 +61057,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_wrap_profile_index",
         "kind": "static_from",
-        "line": 1077,
+        "line": 1082,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -58149,7 +61071,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -58158,7 +61080,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.lora_nodes:EasyUseAnimaLoraPreset",
         "kind": "static_from",
-        "line": 1086,
+        "line": 1091,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -58172,7 +61094,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -58181,7 +61103,7 @@
         "conditional": true,
         "imported": "anima_prompt:correct_prompt",
         "kind": "static_from",
-        "line": 1089,
+        "line": 1094,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -58195,7 +61117,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -58204,7 +61126,7 @@
         "conditional": true,
         "imported": "anima_prompt:load_knowledge_base",
         "kind": "static_from",
-        "line": 1089,
+        "line": 1094,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -58218,7 +61140,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -58227,7 +61149,7 @@
         "conditional": true,
         "imported": "anima_prompt.parser:parse_prompt",
         "kind": "static_from",
-        "line": 1090,
+        "line": 1095,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -58241,7 +61163,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -58250,7 +61172,7 @@
         "conditional": true,
         "imported": "settings:resolve_metadata_filter_words",
         "kind": "static_from",
-        "line": 1091,
+        "line": 1096,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -58264,7 +61186,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -58273,7 +61195,7 @@
         "conditional": true,
         "imported": "settings:resolve_naia_settings",
         "kind": "static_from",
-        "line": 1091,
+        "line": 1096,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -58287,7 +61209,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -58296,7 +61218,7 @@
         "conditional": true,
         "imported": "settings:resolve_prompt_translation_settings",
         "kind": "static_from",
-        "line": 1091,
+        "line": 1096,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -58310,20 +61232,20 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
-        "imported": "prompt_translation:has_prompt_translation_markers",
+        "imported": "easyuse_anima.translation.markers:has_prompt_translation_markers",
         "kind": "static_from",
-        "line": 1096,
+        "line": 1101,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
-        "target": "prompt_translation.py"
+        "target": "easyuse_anima/translation/markers.py"
       },
       {
         "branch_context": [
@@ -58333,20 +61255,20 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
-        "imported": "prompt_translation:translate_prompt_markers",
+        "imported": "easyuse_anima.translation.service:translate_prompt_markers",
         "kind": "static_from",
-        "line": 1096,
+        "line": 1104,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
-        "target": "prompt_translation.py"
+        "target": "easyuse_anima/translation/service.py"
       },
       {
         "branch_context": [
@@ -58356,7 +61278,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -58365,7 +61287,7 @@
         "conditional": true,
         "imported": "wildcard_engine:MAX_SEED",
         "kind": "static_from",
-        "line": 1097,
+        "line": 1107,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -58379,7 +61301,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -58388,7 +61310,7 @@
         "conditional": true,
         "imported": "wildcard_engine:PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "kind": "static_from",
-        "line": 1097,
+        "line": 1107,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -58402,7 +61324,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -58411,7 +61333,7 @@
         "conditional": true,
         "imported": "wildcard_engine:PUBLIC_MAX_SEED",
         "kind": "static_from",
-        "line": 1097,
+        "line": 1107,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -58425,7 +61347,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -58434,7 +61356,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_DECREMENT",
         "kind": "static_from",
-        "line": 1097,
+        "line": 1107,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -58448,7 +61370,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -58457,7 +61379,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_FIXED",
         "kind": "static_from",
-        "line": 1097,
+        "line": 1107,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -58471,7 +61393,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -58480,7 +61402,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_INCREMENT",
         "kind": "static_from",
-        "line": 1097,
+        "line": 1107,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -58494,7 +61416,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -58503,7 +61425,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_MODES",
         "kind": "static_from",
-        "line": 1097,
+        "line": 1107,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -58517,7 +61439,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -58526,7 +61448,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_RANDOMIZE",
         "kind": "static_from",
-        "line": 1097,
+        "line": 1107,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -58540,7 +61462,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -58549,7 +61471,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_FIXED",
         "kind": "static_from",
-        "line": 1097,
+        "line": 1107,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -58563,7 +61485,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -58572,7 +61494,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_POPULATE",
         "kind": "static_from",
-        "line": 1097,
+        "line": 1107,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -58586,7 +61508,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -58595,7 +61517,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_SEQUENTIAL",
         "kind": "static_from",
-        "line": 1097,
+        "line": 1107,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -58609,7 +61531,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -58618,7 +61540,7 @@
         "conditional": true,
         "imported": "wildcard_engine:expand_wildcard_texts",
         "kind": "static_from",
-        "line": 1097,
+        "line": 1107,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -58632,7 +61554,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -58641,7 +61563,7 @@
         "conditional": true,
         "imported": "wildcard_engine:expand_wildcards",
         "kind": "static_from",
-        "line": 1097,
+        "line": 1107,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -58655,7 +61577,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -58664,7 +61586,7 @@
         "conditional": true,
         "imported": "wildcard_engine:has_wildcard_syntax",
         "kind": "static_from",
-        "line": 1097,
+        "line": 1107,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -58678,7 +61600,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -58687,7 +61609,7 @@
         "conditional": true,
         "imported": "wildcard_engine:next_seed",
         "kind": "static_from",
-        "line": 1097,
+        "line": 1107,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -58701,7 +61623,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -58710,7 +61632,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_prompt_studio_wildcard_mode",
         "kind": "static_from",
-        "line": 1097,
+        "line": 1107,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -58724,7 +61646,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -58733,7 +61655,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_seed",
         "kind": "static_from",
-        "line": 1097,
+        "line": 1107,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -58747,7 +61669,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -58756,7 +61678,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_wildcard_mode",
         "kind": "static_from",
-        "line": 1097,
+        "line": 1107,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -58770,7 +61692,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 566,
             "kind": "try",
             "line": 4
           }
@@ -58779,11 +61701,839 @@
         "conditional": true,
         "imported": "wildcard_engine:wildcard_sources_signature",
         "kind": "static_from",
-        "line": 1097,
+        "line": 1107,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
         "target": "wildcard_engine.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 50,
+            "kind": "try",
+            "line": 5
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.translation.contracts:DEFAULT_PROMPT_TRANSLATION_SOURCE",
+        "kind": "static_from",
+        "line": 51,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "prompt_translation.py",
+        "target": "easyuse_anima/translation/contracts.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 50,
+            "kind": "try",
+            "line": 5
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.translation.contracts:DEFAULT_PROMPT_TRANSLATION_TARGET",
+        "kind": "static_from",
+        "line": 51,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "prompt_translation.py",
+        "target": "easyuse_anima/translation/contracts.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 50,
+            "kind": "try",
+            "line": 5
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.translation.contracts:MAX_PROMPT_TRANSLATION_MARKERS",
+        "kind": "static_from",
+        "line": 51,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "prompt_translation.py",
+        "target": "easyuse_anima/translation/contracts.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 50,
+            "kind": "try",
+            "line": 5
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.translation.contracts:MAX_PROMPT_TRANSLATION_MARKER_CHARACTERS",
+        "kind": "static_from",
+        "line": 51,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "prompt_translation.py",
+        "target": "easyuse_anima/translation/contracts.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 50,
+            "kind": "try",
+            "line": 5
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.translation.contracts:MAX_PROMPT_TRANSLATION_TOTAL_CHARACTERS",
+        "kind": "static_from",
+        "line": 51,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "prompt_translation.py",
+        "target": "easyuse_anima/translation/contracts.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 50,
+            "kind": "try",
+            "line": 5
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.translation.contracts:PROMPT_TRANSLATION_CACHE_MAX_ENTRIES",
+        "kind": "static_from",
+        "line": 51,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "prompt_translation.py",
+        "target": "easyuse_anima/translation/contracts.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 50,
+            "kind": "try",
+            "line": 5
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.translation.contracts:PROMPT_TRANSLATION_CACHE_TTL_SECONDS",
+        "kind": "static_from",
+        "line": 51,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "prompt_translation.py",
+        "target": "easyuse_anima/translation/contracts.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 50,
+            "kind": "try",
+            "line": 5
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.translation.contracts:PROMPT_TRANSLATION_PROVIDERS",
+        "kind": "static_from",
+        "line": 51,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "prompt_translation.py",
+        "target": "easyuse_anima/translation/contracts.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 50,
+            "kind": "try",
+            "line": 5
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.translation.contracts:PROMPT_TRANSLATION_PROVIDER_GOOGLE",
+        "kind": "static_from",
+        "line": 51,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "prompt_translation.py",
+        "target": "easyuse_anima/translation/contracts.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 50,
+            "kind": "try",
+            "line": 5
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.translation.contracts:PROMPT_TRANSLATION_PROVIDER_OFF",
+        "kind": "static_from",
+        "line": 51,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "prompt_translation.py",
+        "target": "easyuse_anima/translation/contracts.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 50,
+            "kind": "try",
+            "line": 5
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.translation.contracts:PROMPT_TRANSLATION_PROVIDER_TIMEOUT_SECONDS",
+        "kind": "static_from",
+        "line": 51,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "prompt_translation.py",
+        "target": "easyuse_anima/translation/contracts.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 50,
+            "kind": "try",
+            "line": 5
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.translation.contracts:PromptTranslationError",
+        "kind": "static_from",
+        "line": 51,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "prompt_translation.py",
+        "target": "easyuse_anima/translation/contracts.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 50,
+            "kind": "try",
+            "line": 5
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.translation.contracts:PromptTranslationLimitError",
+        "kind": "static_from",
+        "line": 51,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "prompt_translation.py",
+        "target": "easyuse_anima/translation/contracts.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 50,
+            "kind": "try",
+            "line": 5
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.translation.contracts:PromptTranslationSettings",
+        "kind": "static_from",
+        "line": 51,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "prompt_translation.py",
+        "target": "easyuse_anima/translation/contracts.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 50,
+            "kind": "try",
+            "line": 5
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.translation.contracts:TranslationBusyError",
+        "kind": "static_from",
+        "line": 51,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "prompt_translation.py",
+        "target": "easyuse_anima/translation/contracts.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 50,
+            "kind": "try",
+            "line": 5
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.translation.contracts:TranslationCacheKey",
+        "kind": "static_from",
+        "line": 51,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "prompt_translation.py",
+        "target": "easyuse_anima/translation/contracts.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 50,
+            "kind": "try",
+            "line": 5
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.translation.contracts:TranslationCancelledError",
+        "kind": "static_from",
+        "line": 51,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "prompt_translation.py",
+        "target": "easyuse_anima/translation/contracts.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 50,
+            "kind": "try",
+            "line": 5
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.translation.contracts:TranslationMarkerCountError",
+        "kind": "static_from",
+        "line": 51,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "prompt_translation.py",
+        "target": "easyuse_anima/translation/contracts.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 50,
+            "kind": "try",
+            "line": 5
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.translation.contracts:TranslationMarkerSizeError",
+        "kind": "static_from",
+        "line": 51,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "prompt_translation.py",
+        "target": "easyuse_anima/translation/contracts.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 50,
+            "kind": "try",
+            "line": 5
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.translation.contracts:TranslationProvider",
+        "kind": "static_from",
+        "line": 51,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "prompt_translation.py",
+        "target": "easyuse_anima/translation/contracts.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 50,
+            "kind": "try",
+            "line": 5
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.translation.contracts:TranslationProviderUnavailableError",
+        "kind": "static_from",
+        "line": 51,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "prompt_translation.py",
+        "target": "easyuse_anima/translation/contracts.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 50,
+            "kind": "try",
+            "line": 5
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.translation.contracts:TranslationTimeoutError",
+        "kind": "static_from",
+        "line": 51,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "prompt_translation.py",
+        "target": "easyuse_anima/translation/contracts.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 50,
+            "kind": "try",
+            "line": 5
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.translation.contracts:TranslationTotalSizeError",
+        "kind": "static_from",
+        "line": 51,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "prompt_translation.py",
+        "target": "easyuse_anima/translation/contracts.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 50,
+            "kind": "try",
+            "line": 5
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.translation.contracts:TranslationUpstreamError",
+        "kind": "static_from",
+        "line": 51,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "prompt_translation.py",
+        "target": "easyuse_anima/translation/contracts.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 50,
+            "kind": "try",
+            "line": 5
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.translation.contracts:normalize_prompt_translation_language",
+        "kind": "static_from",
+        "line": 51,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "prompt_translation.py",
+        "target": "easyuse_anima/translation/contracts.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 50,
+            "kind": "try",
+            "line": 5
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.translation.contracts:normalize_prompt_translation_provider",
+        "kind": "static_from",
+        "line": 51,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "prompt_translation.py",
+        "target": "easyuse_anima/translation/contracts.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 50,
+            "kind": "try",
+            "line": 5
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.translation.markers:PROMPT_TRANSLATION_MARKER_LABEL",
+        "kind": "static_from",
+        "line": 79,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "prompt_translation.py",
+        "target": "easyuse_anima/translation/markers.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 50,
+            "kind": "try",
+            "line": 5
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.translation.markers:has_prompt_translation_markers",
+        "kind": "static_from",
+        "line": 79,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "prompt_translation.py",
+        "target": "easyuse_anima/translation/markers.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 50,
+            "kind": "try",
+            "line": 5
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.translation.markers:iter_prompt_translation_markers",
+        "kind": "static_from",
+        "line": 79,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "prompt_translation.py",
+        "target": "easyuse_anima/translation/markers.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 50,
+            "kind": "try",
+            "line": 5
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.translation.providers.google:GoogleTranslationProvider",
+        "kind": "static_from",
+        "line": 84,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "prompt_translation.py",
+        "target": "easyuse_anima/translation/providers/google.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 50,
+            "kind": "try",
+            "line": 5
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.translation.service:BoundedTranslationCache",
+        "kind": "static_from",
+        "line": 87,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "prompt_translation.py",
+        "target": "easyuse_anima/translation/service.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 50,
+            "kind": "try",
+            "line": 5
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.translation.service:PromptTranslationService",
+        "kind": "static_from",
+        "line": 87,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "prompt_translation.py",
+        "target": "easyuse_anima/translation/service.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 50,
+            "kind": "try",
+            "line": 5
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.translation.service:get_translation_provider",
+        "kind": "static_from",
+        "line": 87,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "prompt_translation.py",
+        "target": "easyuse_anima/translation/service.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 50,
+            "kind": "try",
+            "line": 5
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.translation.service:google_translate_text",
+        "kind": "static_from",
+        "line": 87,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "prompt_translation.py",
+        "target": "easyuse_anima/translation/service.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 50,
+            "kind": "try",
+            "line": 5
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.translation.service:strip_prompt_translation_markers",
+        "kind": "static_from",
+        "line": 87,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "prompt_translation.py",
+        "target": "easyuse_anima/translation/service.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 50,
+            "kind": "try",
+            "line": 5
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.translation.service:translate_prompt_markers",
+        "kind": "static_from",
+        "line": 87,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "prompt_translation.py",
+        "target": "easyuse_anima/translation/service.py"
       },
       {
         "branch_context": [
@@ -58846,13 +62596,13 @@
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
-        "imported": "prompt_translation:DEFAULT_PROMPT_TRANSLATION_SOURCE",
+        "imported": "easyuse_anima.translation.contracts:DEFAULT_PROMPT_TRANSLATION_SOURCE",
         "kind": "static_from",
         "line": 18,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "settings.py",
-        "target": "prompt_translation.py"
+        "target": "easyuse_anima/translation/contracts.py"
       },
       {
         "branch_context": [
@@ -58869,13 +62619,13 @@
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
-        "imported": "prompt_translation:DEFAULT_PROMPT_TRANSLATION_TARGET",
+        "imported": "easyuse_anima.translation.contracts:DEFAULT_PROMPT_TRANSLATION_TARGET",
         "kind": "static_from",
         "line": 18,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "settings.py",
-        "target": "prompt_translation.py"
+        "target": "easyuse_anima/translation/contracts.py"
       },
       {
         "branch_context": [
@@ -58892,13 +62642,13 @@
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
-        "imported": "prompt_translation:PROMPT_TRANSLATION_PROVIDER_OFF",
+        "imported": "easyuse_anima.translation.contracts:PROMPT_TRANSLATION_PROVIDER_OFF",
         "kind": "static_from",
         "line": 18,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "settings.py",
-        "target": "prompt_translation.py"
+        "target": "easyuse_anima/translation/contracts.py"
       },
       {
         "branch_context": [
@@ -58915,13 +62665,13 @@
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
-        "imported": "prompt_translation:PromptTranslationSettings",
+        "imported": "easyuse_anima.translation.contracts:PromptTranslationSettings",
         "kind": "static_from",
         "line": 18,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "settings.py",
-        "target": "prompt_translation.py"
+        "target": "easyuse_anima/translation/contracts.py"
       },
       {
         "branch_context": [
@@ -58938,13 +62688,13 @@
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
-        "imported": "prompt_translation:normalize_prompt_translation_language",
+        "imported": "easyuse_anima.translation.contracts:normalize_prompt_translation_language",
         "kind": "static_from",
         "line": 18,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "settings.py",
-        "target": "prompt_translation.py"
+        "target": "easyuse_anima/translation/contracts.py"
       },
       {
         "branch_context": [
@@ -58961,13 +62711,13 @@
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
-        "imported": "prompt_translation:normalize_prompt_translation_provider",
+        "imported": "easyuse_anima.translation.contracts:normalize_prompt_translation_provider",
         "kind": "static_from",
         "line": 18,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "settings.py",
-        "target": "prompt_translation.py"
+        "target": "easyuse_anima/translation/contracts.py"
       },
       {
         "branch_context": [
@@ -59024,7 +62774,8 @@
     ],
     "entry_modules": [
       "__init__.py",
-      "nodes.py"
+      "nodes.py",
+      "prompt_translation.py"
     ],
     "external_imports": [
       {
@@ -59410,14 +63161,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 438
+            "line": 440
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 439,
+        "line": 441,
         "optional": true,
         "role": "optional_dependency",
         "source": "api.py"
@@ -59429,14 +63180,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 464
+            "line": 466
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 465,
+        "line": 467,
         "optional": true,
         "role": "optional_dependency",
         "source": "api.py"
@@ -59448,14 +63199,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1005
+            "line": 1007
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 1006,
+        "line": 1008,
         "optional": true,
         "role": "optional_dependency",
         "source": "api.py"
@@ -63725,6 +67476,201 @@
         "line": 3,
         "optional": false,
         "role": "ordinary",
+        "source": "easyuse_anima/translation/contracts.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "dataclasses:dataclass",
+        "kind": "static_from",
+        "line": 5,
+        "optional": false,
+        "role": "ordinary",
+        "source": "easyuse_anima/translation/contracts.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "typing:Protocol",
+        "kind": "static_from",
+        "line": 6,
+        "optional": false,
+        "role": "ordinary",
+        "source": "easyuse_anima/translation/contracts.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "__future__:annotations",
+        "kind": "static_from",
+        "line": 3,
+        "optional": false,
+        "role": "ordinary",
+        "source": "easyuse_anima/translation/markers.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "__future__:annotations",
+        "kind": "static_from",
+        "line": 3,
+        "optional": false,
+        "role": "ordinary",
+        "source": "easyuse_anima/translation/providers/google.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "html",
+        "kind": "static_import",
+        "line": 5,
+        "optional": false,
+        "role": "ordinary",
+        "source": "easyuse_anima/translation/providers/google.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "threading",
+        "kind": "static_import",
+        "line": 6,
+        "optional": false,
+        "role": "ordinary",
+        "source": "easyuse_anima/translation/providers/google.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "collections.abc:Callable",
+        "kind": "static_from",
+        "line": 7,
+        "optional": false,
+        "role": "ordinary",
+        "source": "easyuse_anima/translation/providers/google.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "typing:Protocol",
+        "kind": "static_from",
+        "line": 8,
+        "optional": false,
+        "role": "ordinary",
+        "source": "easyuse_anima/translation/providers/google.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 48
+          }
+        ],
+        "classification": "external",
+        "conditional": true,
+        "imported": "googletrans:Translator",
+        "kind": "static_from",
+        "line": 49,
+        "optional": true,
+        "role": "optional_dependency",
+        "source": "easyuse_anima/translation/providers/google.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "__future__:annotations",
+        "kind": "static_from",
+        "line": 3,
+        "optional": false,
+        "role": "ordinary",
+        "source": "easyuse_anima/translation/service.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "threading",
+        "kind": "static_import",
+        "line": 5,
+        "optional": false,
+        "role": "ordinary",
+        "source": "easyuse_anima/translation/service.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "time",
+        "kind": "static_import",
+        "line": 6,
+        "optional": false,
+        "role": "ordinary",
+        "source": "easyuse_anima/translation/service.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "collections:OrderedDict",
+        "kind": "static_from",
+        "line": 7,
+        "optional": false,
+        "role": "ordinary",
+        "source": "easyuse_anima/translation/service.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "collections.abc:Callable",
+        "kind": "static_from",
+        "line": 8,
+        "optional": false,
+        "role": "ordinary",
+        "source": "easyuse_anima/translation/service.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "contextlib:contextmanager",
+        "kind": "static_from",
+        "line": 9,
+        "optional": false,
+        "role": "ordinary",
+        "source": "easyuse_anima/translation/service.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "dataclasses:dataclass",
+        "kind": "static_from",
+        "line": 10,
+        "optional": false,
+        "role": "ordinary",
+        "source": "easyuse_anima/translation/service.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "__future__:annotations",
+        "kind": "static_from",
+        "line": 3,
+        "optional": false,
+        "role": "ordinary",
         "source": "easyuse_anima/workflow.py"
       },
       {
@@ -63744,116 +67690,9 @@
         "conditional": false,
         "imported": "__future__:annotations",
         "kind": "static_from",
-        "line": 1,
-        "optional": false,
-        "role": "ordinary",
-        "source": "prompt_translation.py"
-      },
-      {
-        "branch_context": [],
-        "classification": "external",
-        "conditional": false,
-        "imported": "html",
-        "kind": "static_import",
         "line": 3,
         "optional": false,
         "role": "ordinary",
-        "source": "prompt_translation.py"
-      },
-      {
-        "branch_context": [],
-        "classification": "external",
-        "conditional": false,
-        "imported": "threading",
-        "kind": "static_import",
-        "line": 4,
-        "optional": false,
-        "role": "ordinary",
-        "source": "prompt_translation.py"
-      },
-      {
-        "branch_context": [],
-        "classification": "external",
-        "conditional": false,
-        "imported": "time",
-        "kind": "static_import",
-        "line": 5,
-        "optional": false,
-        "role": "ordinary",
-        "source": "prompt_translation.py"
-      },
-      {
-        "branch_context": [],
-        "classification": "external",
-        "conditional": false,
-        "imported": "collections:OrderedDict",
-        "kind": "static_from",
-        "line": 6,
-        "optional": false,
-        "role": "ordinary",
-        "source": "prompt_translation.py"
-      },
-      {
-        "branch_context": [],
-        "classification": "external",
-        "conditional": false,
-        "imported": "contextlib:contextmanager",
-        "kind": "static_from",
-        "line": 7,
-        "optional": false,
-        "role": "ordinary",
-        "source": "prompt_translation.py"
-      },
-      {
-        "branch_context": [],
-        "classification": "external",
-        "conditional": false,
-        "imported": "dataclasses:dataclass",
-        "kind": "static_from",
-        "line": 8,
-        "optional": false,
-        "role": "ordinary",
-        "source": "prompt_translation.py"
-      },
-      {
-        "branch_context": [],
-        "classification": "external",
-        "conditional": false,
-        "imported": "typing:Callable",
-        "kind": "static_from",
-        "line": 9,
-        "optional": false,
-        "role": "ordinary",
-        "source": "prompt_translation.py"
-      },
-      {
-        "branch_context": [],
-        "classification": "external",
-        "conditional": false,
-        "imported": "typing:Protocol",
-        "kind": "static_from",
-        "line": 9,
-        "optional": false,
-        "role": "ordinary",
-        "source": "prompt_translation.py"
-      },
-      {
-        "branch_context": [
-          {
-            "branch": "body",
-            "handles_import_failure": true,
-            "has_import_fallback_handler": true,
-            "kind": "try",
-            "line": 169
-          }
-        ],
-        "classification": "external",
-        "conditional": true,
-        "imported": "googletrans:Translator",
-        "kind": "static_from",
-        "line": 170,
-        "optional": true,
-        "role": "optional_dependency",
         "source": "prompt_translation.py"
       },
       {
@@ -64342,14 +68181,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 438
+            "line": 440
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 439,
+        "line": 441,
         "optional": true,
         "role": "optional_dependency",
         "source": "api.py"
@@ -64361,14 +68200,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 464
+            "line": 466
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 465,
+        "line": 467,
         "optional": true,
         "role": "optional_dependency",
         "source": "api.py"
@@ -64380,14 +68219,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1005
+            "line": 1007
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 1006,
+        "line": 1008,
         "optional": true,
         "role": "optional_dependency",
         "source": "api.py"
@@ -65146,17 +68985,17 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 169
+            "line": 48
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "googletrans:Translator",
         "kind": "static_from",
-        "line": 170,
+        "line": 49,
         "optional": true,
         "role": "optional_dependency",
-        "source": "prompt_translation.py"
+        "source": "easyuse_anima/translation/providers/google.py"
       },
       {
         "branch_context": [
@@ -65336,6 +69175,12 @@
       "easyuse_anima/seed/execution_session.py",
       "easyuse_anima/seed/reservation.py",
       "easyuse_anima/seed/service.py",
+      "easyuse_anima/translation/__init__.py",
+      "easyuse_anima/translation/contracts.py",
+      "easyuse_anima/translation/markers.py",
+      "easyuse_anima/translation/providers/__init__.py",
+      "easyuse_anima/translation/providers/google.py",
+      "easyuse_anima/translation/service.py",
       "easyuse_anima/workflow.py",
       "nodes.py",
       "prompt_translation.py",
@@ -65443,6 +69288,12 @@
       "easyuse_anima/seed/execution_session.py",
       "easyuse_anima/seed/reservation.py",
       "easyuse_anima/seed/service.py",
+      "easyuse_anima/translation/__init__.py",
+      "easyuse_anima/translation/contracts.py",
+      "easyuse_anima/translation/markers.py",
+      "easyuse_anima/translation/providers/__init__.py",
+      "easyuse_anima/translation/providers/google.py",
+      "easyuse_anima/translation/service.py",
       "easyuse_anima/workflow.py",
       "nodes.py",
       "prompt_translation.py",
@@ -65631,7 +69482,7 @@
         "column": 29,
         "context": "assign:INVALID_PROFILE_NAME_CHARS",
         "kind": "import_time_call",
-        "line": 108,
+        "line": 110,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -65640,7 +69491,7 @@
         "column": 33,
         "context": "assign:WINDOWS_RESERVED_FILE_BASENAMES",
         "kind": "import_time_call",
-        "line": 133,
+        "line": 135,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -65649,7 +69500,7 @@
         "column": 33,
         "context": "assign:WINDOWS_RESERVED_FILE_BASENAMES",
         "kind": "import_time_call",
-        "line": 134,
+        "line": 136,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -65658,7 +69509,7 @@
         "column": 10,
         "context": "assign:_LOGGER",
         "kind": "import_time_call",
-        "line": 140,
+        "line": 142,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -65667,7 +69518,7 @@
         "column": 25,
         "context": "assign:_FILE_IO_LIMITERS_LOCK",
         "kind": "import_time_call",
-        "line": 147,
+        "line": 149,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -65676,7 +69527,7 @@
         "column": 47,
         "context": "assign:_FILE_IO_LIMITERS",
         "kind": "import_time_call",
-        "line": 148,
+        "line": 150,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -65685,7 +69536,7 @@
         "column": 29,
         "context": "assign:_PROMPT_TRANSLATION_WORKER",
         "kind": "import_time_call",
-        "line": 197,
+        "line": 199,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -65694,7 +69545,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 198,
+        "line": 200,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -65703,7 +69554,7 @@
         "column": 36,
         "context": "assign:_SAFE_PROFILE_VALIDATION_MESSAGES",
         "kind": "import_time_call",
-        "line": 1032,
+        "line": 1034,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -65712,7 +69563,7 @@
         "column": 9,
         "context": "assign:routes",
         "kind": "route_registry_creation",
-        "line": 1189,
+        "line": 1191,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -65721,7 +69572,7 @@
         "column": 19,
         "context": "assign:_ROUTE_SIGNATURE",
         "kind": "route_registry_creation",
-        "line": 1532,
+        "line": 1534,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -65730,7 +69581,7 @@
         "column": 5,
         "context": "assign:_ROUTE_SIGNATURE",
         "kind": "route_registry_creation",
-        "line": 1533,
+        "line": 1535,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -65739,7 +69590,7 @@
         "column": 19,
         "context": "assign:_INLINE_SPACE_RE",
         "kind": "import_time_call",
-        "line": 85,
+        "line": 89,
         "module": "autocomplete_dataset.py",
         "scope": "<module>"
       },
@@ -65748,7 +69599,7 @@
         "column": 26,
         "context": "assign:_AUTOCOMPLETE_INDEX_DIR",
         "kind": "import_time_call",
-        "line": 126,
+        "line": 130,
         "module": "autocomplete_dataset.py",
         "scope": "<module>"
       },
@@ -65757,7 +69608,7 @@
         "column": 12,
         "context": "assign:_COUNT_RE",
         "kind": "import_time_call",
-        "line": 127,
+        "line": 131,
         "module": "autocomplete_dataset.py",
         "scope": "<module>"
       },
@@ -65766,7 +69617,7 @@
         "column": 20,
         "context": "assign:_WEIGHT_NUMBER_RE",
         "kind": "import_time_call",
-        "line": 132,
+        "line": 136,
         "module": "autocomplete_dataset.py",
         "scope": "<module>"
       },
@@ -65775,7 +69626,7 @@
         "column": 21,
         "context": "assign:_WEIGHTED_TOKEN_RE",
         "kind": "import_time_call",
-        "line": 133,
+        "line": 137,
         "module": "autocomplete_dataset.py",
         "scope": "<module>"
       },
@@ -65784,7 +69635,7 @@
         "column": 21,
         "context": "assign:_WILDCARD_TOKEN_RE",
         "kind": "import_time_call",
-        "line": 134,
+        "line": 138,
         "module": "autocomplete_dataset.py",
         "scope": "<module>"
       },
@@ -65793,7 +69644,7 @@
         "column": 22,
         "context": "assign:_WILDCARD_SYNTAX_RE",
         "kind": "import_time_call",
-        "line": 135,
+        "line": 139,
         "module": "autocomplete_dataset.py",
         "scope": "<module>"
       },
@@ -65802,7 +69653,7 @@
         "column": 27,
         "context": "assign:_DYNAMIC_PROMPT_TOKEN_RE",
         "kind": "import_time_call",
-        "line": 136,
+        "line": 140,
         "module": "autocomplete_dataset.py",
         "scope": "<module>"
       },
@@ -65811,7 +69662,7 @@
         "column": 28,
         "context": "assign:_DYNAMIC_PROMPT_SYNTAX_RE",
         "kind": "import_time_call",
-        "line": 137,
+        "line": 141,
         "module": "autocomplete_dataset.py",
         "scope": "<module>"
       },
@@ -65820,7 +69671,7 @@
         "column": 25,
         "context": "assign:_DESCRIPTION_PREFIX_RE",
         "kind": "import_time_call",
-        "line": 138,
+        "line": 142,
         "module": "autocomplete_dataset.py",
         "scope": "<module>"
       },
@@ -65829,7 +69680,7 @@
         "column": 14,
         "context": "assign:_COMMENT_RE",
         "kind": "import_time_call",
-        "line": 139,
+        "line": 143,
         "module": "autocomplete_dataset.py",
         "scope": "<module>"
       },
@@ -65838,7 +69689,7 @@
         "column": 1,
         "context": "decorator:AutocompleteEntry",
         "kind": "import_time_call",
-        "line": 141,
+        "line": 145,
         "module": "autocomplete_dataset.py",
         "scope": "<module>"
       },
@@ -65847,7 +69698,7 @@
         "column": 1,
         "context": "decorator:_AutocompleteCacheKey",
         "kind": "import_time_call",
-        "line": 151,
+        "line": 155,
         "module": "autocomplete_dataset.py",
         "scope": "<module>"
       },
@@ -65856,7 +69707,7 @@
         "column": 1,
         "context": "decorator:_AutocompleteSnapshot",
         "kind": "import_time_call",
-        "line": 159,
+        "line": 163,
         "module": "autocomplete_dataset.py",
         "scope": "<module>"
       },
@@ -65865,7 +69716,7 @@
         "column": 14,
         "context": "assign:_CACHE_LOCK",
         "kind": "import_time_call",
-        "line": 170,
+        "line": 174,
         "module": "autocomplete_dataset.py",
         "scope": "<module>"
       },
@@ -66720,7 +70571,7 @@
         "column": 28,
         "context": "assign:_ADVANCED_FIELD_SOCKET_RE",
         "kind": "import_time_call",
-        "line": 132,
+        "line": 131,
         "module": "easyuse_anima/prompt/advanced.py",
         "scope": "<module>"
       },
@@ -66918,8 +70769,8 @@
         "column": 1,
         "context": "decorator:PromptTranslationSettings",
         "kind": "import_time_call",
-        "line": 30,
-        "module": "prompt_translation.py",
+        "line": 27,
+        "module": "easyuse_anima/translation/contracts.py",
         "scope": "<module>"
       },
       {
@@ -66927,8 +70778,8 @@
         "column": 29,
         "context": "assign:_TRANSLATION_PROVIDER_LOCK",
         "kind": "import_time_call",
-        "line": 204,
-        "module": "prompt_translation.py",
+        "line": 43,
+        "module": "easyuse_anima/translation/service.py",
         "scope": "<module>"
       },
       {
@@ -66936,8 +70787,8 @@
         "column": 14,
         "context": "assign:_CACHE_MISS",
         "kind": "import_time_call",
-        "line": 249,
-        "module": "prompt_translation.py",
+        "line": 107,
+        "module": "easyuse_anima/translation/service.py",
         "scope": "<module>"
       },
       {
@@ -66945,8 +70796,8 @@
         "column": 31,
         "context": "assign:_DEFAULT_TRANSLATION_SERVICE",
         "kind": "import_time_call",
-        "line": 410,
-        "module": "prompt_translation.py",
+        "line": 321,
+        "module": "easyuse_anima/translation/service.py",
         "scope": "<module>"
       },
       {
@@ -67195,49 +71046,49 @@
       },
       {
         "kind": "set",
-        "line": 112,
+        "line": 114,
         "module": "api.py",
         "name": "AIO_RESERVED_PROFILE_NAMES"
       },
       {
         "kind": "set",
-        "line": 128,
+        "line": 130,
         "module": "api.py",
         "name": "WINDOWS_RESERVED_FILE_BASENAMES"
       },
       {
         "kind": "dict",
-        "line": 55,
+        "line": 59,
         "module": "autocomplete_dataset.py",
         "name": "AUTOCOMPLETE_SOURCES"
       },
       {
         "kind": "dict",
-        "line": 171,
+        "line": 175,
         "module": "autocomplete_dataset.py",
         "name": "_CACHE"
       },
       {
         "kind": "dict",
-        "line": 86,
+        "line": 90,
         "module": "autocomplete_dataset.py",
         "name": "_DANBOORU_CATEGORY_NAMES"
       },
       {
         "kind": "dict",
-        "line": 93,
+        "line": 97,
         "module": "autocomplete_dataset.py",
         "name": "_E621_CATEGORY_NAMES"
       },
       {
         "kind": "dict",
-        "line": 172,
+        "line": 176,
         "module": "autocomplete_dataset.py",
         "name": "_INFLIGHT"
       },
       {
         "kind": "dict",
-        "line": 102,
+        "line": 106,
         "module": "autocomplete_dataset.py",
         "name": "_MERGED_E621_CATEGORY_NAMES"
       },
@@ -67345,37 +71196,37 @@
       },
       {
         "kind": "dict",
-        "line": 53,
+        "line": 52,
         "module": "easyuse_anima/prompt/advanced.py",
         "name": "ADVANCED_FIELD_LABELS"
       },
       {
         "kind": "set",
-        "line": 52,
+        "line": 51,
         "module": "easyuse_anima/prompt/advanced.py",
         "name": "ADVANCED_FIELD_PANES"
       },
       {
         "kind": "set",
-        "line": 51,
+        "line": 50,
         "module": "easyuse_anima/prompt/advanced.py",
         "name": "ADVANCED_FIELD_TYPES"
       },
       {
         "kind": "list",
-        "line": 82,
+        "line": 81,
         "module": "easyuse_anima/prompt/advanced.py",
         "name": "EXTEND_PROMPT_SLOT_SPECS"
       },
       {
         "kind": "set",
-        "line": 76,
+        "line": 75,
         "module": "easyuse_anima/prompt/advanced.py",
         "name": "PROMPT_STUDIO_LEGACY_FIXED_WILDCARD_MODES"
       },
       {
         "kind": "dict",
-        "line": 66,
+        "line": 65,
         "module": "easyuse_anima/prompt/advanced.py",
         "name": "PROMPT_STUDIO_WILDCARD_SEED_CONTROL_ALIASES"
       },
@@ -67440,28 +71291,28 @@
         "name": "_LEGACY_SELECTION_BY_SEED"
       },
       {
-        "kind": "list",
-        "line": 1119,
-        "module": "nodes.py",
-        "name": "__all__"
-      },
-      {
         "kind": "set",
-        "line": 14,
-        "module": "prompt_translation.py",
+        "line": 10,
+        "module": "easyuse_anima/translation/contracts.py",
         "name": "PROMPT_TRANSLATION_PROVIDERS"
       },
       {
         "kind": "dict",
-        "line": 200,
-        "module": "prompt_translation.py",
+        "line": 36,
+        "module": "easyuse_anima/translation/service.py",
         "name": "_TRANSLATION_PROVIDER_FACTORIES"
       },
       {
         "kind": "dict",
-        "line": 203,
-        "module": "prompt_translation.py",
+        "line": 42,
+        "module": "easyuse_anima/translation/service.py",
         "name": "_TRANSLATION_PROVIDER_INSTANCES"
+      },
+      {
+        "kind": "list",
+        "line": 1129,
+        "module": "nodes.py",
+        "name": "__all__"
       },
       {
         "kind": "set",
@@ -67566,7 +71417,7 @@
           "lock"
         ],
         "initializer": "threading.Lock",
-        "line": 147,
+        "line": 149,
         "module": "api.py",
         "name": "_FILE_IO_LIMITERS_LOCK"
       },
@@ -67575,7 +71426,7 @@
           "executor"
         ],
         "initializer": "_PromptTranslationWorker",
-        "line": 197,
+        "line": 199,
         "module": "api.py",
         "name": "_PROMPT_TRANSLATION_WORKER"
       },
@@ -67585,7 +71436,7 @@
           "mutable_container"
         ],
         "initializer": "Dict",
-        "line": 171,
+        "line": 175,
         "module": "autocomplete_dataset.py",
         "name": "_CACHE"
       },
@@ -67594,7 +71445,7 @@
           "lock"
         ],
         "initializer": "threading.Lock",
-        "line": 170,
+        "line": 174,
         "module": "autocomplete_dataset.py",
         "name": "_CACHE_LOCK"
       },
@@ -67605,7 +71456,7 @@
           "single_flight"
         ],
         "initializer": "Dict",
-        "line": 172,
+        "line": 176,
         "module": "autocomplete_dataset.py",
         "name": "_INFLIGHT"
       },
@@ -67682,8 +71533,8 @@
           "mutable_container"
         ],
         "initializer": "Dict",
-        "line": 203,
-        "module": "prompt_translation.py",
+        "line": 42,
+        "module": "easyuse_anima/translation/service.py",
         "name": "_TRANSLATION_PROVIDER_INSTANCES"
       },
       {
@@ -67691,8 +71542,8 @@
           "lock"
         ],
         "initializer": "threading.RLock",
-        "line": 204,
-        "module": "prompt_translation.py",
+        "line": 43,
+        "module": "easyuse_anima/translation/service.py",
         "name": "_TRANSLATION_PROVIDER_LOCK"
       },
       {

--- a/tests/fixtures/python_compatibility_surface.v1.json
+++ b/tests/fixtures/python_compatibility_surface.v1.json
@@ -118,8 +118,8 @@
   "expected_counts": {
     "root_entrypoints": 3,
     "excluded_preamble_implementation_bindings": 0,
-    "nodes_canonical_bindings": 289,
-    "nodes_legacy_bindings": 27,
+    "nodes_canonical_bindings": 291,
+    "nodes_legacy_bindings": 25,
     "nodes_public_exports": 18,
     "mapped_public_classes": 18,
     "unmapped_classes": 2,
@@ -2685,6 +2685,64 @@
       "lifecycle_state": "unsupported"
     },
     {
+      "id": "nodes_canonical_bindings:easyuse_anima.translation.markers:unsupported_test_only",
+      "surface": "nodes_canonical_bindings",
+      "symbols": {
+        "has_prompt_translation_markers": "has_prompt_translation_markers"
+      },
+      "classification": "unsupported_test_only",
+      "current_target": "nodes.py",
+      "canonical_target": "easyuse_anima.translation.markers",
+      "target_state": "canonical",
+      "identity_requirement": "not_applicable",
+      "binding_shape": "direct_import",
+      "import_target": "easyuse_anima.translation.markers",
+      "owner": "#184/#188",
+      "first_release": null,
+      "known_consumers": [
+        "repository tests may import this root name"
+      ],
+      "evidence": [
+        "AST:no nodes.py runtime load",
+        "test-only consumption is not public support evidence"
+      ],
+      "removal_gates": [
+        "test imports migrate to canonical targets",
+        "no production consumer evidence",
+        "separate B-10b removal review"
+      ],
+      "lifecycle_state": "unsupported"
+    },
+    {
+      "id": "nodes_canonical_bindings:easyuse_anima.translation.service:unsupported_test_only",
+      "surface": "nodes_canonical_bindings",
+      "symbols": {
+        "translate_prompt_markers": "translate_prompt_markers"
+      },
+      "classification": "unsupported_test_only",
+      "current_target": "nodes.py",
+      "canonical_target": "easyuse_anima.translation.service",
+      "target_state": "canonical",
+      "identity_requirement": "not_applicable",
+      "binding_shape": "direct_import",
+      "import_target": "easyuse_anima.translation.service",
+      "owner": "#184/#188",
+      "first_release": null,
+      "known_consumers": [
+        "repository tests may import this root name"
+      ],
+      "evidence": [
+        "AST:no nodes.py runtime load",
+        "test-only consumption is not public support evidence"
+      ],
+      "removal_gates": [
+        "test imports migrate to canonical targets",
+        "no production consumer evidence",
+        "separate B-10b removal review"
+      ],
+      "lifecycle_state": "unsupported"
+    },
+    {
       "id": "nodes_canonical_bindings:easyuse_anima.workflow:unsupported_test_only",
       "surface": "nodes_canonical_bindings",
       "symbols": {
@@ -2757,36 +2815,6 @@
       "binding_shape": "direct_import",
       "import_target": "anima_prompt",
       "owner": "#184/#186",
-      "first_release": null,
-      "known_consumers": [
-        "repository tests may import this root name"
-      ],
-      "evidence": [
-        "AST:no nodes.py runtime load",
-        "test-only consumption is not public support evidence"
-      ],
-      "removal_gates": [
-        "test imports migrate to canonical targets",
-        "no production consumer evidence",
-        "separate B-10b removal review"
-      ],
-      "lifecycle_state": "unsupported"
-    },
-    {
-      "id": "nodes_legacy_bindings:prompt_translation:unsupported_test_only",
-      "surface": "nodes_legacy_bindings",
-      "symbols": {
-        "has_prompt_translation_markers": "has_prompt_translation_markers",
-        "translate_prompt_markers": "translate_prompt_markers"
-      },
-      "classification": "unsupported_test_only",
-      "current_target": "nodes.py",
-      "canonical_target": null,
-      "target_state": "legacy_owner",
-      "identity_requirement": "not_applicable",
-      "binding_shape": "direct_import",
-      "import_target": "prompt_translation",
-      "owner": "#164/#186",
       "first_release": null,
       "known_consumers": [
         "repository tests may import this root name"

--- a/tests/fixtures/python_import_boundary_contract.v1.json
+++ b/tests/fixtures/python_import_boundary_contract.v1.json
@@ -36,6 +36,12 @@
       "owner_issue": 163,
       "prefix": "easyuse_anima/profiles/",
       "role": "feature"
+    },
+    {
+      "group": "translation",
+      "owner_issue": 186,
+      "prefix": "easyuse_anima/translation/",
+      "role": "feature"
     }
   ]
 }

--- a/tests/test_nodes_module_analyzer.py
+++ b/tests/test_nodes_module_analyzer.py
@@ -73,12 +73,12 @@ def load_dynamic():
     def test_current_nodes_module_shape_matches_recorded_baseline(self):
         report = analyzer.analyze_path(ROOT / "nodes.py")
 
-        self.assertEqual(report["git_blob_sha1"], "d57d76310253976c1f725974802aba61f456c225")
+        self.assertEqual(report["git_blob_sha1"], "a1503e8f532e717667138686fd6881627eb86814")
         # B-11d removes the final residual implementation globals and records
         # the supported mapped class surface in an explicit __all__.
         self.assertEqual(report["top_level"]["function_count"], 0)
         self.assertEqual(report["top_level"]["class_count"], 0)
-        self.assertEqual(report["line_count"], 1_138)
+        self.assertEqual(report["line_count"], 1_148)
         class_names = {item["name"] for item in report["top_level"]["classes"]}
         self.assertNotIn("EasyUseAnimaAIOGenerator", class_names)
         self.assertNotIn("EasyUseAnimaInput", class_names)

--- a/tests/test_prompt_corrector.py
+++ b/tests/test_prompt_corrector.py
@@ -64,11 +64,13 @@ from autocomplete_dataset import (
     resolve_autocomplete_source,
     search_autocomplete,
 )
-from prompt_translation import (
+from easyuse_anima.translation.contracts import (
     PROMPT_TRANSLATION_PROVIDER_GOOGLE,
     PROMPT_TRANSLATION_PROVIDER_OFF,
     PromptTranslationSettings,
     normalize_prompt_translation_provider,
+)
+from easyuse_anima.translation.service import (
     strip_prompt_translation_markers,
     translate_prompt_markers,
 )
@@ -127,7 +129,10 @@ class PromptCorrectorTests(unittest.TestCase):
             self.assertEqual(target, "en")
             return {"빨간 머리의 소녀": "girl with red hair"}[text]
 
-        with patch("prompt_translation.google_translate_text", side_effect=fake_translate):
+        with patch(
+            "easyuse_anima.translation.service.google_translate_text",
+            side_effect=fake_translate,
+        ):
             translated = translate_prompt_markers(
                 "1girl, %{빨간 머리의 소녀}, blue eyes",
                 PromptTranslationSettings(
@@ -148,9 +153,13 @@ class PromptCorrectorTests(unittest.TestCase):
     def test_prompt_translation_defaults_off_and_does_not_auto_read_api_keys(self):
         self.assertEqual(PromptTranslationSettings().provider, PROMPT_TRANSLATION_PROVIDER_OFF)
         self.assertEqual(normalize_prompt_translation_provider("unknown"), PROMPT_TRANSLATION_PROVIDER_OFF)
-        source = (Path(__file__).resolve().parents[1] / "prompt_translation.py").read_text(
-            encoding="utf-8"
-        )
+        source = (
+            Path(__file__).resolve().parents[1]
+            / "easyuse_anima"
+            / "translation"
+            / "providers"
+            / "google.py"
+        ).read_text(encoding="utf-8")
         self.assertNotIn("GOOGLE_TRANSLATION_API_KEY", source)
         self.assertNotIn("requests.post", source)
 
@@ -212,7 +221,10 @@ class PromptCorrectorTests(unittest.TestCase):
                     target="en",
                 ),
             ),
-            patch("prompt_translation.google_translate_text", return_value="long_hair, 1girl"),
+            patch(
+                "easyuse_anima.translation.service.google_translate_text",
+                return_value="long_hair, 1girl",
+            ),
         ):
             corrected, report = EasyUseAnimaPromptCorrector().correct("%{긴 머리 소녀}", "", "")
             simple = EasyUseAnimaPromptCorrectorSimple().correct("%{긴 머리 소녀}")[0]
@@ -231,7 +243,10 @@ class PromptCorrectorTests(unittest.TestCase):
                     target="en",
                 ),
             ),
-            patch("prompt_translation.google_translate_text", return_value="girl with red hair"),
+            patch(
+                "easyuse_anima.translation.service.google_translate_text",
+                return_value="girl with red hair",
+            ),
         ):
             prompt, _quality, _use_amg, metadata_prompt = EasyUseAnimaPromptBuilder().build(
                 False,
@@ -1257,7 +1272,10 @@ class PromptBuilderTests(unittest.TestCase):
                     target="en",
                 ),
             ),
-            patch("prompt_translation.google_translate_text", return_value="girl with red hair"),
+            patch(
+                "easyuse_anima.translation.service.google_translate_text",
+                return_value="girl with red hair",
+            ),
         ):
             result = EasyUseAnimaPromptStudioAdvancedV2().build(
                 False,

--- a/tests/test_prompt_translation.py
+++ b/tests/test_prompt_translation.py
@@ -9,12 +9,11 @@ from concurrent.futures import ThreadPoolExecutor
 from types import SimpleNamespace
 from unittest.mock import patch
 
-from prompt_translation import (
+import prompt_translation as root_translation
+from easyuse_anima.translation import contracts, markers, service
+from easyuse_anima.translation.contracts import (
     PROMPT_TRANSLATION_PROVIDER_GOOGLE,
     PROMPT_TRANSLATION_PROVIDER_TIMEOUT_SECONDS,
-    BoundedTranslationCache,
-    GoogleTranslationProvider,
-    PromptTranslationService,
     PromptTranslationSettings,
     TranslationMarkerCountError,
     TranslationMarkerSizeError,
@@ -22,6 +21,14 @@ from prompt_translation import (
     TranslationTimeoutError,
     TranslationTotalSizeError,
     TranslationUpstreamError,
+)
+from easyuse_anima.translation.providers import google as google_provider
+from easyuse_anima.translation.providers.google import (
+    GoogleTranslationProvider,
+)
+from easyuse_anima.translation.service import (
+    BoundedTranslationCache,
+    PromptTranslationService,
     _TRANSLATION_PROVIDER_FACTORIES,
     _TRANSLATION_PROVIDER_INSTANCES,
     get_translation_provider,
@@ -35,6 +42,29 @@ GOOGLE_SETTINGS = PromptTranslationSettings(
 )
 
 
+class PromptTranslationCompatibilityTests(unittest.TestCase):
+    def test_root_shim_exports_identical_canonical_objects(self):
+        canonical = {
+            name: getattr(module, name)
+            for module in (
+                contracts,
+                markers,
+                google_provider,
+                service,
+            )
+            for name in module.__all__
+        }
+
+        self.assertEqual(set(root_translation.__all__), set(canonical))
+        self.assertEqual(
+            len(root_translation.__all__),
+            len(set(root_translation.__all__)),
+        )
+        for name, value in canonical.items():
+            with self.subTest(name=name):
+                self.assertIs(getattr(root_translation, name), value)
+
+
 class PromptTranslationServiceTests(unittest.TestCase):
     def test_repeated_identical_markers_call_provider_once_and_replace_every_position(self):
         service = PromptTranslationService(
@@ -42,7 +72,7 @@ class PromptTranslationServiceTests(unittest.TestCase):
         )
 
         with patch(
-            "prompt_translation.google_translate_text",
+            "easyuse_anima.translation.service.google_translate_text",
             return_value="girl with red hair",
         ) as provider:
             translated = service.translate_prompt(
@@ -67,7 +97,9 @@ class PromptTranslationServiceTests(unittest.TestCase):
 
         with (
             patch("builtins.__import__", side_effect=guarded_import),
-            patch("prompt_translation.get_translation_provider") as provider_factory,
+            patch(
+                "easyuse_anima.translation.service.get_translation_provider"
+            ) as provider_factory,
         ):
             translated = service.translate_prompt(
                 r"1girl, %{검은 드레스}, \%{literal}",
@@ -154,7 +186,7 @@ class PromptTranslationServiceTests(unittest.TestCase):
         lru_service = PromptTranslationService(cache=lru_cache)
 
         with patch(
-            "prompt_translation.google_translate_text",
+            "easyuse_anima.translation.service.google_translate_text",
             side_effect=lambda text, source, target: text.upper(),
         ) as provider:
             self.assertEqual(lru_service.translate_prompt("%{a}", GOOGLE_SETTINGS), "A")
@@ -173,7 +205,7 @@ class PromptTranslationServiceTests(unittest.TestCase):
         ttl_service = PromptTranslationService(cache=ttl_cache)
         now[0] = 0.0
         with patch(
-            "prompt_translation.google_translate_text",
+            "easyuse_anima.translation.service.google_translate_text",
             return_value="cached",
         ) as provider:
             ttl_service.translate_prompt("%{ttl}", GOOGLE_SETTINGS)
@@ -194,7 +226,7 @@ class PromptTranslationServiceTests(unittest.TestCase):
         )
 
         with patch(
-            "prompt_translation.google_translate_text",
+            "easyuse_anima.translation.service.google_translate_text",
             side_effect=lambda text, source, target: f"{source}:{target}:{text}",
         ) as provider:
             for item in settings:
@@ -214,7 +246,7 @@ class PromptTranslationServiceTests(unittest.TestCase):
             return "shared"
 
         with patch(
-            "prompt_translation.google_translate_text",
+            "easyuse_anima.translation.service.google_translate_text",
             side_effect=translate,
         ) as provider:
             with ThreadPoolExecutor(max_workers=8) as executor:
@@ -239,7 +271,7 @@ class PromptTranslationServiceTests(unittest.TestCase):
             return text.upper()
 
         with patch(
-            "prompt_translation.google_translate_text",
+            "easyuse_anima.translation.service.google_translate_text",
             side_effect=translate,
         ):
             with ThreadPoolExecutor(max_workers=2) as executor:
@@ -264,7 +296,9 @@ class PromptTranslationServiceTests(unittest.TestCase):
             ("%{abcd}%{abc}", TranslationTotalSizeError),
         )
 
-        with patch("prompt_translation.google_translate_text") as provider:
+        with patch(
+            "easyuse_anima.translation.service.google_translate_text"
+        ) as provider:
             for text, error_type in cases:
                 with self.subTest(error=error_type.__name__):
                     with self.assertRaises(error_type):

--- a/tests/test_prompt_translation_api.py
+++ b/tests/test_prompt_translation_api.py
@@ -62,21 +62,38 @@ def load_api_routes():
     )
     module = importlib.util.module_from_spec(spec)
     sys.modules[spec.name] = module
-    with patch.dict(sys.modules, {"server": fake_server, "aiohttp": fake_aiohttp}):
+    missing = object()
+    previous_modules = {
+        name: sys.modules.get(name, missing)
+        for name in ("server", "aiohttp")
+    }
+    sys.modules.update({"server": fake_server, "aiohttp": fake_aiohttp})
+    try:
         spec.loader.exec_module(module)
         module.register_routes()
-        translation = sys.modules[module.translate_prompt_markers.__module__]
-    return module, routes, translation
+        translation_contracts = sys.modules[
+            module.PromptTranslationError.__module__
+        ]
+        translation_service = sys.modules[
+            module.translate_prompt_markers.__module__
+        ]
+    finally:
+        for name, previous in previous_modules.items():
+            if previous is missing:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = previous
+    return module, routes, translation_contracts, translation_service
 
 
 class PromptTranslationApiTests(unittest.TestCase):
     def load_routes(self):
-        api, routes, translation = load_api_routes()
+        api, routes, translation, translation_service = load_api_routes()
         self.addCleanup(api._PROMPT_TRANSLATION_WORKER.shutdown)
-        return api, routes, translation
+        return api, routes, translation, translation_service
 
     def test_route_runs_sync_translation_off_event_loop(self):
-        api, routes, translation = self.load_routes()
+        api, routes, translation, _translation_service = self.load_routes()
         handler = routes.handlers[ROUTE]
         worker_started = threading.Event()
 
@@ -109,7 +126,7 @@ class PromptTranslationApiTests(unittest.TestCase):
         self.assertGreaterEqual(heartbeat, 3)
 
     def test_timeout_keeps_bounded_admission_without_using_shared_executor(self):
-        api, routes, translation = self.load_routes()
+        api, routes, translation, _translation_service = self.load_routes()
         handler = routes.handlers[ROUTE]
         worker_started = threading.Event()
         release_worker = threading.Event()
@@ -199,7 +216,7 @@ class PromptTranslationApiTests(unittest.TestCase):
         )
 
     def test_route_cancellation_stops_waiting_with_stable_499_json(self):
-        api, routes, translation = self.load_routes()
+        api, routes, translation, _translation_service = self.load_routes()
         handler = routes.handlers[ROUTE]
         worker_started = threading.Event()
         release_worker = threading.Event()
@@ -254,7 +271,7 @@ class PromptTranslationApiTests(unittest.TestCase):
         self.assertFalse(api._PROMPT_TRANSLATION_WORKER.has_in_flight)
 
     def test_route_maps_only_prompt_translation_errors(self):
-        api, routes, translation = self.load_routes()
+        api, routes, translation, _translation_service = self.load_routes()
         handler = routes.handlers[ROUTE]
         settings = translation.PromptTranslationSettings(provider="google")
         cases = (
@@ -300,7 +317,7 @@ class PromptTranslationApiTests(unittest.TestCase):
                 )
 
     def test_route_does_not_mask_settings_or_payload_programming_errors_as_upstream(self):
-        api, routes, _translation = self.load_routes()
+        api, routes, _translation, _translation_service = self.load_routes()
         handler = routes.handlers[ROUTE]
 
         for error in (
@@ -327,7 +344,7 @@ class PromptTranslationApiTests(unittest.TestCase):
         self.assertEqual(response["payload"]["code"], "json_object_required")
 
     def test_all_marker_budgets_return_413_before_provider_resolution(self):
-        api, routes, translation = self.load_routes()
+        api, routes, translation, translation_service = self.load_routes()
         handler = routes.handlers[ROUTE]
         settings = translation.PromptTranslationSettings(provider="google")
         cases = (
@@ -352,7 +369,10 @@ class PromptTranslationApiTests(unittest.TestCase):
 
         with (
             patch.object(api, "resolve_prompt_translation_settings", return_value=settings),
-            patch.object(translation, "get_translation_provider") as provider_factory,
+            patch.object(
+                translation_service,
+                "get_translation_provider",
+            ) as provider_factory,
         ):
             for text, code in cases:
                 with self.subTest(code=code):

--- a/tests/test_python_backend_analyzer.py
+++ b/tests/test_python_backend_analyzer.py
@@ -691,12 +691,12 @@ ignored/
 
         self.assertEqual(analyzer.render_json(report), expected_text)
         self.assertEqual(report["schema_version"], 2)
-        self.assertEqual(report["inventory"]["module_count"], 105)
-        self.assertEqual(len(report["registry"]["shipped_python_modules"]), 105)
-        self.assertEqual(len(report["registry"]["runtime_import_closure"]), 105)
+        self.assertEqual(report["inventory"]["module_count"], 111)
+        self.assertEqual(len(report["registry"]["shipped_python_modules"]), 111)
+        self.assertEqual(len(report["registry"]["runtime_import_closure"]), 111)
         self.assertEqual(
             report["registry"]["entry_modules"],
-            ["__init__.py", "nodes.py"],
+            ["__init__.py", "nodes.py", "prompt_translation.py"],
         )
         self.assertEqual(report["registry"]["missing_internal_imports"], [])
         self.assertEqual(report["registry"]["unreachable_shipped_python_modules"], [])
@@ -769,6 +769,12 @@ ignored/
                 "easyuse_anima/profiles/__init__.py",
                 "easyuse_anima/profiles/contract.py",
                 "easyuse_anima/profiles/mutation.py",
+                "easyuse_anima/translation/__init__.py",
+                "easyuse_anima/translation/contracts.py",
+                "easyuse_anima/translation/markers.py",
+                "easyuse_anima/translation/providers/__init__.py",
+                "easyuse_anima/translation/providers/google.py",
+                "easyuse_anima/translation/service.py",
                 "easyuse_anima/registration.py",
                 "easyuse_anima/runtime.py",
                 "easyuse_anima/seed/__init__.py",
@@ -837,6 +843,12 @@ ignored/
                 "easyuse_anima/profiles/__init__.py",
                 "easyuse_anima/profiles/contract.py",
                 "easyuse_anima/profiles/mutation.py",
+                "easyuse_anima/translation/__init__.py",
+                "easyuse_anima/translation/contracts.py",
+                "easyuse_anima/translation/markers.py",
+                "easyuse_anima/translation/providers/__init__.py",
+                "easyuse_anima/translation/providers/google.py",
+                "easyuse_anima/translation/service.py",
                 "easyuse_anima/runtime.py",
                 "easyuse_anima/seed/execution_identity.py",
                 "easyuse_anima/seed/execution_session.py",
@@ -887,7 +899,6 @@ ignored/
                 ("api.py", "storage.py"),
                 ("api.py", "easyuse_anima/profiles/contract.py"),
                 ("api.py", "easyuse_anima/profiles/mutation.py"),
-                ("nodes.py", "prompt_translation.py"),
                 ("nodes.py", "settings.py"),
                 ("nodes.py", "wildcard_engine.py"),
                 ("wildcard_engine.py", "settings.py"),

--- a/tests/test_python_compatibility_surface.py
+++ b/tests/test_python_compatibility_surface.py
@@ -2362,8 +2362,8 @@ def _build_document() -> dict[str, Any]:
         "expected_counts": {
             "root_entrypoints": 3,
             "excluded_preamble_implementation_bindings": 0,
-            "nodes_canonical_bindings": 289,
-            "nodes_legacy_bindings": 27,
+            "nodes_canonical_bindings": 291,
+            "nodes_legacy_bindings": 25,
             "nodes_public_exports": 18,
             "mapped_public_classes": 18,
             "unmapped_classes": 2,

--- a/tests/test_python_package_skeleton.py
+++ b/tests/test_python_package_skeleton.py
@@ -66,6 +66,12 @@ PACKAGE_MODULES = (
     "easyuse_anima.profiles",
     "easyuse_anima.profiles.contract",
     "easyuse_anima.profiles.mutation",
+    "easyuse_anima.translation",
+    "easyuse_anima.translation.contracts",
+    "easyuse_anima.translation.markers",
+    "easyuse_anima.translation.providers",
+    "easyuse_anima.translation.providers.google",
+    "easyuse_anima.translation.service",
     "easyuse_anima.seed.execution_identity",
     "easyuse_anima.seed.execution_session",
     "easyuse_anima.seed.service",
@@ -193,6 +199,58 @@ print(json.dumps({{
         ] = [
             "is_comfy_processing_interruption",
             "seed_execution_session",
+        ]
+        expected_all[
+            PACKAGE_MODULES.index("easyuse_anima.translation.contracts")
+        ] = [
+            "DEFAULT_PROMPT_TRANSLATION_SOURCE",
+            "DEFAULT_PROMPT_TRANSLATION_TARGET",
+            "MAX_PROMPT_TRANSLATION_MARKER_CHARACTERS",
+            "MAX_PROMPT_TRANSLATION_MARKERS",
+            "MAX_PROMPT_TRANSLATION_TOTAL_CHARACTERS",
+            "PROMPT_TRANSLATION_CACHE_MAX_ENTRIES",
+            "PROMPT_TRANSLATION_CACHE_TTL_SECONDS",
+            "PROMPT_TRANSLATION_PROVIDER_GOOGLE",
+            "PROMPT_TRANSLATION_PROVIDER_OFF",
+            "PROMPT_TRANSLATION_PROVIDER_TIMEOUT_SECONDS",
+            "PROMPT_TRANSLATION_PROVIDERS",
+            "PromptTranslationError",
+            "PromptTranslationLimitError",
+            "PromptTranslationSettings",
+            "TranslationBusyError",
+            "TranslationCacheKey",
+            "TranslationCancelledError",
+            "TranslationMarkerCountError",
+            "TranslationMarkerSizeError",
+            "TranslationProvider",
+            "TranslationProviderUnavailableError",
+            "TranslationTimeoutError",
+            "TranslationTotalSizeError",
+            "TranslationUpstreamError",
+            "normalize_prompt_translation_language",
+            "normalize_prompt_translation_provider",
+        ]
+        expected_all[
+            PACKAGE_MODULES.index("easyuse_anima.translation.markers")
+        ] = [
+            "PROMPT_TRANSLATION_MARKER_LABEL",
+            "has_prompt_translation_markers",
+            "iter_prompt_translation_markers",
+        ]
+        expected_all[
+            PACKAGE_MODULES.index(
+                "easyuse_anima.translation.providers.google"
+            )
+        ] = ["GoogleTranslationProvider"]
+        expected_all[
+            PACKAGE_MODULES.index("easyuse_anima.translation.service")
+        ] = [
+            "BoundedTranslationCache",
+            "PromptTranslationService",
+            "get_translation_provider",
+            "google_translate_text",
+            "strip_prompt_translation_markers",
+            "translate_prompt_markers",
         ]
         self.assertEqual(payload["declared_all"], expected_all)
         self.assertEqual(payload["new_forbidden"], [])

--- a/tools/analyze_python_backend.py
+++ b/tools/analyze_python_backend.py
@@ -30,7 +30,11 @@ from typing import Iterable, Mapping, Sequence
 REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
 ROOT_MODULE = "__root__"
 SCHEMA_VERSION = 2
-REGISTRY_ENTRY_MODULE_CANDIDATES = ("__init__.py", "nodes.py")
+REGISTRY_ENTRY_MODULE_CANDIDATES = (
+    "__init__.py",
+    "nodes.py",
+    "prompt_translation.py",
+)
 DYNAMIC_IMPORT_CALLEES = frozenset({"__import__", "importlib.import_module"})
 MUTABLE_CONSTRUCTORS = {
     "ChainMap": "dict",

--- a/tools/check_python_import_boundaries.py
+++ b/tools/check_python_import_boundaries.py
@@ -36,6 +36,7 @@ EXPECTED_GROUPS = (
     ("lora", 184, "easyuse_anima/lora/", "feature"),
     ("naia", 184, "easyuse_anima/naia/", "feature"),
     ("profiles", 163, "easyuse_anima/profiles/", "feature"),
+    ("translation", 186, "easyuse_anima/translation/", "feature"),
 )
 ALLOWED_ROLES = frozenset({"common", "feature", "infrastructure"})
 BACK_REFERENCE_PREFIXES_BY_ROLE = {


### PR DESCRIPTION
## 작업 단위

- Task: D-01
- Owner: #186
- Type: Move
- Base: `dev@d002a9bea1b268d7a79d7c5bbd7c73f2a62f2d77`
- Behavior prerequisite: #164 complete
- 상태: 검증 완료

## 변경 요약

루트 `prompt_translation.py`의 구현을 `easyuse_anima.translation` 아래로 이동했습니다.

- `contracts.py`: 설정, 상수, limit, error, provider protocol
- `markers.py`: `%{...}` marker 탐색
- `providers/google.py`: lazy Google provider adapter
- `service.py`: provider reuse, bounded cache, single-flight, translation facade
- root `prompt_translation.py`: 지원 symbol의 명시적 direct re-export shim
- production caller: root shim 대신 precise canonical module을 import
- analyzer/package/import/compatibility fixtures: 새 module과 공개 shim entrypoint 반영

## Symbol / caller / alias / global-state inventory

상세 inventory와 allowed-file boundary는 `docs/architecture/translation-canonical-move.md`에 기록했습니다.

- supported root surface는 명시적 `__all__`과 root/canonical object identity로 고정
- private provider registry, locks, cache sentinel, flight/default-service internals는 unsupported test-only seam
- provider factory/instance registry, lazy client, bounded cache, per-key single-flight의 process-local ownership 유지
- `googletrans` import와 client 생성은 provider 호출 시까지 계속 지연

## 주요 파일

- `prompt_translation.py`
- `easyuse_anima/translation/{contracts,markers,service}.py`
- `easyuse_anima/translation/providers/google.py`
- `api.py`, `settings.py`, `autocomplete_dataset.py`, `nodes.py`
- `easyuse_anima/prompt/{correction,advanced}.py`
- Python package/import/analyzer/compatibility tests와 exact fixtures
- compatibility-shim registry와 backend roadmap

## 검증

통과:

- focused translation service: 13 tests
- focused translation API: 6 tests
- package skeleton: 1 test
- import boundary: 16 tests
- corrector canonical integration: 1 test
- nodes analyzer baseline: 1 test
- compatibility surface class: 19 tests
- focused Pyright for new contracts/provider: 0 errors
- official `tools/check_project.ps1 -Profile full`
  - Pyright baseline ratchet passed
  - 7 completed import-boundary groups, 0 violations
  - Python unittest: 1,129 passed
  - frontend: 112 JavaScript files, TypeScript 6.0.3
  - `git diff --check` passed

초기 full 과정에서 새 module 타입 2건과 예상 analyzer/compatibility fixture 갱신 누락을 발견해 교정했습니다. 최종 full은 통과했습니다.

## 테스트 표면과 남은 위험

- ComfyUI Codex test surface: static/package/API/module/frontend contract validation
- Live ComfyUI smoke: 실행하지 않음
- 서버, 브라우저, 모델, optional provider client, 실제 외부 번역 요청: 실행하지 않음
- marker/normalization/limit/provider/error/cache/API/settings/node/workflow 동작 변경 없음
- lifecycle ownership 변경은 E-04 후속 범위로 유지
