### PR TITLE
refactor: move wildcard source discovery and parsing

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -24,7 +24,7 @@ from .easyuse_anima.registration import (  # noqa: F401 - mapped class attribute
 )
 from . import api
 from .easyuse_anima.bootstrap import initialize as _initialize
-from .wildcard_engine import ensure_default_wildcard_root
+from .easyuse_anima.wildcard.sources import ensure_default_wildcard_root
 
 
 def _load_comfy_nodes():

--- a/api.py
+++ b/api.py
@@ -36,8 +36,9 @@ from .easyuse_anima.autocomplete.dataset import (
 from .easyuse_anima.autocomplete.search import (
     search_autocomplete,
 )
+from .easyuse_anima.wildcard.sources import resolve_wildcard_roots
 from .autocomplete_dataset import classify_prompt_text
-from .wildcard_engine import list_wildcards, resolve_wildcard_roots
+from .wildcard_engine import list_wildcards
 from .easyuse_anima.translation.contracts import (
     PromptTranslationError,
     TranslationBusyError,

--- a/docs/architecture/python-backend-execution-roadmap.md
+++ b/docs/architecture/python-backend-execution-roadmap.md
@@ -33,7 +33,7 @@ merged PR, the owning issue's evidence record, and every stated exit gate.
 | A - baseline | Complete; #191 is closed | Keep fixtures and analyzers current during later moves |
 | B - `nodes.py` extraction | Complete in B-11d / PR #356 | Preserve the audited compatibility shim until ADR-002 retirement gates are met |
 | C - feature contracts/behavior | Partially complete through S167-01a / PR #344 | Continue #167 and #169 in separate Contract/Move/Behavior PRs |
-| D - root consolidation | D-01, D-08, D-09, and D-10 complete on `dev`; D-11a/#385, D-11b/#386, and D-12a/#387 validated | Continue D-12 source/snapshot/expansion slices, then D-13; finish D-11 classification only after D-13 removes its root-package dependency |
+| D - root consolidation | D-01, D-08, D-09, and D-10 complete on `dev`; D-11a/#385, D-11b/#386, D-12a/#387, and D-12b/#388 validated | Continue D-12 snapshot/expansion slices, then D-13; finish D-11 classification only after D-13 removes its root-package dependency |
 | E - runtime ownership | Partial: E-02a and E-07a/E-07b integrated | Continue #187 only where canonical feature owners and explicit contracts exist |
 | F - typed boundaries | Partial patterns exist | Extend typed request/result/config and pure migration patterns feature by feature |
 | G - quality ratchet | G-01, G-02a/G-02b, and G-03a complete | Extend G-03 enrollment, then continue with G-04 through G-06 |
@@ -408,7 +408,7 @@ mechanical retirement series.
 | 15 | S167 backend seed reservation series | S167-01 through S167-03d COMPLETE on `dev`; S167-03e AiO cutover VALIDATED with isolated API/module/browser-load parity | Contract then Move then Behavior | #167 | Canonical AiO/node seams |
 | 16 | A169 stage pipeline series | A169-01 through A169-08 MERGED; A169-09 final adapter/integration VALIDATED in PR #372 | Contract then Behavior | #169 | Typed config and mechanical AiO move |
 | 17 | A169 first-pass cache policy | COMPLETE through CACHE-06; 4K/batch evidence VALIDATED in PR #380 | Contract then Behavior | #169 | Mechanical cache move and stable stage seam |
-| 18 | D-series canonical root consolidation | D-01 translation, D-08 filesystem, D-09 settings, and D-10 profiles COMPLETE on `dev`; D-11a/#385 and D-11b/#386 autocomplete VALIDATED; D-12a wildcard models VALIDATED in PR #387 | Move | #186 | Phase B exit; per-feature behavior stable |
+| 18 | D-series canonical root consolidation | D-01 translation, D-08 filesystem, D-09 settings, and D-10 profiles COMPLETE on `dev`; D-11a/#385 and D-11b/#386 autocomplete VALIDATED; D-12a/#387 wildcard models and D-12b/#388 wildcard sources VALIDATED | Move | #186 | Phase B exit; per-feature behavior stable |
 | 19 | E-series RuntimeServices/lifecycle | BLOCKED by canonical owners | Move/Contract, split PRs | #187 | Relevant D moves |
 | 20 | G-04 through G-06 and H | INCREMENTAL/LATER | Gate/Contract | #188 | Appropriate package and release evidence |
 
@@ -1339,7 +1339,10 @@ D-12 is split to keep Move work separate from E-06 lifecycle ownership.
 D-12a moves immutable option/budget/result models and their fixed limit
 constants to `easyuse_anima.wildcard.models`, while root
 `wildcard_engine.py` retains source scanning, snapshot state, selector/seed,
-and expansion implementation for later slices.
+and expansion implementation for later slices. D-12b moves root discovery,
+TXT/YAML parsing, immutable source metadata, and source scanning to
+`easyuse_anima.wildcard.sources`; root keeps direct supported-name aliases and
+retains snapshot publication/cache/single-flight, selector/seed, and expansion.
 
 ## 12. Phase E — Runtime ownership and lifecycle
 

--- a/docs/architecture/python-compatibility-shims.md
+++ b/docs/architecture/python-compatibility-shims.md
@@ -64,7 +64,7 @@ import them.
 | `storage.py` | Explicit direct re-export shim (D-08) | `easyuse_anima.infrastructure.filesystem.atomic_json` and `.paths` | #163, #186 D-08 | Existing 0.5.2 supported module-owned public surface; exact `__all__` and identity fixture | External/legacy imports and storage compatibility tests; production callers use canonical modules | Unscheduled; first canonical+shim release N not yet recorded, then N+1 gate and last-known-good/atomic-write parity |
 | `autocomplete_index.py` | Explicit direct re-export shim (D-11a) | `easyuse_anima.autocomplete.index` | #162, #186 D-11a | Existing indexed-search surface; exact seven-name `__all__` and identity fixture | External/legacy imports; `autocomplete_dataset.py` now uses the canonical owner | Unscheduled; first canonical+shim release N not yet recorded, then N+1 gate and index/ranking/rebuild parity |
 | `autocomplete_dataset.py` | Partial explicit compatibility module after D-11b; prompt classification remains root-owned | `easyuse_anima.autocomplete.dataset` and `.search`; classification target waits for D-13 | #162, #186 D-11 | Existing 0.5.2 dataset/search surface canonicalized in PR #386 with direct identity aliases; final shim waits for root `anima_prompt` removal | External/legacy imports and prompt tests; `api.py` uses canonical dataset/search and root classification | Unscheduled; D-13 dependency removal, final identity surface, N+1 gate, and classification/result/API parity |
-| `wildcard_engine.py` | Partial compatibility module after D-12a; source/snapshot/selector/seed/expansion remain root-owned | `easyuse_anima.wildcard.models`, then sources/snapshot/expansion modules | #184, #186 D-12 | Existing 0.5.2 immutable model/limit surface canonicalized in PR #387 with direct identity aliases; later D-12 slices remain | root entrypoint, `nodes.py`, `api.py`, wildcard/workflow tests | Unscheduled; full D-12 move, final identity surface, N+1 gate, and seed/expansion/workflow parity |
+| `wildcard_engine.py` | Partial compatibility module after D-12b; snapshot/selector/seed/expansion remain root-owned | `easyuse_anima.wildcard.models`, `.sources`, then snapshot/expansion modules | #184, #186 D-12 | Existing 0.5.2 model/limit surface canonicalized in PR #387 and source/path surface in PR #388 with direct identity aliases; later D-12 slices remain | root entrypoint, `nodes.py`, `api.py`, wildcard/workflow tests | Unscheduled; full D-12 move, final identity surface, N+1 gate, and seed/expansion/workflow parity |
 | `prompt_translation.py` | Explicit direct re-export shim (D-01) | `easyuse_anima.translation.*` | #164, #186 D-01 | Existing 0.5.2 supported module-owned public surface; exact `__all__` and identity fixture | External/legacy imports and translation compatibility tests; production callers use canonical modules | Unscheduled; first canonical+shim release N not yet recorded, then N+1 gate and provider-off/API parity |
 | `anima_prompt/` package | Current implementation; planned package shim | `easyuse_anima.prompt.anima.*` | #184, #186 D-13 | Existing 0.5.2 surface; convert in D-13/D-14 | `nodes.py`, `autocomplete_dataset.py`, prompt tests | Unscheduled; N+1 gate and prompt correction/parser parity |
 
@@ -1464,9 +1464,13 @@ EasyUseAnimaWildcard
 - D-12a moves immutable `WildcardOption`, `WildcardExpansionBudget`,
   `WildcardExpansionResult`, and their fixed budget constants to
   `easyuse_anima.wildcard.models`.
-- Root binds the 12 moved supported names directly to canonical objects.
-  Source scanning, snapshot cache/condition, selector/seed, parsing, expansion,
-  enforcement, and diagnostics remain root-owned for later D-12 slices.
+- D-12b moves root discovery, extra-path resolution, TXT/YAML parsing,
+  immutable source metadata, and source scanning to
+  `easyuse_anima.wildcard.sources`.
+- Root binds the 12 model names and eight supported source names directly to
+  canonical objects. Snapshot construction/cache/condition/single-flight,
+  selector/seed, expansion, enforcement, and diagnostics remain root-owned for
+  later D-12 slices.
 - Canonical target for the remaining implementation:
   `easyuse_anima.wildcard` sources/snapshot/expansion modules. Snapshot
   lifecycle/factory/cleanup remains E-06.

--- a/docs/architecture/wildcard-sources-canonical-move.md
+++ b/docs/architecture/wildcard-sources-canonical-move.md
@@ -8,7 +8,7 @@
 - Parent roadmap unit: D-12 Wildcard
 - PR type: Move
 - Baseline: `dev@105a3ae2c4d89bbf6ea2b7369a627e63fbd92847`
-- State: READY
+- State: VALIDATED
 - Production behavior changes: forbidden
 
 ## Responsibility boundary
@@ -178,3 +178,20 @@ Supporting:
 - canonical sources has zero root imports;
 - official full runner once at the PR checkpoint; and
 - root retains all snapshot/cache/selector/seed/expansion implementation.
+
+## Validation evidence
+
+- wildcard behavior and identity: 73 tests passed;
+- bootstrap contracts: 82 tests passed;
+- API canonical import alias: 1 focused test passed;
+- package skeleton: 1 test passed;
+- Registry scanner safety: 8 tests passed;
+- Python import boundaries: 16 tests passed;
+- backend analyzer: 18 tests passed;
+- canonical `sources.py` Pyright 1.1.411: 0 diagnostics;
+- official full: 1,136 Python tests and 112 frontend files passed, G-03a
+  remained 10 completed groups with 0 violations, and the existing 14-error
+  Pyright baseline passed; and
+- local Registry validation passed; the 258-entry archive contained root
+  `wildcard_engine.py` and canonical wildcard `__init__.py`, `models.py`, and
+  `sources.py`.

--- a/docs/architecture/wildcard-sources-canonical-move.md
+++ b/docs/architecture/wildcard-sources-canonical-move.md
@@ -1,0 +1,180 @@
+# D-12b Wildcard sources canonical Move
+
+- Owner issue: [#186](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/186)
+- Behavior prerequisites:
+  [#159](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/159) and
+  [#160](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/160) — complete
+- Roadmap unit: D-12b
+- Parent roadmap unit: D-12 Wildcard
+- PR type: Move
+- Baseline: `dev@105a3ae2c4d89bbf6ea2b7369a627e63fbd92847`
+- State: READY
+- Production behavior changes: forbidden
+
+## Responsibility boundary
+
+After D-12a, root `wildcard_engine.py` still owns source discovery/parsing,
+snapshot publication/cache, selector/seed, and expansion. Source discovery and
+file parsing form a dependency-free leaf below snapshot and expansion:
+
+- they read roots and TXT/YAML files;
+- they produce immutable source metadata and `WildcardOption` lists; and
+- they own no mutable cache, lock, selector, or expansion state.
+
+D-12b moves that leaf to:
+
+- `easyuse_anima.wildcard.sources`.
+
+Snapshot construction/publication, cache/condition/single-flight behavior,
+listing/signature, selector/PRNG, seed control, and expansion remain in root.
+
+## Supported moved surface
+
+Source constants:
+
+- `WILDCARD_DIR_NAME`;
+- `DEFAULT_TEST_WILDCARD_FILE`;
+- `DEFAULT_TEST_WILDCARD_TEXT`; and
+- `WILDCARD_EXTENSIONS`.
+
+Public source/path helpers:
+
+- `default_wildcard_root`;
+- `ensure_default_wildcard_root`;
+- `parse_wildcard_extra_paths`; and
+- `resolve_wildcard_roots`.
+
+Root binds every moved supported name directly to the identical canonical
+object. No wrapper, proxy, duplicate constant, `import *`, or lazy module hook
+is allowed.
+
+## Private symbol inventory
+
+Source metadata:
+
+- `_WildcardSourceFile`;
+- `_WildcardSourceState`; and
+- their existing `cache_key` properties.
+
+Path/source helpers:
+
+- `_comfy_base_path`;
+- `_resolve_path`;
+- `_normalize_wildcard_key`;
+- `_wildcard_root_identity`; and
+- `_scan_wildcard_sources`.
+
+Parser/loader helpers:
+
+- `WEIGHT_PREFIX_RE`;
+- `_read_text_file`;
+- `_parse_option`;
+- `_options_from_lines`;
+- `_stringify_yaml_scalar`;
+- `_yaml_entries`;
+- `_load_yaml_entries`; and
+- `_load_wildcard_file`.
+
+These private names become canonical snapshot/expansion test seams. They are
+not newly supported public API.
+
+## Caller and alias inventory
+
+Production:
+
+- root `wildcard_engine.py` imports the canonical source metadata and private
+  helpers needed by snapshot and expansion, while retaining snapshot/selector/
+  expansion implementation;
+- root `api.py` imports `resolve_wildcard_roots` directly from canonical
+  sources and keeps `list_wildcards` from root snapshot behavior;
+- root `__init__.py` imports `ensure_default_wildcard_root` directly from
+  canonical sources; and
+- node source/signature/expansion callers remain root-owned in this slice.
+
+Tests:
+
+- `tests/test_wildcards.py` moves private source/YAML patches to canonical
+  sources and keeps root public identity/behavior coverage;
+- API and bootstrap tests patch their direct module-bound aliases unchanged;
+- package skeleton, Registry scanner, and backend analyzer gain the canonical
+  source module and exact graph/fixture evidence.
+
+## Global-state inventory
+
+D-12b moves no mutable runtime state.
+
+Canonical sources has only:
+
+- immutable constants;
+- optional module binding `yaml`;
+- pure/path/file helper functions; and
+- immutable source-state instances created per scan.
+
+Root retains:
+
+- `_SNAPSHOT_CONDITION`;
+- `_SNAPSHOT_CACHE`;
+- `_SNAPSHOT_BUILDING`;
+- `_SNAPSHOT_CACHE_LIMIT`; and
+- snapshot, library, selector, expansion-lane, and per-call expansion state.
+
+Snapshot lifecycle/factory/cleanup belongs to the later snapshot slice and
+E-06. D-12b creates no cache, singleton, lock, background task, cleanup hook,
+factory, or dependency-injection seam.
+
+## Compatibility and behavior invariants
+
+- default root location, sample file name/text, create-on-demand policy, and
+  error propagation are unchanged;
+- extra-path newline parsing, quote stripping, environment/user expansion,
+  Comfy base fallback, resolution, deduplication, and default-root ordering are
+  unchanged;
+- UTF-8/ISO-8859-1 fallback, comment/blank-line policy, weight parsing and
+  clamping, key normalization/rejection, YAML scalar conversion, alias
+  aggregation, malformed-YAML handling, extension policy, and root precedence
+  are unchanged;
+- recursive scan ordering, file filtering, stat metadata, root identity, and
+  cache-key shape are unchanged;
+- optional PyYAML behavior and import timing are unchanged for source users;
+- snapshot/cache/lock/retry/atomic-publish, selector/seed/PCG64, expansion,
+  output, diagnostics, API, node, workflow, and frontend behavior are
+  unchanged.
+
+## Allowed-file boundary
+
+Production:
+
+- root `wildcard_engine.py`;
+- wildcard import lines only in root `api.py`;
+- wildcard initialization import line only in root `__init__.py`; and
+- new `easyuse_anima/wildcard/sources.py`.
+
+Supporting:
+
+- wildcard source/identity behavior tests;
+- package skeleton, Registry scanner, backend analyzer, and exact fixture;
+- this inventory, compatibility-shim ledger, and execution roadmap.
+
+## Forbidden
+
+- snapshot construction/publication/cache/lock/single-flight/lifecycle changes;
+- list/signature payload changes;
+- selector, PRNG, seed, mode, parsing outside source option/YAML parsing,
+  expansion, budget enforcement, or diagnostics behavior changes;
+- moving snapshot or expansion implementation in this PR;
+- G-03 completed-package enrollment before full D-12 completion;
+- API route, node, bootstrap behavior, frontend, workflow, Registry metadata,
+  release, or instance changes; and
+- server, browser, live-instance, model, provider, or network execution.
+
+## Validation and exit
+
+- exact root/canonical identity for every moved supported name;
+- source roots, paths, TXT/YAML parsing, scan metadata/order, and source key
+  behavior;
+- wildcard snapshot/cache/expansion behavior suite remains unchanged;
+- package skeleton, Registry scanner, backend analyzer, and packed archive
+  include canonical `sources.py`;
+- canonical sources has zero root imports;
+- official full runner once at the PR checkpoint; and
+- root retains all snapshot/cache/selector/seed/expansion implementation.

--- a/easyuse_anima/wildcard/sources.py
+++ b/easyuse_anima/wildcard/sources.py
@@ -1,0 +1,307 @@
+"""Wildcard root discovery, source metadata, and TXT/YAML parsing."""
+
+from __future__ import annotations
+
+import os
+import re
+from dataclasses import dataclass
+from pathlib import Path
+
+try:
+    import yaml
+except Exception:  # pragma: no cover - YAML files are skipped without PyYAML.
+    yaml = None
+
+from ..infrastructure.filesystem.paths import USER_DATA_DIR
+from .models import WildcardOption
+
+WILDCARD_DIR_NAME = "wildcards"
+DEFAULT_TEST_WILDCARD_FILE = "easyuse_anima_test.txt"
+DEFAULT_TEST_WILDCARD_TEXT = (
+    "# EasyUse Anima test wildcard\nsimple wildcard\nanima wildcard\n"
+)
+WILDCARD_EXTENSIONS = {".txt", ".yaml", ".yml"}
+
+__all__ = (
+    "WILDCARD_DIR_NAME",
+    "DEFAULT_TEST_WILDCARD_FILE",
+    "DEFAULT_TEST_WILDCARD_TEXT",
+    "WILDCARD_EXTENSIONS",
+    "default_wildcard_root",
+    "ensure_default_wildcard_root",
+    "parse_wildcard_extra_paths",
+    "resolve_wildcard_roots",
+)
+
+WEIGHT_PREFIX_RE = re.compile(
+    r"^\s*([+-]?(?:\d+(?:\.\d*)?|\.\d+))::(.*)$",
+    re.DOTALL,
+)
+
+
+@dataclass(frozen=True)
+class _WildcardSourceFile:
+    root_index: int
+    root: str
+    relative_path: str
+    path: Path
+    mtime_ns: int
+    size: int
+
+    @property
+    def cache_key(self) -> tuple[int, str, int, int]:
+        return (self.root_index, self.relative_path, self.mtime_ns, self.size)
+
+
+@dataclass(frozen=True)
+class _WildcardSourceState:
+    roots: tuple[Path, ...]
+    root_identities: tuple[str, ...]
+    files: tuple[_WildcardSourceFile, ...]
+
+    @property
+    def cache_key(self) -> tuple:
+        roots = tuple(
+            (identity, str(root))
+            for identity, root in zip(self.root_identities, self.roots)
+        )
+        return roots, tuple(source.cache_key for source in self.files)
+
+
+def default_wildcard_root() -> Path:
+    return USER_DATA_DIR / WILDCARD_DIR_NAME
+
+
+def ensure_default_wildcard_root(create_sample: bool = True) -> Path:
+    root = default_wildcard_root()
+    root.mkdir(parents=True, exist_ok=True)
+    if create_sample:
+        sample_path = root / DEFAULT_TEST_WILDCARD_FILE
+        if not sample_path.exists():
+            sample_path.write_text(DEFAULT_TEST_WILDCARD_TEXT, encoding="utf-8")
+    return root
+
+
+def parse_wildcard_extra_paths(value: str) -> list[str]:
+    paths = []
+    for line in str(value or "").splitlines():
+        path = line.strip().strip('"')
+        if path:
+            paths.append(path)
+    return paths
+
+
+def _comfy_base_path() -> Path:
+    try:
+        import folder_paths  # type: ignore
+
+        base_path = getattr(folder_paths, "base_path", None)
+        if base_path:
+            return Path(base_path)
+    except Exception:
+        pass
+    return Path.cwd()
+
+
+def _resolve_path(value: str, base_path: Path) -> Path:
+    expanded = os.path.expandvars(os.path.expanduser(value))
+    path = Path(expanded)
+    if not path.is_absolute():
+        path = base_path / path
+    return path.resolve()
+
+
+def resolve_wildcard_roots(extra_paths: str | None = None) -> list[Path]:
+    if extra_paths is None:
+        from ..settings.repository import get_settings
+
+        extra_paths = get_settings().get("wildcard.extra_paths", "")
+
+    base_path = _comfy_base_path()
+    roots: list[Path] = []
+    seen = set()
+    for raw_path in parse_wildcard_extra_paths(extra_paths or ""):
+        try:
+            root = _resolve_path(raw_path, base_path)
+        except (OSError, RuntimeError, ValueError):
+            continue
+        key = os.path.normcase(str(root))
+        if key not in seen:
+            seen.add(key)
+            roots.append(root)
+
+    try:
+        default_root = ensure_default_wildcard_root().resolve()
+    except OSError:
+        default_root = default_wildcard_root().resolve()
+    default_key = os.path.normcase(str(default_root))
+    if default_key not in seen:
+        roots.append(default_root)
+    return roots
+
+
+def _normalize_wildcard_key(value: str) -> str | None:
+    key = str(value or "").replace("\\", "/").replace(" ", "-").strip().strip("/")
+    if not key:
+        return None
+    if key.startswith("/") or re.match(r"^[a-zA-Z]:", key):
+        return None
+    parts = [part for part in key.split("/") if part]
+    if any(part == ".." for part in parts):
+        return None
+    return "/".join(parts).lower()
+
+
+def _read_text_file(path: Path) -> str:
+    try:
+        return path.read_text(encoding="utf-8")
+    except UnicodeDecodeError:
+        return path.read_text(encoding="iso-8859-1")
+
+
+def _parse_option(value) -> WildcardOption | None:
+    text = "" if value is None else str(value).strip()
+    if not text:
+        return None
+    match = WEIGHT_PREFIX_RE.match(text)
+    if not match:
+        return WildcardOption(text=text, weight=1.0)
+    try:
+        weight = float(match.group(1))
+    except ValueError:
+        return WildcardOption(text=text, weight=1.0)
+    return WildcardOption(text=match.group(2).strip(), weight=max(0.0, weight))
+
+
+def _options_from_lines(text: str) -> list[WildcardOption]:
+    options = []
+    for raw_line in text.splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+        option = _parse_option(line)
+        if option is not None:
+            options.append(option)
+    return options
+
+
+def _stringify_yaml_scalar(value) -> str:
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    return "" if value is None else str(value)
+
+
+def _yaml_entries(data, prefix: str = "") -> dict[str, list[WildcardOption]]:
+    entries: dict[str, list[WildcardOption]] = {}
+
+    def collect(
+        value,
+        path_prefix: str,
+        publish_alias: bool = True,
+    ) -> list[WildcardOption]:
+        aggregate: list[WildcardOption] = []
+        if isinstance(value, dict):
+            for raw_key, child_value in value.items():
+                child_key = _normalize_wildcard_key(raw_key)
+                if child_key is None:
+                    continue
+                path_key = f"{path_prefix}/{child_key}" if path_prefix else child_key
+                aggregate.extend(collect(child_value, path_key))
+        elif isinstance(value, list):
+            for item in value:
+                if isinstance(item, (dict, list)):
+                    # The containing list owns this alias. Nested containers
+                    # still publish their distinct child paths, but not the
+                    # same prefix again through an intermediate frame.
+                    aggregate.extend(collect(item, path_prefix, publish_alias=False))
+                    continue
+                option = _parse_option(_stringify_yaml_scalar(item))
+                if option is not None:
+                    aggregate.append(option)
+        else:
+            option = _parse_option(_stringify_yaml_scalar(value))
+            if option is not None:
+                aggregate.append(option)
+
+        if publish_alias and path_prefix and aggregate:
+            entries.setdefault(path_prefix, []).extend(aggregate)
+        return aggregate
+
+    collect(data, prefix)
+    return entries
+
+
+def _load_yaml_entries(path: Path) -> dict[str, list[WildcardOption]]:
+    if yaml is None:
+        return {}
+    text = _read_text_file(path)
+    try:
+        data = yaml.safe_load(text)
+    except Exception:
+        return {}
+    return _yaml_entries(data)
+
+
+def _load_wildcard_file(
+    root: Path,
+    path: Path,
+) -> dict[str, list[WildcardOption]]:
+    suffix = path.suffix.lower()
+    if suffix not in WILDCARD_EXTENSIONS:
+        return {}
+    if suffix in {".yaml", ".yml"}:
+        return _load_yaml_entries(path)
+    try:
+        relative_key = path.relative_to(root).with_suffix("").as_posix()
+    except ValueError:
+        return {}
+    key = _normalize_wildcard_key(relative_key)
+    if key is None:
+        return {}
+    return {key: _options_from_lines(_read_text_file(path))}
+
+
+def _wildcard_root_identity(root: Path) -> str:
+    try:
+        return os.path.normcase(os.path.abspath(os.fspath(root)))
+    except (OSError, TypeError, ValueError):
+        return os.path.normcase(str(root))
+
+
+def _scan_wildcard_sources(roots: tuple[Path, ...]) -> _WildcardSourceState:
+    files: list[_WildcardSourceFile] = []
+    for root_index, root in enumerate(roots):
+        if not root.is_dir():
+            continue
+        try:
+            candidates = sorted(
+                root.rglob("*"),
+                key=lambda item: item.as_posix().lower(),
+            )
+        except OSError:
+            continue
+        for path in candidates:
+            if path.suffix.lower() not in WILDCARD_EXTENSIONS:
+                continue
+            try:
+                if not path.is_file():
+                    continue
+                stat = path.stat()
+                relative = path.relative_to(root).as_posix()
+            except (OSError, ValueError):
+                continue
+            files.append(
+                _WildcardSourceFile(
+                    root_index=root_index,
+                    root=str(root),
+                    relative_path=relative,
+                    path=path,
+                    mtime_ns=stat.st_mtime_ns,
+                    size=stat.st_size,
+                )
+            )
+    return _WildcardSourceState(
+        roots=roots,
+        root_identities=tuple(_wildcard_root_identity(root) for root in roots),
+        files=tuple(files),
+    )

--- a/tests/fixtures/python_backend_baseline.json
+++ b/tests/fixtures/python_backend_baseline.json
@@ -414,16 +414,16 @@
         "classification": "internal",
         "column": 0,
         "conditional": false,
-        "imported": ".wildcard_engine:ensure_default_wildcard_root",
+        "imported": ".easyuse_anima.wildcard.sources:ensure_default_wildcard_root",
         "kind": "static_from",
         "line": 27,
         "name": "ensure_default_wildcard_root",
         "optional": false,
-        "requested": ".wildcard_engine",
+        "requested": ".easyuse_anima.wildcard.sources",
         "role": "ordinary",
         "scope": "<module>",
         "source": "__init__.py",
-        "target": "wildcard_engine.py"
+        "target": "easyuse_anima/wildcard/sources.py"
       },
       {
         "alias": "comfy_nodes",
@@ -1645,6 +1645,24 @@
       },
       {
         "alias": null,
+        "bound_name": "resolve_wildcard_roots",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".easyuse_anima.wildcard.sources:resolve_wildcard_roots",
+        "kind": "static_from",
+        "line": 39,
+        "name": "resolve_wildcard_roots",
+        "optional": false,
+        "requested": ".easyuse_anima.wildcard.sources",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "api.py",
+        "target": "easyuse_anima/wildcard/sources.py"
+      },
+      {
+        "alias": null,
         "bound_name": "classify_prompt_text",
         "branch_context": [],
         "classification": "internal",
@@ -1652,7 +1670,7 @@
         "conditional": false,
         "imported": ".autocomplete_dataset:classify_prompt_text",
         "kind": "static_from",
-        "line": 39,
+        "line": 40,
         "name": "classify_prompt_text",
         "optional": false,
         "requested": ".autocomplete_dataset",
@@ -1670,26 +1688,8 @@
         "conditional": false,
         "imported": ".wildcard_engine:list_wildcards",
         "kind": "static_from",
-        "line": 40,
+        "line": 41,
         "name": "list_wildcards",
-        "optional": false,
-        "requested": ".wildcard_engine",
-        "role": "ordinary",
-        "scope": "<module>",
-        "source": "api.py",
-        "target": "wildcard_engine.py"
-      },
-      {
-        "alias": null,
-        "bound_name": "resolve_wildcard_roots",
-        "branch_context": [],
-        "classification": "internal",
-        "column": 0,
-        "conditional": false,
-        "imported": ".wildcard_engine:resolve_wildcard_roots",
-        "kind": "static_from",
-        "line": 40,
-        "name": "resolve_wildcard_roots",
         "optional": false,
         "requested": ".wildcard_engine",
         "role": "ordinary",
@@ -1706,7 +1706,7 @@
         "conditional": false,
         "imported": ".easyuse_anima.translation.contracts:PromptTranslationError",
         "kind": "static_from",
-        "line": 41,
+        "line": 42,
         "name": "PromptTranslationError",
         "optional": false,
         "requested": ".easyuse_anima.translation.contracts",
@@ -1724,7 +1724,7 @@
         "conditional": false,
         "imported": ".easyuse_anima.translation.contracts:TranslationBusyError",
         "kind": "static_from",
-        "line": 41,
+        "line": 42,
         "name": "TranslationBusyError",
         "optional": false,
         "requested": ".easyuse_anima.translation.contracts",
@@ -1742,7 +1742,7 @@
         "conditional": false,
         "imported": ".easyuse_anima.translation.contracts:TranslationCancelledError",
         "kind": "static_from",
-        "line": 41,
+        "line": 42,
         "name": "TranslationCancelledError",
         "optional": false,
         "requested": ".easyuse_anima.translation.contracts",
@@ -1760,7 +1760,7 @@
         "conditional": false,
         "imported": ".easyuse_anima.translation.contracts:TranslationTimeoutError",
         "kind": "static_from",
-        "line": 41,
+        "line": 42,
         "name": "TranslationTimeoutError",
         "optional": false,
         "requested": ".easyuse_anima.translation.contracts",
@@ -1778,7 +1778,7 @@
         "conditional": false,
         "imported": ".easyuse_anima.translation.service:translate_prompt_markers",
         "kind": "static_from",
-        "line": 47,
+        "line": 48,
         "name": "translate_prompt_markers",
         "optional": false,
         "requested": ".easyuse_anima.translation.service",
@@ -1796,7 +1796,7 @@
         "conditional": false,
         "imported": ".api_contract:ApiContractError",
         "kind": "static_from",
-        "line": 50,
+        "line": 51,
         "name": "ApiContractError",
         "optional": false,
         "requested": ".api_contract",
@@ -1814,7 +1814,7 @@
         "conditional": false,
         "imported": ".api_contract:attach_request_id_header",
         "kind": "static_from",
-        "line": 50,
+        "line": 51,
         "name": "attach_request_id_header",
         "optional": false,
         "requested": ".api_contract",
@@ -1832,7 +1832,7 @@
         "conditional": false,
         "imported": ".api_contract:correlate_response",
         "kind": "static_from",
-        "line": 50,
+        "line": 51,
         "name": "correlate_response",
         "optional": false,
         "requested": ".api_contract",
@@ -1850,7 +1850,7 @@
         "conditional": false,
         "imported": ".api_contract:create_request_id",
         "kind": "static_from",
-        "line": 50,
+        "line": 51,
         "name": "create_request_id",
         "optional": false,
         "requested": ".api_contract",
@@ -1868,7 +1868,7 @@
         "conditional": false,
         "imported": ".api_contract:error_payload",
         "kind": "static_from",
-        "line": 50,
+        "line": 51,
         "name": "error_payload",
         "optional": false,
         "requested": ".api_contract",
@@ -1886,7 +1886,7 @@
         "conditional": false,
         "imported": ".api_contract:json_boolean",
         "kind": "static_from",
-        "line": 50,
+        "line": 51,
         "name": "json_boolean",
         "optional": false,
         "requested": ".api_contract",
@@ -1904,7 +1904,7 @@
         "conditional": false,
         "imported": ".api_contract:json_integer",
         "kind": "static_from",
-        "line": 50,
+        "line": 51,
         "name": "json_integer",
         "optional": false,
         "requested": ".api_contract",
@@ -1922,7 +1922,7 @@
         "conditional": false,
         "imported": ".api_contract:json_object",
         "kind": "static_from",
-        "line": 50,
+        "line": 51,
         "name": "json_object",
         "optional": false,
         "requested": ".api_contract",
@@ -1940,7 +1940,7 @@
         "conditional": false,
         "imported": ".api_contract:json_string",
         "kind": "static_from",
-        "line": 50,
+        "line": 51,
         "name": "json_string",
         "optional": false,
         "requested": ".api_contract",
@@ -1958,7 +1958,7 @@
         "conditional": false,
         "imported": ".api_contract:json_uuid_string",
         "kind": "static_from",
-        "line": 50,
+        "line": 51,
         "name": "json_uuid_string",
         "optional": false,
         "requested": ".api_contract",
@@ -1976,7 +1976,7 @@
         "conditional": false,
         "imported": ".api_contract:parse_json_object",
         "kind": "static_from",
-        "line": 50,
+        "line": 51,
         "name": "parse_json_object",
         "optional": false,
         "requested": ".api_contract",
@@ -1994,7 +1994,7 @@
         "conditional": false,
         "imported": ".easyuse_anima.profiles:aio",
         "kind": "static_from",
-        "line": 63,
+        "line": 64,
         "name": "aio",
         "optional": false,
         "requested": ".easyuse_anima.profiles",
@@ -2012,7 +2012,7 @@
         "conditional": false,
         "imported": ".easyuse_anima.profiles:contract",
         "kind": "static_from",
-        "line": 64,
+        "line": 65,
         "name": "contract",
         "optional": false,
         "requested": ".easyuse_anima.profiles",
@@ -2030,7 +2030,7 @@
         "conditional": false,
         "imported": ".easyuse_anima.profiles:lora",
         "kind": "static_from",
-        "line": 65,
+        "line": 66,
         "name": "lora",
         "optional": false,
         "requested": ".easyuse_anima.profiles",
@@ -2048,7 +2048,7 @@
         "conditional": false,
         "imported": ".easyuse_anima.profiles:mutation",
         "kind": "static_from",
-        "line": 66,
+        "line": 67,
         "name": "mutation",
         "optional": false,
         "requested": ".easyuse_anima.profiles",
@@ -2066,7 +2066,7 @@
         "conditional": false,
         "imported": ".easyuse_anima.profiles:repository",
         "kind": "static_from",
-        "line": 67,
+        "line": 68,
         "name": "repository",
         "optional": false,
         "requested": ".easyuse_anima.profiles",
@@ -2084,7 +2084,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 323
+            "line": 324
           }
         ],
         "classification": "external",
@@ -2092,7 +2092,7 @@
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 324,
+        "line": 325,
         "name": null,
         "optional": true,
         "requested": "folder_paths",
@@ -27329,6 +27329,202 @@
         "role": "ordinary",
         "scope": "<module>",
         "source": "easyuse_anima/wildcard/models.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "annotations",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "__future__:annotations",
+        "kind": "static_from",
+        "line": 3,
+        "name": "annotations",
+        "optional": false,
+        "requested": "__future__",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/wildcard/sources.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "os",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "os",
+        "kind": "static_import",
+        "line": 5,
+        "name": null,
+        "optional": false,
+        "requested": "os",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/wildcard/sources.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "re",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "re",
+        "kind": "static_import",
+        "line": 6,
+        "name": null,
+        "optional": false,
+        "requested": "re",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/wildcard/sources.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "dataclass",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "dataclasses:dataclass",
+        "kind": "static_from",
+        "line": 7,
+        "name": "dataclass",
+        "optional": false,
+        "requested": "dataclasses",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/wildcard/sources.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "Path",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "pathlib:Path",
+        "kind": "static_from",
+        "line": 8,
+        "name": "Path",
+        "optional": false,
+        "requested": "pathlib",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/wildcard/sources.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "yaml",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": false,
+            "kind": "try",
+            "line": 10
+          }
+        ],
+        "classification": "external",
+        "column": 4,
+        "conditional": true,
+        "imported": "yaml",
+        "kind": "static_import",
+        "line": 11,
+        "name": null,
+        "optional": true,
+        "requested": "yaml",
+        "role": "optional_dependency",
+        "scope": "<module>",
+        "source": "easyuse_anima/wildcard/sources.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "USER_DATA_DIR",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": "..infrastructure.filesystem.paths:USER_DATA_DIR",
+        "kind": "static_from",
+        "line": 15,
+        "name": "USER_DATA_DIR",
+        "optional": false,
+        "requested": "..infrastructure.filesystem.paths",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/wildcard/sources.py",
+        "target": "easyuse_anima/infrastructure/filesystem/paths.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "WildcardOption",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".models:WildcardOption",
+        "kind": "static_from",
+        "line": 16,
+        "name": "WildcardOption",
+        "optional": false,
+        "requested": ".models",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/wildcard/sources.py",
+        "target": "easyuse_anima/wildcard/models.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "folder_paths",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": false,
+            "kind": "try",
+            "line": 95
+          }
+        ],
+        "classification": "external",
+        "column": 8,
+        "conditional": true,
+        "imported": "folder_paths",
+        "kind": "static_import",
+        "line": 96,
+        "name": null,
+        "optional": true,
+        "requested": "folder_paths",
+        "role": "optional_dependency",
+        "scope": "_comfy_base_path",
+        "source": "easyuse_anima/wildcard/sources.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "get_settings",
+        "branch_context": [
+          {
+            "branch": "body",
+            "kind": "if",
+            "line": 115,
+            "type_checking": false
+          }
+        ],
+        "classification": "internal",
+        "column": 8,
+        "conditional": true,
+        "imported": "..settings.repository:get_settings",
+        "kind": "static_from",
+        "line": 116,
+        "name": "get_settings",
+        "optional": false,
+        "requested": "..settings.repository",
+        "role": "ordinary",
+        "scope": "resolve_wildcard_roots",
+        "source": "easyuse_anima/wildcard/sources.py",
+        "target": "easyuse_anima/settings/repository.py"
       },
       {
         "alias": null,
@@ -53277,23 +53473,6 @@
       },
       {
         "alias": null,
-        "bound_name": "os",
-        "branch_context": [],
-        "classification": "external",
-        "column": 0,
-        "conditional": false,
-        "imported": "os",
-        "kind": "static_import",
-        "line": 8,
-        "name": null,
-        "optional": false,
-        "requested": "os",
-        "role": "ordinary",
-        "scope": "<module>",
-        "source": "wildcard_engine.py"
-      },
-      {
-        "alias": null,
         "bound_name": "random",
         "branch_context": [],
         "classification": "external",
@@ -53301,7 +53480,7 @@
         "conditional": false,
         "imported": "random",
         "kind": "static_import",
-        "line": 9,
+        "line": 8,
         "name": null,
         "optional": false,
         "requested": "random",
@@ -53318,7 +53497,7 @@
         "conditional": false,
         "imported": "re",
         "kind": "static_import",
-        "line": 10,
+        "line": 9,
         "name": null,
         "optional": false,
         "requested": "re",
@@ -53335,7 +53514,7 @@
         "conditional": false,
         "imported": "threading",
         "kind": "static_import",
-        "line": 11,
+        "line": 10,
         "name": null,
         "optional": false,
         "requested": "threading",
@@ -53352,7 +53531,7 @@
         "conditional": false,
         "imported": "dataclasses:dataclass",
         "kind": "static_from",
-        "line": 12,
+        "line": 11,
         "name": "dataclass",
         "optional": false,
         "requested": "dataclasses",
@@ -53369,7 +53548,7 @@
         "conditional": false,
         "imported": "pathlib:Path",
         "kind": "static_from",
-        "line": 13,
+        "line": 12,
         "name": "Path",
         "optional": false,
         "requested": "pathlib",
@@ -53386,7 +53565,7 @@
         "conditional": false,
         "imported": "types:MappingProxyType",
         "kind": "static_from",
-        "line": 14,
+        "line": 13,
         "name": "MappingProxyType",
         "optional": false,
         "requested": "types",
@@ -53403,7 +53582,7 @@
         "conditional": false,
         "imported": "typing:Iterable",
         "kind": "static_from",
-        "line": 15,
+        "line": 14,
         "name": "Iterable",
         "optional": false,
         "requested": "typing",
@@ -53420,7 +53599,7 @@
         "conditional": false,
         "imported": "typing:Mapping",
         "kind": "static_from",
-        "line": 15,
+        "line": 14,
         "name": "Mapping",
         "optional": false,
         "requested": "typing",
@@ -53437,7 +53616,7 @@
         "conditional": false,
         "imported": "typing:Sequence",
         "kind": "static_from",
-        "line": 15,
+        "line": 14,
         "name": "Sequence",
         "optional": false,
         "requested": "typing",
@@ -53454,7 +53633,7 @@
         "conditional": false,
         "imported": "numpy",
         "kind": "static_import",
-        "line": 19,
+        "line": 18,
         "name": null,
         "optional": false,
         "requested": "numpy",
@@ -53464,96 +53643,6 @@
       },
       {
         "alias": null,
-        "bound_name": "yaml",
-        "branch_context": [
-          {
-            "branch": "body",
-            "handles_import_failure": true,
-            "has_import_fallback_handler": false,
-            "kind": "try",
-            "line": 21
-          }
-        ],
-        "classification": "external",
-        "column": 4,
-        "conditional": true,
-        "imported": "yaml",
-        "kind": "static_import",
-        "line": 22,
-        "name": null,
-        "optional": true,
-        "requested": "yaml",
-        "role": "optional_dependency",
-        "scope": "<module>",
-        "source": "wildcard_engine.py"
-      },
-      {
-        "alias": null,
-        "bound_name": "USER_DATA_DIR",
-        "branch_context": [
-          {
-            "branch": "body",
-            "handles_import_failure": true,
-            "has_import_fallback_handler": true,
-            "kind": "try",
-            "line": 26
-          }
-        ],
-        "classification": "internal",
-        "column": 4,
-        "compatibility_pair": {
-          "bound_name": "USER_DATA_DIR",
-          "target": "easyuse_anima/infrastructure/filesystem/paths.py",
-          "try_line": 26
-        },
-        "conditional": true,
-        "imported": ".easyuse_anima.infrastructure.filesystem.paths:USER_DATA_DIR",
-        "kind": "static_from",
-        "line": 27,
-        "name": "USER_DATA_DIR",
-        "optional": false,
-        "requested": ".easyuse_anima.infrastructure.filesystem.paths",
-        "role": "compatibility_primary",
-        "scope": "<module>",
-        "source": "wildcard_engine.py",
-        "target": "easyuse_anima/infrastructure/filesystem/paths.py"
-      },
-      {
-        "alias": null,
-        "bound_name": "USER_DATA_DIR",
-        "branch_context": [
-          {
-            "branch": "except",
-            "catches_import_error": true,
-            "exceptions": [
-              "ImportError"
-            ],
-            "handler_line": 28,
-            "kind": "try",
-            "line": 26
-          }
-        ],
-        "classification": "compatibility_fallback",
-        "column": 4,
-        "compatibility_pair": {
-          "bound_name": "USER_DATA_DIR",
-          "target": "easyuse_anima/infrastructure/filesystem/paths.py",
-          "try_line": 26
-        },
-        "conditional": true,
-        "imported": "easyuse_anima.infrastructure.filesystem.paths:USER_DATA_DIR",
-        "kind": "static_from",
-        "line": 29,
-        "name": "USER_DATA_DIR",
-        "optional": false,
-        "requested": "easyuse_anima.infrastructure.filesystem.paths",
-        "role": "compatibility_fallback",
-        "scope": "<module>",
-        "source": "wildcard_engine.py",
-        "target": "easyuse_anima/infrastructure/filesystem/paths.py"
-      },
-      {
-        "alias": null,
         "bound_name": "DEFAULT_MAX_EXPANSION_DEPTH",
         "branch_context": [
           {
@@ -53561,7 +53650,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 31
+            "line": 20
           }
         ],
         "classification": "internal",
@@ -53569,12 +53658,12 @@
         "compatibility_pair": {
           "bound_name": "DEFAULT_MAX_EXPANSION_DEPTH",
           "target": "easyuse_anima/wildcard/models.py",
-          "try_line": 31
+          "try_line": 20
         },
         "conditional": true,
         "imported": ".easyuse_anima.wildcard.models:DEFAULT_MAX_EXPANSION_DEPTH",
         "kind": "static_from",
-        "line": 32,
+        "line": 21,
         "name": "DEFAULT_MAX_EXPANSION_DEPTH",
         "optional": false,
         "requested": ".easyuse_anima.wildcard.models",
@@ -53592,7 +53681,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 31
+            "line": 20
           }
         ],
         "classification": "internal",
@@ -53600,12 +53689,12 @@
         "compatibility_pair": {
           "bound_name": "DEFAULT_MAX_EXPANSION_GROWTH_PER_PASS",
           "target": "easyuse_anima/wildcard/models.py",
-          "try_line": 31
+          "try_line": 20
         },
         "conditional": true,
         "imported": ".easyuse_anima.wildcard.models:DEFAULT_MAX_EXPANSION_GROWTH_PER_PASS",
         "kind": "static_from",
-        "line": 32,
+        "line": 21,
         "name": "DEFAULT_MAX_EXPANSION_GROWTH_PER_PASS",
         "optional": false,
         "requested": ".easyuse_anima.wildcard.models",
@@ -53623,7 +53712,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 31
+            "line": 20
           }
         ],
         "classification": "internal",
@@ -53631,12 +53720,12 @@
         "compatibility_pair": {
           "bound_name": "DEFAULT_MAX_EXPANSION_OUTPUT_CHARS",
           "target": "easyuse_anima/wildcard/models.py",
-          "try_line": 31
+          "try_line": 20
         },
         "conditional": true,
         "imported": ".easyuse_anima.wildcard.models:DEFAULT_MAX_EXPANSION_OUTPUT_CHARS",
         "kind": "static_from",
-        "line": 32,
+        "line": 21,
         "name": "DEFAULT_MAX_EXPANSION_OUTPUT_CHARS",
         "optional": false,
         "requested": ".easyuse_anima.wildcard.models",
@@ -53654,7 +53743,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 31
+            "line": 20
           }
         ],
         "classification": "internal",
@@ -53662,12 +53751,12 @@
         "compatibility_pair": {
           "bound_name": "DEFAULT_MAX_EXPANSION_REPLACEMENTS",
           "target": "easyuse_anima/wildcard/models.py",
-          "try_line": 31
+          "try_line": 20
         },
         "conditional": true,
         "imported": ".easyuse_anima.wildcard.models:DEFAULT_MAX_EXPANSION_REPLACEMENTS",
         "kind": "static_from",
-        "line": 32,
+        "line": 21,
         "name": "DEFAULT_MAX_EXPANSION_REPLACEMENTS",
         "optional": false,
         "requested": ".easyuse_anima.wildcard.models",
@@ -53685,7 +53774,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 31
+            "line": 20
           }
         ],
         "classification": "internal",
@@ -53693,12 +53782,12 @@
         "compatibility_pair": {
           "bound_name": "MAX_EXPANSION_DEPTH",
           "target": "easyuse_anima/wildcard/models.py",
-          "try_line": 31
+          "try_line": 20
         },
         "conditional": true,
         "imported": ".easyuse_anima.wildcard.models:MAX_EXPANSION_DEPTH",
         "kind": "static_from",
-        "line": 32,
+        "line": 21,
         "name": "MAX_EXPANSION_DEPTH",
         "optional": false,
         "requested": ".easyuse_anima.wildcard.models",
@@ -53716,7 +53805,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 31
+            "line": 20
           }
         ],
         "classification": "internal",
@@ -53724,12 +53813,12 @@
         "compatibility_pair": {
           "bound_name": "MAX_EXPANSION_GROWTH_PER_PASS",
           "target": "easyuse_anima/wildcard/models.py",
-          "try_line": 31
+          "try_line": 20
         },
         "conditional": true,
         "imported": ".easyuse_anima.wildcard.models:MAX_EXPANSION_GROWTH_PER_PASS",
         "kind": "static_from",
-        "line": 32,
+        "line": 21,
         "name": "MAX_EXPANSION_GROWTH_PER_PASS",
         "optional": false,
         "requested": ".easyuse_anima.wildcard.models",
@@ -53747,7 +53836,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 31
+            "line": 20
           }
         ],
         "classification": "internal",
@@ -53755,12 +53844,12 @@
         "compatibility_pair": {
           "bound_name": "MAX_EXPANSION_OUTPUT_CHARS",
           "target": "easyuse_anima/wildcard/models.py",
-          "try_line": 31
+          "try_line": 20
         },
         "conditional": true,
         "imported": ".easyuse_anima.wildcard.models:MAX_EXPANSION_OUTPUT_CHARS",
         "kind": "static_from",
-        "line": 32,
+        "line": 21,
         "name": "MAX_EXPANSION_OUTPUT_CHARS",
         "optional": false,
         "requested": ".easyuse_anima.wildcard.models",
@@ -53778,7 +53867,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 31
+            "line": 20
           }
         ],
         "classification": "internal",
@@ -53786,12 +53875,12 @@
         "compatibility_pair": {
           "bound_name": "MAX_EXPANSION_REPLACEMENTS",
           "target": "easyuse_anima/wildcard/models.py",
-          "try_line": 31
+          "try_line": 20
         },
         "conditional": true,
         "imported": ".easyuse_anima.wildcard.models:MAX_EXPANSION_REPLACEMENTS",
         "kind": "static_from",
-        "line": 32,
+        "line": 21,
         "name": "MAX_EXPANSION_REPLACEMENTS",
         "optional": false,
         "requested": ".easyuse_anima.wildcard.models",
@@ -53809,7 +53898,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 31
+            "line": 20
           }
         ],
         "classification": "internal",
@@ -53817,12 +53906,12 @@
         "compatibility_pair": {
           "bound_name": "REPLACE_DEPTH",
           "target": "easyuse_anima/wildcard/models.py",
-          "try_line": 31
+          "try_line": 20
         },
         "conditional": true,
         "imported": ".easyuse_anima.wildcard.models:REPLACE_DEPTH",
         "kind": "static_from",
-        "line": 32,
+        "line": 21,
         "name": "REPLACE_DEPTH",
         "optional": false,
         "requested": ".easyuse_anima.wildcard.models",
@@ -53840,7 +53929,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 31
+            "line": 20
           }
         ],
         "classification": "internal",
@@ -53848,12 +53937,12 @@
         "compatibility_pair": {
           "bound_name": "WildcardExpansionBudget",
           "target": "easyuse_anima/wildcard/models.py",
-          "try_line": 31
+          "try_line": 20
         },
         "conditional": true,
         "imported": ".easyuse_anima.wildcard.models:WildcardExpansionBudget",
         "kind": "static_from",
-        "line": 32,
+        "line": 21,
         "name": "WildcardExpansionBudget",
         "optional": false,
         "requested": ".easyuse_anima.wildcard.models",
@@ -53871,7 +53960,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 31
+            "line": 20
           }
         ],
         "classification": "internal",
@@ -53879,12 +53968,12 @@
         "compatibility_pair": {
           "bound_name": "WildcardExpansionResult",
           "target": "easyuse_anima/wildcard/models.py",
-          "try_line": 31
+          "try_line": 20
         },
         "conditional": true,
         "imported": ".easyuse_anima.wildcard.models:WildcardExpansionResult",
         "kind": "static_from",
-        "line": 32,
+        "line": 21,
         "name": "WildcardExpansionResult",
         "optional": false,
         "requested": ".easyuse_anima.wildcard.models",
@@ -53902,7 +53991,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 31
+            "line": 20
           }
         ],
         "classification": "internal",
@@ -53910,12 +53999,12 @@
         "compatibility_pair": {
           "bound_name": "WildcardOption",
           "target": "easyuse_anima/wildcard/models.py",
-          "try_line": 31
+          "try_line": 20
         },
         "conditional": true,
         "imported": ".easyuse_anima.wildcard.models:WildcardOption",
         "kind": "static_from",
-        "line": 32,
+        "line": 21,
         "name": "WildcardOption",
         "optional": false,
         "requested": ".easyuse_anima.wildcard.models",
@@ -53934,9 +54023,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 46,
+            "handler_line": 35,
             "kind": "try",
-            "line": 31
+            "line": 20
           }
         ],
         "classification": "compatibility_fallback",
@@ -53944,12 +54033,12 @@
         "compatibility_pair": {
           "bound_name": "DEFAULT_MAX_EXPANSION_DEPTH",
           "target": "easyuse_anima/wildcard/models.py",
-          "try_line": 31
+          "try_line": 20
         },
         "conditional": true,
         "imported": "easyuse_anima.wildcard.models:DEFAULT_MAX_EXPANSION_DEPTH",
         "kind": "static_from",
-        "line": 47,
+        "line": 36,
         "name": "DEFAULT_MAX_EXPANSION_DEPTH",
         "optional": false,
         "requested": "easyuse_anima.wildcard.models",
@@ -53968,9 +54057,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 46,
+            "handler_line": 35,
             "kind": "try",
-            "line": 31
+            "line": 20
           }
         ],
         "classification": "compatibility_fallback",
@@ -53978,12 +54067,12 @@
         "compatibility_pair": {
           "bound_name": "DEFAULT_MAX_EXPANSION_GROWTH_PER_PASS",
           "target": "easyuse_anima/wildcard/models.py",
-          "try_line": 31
+          "try_line": 20
         },
         "conditional": true,
         "imported": "easyuse_anima.wildcard.models:DEFAULT_MAX_EXPANSION_GROWTH_PER_PASS",
         "kind": "static_from",
-        "line": 47,
+        "line": 36,
         "name": "DEFAULT_MAX_EXPANSION_GROWTH_PER_PASS",
         "optional": false,
         "requested": "easyuse_anima.wildcard.models",
@@ -54002,9 +54091,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 46,
+            "handler_line": 35,
             "kind": "try",
-            "line": 31
+            "line": 20
           }
         ],
         "classification": "compatibility_fallback",
@@ -54012,12 +54101,12 @@
         "compatibility_pair": {
           "bound_name": "DEFAULT_MAX_EXPANSION_OUTPUT_CHARS",
           "target": "easyuse_anima/wildcard/models.py",
-          "try_line": 31
+          "try_line": 20
         },
         "conditional": true,
         "imported": "easyuse_anima.wildcard.models:DEFAULT_MAX_EXPANSION_OUTPUT_CHARS",
         "kind": "static_from",
-        "line": 47,
+        "line": 36,
         "name": "DEFAULT_MAX_EXPANSION_OUTPUT_CHARS",
         "optional": false,
         "requested": "easyuse_anima.wildcard.models",
@@ -54036,9 +54125,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 46,
+            "handler_line": 35,
             "kind": "try",
-            "line": 31
+            "line": 20
           }
         ],
         "classification": "compatibility_fallback",
@@ -54046,12 +54135,12 @@
         "compatibility_pair": {
           "bound_name": "DEFAULT_MAX_EXPANSION_REPLACEMENTS",
           "target": "easyuse_anima/wildcard/models.py",
-          "try_line": 31
+          "try_line": 20
         },
         "conditional": true,
         "imported": "easyuse_anima.wildcard.models:DEFAULT_MAX_EXPANSION_REPLACEMENTS",
         "kind": "static_from",
-        "line": 47,
+        "line": 36,
         "name": "DEFAULT_MAX_EXPANSION_REPLACEMENTS",
         "optional": false,
         "requested": "easyuse_anima.wildcard.models",
@@ -54070,9 +54159,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 46,
+            "handler_line": 35,
             "kind": "try",
-            "line": 31
+            "line": 20
           }
         ],
         "classification": "compatibility_fallback",
@@ -54080,12 +54169,12 @@
         "compatibility_pair": {
           "bound_name": "MAX_EXPANSION_DEPTH",
           "target": "easyuse_anima/wildcard/models.py",
-          "try_line": 31
+          "try_line": 20
         },
         "conditional": true,
         "imported": "easyuse_anima.wildcard.models:MAX_EXPANSION_DEPTH",
         "kind": "static_from",
-        "line": 47,
+        "line": 36,
         "name": "MAX_EXPANSION_DEPTH",
         "optional": false,
         "requested": "easyuse_anima.wildcard.models",
@@ -54104,9 +54193,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 46,
+            "handler_line": 35,
             "kind": "try",
-            "line": 31
+            "line": 20
           }
         ],
         "classification": "compatibility_fallback",
@@ -54114,12 +54203,12 @@
         "compatibility_pair": {
           "bound_name": "MAX_EXPANSION_GROWTH_PER_PASS",
           "target": "easyuse_anima/wildcard/models.py",
-          "try_line": 31
+          "try_line": 20
         },
         "conditional": true,
         "imported": "easyuse_anima.wildcard.models:MAX_EXPANSION_GROWTH_PER_PASS",
         "kind": "static_from",
-        "line": 47,
+        "line": 36,
         "name": "MAX_EXPANSION_GROWTH_PER_PASS",
         "optional": false,
         "requested": "easyuse_anima.wildcard.models",
@@ -54138,9 +54227,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 46,
+            "handler_line": 35,
             "kind": "try",
-            "line": 31
+            "line": 20
           }
         ],
         "classification": "compatibility_fallback",
@@ -54148,12 +54237,12 @@
         "compatibility_pair": {
           "bound_name": "MAX_EXPANSION_OUTPUT_CHARS",
           "target": "easyuse_anima/wildcard/models.py",
-          "try_line": 31
+          "try_line": 20
         },
         "conditional": true,
         "imported": "easyuse_anima.wildcard.models:MAX_EXPANSION_OUTPUT_CHARS",
         "kind": "static_from",
-        "line": 47,
+        "line": 36,
         "name": "MAX_EXPANSION_OUTPUT_CHARS",
         "optional": false,
         "requested": "easyuse_anima.wildcard.models",
@@ -54172,9 +54261,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 46,
+            "handler_line": 35,
             "kind": "try",
-            "line": 31
+            "line": 20
           }
         ],
         "classification": "compatibility_fallback",
@@ -54182,12 +54271,12 @@
         "compatibility_pair": {
           "bound_name": "MAX_EXPANSION_REPLACEMENTS",
           "target": "easyuse_anima/wildcard/models.py",
-          "try_line": 31
+          "try_line": 20
         },
         "conditional": true,
         "imported": "easyuse_anima.wildcard.models:MAX_EXPANSION_REPLACEMENTS",
         "kind": "static_from",
-        "line": 47,
+        "line": 36,
         "name": "MAX_EXPANSION_REPLACEMENTS",
         "optional": false,
         "requested": "easyuse_anima.wildcard.models",
@@ -54206,9 +54295,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 46,
+            "handler_line": 35,
             "kind": "try",
-            "line": 31
+            "line": 20
           }
         ],
         "classification": "compatibility_fallback",
@@ -54216,12 +54305,12 @@
         "compatibility_pair": {
           "bound_name": "REPLACE_DEPTH",
           "target": "easyuse_anima/wildcard/models.py",
-          "try_line": 31
+          "try_line": 20
         },
         "conditional": true,
         "imported": "easyuse_anima.wildcard.models:REPLACE_DEPTH",
         "kind": "static_from",
-        "line": 47,
+        "line": 36,
         "name": "REPLACE_DEPTH",
         "optional": false,
         "requested": "easyuse_anima.wildcard.models",
@@ -54240,9 +54329,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 46,
+            "handler_line": 35,
             "kind": "try",
-            "line": 31
+            "line": 20
           }
         ],
         "classification": "compatibility_fallback",
@@ -54250,12 +54339,12 @@
         "compatibility_pair": {
           "bound_name": "WildcardExpansionBudget",
           "target": "easyuse_anima/wildcard/models.py",
-          "try_line": 31
+          "try_line": 20
         },
         "conditional": true,
         "imported": "easyuse_anima.wildcard.models:WildcardExpansionBudget",
         "kind": "static_from",
-        "line": 47,
+        "line": 36,
         "name": "WildcardExpansionBudget",
         "optional": false,
         "requested": "easyuse_anima.wildcard.models",
@@ -54274,9 +54363,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 46,
+            "handler_line": 35,
             "kind": "try",
-            "line": 31
+            "line": 20
           }
         ],
         "classification": "compatibility_fallback",
@@ -54284,12 +54373,12 @@
         "compatibility_pair": {
           "bound_name": "WildcardExpansionResult",
           "target": "easyuse_anima/wildcard/models.py",
-          "try_line": 31
+          "try_line": 20
         },
         "conditional": true,
         "imported": "easyuse_anima.wildcard.models:WildcardExpansionResult",
         "kind": "static_from",
-        "line": 47,
+        "line": 36,
         "name": "WildcardExpansionResult",
         "optional": false,
         "requested": "easyuse_anima.wildcard.models",
@@ -54308,9 +54397,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 46,
+            "handler_line": 35,
             "kind": "try",
-            "line": 31
+            "line": 20
           }
         ],
         "classification": "compatibility_fallback",
@@ -54318,12 +54407,12 @@
         "compatibility_pair": {
           "bound_name": "WildcardOption",
           "target": "easyuse_anima/wildcard/models.py",
-          "try_line": 31
+          "try_line": 20
         },
         "conditional": true,
         "imported": "easyuse_anima.wildcard.models:WildcardOption",
         "kind": "static_from",
-        "line": 47,
+        "line": 36,
         "name": "WildcardOption",
         "optional": false,
         "requested": "easyuse_anima.wildcard.models",
@@ -54333,106 +54422,719 @@
         "target": "easyuse_anima/wildcard/models.py"
       },
       {
-        "alias": null,
-        "bound_name": "folder_paths",
+        "alias": "_wildcard_sources",
+        "bound_name": "_wildcard_sources",
         "branch_context": [
-          {
-            "branch": "body",
-            "handles_import_failure": true,
-            "has_import_fallback_handler": false,
-            "kind": "try",
-            "line": 482
-          }
-        ],
-        "classification": "external",
-        "column": 8,
-        "conditional": true,
-        "imported": "folder_paths",
-        "kind": "static_import",
-        "line": 483,
-        "name": null,
-        "optional": true,
-        "requested": "folder_paths",
-        "role": "optional_dependency",
-        "scope": "_comfy_base_path",
-        "source": "wildcard_engine.py"
-      },
-      {
-        "alias": null,
-        "bound_name": "get_settings",
-        "branch_context": [
-          {
-            "branch": "body",
-            "kind": "if",
-            "line": 502,
-            "type_checking": false
-          },
           {
             "branch": "body",
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 503
+            "line": 51
           }
         ],
         "classification": "internal",
-        "column": 12,
+        "column": 4,
         "compatibility_pair": {
-          "bound_name": "get_settings",
-          "target": "easyuse_anima/settings/repository.py",
-          "try_line": 503
+          "bound_name": "_wildcard_sources",
+          "target": "easyuse_anima/wildcard/sources.py",
+          "try_line": 51
         },
         "conditional": true,
-        "imported": ".easyuse_anima.settings.repository:get_settings",
+        "imported": ".easyuse_anima.wildcard:sources",
         "kind": "static_from",
-        "line": 504,
-        "name": "get_settings",
+        "line": 52,
+        "name": "sources",
         "optional": false,
-        "requested": ".easyuse_anima.settings.repository",
+        "requested": ".easyuse_anima.wildcard",
         "role": "compatibility_primary",
-        "scope": "resolve_wildcard_roots",
+        "scope": "<module>",
         "source": "wildcard_engine.py",
-        "target": "easyuse_anima/settings/repository.py"
+        "target": "easyuse_anima/wildcard/sources.py"
       },
       {
         "alias": null,
-        "bound_name": "get_settings",
+        "bound_name": "DEFAULT_TEST_WILDCARD_FILE",
         "branch_context": [
           {
             "branch": "body",
-            "kind": "if",
-            "line": 502,
-            "type_checking": false
-          },
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 51
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "DEFAULT_TEST_WILDCARD_FILE",
+          "target": "easyuse_anima/wildcard/sources.py",
+          "try_line": 51
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.wildcard.sources:DEFAULT_TEST_WILDCARD_FILE",
+        "kind": "static_from",
+        "line": 53,
+        "name": "DEFAULT_TEST_WILDCARD_FILE",
+        "optional": false,
+        "requested": ".easyuse_anima.wildcard.sources",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "wildcard_engine.py",
+        "target": "easyuse_anima/wildcard/sources.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "DEFAULT_TEST_WILDCARD_TEXT",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 51
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "DEFAULT_TEST_WILDCARD_TEXT",
+          "target": "easyuse_anima/wildcard/sources.py",
+          "try_line": 51
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.wildcard.sources:DEFAULT_TEST_WILDCARD_TEXT",
+        "kind": "static_from",
+        "line": 53,
+        "name": "DEFAULT_TEST_WILDCARD_TEXT",
+        "optional": false,
+        "requested": ".easyuse_anima.wildcard.sources",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "wildcard_engine.py",
+        "target": "easyuse_anima/wildcard/sources.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "WILDCARD_DIR_NAME",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 51
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "WILDCARD_DIR_NAME",
+          "target": "easyuse_anima/wildcard/sources.py",
+          "try_line": 51
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.wildcard.sources:WILDCARD_DIR_NAME",
+        "kind": "static_from",
+        "line": 53,
+        "name": "WILDCARD_DIR_NAME",
+        "optional": false,
+        "requested": ".easyuse_anima.wildcard.sources",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "wildcard_engine.py",
+        "target": "easyuse_anima/wildcard/sources.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "WILDCARD_EXTENSIONS",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 51
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "WILDCARD_EXTENSIONS",
+          "target": "easyuse_anima/wildcard/sources.py",
+          "try_line": 51
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.wildcard.sources:WILDCARD_EXTENSIONS",
+        "kind": "static_from",
+        "line": 53,
+        "name": "WILDCARD_EXTENSIONS",
+        "optional": false,
+        "requested": ".easyuse_anima.wildcard.sources",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "wildcard_engine.py",
+        "target": "easyuse_anima/wildcard/sources.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_WildcardSourceFile",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 51
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "_WildcardSourceFile",
+          "target": "easyuse_anima/wildcard/sources.py",
+          "try_line": 51
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.wildcard.sources:_WildcardSourceFile",
+        "kind": "static_from",
+        "line": 53,
+        "name": "_WildcardSourceFile",
+        "optional": false,
+        "requested": ".easyuse_anima.wildcard.sources",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "wildcard_engine.py",
+        "target": "easyuse_anima/wildcard/sources.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_WildcardSourceState",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 51
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "_WildcardSourceState",
+          "target": "easyuse_anima/wildcard/sources.py",
+          "try_line": 51
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.wildcard.sources:_WildcardSourceState",
+        "kind": "static_from",
+        "line": 53,
+        "name": "_WildcardSourceState",
+        "optional": false,
+        "requested": ".easyuse_anima.wildcard.sources",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "wildcard_engine.py",
+        "target": "easyuse_anima/wildcard/sources.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "default_wildcard_root",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 51
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "default_wildcard_root",
+          "target": "easyuse_anima/wildcard/sources.py",
+          "try_line": 51
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.wildcard.sources:default_wildcard_root",
+        "kind": "static_from",
+        "line": 53,
+        "name": "default_wildcard_root",
+        "optional": false,
+        "requested": ".easyuse_anima.wildcard.sources",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "wildcard_engine.py",
+        "target": "easyuse_anima/wildcard/sources.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "ensure_default_wildcard_root",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 51
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "ensure_default_wildcard_root",
+          "target": "easyuse_anima/wildcard/sources.py",
+          "try_line": 51
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.wildcard.sources:ensure_default_wildcard_root",
+        "kind": "static_from",
+        "line": 53,
+        "name": "ensure_default_wildcard_root",
+        "optional": false,
+        "requested": ".easyuse_anima.wildcard.sources",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "wildcard_engine.py",
+        "target": "easyuse_anima/wildcard/sources.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "parse_wildcard_extra_paths",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 51
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "parse_wildcard_extra_paths",
+          "target": "easyuse_anima/wildcard/sources.py",
+          "try_line": 51
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.wildcard.sources:parse_wildcard_extra_paths",
+        "kind": "static_from",
+        "line": 53,
+        "name": "parse_wildcard_extra_paths",
+        "optional": false,
+        "requested": ".easyuse_anima.wildcard.sources",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "wildcard_engine.py",
+        "target": "easyuse_anima/wildcard/sources.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "resolve_wildcard_roots",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 51
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "resolve_wildcard_roots",
+          "target": "easyuse_anima/wildcard/sources.py",
+          "try_line": 51
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.wildcard.sources:resolve_wildcard_roots",
+        "kind": "static_from",
+        "line": 53,
+        "name": "resolve_wildcard_roots",
+        "optional": false,
+        "requested": ".easyuse_anima.wildcard.sources",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "wildcard_engine.py",
+        "target": "easyuse_anima/wildcard/sources.py"
+      },
+      {
+        "alias": "_wildcard_sources",
+        "bound_name": "_wildcard_sources",
+        "branch_context": [
           {
             "branch": "except",
             "catches_import_error": true,
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 505,
+            "handler_line": 65,
             "kind": "try",
-            "line": 503
+            "line": 51
           }
         ],
         "classification": "compatibility_fallback",
-        "column": 12,
+        "column": 4,
         "compatibility_pair": {
-          "bound_name": "get_settings",
-          "target": "easyuse_anima/settings/repository.py",
-          "try_line": 503
+          "bound_name": "_wildcard_sources",
+          "target": "easyuse_anima/wildcard/sources.py",
+          "try_line": 51
         },
         "conditional": true,
-        "imported": "easyuse_anima.settings.repository:get_settings",
+        "imported": "easyuse_anima.wildcard:sources",
         "kind": "static_from",
-        "line": 506,
-        "name": "get_settings",
+        "line": 66,
+        "name": "sources",
         "optional": false,
-        "requested": "easyuse_anima.settings.repository",
+        "requested": "easyuse_anima.wildcard",
         "role": "compatibility_fallback",
-        "scope": "resolve_wildcard_roots",
+        "scope": "<module>",
         "source": "wildcard_engine.py",
-        "target": "easyuse_anima/settings/repository.py"
+        "target": "easyuse_anima/wildcard/sources.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "DEFAULT_TEST_WILDCARD_FILE",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 65,
+            "kind": "try",
+            "line": 51
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "DEFAULT_TEST_WILDCARD_FILE",
+          "target": "easyuse_anima/wildcard/sources.py",
+          "try_line": 51
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.wildcard.sources:DEFAULT_TEST_WILDCARD_FILE",
+        "kind": "static_from",
+        "line": 67,
+        "name": "DEFAULT_TEST_WILDCARD_FILE",
+        "optional": false,
+        "requested": "easyuse_anima.wildcard.sources",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "wildcard_engine.py",
+        "target": "easyuse_anima/wildcard/sources.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "DEFAULT_TEST_WILDCARD_TEXT",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 65,
+            "kind": "try",
+            "line": 51
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "DEFAULT_TEST_WILDCARD_TEXT",
+          "target": "easyuse_anima/wildcard/sources.py",
+          "try_line": 51
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.wildcard.sources:DEFAULT_TEST_WILDCARD_TEXT",
+        "kind": "static_from",
+        "line": 67,
+        "name": "DEFAULT_TEST_WILDCARD_TEXT",
+        "optional": false,
+        "requested": "easyuse_anima.wildcard.sources",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "wildcard_engine.py",
+        "target": "easyuse_anima/wildcard/sources.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "WILDCARD_DIR_NAME",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 65,
+            "kind": "try",
+            "line": 51
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "WILDCARD_DIR_NAME",
+          "target": "easyuse_anima/wildcard/sources.py",
+          "try_line": 51
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.wildcard.sources:WILDCARD_DIR_NAME",
+        "kind": "static_from",
+        "line": 67,
+        "name": "WILDCARD_DIR_NAME",
+        "optional": false,
+        "requested": "easyuse_anima.wildcard.sources",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "wildcard_engine.py",
+        "target": "easyuse_anima/wildcard/sources.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "WILDCARD_EXTENSIONS",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 65,
+            "kind": "try",
+            "line": 51
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "WILDCARD_EXTENSIONS",
+          "target": "easyuse_anima/wildcard/sources.py",
+          "try_line": 51
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.wildcard.sources:WILDCARD_EXTENSIONS",
+        "kind": "static_from",
+        "line": 67,
+        "name": "WILDCARD_EXTENSIONS",
+        "optional": false,
+        "requested": "easyuse_anima.wildcard.sources",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "wildcard_engine.py",
+        "target": "easyuse_anima/wildcard/sources.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_WildcardSourceFile",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 65,
+            "kind": "try",
+            "line": 51
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "_WildcardSourceFile",
+          "target": "easyuse_anima/wildcard/sources.py",
+          "try_line": 51
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.wildcard.sources:_WildcardSourceFile",
+        "kind": "static_from",
+        "line": 67,
+        "name": "_WildcardSourceFile",
+        "optional": false,
+        "requested": "easyuse_anima.wildcard.sources",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "wildcard_engine.py",
+        "target": "easyuse_anima/wildcard/sources.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_WildcardSourceState",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 65,
+            "kind": "try",
+            "line": 51
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "_WildcardSourceState",
+          "target": "easyuse_anima/wildcard/sources.py",
+          "try_line": 51
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.wildcard.sources:_WildcardSourceState",
+        "kind": "static_from",
+        "line": 67,
+        "name": "_WildcardSourceState",
+        "optional": false,
+        "requested": "easyuse_anima.wildcard.sources",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "wildcard_engine.py",
+        "target": "easyuse_anima/wildcard/sources.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "default_wildcard_root",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 65,
+            "kind": "try",
+            "line": 51
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "default_wildcard_root",
+          "target": "easyuse_anima/wildcard/sources.py",
+          "try_line": 51
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.wildcard.sources:default_wildcard_root",
+        "kind": "static_from",
+        "line": 67,
+        "name": "default_wildcard_root",
+        "optional": false,
+        "requested": "easyuse_anima.wildcard.sources",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "wildcard_engine.py",
+        "target": "easyuse_anima/wildcard/sources.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "ensure_default_wildcard_root",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 65,
+            "kind": "try",
+            "line": 51
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "ensure_default_wildcard_root",
+          "target": "easyuse_anima/wildcard/sources.py",
+          "try_line": 51
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.wildcard.sources:ensure_default_wildcard_root",
+        "kind": "static_from",
+        "line": 67,
+        "name": "ensure_default_wildcard_root",
+        "optional": false,
+        "requested": "easyuse_anima.wildcard.sources",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "wildcard_engine.py",
+        "target": "easyuse_anima/wildcard/sources.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "parse_wildcard_extra_paths",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 65,
+            "kind": "try",
+            "line": 51
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "parse_wildcard_extra_paths",
+          "target": "easyuse_anima/wildcard/sources.py",
+          "try_line": 51
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.wildcard.sources:parse_wildcard_extra_paths",
+        "kind": "static_from",
+        "line": 67,
+        "name": "parse_wildcard_extra_paths",
+        "optional": false,
+        "requested": "easyuse_anima.wildcard.sources",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "wildcard_engine.py",
+        "target": "easyuse_anima/wildcard/sources.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "resolve_wildcard_roots",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 65,
+            "kind": "try",
+            "line": 51
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "resolve_wildcard_roots",
+          "target": "easyuse_anima/wildcard/sources.py",
+          "try_line": 51
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.wildcard.sources:resolve_wildcard_roots",
+        "kind": "static_from",
+        "line": 67,
+        "name": "resolve_wildcard_roots",
+        "optional": false,
+        "requested": "easyuse_anima.wildcard.sources",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "wildcard_engine.py",
+        "target": "easyuse_anima/wildcard/sources.py"
       }
     ],
     "module_graph": [
@@ -54450,7 +55152,7 @@
       },
       {
         "from": "__init__.py",
-        "to": "wildcard_engine.py"
+        "to": "easyuse_anima/wildcard/sources.py"
       },
       {
         "from": "anima_prompt/__init__.py",
@@ -54559,6 +55261,10 @@
       {
         "from": "api.py",
         "to": "easyuse_anima/translation/service.py"
+      },
+      {
+        "from": "api.py",
+        "to": "easyuse_anima/wildcard/sources.py"
       },
       {
         "from": "api.py",
@@ -55765,6 +56471,18 @@
         "to": "easyuse_anima/translation/providers/google.py"
       },
       {
+        "from": "easyuse_anima/wildcard/sources.py",
+        "to": "easyuse_anima/infrastructure/filesystem/paths.py"
+      },
+      {
+        "from": "easyuse_anima/wildcard/sources.py",
+        "to": "easyuse_anima/settings/repository.py"
+      },
+      {
+        "from": "easyuse_anima/wildcard/sources.py",
+        "to": "easyuse_anima/wildcard/models.py"
+      },
+      {
         "from": "easyuse_anima/workflow.py",
         "to": "easyuse_anima/common/values.py"
       },
@@ -56022,15 +56740,11 @@
       },
       {
         "from": "wildcard_engine.py",
-        "to": "easyuse_anima/infrastructure/filesystem/paths.py"
-      },
-      {
-        "from": "wildcard_engine.py",
-        "to": "easyuse_anima/settings/repository.py"
-      },
-      {
-        "from": "wildcard_engine.py",
         "to": "easyuse_anima/wildcard/models.py"
+      },
+      {
+        "from": "wildcard_engine.py",
+        "to": "easyuse_anima/wildcard/sources.py"
       }
     ],
     "module_graph_policy": {
@@ -56774,6 +57488,12 @@
       {
         "cyclic": false,
         "modules": [
+          "easyuse_anima/wildcard/sources.py"
+        ]
+      },
+      {
+        "cyclic": false,
+        "modules": [
           "easyuse_anima/workflow.py"
         ]
       },
@@ -56810,13 +57530,13 @@
     ]
   },
   "inventory": {
-    "module_count": 127,
+    "module_count": 128,
     "modules": [
       {
         "is_package": true,
         "loc": 50,
         "module": "__root__",
-        "normalized_git_blob_sha1": "923eac5d9e4cad69f2aad4fbb8b3158f4d7ced9d",
+        "normalized_git_blob_sha1": "7db671f4bf5c5f2dd9c68f6ad89fa6c814bbb398",
         "path": "__init__.py",
         "top_level": {
           "class_count": 0,
@@ -56910,9 +57630,9 @@
       },
       {
         "is_package": false,
-        "loc": 874,
+        "loc": 875,
         "module": "api",
-        "normalized_git_blob_sha1": "fde9c8fa203ba217b59c793451f0e7ce0f097ee6",
+        "normalized_git_blob_sha1": "b10837e70d997f09d4f3ad17c78f5d331e71f997",
         "path": "api.py",
         "top_level": {
           "class_count": 1,
@@ -58254,14 +58974,26 @@
       },
       {
         "is_package": false,
-        "loc": 115,
+        "loc": 118,
         "module": "easyuse_anima.wildcard.models",
-        "normalized_git_blob_sha1": "8c59f32b85b4cc411de2bba6360edabcc20f0465",
+        "normalized_git_blob_sha1": "26f6d50f4cc9894b9e981fc6501c594b2972ff44",
         "path": "easyuse_anima/wildcard/models.py",
         "top_level": {
           "class_count": 3,
           "function_count": 2,
           "global_count": 10
+        }
+      },
+      {
+        "is_package": false,
+        "loc": 307,
+        "module": "easyuse_anima.wildcard.sources",
+        "normalized_git_blob_sha1": "30c9336418c0985563b53e153b678d8be9374428",
+        "path": "easyuse_anima/wildcard/sources.py",
+        "top_level": {
+          "class_count": 2,
+          "function_count": 16,
+          "global_count": 7
         }
       },
       {
@@ -58326,14 +59058,14 @@
       },
       {
         "is_package": false,
-        "loc": 1212,
+        "loc": 968,
         "module": "wildcard_engine",
-        "normalized_git_blob_sha1": "083098efac3c6d049600876b48cc621fac2d15a8",
+        "normalized_git_blob_sha1": "a2a3278286d9b6d784dfe80623d9dee42879c18b",
         "path": "wildcard_engine.py",
         "top_level": {
-          "class_count": 10,
-          "function_count": 39,
-          "global_count": 31
+          "class_count": 8,
+          "function_count": 23,
+          "global_count": 25
         }
       }
     ]
@@ -58522,10 +59254,10 @@
       },
       {
         "declared_in_all": false,
-        "imported": ".wildcard_engine:ensure_default_wildcard_root",
+        "imported": ".easyuse_anima.wildcard.sources:ensure_default_wildcard_root",
         "line": 27,
         "name": "ensure_default_wildcard_root",
-        "source": "wildcard_engine.py"
+        "source": "easyuse_anima/wildcard/sources.py"
       }
     ],
     "root": "__init__.py"
@@ -68729,39 +69461,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 28,
+            "handler_line": 35,
             "kind": "try",
-            "line": 26
-          }
-        ],
-        "classification": "compatibility_fallback",
-        "conditional": true,
-        "imported": "easyuse_anima.infrastructure.filesystem.paths:USER_DATA_DIR",
-        "kind": "static_from",
-        "line": 29,
-        "optional": false,
-        "role": "compatibility_fallback",
-        "source": "wildcard_engine.py",
-        "target": "easyuse_anima/infrastructure/filesystem/paths.py"
-      },
-      {
-        "branch_context": [
-          {
-            "branch": "except",
-            "catches_import_error": true,
-            "exceptions": [
-              "ImportError"
-            ],
-            "handler_line": 46,
-            "kind": "try",
-            "line": 31
+            "line": 20
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.wildcard.models:DEFAULT_MAX_EXPANSION_DEPTH",
         "kind": "static_from",
-        "line": 47,
+        "line": 36,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "wildcard_engine.py",
@@ -68775,16 +69484,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 46,
+            "handler_line": 35,
             "kind": "try",
-            "line": 31
+            "line": 20
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.wildcard.models:DEFAULT_MAX_EXPANSION_GROWTH_PER_PASS",
         "kind": "static_from",
-        "line": 47,
+        "line": 36,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "wildcard_engine.py",
@@ -68798,16 +69507,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 46,
+            "handler_line": 35,
             "kind": "try",
-            "line": 31
+            "line": 20
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.wildcard.models:DEFAULT_MAX_EXPANSION_OUTPUT_CHARS",
         "kind": "static_from",
-        "line": 47,
+        "line": 36,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "wildcard_engine.py",
@@ -68821,16 +69530,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 46,
+            "handler_line": 35,
             "kind": "try",
-            "line": 31
+            "line": 20
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.wildcard.models:DEFAULT_MAX_EXPANSION_REPLACEMENTS",
         "kind": "static_from",
-        "line": 47,
+        "line": 36,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "wildcard_engine.py",
@@ -68844,16 +69553,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 46,
+            "handler_line": 35,
             "kind": "try",
-            "line": 31
+            "line": 20
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.wildcard.models:MAX_EXPANSION_DEPTH",
         "kind": "static_from",
-        "line": 47,
+        "line": 36,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "wildcard_engine.py",
@@ -68867,16 +69576,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 46,
+            "handler_line": 35,
             "kind": "try",
-            "line": 31
+            "line": 20
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.wildcard.models:MAX_EXPANSION_GROWTH_PER_PASS",
         "kind": "static_from",
-        "line": 47,
+        "line": 36,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "wildcard_engine.py",
@@ -68890,16 +69599,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 46,
+            "handler_line": 35,
             "kind": "try",
-            "line": 31
+            "line": 20
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.wildcard.models:MAX_EXPANSION_OUTPUT_CHARS",
         "kind": "static_from",
-        "line": 47,
+        "line": 36,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "wildcard_engine.py",
@@ -68913,16 +69622,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 46,
+            "handler_line": 35,
             "kind": "try",
-            "line": 31
+            "line": 20
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.wildcard.models:MAX_EXPANSION_REPLACEMENTS",
         "kind": "static_from",
-        "line": 47,
+        "line": 36,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "wildcard_engine.py",
@@ -68936,16 +69645,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 46,
+            "handler_line": 35,
             "kind": "try",
-            "line": 31
+            "line": 20
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.wildcard.models:REPLACE_DEPTH",
         "kind": "static_from",
-        "line": 47,
+        "line": 36,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "wildcard_engine.py",
@@ -68959,16 +69668,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 46,
+            "handler_line": 35,
             "kind": "try",
-            "line": 31
+            "line": 20
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.wildcard.models:WildcardExpansionBudget",
         "kind": "static_from",
-        "line": 47,
+        "line": 36,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "wildcard_engine.py",
@@ -68982,16 +69691,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 46,
+            "handler_line": 35,
             "kind": "try",
-            "line": 31
+            "line": 20
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.wildcard.models:WildcardExpansionResult",
         "kind": "static_from",
-        "line": 47,
+        "line": 36,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "wildcard_engine.py",
@@ -69005,16 +69714,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 46,
+            "handler_line": 35,
             "kind": "try",
-            "line": 31
+            "line": 20
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.wildcard.models:WildcardOption",
         "kind": "static_from",
-        "line": 47,
+        "line": 36,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "wildcard_engine.py",
@@ -69023,31 +69732,255 @@
       {
         "branch_context": [
           {
-            "branch": "body",
-            "kind": "if",
-            "line": 502,
-            "type_checking": false
-          },
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 65,
+            "kind": "try",
+            "line": 51
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.wildcard:sources",
+        "kind": "static_from",
+        "line": 66,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "wildcard_engine.py",
+        "target": "easyuse_anima/wildcard/sources.py"
+      },
+      {
+        "branch_context": [
           {
             "branch": "except",
             "catches_import_error": true,
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 505,
+            "handler_line": 65,
             "kind": "try",
-            "line": 503
+            "line": 51
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
-        "imported": "easyuse_anima.settings.repository:get_settings",
+        "imported": "easyuse_anima.wildcard.sources:DEFAULT_TEST_WILDCARD_FILE",
         "kind": "static_from",
-        "line": 506,
+        "line": 67,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "wildcard_engine.py",
-        "target": "easyuse_anima/settings/repository.py"
+        "target": "easyuse_anima/wildcard/sources.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 65,
+            "kind": "try",
+            "line": 51
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.wildcard.sources:DEFAULT_TEST_WILDCARD_TEXT",
+        "kind": "static_from",
+        "line": 67,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "wildcard_engine.py",
+        "target": "easyuse_anima/wildcard/sources.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 65,
+            "kind": "try",
+            "line": 51
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.wildcard.sources:WILDCARD_DIR_NAME",
+        "kind": "static_from",
+        "line": 67,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "wildcard_engine.py",
+        "target": "easyuse_anima/wildcard/sources.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 65,
+            "kind": "try",
+            "line": 51
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.wildcard.sources:WILDCARD_EXTENSIONS",
+        "kind": "static_from",
+        "line": 67,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "wildcard_engine.py",
+        "target": "easyuse_anima/wildcard/sources.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 65,
+            "kind": "try",
+            "line": 51
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.wildcard.sources:_WildcardSourceFile",
+        "kind": "static_from",
+        "line": 67,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "wildcard_engine.py",
+        "target": "easyuse_anima/wildcard/sources.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 65,
+            "kind": "try",
+            "line": 51
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.wildcard.sources:_WildcardSourceState",
+        "kind": "static_from",
+        "line": 67,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "wildcard_engine.py",
+        "target": "easyuse_anima/wildcard/sources.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 65,
+            "kind": "try",
+            "line": 51
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.wildcard.sources:default_wildcard_root",
+        "kind": "static_from",
+        "line": 67,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "wildcard_engine.py",
+        "target": "easyuse_anima/wildcard/sources.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 65,
+            "kind": "try",
+            "line": 51
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.wildcard.sources:ensure_default_wildcard_root",
+        "kind": "static_from",
+        "line": 67,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "wildcard_engine.py",
+        "target": "easyuse_anima/wildcard/sources.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 65,
+            "kind": "try",
+            "line": 51
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.wildcard.sources:parse_wildcard_extra_paths",
+        "kind": "static_from",
+        "line": 67,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "wildcard_engine.py",
+        "target": "easyuse_anima/wildcard/sources.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 65,
+            "kind": "try",
+            "line": 51
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.wildcard.sources:resolve_wildcard_roots",
+        "kind": "static_from",
+        "line": 67,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "wildcard_engine.py",
+        "target": "easyuse_anima/wildcard/sources.py"
       }
     ],
     "entry_modules": [
@@ -69420,14 +70353,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 323
+            "line": 324
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 324,
+        "line": 325,
         "optional": true,
         "role": "optional_dependency",
         "source": "api.py"
@@ -74474,6 +75407,99 @@
         "line": 3,
         "optional": false,
         "role": "ordinary",
+        "source": "easyuse_anima/wildcard/sources.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "os",
+        "kind": "static_import",
+        "line": 5,
+        "optional": false,
+        "role": "ordinary",
+        "source": "easyuse_anima/wildcard/sources.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "re",
+        "kind": "static_import",
+        "line": 6,
+        "optional": false,
+        "role": "ordinary",
+        "source": "easyuse_anima/wildcard/sources.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "dataclasses:dataclass",
+        "kind": "static_from",
+        "line": 7,
+        "optional": false,
+        "role": "ordinary",
+        "source": "easyuse_anima/wildcard/sources.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "pathlib:Path",
+        "kind": "static_from",
+        "line": 8,
+        "optional": false,
+        "role": "ordinary",
+        "source": "easyuse_anima/wildcard/sources.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": false,
+            "kind": "try",
+            "line": 10
+          }
+        ],
+        "classification": "external",
+        "conditional": true,
+        "imported": "yaml",
+        "kind": "static_import",
+        "line": 11,
+        "optional": true,
+        "role": "optional_dependency",
+        "source": "easyuse_anima/wildcard/sources.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": false,
+            "kind": "try",
+            "line": 95
+          }
+        ],
+        "classification": "external",
+        "conditional": true,
+        "imported": "folder_paths",
+        "kind": "static_import",
+        "line": 96,
+        "optional": true,
+        "role": "optional_dependency",
+        "source": "easyuse_anima/wildcard/sources.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "__future__:annotations",
+        "kind": "static_from",
+        "line": 3,
+        "optional": false,
+        "role": "ordinary",
         "source": "easyuse_anima/workflow.py"
       },
       {
@@ -74590,7 +75616,7 @@
         "branch_context": [],
         "classification": "external",
         "conditional": false,
-        "imported": "os",
+        "imported": "random",
         "kind": "static_import",
         "line": 8,
         "optional": false,
@@ -74601,7 +75627,7 @@
         "branch_context": [],
         "classification": "external",
         "conditional": false,
-        "imported": "random",
+        "imported": "re",
         "kind": "static_import",
         "line": 9,
         "optional": false,
@@ -74612,7 +75638,7 @@
         "branch_context": [],
         "classification": "external",
         "conditional": false,
-        "imported": "re",
+        "imported": "threading",
         "kind": "static_import",
         "line": 10,
         "optional": false,
@@ -74623,20 +75649,9 @@
         "branch_context": [],
         "classification": "external",
         "conditional": false,
-        "imported": "threading",
-        "kind": "static_import",
-        "line": 11,
-        "optional": false,
-        "role": "ordinary",
-        "source": "wildcard_engine.py"
-      },
-      {
-        "branch_context": [],
-        "classification": "external",
-        "conditional": false,
         "imported": "dataclasses:dataclass",
         "kind": "static_from",
-        "line": 12,
+        "line": 11,
         "optional": false,
         "role": "ordinary",
         "source": "wildcard_engine.py"
@@ -74647,7 +75662,7 @@
         "conditional": false,
         "imported": "pathlib:Path",
         "kind": "static_from",
-        "line": 13,
+        "line": 12,
         "optional": false,
         "role": "ordinary",
         "source": "wildcard_engine.py"
@@ -74658,7 +75673,7 @@
         "conditional": false,
         "imported": "types:MappingProxyType",
         "kind": "static_from",
-        "line": 14,
+        "line": 13,
         "optional": false,
         "role": "ordinary",
         "source": "wildcard_engine.py"
@@ -74669,7 +75684,7 @@
         "conditional": false,
         "imported": "typing:Iterable",
         "kind": "static_from",
-        "line": 15,
+        "line": 14,
         "optional": false,
         "role": "ordinary",
         "source": "wildcard_engine.py"
@@ -74680,7 +75695,7 @@
         "conditional": false,
         "imported": "typing:Mapping",
         "kind": "static_from",
-        "line": 15,
+        "line": 14,
         "optional": false,
         "role": "ordinary",
         "source": "wildcard_engine.py"
@@ -74691,7 +75706,7 @@
         "conditional": false,
         "imported": "typing:Sequence",
         "kind": "static_from",
-        "line": 15,
+        "line": 14,
         "optional": false,
         "role": "ordinary",
         "source": "wildcard_engine.py"
@@ -74702,47 +75717,9 @@
         "conditional": false,
         "imported": "numpy",
         "kind": "static_import",
-        "line": 19,
+        "line": 18,
         "optional": false,
         "role": "ordinary",
-        "source": "wildcard_engine.py"
-      },
-      {
-        "branch_context": [
-          {
-            "branch": "body",
-            "handles_import_failure": true,
-            "has_import_fallback_handler": false,
-            "kind": "try",
-            "line": 21
-          }
-        ],
-        "classification": "external",
-        "conditional": true,
-        "imported": "yaml",
-        "kind": "static_import",
-        "line": 22,
-        "optional": true,
-        "role": "optional_dependency",
-        "source": "wildcard_engine.py"
-      },
-      {
-        "branch_context": [
-          {
-            "branch": "body",
-            "handles_import_failure": true,
-            "has_import_fallback_handler": false,
-            "kind": "try",
-            "line": 482
-          }
-        ],
-        "classification": "external",
-        "conditional": true,
-        "imported": "folder_paths",
-        "kind": "static_import",
-        "line": 483,
-        "optional": true,
-        "role": "optional_dependency",
         "source": "wildcard_engine.py"
       }
     ],
@@ -74814,14 +75791,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 323
+            "line": 324
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 324,
+        "line": 325,
         "optional": true,
         "role": "optional_dependency",
         "source": "api.py"
@@ -75675,17 +76652,17 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 21
+            "line": 10
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "yaml",
         "kind": "static_import",
-        "line": 22,
+        "line": 11,
         "optional": true,
         "role": "optional_dependency",
-        "source": "wildcard_engine.py"
+        "source": "easyuse_anima/wildcard/sources.py"
       },
       {
         "branch_context": [
@@ -75694,17 +76671,17 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 482
+            "line": 95
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 483,
+        "line": 96,
         "optional": true,
         "role": "optional_dependency",
-        "source": "wildcard_engine.py"
+        "source": "easyuse_anima/wildcard/sources.py"
       }
     ],
     "package_root": ".",
@@ -75830,6 +76807,7 @@
       "easyuse_anima/translation/service.py",
       "easyuse_anima/wildcard/__init__.py",
       "easyuse_anima/wildcard/models.py",
+      "easyuse_anima/wildcard/sources.py",
       "easyuse_anima/workflow.py",
       "nodes.py",
       "prompt_translation.py",
@@ -75959,6 +76937,7 @@
       "easyuse_anima/translation/service.py",
       "easyuse_anima/wildcard/__init__.py",
       "easyuse_anima/wildcard/models.py",
+      "easyuse_anima/wildcard/sources.py",
       "easyuse_anima/workflow.py",
       "nodes.py",
       "prompt_translation.py",
@@ -76147,7 +77126,7 @@
         "column": 10,
         "context": "assign:_LOGGER",
         "kind": "import_time_call",
-        "line": 147,
+        "line": 148,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -76156,7 +77135,7 @@
         "column": 25,
         "context": "assign:_FILE_IO_LIMITERS_LOCK",
         "kind": "import_time_call",
-        "line": 150,
+        "line": 151,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -76165,7 +77144,7 @@
         "column": 47,
         "context": "assign:_FILE_IO_LIMITERS",
         "kind": "import_time_call",
-        "line": 151,
+        "line": 152,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -76174,7 +77153,7 @@
         "column": 29,
         "context": "assign:_PROMPT_TRANSLATION_WORKER",
         "kind": "import_time_call",
-        "line": 200,
+        "line": 201,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -76183,7 +77162,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 201,
+        "line": 202,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -76192,7 +77171,7 @@
         "column": 36,
         "context": "assign:_SAFE_PROFILE_VALIDATION_MESSAGES",
         "kind": "import_time_call",
-        "line": 350,
+        "line": 351,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -76201,7 +77180,7 @@
         "column": 9,
         "context": "assign:routes",
         "kind": "route_registry_creation",
-        "line": 507,
+        "line": 508,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -76210,7 +77189,7 @@
         "column": 19,
         "context": "assign:_ROUTE_SIGNATURE",
         "kind": "route_registry_creation",
-        "line": 850,
+        "line": 851,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -76219,7 +77198,7 @@
         "column": 5,
         "context": "assign:_ROUTE_SIGNATURE",
         "kind": "route_registry_creation",
-        "line": 851,
+        "line": 852,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -77524,7 +78503,7 @@
         "column": 1,
         "context": "decorator:WildcardOption",
         "kind": "import_time_call",
-        "line": 34,
+        "line": 37,
         "module": "easyuse_anima/wildcard/models.py",
         "scope": "<module>"
       },
@@ -77533,7 +78512,7 @@
         "column": 1,
         "context": "decorator:WildcardExpansionBudget",
         "kind": "import_time_call",
-        "line": 58,
+        "line": 61,
         "module": "easyuse_anima/wildcard/models.py",
         "scope": "<module>"
       },
@@ -77542,8 +78521,35 @@
         "column": 1,
         "context": "decorator:WildcardExpansionResult",
         "kind": "import_time_call",
-        "line": 108,
+        "line": 111,
         "module": "easyuse_anima/wildcard/models.py",
+        "scope": "<module>"
+      },
+      {
+        "callee": "re.compile",
+        "column": 19,
+        "context": "assign:WEIGHT_PREFIX_RE",
+        "kind": "import_time_call",
+        "line": 36,
+        "module": "easyuse_anima/wildcard/sources.py",
+        "scope": "<module>"
+      },
+      {
+        "callee": "dataclass",
+        "column": 1,
+        "context": "decorator:_WildcardSourceFile",
+        "kind": "import_time_call",
+        "line": 42,
+        "module": "easyuse_anima/wildcard/sources.py",
+        "scope": "<module>"
+      },
+      {
+        "callee": "dataclass",
+        "column": 1,
+        "context": "decorator:_WildcardSourceState",
+        "kind": "import_time_call",
+        "line": 56,
+        "module": "easyuse_anima/wildcard/sources.py",
         "scope": "<module>"
       },
       {
@@ -77551,7 +78557,7 @@
         "column": 13,
         "context": "assign:COMMENT_RE",
         "kind": "import_time_call",
-        "line": 112,
+        "line": 125,
         "module": "wildcard_engine.py",
         "scope": "<module>"
       },
@@ -77560,7 +78566,7 @@
         "column": 13,
         "context": "assign:DYNAMIC_RE",
         "kind": "import_time_call",
-        "line": 113,
+        "line": 126,
         "module": "wildcard_engine.py",
         "scope": "<module>"
       },
@@ -77569,7 +78575,7 @@
         "column": 14,
         "context": "assign:WILDCARD_RE",
         "kind": "import_time_call",
-        "line": 114,
+        "line": 127,
         "module": "wildcard_engine.py",
         "scope": "<module>"
       },
@@ -77578,7 +78584,7 @@
         "column": 19,
         "context": "assign:WILDCARD_FULL_RE",
         "kind": "import_time_call",
-        "line": 115,
+        "line": 128,
         "module": "wildcard_engine.py",
         "scope": "<module>"
       },
@@ -77587,16 +78593,7 @@
         "column": 25,
         "context": "assign:WILDCARD_QUANTIFIER_RE",
         "kind": "import_time_call",
-        "line": 116,
-        "module": "wildcard_engine.py",
-        "scope": "<module>"
-      },
-      {
-        "callee": "re.compile",
-        "column": 19,
-        "context": "assign:WEIGHT_PREFIX_RE",
-        "kind": "import_time_call",
-        "line": 120,
+        "line": 129,
         "module": "wildcard_engine.py",
         "scope": "<module>"
       },
@@ -77605,25 +78602,7 @@
         "column": 16,
         "context": "assign:COUNT_SPEC_RE",
         "kind": "import_time_call",
-        "line": 121,
-        "module": "wildcard_engine.py",
-        "scope": "<module>"
-      },
-      {
-        "callee": "dataclass",
-        "column": 1,
-        "context": "decorator:_WildcardSourceFile",
-        "kind": "import_time_call",
-        "line": 126,
-        "module": "wildcard_engine.py",
-        "scope": "<module>"
-      },
-      {
-        "callee": "dataclass",
-        "column": 1,
-        "context": "decorator:_WildcardSourceState",
-        "kind": "import_time_call",
-        "line": 140,
+        "line": 133,
         "module": "wildcard_engine.py",
         "scope": "<module>"
       },
@@ -77632,7 +78611,7 @@
         "column": 1,
         "context": "decorator:_WildcardSnapshot",
         "kind": "import_time_call",
-        "line": 155,
+        "line": 138,
         "module": "wildcard_engine.py",
         "scope": "<module>"
       },
@@ -77641,7 +78620,7 @@
         "column": 22,
         "context": "assign:_SNAPSHOT_CONDITION",
         "kind": "import_time_call",
-        "line": 180,
+        "line": 163,
         "module": "wildcard_engine.py",
         "scope": "<module>"
       },
@@ -77650,7 +78629,7 @@
         "column": 57,
         "context": "assign:_SNAPSHOT_CACHE",
         "kind": "import_time_call",
-        "line": 181,
+        "line": 164,
         "module": "wildcard_engine.py",
         "scope": "<module>"
       },
@@ -77659,7 +78638,7 @@
         "column": 33,
         "context": "assign:_SNAPSHOT_BUILDING",
         "kind": "import_time_call",
-        "line": 182,
+        "line": 165,
         "module": "wildcard_engine.py",
         "scope": "<module>"
       },
@@ -77668,7 +78647,7 @@
         "column": 1,
         "context": "decorator:_ExpansionSegment",
         "kind": "import_time_call",
-        "line": 200,
+        "line": 183,
         "module": "wildcard_engine.py",
         "scope": "<module>"
       },
@@ -77677,7 +78656,7 @@
         "column": 1,
         "context": "decorator:_Replacement",
         "kind": "import_time_call",
-        "line": 273,
+        "line": 256,
         "module": "wildcard_engine.py",
         "scope": "<module>"
       }
@@ -78046,32 +79025,32 @@
         "name": "_TRANSLATION_PROVIDER_INSTANCES"
       },
       {
+        "kind": "set",
+        "line": 23,
+        "module": "easyuse_anima/wildcard/sources.py",
+        "name": "WILDCARD_EXTENSIONS"
+      },
+      {
         "kind": "list",
         "line": 1129,
         "module": "nodes.py",
         "name": "__all__"
       },
       {
-        "kind": "set",
-        "line": 110,
-        "module": "wildcard_engine.py",
-        "name": "WILDCARD_EXTENSIONS"
-      },
-      {
         "kind": "dict",
-        "line": 83,
+        "line": 98,
         "module": "wildcard_engine.py",
         "name": "WILDCARD_MODE_ALIASES"
       },
       {
         "kind": "set",
-        "line": 182,
+        "line": 165,
         "module": "wildcard_engine.py",
         "name": "_SNAPSHOT_BUILDING"
       },
       {
         "kind": "dict",
-        "line": 181,
+        "line": 164,
         "module": "wildcard_engine.py",
         "name": "_SNAPSHOT_CACHE"
       }
@@ -78082,7 +79061,7 @@
           "lock"
         ],
         "initializer": "threading.Lock",
-        "line": 150,
+        "line": 151,
         "module": "api.py",
         "name": "_FILE_IO_LIMITERS_LOCK"
       },
@@ -78091,7 +79070,7 @@
           "executor"
         ],
         "initializer": "_PromptTranslationWorker",
-        "line": 200,
+        "line": 201,
         "module": "api.py",
         "name": "_PROMPT_TRANSLATION_WORKER"
       },
@@ -78236,7 +79215,7 @@
           "single_flight"
         ],
         "initializer": "set",
-        "line": 182,
+        "line": 165,
         "module": "wildcard_engine.py",
         "name": "_SNAPSHOT_BUILDING"
       },
@@ -78246,7 +79225,7 @@
           "mutable_container"
         ],
         "initializer": "OrderedDict",
-        "line": 181,
+        "line": 164,
         "module": "wildcard_engine.py",
         "name": "_SNAPSHOT_CACHE"
       }

--- a/tests/test_node_contracts.py
+++ b/tests/test_node_contracts.py
@@ -327,10 +327,16 @@ def _loaded_package_entrypoint():
         sys.modules[nodes_spec.name] = package_nodes
         nodes_spec.loader.exec_module(package_nodes)
 
-        wildcard_module = sys.modules.get(f"{package_name}.wildcard_engine")
-        if wildcard_module is None:
-            raise AssertionError("Package nodes did not load wildcard_engine")
-        with patch.object(wildcard_module, "ensure_default_wildcard_root", return_value=None):
+        wildcard_sources_module = sys.modules.get(
+            f"{package_name}.easyuse_anima.wildcard.sources"
+        )
+        if wildcard_sources_module is None:
+            raise AssertionError("Package nodes did not load canonical wildcard sources")
+        with patch.object(
+            wildcard_sources_module,
+            "ensure_default_wildcard_root",
+            return_value=None,
+        ):
             package_spec.loader.exec_module(package_module)
             yield package_module, package_nodes
     finally:

--- a/tests/test_python_backend_analyzer.py
+++ b/tests/test_python_backend_analyzer.py
@@ -691,9 +691,9 @@ ignored/
 
         self.assertEqual(analyzer.render_json(report), expected_text)
         self.assertEqual(report["schema_version"], 2)
-        self.assertEqual(report["inventory"]["module_count"], 127)
-        self.assertEqual(len(report["registry"]["shipped_python_modules"]), 127)
-        self.assertEqual(len(report["registry"]["runtime_import_closure"]), 127)
+        self.assertEqual(report["inventory"]["module_count"], 128)
+        self.assertEqual(len(report["registry"]["shipped_python_modules"]), 128)
+        self.assertEqual(len(report["registry"]["runtime_import_closure"]), 128)
         self.assertEqual(
             report["registry"]["entry_modules"],
             [
@@ -953,9 +953,24 @@ ignored/
             },
             report["imports"]["module_graph"],
         )
+        self.assertIn(
+            {
+                "from": "wildcard_engine.py",
+                "to": "easyuse_anima/wildcard/sources.py",
+            },
+            report["imports"]["module_graph"],
+        )
+        self.assertIn(
+            {
+                "from": "api.py",
+                "to": "easyuse_anima/wildcard/sources.py",
+            },
+            report["imports"]["module_graph"],
+        )
         for module in (
             "easyuse_anima/wildcard/__init__.py",
             "easyuse_anima/wildcard/models.py",
+            "easyuse_anima/wildcard/sources.py",
         ):
             with self.subTest(module=module):
                 self.assertIn(

--- a/tests/test_python_package_skeleton.py
+++ b/tests/test_python_package_skeleton.py
@@ -88,6 +88,7 @@ PACKAGE_MODULES = (
     "easyuse_anima.translation.service",
     "easyuse_anima.wildcard",
     "easyuse_anima.wildcard.models",
+    "easyuse_anima.wildcard.sources",
     "easyuse_anima.seed.execution_identity",
     "easyuse_anima.seed.execution_session",
     "easyuse_anima.seed.service",
@@ -380,6 +381,18 @@ print(json.dumps({{
             "WildcardOption",
             "WildcardExpansionBudget",
             "WildcardExpansionResult",
+        ]
+        expected_all[
+            PACKAGE_MODULES.index("easyuse_anima.wildcard.sources")
+        ] = [
+            "WILDCARD_DIR_NAME",
+            "DEFAULT_TEST_WILDCARD_FILE",
+            "DEFAULT_TEST_WILDCARD_TEXT",
+            "WILDCARD_EXTENSIONS",
+            "default_wildcard_root",
+            "ensure_default_wildcard_root",
+            "parse_wildcard_extra_paths",
+            "resolve_wildcard_roots",
         ]
         self.assertEqual(payload["declared_all"], expected_all)
         self.assertEqual(payload["new_forbidden"], [])

--- a/tests/test_registry_scanner_safety.py
+++ b/tests/test_registry_scanner_safety.py
@@ -83,6 +83,7 @@ EXPECTED_PYTHON_PACKAGE_FILES = {
     "easyuse_anima/settings/service.py",
     "easyuse_anima/wildcard/__init__.py",
     "easyuse_anima/wildcard/models.py",
+    "easyuse_anima/wildcard/sources.py",
     "easyuse_anima/registration.py",
     "easyuse_anima/prompt/__init__.py",
     "easyuse_anima/prompt/correction.py",

--- a/tests/test_wildcards.py
+++ b/tests/test_wildcards.py
@@ -13,6 +13,7 @@ from easyuse_anima.nodes import wildcard_nodes
 from easyuse_anima.prompt import advanced as prompt_advanced
 from easyuse_anima.seed import compatibility as seed_compatibility
 from easyuse_anima.wildcard import models as wildcard_models
+from easyuse_anima.wildcard import sources as wildcard_sources
 from nodes import (
     EasyUseAnimaPromptStudioAdvanced,
     EasyUseAnimaPromptStudioAdvancedV2,
@@ -33,6 +34,25 @@ from wildcard_engine import (
 
 
 class WildcardEngineTests(unittest.TestCase):
+    def test_root_source_surface_has_canonical_identity(self):
+        expected = (
+            "WILDCARD_DIR_NAME",
+            "DEFAULT_TEST_WILDCARD_FILE",
+            "DEFAULT_TEST_WILDCARD_TEXT",
+            "WILDCARD_EXTENSIONS",
+            "default_wildcard_root",
+            "ensure_default_wildcard_root",
+            "parse_wildcard_extra_paths",
+            "resolve_wildcard_roots",
+        )
+        self.assertEqual(wildcard_sources.__all__, expected)
+        for name in expected:
+            with self.subTest(name=name):
+                self.assertIs(
+                    getattr(wildcard_engine, name),
+                    getattr(wildcard_sources, name),
+                )
+
     def test_root_model_surface_has_canonical_identity(self):
         expected = (
             "MAX_EXPANSION_DEPTH",
@@ -108,7 +128,7 @@ class WildcardEngineTests(unittest.TestCase):
 
     def test_default_root_is_created_with_test_wildcard(self):
         with tempfile.TemporaryDirectory() as temp:
-            with patch.object(wildcard_engine, "USER_DATA_DIR", Path(temp)):
+            with patch.object(wildcard_sources, "USER_DATA_DIR", Path(temp)):
                 root = ensure_default_wildcard_root()
 
                 self.assertTrue(root.is_dir())
@@ -548,15 +568,15 @@ class WildcardEngineTests(unittest.TestCase):
         )
 
     def test_unchanged_list_signature_and_expand_reuse_one_yaml_parse(self):
-        self.assertIsNotNone(wildcard_engine.yaml)
+        self.assertIsNotNone(wildcard_sources.yaml)
         with tempfile.TemporaryDirectory() as temp:
             root = Path(temp)
             (root / "colors.yaml").write_text("colors: [red]\n", encoding="utf-8")
 
             with patch.object(
-                wildcard_engine.yaml,
+                wildcard_sources.yaml,
                 "safe_load",
-                wraps=wildcard_engine.yaml.safe_load,
+                wraps=wildcard_sources.yaml.safe_load,
             ) as safe_load:
                 first_list = list_wildcards(roots=[root])
                 first_signature = wildcard_engine.wildcard_sources_signature(roots=[root])
@@ -654,7 +674,7 @@ class WildcardEngineTests(unittest.TestCase):
         self.assertEqual(missing.missing_keys, ("colors",))
 
     def test_transient_loader_oserror_is_not_cached(self):
-        original_loader = wildcard_engine._load_wildcard_file
+        original_loader = wildcard_sources._load_wildcard_file
         attempts = []
 
         def flaky_loader(root, path):
@@ -666,10 +686,10 @@ class WildcardEngineTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as temp:
             root = Path(temp)
             (root / "color.txt").write_text("red\n", encoding="utf-8")
-            cache_key = wildcard_engine._scan_wildcard_sources((root,)).cache_key
+            cache_key = wildcard_sources._scan_wildcard_sources((root,)).cache_key
 
             with patch.object(
-                wildcard_engine,
+                wildcard_sources,
                 "_load_wildcard_file",
                 side_effect=flaky_loader,
             ) as loader:
@@ -684,16 +704,16 @@ class WildcardEngineTests(unittest.TestCase):
         self.assertEqual(loader.call_count, 2)
 
     def test_invalid_yaml_parse_remains_cacheable_as_empty(self):
-        self.assertIsNotNone(wildcard_engine.yaml)
+        self.assertIsNotNone(wildcard_sources.yaml)
         with tempfile.TemporaryDirectory() as temp:
             root = Path(temp)
             (root / "invalid.yaml").write_text("color: [red\n", encoding="utf-8")
-            cache_key = wildcard_engine._scan_wildcard_sources((root,)).cache_key
+            cache_key = wildcard_sources._scan_wildcard_sources((root,)).cache_key
 
             with patch.object(
-                wildcard_engine.yaml,
+                wildcard_sources.yaml,
                 "safe_load",
-                wraps=wildcard_engine.yaml.safe_load,
+                wraps=wildcard_sources.yaml.safe_load,
             ) as safe_load:
                 first = expand_wildcards("__color__", seed=0, roots=[root])
                 second = expand_wildcards("__color__", seed=0, roots=[root])
@@ -727,10 +747,10 @@ class WildcardEngineTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as temp:
             root = Path(temp)
             (root / "library.yaml").write_text("color: [red]\n", encoding="utf-8")
-            cache_key = wildcard_engine._scan_wildcard_sources((root,)).cache_key
+            cache_key = wildcard_sources._scan_wildcard_sources((root,)).cache_key
 
             with patch.object(
-                wildcard_engine,
+                wildcard_sources,
                 "_read_text_file",
                 side_effect=unreadable_yaml,
             ), patch.object(

--- a/wildcard_engine.py
+++ b/wildcard_engine.py
@@ -5,7 +5,6 @@ from collections import OrderedDict
 import fnmatch
 import hashlib
 import math
-import os
 import random
 import re
 import threading
@@ -17,16 +16,6 @@ from typing import Iterable, Mapping, Sequence
 # NumPy is mandatory in supported ComfyUI runtimes and defines the seeded
 # wildcard sampling contract. A stdlib fallback would produce different results.
 import numpy as np
-
-try:
-    import yaml
-except Exception:  # pragma: no cover - YAML files are skipped without PyYAML.
-    yaml = None
-
-try:
-    from .easyuse_anima.infrastructure.filesystem.paths import USER_DATA_DIR
-except ImportError:
-    from easyuse_anima.infrastructure.filesystem.paths import USER_DATA_DIR
 
 try:
     from .easyuse_anima.wildcard.models import (
@@ -59,10 +48,36 @@ except ImportError:
         WildcardOption,
     )
 
+try:
+    from .easyuse_anima.wildcard import sources as _wildcard_sources
+    from .easyuse_anima.wildcard.sources import (
+        DEFAULT_TEST_WILDCARD_FILE,
+        DEFAULT_TEST_WILDCARD_TEXT,
+        WILDCARD_DIR_NAME,
+        WILDCARD_EXTENSIONS,
+        _WildcardSourceFile,
+        _WildcardSourceState,
+        default_wildcard_root,
+        ensure_default_wildcard_root,
+        parse_wildcard_extra_paths,
+        resolve_wildcard_roots,
+    )
+except ImportError:
+    from easyuse_anima.wildcard import sources as _wildcard_sources
+    from easyuse_anima.wildcard.sources import (
+        DEFAULT_TEST_WILDCARD_FILE,
+        DEFAULT_TEST_WILDCARD_TEXT,
+        WILDCARD_DIR_NAME,
+        WILDCARD_EXTENSIONS,
+        _WildcardSourceFile,
+        _WildcardSourceState,
+        default_wildcard_root,
+        ensure_default_wildcard_root,
+        parse_wildcard_extra_paths,
+        resolve_wildcard_roots,
+    )
 
-WILDCARD_DIR_NAME = "wildcards"
-DEFAULT_TEST_WILDCARD_FILE = "easyuse_anima_test.txt"
-DEFAULT_TEST_WILDCARD_TEXT = "# EasyUse Anima test wildcard\nsimple wildcard\nanima wildcard\n"
+
 WILDCARD_MODE_POPULATE = "populate"
 WILDCARD_MODE_FIXED = "fixed"
 WILDCARD_MODE_SEQUENTIAL = "sequential"
@@ -107,8 +122,6 @@ SEED_CONTROL_MODES = (
 
 MAX_SEED = 0xFFFFFFFFFFFFFFFF
 PUBLIC_MAX_SEED = (1 << 53) - 1
-WILDCARD_EXTENSIONS = {".txt", ".yaml", ".yml"}
-
 COMMENT_RE = re.compile(r"^\s*#.*(?:\n|$)", re.MULTILINE)
 DYNAMIC_RE = re.compile(r"(?<![\\%])\{((?:[^{}]|(?<=\\)[{}])*?)(?<!\\)\}")
 WILDCARD_RE = re.compile(r"__(?P<keyword>[\w.\-+/*\\]+?)__", re.IGNORECASE)
@@ -117,39 +130,9 @@ WILDCARD_QUANTIFIER_RE = re.compile(
     r"(?P<quantifier>\d+)#__(?P<keyword>[\w.\-+/*\\]+?)__",
     re.IGNORECASE,
 )
-WEIGHT_PREFIX_RE = re.compile(r"^\s*([+-]?(?:\d+(?:\.\d*)?|\.\d+))::(.*)$", re.DOTALL)
 COUNT_SPEC_RE = re.compile(
     r"(?:(?P<fixed>\d+)|(?P<minimum>\d*)\s*-\s*(?P<maximum>\d*))"
 )
-
-
-@dataclass(frozen=True)
-class _WildcardSourceFile:
-    root_index: int
-    root: str
-    relative_path: str
-    path: Path
-    mtime_ns: int
-    size: int
-
-    @property
-    def cache_key(self) -> tuple[int, str, int, int]:
-        return (self.root_index, self.relative_path, self.mtime_ns, self.size)
-
-
-@dataclass(frozen=True)
-class _WildcardSourceState:
-    roots: tuple[Path, ...]
-    root_identities: tuple[str, ...]
-    files: tuple[_WildcardSourceFile, ...]
-
-    @property
-    def cache_key(self) -> tuple:
-        roots = tuple(
-            (identity, str(root))
-            for identity, root in zip(self.root_identities, self.roots)
-        )
-        return roots, tuple(source.cache_key for source in self.files)
 
 
 @dataclass(frozen=True)
@@ -322,7 +305,9 @@ class _ExpansionState:
             cycle_parts = (*candidate.parts, candidate.separator)
         for part in cycle_parts:
             for match in WILDCARD_RE.finditer(part):
-                key = _normalize_wildcard_key(match.group("keyword"))
+                key = _wildcard_sources._normalize_wildcard_key(
+                    match.group("keyword")
+                )
                 if key is not None and key in key_stack:
                     self.cycle_detected = True
                     return None
@@ -405,20 +390,6 @@ class _ExpansionState:
         return _ExpansionText(output)
 
 
-def default_wildcard_root() -> Path:
-    return USER_DATA_DIR / WILDCARD_DIR_NAME
-
-
-def ensure_default_wildcard_root(create_sample: bool = True) -> Path:
-    root = default_wildcard_root()
-    root.mkdir(parents=True, exist_ok=True)
-    if create_sample:
-        sample_path = root / DEFAULT_TEST_WILDCARD_FILE
-        if not sample_path.exists():
-            sample_path.write_text(DEFAULT_TEST_WILDCARD_TEXT, encoding="utf-8")
-    return root
-
-
 def normalize_wildcard_mode(mode: str) -> str:
     value = str(mode or "").strip()
     return WILDCARD_MODE_ALIASES.get(value, WILDCARD_MODE_POPULATE)
@@ -469,231 +440,13 @@ def has_wildcard_syntax(text: str) -> bool:
     return bool(DYNAMIC_RE.search(value) or WILDCARD_RE.search(value) or WILDCARD_QUANTIFIER_RE.search(value))
 
 
-def parse_wildcard_extra_paths(value: str) -> list[str]:
-    paths = []
-    for line in str(value or "").splitlines():
-        path = line.strip().strip('"')
-        if path:
-            paths.append(path)
-    return paths
-
-
-def _comfy_base_path() -> Path:
-    try:
-        import folder_paths  # type: ignore
-
-        base_path = getattr(folder_paths, "base_path", None)
-        if base_path:
-            return Path(base_path)
-    except Exception:
-        pass
-    return Path.cwd()
-
-
-def _resolve_path(value: str, base_path: Path) -> Path:
-    expanded = os.path.expandvars(os.path.expanduser(value))
-    path = Path(expanded)
-    if not path.is_absolute():
-        path = base_path / path
-    return path.resolve()
-
-
-def resolve_wildcard_roots(extra_paths: str | None = None) -> list[Path]:
-    if extra_paths is None:
-        try:
-            from .easyuse_anima.settings.repository import get_settings
-        except ImportError:
-            from easyuse_anima.settings.repository import get_settings
-
-        extra_paths = get_settings().get("wildcard.extra_paths", "")
-
-    base_path = _comfy_base_path()
-    roots: list[Path] = []
-    seen = set()
-    for raw_path in parse_wildcard_extra_paths(extra_paths or ""):
-        try:
-            root = _resolve_path(raw_path, base_path)
-        except (OSError, RuntimeError, ValueError):
-            continue
-        key = os.path.normcase(str(root))
-        if key not in seen:
-            seen.add(key)
-            roots.append(root)
-
-    try:
-        default_root = ensure_default_wildcard_root().resolve()
-    except OSError:
-        default_root = default_wildcard_root().resolve()
-    default_key = os.path.normcase(str(default_root))
-    if default_key not in seen:
-        roots.append(default_root)
-    return roots
-
-
-def _normalize_wildcard_key(value: str) -> str | None:
-    key = str(value or "").replace("\\", "/").replace(" ", "-").strip().strip("/")
-    if not key:
-        return None
-    if key.startswith("/") or re.match(r"^[a-zA-Z]:", key):
-        return None
-    parts = [part for part in key.split("/") if part]
-    if any(part == ".." for part in parts):
-        return None
-    return "/".join(parts).lower()
-
-
-def _read_text_file(path: Path) -> str:
-    try:
-        return path.read_text(encoding="utf-8")
-    except UnicodeDecodeError:
-        return path.read_text(encoding="iso-8859-1")
-
-
-def _parse_option(value) -> WildcardOption | None:
-    text = "" if value is None else str(value).strip()
-    if not text:
-        return None
-    match = WEIGHT_PREFIX_RE.match(text)
-    if not match:
-        return WildcardOption(text=text, weight=1.0)
-    try:
-        weight = float(match.group(1))
-    except ValueError:
-        return WildcardOption(text=text, weight=1.0)
-    return WildcardOption(text=match.group(2).strip(), weight=max(0.0, weight))
-
-
-def _options_from_lines(text: str) -> list[WildcardOption]:
-    options = []
-    for raw_line in text.splitlines():
-        line = raw_line.strip()
-        if not line or line.startswith("#"):
-            continue
-        option = _parse_option(line)
-        if option is not None:
-            options.append(option)
-    return options
-
-
-def _stringify_yaml_scalar(value) -> str:
-    if isinstance(value, bool):
-        return "true" if value else "false"
-    return "" if value is None else str(value)
-
-
-def _yaml_entries(data, prefix: str = "") -> dict[str, list[WildcardOption]]:
-    entries: dict[str, list[WildcardOption]] = {}
-
-    def collect(value, path_prefix: str, publish_alias: bool = True) -> list[WildcardOption]:
-        aggregate: list[WildcardOption] = []
-        if isinstance(value, dict):
-            for raw_key, child_value in value.items():
-                child_key = _normalize_wildcard_key(raw_key)
-                if child_key is None:
-                    continue
-                path_key = f"{path_prefix}/{child_key}" if path_prefix else child_key
-                aggregate.extend(collect(child_value, path_key))
-        elif isinstance(value, list):
-            for item in value:
-                if isinstance(item, (dict, list)):
-                    # The containing list owns this alias. Nested containers still
-                    # publish their distinct child paths, but not the same prefix
-                    # again through an intermediate recursion frame.
-                    aggregate.extend(collect(item, path_prefix, publish_alias=False))
-                    continue
-                option = _parse_option(_stringify_yaml_scalar(item))
-                if option is not None:
-                    aggregate.append(option)
-        else:
-            option = _parse_option(_stringify_yaml_scalar(value))
-            if option is not None:
-                aggregate.append(option)
-
-        if publish_alias and path_prefix and aggregate:
-            entries.setdefault(path_prefix, []).extend(aggregate)
-        return aggregate
-
-    collect(data, prefix)
-    return entries
-
-
-def _load_yaml_entries(path: Path) -> dict[str, list[WildcardOption]]:
-    if yaml is None:
-        return {}
-    text = _read_text_file(path)
-    try:
-        data = yaml.safe_load(text)
-    except Exception:
-        return {}
-    return _yaml_entries(data)
-
-
-def _load_wildcard_file(root: Path, path: Path) -> dict[str, list[WildcardOption]]:
-    suffix = path.suffix.lower()
-    if suffix not in WILDCARD_EXTENSIONS:
-        return {}
-    if suffix in {".yaml", ".yml"}:
-        return _load_yaml_entries(path)
-    try:
-        relative_key = path.relative_to(root).with_suffix("").as_posix()
-    except ValueError:
-        return {}
-    key = _normalize_wildcard_key(relative_key)
-    if key is None:
-        return {}
-    return {key: _options_from_lines(_read_text_file(path))}
-
-
-def _wildcard_root_identity(root: Path) -> str:
-    try:
-        return os.path.normcase(os.path.abspath(os.fspath(root)))
-    except (OSError, TypeError, ValueError):
-        return os.path.normcase(str(root))
-
-
-def _scan_wildcard_sources(roots: tuple[Path, ...]) -> _WildcardSourceState:
-    files: list[_WildcardSourceFile] = []
-    for root_index, root in enumerate(roots):
-        if not root.is_dir():
-            continue
-        try:
-            candidates = sorted(root.rglob("*"), key=lambda item: item.as_posix().lower())
-        except OSError:
-            continue
-        for path in candidates:
-            if path.suffix.lower() not in WILDCARD_EXTENSIONS:
-                continue
-            try:
-                if not path.is_file():
-                    continue
-                stat = path.stat()
-                relative = path.relative_to(root).as_posix()
-            except (OSError, ValueError):
-                continue
-            files.append(
-                _WildcardSourceFile(
-                    root_index=root_index,
-                    root=str(root),
-                    relative_path=relative,
-                    path=path,
-                    mtime_ns=stat.st_mtime_ns,
-                    size=stat.st_size,
-                )
-            )
-    return _WildcardSourceState(
-        roots=roots,
-        root_identities=tuple(_wildcard_root_identity(root) for root in roots),
-        files=tuple(files),
-    )
-
-
 def _build_wildcard_snapshot(source_state: _WildcardSourceState) -> _WildcardSnapshot:
     mapping: dict[str, list[WildcardOption]] = {}
     cacheable = True
     for source in source_state.files:
         root = source_state.roots[source.root_index]
         try:
-            entries = _load_wildcard_file(root, source.path)
+            entries = _wildcard_sources._load_wildcard_file(root, source.path)
         except OSError:
             cacheable = False
             continue
@@ -717,7 +470,7 @@ def _build_wildcard_snapshot(source_state: _WildcardSourceState) -> _WildcardSna
 def _wildcard_snapshot(roots: Iterable[Path]) -> _WildcardSnapshot:
     resolved_roots = tuple(Path(root) for root in roots)
     while True:
-        source_state = _scan_wildcard_sources(resolved_roots)
+        source_state = _wildcard_sources._scan_wildcard_sources(resolved_roots)
         cache_key = source_state.cache_key
         with _SNAPSHOT_CONDITION:
             cached = _SNAPSHOT_CACHE.get(cache_key)
@@ -733,7 +486,7 @@ def _wildcard_snapshot(roots: Iterable[Path]) -> _WildcardSnapshot:
         failure: BaseException | None = None
         try:
             candidate = _build_wildcard_snapshot(source_state)
-            verified_state = _scan_wildcard_sources(resolved_roots)
+            verified_state = _wildcard_sources._scan_wildcard_sources(resolved_roots)
             if verified_state.cache_key == cache_key:
                 snapshot = candidate
         except BaseException as exc:
@@ -852,7 +605,7 @@ class _WildcardLibrary:
             self.missing.append(key)
 
     def options_for(self, raw_key: str) -> Sequence[WildcardOption]:
-        key = _normalize_wildcard_key(raw_key)
+        key = _wildcard_sources._normalize_wildcard_key(raw_key)
         if key is None:
             return []
         options = self._options_for_normalized_key(key)
@@ -908,7 +661,7 @@ def _split_unescaped(value: str, separator: str) -> list[str]:
 def _parse_dynamic_options(value: str) -> list[WildcardOption]:
     options = []
     for option in _split_unescaped(value, "|"):
-        parsed = _parse_option(option)
+        parsed = _wildcard_sources._parse_option(option)
         if parsed is not None:
             options.append(parsed)
     return options
@@ -943,7 +696,10 @@ def _expand_multiselect_options(
     if not match:
         return options, None
     raw_key = match.group("keyword")
-    return library.options_for(raw_key), _normalize_wildcard_key(raw_key)
+    return (
+        library.options_for(raw_key),
+        _wildcard_sources._normalize_wildcard_key(raw_key),
+    )
 
 
 def _replace_dynamic(
@@ -1003,7 +759,7 @@ def _replace_quantified_wildcards(
         raw_key = match.group("keyword")
         options = library.options_for(raw_key)
         selected = selector.choose_many(options, count)
-        key = _normalize_wildcard_key(raw_key)
+        key = _wildcard_sources._normalize_wildcard_key(raw_key)
         if not selected or key is None:
             return None
         return state.candidate(
@@ -1025,7 +781,7 @@ def _replace_file_wildcards(
         raw_key = match.group("keyword")
         options = library.options_for(raw_key)
         selected = selector.choose_one(options)
-        key = _normalize_wildcard_key(raw_key)
+        key = _wildcard_sources._normalize_wildcard_key(raw_key)
         if selected is None or key is None:
             return None
         return state.candidate((selected.text,), "", key_stack + (key,))


### PR DESCRIPTION
## 작업

- Task: D-12b Wildcard sources canonical Move
- Parent: D-12 / owner #186
- Behavior prerequisites: #159, #160 complete
- Type: Move
- Base: `dev@105a3ae2c4d89bbf6ea2b7369a627e63fbd92847`
- Behavior changes: forbidden

## 변경 요약

- wildcard root discovery, extra-path resolution, TXT/YAML parsing, immutable source metadata, source scanning을 `easyuse_anima.wildcard.sources`로 이동했습니다.
- root `wildcard_engine.py`는 기존 8개 supported source name을 canonical object에 직접 바인딩합니다.
- root snapshot construction/publication/cache/condition/single-flight, listing/signature, selector/PCG64/seed, expansion은 그대로 유지합니다.
- `api.py`의 root resolution과 root `__init__.py`의 startup directory initialization만 canonical source를 직접 사용합니다.
- canonical private helper는 module-qualified call로 사용해 patch seam과 단일 소유권을 유지합니다.
- G-03 completed-package enrollment, route/node/frontend/workflow/Registry metadata 변경은 없습니다.

## 주요 파일

- `easyuse_anima/wildcard/sources.py`
- `wildcard_engine.py`
- `api.py`, `__init__.py`
- wildcard/API/bootstrap/package/Registry/analyzer tests 및 analyzer baseline
- `docs/architecture/wildcard-sources-canonical-move.md`
- roadmap 및 compatibility-shim ledger

## 검증

- wildcard behavior/identity: 73 passed
- bootstrap contracts: 82 passed
- API canonical alias: 1 passed
- package skeleton: 1 passed
- Registry scanner safety: 8 passed
- Python import boundaries: 16 passed
- backend analyzer: 18 passed
- Pyright 1.1.411, canonical `sources.py`: 0 diagnostics
- official full: Python 1,136 passed; frontend 112 files passed; G-03a 10 groups / 0 violations; existing Pyright baseline 14 errors passed
- `comfy node validate`: passed
- `comfy node pack`: 258 entries; root engine와 canonical wildcard `__init__.py`, `models.py`, `sources.py` 포함 확인
- `git diff --check`: passed

## 테스트 표면

- Repository-owned focused unittest and static contracts
- ComfyUI Codex test environment: official project full runner
- Live ComfyUI/server/browser smoke: not run (Move boundary상 불필요)

## 남은 위험 / 미확인

- source I/O 및 parsing behavior는 기존 테스트와 full suite로 고정했으며 의도된 behavior 변화는 없습니다.
- snapshot lifecycle/factory/cleanup은 D-12 후속 및 E-06 범위입니다.
- selector/seed/expansion canonicalization은 후속 D-12 slice에서 별도로 진행합니다.

상세 symbol/caller/alias/global-state inventory와 allowed-file boundary는 `docs/architecture/wildcard-sources-canonical-move.md`에 기록했습니다.