### PR TITLE
refactor: move wildcard models to canonical package

### DIFF
--- a/docs/architecture/python-backend-execution-roadmap.md
+++ b/docs/architecture/python-backend-execution-roadmap.md
@@ -33,7 +33,7 @@ merged PR, the owning issue's evidence record, and every stated exit gate.
 | A - baseline | Complete; #191 is closed | Keep fixtures and analyzers current during later moves |
 | B - `nodes.py` extraction | Complete in B-11d / PR #356 | Preserve the audited compatibility shim until ADR-002 retirement gates are met |
 | C - feature contracts/behavior | Partially complete through S167-01a / PR #344 | Continue #167 and #169 in separate Contract/Move/Behavior PRs |
-| D - root consolidation | D-01, D-08, D-09, and D-10 complete on `dev`; D-11a validated in PR #385 and D-11b validated in PR #386 | Continue D-12/D-13; finish D-11 classification only after D-13 removes its root-package dependency |
+| D - root consolidation | D-01, D-08, D-09, and D-10 complete on `dev`; D-11a/#385, D-11b/#386, and D-12a/#387 validated | Continue D-12 source/snapshot/expansion slices, then D-13; finish D-11 classification only after D-13 removes its root-package dependency |
 | E - runtime ownership | Partial: E-02a and E-07a/E-07b integrated | Continue #187 only where canonical feature owners and explicit contracts exist |
 | F - typed boundaries | Partial patterns exist | Extend typed request/result/config and pure migration patterns feature by feature |
 | G - quality ratchet | G-01, G-02a/G-02b, and G-03a complete | Extend G-03 enrollment, then continue with G-04 through G-06 |
@@ -408,7 +408,7 @@ mechanical retirement series.
 | 15 | S167 backend seed reservation series | S167-01 through S167-03d COMPLETE on `dev`; S167-03e AiO cutover VALIDATED with isolated API/module/browser-load parity | Contract then Move then Behavior | #167 | Canonical AiO/node seams |
 | 16 | A169 stage pipeline series | A169-01 through A169-08 MERGED; A169-09 final adapter/integration VALIDATED in PR #372 | Contract then Behavior | #169 | Typed config and mechanical AiO move |
 | 17 | A169 first-pass cache policy | COMPLETE through CACHE-06; 4K/batch evidence VALIDATED in PR #380 | Contract then Behavior | #169 | Mechanical cache move and stable stage seam |
-| 18 | D-series canonical root consolidation | D-01 translation, D-08 filesystem, D-09 settings, and D-10 profiles COMPLETE on `dev`; D-11a autocomplete index VALIDATED in PR #385; D-11b dataset/search VALIDATED in PR #386 | Move | #186 | Phase B exit; per-feature behavior stable |
+| 18 | D-series canonical root consolidation | D-01 translation, D-08 filesystem, D-09 settings, and D-10 profiles COMPLETE on `dev`; D-11a/#385 and D-11b/#386 autocomplete VALIDATED; D-12a wildcard models VALIDATED in PR #387 | Move | #186 | Phase B exit; per-feature behavior stable |
 | 19 | E-series RuntimeServices/lifecycle | BLOCKED by canonical owners | Move/Contract, split PRs | #187 | Relevant D moves |
 | 20 | G-04 through G-06 and H | INCREMENTAL/LATER | Gate/Contract | #188 | Appropriate package and release evidence |
 
@@ -1334,6 +1334,12 @@ snapshot/cache/status, and fallback/index search to
 `autocomplete_dataset.py` retains prompt classification plus direct canonical
 aliases because classification still imports root `anima_prompt`; D-13 must
 canonicalize that package before the final D-11 shim slice.
+
+D-12 is split to keep Move work separate from E-06 lifecycle ownership.
+D-12a moves immutable option/budget/result models and their fixed limit
+constants to `easyuse_anima.wildcard.models`, while root
+`wildcard_engine.py` retains source scanning, snapshot state, selector/seed,
+and expansion implementation for later slices.
 
 ## 12. Phase E — Runtime ownership and lifecycle
 

--- a/docs/architecture/python-compatibility-shims.md
+++ b/docs/architecture/python-compatibility-shims.md
@@ -64,7 +64,7 @@ import them.
 | `storage.py` | Explicit direct re-export shim (D-08) | `easyuse_anima.infrastructure.filesystem.atomic_json` and `.paths` | #163, #186 D-08 | Existing 0.5.2 supported module-owned public surface; exact `__all__` and identity fixture | External/legacy imports and storage compatibility tests; production callers use canonical modules | Unscheduled; first canonical+shim release N not yet recorded, then N+1 gate and last-known-good/atomic-write parity |
 | `autocomplete_index.py` | Explicit direct re-export shim (D-11a) | `easyuse_anima.autocomplete.index` | #162, #186 D-11a | Existing indexed-search surface; exact seven-name `__all__` and identity fixture | External/legacy imports; `autocomplete_dataset.py` now uses the canonical owner | Unscheduled; first canonical+shim release N not yet recorded, then N+1 gate and index/ranking/rebuild parity |
 | `autocomplete_dataset.py` | Partial explicit compatibility module after D-11b; prompt classification remains root-owned | `easyuse_anima.autocomplete.dataset` and `.search`; classification target waits for D-13 | #162, #186 D-11 | Existing 0.5.2 dataset/search surface canonicalized in PR #386 with direct identity aliases; final shim waits for root `anima_prompt` removal | External/legacy imports and prompt tests; `api.py` uses canonical dataset/search and root classification | Unscheduled; D-13 dependency removal, final identity surface, N+1 gate, and classification/result/API parity |
-| `wildcard_engine.py` | Current implementation; planned wildcard shim | `easyuse_anima.wildcard.*` | #184, #186 D-12 | Existing 0.5.2 surface; convert in D-12/D-14 | root entrypoint, `nodes.py`, `api.py`, wildcard/workflow tests | Unscheduled; N+1 gate and seed/expansion/workflow parity |
+| `wildcard_engine.py` | Partial compatibility module after D-12a; source/snapshot/selector/seed/expansion remain root-owned | `easyuse_anima.wildcard.models`, then sources/snapshot/expansion modules | #184, #186 D-12 | Existing 0.5.2 immutable model/limit surface canonicalized in PR #387 with direct identity aliases; later D-12 slices remain | root entrypoint, `nodes.py`, `api.py`, wildcard/workflow tests | Unscheduled; full D-12 move, final identity surface, N+1 gate, and seed/expansion/workflow parity |
 | `prompt_translation.py` | Explicit direct re-export shim (D-01) | `easyuse_anima.translation.*` | #164, #186 D-01 | Existing 0.5.2 supported module-owned public surface; exact `__all__` and identity fixture | External/legacy imports and translation compatibility tests; production callers use canonical modules | Unscheduled; first canonical+shim release N not yet recorded, then N+1 gate and provider-off/API parity |
 | `anima_prompt/` package | Current implementation; planned package shim | `easyuse_anima.prompt.anima.*` | #184, #186 D-13 | Existing 0.5.2 surface; convert in D-13/D-14 | `nodes.py`, `autocomplete_dataset.py`, prompt tests | Unscheduled; N+1 gate and prompt correction/parser parity |
 
@@ -1461,8 +1461,15 @@ EasyUseAnimaWildcard
 
 - Confirmed current consumers include root initialization, node expansion and
   seed constants/helpers, and API list/root helpers.
-- Canonical target: `easyuse_anima.wildcard` models/sources/snapshot/expansion/
-  service modules.
+- D-12a moves immutable `WildcardOption`, `WildcardExpansionBudget`,
+  `WildcardExpansionResult`, and their fixed budget constants to
+  `easyuse_anima.wildcard.models`.
+- Root binds the 12 moved supported names directly to canonical objects.
+  Source scanning, snapshot cache/condition, selector/seed, parsing, expansion,
+  enforcement, and diagnostics remain root-owned for later D-12 slices.
+- Canonical target for the remaining implementation:
+  `easyuse_anima.wildcard` sources/snapshot/expansion modules. Snapshot
+  lifecycle/factory/cleanup remains E-06.
 - Removal gate: #159/#160 behavior fixtures, seed and expansion parity,
   0.5.2 workflow load/save/reload, root/canonical identity, and archive closure.
 

--- a/docs/architecture/wildcard-models-canonical-move.md
+++ b/docs/architecture/wildcard-models-canonical-move.md
@@ -8,7 +8,7 @@
 - Parent roadmap unit: D-12 Wildcard
 - PR type: Move
 - Baseline: `dev@7fdee04d4102a1273025624f57e955b3295e4a8a`
-- State: READY
+- State: VALIDATED in PR #387
 - Production behavior changes: forbidden
 
 ## Responsibility boundary
@@ -150,3 +150,19 @@ Supporting:
 - canonical model module has zero root imports;
 - official full runner once at the PR checkpoint; and
 - root retains all source/snapshot/selector/seed/expansion implementation.
+
+Validation evidence:
+
+- wildcard behavior and root/canonical identity: 72 tests passed;
+- package skeleton: 1 test passed;
+- Registry scanner: 8 tests passed;
+- backend analyzer: 18 tests passed, 127 shipped/runtime modules and zero
+  unreachable modules;
+- G-03 import boundary: 16 tests passed;
+- canonical model Pyright diagnostics: 0;
+- official full: 1,135 Python tests and 112 frontend files passed; G-03 kept
+  10 completed package groups with zero violations and the existing Pyright
+  baseline remained 14 errors; and
+- `comfy node validate` passed; `comfy node pack` produced 257 entries and
+  included root `wildcard_engine.py` plus canonical wildcard `__init__.py` and
+  `models.py`.

--- a/docs/architecture/wildcard-models-canonical-move.md
+++ b/docs/architecture/wildcard-models-canonical-move.md
@@ -1,0 +1,152 @@
+# D-12a Wildcard models canonical Move
+
+- Owner issue: [#186](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/186)
+- Behavior prerequisites:
+  [#159](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/159) and
+  [#160](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/160) — complete
+- Roadmap unit: D-12a
+- Parent roadmap unit: D-12 Wildcard
+- PR type: Move
+- Baseline: `dev@7fdee04d4102a1273025624f57e955b3295e4a8a`
+- State: READY
+- Production behavior changes: forbidden
+
+## Responsibility boundary
+
+Root `wildcard_engine.py` combines immutable public models, source discovery and
+snapshot state, selector/PRNG logic, and expansion orchestration. Moving the
+whole module would mix the D-12 Move with E-06 snapshot lifecycle ownership and
+make review of the seed/expansion behavior contract unnecessarily broad.
+
+D-12a moves only the dependency-free immutable model leaf to:
+
+- `easyuse_anima.wildcard.models`.
+
+Source scanning, snapshot publication, filesystem paths, YAML loading, selector
+state, seeded choice, seed control, parsing, expansion, limits enforcement, and
+diagnostics production remain in root for later D-12 slices.
+
+## Supported moved surface
+
+Budget constants:
+
+- `MAX_EXPANSION_DEPTH`;
+- `REPLACE_DEPTH`;
+- `DEFAULT_MAX_EXPANSION_DEPTH`;
+- `DEFAULT_MAX_EXPANSION_REPLACEMENTS`;
+- `DEFAULT_MAX_EXPANSION_OUTPUT_CHARS`;
+- `DEFAULT_MAX_EXPANSION_GROWTH_PER_PASS`;
+- `MAX_EXPANSION_REPLACEMENTS`;
+- `MAX_EXPANSION_OUTPUT_CHARS`; and
+- `MAX_EXPANSION_GROWTH_PER_PASS`.
+
+Immutable models:
+
+- `WildcardOption`;
+- `WildcardExpansionBudget`; and
+- `WildcardExpansionResult`.
+
+Root binds every moved supported name directly to the identical canonical
+object. No wrapper, proxy, subclass, duplicate constant, `import *`, or lazy
+module hook is allowed.
+
+## Private symbol inventory
+
+The canonical model owner also takes the model-only coercion helpers:
+
+- `_bounded_int`; and
+- `_bounded_float`.
+
+They are private implementation details of `WildcardExpansionBudget` and are
+not added to the root compatibility surface.
+
+## Caller and alias inventory
+
+Production:
+
+- root `wildcard_engine.py` continues using every model and constant while
+  owning source/snapshot/expansion behavior;
+- no canonical package module currently imports these model names directly;
+  later D-12 source/snapshot/expansion slices will do so; and
+- node/API/bootstrap imports of root source, expansion, and seed helpers remain
+  unchanged in this slice.
+
+Tests:
+
+- `tests/test_wildcards.py` retains root behavior imports, adds exact
+  root/canonical identity coverage, and may use the canonical model owner for
+  private model construction;
+- package skeleton and Registry scanner gain the wildcard package and model
+  module; and
+- backend analyzer fixtures enroll both shipped/runtime modules without
+  declaring D-12 package completion in G-03.
+
+Aliases:
+
+- `REPLACE_DEPTH is MAX_EXPANSION_DEPTH` remains a value alias;
+- root model class objects are direct canonical aliases; and
+- there are no compatibility aliases for `_bounded_int` or `_bounded_float`.
+
+## Global-state inventory
+
+D-12a moves no mutable global state.
+
+The following remain root-owned and unchanged:
+
+- `_SNAPSHOT_CONDITION`;
+- `_SNAPSHOT_CACHE`;
+- `_SNAPSHOT_BUILDING`;
+- `_SNAPSHOT_CACHE_LIMIT`; and
+- all selector, library, expansion-lane, and per-call expansion state.
+
+Their owner/lifetime/lock/cleanup migration belongs to later D-12 slices and
+E-06. D-12a creates no singleton, lock, cache, background task, cleanup hook,
+factory, or dependency-injection seam.
+
+## Compatibility and behavior invariants
+
+- dataclass frozen state, field order, defaults, equality, repr, and accepted
+  constructor inputs are unchanged;
+- budget coercion, invalid-number fallback, finite-float policy, min/max
+  clamping, and hard ceilings are unchanged;
+- result tuple defaults and `limit_reason` semantics are unchanged;
+- wildcard option text/weight defaults are unchanged;
+- seed, selection, PCG64, source, snapshot, YAML, path, ordering, expansion,
+  output, diagnostics, and exception behavior are unchanged; and
+- no Node, workflow, API, frontend, or Registry metadata behavior changes.
+
+## Allowed-file boundary
+
+Production:
+
+- root `wildcard_engine.py`;
+- new `easyuse_anima/wildcard/__init__.py`; and
+- new `easyuse_anima/wildcard/models.py`.
+
+Supporting:
+
+- wildcard identity/model tests;
+- package skeleton, Registry scanner, backend analyzer, and exact fixture;
+- this inventory, compatibility-shim ledger, and execution roadmap.
+
+## Forbidden
+
+- source/path scanning, YAML loading, snapshot/cache/lock/lifecycle changes;
+- selector, PRNG, seed, mode, parsing, expansion, budget enforcement, or
+  diagnostics behavior changes;
+- moving source/snapshot/expansion helpers in this PR;
+- G-03 completed-package enrollment before the full D-12 package is canonical;
+- node, API, bootstrap, frontend, workflow, Registry metadata, release, or
+  instance changes; and
+- server, browser, live-instance, model, provider, or network execution.
+
+## Validation and exit
+
+- exact root/canonical identity for every moved supported name;
+- model defaults, coercion, clamping, frozen state, and result fields;
+- wildcard behavior suite remains unchanged;
+- package skeleton, Registry scanner, backend analyzer, and packed archive
+  include the root shim path and both canonical wildcard modules;
+- canonical model module has zero root imports;
+- official full runner once at the PR checkpoint; and
+- root retains all source/snapshot/selector/seed/expansion implementation.

--- a/easyuse_anima/wildcard/__init__.py
+++ b/easyuse_anima/wildcard/__init__.py
@@ -1,0 +1,3 @@
+"""Canonical wildcard package."""
+
+__all__ = ()

--- a/easyuse_anima/wildcard/models.py
+++ b/easyuse_anima/wildcard/models.py
@@ -1,0 +1,118 @@
+"""Immutable wildcard models and expansion budget contracts."""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+
+# Defaults stop exponential inputs well before they become memory hazards while
+# leaving ample room for ordinary nested wildcard libraries. The old depth is
+# retained as a hard ceiling for callers that provide a custom budget.
+MAX_EXPANSION_DEPTH = 100
+REPLACE_DEPTH = MAX_EXPANSION_DEPTH
+DEFAULT_MAX_EXPANSION_DEPTH = 32
+DEFAULT_MAX_EXPANSION_REPLACEMENTS = 4096
+DEFAULT_MAX_EXPANSION_OUTPUT_CHARS = 256 * 1024
+DEFAULT_MAX_EXPANSION_GROWTH_PER_PASS = 8.0
+MAX_EXPANSION_REPLACEMENTS = 65536
+MAX_EXPANSION_OUTPUT_CHARS = 1024 * 1024
+MAX_EXPANSION_GROWTH_PER_PASS = 32.0
+
+__all__ = (
+    "MAX_EXPANSION_DEPTH",
+    "REPLACE_DEPTH",
+    "DEFAULT_MAX_EXPANSION_DEPTH",
+    "DEFAULT_MAX_EXPANSION_REPLACEMENTS",
+    "DEFAULT_MAX_EXPANSION_OUTPUT_CHARS",
+    "DEFAULT_MAX_EXPANSION_GROWTH_PER_PASS",
+    "MAX_EXPANSION_REPLACEMENTS",
+    "MAX_EXPANSION_OUTPUT_CHARS",
+    "MAX_EXPANSION_GROWTH_PER_PASS",
+    "WildcardOption",
+    "WildcardExpansionBudget",
+    "WildcardExpansionResult",
+)
+
+
+@dataclass(frozen=True)
+class WildcardOption:
+    text: str
+    weight: float = 1.0
+
+
+def _bounded_int(value, default: int, minimum: int, maximum: int) -> int:
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError, OverflowError):
+        parsed = default
+    return max(minimum, min(maximum, parsed))
+
+
+def _bounded_float(value, default: float, minimum: float, maximum: float) -> float:
+    try:
+        parsed = float(value)
+    except (TypeError, ValueError, OverflowError):
+        parsed = default
+    if not math.isfinite(parsed):
+        parsed = default
+    return max(minimum, min(maximum, parsed))
+
+
+@dataclass(frozen=True)
+class WildcardExpansionBudget:
+    max_depth: int = DEFAULT_MAX_EXPANSION_DEPTH
+    max_replacements: int = DEFAULT_MAX_EXPANSION_REPLACEMENTS
+    max_output_chars: int = DEFAULT_MAX_EXPANSION_OUTPUT_CHARS
+    max_growth_per_pass: float = DEFAULT_MAX_EXPANSION_GROWTH_PER_PASS
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self,
+            "max_depth",
+            _bounded_int(
+                self.max_depth,
+                DEFAULT_MAX_EXPANSION_DEPTH,
+                0,
+                MAX_EXPANSION_DEPTH,
+            ),
+        )
+        object.__setattr__(
+            self,
+            "max_replacements",
+            _bounded_int(
+                self.max_replacements,
+                DEFAULT_MAX_EXPANSION_REPLACEMENTS,
+                0,
+                MAX_EXPANSION_REPLACEMENTS,
+            ),
+        )
+        object.__setattr__(
+            self,
+            "max_output_chars",
+            _bounded_int(
+                self.max_output_chars,
+                DEFAULT_MAX_EXPANSION_OUTPUT_CHARS,
+                1,
+                MAX_EXPANSION_OUTPUT_CHARS,
+            ),
+        )
+        object.__setattr__(
+            self,
+            "max_growth_per_pass",
+            _bounded_float(
+                self.max_growth_per_pass,
+                DEFAULT_MAX_EXPANSION_GROWTH_PER_PASS,
+                1.0,
+                MAX_EXPANSION_GROWTH_PER_PASS,
+            ),
+        )
+
+
+@dataclass(frozen=True)
+class WildcardExpansionResult:
+    text: str
+    changed: bool
+    used_keys: tuple[str, ...] = ()
+    missing_keys: tuple[str, ...] = ()
+    replacement_count: int = 0
+    limit_reason: str | None = None

--- a/tests/fixtures/python_backend_baseline.json
+++ b/tests/fixtures/python_backend_baseline.json
@@ -27294,6 +27294,57 @@
         "requested": "__future__",
         "role": "ordinary",
         "scope": "<module>",
+        "source": "easyuse_anima/wildcard/models.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "math",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "math",
+        "kind": "static_import",
+        "line": 5,
+        "name": null,
+        "optional": false,
+        "requested": "math",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/wildcard/models.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "dataclass",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "dataclasses:dataclass",
+        "kind": "static_from",
+        "line": 6,
+        "name": "dataclass",
+        "optional": false,
+        "requested": "dataclasses",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/wildcard/models.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "annotations",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "__future__:annotations",
+        "kind": "static_from",
+        "line": 3,
+        "name": "annotations",
+        "optional": false,
+        "requested": "__future__",
+        "role": "ordinary",
+        "scope": "<module>",
         "source": "easyuse_anima/workflow.py"
       },
       {
@@ -53503,6 +53554,786 @@
       },
       {
         "alias": null,
+        "bound_name": "DEFAULT_MAX_EXPANSION_DEPTH",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 31
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "DEFAULT_MAX_EXPANSION_DEPTH",
+          "target": "easyuse_anima/wildcard/models.py",
+          "try_line": 31
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.wildcard.models:DEFAULT_MAX_EXPANSION_DEPTH",
+        "kind": "static_from",
+        "line": 32,
+        "name": "DEFAULT_MAX_EXPANSION_DEPTH",
+        "optional": false,
+        "requested": ".easyuse_anima.wildcard.models",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "wildcard_engine.py",
+        "target": "easyuse_anima/wildcard/models.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "DEFAULT_MAX_EXPANSION_GROWTH_PER_PASS",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 31
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "DEFAULT_MAX_EXPANSION_GROWTH_PER_PASS",
+          "target": "easyuse_anima/wildcard/models.py",
+          "try_line": 31
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.wildcard.models:DEFAULT_MAX_EXPANSION_GROWTH_PER_PASS",
+        "kind": "static_from",
+        "line": 32,
+        "name": "DEFAULT_MAX_EXPANSION_GROWTH_PER_PASS",
+        "optional": false,
+        "requested": ".easyuse_anima.wildcard.models",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "wildcard_engine.py",
+        "target": "easyuse_anima/wildcard/models.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "DEFAULT_MAX_EXPANSION_OUTPUT_CHARS",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 31
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "DEFAULT_MAX_EXPANSION_OUTPUT_CHARS",
+          "target": "easyuse_anima/wildcard/models.py",
+          "try_line": 31
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.wildcard.models:DEFAULT_MAX_EXPANSION_OUTPUT_CHARS",
+        "kind": "static_from",
+        "line": 32,
+        "name": "DEFAULT_MAX_EXPANSION_OUTPUT_CHARS",
+        "optional": false,
+        "requested": ".easyuse_anima.wildcard.models",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "wildcard_engine.py",
+        "target": "easyuse_anima/wildcard/models.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "DEFAULT_MAX_EXPANSION_REPLACEMENTS",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 31
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "DEFAULT_MAX_EXPANSION_REPLACEMENTS",
+          "target": "easyuse_anima/wildcard/models.py",
+          "try_line": 31
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.wildcard.models:DEFAULT_MAX_EXPANSION_REPLACEMENTS",
+        "kind": "static_from",
+        "line": 32,
+        "name": "DEFAULT_MAX_EXPANSION_REPLACEMENTS",
+        "optional": false,
+        "requested": ".easyuse_anima.wildcard.models",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "wildcard_engine.py",
+        "target": "easyuse_anima/wildcard/models.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "MAX_EXPANSION_DEPTH",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 31
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "MAX_EXPANSION_DEPTH",
+          "target": "easyuse_anima/wildcard/models.py",
+          "try_line": 31
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.wildcard.models:MAX_EXPANSION_DEPTH",
+        "kind": "static_from",
+        "line": 32,
+        "name": "MAX_EXPANSION_DEPTH",
+        "optional": false,
+        "requested": ".easyuse_anima.wildcard.models",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "wildcard_engine.py",
+        "target": "easyuse_anima/wildcard/models.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "MAX_EXPANSION_GROWTH_PER_PASS",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 31
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "MAX_EXPANSION_GROWTH_PER_PASS",
+          "target": "easyuse_anima/wildcard/models.py",
+          "try_line": 31
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.wildcard.models:MAX_EXPANSION_GROWTH_PER_PASS",
+        "kind": "static_from",
+        "line": 32,
+        "name": "MAX_EXPANSION_GROWTH_PER_PASS",
+        "optional": false,
+        "requested": ".easyuse_anima.wildcard.models",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "wildcard_engine.py",
+        "target": "easyuse_anima/wildcard/models.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "MAX_EXPANSION_OUTPUT_CHARS",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 31
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "MAX_EXPANSION_OUTPUT_CHARS",
+          "target": "easyuse_anima/wildcard/models.py",
+          "try_line": 31
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.wildcard.models:MAX_EXPANSION_OUTPUT_CHARS",
+        "kind": "static_from",
+        "line": 32,
+        "name": "MAX_EXPANSION_OUTPUT_CHARS",
+        "optional": false,
+        "requested": ".easyuse_anima.wildcard.models",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "wildcard_engine.py",
+        "target": "easyuse_anima/wildcard/models.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "MAX_EXPANSION_REPLACEMENTS",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 31
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "MAX_EXPANSION_REPLACEMENTS",
+          "target": "easyuse_anima/wildcard/models.py",
+          "try_line": 31
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.wildcard.models:MAX_EXPANSION_REPLACEMENTS",
+        "kind": "static_from",
+        "line": 32,
+        "name": "MAX_EXPANSION_REPLACEMENTS",
+        "optional": false,
+        "requested": ".easyuse_anima.wildcard.models",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "wildcard_engine.py",
+        "target": "easyuse_anima/wildcard/models.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "REPLACE_DEPTH",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 31
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "REPLACE_DEPTH",
+          "target": "easyuse_anima/wildcard/models.py",
+          "try_line": 31
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.wildcard.models:REPLACE_DEPTH",
+        "kind": "static_from",
+        "line": 32,
+        "name": "REPLACE_DEPTH",
+        "optional": false,
+        "requested": ".easyuse_anima.wildcard.models",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "wildcard_engine.py",
+        "target": "easyuse_anima/wildcard/models.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "WildcardExpansionBudget",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 31
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "WildcardExpansionBudget",
+          "target": "easyuse_anima/wildcard/models.py",
+          "try_line": 31
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.wildcard.models:WildcardExpansionBudget",
+        "kind": "static_from",
+        "line": 32,
+        "name": "WildcardExpansionBudget",
+        "optional": false,
+        "requested": ".easyuse_anima.wildcard.models",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "wildcard_engine.py",
+        "target": "easyuse_anima/wildcard/models.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "WildcardExpansionResult",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 31
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "WildcardExpansionResult",
+          "target": "easyuse_anima/wildcard/models.py",
+          "try_line": 31
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.wildcard.models:WildcardExpansionResult",
+        "kind": "static_from",
+        "line": 32,
+        "name": "WildcardExpansionResult",
+        "optional": false,
+        "requested": ".easyuse_anima.wildcard.models",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "wildcard_engine.py",
+        "target": "easyuse_anima/wildcard/models.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "WildcardOption",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 31
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "WildcardOption",
+          "target": "easyuse_anima/wildcard/models.py",
+          "try_line": 31
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.wildcard.models:WildcardOption",
+        "kind": "static_from",
+        "line": 32,
+        "name": "WildcardOption",
+        "optional": false,
+        "requested": ".easyuse_anima.wildcard.models",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "wildcard_engine.py",
+        "target": "easyuse_anima/wildcard/models.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "DEFAULT_MAX_EXPANSION_DEPTH",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 46,
+            "kind": "try",
+            "line": 31
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "DEFAULT_MAX_EXPANSION_DEPTH",
+          "target": "easyuse_anima/wildcard/models.py",
+          "try_line": 31
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.wildcard.models:DEFAULT_MAX_EXPANSION_DEPTH",
+        "kind": "static_from",
+        "line": 47,
+        "name": "DEFAULT_MAX_EXPANSION_DEPTH",
+        "optional": false,
+        "requested": "easyuse_anima.wildcard.models",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "wildcard_engine.py",
+        "target": "easyuse_anima/wildcard/models.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "DEFAULT_MAX_EXPANSION_GROWTH_PER_PASS",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 46,
+            "kind": "try",
+            "line": 31
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "DEFAULT_MAX_EXPANSION_GROWTH_PER_PASS",
+          "target": "easyuse_anima/wildcard/models.py",
+          "try_line": 31
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.wildcard.models:DEFAULT_MAX_EXPANSION_GROWTH_PER_PASS",
+        "kind": "static_from",
+        "line": 47,
+        "name": "DEFAULT_MAX_EXPANSION_GROWTH_PER_PASS",
+        "optional": false,
+        "requested": "easyuse_anima.wildcard.models",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "wildcard_engine.py",
+        "target": "easyuse_anima/wildcard/models.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "DEFAULT_MAX_EXPANSION_OUTPUT_CHARS",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 46,
+            "kind": "try",
+            "line": 31
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "DEFAULT_MAX_EXPANSION_OUTPUT_CHARS",
+          "target": "easyuse_anima/wildcard/models.py",
+          "try_line": 31
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.wildcard.models:DEFAULT_MAX_EXPANSION_OUTPUT_CHARS",
+        "kind": "static_from",
+        "line": 47,
+        "name": "DEFAULT_MAX_EXPANSION_OUTPUT_CHARS",
+        "optional": false,
+        "requested": "easyuse_anima.wildcard.models",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "wildcard_engine.py",
+        "target": "easyuse_anima/wildcard/models.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "DEFAULT_MAX_EXPANSION_REPLACEMENTS",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 46,
+            "kind": "try",
+            "line": 31
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "DEFAULT_MAX_EXPANSION_REPLACEMENTS",
+          "target": "easyuse_anima/wildcard/models.py",
+          "try_line": 31
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.wildcard.models:DEFAULT_MAX_EXPANSION_REPLACEMENTS",
+        "kind": "static_from",
+        "line": 47,
+        "name": "DEFAULT_MAX_EXPANSION_REPLACEMENTS",
+        "optional": false,
+        "requested": "easyuse_anima.wildcard.models",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "wildcard_engine.py",
+        "target": "easyuse_anima/wildcard/models.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "MAX_EXPANSION_DEPTH",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 46,
+            "kind": "try",
+            "line": 31
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "MAX_EXPANSION_DEPTH",
+          "target": "easyuse_anima/wildcard/models.py",
+          "try_line": 31
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.wildcard.models:MAX_EXPANSION_DEPTH",
+        "kind": "static_from",
+        "line": 47,
+        "name": "MAX_EXPANSION_DEPTH",
+        "optional": false,
+        "requested": "easyuse_anima.wildcard.models",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "wildcard_engine.py",
+        "target": "easyuse_anima/wildcard/models.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "MAX_EXPANSION_GROWTH_PER_PASS",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 46,
+            "kind": "try",
+            "line": 31
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "MAX_EXPANSION_GROWTH_PER_PASS",
+          "target": "easyuse_anima/wildcard/models.py",
+          "try_line": 31
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.wildcard.models:MAX_EXPANSION_GROWTH_PER_PASS",
+        "kind": "static_from",
+        "line": 47,
+        "name": "MAX_EXPANSION_GROWTH_PER_PASS",
+        "optional": false,
+        "requested": "easyuse_anima.wildcard.models",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "wildcard_engine.py",
+        "target": "easyuse_anima/wildcard/models.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "MAX_EXPANSION_OUTPUT_CHARS",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 46,
+            "kind": "try",
+            "line": 31
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "MAX_EXPANSION_OUTPUT_CHARS",
+          "target": "easyuse_anima/wildcard/models.py",
+          "try_line": 31
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.wildcard.models:MAX_EXPANSION_OUTPUT_CHARS",
+        "kind": "static_from",
+        "line": 47,
+        "name": "MAX_EXPANSION_OUTPUT_CHARS",
+        "optional": false,
+        "requested": "easyuse_anima.wildcard.models",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "wildcard_engine.py",
+        "target": "easyuse_anima/wildcard/models.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "MAX_EXPANSION_REPLACEMENTS",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 46,
+            "kind": "try",
+            "line": 31
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "MAX_EXPANSION_REPLACEMENTS",
+          "target": "easyuse_anima/wildcard/models.py",
+          "try_line": 31
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.wildcard.models:MAX_EXPANSION_REPLACEMENTS",
+        "kind": "static_from",
+        "line": 47,
+        "name": "MAX_EXPANSION_REPLACEMENTS",
+        "optional": false,
+        "requested": "easyuse_anima.wildcard.models",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "wildcard_engine.py",
+        "target": "easyuse_anima/wildcard/models.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "REPLACE_DEPTH",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 46,
+            "kind": "try",
+            "line": 31
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "REPLACE_DEPTH",
+          "target": "easyuse_anima/wildcard/models.py",
+          "try_line": 31
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.wildcard.models:REPLACE_DEPTH",
+        "kind": "static_from",
+        "line": 47,
+        "name": "REPLACE_DEPTH",
+        "optional": false,
+        "requested": "easyuse_anima.wildcard.models",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "wildcard_engine.py",
+        "target": "easyuse_anima/wildcard/models.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "WildcardExpansionBudget",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 46,
+            "kind": "try",
+            "line": 31
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "WildcardExpansionBudget",
+          "target": "easyuse_anima/wildcard/models.py",
+          "try_line": 31
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.wildcard.models:WildcardExpansionBudget",
+        "kind": "static_from",
+        "line": 47,
+        "name": "WildcardExpansionBudget",
+        "optional": false,
+        "requested": "easyuse_anima.wildcard.models",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "wildcard_engine.py",
+        "target": "easyuse_anima/wildcard/models.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "WildcardExpansionResult",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 46,
+            "kind": "try",
+            "line": 31
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "WildcardExpansionResult",
+          "target": "easyuse_anima/wildcard/models.py",
+          "try_line": 31
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.wildcard.models:WildcardExpansionResult",
+        "kind": "static_from",
+        "line": 47,
+        "name": "WildcardExpansionResult",
+        "optional": false,
+        "requested": "easyuse_anima.wildcard.models",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "wildcard_engine.py",
+        "target": "easyuse_anima/wildcard/models.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "WildcardOption",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 46,
+            "kind": "try",
+            "line": 31
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "WildcardOption",
+          "target": "easyuse_anima/wildcard/models.py",
+          "try_line": 31
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.wildcard.models:WildcardOption",
+        "kind": "static_from",
+        "line": 47,
+        "name": "WildcardOption",
+        "optional": false,
+        "requested": "easyuse_anima.wildcard.models",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "wildcard_engine.py",
+        "target": "easyuse_anima/wildcard/models.py"
+      },
+      {
+        "alias": null,
         "bound_name": "folder_paths",
         "branch_context": [
           {
@@ -53510,7 +54341,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 542
+            "line": 482
           }
         ],
         "classification": "external",
@@ -53518,7 +54349,7 @@
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 543,
+        "line": 483,
         "name": null,
         "optional": true,
         "requested": "folder_paths",
@@ -53533,7 +54364,7 @@
           {
             "branch": "body",
             "kind": "if",
-            "line": 562,
+            "line": 502,
             "type_checking": false
           },
           {
@@ -53541,7 +54372,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 563
+            "line": 503
           }
         ],
         "classification": "internal",
@@ -53549,12 +54380,12 @@
         "compatibility_pair": {
           "bound_name": "get_settings",
           "target": "easyuse_anima/settings/repository.py",
-          "try_line": 563
+          "try_line": 503
         },
         "conditional": true,
         "imported": ".easyuse_anima.settings.repository:get_settings",
         "kind": "static_from",
-        "line": 564,
+        "line": 504,
         "name": "get_settings",
         "optional": false,
         "requested": ".easyuse_anima.settings.repository",
@@ -53570,7 +54401,7 @@
           {
             "branch": "body",
             "kind": "if",
-            "line": 562,
+            "line": 502,
             "type_checking": false
           },
           {
@@ -53579,9 +54410,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 505,
             "kind": "try",
-            "line": 563
+            "line": 503
           }
         ],
         "classification": "compatibility_fallback",
@@ -53589,12 +54420,12 @@
         "compatibility_pair": {
           "bound_name": "get_settings",
           "target": "easyuse_anima/settings/repository.py",
-          "try_line": 563
+          "try_line": 503
         },
         "conditional": true,
         "imported": "easyuse_anima.settings.repository:get_settings",
         "kind": "static_from",
-        "line": 566,
+        "line": 506,
         "name": "get_settings",
         "optional": false,
         "requested": "easyuse_anima.settings.repository",
@@ -55196,6 +56027,10 @@
       {
         "from": "wildcard_engine.py",
         "to": "easyuse_anima/settings/repository.py"
+      },
+      {
+        "from": "wildcard_engine.py",
+        "to": "easyuse_anima/wildcard/models.py"
       }
     ],
     "module_graph_policy": {
@@ -55927,6 +56762,18 @@
       {
         "cyclic": false,
         "modules": [
+          "easyuse_anima/wildcard/__init__.py"
+        ]
+      },
+      {
+        "cyclic": false,
+        "modules": [
+          "easyuse_anima/wildcard/models.py"
+        ]
+      },
+      {
+        "cyclic": false,
+        "modules": [
           "easyuse_anima/workflow.py"
         ]
       },
@@ -55963,7 +56810,7 @@
     ]
   },
   "inventory": {
-    "module_count": 125,
+    "module_count": 127,
     "modules": [
       {
         "is_package": true,
@@ -57394,6 +58241,30 @@
         }
       },
       {
+        "is_package": true,
+        "loc": 3,
+        "module": "easyuse_anima.wildcard",
+        "normalized_git_blob_sha1": "7a2e79b7d7b4d9418622582f7816fb501c057d87",
+        "path": "easyuse_anima/wildcard/__init__.py",
+        "top_level": {
+          "class_count": 0,
+          "function_count": 0,
+          "global_count": 1
+        }
+      },
+      {
+        "is_package": false,
+        "loc": 115,
+        "module": "easyuse_anima.wildcard.models",
+        "normalized_git_blob_sha1": "8c59f32b85b4cc411de2bba6360edabcc20f0465",
+        "path": "easyuse_anima/wildcard/models.py",
+        "top_level": {
+          "class_count": 3,
+          "function_count": 2,
+          "global_count": 10
+        }
+      },
+      {
         "is_package": false,
         "loc": 50,
         "module": "easyuse_anima.workflow",
@@ -57455,14 +58326,14 @@
       },
       {
         "is_package": false,
-        "loc": 1272,
+        "loc": 1212,
         "module": "wildcard_engine",
-        "normalized_git_blob_sha1": "a1d42005ed4069c0a2f5b6a1d6282f4db535e7fa",
+        "normalized_git_blob_sha1": "083098efac3c6d049600876b48cc621fac2d15a8",
         "path": "wildcard_engine.py",
         "top_level": {
-          "class_count": 13,
-          "function_count": 41,
-          "global_count": 40
+          "class_count": 10,
+          "function_count": 39,
+          "global_count": 31
         }
       }
     ]
@@ -67876,9 +68747,285 @@
       {
         "branch_context": [
           {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 46,
+            "kind": "try",
+            "line": 31
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.wildcard.models:DEFAULT_MAX_EXPANSION_DEPTH",
+        "kind": "static_from",
+        "line": 47,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "wildcard_engine.py",
+        "target": "easyuse_anima/wildcard/models.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 46,
+            "kind": "try",
+            "line": 31
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.wildcard.models:DEFAULT_MAX_EXPANSION_GROWTH_PER_PASS",
+        "kind": "static_from",
+        "line": 47,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "wildcard_engine.py",
+        "target": "easyuse_anima/wildcard/models.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 46,
+            "kind": "try",
+            "line": 31
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.wildcard.models:DEFAULT_MAX_EXPANSION_OUTPUT_CHARS",
+        "kind": "static_from",
+        "line": 47,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "wildcard_engine.py",
+        "target": "easyuse_anima/wildcard/models.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 46,
+            "kind": "try",
+            "line": 31
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.wildcard.models:DEFAULT_MAX_EXPANSION_REPLACEMENTS",
+        "kind": "static_from",
+        "line": 47,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "wildcard_engine.py",
+        "target": "easyuse_anima/wildcard/models.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 46,
+            "kind": "try",
+            "line": 31
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.wildcard.models:MAX_EXPANSION_DEPTH",
+        "kind": "static_from",
+        "line": 47,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "wildcard_engine.py",
+        "target": "easyuse_anima/wildcard/models.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 46,
+            "kind": "try",
+            "line": 31
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.wildcard.models:MAX_EXPANSION_GROWTH_PER_PASS",
+        "kind": "static_from",
+        "line": 47,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "wildcard_engine.py",
+        "target": "easyuse_anima/wildcard/models.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 46,
+            "kind": "try",
+            "line": 31
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.wildcard.models:MAX_EXPANSION_OUTPUT_CHARS",
+        "kind": "static_from",
+        "line": 47,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "wildcard_engine.py",
+        "target": "easyuse_anima/wildcard/models.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 46,
+            "kind": "try",
+            "line": 31
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.wildcard.models:MAX_EXPANSION_REPLACEMENTS",
+        "kind": "static_from",
+        "line": 47,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "wildcard_engine.py",
+        "target": "easyuse_anima/wildcard/models.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 46,
+            "kind": "try",
+            "line": 31
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.wildcard.models:REPLACE_DEPTH",
+        "kind": "static_from",
+        "line": 47,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "wildcard_engine.py",
+        "target": "easyuse_anima/wildcard/models.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 46,
+            "kind": "try",
+            "line": 31
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.wildcard.models:WildcardExpansionBudget",
+        "kind": "static_from",
+        "line": 47,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "wildcard_engine.py",
+        "target": "easyuse_anima/wildcard/models.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 46,
+            "kind": "try",
+            "line": 31
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.wildcard.models:WildcardExpansionResult",
+        "kind": "static_from",
+        "line": 47,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "wildcard_engine.py",
+        "target": "easyuse_anima/wildcard/models.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 46,
+            "kind": "try",
+            "line": 31
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.wildcard.models:WildcardOption",
+        "kind": "static_from",
+        "line": 47,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "wildcard_engine.py",
+        "target": "easyuse_anima/wildcard/models.py"
+      },
+      {
+        "branch_context": [
+          {
             "branch": "body",
             "kind": "if",
-            "line": 562,
+            "line": 502,
             "type_checking": false
           },
           {
@@ -67887,16 +69034,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 505,
             "kind": "try",
-            "line": 563
+            "line": 503
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.settings.repository:get_settings",
         "kind": "static_from",
-        "line": 566,
+        "line": 506,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "wildcard_engine.py",
@@ -73294,6 +74441,39 @@
         "line": 3,
         "optional": false,
         "role": "ordinary",
+        "source": "easyuse_anima/wildcard/models.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "math",
+        "kind": "static_import",
+        "line": 5,
+        "optional": false,
+        "role": "ordinary",
+        "source": "easyuse_anima/wildcard/models.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "dataclasses:dataclass",
+        "kind": "static_from",
+        "line": 6,
+        "optional": false,
+        "role": "ordinary",
+        "source": "easyuse_anima/wildcard/models.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "__future__:annotations",
+        "kind": "static_from",
+        "line": 3,
+        "optional": false,
+        "role": "ordinary",
         "source": "easyuse_anima/workflow.py"
       },
       {
@@ -73553,14 +74733,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 542
+            "line": 482
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 543,
+        "line": 483,
         "optional": true,
         "role": "optional_dependency",
         "source": "wildcard_engine.py"
@@ -74514,14 +75694,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 542
+            "line": 482
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 543,
+        "line": 483,
         "optional": true,
         "role": "optional_dependency",
         "source": "wildcard_engine.py"
@@ -74648,6 +75828,8 @@
       "easyuse_anima/translation/providers/__init__.py",
       "easyuse_anima/translation/providers/google.py",
       "easyuse_anima/translation/service.py",
+      "easyuse_anima/wildcard/__init__.py",
+      "easyuse_anima/wildcard/models.py",
       "easyuse_anima/workflow.py",
       "nodes.py",
       "prompt_translation.py",
@@ -74775,6 +75957,8 @@
       "easyuse_anima/translation/providers/__init__.py",
       "easyuse_anima/translation/providers/google.py",
       "easyuse_anima/translation/service.py",
+      "easyuse_anima/wildcard/__init__.py",
+      "easyuse_anima/wildcard/models.py",
       "easyuse_anima/workflow.py",
       "nodes.py",
       "prompt_translation.py",
@@ -76336,11 +77520,38 @@
         "scope": "<module>"
       },
       {
+        "callee": "dataclass",
+        "column": 1,
+        "context": "decorator:WildcardOption",
+        "kind": "import_time_call",
+        "line": 34,
+        "module": "easyuse_anima/wildcard/models.py",
+        "scope": "<module>"
+      },
+      {
+        "callee": "dataclass",
+        "column": 1,
+        "context": "decorator:WildcardExpansionBudget",
+        "kind": "import_time_call",
+        "line": 58,
+        "module": "easyuse_anima/wildcard/models.py",
+        "scope": "<module>"
+      },
+      {
+        "callee": "dataclass",
+        "column": 1,
+        "context": "decorator:WildcardExpansionResult",
+        "kind": "import_time_call",
+        "line": 108,
+        "module": "easyuse_anima/wildcard/models.py",
+        "scope": "<module>"
+      },
+      {
         "callee": "re.compile",
         "column": 13,
         "context": "assign:COMMENT_RE",
         "kind": "import_time_call",
-        "line": 93,
+        "line": 112,
         "module": "wildcard_engine.py",
         "scope": "<module>"
       },
@@ -76349,7 +77560,7 @@
         "column": 13,
         "context": "assign:DYNAMIC_RE",
         "kind": "import_time_call",
-        "line": 94,
+        "line": 113,
         "module": "wildcard_engine.py",
         "scope": "<module>"
       },
@@ -76358,7 +77569,7 @@
         "column": 14,
         "context": "assign:WILDCARD_RE",
         "kind": "import_time_call",
-        "line": 95,
+        "line": 114,
         "module": "wildcard_engine.py",
         "scope": "<module>"
       },
@@ -76367,7 +77578,7 @@
         "column": 19,
         "context": "assign:WILDCARD_FULL_RE",
         "kind": "import_time_call",
-        "line": 96,
+        "line": 115,
         "module": "wildcard_engine.py",
         "scope": "<module>"
       },
@@ -76376,7 +77587,7 @@
         "column": 25,
         "context": "assign:WILDCARD_QUANTIFIER_RE",
         "kind": "import_time_call",
-        "line": 97,
+        "line": 116,
         "module": "wildcard_engine.py",
         "scope": "<module>"
       },
@@ -76385,7 +77596,7 @@
         "column": 19,
         "context": "assign:WEIGHT_PREFIX_RE",
         "kind": "import_time_call",
-        "line": 101,
+        "line": 120,
         "module": "wildcard_engine.py",
         "scope": "<module>"
       },
@@ -76394,16 +77605,7 @@
         "column": 16,
         "context": "assign:COUNT_SPEC_RE",
         "kind": "import_time_call",
-        "line": 102,
-        "module": "wildcard_engine.py",
-        "scope": "<module>"
-      },
-      {
-        "callee": "dataclass",
-        "column": 1,
-        "context": "decorator:WildcardOption",
-        "kind": "import_time_call",
-        "line": 107,
+        "line": 121,
         "module": "wildcard_engine.py",
         "scope": "<module>"
       },
@@ -76412,7 +77614,7 @@
         "column": 1,
         "context": "decorator:_WildcardSourceFile",
         "kind": "import_time_call",
-        "line": 113,
+        "line": 126,
         "module": "wildcard_engine.py",
         "scope": "<module>"
       },
@@ -76421,7 +77623,7 @@
         "column": 1,
         "context": "decorator:_WildcardSourceState",
         "kind": "import_time_call",
-        "line": 127,
+        "line": 140,
         "module": "wildcard_engine.py",
         "scope": "<module>"
       },
@@ -76430,7 +77632,7 @@
         "column": 1,
         "context": "decorator:_WildcardSnapshot",
         "kind": "import_time_call",
-        "line": 142,
+        "line": 155,
         "module": "wildcard_engine.py",
         "scope": "<module>"
       },
@@ -76439,7 +77641,7 @@
         "column": 22,
         "context": "assign:_SNAPSHOT_CONDITION",
         "kind": "import_time_call",
-        "line": 167,
+        "line": 180,
         "module": "wildcard_engine.py",
         "scope": "<module>"
       },
@@ -76448,7 +77650,7 @@
         "column": 57,
         "context": "assign:_SNAPSHOT_CACHE",
         "kind": "import_time_call",
-        "line": 168,
+        "line": 181,
         "module": "wildcard_engine.py",
         "scope": "<module>"
       },
@@ -76457,25 +77659,7 @@
         "column": 33,
         "context": "assign:_SNAPSHOT_BUILDING",
         "kind": "import_time_call",
-        "line": 169,
-        "module": "wildcard_engine.py",
-        "scope": "<module>"
-      },
-      {
-        "callee": "dataclass",
-        "column": 1,
-        "context": "decorator:WildcardExpansionBudget",
-        "kind": "import_time_call",
-        "line": 190,
-        "module": "wildcard_engine.py",
-        "scope": "<module>"
-      },
-      {
-        "callee": "dataclass",
-        "column": 1,
-        "context": "decorator:WildcardExpansionResult",
-        "kind": "import_time_call",
-        "line": 235,
+        "line": 182,
         "module": "wildcard_engine.py",
         "scope": "<module>"
       },
@@ -76484,7 +77668,7 @@
         "column": 1,
         "context": "decorator:_ExpansionSegment",
         "kind": "import_time_call",
-        "line": 260,
+        "line": 200,
         "module": "wildcard_engine.py",
         "scope": "<module>"
       },
@@ -76493,7 +77677,7 @@
         "column": 1,
         "context": "decorator:_Replacement",
         "kind": "import_time_call",
-        "line": 333,
+        "line": 273,
         "module": "wildcard_engine.py",
         "scope": "<module>"
       }
@@ -76869,25 +78053,25 @@
       },
       {
         "kind": "set",
-        "line": 91,
+        "line": 110,
         "module": "wildcard_engine.py",
         "name": "WILDCARD_EXTENSIONS"
       },
       {
         "kind": "dict",
-        "line": 52,
+        "line": 83,
         "module": "wildcard_engine.py",
         "name": "WILDCARD_MODE_ALIASES"
       },
       {
         "kind": "set",
-        "line": 169,
+        "line": 182,
         "module": "wildcard_engine.py",
         "name": "_SNAPSHOT_BUILDING"
       },
       {
         "kind": "dict",
-        "line": 168,
+        "line": 181,
         "module": "wildcard_engine.py",
         "name": "_SNAPSHOT_CACHE"
       }
@@ -77052,7 +78236,7 @@
           "single_flight"
         ],
         "initializer": "set",
-        "line": 169,
+        "line": 182,
         "module": "wildcard_engine.py",
         "name": "_SNAPSHOT_BUILDING"
       },
@@ -77062,7 +78246,7 @@
           "mutable_container"
         ],
         "initializer": "OrderedDict",
-        "line": 168,
+        "line": 181,
         "module": "wildcard_engine.py",
         "name": "_SNAPSHOT_CACHE"
       }

--- a/tests/test_python_backend_analyzer.py
+++ b/tests/test_python_backend_analyzer.py
@@ -691,9 +691,9 @@ ignored/
 
         self.assertEqual(analyzer.render_json(report), expected_text)
         self.assertEqual(report["schema_version"], 2)
-        self.assertEqual(report["inventory"]["module_count"], 125)
-        self.assertEqual(len(report["registry"]["shipped_python_modules"]), 125)
-        self.assertEqual(len(report["registry"]["runtime_import_closure"]), 125)
+        self.assertEqual(report["inventory"]["module_count"], 127)
+        self.assertEqual(len(report["registry"]["shipped_python_modules"]), 127)
+        self.assertEqual(len(report["registry"]["runtime_import_closure"]), 127)
         self.assertEqual(
             report["registry"]["entry_modules"],
             [
@@ -946,6 +946,26 @@ ignored/
             },
             report["imports"]["module_graph"],
         )
+        self.assertIn(
+            {
+                "from": "wildcard_engine.py",
+                "to": "easyuse_anima/wildcard/models.py",
+            },
+            report["imports"]["module_graph"],
+        )
+        for module in (
+            "easyuse_anima/wildcard/__init__.py",
+            "easyuse_anima/wildcard/models.py",
+        ):
+            with self.subTest(module=module):
+                self.assertIn(
+                    module,
+                    report["registry"]["shipped_python_modules"],
+                )
+                self.assertIn(
+                    module,
+                    report["registry"]["runtime_import_closure"],
+                )
         self.assertIn(
             {"from": "api.py", "to": "api_contract.py"},
             report["imports"]["module_graph"],

--- a/tests/test_python_package_skeleton.py
+++ b/tests/test_python_package_skeleton.py
@@ -86,6 +86,8 @@ PACKAGE_MODULES = (
     "easyuse_anima.translation.providers",
     "easyuse_anima.translation.providers.google",
     "easyuse_anima.translation.service",
+    "easyuse_anima.wildcard",
+    "easyuse_anima.wildcard.models",
     "easyuse_anima.seed.execution_identity",
     "easyuse_anima.seed.execution_session",
     "easyuse_anima.seed.service",
@@ -362,6 +364,22 @@ print(json.dumps({{
             "google_translate_text",
             "strip_prompt_translation_markers",
             "translate_prompt_markers",
+        ]
+        expected_all[
+            PACKAGE_MODULES.index("easyuse_anima.wildcard.models")
+        ] = [
+            "MAX_EXPANSION_DEPTH",
+            "REPLACE_DEPTH",
+            "DEFAULT_MAX_EXPANSION_DEPTH",
+            "DEFAULT_MAX_EXPANSION_REPLACEMENTS",
+            "DEFAULT_MAX_EXPANSION_OUTPUT_CHARS",
+            "DEFAULT_MAX_EXPANSION_GROWTH_PER_PASS",
+            "MAX_EXPANSION_REPLACEMENTS",
+            "MAX_EXPANSION_OUTPUT_CHARS",
+            "MAX_EXPANSION_GROWTH_PER_PASS",
+            "WildcardOption",
+            "WildcardExpansionBudget",
+            "WildcardExpansionResult",
         ]
         self.assertEqual(payload["declared_all"], expected_all)
         self.assertEqual(payload["new_forbidden"], [])

--- a/tests/test_registry_scanner_safety.py
+++ b/tests/test_registry_scanner_safety.py
@@ -81,6 +81,8 @@ EXPECTED_PYTHON_PACKAGE_FILES = {
     "easyuse_anima/settings/repository.py",
     "easyuse_anima/settings/schema.py",
     "easyuse_anima/settings/service.py",
+    "easyuse_anima/wildcard/__init__.py",
+    "easyuse_anima/wildcard/models.py",
     "easyuse_anima/registration.py",
     "easyuse_anima/prompt/__init__.py",
     "easyuse_anima/prompt/correction.py",

--- a/tests/test_wildcards.py
+++ b/tests/test_wildcards.py
@@ -12,6 +12,7 @@ import nodes as nodes_module
 from easyuse_anima.nodes import wildcard_nodes
 from easyuse_anima.prompt import advanced as prompt_advanced
 from easyuse_anima.seed import compatibility as seed_compatibility
+from easyuse_anima.wildcard import models as wildcard_models
 from nodes import (
     EasyUseAnimaPromptStudioAdvanced,
     EasyUseAnimaPromptStudioAdvancedV2,
@@ -32,6 +33,29 @@ from wildcard_engine import (
 
 
 class WildcardEngineTests(unittest.TestCase):
+    def test_root_model_surface_has_canonical_identity(self):
+        expected = (
+            "MAX_EXPANSION_DEPTH",
+            "REPLACE_DEPTH",
+            "DEFAULT_MAX_EXPANSION_DEPTH",
+            "DEFAULT_MAX_EXPANSION_REPLACEMENTS",
+            "DEFAULT_MAX_EXPANSION_OUTPUT_CHARS",
+            "DEFAULT_MAX_EXPANSION_GROWTH_PER_PASS",
+            "MAX_EXPANSION_REPLACEMENTS",
+            "MAX_EXPANSION_OUTPUT_CHARS",
+            "MAX_EXPANSION_GROWTH_PER_PASS",
+            "WildcardOption",
+            "WildcardExpansionBudget",
+            "WildcardExpansionResult",
+        )
+        self.assertEqual(wildcard_models.__all__, expected)
+        for name in expected:
+            with self.subTest(name=name):
+                self.assertIs(
+                    getattr(wildcard_engine, name),
+                    getattr(wildcard_models, name),
+                )
+
     def test_reserved_seed_consumer_root_symbols_are_direct_aliases(self):
         self.assertIs(
             nodes_module._consume_reserved_wildcard_next_seed,

--- a/wildcard_engine.py
+++ b/wildcard_engine.py
@@ -28,6 +28,37 @@ try:
 except ImportError:
     from easyuse_anima.infrastructure.filesystem.paths import USER_DATA_DIR
 
+try:
+    from .easyuse_anima.wildcard.models import (
+        DEFAULT_MAX_EXPANSION_DEPTH,
+        DEFAULT_MAX_EXPANSION_GROWTH_PER_PASS,
+        DEFAULT_MAX_EXPANSION_OUTPUT_CHARS,
+        DEFAULT_MAX_EXPANSION_REPLACEMENTS,
+        MAX_EXPANSION_DEPTH,
+        MAX_EXPANSION_GROWTH_PER_PASS,
+        MAX_EXPANSION_OUTPUT_CHARS,
+        MAX_EXPANSION_REPLACEMENTS,
+        REPLACE_DEPTH,
+        WildcardExpansionBudget,
+        WildcardExpansionResult,
+        WildcardOption,
+    )
+except ImportError:
+    from easyuse_anima.wildcard.models import (
+        DEFAULT_MAX_EXPANSION_DEPTH,
+        DEFAULT_MAX_EXPANSION_GROWTH_PER_PASS,
+        DEFAULT_MAX_EXPANSION_OUTPUT_CHARS,
+        DEFAULT_MAX_EXPANSION_REPLACEMENTS,
+        MAX_EXPANSION_DEPTH,
+        MAX_EXPANSION_GROWTH_PER_PASS,
+        MAX_EXPANSION_OUTPUT_CHARS,
+        MAX_EXPANSION_REPLACEMENTS,
+        REPLACE_DEPTH,
+        WildcardExpansionBudget,
+        WildcardExpansionResult,
+        WildcardOption,
+    )
+
 
 WILDCARD_DIR_NAME = "wildcards"
 DEFAULT_TEST_WILDCARD_FILE = "easyuse_anima_test.txt"
@@ -76,18 +107,6 @@ SEED_CONTROL_MODES = (
 
 MAX_SEED = 0xFFFFFFFFFFFFFFFF
 PUBLIC_MAX_SEED = (1 << 53) - 1
-# Defaults stop exponential inputs well before they become memory hazards while
-# leaving ample room for ordinary nested wildcard libraries.  The old depth is
-# retained as a hard ceiling for callers that provide a custom budget.
-MAX_EXPANSION_DEPTH = 100
-REPLACE_DEPTH = MAX_EXPANSION_DEPTH
-DEFAULT_MAX_EXPANSION_DEPTH = 32
-DEFAULT_MAX_EXPANSION_REPLACEMENTS = 4096
-DEFAULT_MAX_EXPANSION_OUTPUT_CHARS = 256 * 1024
-DEFAULT_MAX_EXPANSION_GROWTH_PER_PASS = 8.0
-MAX_EXPANSION_REPLACEMENTS = 65536
-MAX_EXPANSION_OUTPUT_CHARS = 1024 * 1024
-MAX_EXPANSION_GROWTH_PER_PASS = 32.0
 WILDCARD_EXTENSIONS = {".txt", ".yaml", ".yml"}
 
 COMMENT_RE = re.compile(r"^\s*#.*(?:\n|$)", re.MULTILINE)
@@ -102,12 +121,6 @@ WEIGHT_PREFIX_RE = re.compile(r"^\s*([+-]?(?:\d+(?:\.\d*)?|\.\d+))::(.*)$", re.D
 COUNT_SPEC_RE = re.compile(
     r"(?:(?P<fixed>\d+)|(?P<minimum>\d*)\s*-\s*(?P<maximum>\d*))"
 )
-
-
-@dataclass(frozen=True)
-class WildcardOption:
-    text: str
-    weight: float = 1.0
 
 
 @dataclass(frozen=True)
@@ -167,79 +180,6 @@ _SNAPSHOT_CACHE_LIMIT = 16
 _SNAPSHOT_CONDITION = threading.Condition()
 _SNAPSHOT_CACHE: OrderedDict[tuple, _WildcardSnapshot] = OrderedDict()
 _SNAPSHOT_BUILDING: set[tuple] = set()
-
-
-def _bounded_int(value, default: int, minimum: int, maximum: int) -> int:
-    try:
-        parsed = int(value)
-    except (TypeError, ValueError, OverflowError):
-        parsed = default
-    return max(minimum, min(maximum, parsed))
-
-
-def _bounded_float(value, default: float, minimum: float, maximum: float) -> float:
-    try:
-        parsed = float(value)
-    except (TypeError, ValueError, OverflowError):
-        parsed = default
-    if not math.isfinite(parsed):
-        parsed = default
-    return max(minimum, min(maximum, parsed))
-
-
-@dataclass(frozen=True)
-class WildcardExpansionBudget:
-    max_depth: int = DEFAULT_MAX_EXPANSION_DEPTH
-    max_replacements: int = DEFAULT_MAX_EXPANSION_REPLACEMENTS
-    max_output_chars: int = DEFAULT_MAX_EXPANSION_OUTPUT_CHARS
-    max_growth_per_pass: float = DEFAULT_MAX_EXPANSION_GROWTH_PER_PASS
-
-    def __post_init__(self) -> None:
-        object.__setattr__(
-            self,
-            "max_depth",
-            _bounded_int(self.max_depth, DEFAULT_MAX_EXPANSION_DEPTH, 0, MAX_EXPANSION_DEPTH),
-        )
-        object.__setattr__(
-            self,
-            "max_replacements",
-            _bounded_int(
-                self.max_replacements,
-                DEFAULT_MAX_EXPANSION_REPLACEMENTS,
-                0,
-                MAX_EXPANSION_REPLACEMENTS,
-            ),
-        )
-        object.__setattr__(
-            self,
-            "max_output_chars",
-            _bounded_int(
-                self.max_output_chars,
-                DEFAULT_MAX_EXPANSION_OUTPUT_CHARS,
-                1,
-                MAX_EXPANSION_OUTPUT_CHARS,
-            ),
-        )
-        object.__setattr__(
-            self,
-            "max_growth_per_pass",
-            _bounded_float(
-                self.max_growth_per_pass,
-                DEFAULT_MAX_EXPANSION_GROWTH_PER_PASS,
-                1.0,
-                MAX_EXPANSION_GROWTH_PER_PASS,
-            ),
-        )
-
-
-@dataclass(frozen=True)
-class WildcardExpansionResult:
-    text: str
-    changed: bool
-    used_keys: tuple[str, ...] = ()
-    missing_keys: tuple[str, ...] = ()
-    replacement_count: int = 0
-    limit_reason: str | None = None
 
 
 def _utf8_width(char: str) -> int:


### PR DESCRIPTION
## 작업

- Task: D-12a Wildcard models canonical Move
- Parent: D-12 / owner #186
- Behavior prerequisites: #159, #160 complete
- Type: Move
- Base: `dev@7fdee04d4102a1273025624f57e955b3295e4a8a`
- Head: `4368874`
- Behavior changes: 없음

## 경계 결정

`wildcard_engine.py` 전체 이동은 D-12 Move와 E-06 snapshot lifecycle, seed/expansion behavior를 섞습니다. D-12a는 mutable state가 없는 dependency-free model leaf만 `easyuse_anima.wildcard.models`로 이동합니다.

### 작업 전 inventory

Supported moved surface:

- budget constants 9개: `MAX_EXPANSION_DEPTH`, `REPLACE_DEPTH`, `DEFAULT_MAX_EXPANSION_*`, `MAX_EXPANSION_*`
- immutable models: `WildcardOption`, `WildcardExpansionBudget`, `WildcardExpansionResult`
- private model coercion: `_bounded_int`, `_bounded_float`

Root는 supported name을 wrapper 없이 동일 canonical 객체로 직접 bind합니다.

Callers/aliases:

- root `wildcard_engine.py`는 canonical models를 사용하면서 source/snapshot/selector/seed/expansion 구현을 계속 소유
- node/API/bootstrap의 root source·expansion·seed helper import는 이 slice에서 유지
- wildcard tests는 기존 behavior import를 유지하고 root/canonical identity를 검증
- package/Registry/analyzer fixtures는 wildcard package와 models module만 추가

Global state:

- 이동 없음
- `_SNAPSHOT_CONDITION`, `_SNAPSHOT_CACHE`, `_SNAPSHOT_BUILDING`, cache limit 및 per-call selector/expansion state는 root 유지
- lifecycle 이동은 later D-12/E-06 소유

## 변경 파일

- production: `wildcard_engine.py`, `easyuse_anima/wildcard/__init__.py`, `easyuse_anima/wildcard/models.py`
- tests: wildcard identity/behavior, package skeleton, Registry scanner, backend analyzer fixture
- docs: D-12a inventory, roadmap, compatibility-shim ledger

## 검증

- wildcard behavior 및 root/canonical identity: 72 tests 통과
- package skeleton: 1 test 통과
- Registry scanner: 8 tests 통과
- backend analyzer: 18 tests 통과; 127 shipped/runtime modules, unreachable 0
- G-03 import boundary: 16 tests 통과
- canonical model Pyright diagnostics: 0
- official full: Python 1,135 tests 및 frontend 112 files 통과; G-03 10 groups/0 violations; 기존 Pyright baseline 14 errors 유지
- `comfy node validate`: 통과
- `comfy node pack`: 257 entries; root `wildcard_engine.py` 및 canonical wildcard `__init__.py`/`models.py` 포함
- ComfyUI 표면: repository-owned module/frontend regression suite
- Live ComfyUI smoke: 실행하지 않음 — immutable Move PR 경계상 불필요

## 남은 위험 / 후속

- source scan, YAML, snapshot cache/condition, selector/seed, expansion implementation은 root에 유지됩니다.
- 다음 D-12 slice에서 dependency graph에 따라 source/snapshot과 expansion을 분리합니다.
- snapshot lifecycle/factory/cleanup은 E-06이며 이번 PR에서 변경하지 않았습니다.