### PR TITLE
refactor: move wildcard snapshot materialization

### DIFF
--- a/docs/architecture/python-backend-execution-roadmap.md
+++ b/docs/architecture/python-backend-execution-roadmap.md
@@ -33,7 +33,7 @@ merged PR, the owning issue's evidence record, and every stated exit gate.
 | A - baseline | Complete; #191 is closed | Keep fixtures and analyzers current during later moves |
 | B - `nodes.py` extraction | Complete in B-11d / PR #356 | Preserve the audited compatibility shim until ADR-002 retirement gates are met |
 | C - feature contracts/behavior | Partially complete through S167-01a / PR #344 | Continue #167 and #169 in separate Contract/Move/Behavior PRs |
-| D - root consolidation | D-01, D-08, D-09, and D-10 complete on `dev`; D-11a/#385, D-11b/#386, D-12a/#387, and D-12b/#388 validated | Continue D-12 snapshot/expansion slices, then D-13; finish D-11 classification only after D-13 removes its root-package dependency |
+| D - root consolidation | D-01, D-08, D-09, and D-10 complete on `dev`; D-11a/#385, D-11b/#386, D-12a/#387, D-12b/#388, and D-12c/#389 validated | Continue D-12 lifecycle/expansion slices, then D-13; finish D-11 classification only after D-13 removes its root-package dependency |
 | E - runtime ownership | Partial: E-02a and E-07a/E-07b integrated | Continue #187 only where canonical feature owners and explicit contracts exist |
 | F - typed boundaries | Partial patterns exist | Extend typed request/result/config and pure migration patterns feature by feature |
 | G - quality ratchet | G-01, G-02a/G-02b, and G-03a complete | Extend G-03 enrollment, then continue with G-04 through G-06 |
@@ -408,7 +408,7 @@ mechanical retirement series.
 | 15 | S167 backend seed reservation series | S167-01 through S167-03d COMPLETE on `dev`; S167-03e AiO cutover VALIDATED with isolated API/module/browser-load parity | Contract then Move then Behavior | #167 | Canonical AiO/node seams |
 | 16 | A169 stage pipeline series | A169-01 through A169-08 MERGED; A169-09 final adapter/integration VALIDATED in PR #372 | Contract then Behavior | #169 | Typed config and mechanical AiO move |
 | 17 | A169 first-pass cache policy | COMPLETE through CACHE-06; 4K/batch evidence VALIDATED in PR #380 | Contract then Behavior | #169 | Mechanical cache move and stable stage seam |
-| 18 | D-series canonical root consolidation | D-01 translation, D-08 filesystem, D-09 settings, and D-10 profiles COMPLETE on `dev`; D-11a/#385 and D-11b/#386 autocomplete VALIDATED; D-12a/#387 wildcard models and D-12b/#388 wildcard sources VALIDATED | Move | #186 | Phase B exit; per-feature behavior stable |
+| 18 | D-series canonical root consolidation | D-01 translation, D-08 filesystem, D-09 settings, and D-10 profiles COMPLETE on `dev`; D-11a/#385 and D-11b/#386 autocomplete VALIDATED; D-12a/#387 models, D-12b/#388 sources, and D-12c/#389 snapshot materialization VALIDATED | Move | #186 | Phase B exit; per-feature behavior stable |
 | 19 | E-series RuntimeServices/lifecycle | BLOCKED by canonical owners | Move/Contract, split PRs | #187 | Relevant D moves |
 | 20 | G-04 through G-06 and H | INCREMENTAL/LATER | Gate/Contract | #188 | Appropriate package and release evidence |
 
@@ -1343,6 +1343,10 @@ and expansion implementation for later slices. D-12b moves root discovery,
 TXT/YAML parsing, immutable source metadata, and source scanning to
 `easyuse_anima.wildcard.sources`; root keeps direct supported-name aliases and
 retains snapshot publication/cache/single-flight, selector/seed, and expansion.
+D-12c moves the immutable snapshot value and stateless materialization to
+`easyuse_anima.wildcard.snapshot`; root retains source verification,
+publication/cache/single-flight/retry, all public callers, selector/seed, and
+expansion so E-06 lifecycle ownership remains separate.
 
 ## 12. Phase E — Runtime ownership and lifecycle
 

--- a/docs/architecture/python-compatibility-shims.md
+++ b/docs/architecture/python-compatibility-shims.md
@@ -64,7 +64,7 @@ import them.
 | `storage.py` | Explicit direct re-export shim (D-08) | `easyuse_anima.infrastructure.filesystem.atomic_json` and `.paths` | #163, #186 D-08 | Existing 0.5.2 supported module-owned public surface; exact `__all__` and identity fixture | External/legacy imports and storage compatibility tests; production callers use canonical modules | Unscheduled; first canonical+shim release N not yet recorded, then N+1 gate and last-known-good/atomic-write parity |
 | `autocomplete_index.py` | Explicit direct re-export shim (D-11a) | `easyuse_anima.autocomplete.index` | #162, #186 D-11a | Existing indexed-search surface; exact seven-name `__all__` and identity fixture | External/legacy imports; `autocomplete_dataset.py` now uses the canonical owner | Unscheduled; first canonical+shim release N not yet recorded, then N+1 gate and index/ranking/rebuild parity |
 | `autocomplete_dataset.py` | Partial explicit compatibility module after D-11b; prompt classification remains root-owned | `easyuse_anima.autocomplete.dataset` and `.search`; classification target waits for D-13 | #162, #186 D-11 | Existing 0.5.2 dataset/search surface canonicalized in PR #386 with direct identity aliases; final shim waits for root `anima_prompt` removal | External/legacy imports and prompt tests; `api.py` uses canonical dataset/search and root classification | Unscheduled; D-13 dependency removal, final identity surface, N+1 gate, and classification/result/API parity |
-| `wildcard_engine.py` | Partial compatibility module after D-12b; snapshot/selector/seed/expansion remain root-owned | `easyuse_anima.wildcard.models`, `.sources`, then snapshot/expansion modules | #184, #186 D-12 | Existing 0.5.2 model/limit surface canonicalized in PR #387 and source/path surface in PR #388 with direct identity aliases; later D-12 slices remain | root entrypoint, `nodes.py`, `api.py`, wildcard/workflow tests | Unscheduled; full D-12 move, final identity surface, N+1 gate, and seed/expansion/workflow parity |
+| `wildcard_engine.py` | Partial compatibility module after D-12c; snapshot lifecycle/selector/seed/expansion remain root-owned | `easyuse_anima.wildcard.models`, `.sources`, `.snapshot`, then lifecycle/expansion modules | #184, #186 D-12 | Existing 0.5.2 model/limit surface canonicalized in PR #387, source/path surface in PR #388, and immutable snapshot materialization in PR #389 with direct aliases; later D-12 slices remain | root entrypoint, `nodes.py`, `api.py`, wildcard/workflow tests | Unscheduled; full D-12 move, final identity surface, N+1 gate, and seed/expansion/workflow parity |
 | `prompt_translation.py` | Explicit direct re-export shim (D-01) | `easyuse_anima.translation.*` | #164, #186 D-01 | Existing 0.5.2 supported module-owned public surface; exact `__all__` and identity fixture | External/legacy imports and translation compatibility tests; production callers use canonical modules | Unscheduled; first canonical+shim release N not yet recorded, then N+1 gate and provider-off/API parity |
 | `anima_prompt/` package | Current implementation; planned package shim | `easyuse_anima.prompt.anima.*` | #184, #186 D-13 | Existing 0.5.2 surface; convert in D-13/D-14 | `nodes.py`, `autocomplete_dataset.py`, prompt tests | Unscheduled; N+1 gate and prompt correction/parser parity |
 
@@ -1467,10 +1467,14 @@ EasyUseAnimaWildcard
 - D-12b moves root discovery, extra-path resolution, TXT/YAML parsing,
   immutable source metadata, and source scanning to
   `easyuse_anima.wildcard.sources`.
-- Root binds the 12 model names and eight supported source names directly to
-  canonical objects. Snapshot construction/cache/condition/single-flight,
-  selector/seed, expansion, enforcement, and diagnostics remain root-owned for
-  later D-12 slices.
+- D-12c moves immutable `_WildcardSnapshot` and stateless
+  `_build_wildcard_snapshot` materialization to
+  `easyuse_anima.wildcard.snapshot`.
+- Root binds the 12 model names, eight supported source names, and two private
+  snapshot seams directly to canonical objects. Source verification,
+  snapshot publication/cache/condition/single-flight/retry, selector/seed,
+  expansion, enforcement, and diagnostics remain root-owned for later D-12
+  slices and E-06.
 - Canonical target for the remaining implementation:
   `easyuse_anima.wildcard` sources/snapshot/expansion modules. Snapshot
   lifecycle/factory/cleanup remains E-06.

--- a/docs/architecture/wildcard-snapshot-materialization-canonical-move.md
+++ b/docs/architecture/wildcard-snapshot-materialization-canonical-move.md
@@ -1,0 +1,183 @@
+# D-12c Wildcard snapshot materialization canonical Move
+
+- Owner issue: [#186](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/186)
+- Behavior prerequisites:
+  [#159](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/159) and
+  [#160](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/160) — complete
+- Roadmap unit: D-12c
+- Parent roadmap unit: D-12 Wildcard
+- PR type: Move
+- Baseline: `dev@6f32f88b3e484a7e14751f8c179daa8758c2fcd5`
+- State: READY
+- Production behavior changes: forbidden
+
+## Responsibility boundary
+
+After D-12b, `easyuse_anima.wildcard.sources` owns source discovery and
+parsing, while root `wildcard_engine.py` owns both immutable snapshot
+materialization and mutable snapshot publication/cache lifecycle.
+
+D-12c separates only the immutable value/materialization leaf:
+
+- `_WildcardSnapshot`; and
+- `_build_wildcard_snapshot`.
+
+They move to:
+
+- `easyuse_anima.wildcard.snapshot`.
+
+Root retains source-state verification, publication, cache lookup/eviction,
+condition waiting, single-flight coordination, retry, and every public
+listing/signature/expansion caller. This keeps D-12c a Move and leaves runtime
+ownership/factory/cleanup decisions to the later lifecycle slice and E-06.
+
+## Moved symbol inventory
+
+### `_WildcardSnapshot`
+
+Immutable fields:
+
+- `cache_key`;
+- immutable mapping of normalized names to `WildcardOption` tuples;
+- sorted `wildcard_names`;
+- stringified root paths;
+- immutable source-file metadata tuple; and
+- `cacheable`.
+
+Its `public_signature()` projection remains part of the moved value object and
+keeps the existing roots/files payload shape.
+
+### `_build_wildcard_snapshot`
+
+Materialization behavior:
+
+- consumes one immutable `_WildcardSourceState`;
+- loads each source through canonical source parsing;
+- preserves first-root/first-key precedence;
+- ignores empty option lists;
+- marks a candidate non-cacheable after a transient `OSError`;
+- freezes option lists into tuples and the mapping into `MappingProxyType`;
+- sorts public wildcard names; and
+- copies source cache key, roots, and file metadata without mutation.
+
+The function owns no cache lookup, publication, retry loop, lock, condition,
+or cleanup.
+
+## Caller and alias inventory
+
+Root direct aliases:
+
+- `wildcard_engine._WildcardSnapshot`; and
+- `wildcard_engine._build_wildcard_snapshot`.
+
+These private names remain direct aliases to the identical canonical objects.
+They are retained as compatibility/test seams but are not added to a supported
+public `__all__`.
+
+Root runtime callers:
+
+- `_wildcard_snapshot` calls the root-bound build alias after acquiring the
+  source-state single-flight lane;
+- `_SNAPSHOT_CACHE` keeps `_WildcardSnapshot` values;
+- `_load_wildcard_map` returns a mutable copy of snapshot options;
+- `list_wildcards` reads `wildcard_names`;
+- `wildcard_sources_signature` calls `public_signature`;
+- `_WildcardLibrary` reuses the immutable mapping; and
+- expansion entrypoints acquire a root-owned snapshot before selection and
+  replacement.
+
+External production callers do not import the private snapshot symbols.
+Nodes and API surfaces continue to use root public listing/signature/expansion
+helpers unchanged.
+
+Tests:
+
+- `tests/test_wildcards.py` keeps root patch seams for build blocking,
+  file-change retry, single-flight, and atomic-publication coverage;
+- it adds exact root/canonical identity and immutable materialization coverage;
+- package skeleton and Registry scanner include the canonical module; and
+- backend analyzer fixtures record the canonical dependency graph.
+
+## Global-state inventory
+
+D-12c moves no mutable runtime state.
+
+Root retains:
+
+- `_SNAPSHOT_CACHE_LIMIT`;
+- `_SNAPSHOT_CONDITION`;
+- `_SNAPSHOT_CACHE`;
+- `_SNAPSHOT_BUILDING`;
+- source-state rescan verification;
+- cache hit/LRU mutation and eviction;
+- wait/notify and single-flight ownership;
+- exception propagation and retry; and
+- publication eligibility decisions based on `cacheable`.
+
+Canonical `snapshot.py` contains only:
+
+- immutable type definitions;
+- a stateless materialization function; and
+- imports of canonical source/model types and helpers.
+
+It creates no module-level mutable container, lock, condition, singleton,
+factory, background task, cleanup hook, or dependency-injection seam.
+
+## Compatibility and behavior invariants
+
+- exact root private identity is retained without wrapper, proxy, duplicate
+  class, or lazy module hook;
+- mapping precedence, empty-option behavior, normalized keys, tuple freezing,
+  mapping immutability, wildcard-name ordering, root ordering, file metadata,
+  cache-key shape, and public signature shape are unchanged;
+- transient loader `OSError` still returns a non-cacheable snapshot candidate;
+- malformed YAML remains a cacheable empty parse as owned by canonical sources;
+- source changes during build still force root rescan and retry before publish;
+- same-key parallel requests still build once and publish atomically;
+- failed builds still clear the root building key and notify waiters;
+- cache capacity, eviction ordering, condition timing, and exception behavior
+  are unchanged;
+- selector, PCG64, seed control, expansion, budgets, diagnostics, API, nodes,
+  workflows, and frontend behavior are unchanged; and
+- import timing remains package-internal with no root import from canonical
+  snapshot code.
+
+## Allowed-file boundary
+
+Production:
+
+- root `wildcard_engine.py`; and
+- new `easyuse_anima/wildcard/snapshot.py`.
+
+Supporting:
+
+- wildcard snapshot identity/materialization and existing lifecycle tests;
+- package skeleton, Registry scanner, backend analyzer, and exact fixture;
+- this inventory, compatibility-shim ledger, and execution roadmap.
+
+## Forbidden
+
+- moving or changing `_wildcard_snapshot`;
+- moving or changing cache/condition/building/limit state;
+- cache policy, capacity, key, eviction, retry, publication, wait/notify,
+  single-flight, factory, or cleanup changes;
+- source discovery/parsing changes;
+- list/signature payload changes;
+- selector, PRNG, seed, mode, expansion, budget, or diagnostics changes;
+- G-03 completed-package enrollment before full D-12 completion;
+- API, node, bootstrap, frontend, workflow, Registry metadata, release, or
+  instance changes; and
+- server, browser, live-instance, model, provider, or network execution.
+
+## Validation and exit
+
+- exact root/canonical identity for both moved private names;
+- immutable mapping, tuple options, ordering, precedence, signature, and
+  transient-read cacheability behavior;
+- existing file-change retry, same-key single-flight, atomic publication,
+  failure cleanup, and mutable-copy tests remain unchanged;
+- package skeleton, Registry scanner, backend analyzer, and packed archive
+  include canonical `snapshot.py`;
+- canonical snapshot has zero root imports and no mutable globals;
+- official full runner once at the PR checkpoint; and
+- root retains every lifecycle/global-state and public behavior caller.

--- a/docs/architecture/wildcard-snapshot-materialization-canonical-move.md
+++ b/docs/architecture/wildcard-snapshot-materialization-canonical-move.md
@@ -8,7 +8,7 @@
 - Parent roadmap unit: D-12 Wildcard
 - PR type: Move
 - Baseline: `dev@6f32f88b3e484a7e14751f8c179daa8758c2fcd5`
-- State: READY
+- State: VALIDATED
 - Production behavior changes: forbidden
 
 ## Responsibility boundary
@@ -181,3 +181,19 @@ Supporting:
 - canonical snapshot has zero root imports and no mutable globals;
 - official full runner once at the PR checkpoint; and
 - root retains every lifecycle/global-state and public behavior caller.
+
+## Validation evidence
+
+- wildcard behavior, identity, retry, and single-flight: 74 tests passed;
+- package skeleton: 1 test passed;
+- Registry scanner safety: 8 tests passed;
+- Python import boundaries: 16 tests passed;
+- backend analyzer: 18 tests passed;
+- canonical `snapshot.py` Ruff: 0 findings;
+- canonical `snapshot.py` Pyright 1.1.411: 0 diagnostics;
+- official full: 1,137 Python tests and 112 frontend files passed, G-03a
+  remained 10 completed groups with 0 violations, and the existing 14-error
+  Pyright baseline passed; and
+- local Registry validation passed; the 259-entry archive contained root
+  `wildcard_engine.py` and canonical wildcard `__init__.py`, `models.py`,
+  `sources.py`, and `snapshot.py`.

--- a/easyuse_anima/wildcard/snapshot.py
+++ b/easyuse_anima/wildcard/snapshot.py
@@ -1,0 +1,66 @@
+"""Immutable wildcard snapshot values and stateless materialization."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from types import MappingProxyType
+
+from . import sources as _wildcard_sources
+from .models import WildcardOption
+from .sources import _WildcardSourceFile, _WildcardSourceState
+
+__all__ = ()
+
+
+@dataclass(frozen=True)
+class _WildcardSnapshot:
+    cache_key: tuple
+    mapping: Mapping[str, tuple[WildcardOption, ...]]
+    wildcard_names: tuple[str, ...]
+    roots: tuple[str, ...]
+    files: tuple[_WildcardSourceFile, ...]
+    cacheable: bool
+
+    def public_signature(self) -> dict:
+        return {
+            "roots": list(self.roots),
+            "files": [
+                {
+                    "root": source.root,
+                    "path": source.relative_path,
+                    "mtime_ns": source.mtime_ns,
+                    "size": source.size,
+                }
+                for source in self.files
+            ],
+        }
+
+
+def _build_wildcard_snapshot(
+    source_state: _WildcardSourceState,
+) -> _WildcardSnapshot:
+    mapping: dict[str, list[WildcardOption]] = {}
+    cacheable = True
+    for source in source_state.files:
+        root = source_state.roots[source.root_index]
+        try:
+            entries = _wildcard_sources._load_wildcard_file(root, source.path)
+        except OSError:
+            cacheable = False
+            continue
+        for key, options in entries.items():
+            if key not in mapping and options:
+                mapping[key] = options
+
+    frozen_mapping = MappingProxyType(
+        {key: tuple(options) for key, options in mapping.items()}
+    )
+    return _WildcardSnapshot(
+        cache_key=source_state.cache_key,
+        mapping=frozen_mapping,
+        wildcard_names=tuple(sorted(frozen_mapping)),
+        roots=tuple(str(root) for root in source_state.roots),
+        files=source_state.files,
+        cacheable=cacheable,
+    )

--- a/tests/fixtures/python_backend_baseline.json
+++ b/tests/fixtures/python_backend_baseline.json
@@ -27345,6 +27345,146 @@
         "requested": "__future__",
         "role": "ordinary",
         "scope": "<module>",
+        "source": "easyuse_anima/wildcard/snapshot.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "dataclass",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "dataclasses:dataclass",
+        "kind": "static_from",
+        "line": 5,
+        "name": "dataclass",
+        "optional": false,
+        "requested": "dataclasses",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/wildcard/snapshot.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "MappingProxyType",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "types:MappingProxyType",
+        "kind": "static_from",
+        "line": 6,
+        "name": "MappingProxyType",
+        "optional": false,
+        "requested": "types",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/wildcard/snapshot.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "Mapping",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "typing:Mapping",
+        "kind": "static_from",
+        "line": 7,
+        "name": "Mapping",
+        "optional": false,
+        "requested": "typing",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/wildcard/snapshot.py"
+      },
+      {
+        "alias": "_wildcard_sources",
+        "bound_name": "_wildcard_sources",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".:sources",
+        "kind": "static_from",
+        "line": 9,
+        "name": "sources",
+        "optional": false,
+        "requested": ".",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/wildcard/snapshot.py",
+        "target": "easyuse_anima/wildcard/sources.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "WildcardOption",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".models:WildcardOption",
+        "kind": "static_from",
+        "line": 10,
+        "name": "WildcardOption",
+        "optional": false,
+        "requested": ".models",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/wildcard/snapshot.py",
+        "target": "easyuse_anima/wildcard/models.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_WildcardSourceFile",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".sources:_WildcardSourceFile",
+        "kind": "static_from",
+        "line": 11,
+        "name": "_WildcardSourceFile",
+        "optional": false,
+        "requested": ".sources",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/wildcard/snapshot.py",
+        "target": "easyuse_anima/wildcard/sources.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_WildcardSourceState",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".sources:_WildcardSourceState",
+        "kind": "static_from",
+        "line": 11,
+        "name": "_WildcardSourceState",
+        "optional": false,
+        "requested": ".sources",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/wildcard/snapshot.py",
+        "target": "easyuse_anima/wildcard/sources.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "annotations",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "__future__:annotations",
+        "kind": "static_from",
+        "line": 3,
+        "name": "annotations",
+        "optional": false,
+        "requested": "__future__",
+        "role": "ordinary",
+        "scope": "<module>",
         "source": "easyuse_anima/wildcard/sources.py"
       },
       {
@@ -53558,23 +53698,6 @@
       },
       {
         "alias": null,
-        "bound_name": "MappingProxyType",
-        "branch_context": [],
-        "classification": "external",
-        "column": 0,
-        "conditional": false,
-        "imported": "types:MappingProxyType",
-        "kind": "static_from",
-        "line": 13,
-        "name": "MappingProxyType",
-        "optional": false,
-        "requested": "types",
-        "role": "ordinary",
-        "scope": "<module>",
-        "source": "wildcard_engine.py"
-      },
-      {
-        "alias": null,
         "bound_name": "Iterable",
         "branch_context": [],
         "classification": "external",
@@ -53582,25 +53705,8 @@
         "conditional": false,
         "imported": "typing:Iterable",
         "kind": "static_from",
-        "line": 14,
+        "line": 13,
         "name": "Iterable",
-        "optional": false,
-        "requested": "typing",
-        "role": "ordinary",
-        "scope": "<module>",
-        "source": "wildcard_engine.py"
-      },
-      {
-        "alias": null,
-        "bound_name": "Mapping",
-        "branch_context": [],
-        "classification": "external",
-        "column": 0,
-        "conditional": false,
-        "imported": "typing:Mapping",
-        "kind": "static_from",
-        "line": 14,
-        "name": "Mapping",
         "optional": false,
         "requested": "typing",
         "role": "ordinary",
@@ -53616,7 +53722,7 @@
         "conditional": false,
         "imported": "typing:Sequence",
         "kind": "static_from",
-        "line": 14,
+        "line": 13,
         "name": "Sequence",
         "optional": false,
         "requested": "typing",
@@ -53633,7 +53739,7 @@
         "conditional": false,
         "imported": "numpy",
         "kind": "static_import",
-        "line": 18,
+        "line": 17,
         "name": null,
         "optional": false,
         "requested": "numpy",
@@ -53650,7 +53756,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 20
+            "line": 19
           }
         ],
         "classification": "internal",
@@ -53658,12 +53764,12 @@
         "compatibility_pair": {
           "bound_name": "DEFAULT_MAX_EXPANSION_DEPTH",
           "target": "easyuse_anima/wildcard/models.py",
-          "try_line": 20
+          "try_line": 19
         },
         "conditional": true,
         "imported": ".easyuse_anima.wildcard.models:DEFAULT_MAX_EXPANSION_DEPTH",
         "kind": "static_from",
-        "line": 21,
+        "line": 20,
         "name": "DEFAULT_MAX_EXPANSION_DEPTH",
         "optional": false,
         "requested": ".easyuse_anima.wildcard.models",
@@ -53681,7 +53787,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 20
+            "line": 19
           }
         ],
         "classification": "internal",
@@ -53689,12 +53795,12 @@
         "compatibility_pair": {
           "bound_name": "DEFAULT_MAX_EXPANSION_GROWTH_PER_PASS",
           "target": "easyuse_anima/wildcard/models.py",
-          "try_line": 20
+          "try_line": 19
         },
         "conditional": true,
         "imported": ".easyuse_anima.wildcard.models:DEFAULT_MAX_EXPANSION_GROWTH_PER_PASS",
         "kind": "static_from",
-        "line": 21,
+        "line": 20,
         "name": "DEFAULT_MAX_EXPANSION_GROWTH_PER_PASS",
         "optional": false,
         "requested": ".easyuse_anima.wildcard.models",
@@ -53712,7 +53818,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 20
+            "line": 19
           }
         ],
         "classification": "internal",
@@ -53720,12 +53826,12 @@
         "compatibility_pair": {
           "bound_name": "DEFAULT_MAX_EXPANSION_OUTPUT_CHARS",
           "target": "easyuse_anima/wildcard/models.py",
-          "try_line": 20
+          "try_line": 19
         },
         "conditional": true,
         "imported": ".easyuse_anima.wildcard.models:DEFAULT_MAX_EXPANSION_OUTPUT_CHARS",
         "kind": "static_from",
-        "line": 21,
+        "line": 20,
         "name": "DEFAULT_MAX_EXPANSION_OUTPUT_CHARS",
         "optional": false,
         "requested": ".easyuse_anima.wildcard.models",
@@ -53743,7 +53849,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 20
+            "line": 19
           }
         ],
         "classification": "internal",
@@ -53751,12 +53857,12 @@
         "compatibility_pair": {
           "bound_name": "DEFAULT_MAX_EXPANSION_REPLACEMENTS",
           "target": "easyuse_anima/wildcard/models.py",
-          "try_line": 20
+          "try_line": 19
         },
         "conditional": true,
         "imported": ".easyuse_anima.wildcard.models:DEFAULT_MAX_EXPANSION_REPLACEMENTS",
         "kind": "static_from",
-        "line": 21,
+        "line": 20,
         "name": "DEFAULT_MAX_EXPANSION_REPLACEMENTS",
         "optional": false,
         "requested": ".easyuse_anima.wildcard.models",
@@ -53774,7 +53880,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 20
+            "line": 19
           }
         ],
         "classification": "internal",
@@ -53782,12 +53888,12 @@
         "compatibility_pair": {
           "bound_name": "MAX_EXPANSION_DEPTH",
           "target": "easyuse_anima/wildcard/models.py",
-          "try_line": 20
+          "try_line": 19
         },
         "conditional": true,
         "imported": ".easyuse_anima.wildcard.models:MAX_EXPANSION_DEPTH",
         "kind": "static_from",
-        "line": 21,
+        "line": 20,
         "name": "MAX_EXPANSION_DEPTH",
         "optional": false,
         "requested": ".easyuse_anima.wildcard.models",
@@ -53805,7 +53911,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 20
+            "line": 19
           }
         ],
         "classification": "internal",
@@ -53813,12 +53919,12 @@
         "compatibility_pair": {
           "bound_name": "MAX_EXPANSION_GROWTH_PER_PASS",
           "target": "easyuse_anima/wildcard/models.py",
-          "try_line": 20
+          "try_line": 19
         },
         "conditional": true,
         "imported": ".easyuse_anima.wildcard.models:MAX_EXPANSION_GROWTH_PER_PASS",
         "kind": "static_from",
-        "line": 21,
+        "line": 20,
         "name": "MAX_EXPANSION_GROWTH_PER_PASS",
         "optional": false,
         "requested": ".easyuse_anima.wildcard.models",
@@ -53836,7 +53942,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 20
+            "line": 19
           }
         ],
         "classification": "internal",
@@ -53844,12 +53950,12 @@
         "compatibility_pair": {
           "bound_name": "MAX_EXPANSION_OUTPUT_CHARS",
           "target": "easyuse_anima/wildcard/models.py",
-          "try_line": 20
+          "try_line": 19
         },
         "conditional": true,
         "imported": ".easyuse_anima.wildcard.models:MAX_EXPANSION_OUTPUT_CHARS",
         "kind": "static_from",
-        "line": 21,
+        "line": 20,
         "name": "MAX_EXPANSION_OUTPUT_CHARS",
         "optional": false,
         "requested": ".easyuse_anima.wildcard.models",
@@ -53867,7 +53973,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 20
+            "line": 19
           }
         ],
         "classification": "internal",
@@ -53875,12 +53981,12 @@
         "compatibility_pair": {
           "bound_name": "MAX_EXPANSION_REPLACEMENTS",
           "target": "easyuse_anima/wildcard/models.py",
-          "try_line": 20
+          "try_line": 19
         },
         "conditional": true,
         "imported": ".easyuse_anima.wildcard.models:MAX_EXPANSION_REPLACEMENTS",
         "kind": "static_from",
-        "line": 21,
+        "line": 20,
         "name": "MAX_EXPANSION_REPLACEMENTS",
         "optional": false,
         "requested": ".easyuse_anima.wildcard.models",
@@ -53898,7 +54004,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 20
+            "line": 19
           }
         ],
         "classification": "internal",
@@ -53906,12 +54012,12 @@
         "compatibility_pair": {
           "bound_name": "REPLACE_DEPTH",
           "target": "easyuse_anima/wildcard/models.py",
-          "try_line": 20
+          "try_line": 19
         },
         "conditional": true,
         "imported": ".easyuse_anima.wildcard.models:REPLACE_DEPTH",
         "kind": "static_from",
-        "line": 21,
+        "line": 20,
         "name": "REPLACE_DEPTH",
         "optional": false,
         "requested": ".easyuse_anima.wildcard.models",
@@ -53929,7 +54035,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 20
+            "line": 19
           }
         ],
         "classification": "internal",
@@ -53937,12 +54043,12 @@
         "compatibility_pair": {
           "bound_name": "WildcardExpansionBudget",
           "target": "easyuse_anima/wildcard/models.py",
-          "try_line": 20
+          "try_line": 19
         },
         "conditional": true,
         "imported": ".easyuse_anima.wildcard.models:WildcardExpansionBudget",
         "kind": "static_from",
-        "line": 21,
+        "line": 20,
         "name": "WildcardExpansionBudget",
         "optional": false,
         "requested": ".easyuse_anima.wildcard.models",
@@ -53960,7 +54066,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 20
+            "line": 19
           }
         ],
         "classification": "internal",
@@ -53968,12 +54074,12 @@
         "compatibility_pair": {
           "bound_name": "WildcardExpansionResult",
           "target": "easyuse_anima/wildcard/models.py",
-          "try_line": 20
+          "try_line": 19
         },
         "conditional": true,
         "imported": ".easyuse_anima.wildcard.models:WildcardExpansionResult",
         "kind": "static_from",
-        "line": 21,
+        "line": 20,
         "name": "WildcardExpansionResult",
         "optional": false,
         "requested": ".easyuse_anima.wildcard.models",
@@ -53991,7 +54097,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 20
+            "line": 19
           }
         ],
         "classification": "internal",
@@ -53999,12 +54105,12 @@
         "compatibility_pair": {
           "bound_name": "WildcardOption",
           "target": "easyuse_anima/wildcard/models.py",
-          "try_line": 20
+          "try_line": 19
         },
         "conditional": true,
         "imported": ".easyuse_anima.wildcard.models:WildcardOption",
         "kind": "static_from",
-        "line": 21,
+        "line": 20,
         "name": "WildcardOption",
         "optional": false,
         "requested": ".easyuse_anima.wildcard.models",
@@ -54023,9 +54129,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 35,
+            "handler_line": 34,
             "kind": "try",
-            "line": 20
+            "line": 19
           }
         ],
         "classification": "compatibility_fallback",
@@ -54033,12 +54139,12 @@
         "compatibility_pair": {
           "bound_name": "DEFAULT_MAX_EXPANSION_DEPTH",
           "target": "easyuse_anima/wildcard/models.py",
-          "try_line": 20
+          "try_line": 19
         },
         "conditional": true,
         "imported": "easyuse_anima.wildcard.models:DEFAULT_MAX_EXPANSION_DEPTH",
         "kind": "static_from",
-        "line": 36,
+        "line": 35,
         "name": "DEFAULT_MAX_EXPANSION_DEPTH",
         "optional": false,
         "requested": "easyuse_anima.wildcard.models",
@@ -54057,9 +54163,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 35,
+            "handler_line": 34,
             "kind": "try",
-            "line": 20
+            "line": 19
           }
         ],
         "classification": "compatibility_fallback",
@@ -54067,12 +54173,12 @@
         "compatibility_pair": {
           "bound_name": "DEFAULT_MAX_EXPANSION_GROWTH_PER_PASS",
           "target": "easyuse_anima/wildcard/models.py",
-          "try_line": 20
+          "try_line": 19
         },
         "conditional": true,
         "imported": "easyuse_anima.wildcard.models:DEFAULT_MAX_EXPANSION_GROWTH_PER_PASS",
         "kind": "static_from",
-        "line": 36,
+        "line": 35,
         "name": "DEFAULT_MAX_EXPANSION_GROWTH_PER_PASS",
         "optional": false,
         "requested": "easyuse_anima.wildcard.models",
@@ -54091,9 +54197,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 35,
+            "handler_line": 34,
             "kind": "try",
-            "line": 20
+            "line": 19
           }
         ],
         "classification": "compatibility_fallback",
@@ -54101,12 +54207,12 @@
         "compatibility_pair": {
           "bound_name": "DEFAULT_MAX_EXPANSION_OUTPUT_CHARS",
           "target": "easyuse_anima/wildcard/models.py",
-          "try_line": 20
+          "try_line": 19
         },
         "conditional": true,
         "imported": "easyuse_anima.wildcard.models:DEFAULT_MAX_EXPANSION_OUTPUT_CHARS",
         "kind": "static_from",
-        "line": 36,
+        "line": 35,
         "name": "DEFAULT_MAX_EXPANSION_OUTPUT_CHARS",
         "optional": false,
         "requested": "easyuse_anima.wildcard.models",
@@ -54125,9 +54231,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 35,
+            "handler_line": 34,
             "kind": "try",
-            "line": 20
+            "line": 19
           }
         ],
         "classification": "compatibility_fallback",
@@ -54135,12 +54241,12 @@
         "compatibility_pair": {
           "bound_name": "DEFAULT_MAX_EXPANSION_REPLACEMENTS",
           "target": "easyuse_anima/wildcard/models.py",
-          "try_line": 20
+          "try_line": 19
         },
         "conditional": true,
         "imported": "easyuse_anima.wildcard.models:DEFAULT_MAX_EXPANSION_REPLACEMENTS",
         "kind": "static_from",
-        "line": 36,
+        "line": 35,
         "name": "DEFAULT_MAX_EXPANSION_REPLACEMENTS",
         "optional": false,
         "requested": "easyuse_anima.wildcard.models",
@@ -54159,9 +54265,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 35,
+            "handler_line": 34,
             "kind": "try",
-            "line": 20
+            "line": 19
           }
         ],
         "classification": "compatibility_fallback",
@@ -54169,12 +54275,12 @@
         "compatibility_pair": {
           "bound_name": "MAX_EXPANSION_DEPTH",
           "target": "easyuse_anima/wildcard/models.py",
-          "try_line": 20
+          "try_line": 19
         },
         "conditional": true,
         "imported": "easyuse_anima.wildcard.models:MAX_EXPANSION_DEPTH",
         "kind": "static_from",
-        "line": 36,
+        "line": 35,
         "name": "MAX_EXPANSION_DEPTH",
         "optional": false,
         "requested": "easyuse_anima.wildcard.models",
@@ -54193,9 +54299,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 35,
+            "handler_line": 34,
             "kind": "try",
-            "line": 20
+            "line": 19
           }
         ],
         "classification": "compatibility_fallback",
@@ -54203,12 +54309,12 @@
         "compatibility_pair": {
           "bound_name": "MAX_EXPANSION_GROWTH_PER_PASS",
           "target": "easyuse_anima/wildcard/models.py",
-          "try_line": 20
+          "try_line": 19
         },
         "conditional": true,
         "imported": "easyuse_anima.wildcard.models:MAX_EXPANSION_GROWTH_PER_PASS",
         "kind": "static_from",
-        "line": 36,
+        "line": 35,
         "name": "MAX_EXPANSION_GROWTH_PER_PASS",
         "optional": false,
         "requested": "easyuse_anima.wildcard.models",
@@ -54227,9 +54333,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 35,
+            "handler_line": 34,
             "kind": "try",
-            "line": 20
+            "line": 19
           }
         ],
         "classification": "compatibility_fallback",
@@ -54237,12 +54343,12 @@
         "compatibility_pair": {
           "bound_name": "MAX_EXPANSION_OUTPUT_CHARS",
           "target": "easyuse_anima/wildcard/models.py",
-          "try_line": 20
+          "try_line": 19
         },
         "conditional": true,
         "imported": "easyuse_anima.wildcard.models:MAX_EXPANSION_OUTPUT_CHARS",
         "kind": "static_from",
-        "line": 36,
+        "line": 35,
         "name": "MAX_EXPANSION_OUTPUT_CHARS",
         "optional": false,
         "requested": "easyuse_anima.wildcard.models",
@@ -54261,9 +54367,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 35,
+            "handler_line": 34,
             "kind": "try",
-            "line": 20
+            "line": 19
           }
         ],
         "classification": "compatibility_fallback",
@@ -54271,12 +54377,12 @@
         "compatibility_pair": {
           "bound_name": "MAX_EXPANSION_REPLACEMENTS",
           "target": "easyuse_anima/wildcard/models.py",
-          "try_line": 20
+          "try_line": 19
         },
         "conditional": true,
         "imported": "easyuse_anima.wildcard.models:MAX_EXPANSION_REPLACEMENTS",
         "kind": "static_from",
-        "line": 36,
+        "line": 35,
         "name": "MAX_EXPANSION_REPLACEMENTS",
         "optional": false,
         "requested": "easyuse_anima.wildcard.models",
@@ -54295,9 +54401,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 35,
+            "handler_line": 34,
             "kind": "try",
-            "line": 20
+            "line": 19
           }
         ],
         "classification": "compatibility_fallback",
@@ -54305,12 +54411,12 @@
         "compatibility_pair": {
           "bound_name": "REPLACE_DEPTH",
           "target": "easyuse_anima/wildcard/models.py",
-          "try_line": 20
+          "try_line": 19
         },
         "conditional": true,
         "imported": "easyuse_anima.wildcard.models:REPLACE_DEPTH",
         "kind": "static_from",
-        "line": 36,
+        "line": 35,
         "name": "REPLACE_DEPTH",
         "optional": false,
         "requested": "easyuse_anima.wildcard.models",
@@ -54329,9 +54435,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 35,
+            "handler_line": 34,
             "kind": "try",
-            "line": 20
+            "line": 19
           }
         ],
         "classification": "compatibility_fallback",
@@ -54339,12 +54445,12 @@
         "compatibility_pair": {
           "bound_name": "WildcardExpansionBudget",
           "target": "easyuse_anima/wildcard/models.py",
-          "try_line": 20
+          "try_line": 19
         },
         "conditional": true,
         "imported": "easyuse_anima.wildcard.models:WildcardExpansionBudget",
         "kind": "static_from",
-        "line": 36,
+        "line": 35,
         "name": "WildcardExpansionBudget",
         "optional": false,
         "requested": "easyuse_anima.wildcard.models",
@@ -54363,9 +54469,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 35,
+            "handler_line": 34,
             "kind": "try",
-            "line": 20
+            "line": 19
           }
         ],
         "classification": "compatibility_fallback",
@@ -54373,12 +54479,12 @@
         "compatibility_pair": {
           "bound_name": "WildcardExpansionResult",
           "target": "easyuse_anima/wildcard/models.py",
-          "try_line": 20
+          "try_line": 19
         },
         "conditional": true,
         "imported": "easyuse_anima.wildcard.models:WildcardExpansionResult",
         "kind": "static_from",
-        "line": 36,
+        "line": 35,
         "name": "WildcardExpansionResult",
         "optional": false,
         "requested": "easyuse_anima.wildcard.models",
@@ -54397,9 +54503,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 35,
+            "handler_line": 34,
             "kind": "try",
-            "line": 20
+            "line": 19
           }
         ],
         "classification": "compatibility_fallback",
@@ -54407,12 +54513,12 @@
         "compatibility_pair": {
           "bound_name": "WildcardOption",
           "target": "easyuse_anima/wildcard/models.py",
-          "try_line": 20
+          "try_line": 19
         },
         "conditional": true,
         "imported": "easyuse_anima.wildcard.models:WildcardOption",
         "kind": "static_from",
-        "line": 36,
+        "line": 35,
         "name": "WildcardOption",
         "optional": false,
         "requested": "easyuse_anima.wildcard.models",
@@ -54430,7 +54536,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 51
+            "line": 50
           }
         ],
         "classification": "internal",
@@ -54438,12 +54544,12 @@
         "compatibility_pair": {
           "bound_name": "_wildcard_sources",
           "target": "easyuse_anima/wildcard/sources.py",
-          "try_line": 51
+          "try_line": 50
         },
         "conditional": true,
         "imported": ".easyuse_anima.wildcard:sources",
         "kind": "static_from",
-        "line": 52,
+        "line": 51,
         "name": "sources",
         "optional": false,
         "requested": ".easyuse_anima.wildcard",
@@ -54461,7 +54567,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 51
+            "line": 50
           }
         ],
         "classification": "internal",
@@ -54469,12 +54575,12 @@
         "compatibility_pair": {
           "bound_name": "DEFAULT_TEST_WILDCARD_FILE",
           "target": "easyuse_anima/wildcard/sources.py",
-          "try_line": 51
+          "try_line": 50
         },
         "conditional": true,
         "imported": ".easyuse_anima.wildcard.sources:DEFAULT_TEST_WILDCARD_FILE",
         "kind": "static_from",
-        "line": 53,
+        "line": 52,
         "name": "DEFAULT_TEST_WILDCARD_FILE",
         "optional": false,
         "requested": ".easyuse_anima.wildcard.sources",
@@ -54492,7 +54598,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 51
+            "line": 50
           }
         ],
         "classification": "internal",
@@ -54500,12 +54606,12 @@
         "compatibility_pair": {
           "bound_name": "DEFAULT_TEST_WILDCARD_TEXT",
           "target": "easyuse_anima/wildcard/sources.py",
-          "try_line": 51
+          "try_line": 50
         },
         "conditional": true,
         "imported": ".easyuse_anima.wildcard.sources:DEFAULT_TEST_WILDCARD_TEXT",
         "kind": "static_from",
-        "line": 53,
+        "line": 52,
         "name": "DEFAULT_TEST_WILDCARD_TEXT",
         "optional": false,
         "requested": ".easyuse_anima.wildcard.sources",
@@ -54523,7 +54629,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 51
+            "line": 50
           }
         ],
         "classification": "internal",
@@ -54531,12 +54637,12 @@
         "compatibility_pair": {
           "bound_name": "WILDCARD_DIR_NAME",
           "target": "easyuse_anima/wildcard/sources.py",
-          "try_line": 51
+          "try_line": 50
         },
         "conditional": true,
         "imported": ".easyuse_anima.wildcard.sources:WILDCARD_DIR_NAME",
         "kind": "static_from",
-        "line": 53,
+        "line": 52,
         "name": "WILDCARD_DIR_NAME",
         "optional": false,
         "requested": ".easyuse_anima.wildcard.sources",
@@ -54554,7 +54660,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 51
+            "line": 50
           }
         ],
         "classification": "internal",
@@ -54562,75 +54668,13 @@
         "compatibility_pair": {
           "bound_name": "WILDCARD_EXTENSIONS",
           "target": "easyuse_anima/wildcard/sources.py",
-          "try_line": 51
+          "try_line": 50
         },
         "conditional": true,
         "imported": ".easyuse_anima.wildcard.sources:WILDCARD_EXTENSIONS",
         "kind": "static_from",
-        "line": 53,
+        "line": 52,
         "name": "WILDCARD_EXTENSIONS",
-        "optional": false,
-        "requested": ".easyuse_anima.wildcard.sources",
-        "role": "compatibility_primary",
-        "scope": "<module>",
-        "source": "wildcard_engine.py",
-        "target": "easyuse_anima/wildcard/sources.py"
-      },
-      {
-        "alias": null,
-        "bound_name": "_WildcardSourceFile",
-        "branch_context": [
-          {
-            "branch": "body",
-            "handles_import_failure": true,
-            "has_import_fallback_handler": true,
-            "kind": "try",
-            "line": 51
-          }
-        ],
-        "classification": "internal",
-        "column": 4,
-        "compatibility_pair": {
-          "bound_name": "_WildcardSourceFile",
-          "target": "easyuse_anima/wildcard/sources.py",
-          "try_line": 51
-        },
-        "conditional": true,
-        "imported": ".easyuse_anima.wildcard.sources:_WildcardSourceFile",
-        "kind": "static_from",
-        "line": 53,
-        "name": "_WildcardSourceFile",
-        "optional": false,
-        "requested": ".easyuse_anima.wildcard.sources",
-        "role": "compatibility_primary",
-        "scope": "<module>",
-        "source": "wildcard_engine.py",
-        "target": "easyuse_anima/wildcard/sources.py"
-      },
-      {
-        "alias": null,
-        "bound_name": "_WildcardSourceState",
-        "branch_context": [
-          {
-            "branch": "body",
-            "handles_import_failure": true,
-            "has_import_fallback_handler": true,
-            "kind": "try",
-            "line": 51
-          }
-        ],
-        "classification": "internal",
-        "column": 4,
-        "compatibility_pair": {
-          "bound_name": "_WildcardSourceState",
-          "target": "easyuse_anima/wildcard/sources.py",
-          "try_line": 51
-        },
-        "conditional": true,
-        "imported": ".easyuse_anima.wildcard.sources:_WildcardSourceState",
-        "kind": "static_from",
-        "line": 53,
-        "name": "_WildcardSourceState",
         "optional": false,
         "requested": ".easyuse_anima.wildcard.sources",
         "role": "compatibility_primary",
@@ -54647,7 +54691,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 51
+            "line": 50
           }
         ],
         "classification": "internal",
@@ -54655,12 +54699,12 @@
         "compatibility_pair": {
           "bound_name": "default_wildcard_root",
           "target": "easyuse_anima/wildcard/sources.py",
-          "try_line": 51
+          "try_line": 50
         },
         "conditional": true,
         "imported": ".easyuse_anima.wildcard.sources:default_wildcard_root",
         "kind": "static_from",
-        "line": 53,
+        "line": 52,
         "name": "default_wildcard_root",
         "optional": false,
         "requested": ".easyuse_anima.wildcard.sources",
@@ -54678,7 +54722,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 51
+            "line": 50
           }
         ],
         "classification": "internal",
@@ -54686,12 +54730,12 @@
         "compatibility_pair": {
           "bound_name": "ensure_default_wildcard_root",
           "target": "easyuse_anima/wildcard/sources.py",
-          "try_line": 51
+          "try_line": 50
         },
         "conditional": true,
         "imported": ".easyuse_anima.wildcard.sources:ensure_default_wildcard_root",
         "kind": "static_from",
-        "line": 53,
+        "line": 52,
         "name": "ensure_default_wildcard_root",
         "optional": false,
         "requested": ".easyuse_anima.wildcard.sources",
@@ -54709,7 +54753,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 51
+            "line": 50
           }
         ],
         "classification": "internal",
@@ -54717,12 +54761,12 @@
         "compatibility_pair": {
           "bound_name": "parse_wildcard_extra_paths",
           "target": "easyuse_anima/wildcard/sources.py",
-          "try_line": 51
+          "try_line": 50
         },
         "conditional": true,
         "imported": ".easyuse_anima.wildcard.sources:parse_wildcard_extra_paths",
         "kind": "static_from",
-        "line": 53,
+        "line": 52,
         "name": "parse_wildcard_extra_paths",
         "optional": false,
         "requested": ".easyuse_anima.wildcard.sources",
@@ -54740,7 +54784,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 51
+            "line": 50
           }
         ],
         "classification": "internal",
@@ -54748,12 +54792,12 @@
         "compatibility_pair": {
           "bound_name": "resolve_wildcard_roots",
           "target": "easyuse_anima/wildcard/sources.py",
-          "try_line": 51
+          "try_line": 50
         },
         "conditional": true,
         "imported": ".easyuse_anima.wildcard.sources:resolve_wildcard_roots",
         "kind": "static_from",
-        "line": 53,
+        "line": 52,
         "name": "resolve_wildcard_roots",
         "optional": false,
         "requested": ".easyuse_anima.wildcard.sources",
@@ -54772,9 +54816,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 65,
+            "handler_line": 62,
             "kind": "try",
-            "line": 51
+            "line": 50
           }
         ],
         "classification": "compatibility_fallback",
@@ -54782,12 +54826,12 @@
         "compatibility_pair": {
           "bound_name": "_wildcard_sources",
           "target": "easyuse_anima/wildcard/sources.py",
-          "try_line": 51
+          "try_line": 50
         },
         "conditional": true,
         "imported": "easyuse_anima.wildcard:sources",
         "kind": "static_from",
-        "line": 66,
+        "line": 63,
         "name": "sources",
         "optional": false,
         "requested": "easyuse_anima.wildcard",
@@ -54806,9 +54850,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 65,
+            "handler_line": 62,
             "kind": "try",
-            "line": 51
+            "line": 50
           }
         ],
         "classification": "compatibility_fallback",
@@ -54816,12 +54860,12 @@
         "compatibility_pair": {
           "bound_name": "DEFAULT_TEST_WILDCARD_FILE",
           "target": "easyuse_anima/wildcard/sources.py",
-          "try_line": 51
+          "try_line": 50
         },
         "conditional": true,
         "imported": "easyuse_anima.wildcard.sources:DEFAULT_TEST_WILDCARD_FILE",
         "kind": "static_from",
-        "line": 67,
+        "line": 64,
         "name": "DEFAULT_TEST_WILDCARD_FILE",
         "optional": false,
         "requested": "easyuse_anima.wildcard.sources",
@@ -54840,9 +54884,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 65,
+            "handler_line": 62,
             "kind": "try",
-            "line": 51
+            "line": 50
           }
         ],
         "classification": "compatibility_fallback",
@@ -54850,12 +54894,12 @@
         "compatibility_pair": {
           "bound_name": "DEFAULT_TEST_WILDCARD_TEXT",
           "target": "easyuse_anima/wildcard/sources.py",
-          "try_line": 51
+          "try_line": 50
         },
         "conditional": true,
         "imported": "easyuse_anima.wildcard.sources:DEFAULT_TEST_WILDCARD_TEXT",
         "kind": "static_from",
-        "line": 67,
+        "line": 64,
         "name": "DEFAULT_TEST_WILDCARD_TEXT",
         "optional": false,
         "requested": "easyuse_anima.wildcard.sources",
@@ -54874,9 +54918,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 65,
+            "handler_line": 62,
             "kind": "try",
-            "line": 51
+            "line": 50
           }
         ],
         "classification": "compatibility_fallback",
@@ -54884,12 +54928,12 @@
         "compatibility_pair": {
           "bound_name": "WILDCARD_DIR_NAME",
           "target": "easyuse_anima/wildcard/sources.py",
-          "try_line": 51
+          "try_line": 50
         },
         "conditional": true,
         "imported": "easyuse_anima.wildcard.sources:WILDCARD_DIR_NAME",
         "kind": "static_from",
-        "line": 67,
+        "line": 64,
         "name": "WILDCARD_DIR_NAME",
         "optional": false,
         "requested": "easyuse_anima.wildcard.sources",
@@ -54908,9 +54952,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 65,
+            "handler_line": 62,
             "kind": "try",
-            "line": 51
+            "line": 50
           }
         ],
         "classification": "compatibility_fallback",
@@ -54918,81 +54962,13 @@
         "compatibility_pair": {
           "bound_name": "WILDCARD_EXTENSIONS",
           "target": "easyuse_anima/wildcard/sources.py",
-          "try_line": 51
+          "try_line": 50
         },
         "conditional": true,
         "imported": "easyuse_anima.wildcard.sources:WILDCARD_EXTENSIONS",
         "kind": "static_from",
-        "line": 67,
+        "line": 64,
         "name": "WILDCARD_EXTENSIONS",
-        "optional": false,
-        "requested": "easyuse_anima.wildcard.sources",
-        "role": "compatibility_fallback",
-        "scope": "<module>",
-        "source": "wildcard_engine.py",
-        "target": "easyuse_anima/wildcard/sources.py"
-      },
-      {
-        "alias": null,
-        "bound_name": "_WildcardSourceFile",
-        "branch_context": [
-          {
-            "branch": "except",
-            "catches_import_error": true,
-            "exceptions": [
-              "ImportError"
-            ],
-            "handler_line": 65,
-            "kind": "try",
-            "line": 51
-          }
-        ],
-        "classification": "compatibility_fallback",
-        "column": 4,
-        "compatibility_pair": {
-          "bound_name": "_WildcardSourceFile",
-          "target": "easyuse_anima/wildcard/sources.py",
-          "try_line": 51
-        },
-        "conditional": true,
-        "imported": "easyuse_anima.wildcard.sources:_WildcardSourceFile",
-        "kind": "static_from",
-        "line": 67,
-        "name": "_WildcardSourceFile",
-        "optional": false,
-        "requested": "easyuse_anima.wildcard.sources",
-        "role": "compatibility_fallback",
-        "scope": "<module>",
-        "source": "wildcard_engine.py",
-        "target": "easyuse_anima/wildcard/sources.py"
-      },
-      {
-        "alias": null,
-        "bound_name": "_WildcardSourceState",
-        "branch_context": [
-          {
-            "branch": "except",
-            "catches_import_error": true,
-            "exceptions": [
-              "ImportError"
-            ],
-            "handler_line": 65,
-            "kind": "try",
-            "line": 51
-          }
-        ],
-        "classification": "compatibility_fallback",
-        "column": 4,
-        "compatibility_pair": {
-          "bound_name": "_WildcardSourceState",
-          "target": "easyuse_anima/wildcard/sources.py",
-          "try_line": 51
-        },
-        "conditional": true,
-        "imported": "easyuse_anima.wildcard.sources:_WildcardSourceState",
-        "kind": "static_from",
-        "line": 67,
-        "name": "_WildcardSourceState",
         "optional": false,
         "requested": "easyuse_anima.wildcard.sources",
         "role": "compatibility_fallback",
@@ -55010,9 +54986,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 65,
+            "handler_line": 62,
             "kind": "try",
-            "line": 51
+            "line": 50
           }
         ],
         "classification": "compatibility_fallback",
@@ -55020,12 +54996,12 @@
         "compatibility_pair": {
           "bound_name": "default_wildcard_root",
           "target": "easyuse_anima/wildcard/sources.py",
-          "try_line": 51
+          "try_line": 50
         },
         "conditional": true,
         "imported": "easyuse_anima.wildcard.sources:default_wildcard_root",
         "kind": "static_from",
-        "line": 67,
+        "line": 64,
         "name": "default_wildcard_root",
         "optional": false,
         "requested": "easyuse_anima.wildcard.sources",
@@ -55044,9 +55020,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 65,
+            "handler_line": 62,
             "kind": "try",
-            "line": 51
+            "line": 50
           }
         ],
         "classification": "compatibility_fallback",
@@ -55054,12 +55030,12 @@
         "compatibility_pair": {
           "bound_name": "ensure_default_wildcard_root",
           "target": "easyuse_anima/wildcard/sources.py",
-          "try_line": 51
+          "try_line": 50
         },
         "conditional": true,
         "imported": "easyuse_anima.wildcard.sources:ensure_default_wildcard_root",
         "kind": "static_from",
-        "line": 67,
+        "line": 64,
         "name": "ensure_default_wildcard_root",
         "optional": false,
         "requested": "easyuse_anima.wildcard.sources",
@@ -55078,9 +55054,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 65,
+            "handler_line": 62,
             "kind": "try",
-            "line": 51
+            "line": 50
           }
         ],
         "classification": "compatibility_fallback",
@@ -55088,12 +55064,12 @@
         "compatibility_pair": {
           "bound_name": "parse_wildcard_extra_paths",
           "target": "easyuse_anima/wildcard/sources.py",
-          "try_line": 51
+          "try_line": 50
         },
         "conditional": true,
         "imported": "easyuse_anima.wildcard.sources:parse_wildcard_extra_paths",
         "kind": "static_from",
-        "line": 67,
+        "line": 64,
         "name": "parse_wildcard_extra_paths",
         "optional": false,
         "requested": "easyuse_anima.wildcard.sources",
@@ -55112,9 +55088,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 65,
+            "handler_line": 62,
             "kind": "try",
-            "line": 51
+            "line": 50
           }
         ],
         "classification": "compatibility_fallback",
@@ -55122,12 +55098,12 @@
         "compatibility_pair": {
           "bound_name": "resolve_wildcard_roots",
           "target": "easyuse_anima/wildcard/sources.py",
-          "try_line": 51
+          "try_line": 50
         },
         "conditional": true,
         "imported": "easyuse_anima.wildcard.sources:resolve_wildcard_roots",
         "kind": "static_from",
-        "line": 67,
+        "line": 64,
         "name": "resolve_wildcard_roots",
         "optional": false,
         "requested": "easyuse_anima.wildcard.sources",
@@ -55135,6 +55111,136 @@
         "scope": "<module>",
         "source": "wildcard_engine.py",
         "target": "easyuse_anima/wildcard/sources.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_WildcardSnapshot",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 75
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "_WildcardSnapshot",
+          "target": "easyuse_anima/wildcard/snapshot.py",
+          "try_line": 75
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.wildcard.snapshot:_WildcardSnapshot",
+        "kind": "static_from",
+        "line": 76,
+        "name": "_WildcardSnapshot",
+        "optional": false,
+        "requested": ".easyuse_anima.wildcard.snapshot",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "wildcard_engine.py",
+        "target": "easyuse_anima/wildcard/snapshot.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_build_wildcard_snapshot",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 75
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "_build_wildcard_snapshot",
+          "target": "easyuse_anima/wildcard/snapshot.py",
+          "try_line": 75
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.wildcard.snapshot:_build_wildcard_snapshot",
+        "kind": "static_from",
+        "line": 76,
+        "name": "_build_wildcard_snapshot",
+        "optional": false,
+        "requested": ".easyuse_anima.wildcard.snapshot",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "wildcard_engine.py",
+        "target": "easyuse_anima/wildcard/snapshot.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_WildcardSnapshot",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 80,
+            "kind": "try",
+            "line": 75
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "_WildcardSnapshot",
+          "target": "easyuse_anima/wildcard/snapshot.py",
+          "try_line": 75
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.wildcard.snapshot:_WildcardSnapshot",
+        "kind": "static_from",
+        "line": 81,
+        "name": "_WildcardSnapshot",
+        "optional": false,
+        "requested": "easyuse_anima.wildcard.snapshot",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "wildcard_engine.py",
+        "target": "easyuse_anima/wildcard/snapshot.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_build_wildcard_snapshot",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 80,
+            "kind": "try",
+            "line": 75
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "_build_wildcard_snapshot",
+          "target": "easyuse_anima/wildcard/snapshot.py",
+          "try_line": 75
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.wildcard.snapshot:_build_wildcard_snapshot",
+        "kind": "static_from",
+        "line": 81,
+        "name": "_build_wildcard_snapshot",
+        "optional": false,
+        "requested": "easyuse_anima.wildcard.snapshot",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "wildcard_engine.py",
+        "target": "easyuse_anima/wildcard/snapshot.py"
       }
     ],
     "module_graph": [
@@ -56471,6 +56577,14 @@
         "to": "easyuse_anima/translation/providers/google.py"
       },
       {
+        "from": "easyuse_anima/wildcard/snapshot.py",
+        "to": "easyuse_anima/wildcard/models.py"
+      },
+      {
+        "from": "easyuse_anima/wildcard/snapshot.py",
+        "to": "easyuse_anima/wildcard/sources.py"
+      },
+      {
         "from": "easyuse_anima/wildcard/sources.py",
         "to": "easyuse_anima/infrastructure/filesystem/paths.py"
       },
@@ -56741,6 +56855,10 @@
       {
         "from": "wildcard_engine.py",
         "to": "easyuse_anima/wildcard/models.py"
+      },
+      {
+        "from": "wildcard_engine.py",
+        "to": "easyuse_anima/wildcard/snapshot.py"
       },
       {
         "from": "wildcard_engine.py",
@@ -57488,6 +57606,12 @@
       {
         "cyclic": false,
         "modules": [
+          "easyuse_anima/wildcard/snapshot.py"
+        ]
+      },
+      {
+        "cyclic": false,
+        "modules": [
           "easyuse_anima/wildcard/sources.py"
         ]
       },
@@ -57530,7 +57654,7 @@
     ]
   },
   "inventory": {
-    "module_count": 128,
+    "module_count": 129,
     "modules": [
       {
         "is_package": true,
@@ -58986,6 +59110,18 @@
       },
       {
         "is_package": false,
+        "loc": 66,
+        "module": "easyuse_anima.wildcard.snapshot",
+        "normalized_git_blob_sha1": "01b60918ffb1ccf6334abdad42226510843e1d48",
+        "path": "easyuse_anima/wildcard/snapshot.py",
+        "top_level": {
+          "class_count": 1,
+          "function_count": 1,
+          "global_count": 1
+        }
+      },
+      {
+        "is_package": false,
         "loc": 307,
         "module": "easyuse_anima.wildcard.sources",
         "normalized_git_blob_sha1": "30c9336418c0985563b53e153b678d8be9374428",
@@ -59058,13 +59194,13 @@
       },
       {
         "is_package": false,
-        "loc": 968,
+        "loc": 922,
         "module": "wildcard_engine",
-        "normalized_git_blob_sha1": "a2a3278286d9b6d784dfe80623d9dee42879c18b",
+        "normalized_git_blob_sha1": "14fe8a2e6356385d99a5c99a1056392ea6f89e92",
         "path": "wildcard_engine.py",
         "top_level": {
-          "class_count": 8,
-          "function_count": 23,
+          "class_count": 7,
+          "function_count": 22,
           "global_count": 25
         }
       }
@@ -69461,16 +69597,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 35,
+            "handler_line": 34,
             "kind": "try",
-            "line": 20
+            "line": 19
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.wildcard.models:DEFAULT_MAX_EXPANSION_DEPTH",
         "kind": "static_from",
-        "line": 36,
+        "line": 35,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "wildcard_engine.py",
@@ -69484,16 +69620,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 35,
+            "handler_line": 34,
             "kind": "try",
-            "line": 20
+            "line": 19
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.wildcard.models:DEFAULT_MAX_EXPANSION_GROWTH_PER_PASS",
         "kind": "static_from",
-        "line": 36,
+        "line": 35,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "wildcard_engine.py",
@@ -69507,16 +69643,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 35,
+            "handler_line": 34,
             "kind": "try",
-            "line": 20
+            "line": 19
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.wildcard.models:DEFAULT_MAX_EXPANSION_OUTPUT_CHARS",
         "kind": "static_from",
-        "line": 36,
+        "line": 35,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "wildcard_engine.py",
@@ -69530,16 +69666,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 35,
+            "handler_line": 34,
             "kind": "try",
-            "line": 20
+            "line": 19
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.wildcard.models:DEFAULT_MAX_EXPANSION_REPLACEMENTS",
         "kind": "static_from",
-        "line": 36,
+        "line": 35,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "wildcard_engine.py",
@@ -69553,16 +69689,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 35,
+            "handler_line": 34,
             "kind": "try",
-            "line": 20
+            "line": 19
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.wildcard.models:MAX_EXPANSION_DEPTH",
         "kind": "static_from",
-        "line": 36,
+        "line": 35,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "wildcard_engine.py",
@@ -69576,16 +69712,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 35,
+            "handler_line": 34,
             "kind": "try",
-            "line": 20
+            "line": 19
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.wildcard.models:MAX_EXPANSION_GROWTH_PER_PASS",
         "kind": "static_from",
-        "line": 36,
+        "line": 35,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "wildcard_engine.py",
@@ -69599,16 +69735,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 35,
+            "handler_line": 34,
             "kind": "try",
-            "line": 20
+            "line": 19
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.wildcard.models:MAX_EXPANSION_OUTPUT_CHARS",
         "kind": "static_from",
-        "line": 36,
+        "line": 35,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "wildcard_engine.py",
@@ -69622,16 +69758,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 35,
+            "handler_line": 34,
             "kind": "try",
-            "line": 20
+            "line": 19
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.wildcard.models:MAX_EXPANSION_REPLACEMENTS",
         "kind": "static_from",
-        "line": 36,
+        "line": 35,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "wildcard_engine.py",
@@ -69645,16 +69781,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 35,
+            "handler_line": 34,
             "kind": "try",
-            "line": 20
+            "line": 19
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.wildcard.models:REPLACE_DEPTH",
         "kind": "static_from",
-        "line": 36,
+        "line": 35,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "wildcard_engine.py",
@@ -69668,16 +69804,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 35,
+            "handler_line": 34,
             "kind": "try",
-            "line": 20
+            "line": 19
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.wildcard.models:WildcardExpansionBudget",
         "kind": "static_from",
-        "line": 36,
+        "line": 35,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "wildcard_engine.py",
@@ -69691,16 +69827,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 35,
+            "handler_line": 34,
             "kind": "try",
-            "line": 20
+            "line": 19
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.wildcard.models:WildcardExpansionResult",
         "kind": "static_from",
-        "line": 36,
+        "line": 35,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "wildcard_engine.py",
@@ -69714,16 +69850,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 35,
+            "handler_line": 34,
             "kind": "try",
-            "line": 20
+            "line": 19
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.wildcard.models:WildcardOption",
         "kind": "static_from",
-        "line": 36,
+        "line": 35,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "wildcard_engine.py",
@@ -69737,16 +69873,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 65,
+            "handler_line": 62,
             "kind": "try",
-            "line": 51
+            "line": 50
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.wildcard:sources",
         "kind": "static_from",
-        "line": 66,
+        "line": 63,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "wildcard_engine.py",
@@ -69760,16 +69896,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 65,
+            "handler_line": 62,
             "kind": "try",
-            "line": 51
+            "line": 50
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.wildcard.sources:DEFAULT_TEST_WILDCARD_FILE",
         "kind": "static_from",
-        "line": 67,
+        "line": 64,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "wildcard_engine.py",
@@ -69783,16 +69919,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 65,
+            "handler_line": 62,
             "kind": "try",
-            "line": 51
+            "line": 50
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.wildcard.sources:DEFAULT_TEST_WILDCARD_TEXT",
         "kind": "static_from",
-        "line": 67,
+        "line": 64,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "wildcard_engine.py",
@@ -69806,16 +69942,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 65,
+            "handler_line": 62,
             "kind": "try",
-            "line": 51
+            "line": 50
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.wildcard.sources:WILDCARD_DIR_NAME",
         "kind": "static_from",
-        "line": 67,
+        "line": 64,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "wildcard_engine.py",
@@ -69829,16 +69965,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 65,
+            "handler_line": 62,
             "kind": "try",
-            "line": 51
+            "line": 50
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.wildcard.sources:WILDCARD_EXTENSIONS",
         "kind": "static_from",
-        "line": 67,
+        "line": 64,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "wildcard_engine.py",
@@ -69852,62 +69988,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 65,
+            "handler_line": 62,
             "kind": "try",
-            "line": 51
-          }
-        ],
-        "classification": "compatibility_fallback",
-        "conditional": true,
-        "imported": "easyuse_anima.wildcard.sources:_WildcardSourceFile",
-        "kind": "static_from",
-        "line": 67,
-        "optional": false,
-        "role": "compatibility_fallback",
-        "source": "wildcard_engine.py",
-        "target": "easyuse_anima/wildcard/sources.py"
-      },
-      {
-        "branch_context": [
-          {
-            "branch": "except",
-            "catches_import_error": true,
-            "exceptions": [
-              "ImportError"
-            ],
-            "handler_line": 65,
-            "kind": "try",
-            "line": 51
-          }
-        ],
-        "classification": "compatibility_fallback",
-        "conditional": true,
-        "imported": "easyuse_anima.wildcard.sources:_WildcardSourceState",
-        "kind": "static_from",
-        "line": 67,
-        "optional": false,
-        "role": "compatibility_fallback",
-        "source": "wildcard_engine.py",
-        "target": "easyuse_anima/wildcard/sources.py"
-      },
-      {
-        "branch_context": [
-          {
-            "branch": "except",
-            "catches_import_error": true,
-            "exceptions": [
-              "ImportError"
-            ],
-            "handler_line": 65,
-            "kind": "try",
-            "line": 51
+            "line": 50
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.wildcard.sources:default_wildcard_root",
         "kind": "static_from",
-        "line": 67,
+        "line": 64,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "wildcard_engine.py",
@@ -69921,16 +70011,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 65,
+            "handler_line": 62,
             "kind": "try",
-            "line": 51
+            "line": 50
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.wildcard.sources:ensure_default_wildcard_root",
         "kind": "static_from",
-        "line": 67,
+        "line": 64,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "wildcard_engine.py",
@@ -69944,16 +70034,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 65,
+            "handler_line": 62,
             "kind": "try",
-            "line": 51
+            "line": 50
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.wildcard.sources:parse_wildcard_extra_paths",
         "kind": "static_from",
-        "line": 67,
+        "line": 64,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "wildcard_engine.py",
@@ -69967,20 +70057,66 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 65,
+            "handler_line": 62,
             "kind": "try",
-            "line": 51
+            "line": 50
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.wildcard.sources:resolve_wildcard_roots",
         "kind": "static_from",
-        "line": 67,
+        "line": 64,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "wildcard_engine.py",
         "target": "easyuse_anima/wildcard/sources.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 80,
+            "kind": "try",
+            "line": 75
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.wildcard.snapshot:_WildcardSnapshot",
+        "kind": "static_from",
+        "line": 81,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "wildcard_engine.py",
+        "target": "easyuse_anima/wildcard/snapshot.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 80,
+            "kind": "try",
+            "line": 75
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.wildcard.snapshot:_build_wildcard_snapshot",
+        "kind": "static_from",
+        "line": 81,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "wildcard_engine.py",
+        "target": "easyuse_anima/wildcard/snapshot.py"
       }
     ],
     "entry_modules": [
@@ -75407,6 +75543,50 @@
         "line": 3,
         "optional": false,
         "role": "ordinary",
+        "source": "easyuse_anima/wildcard/snapshot.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "dataclasses:dataclass",
+        "kind": "static_from",
+        "line": 5,
+        "optional": false,
+        "role": "ordinary",
+        "source": "easyuse_anima/wildcard/snapshot.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "types:MappingProxyType",
+        "kind": "static_from",
+        "line": 6,
+        "optional": false,
+        "role": "ordinary",
+        "source": "easyuse_anima/wildcard/snapshot.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "typing:Mapping",
+        "kind": "static_from",
+        "line": 7,
+        "optional": false,
+        "role": "ordinary",
+        "source": "easyuse_anima/wildcard/snapshot.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "__future__:annotations",
+        "kind": "static_from",
+        "line": 3,
+        "optional": false,
+        "role": "ordinary",
         "source": "easyuse_anima/wildcard/sources.py"
       },
       {
@@ -75671,7 +75851,7 @@
         "branch_context": [],
         "classification": "external",
         "conditional": false,
-        "imported": "types:MappingProxyType",
+        "imported": "typing:Iterable",
         "kind": "static_from",
         "line": 13,
         "optional": false,
@@ -75682,31 +75862,9 @@
         "branch_context": [],
         "classification": "external",
         "conditional": false,
-        "imported": "typing:Iterable",
-        "kind": "static_from",
-        "line": 14,
-        "optional": false,
-        "role": "ordinary",
-        "source": "wildcard_engine.py"
-      },
-      {
-        "branch_context": [],
-        "classification": "external",
-        "conditional": false,
-        "imported": "typing:Mapping",
-        "kind": "static_from",
-        "line": 14,
-        "optional": false,
-        "role": "ordinary",
-        "source": "wildcard_engine.py"
-      },
-      {
-        "branch_context": [],
-        "classification": "external",
-        "conditional": false,
         "imported": "typing:Sequence",
         "kind": "static_from",
-        "line": 14,
+        "line": 13,
         "optional": false,
         "role": "ordinary",
         "source": "wildcard_engine.py"
@@ -75717,7 +75875,7 @@
         "conditional": false,
         "imported": "numpy",
         "kind": "static_import",
-        "line": 18,
+        "line": 17,
         "optional": false,
         "role": "ordinary",
         "source": "wildcard_engine.py"
@@ -76807,6 +76965,7 @@
       "easyuse_anima/translation/service.py",
       "easyuse_anima/wildcard/__init__.py",
       "easyuse_anima/wildcard/models.py",
+      "easyuse_anima/wildcard/snapshot.py",
       "easyuse_anima/wildcard/sources.py",
       "easyuse_anima/workflow.py",
       "nodes.py",
@@ -76937,6 +77096,7 @@
       "easyuse_anima/translation/service.py",
       "easyuse_anima/wildcard/__init__.py",
       "easyuse_anima/wildcard/models.py",
+      "easyuse_anima/wildcard/snapshot.py",
       "easyuse_anima/wildcard/sources.py",
       "easyuse_anima/workflow.py",
       "nodes.py",
@@ -78526,6 +78686,15 @@
         "scope": "<module>"
       },
       {
+        "callee": "dataclass",
+        "column": 1,
+        "context": "decorator:_WildcardSnapshot",
+        "kind": "import_time_call",
+        "line": 16,
+        "module": "easyuse_anima/wildcard/snapshot.py",
+        "scope": "<module>"
+      },
+      {
         "callee": "re.compile",
         "column": 19,
         "context": "assign:WEIGHT_PREFIX_RE",
@@ -78557,7 +78726,7 @@
         "column": 13,
         "context": "assign:COMMENT_RE",
         "kind": "import_time_call",
-        "line": 125,
+        "line": 131,
         "module": "wildcard_engine.py",
         "scope": "<module>"
       },
@@ -78566,7 +78735,7 @@
         "column": 13,
         "context": "assign:DYNAMIC_RE",
         "kind": "import_time_call",
-        "line": 126,
+        "line": 132,
         "module": "wildcard_engine.py",
         "scope": "<module>"
       },
@@ -78575,7 +78744,7 @@
         "column": 14,
         "context": "assign:WILDCARD_RE",
         "kind": "import_time_call",
-        "line": 127,
+        "line": 133,
         "module": "wildcard_engine.py",
         "scope": "<module>"
       },
@@ -78584,7 +78753,7 @@
         "column": 19,
         "context": "assign:WILDCARD_FULL_RE",
         "kind": "import_time_call",
-        "line": 128,
+        "line": 134,
         "module": "wildcard_engine.py",
         "scope": "<module>"
       },
@@ -78593,7 +78762,7 @@
         "column": 25,
         "context": "assign:WILDCARD_QUANTIFIER_RE",
         "kind": "import_time_call",
-        "line": 129,
+        "line": 135,
         "module": "wildcard_engine.py",
         "scope": "<module>"
       },
@@ -78602,16 +78771,7 @@
         "column": 16,
         "context": "assign:COUNT_SPEC_RE",
         "kind": "import_time_call",
-        "line": 133,
-        "module": "wildcard_engine.py",
-        "scope": "<module>"
-      },
-      {
-        "callee": "dataclass",
-        "column": 1,
-        "context": "decorator:_WildcardSnapshot",
-        "kind": "import_time_call",
-        "line": 138,
+        "line": 139,
         "module": "wildcard_engine.py",
         "scope": "<module>"
       },
@@ -78620,7 +78780,7 @@
         "column": 22,
         "context": "assign:_SNAPSHOT_CONDITION",
         "kind": "import_time_call",
-        "line": 163,
+        "line": 144,
         "module": "wildcard_engine.py",
         "scope": "<module>"
       },
@@ -78629,7 +78789,7 @@
         "column": 57,
         "context": "assign:_SNAPSHOT_CACHE",
         "kind": "import_time_call",
-        "line": 164,
+        "line": 145,
         "module": "wildcard_engine.py",
         "scope": "<module>"
       },
@@ -78638,7 +78798,7 @@
         "column": 33,
         "context": "assign:_SNAPSHOT_BUILDING",
         "kind": "import_time_call",
-        "line": 165,
+        "line": 146,
         "module": "wildcard_engine.py",
         "scope": "<module>"
       },
@@ -78647,7 +78807,7 @@
         "column": 1,
         "context": "decorator:_ExpansionSegment",
         "kind": "import_time_call",
-        "line": 183,
+        "line": 164,
         "module": "wildcard_engine.py",
         "scope": "<module>"
       },
@@ -78656,7 +78816,7 @@
         "column": 1,
         "context": "decorator:_Replacement",
         "kind": "import_time_call",
-        "line": 256,
+        "line": 237,
         "module": "wildcard_engine.py",
         "scope": "<module>"
       }
@@ -79038,19 +79198,19 @@
       },
       {
         "kind": "dict",
-        "line": 98,
+        "line": 104,
         "module": "wildcard_engine.py",
         "name": "WILDCARD_MODE_ALIASES"
       },
       {
         "kind": "set",
-        "line": 165,
+        "line": 146,
         "module": "wildcard_engine.py",
         "name": "_SNAPSHOT_BUILDING"
       },
       {
         "kind": "dict",
-        "line": 164,
+        "line": 145,
         "module": "wildcard_engine.py",
         "name": "_SNAPSHOT_CACHE"
       }
@@ -79215,7 +79375,7 @@
           "single_flight"
         ],
         "initializer": "set",
-        "line": 165,
+        "line": 146,
         "module": "wildcard_engine.py",
         "name": "_SNAPSHOT_BUILDING"
       },
@@ -79225,7 +79385,7 @@
           "mutable_container"
         ],
         "initializer": "OrderedDict",
-        "line": 164,
+        "line": 145,
         "module": "wildcard_engine.py",
         "name": "_SNAPSHOT_CACHE"
       }

--- a/tests/test_python_backend_analyzer.py
+++ b/tests/test_python_backend_analyzer.py
@@ -691,9 +691,9 @@ ignored/
 
         self.assertEqual(analyzer.render_json(report), expected_text)
         self.assertEqual(report["schema_version"], 2)
-        self.assertEqual(report["inventory"]["module_count"], 128)
-        self.assertEqual(len(report["registry"]["shipped_python_modules"]), 128)
-        self.assertEqual(len(report["registry"]["runtime_import_closure"]), 128)
+        self.assertEqual(report["inventory"]["module_count"], 129)
+        self.assertEqual(len(report["registry"]["shipped_python_modules"]), 129)
+        self.assertEqual(len(report["registry"]["runtime_import_closure"]), 129)
         self.assertEqual(
             report["registry"]["entry_modules"],
             [
@@ -962,6 +962,27 @@ ignored/
         )
         self.assertIn(
             {
+                "from": "wildcard_engine.py",
+                "to": "easyuse_anima/wildcard/snapshot.py",
+            },
+            report["imports"]["module_graph"],
+        )
+        self.assertIn(
+            {
+                "from": "easyuse_anima/wildcard/snapshot.py",
+                "to": "easyuse_anima/wildcard/models.py",
+            },
+            report["imports"]["module_graph"],
+        )
+        self.assertIn(
+            {
+                "from": "easyuse_anima/wildcard/snapshot.py",
+                "to": "easyuse_anima/wildcard/sources.py",
+            },
+            report["imports"]["module_graph"],
+        )
+        self.assertIn(
+            {
                 "from": "api.py",
                 "to": "easyuse_anima/wildcard/sources.py",
             },
@@ -970,6 +991,7 @@ ignored/
         for module in (
             "easyuse_anima/wildcard/__init__.py",
             "easyuse_anima/wildcard/models.py",
+            "easyuse_anima/wildcard/snapshot.py",
             "easyuse_anima/wildcard/sources.py",
         ):
             with self.subTest(module=module):
@@ -1038,6 +1060,12 @@ ignored/
         self.assertEqual(
             mutable_by_name[("wildcard_engine.py", "_SNAPSHOT_CACHE")],
             "dict",
+        )
+        self.assertFalse(
+            any(
+                module == "easyuse_anima/wildcard/snapshot.py"
+                for module, _name in mutable_by_name
+            )
         )
         owner_by_name = {
             (item["module"], item["name"]): set(item["categories"])

--- a/tests/test_python_package_skeleton.py
+++ b/tests/test_python_package_skeleton.py
@@ -88,6 +88,7 @@ PACKAGE_MODULES = (
     "easyuse_anima.translation.service",
     "easyuse_anima.wildcard",
     "easyuse_anima.wildcard.models",
+    "easyuse_anima.wildcard.snapshot",
     "easyuse_anima.wildcard.sources",
     "easyuse_anima.seed.execution_identity",
     "easyuse_anima.seed.execution_session",

--- a/tests/test_registry_scanner_safety.py
+++ b/tests/test_registry_scanner_safety.py
@@ -83,6 +83,7 @@ EXPECTED_PYTHON_PACKAGE_FILES = {
     "easyuse_anima/settings/service.py",
     "easyuse_anima/wildcard/__init__.py",
     "easyuse_anima/wildcard/models.py",
+    "easyuse_anima/wildcard/snapshot.py",
     "easyuse_anima/wildcard/sources.py",
     "easyuse_anima/registration.py",
     "easyuse_anima/prompt/__init__.py",

--- a/tests/test_wildcards.py
+++ b/tests/test_wildcards.py
@@ -13,6 +13,7 @@ from easyuse_anima.nodes import wildcard_nodes
 from easyuse_anima.prompt import advanced as prompt_advanced
 from easyuse_anima.seed import compatibility as seed_compatibility
 from easyuse_anima.wildcard import models as wildcard_models
+from easyuse_anima.wildcard import snapshot as wildcard_snapshot
 from easyuse_anima.wildcard import sources as wildcard_sources
 from nodes import (
     EasyUseAnimaPromptStudioAdvanced,
@@ -34,6 +35,17 @@ from wildcard_engine import (
 
 
 class WildcardEngineTests(unittest.TestCase):
+    def test_root_snapshot_surface_has_canonical_identity(self):
+        self.assertEqual(wildcard_snapshot.__all__, ())
+        self.assertIs(
+            wildcard_engine._WildcardSnapshot,
+            wildcard_snapshot._WildcardSnapshot,
+        )
+        self.assertIs(
+            wildcard_engine._build_wildcard_snapshot,
+            wildcard_snapshot._build_wildcard_snapshot,
+        )
+
     def test_root_source_surface_has_canonical_identity(self):
         expected = (
             "WILDCARD_DIR_NAME",

--- a/wildcard_engine.py
+++ b/wildcard_engine.py
@@ -10,8 +10,7 @@ import re
 import threading
 from dataclasses import dataclass
 from pathlib import Path
-from types import MappingProxyType
-from typing import Iterable, Mapping, Sequence
+from typing import Iterable, Sequence
 
 # NumPy is mandatory in supported ComfyUI runtimes and defines the seeded
 # wildcard sampling contract. A stdlib fallback would produce different results.
@@ -55,8 +54,6 @@ try:
         DEFAULT_TEST_WILDCARD_TEXT,
         WILDCARD_DIR_NAME,
         WILDCARD_EXTENSIONS,
-        _WildcardSourceFile,
-        _WildcardSourceState,
         default_wildcard_root,
         ensure_default_wildcard_root,
         parse_wildcard_extra_paths,
@@ -69,12 +66,21 @@ except ImportError:
         DEFAULT_TEST_WILDCARD_TEXT,
         WILDCARD_DIR_NAME,
         WILDCARD_EXTENSIONS,
-        _WildcardSourceFile,
-        _WildcardSourceState,
         default_wildcard_root,
         ensure_default_wildcard_root,
         parse_wildcard_extra_paths,
         resolve_wildcard_roots,
+    )
+
+try:
+    from .easyuse_anima.wildcard.snapshot import (
+        _build_wildcard_snapshot,
+        _WildcardSnapshot,
+    )
+except ImportError:
+    from easyuse_anima.wildcard.snapshot import (
+        _build_wildcard_snapshot,
+        _WildcardSnapshot,
     )
 
 
@@ -133,31 +139,6 @@ WILDCARD_QUANTIFIER_RE = re.compile(
 COUNT_SPEC_RE = re.compile(
     r"(?:(?P<fixed>\d+)|(?P<minimum>\d*)\s*-\s*(?P<maximum>\d*))"
 )
-
-
-@dataclass(frozen=True)
-class _WildcardSnapshot:
-    cache_key: tuple
-    mapping: Mapping[str, tuple[WildcardOption, ...]]
-    wildcard_names: tuple[str, ...]
-    roots: tuple[str, ...]
-    files: tuple[_WildcardSourceFile, ...]
-    cacheable: bool
-
-    def public_signature(self) -> dict:
-        return {
-            "roots": list(self.roots),
-            "files": [
-                {
-                    "root": source.root,
-                    "path": source.relative_path,
-                    "mtime_ns": source.mtime_ns,
-                    "size": source.size,
-                }
-                for source in self.files
-            ],
-        }
-
 
 _SNAPSHOT_CACHE_LIMIT = 16
 _SNAPSHOT_CONDITION = threading.Condition()
@@ -438,33 +419,6 @@ def next_seed(seed, control: str) -> int:
 def has_wildcard_syntax(text: str) -> bool:
     value = str(text or "")
     return bool(DYNAMIC_RE.search(value) or WILDCARD_RE.search(value) or WILDCARD_QUANTIFIER_RE.search(value))
-
-
-def _build_wildcard_snapshot(source_state: _WildcardSourceState) -> _WildcardSnapshot:
-    mapping: dict[str, list[WildcardOption]] = {}
-    cacheable = True
-    for source in source_state.files:
-        root = source_state.roots[source.root_index]
-        try:
-            entries = _wildcard_sources._load_wildcard_file(root, source.path)
-        except OSError:
-            cacheable = False
-            continue
-        for key, options in entries.items():
-            if key not in mapping and options:
-                mapping[key] = options
-
-    frozen_mapping = MappingProxyType(
-        {key: tuple(options) for key, options in mapping.items()}
-    )
-    return _WildcardSnapshot(
-        cache_key=source_state.cache_key,
-        mapping=frozen_mapping,
-        wildcard_names=tuple(sorted(frozen_mapping)),
-        roots=tuple(str(root) for root in source_state.roots),
-        files=source_state.files,
-        cacheable=cacheable,
-    )
 
 
 def _wildcard_snapshot(roots: Iterable[Path]) -> _WildcardSnapshot:


### PR DESCRIPTION
## 작업

- Task: D-12c Wildcard snapshot materialization canonical Move
- Parent: D-12 / owner #186
- Behavior prerequisites: #159, #160 complete
- Type: Move
- Base: `dev@6f32f88b3e484a7e14751f8c179daa8758c2fcd5`
- Behavior changes: forbidden

## 변경 요약

- immutable `_WildcardSnapshot` value와 stateless `_build_wildcard_snapshot` materialization을 `easyuse_anima.wildcard.snapshot`으로 이동했습니다.
- root의 두 private name은 identical canonical object에 직접 바인딩해 기존 build patch seam을 유지합니다.
- root `_wildcard_snapshot`, source-state rescan verification, condition/cache/building set/cache limit, single-flight wait/notify, LRU eviction, retry, exception propagation, atomic publication은 그대로 유지합니다.
- list/signature/library/expansion callers, selector/PCG64/seed, expansion behavior는 변경하지 않았습니다.
- canonical snapshot module에는 mutable global이나 root import가 없습니다.
- G-03 enrollment, API/node/bootstrap/frontend/workflow/Registry metadata 변경은 없습니다.

## 주요 파일

- `easyuse_anima/wildcard/snapshot.py`
- `wildcard_engine.py`
- wildcard/package/Registry/analyzer tests 및 analyzer baseline
- `docs/architecture/wildcard-snapshot-materialization-canonical-move.md`
- roadmap 및 compatibility-shim ledger

## 검증

- wildcard behavior/identity/retry/single-flight: 74 passed
- package skeleton: 1 passed
- Registry scanner safety: 8 passed
- Python import boundaries: 16 passed
- backend analyzer: 18 passed
- canonical `snapshot.py` Ruff: 0 findings
- canonical `snapshot.py` Pyright 1.1.411: 0 diagnostics
- official full: Python 1,137 passed; frontend 112 files passed; G-03a 10 groups / 0 violations; existing Pyright baseline 14 errors passed
- `comfy node validate`: passed
- `comfy node pack`: 259 entries; root engine와 canonical wildcard `__init__.py`, `models.py`, `sources.py`, `snapshot.py` 포함 확인
- `git diff --check`: passed

## 테스트 표면

- Repository-owned focused unittest and static contracts
- ComfyUI Codex test environment: official project full runner
- Live ComfyUI/server/browser smoke: not run (Move boundary상 불필요)

## 남은 위험 / 미확인

- snapshot lifecycle/factory/cleanup은 root에 남아 있으며 후속 D-12/E-06 경계입니다.
- selector/seed/expansion canonicalization은 후속 D-12 slice에서 별도로 진행합니다.
- report-only Ruff의 root 기존 top-level import finding은 이 PR 범위에서 확장하지 않았습니다.

상세 symbol/caller/alias/global-state inventory와 allowed-file boundary는 `docs/architecture/wildcard-snapshot-materialization-canonical-move.md`에 기록했습니다.