### PR TITLE
refactor: move wildcard seed control

### DIFF
--- a/docs/architecture/python-backend-execution-roadmap.md
+++ b/docs/architecture/python-backend-execution-roadmap.md
@@ -33,7 +33,7 @@ merged PR, the owning issue's evidence record, and every stated exit gate.
 | A - baseline | Complete; #191 is closed | Keep fixtures and analyzers current during later moves |
 | B - `nodes.py` extraction | Complete in B-11d / PR #356 | Preserve the audited compatibility shim until ADR-002 retirement gates are met |
 | C - feature contracts/behavior | Partially complete through S167-01a / PR #344 | Continue #167 and #169 in separate Contract/Move/Behavior PRs |
-| D - root consolidation | D-01, D-08, D-09, and D-10 complete on `dev`; D-11a/#385, D-11b/#386, D-12a/#387, D-12b/#388, and D-12c/#389 validated | Continue D-12 lifecycle/expansion slices, then D-13; finish D-11 classification only after D-13 removes its root-package dependency |
+| D - root consolidation | D-01, D-08, D-09, and D-10 complete on `dev`; D-11a/#385, D-11b/#386, and D-12a/#387 through D-12d/#390 validated | Continue D-12 mode/selector/lifecycle/expansion slices, then D-13; finish D-11 classification only after D-13 removes its root-package dependency |
 | E - runtime ownership | Partial: E-02a and E-07a/E-07b integrated | Continue #187 only where canonical feature owners and explicit contracts exist |
 | F - typed boundaries | Partial patterns exist | Extend typed request/result/config and pure migration patterns feature by feature |
 | G - quality ratchet | G-01, G-02a/G-02b, and G-03a complete | Extend G-03 enrollment, then continue with G-04 through G-06 |
@@ -408,7 +408,7 @@ mechanical retirement series.
 | 15 | S167 backend seed reservation series | S167-01 through S167-03d COMPLETE on `dev`; S167-03e AiO cutover VALIDATED with isolated API/module/browser-load parity | Contract then Move then Behavior | #167 | Canonical AiO/node seams |
 | 16 | A169 stage pipeline series | A169-01 through A169-08 MERGED; A169-09 final adapter/integration VALIDATED in PR #372 | Contract then Behavior | #169 | Typed config and mechanical AiO move |
 | 17 | A169 first-pass cache policy | COMPLETE through CACHE-06; 4K/batch evidence VALIDATED in PR #380 | Contract then Behavior | #169 | Mechanical cache move and stable stage seam |
-| 18 | D-series canonical root consolidation | D-01 translation, D-08 filesystem, D-09 settings, and D-10 profiles COMPLETE on `dev`; D-11a/#385 and D-11b/#386 autocomplete VALIDATED; D-12a/#387 models, D-12b/#388 sources, and D-12c/#389 snapshot materialization VALIDATED | Move | #186 | Phase B exit; per-feature behavior stable |
+| 18 | D-series canonical root consolidation | D-01 translation, D-08 filesystem, D-09 settings, and D-10 profiles COMPLETE on `dev`; D-11a/#385 and D-11b/#386 autocomplete VALIDATED; D-12a/#387 models through D-12d/#390 seed control VALIDATED | Move | #186 | Phase B exit; per-feature behavior stable |
 | 19 | E-series RuntimeServices/lifecycle | BLOCKED by canonical owners | Move/Contract, split PRs | #187 | Relevant D moves |
 | 20 | G-04 through G-06 and H | INCREMENTAL/LATER | Gate/Contract | #188 | Appropriate package and release evidence |
 
@@ -1346,7 +1346,10 @@ retains snapshot publication/cache/single-flight, selector/seed, and expansion.
 D-12c moves the immutable snapshot value and stateless materialization to
 `easyuse_anima.wildcard.snapshot`; root retains source verification,
 publication/cache/single-flight/retry, all public callers, selector/seed, and
-expansion so E-06 lifecycle ownership remains separate.
+expansion so E-06 lifecycle ownership remains separate. D-12d moves the
+immutable seed-control constants/ranges plus `normalize_seed` and `next_seed`
+to `easyuse_anima.wildcard.seed`; wildcard mode, NumPy/PCG64 selector,
+reservation consumers, and expansion remain root-owned or unchanged.
 
 ## 12. Phase E — Runtime ownership and lifecycle
 

--- a/docs/architecture/python-compatibility-shims.md
+++ b/docs/architecture/python-compatibility-shims.md
@@ -64,7 +64,7 @@ import them.
 | `storage.py` | Explicit direct re-export shim (D-08) | `easyuse_anima.infrastructure.filesystem.atomic_json` and `.paths` | #163, #186 D-08 | Existing 0.5.2 supported module-owned public surface; exact `__all__` and identity fixture | External/legacy imports and storage compatibility tests; production callers use canonical modules | Unscheduled; first canonical+shim release N not yet recorded, then N+1 gate and last-known-good/atomic-write parity |
 | `autocomplete_index.py` | Explicit direct re-export shim (D-11a) | `easyuse_anima.autocomplete.index` | #162, #186 D-11a | Existing indexed-search surface; exact seven-name `__all__` and identity fixture | External/legacy imports; `autocomplete_dataset.py` now uses the canonical owner | Unscheduled; first canonical+shim release N not yet recorded, then N+1 gate and index/ranking/rebuild parity |
 | `autocomplete_dataset.py` | Partial explicit compatibility module after D-11b; prompt classification remains root-owned | `easyuse_anima.autocomplete.dataset` and `.search`; classification target waits for D-13 | #162, #186 D-11 | Existing 0.5.2 dataset/search surface canonicalized in PR #386 with direct identity aliases; final shim waits for root `anima_prompt` removal | External/legacy imports and prompt tests; `api.py` uses canonical dataset/search and root classification | Unscheduled; D-13 dependency removal, final identity surface, N+1 gate, and classification/result/API parity |
-| `wildcard_engine.py` | Partial compatibility module after D-12c; snapshot lifecycle/selector/seed/expansion remain root-owned | `easyuse_anima.wildcard.models`, `.sources`, `.snapshot`, then lifecycle/expansion modules | #184, #186 D-12 | Existing 0.5.2 model/limit surface canonicalized in PR #387, source/path surface in PR #388, and immutable snapshot materialization in PR #389 with direct aliases; later D-12 slices remain | root entrypoint, `nodes.py`, `api.py`, wildcard/workflow tests | Unscheduled; full D-12 move, final identity surface, N+1 gate, and seed/expansion/workflow parity |
+| `wildcard_engine.py` | Partial compatibility module after D-12d; mode/snapshot lifecycle/selector/expansion remain root-owned | `easyuse_anima.wildcard.models`, `.sources`, `.snapshot`, `.seed`, then mode/lifecycle/selection/expansion modules | #184, #186 D-12 | Existing 0.5.2 models in PR #387, sources in #388, snapshot materialization in #389, and seed control in #390 with direct aliases; later D-12 slices remain | root entrypoint, `nodes.py`, `api.py`, wildcard/workflow tests | Unscheduled; full D-12 move, final identity surface, N+1 gate, and seed/expansion/workflow parity |
 | `prompt_translation.py` | Explicit direct re-export shim (D-01) | `easyuse_anima.translation.*` | #164, #186 D-01 | Existing 0.5.2 supported module-owned public surface; exact `__all__` and identity fixture | External/legacy imports and translation compatibility tests; production callers use canonical modules | Unscheduled; first canonical+shim release N not yet recorded, then N+1 gate and provider-off/API parity |
 | `anima_prompt/` package | Current implementation; planned package shim | `easyuse_anima.prompt.anima.*` | #184, #186 D-13 | Existing 0.5.2 surface; convert in D-13/D-14 | `nodes.py`, `autocomplete_dataset.py`, prompt tests | Unscheduled; N+1 gate and prompt correction/parser parity |
 
@@ -1470,11 +1470,13 @@ EasyUseAnimaWildcard
 - D-12c moves immutable `_WildcardSnapshot` and stateless
   `_build_wildcard_snapshot` materialization to
   `easyuse_anima.wildcard.snapshot`.
-- Root binds the 12 model names, eight supported source names, and two private
-  snapshot seams directly to canonical objects. Source verification,
-  snapshot publication/cache/condition/single-flight/retry, selector/seed,
-  expansion, enforcement, and diagnostics remain root-owned for later D-12
-  slices and E-06.
+- D-12d moves the five seed-control names, two seed ranges,
+  `normalize_seed`, and `next_seed` to `easyuse_anima.wildcard.seed`.
+- Root binds the 12 model names, eight supported source names, two private
+  snapshot seams, and nine seed-control names directly to canonical objects.
+  Wildcard mode, source verification, snapshot publication/cache/condition/
+  single-flight/retry, NumPy/PCG64 selector, expansion, enforcement, and
+  diagnostics remain root-owned for later D-12 slices and E-06.
 - Canonical target for the remaining implementation:
   `easyuse_anima.wildcard` sources/snapshot/expansion modules. Snapshot
   lifecycle/factory/cleanup remains E-06.

--- a/docs/architecture/wildcard-seed-control-canonical-move.md
+++ b/docs/architecture/wildcard-seed-control-canonical-move.md
@@ -8,7 +8,7 @@
 - Parent roadmap unit: D-12 Wildcard
 - PR type: Move
 - Baseline: `dev@e9adbe30ec8f7fdf251c515679b142942979f924`
-- State: READY
+- State: VALIDATED
 - Production behavior changes: forbidden
 
 ## Responsibility boundary
@@ -159,3 +159,19 @@ Supporting:
 - canonical seed has zero root/NumPy imports and no mutable globals;
 - official full runner once at the PR checkpoint; and
 - root retains wildcard mode, selector, expansion, and integration callers.
+
+## Validation evidence
+
+- wildcard and seed behavior/identity: 75 tests passed;
+- package skeleton: 1 test passed;
+- Registry scanner safety: 8 tests passed;
+- Python import boundaries: 16 tests passed;
+- backend analyzer: 18 tests passed;
+- canonical `seed.py` Ruff: 0 findings;
+- canonical `seed.py` Pyright 1.1.411: 0 diagnostics;
+- official full: 1,138 Python tests and 112 frontend files passed, G-03a
+  remained 10 completed groups with 0 violations, and the existing 14-error
+  Pyright baseline passed; and
+- local Registry validation passed; the 260-entry archive contained root
+  `wildcard_engine.py` and canonical wildcard `__init__.py`, `models.py`,
+  `seed.py`, `sources.py`, and `snapshot.py`.

--- a/docs/architecture/wildcard-seed-control-canonical-move.md
+++ b/docs/architecture/wildcard-seed-control-canonical-move.md
@@ -1,0 +1,161 @@
+# D-12d Wildcard seed-control canonical Move
+
+- Owner issue: [#186](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/186)
+- Behavior prerequisites:
+  [#159](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/159) and
+  [#160](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/160) — complete
+- Roadmap unit: D-12d
+- Parent roadmap unit: D-12 Wildcard
+- PR type: Move
+- Baseline: `dev@e9adbe30ec8f7fdf251c515679b142942979f924`
+- State: READY
+- Production behavior changes: forbidden
+
+## Responsibility boundary
+
+D-12d moves only the wildcard seed-control leaf to:
+
+- `easyuse_anima.wildcard.seed`.
+
+The leaf defines the accepted backend seed domain, browser-safe next-seed
+domain, after-generate control values, seed normalization, and next-seed
+transition. It does not choose wildcard options or expand text.
+
+Wildcard mode normalization, `_Selector`, NumPy/PCG64 ownership, parsing,
+snapshot lifecycle, expansion, node adapters, and browser reservation
+compatibility remain in their current owners. This avoids coupling the seed
+Move to the package skeleton's no-eager-NumPy gate or to Behavior work.
+
+## Supported moved surface
+
+Seed-control constants:
+
+- `SEED_CONTROL_FIXED`;
+- `SEED_CONTROL_RANDOMIZE`;
+- `SEED_CONTROL_INCREMENT`;
+- `SEED_CONTROL_DECREMENT`; and
+- `SEED_CONTROL_MODES`.
+
+Seed ranges:
+
+- `MAX_SEED`; and
+- `PUBLIC_MAX_SEED`.
+
+Functions:
+
+- `normalize_seed`; and
+- `next_seed`.
+
+Root `wildcard_engine.py` binds every moved supported name directly to the
+identical canonical object. No wrapper, proxy, duplicate constant, `import *`,
+or lazy module hook is allowed.
+
+## Caller and alias inventory
+
+Root runtime callers:
+
+- `_Selector.__init__` normalizes its execution seed;
+- `expand_wildcard_texts` normalizes the requested seed before selector
+  creation; and
+- root public and compatibility consumers import seed names from
+  `wildcard_engine`.
+
+Production consumers through root:
+
+- root `nodes.py` explicit compatibility imports;
+- `easyuse_anima.nodes.wildcard_nodes`;
+- Prompt Studio node adapters and their call-time root wrappers;
+- `easyuse_anima.seed.compatibility` reservation validation; and
+- existing workflow/node input definitions.
+
+D-12d does not cut these callers over. Root direct aliases preserve their
+identity and behavior while later D-12 slices decide mode, selector, and final
+consumer ownership together.
+
+Tests:
+
+- wildcard seed contract tests keep range, legacy uint64, fixed, randomize,
+  increment, and decrement behavior;
+- the `SystemRandom` patch moves from root to canonical seed ownership;
+- exact root/canonical identity is added; and
+- package skeleton, Registry scanner, and backend analyzer include the
+  canonical module.
+
+## Global-state inventory
+
+D-12d moves no mutable runtime state.
+
+Canonical seed contains only:
+
+- immutable strings;
+- an immutable control tuple;
+- immutable integer range constants;
+- stateless normalization/transition functions; and
+- the standard-library `random` module binding used only by `next_seed`.
+
+It creates no mutable container, cache, lock, condition, singleton, selector,
+PRNG instance, background task, factory, or cleanup hook. `SystemRandom` is
+instantiated per randomize call exactly as before.
+
+Root retains:
+
+- wildcard mode constants and mutable alias lookup;
+- `_Selector` and NumPy/PCG64 construction;
+- snapshot/cache lifecycle;
+- expansion state and lanes; and
+- all node/workflow integration.
+
+## Compatibility and behavior invariants
+
+- `normalize_seed` still coerces through `int`, maps `TypeError`/`ValueError`
+  to zero, clamps below zero to zero, and clamps above uint64 max;
+- existing uint64 workflow seeds remain accepted by Python;
+- fixed preserves the normalized current seed, including values above the
+  JavaScript-safe range;
+- randomize creates a fresh `SystemRandom` and samples the inclusive
+  `0..PUBLIC_MAX_SEED` domain;
+- increment and decrement first project legacy values into the public domain,
+  then preserve existing wrap behavior;
+- unknown controls return the normalized current seed;
+- control values, tuple order, range values, function signatures, return
+  types, and exception behavior are unchanged;
+- root import identity and node/workflow serialization behavior are unchanged;
+- wildcard mode, selector/PCG64, expansion, snapshot, diagnostics, API, nodes,
+  frontend, and reservation behavior are unchanged; and
+- canonical seed imports no root module and no NumPy.
+
+## Allowed-file boundary
+
+Production:
+
+- root `wildcard_engine.py`; and
+- new `easyuse_anima/wildcard/seed.py`.
+
+Supporting:
+
+- wildcard seed identity/behavior tests;
+- package skeleton, Registry scanner, backend analyzer, and exact fixture;
+- this inventory, compatibility-shim ledger, and execution roadmap.
+
+## Forbidden
+
+- wildcard mode constants, labels, aliases, or normalization changes;
+- `_Selector` or NumPy/PCG64 movement/import-timing changes;
+- seed reservation, adapter, node, workflow, or frontend caller cutover;
+- random algorithm, domain, timing, or control behavior changes;
+- source, snapshot, cache, expansion, budget, or diagnostics changes;
+- G-03 completed-package enrollment before full D-12 completion;
+- API, bootstrap, Registry metadata, release, or instance changes; and
+- server, browser, live-instance, model, provider, or network execution.
+
+## Validation and exit
+
+- exact root/canonical identity for all nine moved supported names;
+- existing seed normalization and transition tests remain unchanged;
+- canonical `SystemRandom` patch proves the randomize range without real
+  entropy dependence;
+- package skeleton, Registry scanner, backend analyzer, and packed archive
+  include canonical `seed.py`;
+- canonical seed has zero root/NumPy imports and no mutable globals;
+- official full runner once at the PR checkpoint; and
+- root retains wildcard mode, selector, expansion, and integration callers.

--- a/easyuse_anima/wildcard/seed.py
+++ b/easyuse_anima/wildcard/seed.py
@@ -1,0 +1,62 @@
+"""Wildcard seed domains and after-generate transitions."""
+
+from __future__ import annotations
+
+import random
+
+SEED_CONTROL_FIXED = "fixed"
+SEED_CONTROL_RANDOMIZE = "randomize"
+SEED_CONTROL_INCREMENT = "increment"
+SEED_CONTROL_DECREMENT = "decrement"
+SEED_CONTROL_MODES = (
+    SEED_CONTROL_FIXED,
+    SEED_CONTROL_RANDOMIZE,
+    SEED_CONTROL_INCREMENT,
+    SEED_CONTROL_DECREMENT,
+)
+
+MAX_SEED = 0xFFFFFFFFFFFFFFFF
+PUBLIC_MAX_SEED = (1 << 53) - 1
+
+__all__ = (
+    "SEED_CONTROL_FIXED",
+    "SEED_CONTROL_RANDOMIZE",
+    "SEED_CONTROL_INCREMENT",
+    "SEED_CONTROL_DECREMENT",
+    "SEED_CONTROL_MODES",
+    "MAX_SEED",
+    "PUBLIC_MAX_SEED",
+    "normalize_seed",
+    "next_seed",
+)
+
+
+def normalize_seed(value) -> int:
+    try:
+        seed = int(value)
+    except (TypeError, ValueError):
+        seed = 0
+    return max(0, min(MAX_SEED, seed))
+
+
+def next_seed(seed, control: str) -> int:
+    """Return the next public wildcard seed without breaking legacy inputs.
+
+    Existing workflows may contain uint64 values that JavaScript cannot
+    represent exactly. The current generation still consumes that legacy
+    value, and ``fixed`` preserves it. Controls that advance the state first
+    project the value onto the public JavaScript-safe range so every returned
+    non-fixed seed uses the same inclusive range in Python and JavaScript.
+    """
+    seed = normalize_seed(seed)
+    control = str(control or SEED_CONTROL_FIXED).strip()
+    if control == SEED_CONTROL_FIXED:
+        return seed
+    if control == SEED_CONTROL_RANDOMIZE:
+        return random.SystemRandom().randrange(0, PUBLIC_MAX_SEED + 1)
+    public_seed = min(seed, PUBLIC_MAX_SEED)
+    if control == SEED_CONTROL_INCREMENT:
+        return 0 if public_seed >= PUBLIC_MAX_SEED else public_seed + 1
+    if control == SEED_CONTROL_DECREMENT:
+        return PUBLIC_MAX_SEED if public_seed <= 0 else public_seed - 1
+    return seed

--- a/tests/fixtures/python_backend_baseline.json
+++ b/tests/fixtures/python_backend_baseline.json
@@ -27345,6 +27345,57 @@
         "requested": "__future__",
         "role": "ordinary",
         "scope": "<module>",
+        "source": "easyuse_anima/wildcard/seed.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "random",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "random",
+        "kind": "static_import",
+        "line": 5,
+        "name": null,
+        "optional": false,
+        "requested": "random",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/wildcard/seed.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "annotations",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "__future__:annotations",
+        "kind": "static_from",
+        "line": 3,
+        "name": "annotations",
+        "optional": false,
+        "requested": "__future__",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/wildcard/snapshot.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "Mapping",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "collections.abc:Mapping",
+        "kind": "static_from",
+        "line": 5,
+        "name": "Mapping",
+        "optional": false,
+        "requested": "collections.abc",
+        "role": "ordinary",
+        "scope": "<module>",
         "source": "easyuse_anima/wildcard/snapshot.py"
       },
       {
@@ -27356,7 +27407,7 @@
         "conditional": false,
         "imported": "dataclasses:dataclass",
         "kind": "static_from",
-        "line": 5,
+        "line": 6,
         "name": "dataclass",
         "optional": false,
         "requested": "dataclasses",
@@ -27373,27 +27424,10 @@
         "conditional": false,
         "imported": "types:MappingProxyType",
         "kind": "static_from",
-        "line": 6,
+        "line": 7,
         "name": "MappingProxyType",
         "optional": false,
         "requested": "types",
-        "role": "ordinary",
-        "scope": "<module>",
-        "source": "easyuse_anima/wildcard/snapshot.py"
-      },
-      {
-        "alias": null,
-        "bound_name": "Mapping",
-        "branch_context": [],
-        "classification": "external",
-        "column": 0,
-        "conditional": false,
-        "imported": "typing:Mapping",
-        "kind": "static_from",
-        "line": 7,
-        "name": "Mapping",
-        "optional": false,
-        "requested": "typing",
         "role": "ordinary",
         "scope": "<module>",
         "source": "easyuse_anima/wildcard/snapshot.py"
@@ -53613,23 +53647,6 @@
       },
       {
         "alias": null,
-        "bound_name": "random",
-        "branch_context": [],
-        "classification": "external",
-        "column": 0,
-        "conditional": false,
-        "imported": "random",
-        "kind": "static_import",
-        "line": 8,
-        "name": null,
-        "optional": false,
-        "requested": "random",
-        "role": "ordinary",
-        "scope": "<module>",
-        "source": "wildcard_engine.py"
-      },
-      {
-        "alias": null,
         "bound_name": "re",
         "branch_context": [],
         "classification": "external",
@@ -53637,7 +53654,7 @@
         "conditional": false,
         "imported": "re",
         "kind": "static_import",
-        "line": 9,
+        "line": 8,
         "name": null,
         "optional": false,
         "requested": "re",
@@ -53654,7 +53671,7 @@
         "conditional": false,
         "imported": "threading",
         "kind": "static_import",
-        "line": 10,
+        "line": 9,
         "name": null,
         "optional": false,
         "requested": "threading",
@@ -53671,7 +53688,7 @@
         "conditional": false,
         "imported": "dataclasses:dataclass",
         "kind": "static_from",
-        "line": 11,
+        "line": 10,
         "name": "dataclass",
         "optional": false,
         "requested": "dataclasses",
@@ -53688,7 +53705,7 @@
         "conditional": false,
         "imported": "pathlib:Path",
         "kind": "static_from",
-        "line": 12,
+        "line": 11,
         "name": "Path",
         "optional": false,
         "requested": "pathlib",
@@ -53705,7 +53722,7 @@
         "conditional": false,
         "imported": "typing:Iterable",
         "kind": "static_from",
-        "line": 13,
+        "line": 12,
         "name": "Iterable",
         "optional": false,
         "requested": "typing",
@@ -53722,7 +53739,7 @@
         "conditional": false,
         "imported": "typing:Sequence",
         "kind": "static_from",
-        "line": 13,
+        "line": 12,
         "name": "Sequence",
         "optional": false,
         "requested": "typing",
@@ -53739,7 +53756,7 @@
         "conditional": false,
         "imported": "numpy",
         "kind": "static_import",
-        "line": 17,
+        "line": 16,
         "name": null,
         "optional": false,
         "requested": "numpy",
@@ -53756,7 +53773,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 19
+            "line": 18
           }
         ],
         "classification": "internal",
@@ -53764,12 +53781,12 @@
         "compatibility_pair": {
           "bound_name": "DEFAULT_MAX_EXPANSION_DEPTH",
           "target": "easyuse_anima/wildcard/models.py",
-          "try_line": 19
+          "try_line": 18
         },
         "conditional": true,
         "imported": ".easyuse_anima.wildcard.models:DEFAULT_MAX_EXPANSION_DEPTH",
         "kind": "static_from",
-        "line": 20,
+        "line": 19,
         "name": "DEFAULT_MAX_EXPANSION_DEPTH",
         "optional": false,
         "requested": ".easyuse_anima.wildcard.models",
@@ -53787,7 +53804,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 19
+            "line": 18
           }
         ],
         "classification": "internal",
@@ -53795,12 +53812,12 @@
         "compatibility_pair": {
           "bound_name": "DEFAULT_MAX_EXPANSION_GROWTH_PER_PASS",
           "target": "easyuse_anima/wildcard/models.py",
-          "try_line": 19
+          "try_line": 18
         },
         "conditional": true,
         "imported": ".easyuse_anima.wildcard.models:DEFAULT_MAX_EXPANSION_GROWTH_PER_PASS",
         "kind": "static_from",
-        "line": 20,
+        "line": 19,
         "name": "DEFAULT_MAX_EXPANSION_GROWTH_PER_PASS",
         "optional": false,
         "requested": ".easyuse_anima.wildcard.models",
@@ -53818,7 +53835,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 19
+            "line": 18
           }
         ],
         "classification": "internal",
@@ -53826,12 +53843,12 @@
         "compatibility_pair": {
           "bound_name": "DEFAULT_MAX_EXPANSION_OUTPUT_CHARS",
           "target": "easyuse_anima/wildcard/models.py",
-          "try_line": 19
+          "try_line": 18
         },
         "conditional": true,
         "imported": ".easyuse_anima.wildcard.models:DEFAULT_MAX_EXPANSION_OUTPUT_CHARS",
         "kind": "static_from",
-        "line": 20,
+        "line": 19,
         "name": "DEFAULT_MAX_EXPANSION_OUTPUT_CHARS",
         "optional": false,
         "requested": ".easyuse_anima.wildcard.models",
@@ -53849,7 +53866,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 19
+            "line": 18
           }
         ],
         "classification": "internal",
@@ -53857,12 +53874,12 @@
         "compatibility_pair": {
           "bound_name": "DEFAULT_MAX_EXPANSION_REPLACEMENTS",
           "target": "easyuse_anima/wildcard/models.py",
-          "try_line": 19
+          "try_line": 18
         },
         "conditional": true,
         "imported": ".easyuse_anima.wildcard.models:DEFAULT_MAX_EXPANSION_REPLACEMENTS",
         "kind": "static_from",
-        "line": 20,
+        "line": 19,
         "name": "DEFAULT_MAX_EXPANSION_REPLACEMENTS",
         "optional": false,
         "requested": ".easyuse_anima.wildcard.models",
@@ -53880,7 +53897,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 19
+            "line": 18
           }
         ],
         "classification": "internal",
@@ -53888,12 +53905,12 @@
         "compatibility_pair": {
           "bound_name": "MAX_EXPANSION_DEPTH",
           "target": "easyuse_anima/wildcard/models.py",
-          "try_line": 19
+          "try_line": 18
         },
         "conditional": true,
         "imported": ".easyuse_anima.wildcard.models:MAX_EXPANSION_DEPTH",
         "kind": "static_from",
-        "line": 20,
+        "line": 19,
         "name": "MAX_EXPANSION_DEPTH",
         "optional": false,
         "requested": ".easyuse_anima.wildcard.models",
@@ -53911,7 +53928,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 19
+            "line": 18
           }
         ],
         "classification": "internal",
@@ -53919,12 +53936,12 @@
         "compatibility_pair": {
           "bound_name": "MAX_EXPANSION_GROWTH_PER_PASS",
           "target": "easyuse_anima/wildcard/models.py",
-          "try_line": 19
+          "try_line": 18
         },
         "conditional": true,
         "imported": ".easyuse_anima.wildcard.models:MAX_EXPANSION_GROWTH_PER_PASS",
         "kind": "static_from",
-        "line": 20,
+        "line": 19,
         "name": "MAX_EXPANSION_GROWTH_PER_PASS",
         "optional": false,
         "requested": ".easyuse_anima.wildcard.models",
@@ -53942,7 +53959,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 19
+            "line": 18
           }
         ],
         "classification": "internal",
@@ -53950,12 +53967,12 @@
         "compatibility_pair": {
           "bound_name": "MAX_EXPANSION_OUTPUT_CHARS",
           "target": "easyuse_anima/wildcard/models.py",
-          "try_line": 19
+          "try_line": 18
         },
         "conditional": true,
         "imported": ".easyuse_anima.wildcard.models:MAX_EXPANSION_OUTPUT_CHARS",
         "kind": "static_from",
-        "line": 20,
+        "line": 19,
         "name": "MAX_EXPANSION_OUTPUT_CHARS",
         "optional": false,
         "requested": ".easyuse_anima.wildcard.models",
@@ -53973,7 +53990,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 19
+            "line": 18
           }
         ],
         "classification": "internal",
@@ -53981,12 +53998,12 @@
         "compatibility_pair": {
           "bound_name": "MAX_EXPANSION_REPLACEMENTS",
           "target": "easyuse_anima/wildcard/models.py",
-          "try_line": 19
+          "try_line": 18
         },
         "conditional": true,
         "imported": ".easyuse_anima.wildcard.models:MAX_EXPANSION_REPLACEMENTS",
         "kind": "static_from",
-        "line": 20,
+        "line": 19,
         "name": "MAX_EXPANSION_REPLACEMENTS",
         "optional": false,
         "requested": ".easyuse_anima.wildcard.models",
@@ -54004,7 +54021,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 19
+            "line": 18
           }
         ],
         "classification": "internal",
@@ -54012,12 +54029,12 @@
         "compatibility_pair": {
           "bound_name": "REPLACE_DEPTH",
           "target": "easyuse_anima/wildcard/models.py",
-          "try_line": 19
+          "try_line": 18
         },
         "conditional": true,
         "imported": ".easyuse_anima.wildcard.models:REPLACE_DEPTH",
         "kind": "static_from",
-        "line": 20,
+        "line": 19,
         "name": "REPLACE_DEPTH",
         "optional": false,
         "requested": ".easyuse_anima.wildcard.models",
@@ -54035,7 +54052,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 19
+            "line": 18
           }
         ],
         "classification": "internal",
@@ -54043,12 +54060,12 @@
         "compatibility_pair": {
           "bound_name": "WildcardExpansionBudget",
           "target": "easyuse_anima/wildcard/models.py",
-          "try_line": 19
+          "try_line": 18
         },
         "conditional": true,
         "imported": ".easyuse_anima.wildcard.models:WildcardExpansionBudget",
         "kind": "static_from",
-        "line": 20,
+        "line": 19,
         "name": "WildcardExpansionBudget",
         "optional": false,
         "requested": ".easyuse_anima.wildcard.models",
@@ -54066,7 +54083,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 19
+            "line": 18
           }
         ],
         "classification": "internal",
@@ -54074,12 +54091,12 @@
         "compatibility_pair": {
           "bound_name": "WildcardExpansionResult",
           "target": "easyuse_anima/wildcard/models.py",
-          "try_line": 19
+          "try_line": 18
         },
         "conditional": true,
         "imported": ".easyuse_anima.wildcard.models:WildcardExpansionResult",
         "kind": "static_from",
-        "line": 20,
+        "line": 19,
         "name": "WildcardExpansionResult",
         "optional": false,
         "requested": ".easyuse_anima.wildcard.models",
@@ -54097,7 +54114,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 19
+            "line": 18
           }
         ],
         "classification": "internal",
@@ -54105,12 +54122,12 @@
         "compatibility_pair": {
           "bound_name": "WildcardOption",
           "target": "easyuse_anima/wildcard/models.py",
-          "try_line": 19
+          "try_line": 18
         },
         "conditional": true,
         "imported": ".easyuse_anima.wildcard.models:WildcardOption",
         "kind": "static_from",
-        "line": 20,
+        "line": 19,
         "name": "WildcardOption",
         "optional": false,
         "requested": ".easyuse_anima.wildcard.models",
@@ -54129,9 +54146,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 34,
+            "handler_line": 33,
             "kind": "try",
-            "line": 19
+            "line": 18
           }
         ],
         "classification": "compatibility_fallback",
@@ -54139,12 +54156,12 @@
         "compatibility_pair": {
           "bound_name": "DEFAULT_MAX_EXPANSION_DEPTH",
           "target": "easyuse_anima/wildcard/models.py",
-          "try_line": 19
+          "try_line": 18
         },
         "conditional": true,
         "imported": "easyuse_anima.wildcard.models:DEFAULT_MAX_EXPANSION_DEPTH",
         "kind": "static_from",
-        "line": 35,
+        "line": 34,
         "name": "DEFAULT_MAX_EXPANSION_DEPTH",
         "optional": false,
         "requested": "easyuse_anima.wildcard.models",
@@ -54163,9 +54180,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 34,
+            "handler_line": 33,
             "kind": "try",
-            "line": 19
+            "line": 18
           }
         ],
         "classification": "compatibility_fallback",
@@ -54173,12 +54190,12 @@
         "compatibility_pair": {
           "bound_name": "DEFAULT_MAX_EXPANSION_GROWTH_PER_PASS",
           "target": "easyuse_anima/wildcard/models.py",
-          "try_line": 19
+          "try_line": 18
         },
         "conditional": true,
         "imported": "easyuse_anima.wildcard.models:DEFAULT_MAX_EXPANSION_GROWTH_PER_PASS",
         "kind": "static_from",
-        "line": 35,
+        "line": 34,
         "name": "DEFAULT_MAX_EXPANSION_GROWTH_PER_PASS",
         "optional": false,
         "requested": "easyuse_anima.wildcard.models",
@@ -54197,9 +54214,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 34,
+            "handler_line": 33,
             "kind": "try",
-            "line": 19
+            "line": 18
           }
         ],
         "classification": "compatibility_fallback",
@@ -54207,12 +54224,12 @@
         "compatibility_pair": {
           "bound_name": "DEFAULT_MAX_EXPANSION_OUTPUT_CHARS",
           "target": "easyuse_anima/wildcard/models.py",
-          "try_line": 19
+          "try_line": 18
         },
         "conditional": true,
         "imported": "easyuse_anima.wildcard.models:DEFAULT_MAX_EXPANSION_OUTPUT_CHARS",
         "kind": "static_from",
-        "line": 35,
+        "line": 34,
         "name": "DEFAULT_MAX_EXPANSION_OUTPUT_CHARS",
         "optional": false,
         "requested": "easyuse_anima.wildcard.models",
@@ -54231,9 +54248,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 34,
+            "handler_line": 33,
             "kind": "try",
-            "line": 19
+            "line": 18
           }
         ],
         "classification": "compatibility_fallback",
@@ -54241,12 +54258,12 @@
         "compatibility_pair": {
           "bound_name": "DEFAULT_MAX_EXPANSION_REPLACEMENTS",
           "target": "easyuse_anima/wildcard/models.py",
-          "try_line": 19
+          "try_line": 18
         },
         "conditional": true,
         "imported": "easyuse_anima.wildcard.models:DEFAULT_MAX_EXPANSION_REPLACEMENTS",
         "kind": "static_from",
-        "line": 35,
+        "line": 34,
         "name": "DEFAULT_MAX_EXPANSION_REPLACEMENTS",
         "optional": false,
         "requested": "easyuse_anima.wildcard.models",
@@ -54265,9 +54282,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 34,
+            "handler_line": 33,
             "kind": "try",
-            "line": 19
+            "line": 18
           }
         ],
         "classification": "compatibility_fallback",
@@ -54275,12 +54292,12 @@
         "compatibility_pair": {
           "bound_name": "MAX_EXPANSION_DEPTH",
           "target": "easyuse_anima/wildcard/models.py",
-          "try_line": 19
+          "try_line": 18
         },
         "conditional": true,
         "imported": "easyuse_anima.wildcard.models:MAX_EXPANSION_DEPTH",
         "kind": "static_from",
-        "line": 35,
+        "line": 34,
         "name": "MAX_EXPANSION_DEPTH",
         "optional": false,
         "requested": "easyuse_anima.wildcard.models",
@@ -54299,9 +54316,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 34,
+            "handler_line": 33,
             "kind": "try",
-            "line": 19
+            "line": 18
           }
         ],
         "classification": "compatibility_fallback",
@@ -54309,12 +54326,12 @@
         "compatibility_pair": {
           "bound_name": "MAX_EXPANSION_GROWTH_PER_PASS",
           "target": "easyuse_anima/wildcard/models.py",
-          "try_line": 19
+          "try_line": 18
         },
         "conditional": true,
         "imported": "easyuse_anima.wildcard.models:MAX_EXPANSION_GROWTH_PER_PASS",
         "kind": "static_from",
-        "line": 35,
+        "line": 34,
         "name": "MAX_EXPANSION_GROWTH_PER_PASS",
         "optional": false,
         "requested": "easyuse_anima.wildcard.models",
@@ -54333,9 +54350,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 34,
+            "handler_line": 33,
             "kind": "try",
-            "line": 19
+            "line": 18
           }
         ],
         "classification": "compatibility_fallback",
@@ -54343,12 +54360,12 @@
         "compatibility_pair": {
           "bound_name": "MAX_EXPANSION_OUTPUT_CHARS",
           "target": "easyuse_anima/wildcard/models.py",
-          "try_line": 19
+          "try_line": 18
         },
         "conditional": true,
         "imported": "easyuse_anima.wildcard.models:MAX_EXPANSION_OUTPUT_CHARS",
         "kind": "static_from",
-        "line": 35,
+        "line": 34,
         "name": "MAX_EXPANSION_OUTPUT_CHARS",
         "optional": false,
         "requested": "easyuse_anima.wildcard.models",
@@ -54367,9 +54384,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 34,
+            "handler_line": 33,
             "kind": "try",
-            "line": 19
+            "line": 18
           }
         ],
         "classification": "compatibility_fallback",
@@ -54377,12 +54394,12 @@
         "compatibility_pair": {
           "bound_name": "MAX_EXPANSION_REPLACEMENTS",
           "target": "easyuse_anima/wildcard/models.py",
-          "try_line": 19
+          "try_line": 18
         },
         "conditional": true,
         "imported": "easyuse_anima.wildcard.models:MAX_EXPANSION_REPLACEMENTS",
         "kind": "static_from",
-        "line": 35,
+        "line": 34,
         "name": "MAX_EXPANSION_REPLACEMENTS",
         "optional": false,
         "requested": "easyuse_anima.wildcard.models",
@@ -54401,9 +54418,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 34,
+            "handler_line": 33,
             "kind": "try",
-            "line": 19
+            "line": 18
           }
         ],
         "classification": "compatibility_fallback",
@@ -54411,12 +54428,12 @@
         "compatibility_pair": {
           "bound_name": "REPLACE_DEPTH",
           "target": "easyuse_anima/wildcard/models.py",
-          "try_line": 19
+          "try_line": 18
         },
         "conditional": true,
         "imported": "easyuse_anima.wildcard.models:REPLACE_DEPTH",
         "kind": "static_from",
-        "line": 35,
+        "line": 34,
         "name": "REPLACE_DEPTH",
         "optional": false,
         "requested": "easyuse_anima.wildcard.models",
@@ -54435,9 +54452,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 34,
+            "handler_line": 33,
             "kind": "try",
-            "line": 19
+            "line": 18
           }
         ],
         "classification": "compatibility_fallback",
@@ -54445,12 +54462,12 @@
         "compatibility_pair": {
           "bound_name": "WildcardExpansionBudget",
           "target": "easyuse_anima/wildcard/models.py",
-          "try_line": 19
+          "try_line": 18
         },
         "conditional": true,
         "imported": "easyuse_anima.wildcard.models:WildcardExpansionBudget",
         "kind": "static_from",
-        "line": 35,
+        "line": 34,
         "name": "WildcardExpansionBudget",
         "optional": false,
         "requested": "easyuse_anima.wildcard.models",
@@ -54469,9 +54486,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 34,
+            "handler_line": 33,
             "kind": "try",
-            "line": 19
+            "line": 18
           }
         ],
         "classification": "compatibility_fallback",
@@ -54479,12 +54496,12 @@
         "compatibility_pair": {
           "bound_name": "WildcardExpansionResult",
           "target": "easyuse_anima/wildcard/models.py",
-          "try_line": 19
+          "try_line": 18
         },
         "conditional": true,
         "imported": "easyuse_anima.wildcard.models:WildcardExpansionResult",
         "kind": "static_from",
-        "line": 35,
+        "line": 34,
         "name": "WildcardExpansionResult",
         "optional": false,
         "requested": "easyuse_anima.wildcard.models",
@@ -54503,9 +54520,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 34,
+            "handler_line": 33,
             "kind": "try",
-            "line": 19
+            "line": 18
           }
         ],
         "classification": "compatibility_fallback",
@@ -54513,12 +54530,12 @@
         "compatibility_pair": {
           "bound_name": "WildcardOption",
           "target": "easyuse_anima/wildcard/models.py",
-          "try_line": 19
+          "try_line": 18
         },
         "conditional": true,
         "imported": "easyuse_anima.wildcard.models:WildcardOption",
         "kind": "static_from",
-        "line": 35,
+        "line": 34,
         "name": "WildcardOption",
         "optional": false,
         "requested": "easyuse_anima.wildcard.models",
@@ -54536,7 +54553,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 50
+            "line": 49
           }
         ],
         "classification": "internal",
@@ -54544,12 +54561,12 @@
         "compatibility_pair": {
           "bound_name": "_wildcard_sources",
           "target": "easyuse_anima/wildcard/sources.py",
-          "try_line": 50
+          "try_line": 49
         },
         "conditional": true,
         "imported": ".easyuse_anima.wildcard:sources",
         "kind": "static_from",
-        "line": 51,
+        "line": 50,
         "name": "sources",
         "optional": false,
         "requested": ".easyuse_anima.wildcard",
@@ -54567,7 +54584,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 50
+            "line": 49
           }
         ],
         "classification": "internal",
@@ -54575,12 +54592,12 @@
         "compatibility_pair": {
           "bound_name": "DEFAULT_TEST_WILDCARD_FILE",
           "target": "easyuse_anima/wildcard/sources.py",
-          "try_line": 50
+          "try_line": 49
         },
         "conditional": true,
         "imported": ".easyuse_anima.wildcard.sources:DEFAULT_TEST_WILDCARD_FILE",
         "kind": "static_from",
-        "line": 52,
+        "line": 51,
         "name": "DEFAULT_TEST_WILDCARD_FILE",
         "optional": false,
         "requested": ".easyuse_anima.wildcard.sources",
@@ -54598,7 +54615,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 50
+            "line": 49
           }
         ],
         "classification": "internal",
@@ -54606,12 +54623,12 @@
         "compatibility_pair": {
           "bound_name": "DEFAULT_TEST_WILDCARD_TEXT",
           "target": "easyuse_anima/wildcard/sources.py",
-          "try_line": 50
+          "try_line": 49
         },
         "conditional": true,
         "imported": ".easyuse_anima.wildcard.sources:DEFAULT_TEST_WILDCARD_TEXT",
         "kind": "static_from",
-        "line": 52,
+        "line": 51,
         "name": "DEFAULT_TEST_WILDCARD_TEXT",
         "optional": false,
         "requested": ".easyuse_anima.wildcard.sources",
@@ -54629,7 +54646,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 50
+            "line": 49
           }
         ],
         "classification": "internal",
@@ -54637,12 +54654,12 @@
         "compatibility_pair": {
           "bound_name": "WILDCARD_DIR_NAME",
           "target": "easyuse_anima/wildcard/sources.py",
-          "try_line": 50
+          "try_line": 49
         },
         "conditional": true,
         "imported": ".easyuse_anima.wildcard.sources:WILDCARD_DIR_NAME",
         "kind": "static_from",
-        "line": 52,
+        "line": 51,
         "name": "WILDCARD_DIR_NAME",
         "optional": false,
         "requested": ".easyuse_anima.wildcard.sources",
@@ -54660,7 +54677,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 50
+            "line": 49
           }
         ],
         "classification": "internal",
@@ -54668,12 +54685,12 @@
         "compatibility_pair": {
           "bound_name": "WILDCARD_EXTENSIONS",
           "target": "easyuse_anima/wildcard/sources.py",
-          "try_line": 50
+          "try_line": 49
         },
         "conditional": true,
         "imported": ".easyuse_anima.wildcard.sources:WILDCARD_EXTENSIONS",
         "kind": "static_from",
-        "line": 52,
+        "line": 51,
         "name": "WILDCARD_EXTENSIONS",
         "optional": false,
         "requested": ".easyuse_anima.wildcard.sources",
@@ -54691,7 +54708,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 50
+            "line": 49
           }
         ],
         "classification": "internal",
@@ -54699,12 +54716,12 @@
         "compatibility_pair": {
           "bound_name": "default_wildcard_root",
           "target": "easyuse_anima/wildcard/sources.py",
-          "try_line": 50
+          "try_line": 49
         },
         "conditional": true,
         "imported": ".easyuse_anima.wildcard.sources:default_wildcard_root",
         "kind": "static_from",
-        "line": 52,
+        "line": 51,
         "name": "default_wildcard_root",
         "optional": false,
         "requested": ".easyuse_anima.wildcard.sources",
@@ -54722,7 +54739,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 50
+            "line": 49
           }
         ],
         "classification": "internal",
@@ -54730,12 +54747,12 @@
         "compatibility_pair": {
           "bound_name": "ensure_default_wildcard_root",
           "target": "easyuse_anima/wildcard/sources.py",
-          "try_line": 50
+          "try_line": 49
         },
         "conditional": true,
         "imported": ".easyuse_anima.wildcard.sources:ensure_default_wildcard_root",
         "kind": "static_from",
-        "line": 52,
+        "line": 51,
         "name": "ensure_default_wildcard_root",
         "optional": false,
         "requested": ".easyuse_anima.wildcard.sources",
@@ -54753,7 +54770,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 50
+            "line": 49
           }
         ],
         "classification": "internal",
@@ -54761,12 +54778,12 @@
         "compatibility_pair": {
           "bound_name": "parse_wildcard_extra_paths",
           "target": "easyuse_anima/wildcard/sources.py",
-          "try_line": 50
+          "try_line": 49
         },
         "conditional": true,
         "imported": ".easyuse_anima.wildcard.sources:parse_wildcard_extra_paths",
         "kind": "static_from",
-        "line": 52,
+        "line": 51,
         "name": "parse_wildcard_extra_paths",
         "optional": false,
         "requested": ".easyuse_anima.wildcard.sources",
@@ -54784,7 +54801,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 50
+            "line": 49
           }
         ],
         "classification": "internal",
@@ -54792,12 +54809,12 @@
         "compatibility_pair": {
           "bound_name": "resolve_wildcard_roots",
           "target": "easyuse_anima/wildcard/sources.py",
-          "try_line": 50
+          "try_line": 49
         },
         "conditional": true,
         "imported": ".easyuse_anima.wildcard.sources:resolve_wildcard_roots",
         "kind": "static_from",
-        "line": 52,
+        "line": 51,
         "name": "resolve_wildcard_roots",
         "optional": false,
         "requested": ".easyuse_anima.wildcard.sources",
@@ -54816,9 +54833,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 62,
+            "handler_line": 61,
             "kind": "try",
-            "line": 50
+            "line": 49
           }
         ],
         "classification": "compatibility_fallback",
@@ -54826,12 +54843,12 @@
         "compatibility_pair": {
           "bound_name": "_wildcard_sources",
           "target": "easyuse_anima/wildcard/sources.py",
-          "try_line": 50
+          "try_line": 49
         },
         "conditional": true,
         "imported": "easyuse_anima.wildcard:sources",
         "kind": "static_from",
-        "line": 63,
+        "line": 62,
         "name": "sources",
         "optional": false,
         "requested": "easyuse_anima.wildcard",
@@ -54850,9 +54867,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 62,
+            "handler_line": 61,
             "kind": "try",
-            "line": 50
+            "line": 49
           }
         ],
         "classification": "compatibility_fallback",
@@ -54860,12 +54877,12 @@
         "compatibility_pair": {
           "bound_name": "DEFAULT_TEST_WILDCARD_FILE",
           "target": "easyuse_anima/wildcard/sources.py",
-          "try_line": 50
+          "try_line": 49
         },
         "conditional": true,
         "imported": "easyuse_anima.wildcard.sources:DEFAULT_TEST_WILDCARD_FILE",
         "kind": "static_from",
-        "line": 64,
+        "line": 63,
         "name": "DEFAULT_TEST_WILDCARD_FILE",
         "optional": false,
         "requested": "easyuse_anima.wildcard.sources",
@@ -54884,9 +54901,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 62,
+            "handler_line": 61,
             "kind": "try",
-            "line": 50
+            "line": 49
           }
         ],
         "classification": "compatibility_fallback",
@@ -54894,12 +54911,12 @@
         "compatibility_pair": {
           "bound_name": "DEFAULT_TEST_WILDCARD_TEXT",
           "target": "easyuse_anima/wildcard/sources.py",
-          "try_line": 50
+          "try_line": 49
         },
         "conditional": true,
         "imported": "easyuse_anima.wildcard.sources:DEFAULT_TEST_WILDCARD_TEXT",
         "kind": "static_from",
-        "line": 64,
+        "line": 63,
         "name": "DEFAULT_TEST_WILDCARD_TEXT",
         "optional": false,
         "requested": "easyuse_anima.wildcard.sources",
@@ -54918,9 +54935,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 62,
+            "handler_line": 61,
             "kind": "try",
-            "line": 50
+            "line": 49
           }
         ],
         "classification": "compatibility_fallback",
@@ -54928,12 +54945,12 @@
         "compatibility_pair": {
           "bound_name": "WILDCARD_DIR_NAME",
           "target": "easyuse_anima/wildcard/sources.py",
-          "try_line": 50
+          "try_line": 49
         },
         "conditional": true,
         "imported": "easyuse_anima.wildcard.sources:WILDCARD_DIR_NAME",
         "kind": "static_from",
-        "line": 64,
+        "line": 63,
         "name": "WILDCARD_DIR_NAME",
         "optional": false,
         "requested": "easyuse_anima.wildcard.sources",
@@ -54952,9 +54969,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 62,
+            "handler_line": 61,
             "kind": "try",
-            "line": 50
+            "line": 49
           }
         ],
         "classification": "compatibility_fallback",
@@ -54962,12 +54979,12 @@
         "compatibility_pair": {
           "bound_name": "WILDCARD_EXTENSIONS",
           "target": "easyuse_anima/wildcard/sources.py",
-          "try_line": 50
+          "try_line": 49
         },
         "conditional": true,
         "imported": "easyuse_anima.wildcard.sources:WILDCARD_EXTENSIONS",
         "kind": "static_from",
-        "line": 64,
+        "line": 63,
         "name": "WILDCARD_EXTENSIONS",
         "optional": false,
         "requested": "easyuse_anima.wildcard.sources",
@@ -54986,9 +55003,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 62,
+            "handler_line": 61,
             "kind": "try",
-            "line": 50
+            "line": 49
           }
         ],
         "classification": "compatibility_fallback",
@@ -54996,12 +55013,12 @@
         "compatibility_pair": {
           "bound_name": "default_wildcard_root",
           "target": "easyuse_anima/wildcard/sources.py",
-          "try_line": 50
+          "try_line": 49
         },
         "conditional": true,
         "imported": "easyuse_anima.wildcard.sources:default_wildcard_root",
         "kind": "static_from",
-        "line": 64,
+        "line": 63,
         "name": "default_wildcard_root",
         "optional": false,
         "requested": "easyuse_anima.wildcard.sources",
@@ -55020,9 +55037,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 62,
+            "handler_line": 61,
             "kind": "try",
-            "line": 50
+            "line": 49
           }
         ],
         "classification": "compatibility_fallback",
@@ -55030,12 +55047,12 @@
         "compatibility_pair": {
           "bound_name": "ensure_default_wildcard_root",
           "target": "easyuse_anima/wildcard/sources.py",
-          "try_line": 50
+          "try_line": 49
         },
         "conditional": true,
         "imported": "easyuse_anima.wildcard.sources:ensure_default_wildcard_root",
         "kind": "static_from",
-        "line": 64,
+        "line": 63,
         "name": "ensure_default_wildcard_root",
         "optional": false,
         "requested": "easyuse_anima.wildcard.sources",
@@ -55054,9 +55071,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 62,
+            "handler_line": 61,
             "kind": "try",
-            "line": 50
+            "line": 49
           }
         ],
         "classification": "compatibility_fallback",
@@ -55064,12 +55081,12 @@
         "compatibility_pair": {
           "bound_name": "parse_wildcard_extra_paths",
           "target": "easyuse_anima/wildcard/sources.py",
-          "try_line": 50
+          "try_line": 49
         },
         "conditional": true,
         "imported": "easyuse_anima.wildcard.sources:parse_wildcard_extra_paths",
         "kind": "static_from",
-        "line": 64,
+        "line": 63,
         "name": "parse_wildcard_extra_paths",
         "optional": false,
         "requested": "easyuse_anima.wildcard.sources",
@@ -55088,9 +55105,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 62,
+            "handler_line": 61,
             "kind": "try",
-            "line": 50
+            "line": 49
           }
         ],
         "classification": "compatibility_fallback",
@@ -55098,12 +55115,12 @@
         "compatibility_pair": {
           "bound_name": "resolve_wildcard_roots",
           "target": "easyuse_anima/wildcard/sources.py",
-          "try_line": 50
+          "try_line": 49
         },
         "conditional": true,
         "imported": "easyuse_anima.wildcard.sources:resolve_wildcard_roots",
         "kind": "static_from",
-        "line": 64,
+        "line": 63,
         "name": "resolve_wildcard_roots",
         "optional": false,
         "requested": "easyuse_anima.wildcard.sources",
@@ -55121,7 +55138,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 75
+            "line": 74
           }
         ],
         "classification": "internal",
@@ -55129,12 +55146,12 @@
         "compatibility_pair": {
           "bound_name": "_WildcardSnapshot",
           "target": "easyuse_anima/wildcard/snapshot.py",
-          "try_line": 75
+          "try_line": 74
         },
         "conditional": true,
         "imported": ".easyuse_anima.wildcard.snapshot:_WildcardSnapshot",
         "kind": "static_from",
-        "line": 76,
+        "line": 75,
         "name": "_WildcardSnapshot",
         "optional": false,
         "requested": ".easyuse_anima.wildcard.snapshot",
@@ -55152,7 +55169,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 75
+            "line": 74
           }
         ],
         "classification": "internal",
@@ -55160,12 +55177,12 @@
         "compatibility_pair": {
           "bound_name": "_build_wildcard_snapshot",
           "target": "easyuse_anima/wildcard/snapshot.py",
-          "try_line": 75
+          "try_line": 74
         },
         "conditional": true,
         "imported": ".easyuse_anima.wildcard.snapshot:_build_wildcard_snapshot",
         "kind": "static_from",
-        "line": 76,
+        "line": 75,
         "name": "_build_wildcard_snapshot",
         "optional": false,
         "requested": ".easyuse_anima.wildcard.snapshot",
@@ -55184,9 +55201,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 80,
+            "handler_line": 79,
             "kind": "try",
-            "line": 75
+            "line": 74
           }
         ],
         "classification": "compatibility_fallback",
@@ -55194,12 +55211,12 @@
         "compatibility_pair": {
           "bound_name": "_WildcardSnapshot",
           "target": "easyuse_anima/wildcard/snapshot.py",
-          "try_line": 75
+          "try_line": 74
         },
         "conditional": true,
         "imported": "easyuse_anima.wildcard.snapshot:_WildcardSnapshot",
         "kind": "static_from",
-        "line": 81,
+        "line": 80,
         "name": "_WildcardSnapshot",
         "optional": false,
         "requested": "easyuse_anima.wildcard.snapshot",
@@ -55218,9 +55235,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 80,
+            "handler_line": 79,
             "kind": "try",
-            "line": 75
+            "line": 74
           }
         ],
         "classification": "compatibility_fallback",
@@ -55228,12 +55245,12 @@
         "compatibility_pair": {
           "bound_name": "_build_wildcard_snapshot",
           "target": "easyuse_anima/wildcard/snapshot.py",
-          "try_line": 75
+          "try_line": 74
         },
         "conditional": true,
         "imported": "easyuse_anima.wildcard.snapshot:_build_wildcard_snapshot",
         "kind": "static_from",
-        "line": 81,
+        "line": 80,
         "name": "_build_wildcard_snapshot",
         "optional": false,
         "requested": "easyuse_anima.wildcard.snapshot",
@@ -55241,6 +55258,591 @@
         "scope": "<module>",
         "source": "wildcard_engine.py",
         "target": "easyuse_anima/wildcard/snapshot.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "MAX_SEED",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 85
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "MAX_SEED",
+          "target": "easyuse_anima/wildcard/seed.py",
+          "try_line": 85
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.wildcard.seed:MAX_SEED",
+        "kind": "static_from",
+        "line": 86,
+        "name": "MAX_SEED",
+        "optional": false,
+        "requested": ".easyuse_anima.wildcard.seed",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "wildcard_engine.py",
+        "target": "easyuse_anima/wildcard/seed.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "PUBLIC_MAX_SEED",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 85
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "PUBLIC_MAX_SEED",
+          "target": "easyuse_anima/wildcard/seed.py",
+          "try_line": 85
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.wildcard.seed:PUBLIC_MAX_SEED",
+        "kind": "static_from",
+        "line": 86,
+        "name": "PUBLIC_MAX_SEED",
+        "optional": false,
+        "requested": ".easyuse_anima.wildcard.seed",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "wildcard_engine.py",
+        "target": "easyuse_anima/wildcard/seed.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "SEED_CONTROL_DECREMENT",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 85
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "SEED_CONTROL_DECREMENT",
+          "target": "easyuse_anima/wildcard/seed.py",
+          "try_line": 85
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.wildcard.seed:SEED_CONTROL_DECREMENT",
+        "kind": "static_from",
+        "line": 86,
+        "name": "SEED_CONTROL_DECREMENT",
+        "optional": false,
+        "requested": ".easyuse_anima.wildcard.seed",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "wildcard_engine.py",
+        "target": "easyuse_anima/wildcard/seed.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "SEED_CONTROL_FIXED",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 85
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "SEED_CONTROL_FIXED",
+          "target": "easyuse_anima/wildcard/seed.py",
+          "try_line": 85
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.wildcard.seed:SEED_CONTROL_FIXED",
+        "kind": "static_from",
+        "line": 86,
+        "name": "SEED_CONTROL_FIXED",
+        "optional": false,
+        "requested": ".easyuse_anima.wildcard.seed",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "wildcard_engine.py",
+        "target": "easyuse_anima/wildcard/seed.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "SEED_CONTROL_INCREMENT",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 85
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "SEED_CONTROL_INCREMENT",
+          "target": "easyuse_anima/wildcard/seed.py",
+          "try_line": 85
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.wildcard.seed:SEED_CONTROL_INCREMENT",
+        "kind": "static_from",
+        "line": 86,
+        "name": "SEED_CONTROL_INCREMENT",
+        "optional": false,
+        "requested": ".easyuse_anima.wildcard.seed",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "wildcard_engine.py",
+        "target": "easyuse_anima/wildcard/seed.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "SEED_CONTROL_MODES",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 85
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "SEED_CONTROL_MODES",
+          "target": "easyuse_anima/wildcard/seed.py",
+          "try_line": 85
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.wildcard.seed:SEED_CONTROL_MODES",
+        "kind": "static_from",
+        "line": 86,
+        "name": "SEED_CONTROL_MODES",
+        "optional": false,
+        "requested": ".easyuse_anima.wildcard.seed",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "wildcard_engine.py",
+        "target": "easyuse_anima/wildcard/seed.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "SEED_CONTROL_RANDOMIZE",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 85
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "SEED_CONTROL_RANDOMIZE",
+          "target": "easyuse_anima/wildcard/seed.py",
+          "try_line": 85
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.wildcard.seed:SEED_CONTROL_RANDOMIZE",
+        "kind": "static_from",
+        "line": 86,
+        "name": "SEED_CONTROL_RANDOMIZE",
+        "optional": false,
+        "requested": ".easyuse_anima.wildcard.seed",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "wildcard_engine.py",
+        "target": "easyuse_anima/wildcard/seed.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "next_seed",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 85
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "next_seed",
+          "target": "easyuse_anima/wildcard/seed.py",
+          "try_line": 85
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.wildcard.seed:next_seed",
+        "kind": "static_from",
+        "line": 86,
+        "name": "next_seed",
+        "optional": false,
+        "requested": ".easyuse_anima.wildcard.seed",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "wildcard_engine.py",
+        "target": "easyuse_anima/wildcard/seed.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "normalize_seed",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 85
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "normalize_seed",
+          "target": "easyuse_anima/wildcard/seed.py",
+          "try_line": 85
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.wildcard.seed:normalize_seed",
+        "kind": "static_from",
+        "line": 86,
+        "name": "normalize_seed",
+        "optional": false,
+        "requested": ".easyuse_anima.wildcard.seed",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "wildcard_engine.py",
+        "target": "easyuse_anima/wildcard/seed.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "MAX_SEED",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 97,
+            "kind": "try",
+            "line": 85
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "MAX_SEED",
+          "target": "easyuse_anima/wildcard/seed.py",
+          "try_line": 85
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.wildcard.seed:MAX_SEED",
+        "kind": "static_from",
+        "line": 98,
+        "name": "MAX_SEED",
+        "optional": false,
+        "requested": "easyuse_anima.wildcard.seed",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "wildcard_engine.py",
+        "target": "easyuse_anima/wildcard/seed.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "PUBLIC_MAX_SEED",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 97,
+            "kind": "try",
+            "line": 85
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "PUBLIC_MAX_SEED",
+          "target": "easyuse_anima/wildcard/seed.py",
+          "try_line": 85
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.wildcard.seed:PUBLIC_MAX_SEED",
+        "kind": "static_from",
+        "line": 98,
+        "name": "PUBLIC_MAX_SEED",
+        "optional": false,
+        "requested": "easyuse_anima.wildcard.seed",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "wildcard_engine.py",
+        "target": "easyuse_anima/wildcard/seed.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "SEED_CONTROL_DECREMENT",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 97,
+            "kind": "try",
+            "line": 85
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "SEED_CONTROL_DECREMENT",
+          "target": "easyuse_anima/wildcard/seed.py",
+          "try_line": 85
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.wildcard.seed:SEED_CONTROL_DECREMENT",
+        "kind": "static_from",
+        "line": 98,
+        "name": "SEED_CONTROL_DECREMENT",
+        "optional": false,
+        "requested": "easyuse_anima.wildcard.seed",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "wildcard_engine.py",
+        "target": "easyuse_anima/wildcard/seed.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "SEED_CONTROL_FIXED",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 97,
+            "kind": "try",
+            "line": 85
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "SEED_CONTROL_FIXED",
+          "target": "easyuse_anima/wildcard/seed.py",
+          "try_line": 85
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.wildcard.seed:SEED_CONTROL_FIXED",
+        "kind": "static_from",
+        "line": 98,
+        "name": "SEED_CONTROL_FIXED",
+        "optional": false,
+        "requested": "easyuse_anima.wildcard.seed",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "wildcard_engine.py",
+        "target": "easyuse_anima/wildcard/seed.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "SEED_CONTROL_INCREMENT",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 97,
+            "kind": "try",
+            "line": 85
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "SEED_CONTROL_INCREMENT",
+          "target": "easyuse_anima/wildcard/seed.py",
+          "try_line": 85
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.wildcard.seed:SEED_CONTROL_INCREMENT",
+        "kind": "static_from",
+        "line": 98,
+        "name": "SEED_CONTROL_INCREMENT",
+        "optional": false,
+        "requested": "easyuse_anima.wildcard.seed",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "wildcard_engine.py",
+        "target": "easyuse_anima/wildcard/seed.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "SEED_CONTROL_MODES",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 97,
+            "kind": "try",
+            "line": 85
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "SEED_CONTROL_MODES",
+          "target": "easyuse_anima/wildcard/seed.py",
+          "try_line": 85
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.wildcard.seed:SEED_CONTROL_MODES",
+        "kind": "static_from",
+        "line": 98,
+        "name": "SEED_CONTROL_MODES",
+        "optional": false,
+        "requested": "easyuse_anima.wildcard.seed",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "wildcard_engine.py",
+        "target": "easyuse_anima/wildcard/seed.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "SEED_CONTROL_RANDOMIZE",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 97,
+            "kind": "try",
+            "line": 85
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "SEED_CONTROL_RANDOMIZE",
+          "target": "easyuse_anima/wildcard/seed.py",
+          "try_line": 85
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.wildcard.seed:SEED_CONTROL_RANDOMIZE",
+        "kind": "static_from",
+        "line": 98,
+        "name": "SEED_CONTROL_RANDOMIZE",
+        "optional": false,
+        "requested": "easyuse_anima.wildcard.seed",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "wildcard_engine.py",
+        "target": "easyuse_anima/wildcard/seed.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "next_seed",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 97,
+            "kind": "try",
+            "line": 85
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "next_seed",
+          "target": "easyuse_anima/wildcard/seed.py",
+          "try_line": 85
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.wildcard.seed:next_seed",
+        "kind": "static_from",
+        "line": 98,
+        "name": "next_seed",
+        "optional": false,
+        "requested": "easyuse_anima.wildcard.seed",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "wildcard_engine.py",
+        "target": "easyuse_anima/wildcard/seed.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "normalize_seed",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 97,
+            "kind": "try",
+            "line": 85
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "normalize_seed",
+          "target": "easyuse_anima/wildcard/seed.py",
+          "try_line": 85
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.wildcard.seed:normalize_seed",
+        "kind": "static_from",
+        "line": 98,
+        "name": "normalize_seed",
+        "optional": false,
+        "requested": "easyuse_anima.wildcard.seed",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "wildcard_engine.py",
+        "target": "easyuse_anima/wildcard/seed.py"
       }
     ],
     "module_graph": [
@@ -56858,6 +57460,10 @@
       },
       {
         "from": "wildcard_engine.py",
+        "to": "easyuse_anima/wildcard/seed.py"
+      },
+      {
+        "from": "wildcard_engine.py",
         "to": "easyuse_anima/wildcard/snapshot.py"
       },
       {
@@ -57606,6 +58212,12 @@
       {
         "cyclic": false,
         "modules": [
+          "easyuse_anima/wildcard/seed.py"
+        ]
+      },
+      {
+        "cyclic": false,
+        "modules": [
           "easyuse_anima/wildcard/snapshot.py"
         ]
       },
@@ -57654,7 +58266,7 @@
     ]
   },
   "inventory": {
-    "module_count": 129,
+    "module_count": 130,
     "modules": [
       {
         "is_package": true,
@@ -59110,9 +59722,21 @@
       },
       {
         "is_package": false,
+        "loc": 62,
+        "module": "easyuse_anima.wildcard.seed",
+        "normalized_git_blob_sha1": "24994a9a81962b5d139384324187576d7c3f23a7",
+        "path": "easyuse_anima/wildcard/seed.py",
+        "top_level": {
+          "class_count": 0,
+          "function_count": 2,
+          "global_count": 8
+        }
+      },
+      {
+        "is_package": false,
         "loc": 66,
         "module": "easyuse_anima.wildcard.snapshot",
-        "normalized_git_blob_sha1": "01b60918ffb1ccf6334abdad42226510843e1d48",
+        "normalized_git_blob_sha1": "70e40cd3ae10af7b362bf8dd334e6864d6b7059d",
         "path": "easyuse_anima/wildcard/snapshot.py",
         "top_level": {
           "class_count": 1,
@@ -59194,14 +59818,14 @@
       },
       {
         "is_package": false,
-        "loc": 922,
+        "loc": 902,
         "module": "wildcard_engine",
-        "normalized_git_blob_sha1": "14fe8a2e6356385d99a5c99a1056392ea6f89e92",
+        "normalized_git_blob_sha1": "9d9e03181eeb057ce2be490f6f1d2a703123568c",
         "path": "wildcard_engine.py",
         "top_level": {
           "class_count": 7,
-          "function_count": 22,
-          "global_count": 25
+          "function_count": 20,
+          "global_count": 18
         }
       }
     ]
@@ -69597,16 +70221,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 34,
+            "handler_line": 33,
             "kind": "try",
-            "line": 19
+            "line": 18
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.wildcard.models:DEFAULT_MAX_EXPANSION_DEPTH",
         "kind": "static_from",
-        "line": 35,
+        "line": 34,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "wildcard_engine.py",
@@ -69620,16 +70244,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 34,
+            "handler_line": 33,
             "kind": "try",
-            "line": 19
+            "line": 18
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.wildcard.models:DEFAULT_MAX_EXPANSION_GROWTH_PER_PASS",
         "kind": "static_from",
-        "line": 35,
+        "line": 34,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "wildcard_engine.py",
@@ -69643,16 +70267,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 34,
+            "handler_line": 33,
             "kind": "try",
-            "line": 19
+            "line": 18
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.wildcard.models:DEFAULT_MAX_EXPANSION_OUTPUT_CHARS",
         "kind": "static_from",
-        "line": 35,
+        "line": 34,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "wildcard_engine.py",
@@ -69666,16 +70290,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 34,
+            "handler_line": 33,
             "kind": "try",
-            "line": 19
+            "line": 18
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.wildcard.models:DEFAULT_MAX_EXPANSION_REPLACEMENTS",
         "kind": "static_from",
-        "line": 35,
+        "line": 34,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "wildcard_engine.py",
@@ -69689,16 +70313,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 34,
+            "handler_line": 33,
             "kind": "try",
-            "line": 19
+            "line": 18
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.wildcard.models:MAX_EXPANSION_DEPTH",
         "kind": "static_from",
-        "line": 35,
+        "line": 34,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "wildcard_engine.py",
@@ -69712,16 +70336,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 34,
+            "handler_line": 33,
             "kind": "try",
-            "line": 19
+            "line": 18
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.wildcard.models:MAX_EXPANSION_GROWTH_PER_PASS",
         "kind": "static_from",
-        "line": 35,
+        "line": 34,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "wildcard_engine.py",
@@ -69735,16 +70359,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 34,
+            "handler_line": 33,
             "kind": "try",
-            "line": 19
+            "line": 18
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.wildcard.models:MAX_EXPANSION_OUTPUT_CHARS",
         "kind": "static_from",
-        "line": 35,
+        "line": 34,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "wildcard_engine.py",
@@ -69758,16 +70382,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 34,
+            "handler_line": 33,
             "kind": "try",
-            "line": 19
+            "line": 18
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.wildcard.models:MAX_EXPANSION_REPLACEMENTS",
         "kind": "static_from",
-        "line": 35,
+        "line": 34,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "wildcard_engine.py",
@@ -69781,16 +70405,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 34,
+            "handler_line": 33,
             "kind": "try",
-            "line": 19
+            "line": 18
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.wildcard.models:REPLACE_DEPTH",
         "kind": "static_from",
-        "line": 35,
+        "line": 34,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "wildcard_engine.py",
@@ -69804,16 +70428,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 34,
+            "handler_line": 33,
             "kind": "try",
-            "line": 19
+            "line": 18
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.wildcard.models:WildcardExpansionBudget",
         "kind": "static_from",
-        "line": 35,
+        "line": 34,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "wildcard_engine.py",
@@ -69827,16 +70451,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 34,
+            "handler_line": 33,
             "kind": "try",
-            "line": 19
+            "line": 18
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.wildcard.models:WildcardExpansionResult",
         "kind": "static_from",
-        "line": 35,
+        "line": 34,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "wildcard_engine.py",
@@ -69850,16 +70474,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 34,
+            "handler_line": 33,
             "kind": "try",
-            "line": 19
+            "line": 18
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.wildcard.models:WildcardOption",
         "kind": "static_from",
-        "line": 35,
+        "line": 34,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "wildcard_engine.py",
@@ -69873,14 +70497,37 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 62,
+            "handler_line": 61,
             "kind": "try",
-            "line": 50
+            "line": 49
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.wildcard:sources",
+        "kind": "static_from",
+        "line": 62,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "wildcard_engine.py",
+        "target": "easyuse_anima/wildcard/sources.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 61,
+            "kind": "try",
+            "line": 49
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.wildcard.sources:DEFAULT_TEST_WILDCARD_FILE",
         "kind": "static_from",
         "line": 63,
         "optional": false,
@@ -69896,39 +70543,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 62,
+            "handler_line": 61,
             "kind": "try",
-            "line": 50
-          }
-        ],
-        "classification": "compatibility_fallback",
-        "conditional": true,
-        "imported": "easyuse_anima.wildcard.sources:DEFAULT_TEST_WILDCARD_FILE",
-        "kind": "static_from",
-        "line": 64,
-        "optional": false,
-        "role": "compatibility_fallback",
-        "source": "wildcard_engine.py",
-        "target": "easyuse_anima/wildcard/sources.py"
-      },
-      {
-        "branch_context": [
-          {
-            "branch": "except",
-            "catches_import_error": true,
-            "exceptions": [
-              "ImportError"
-            ],
-            "handler_line": 62,
-            "kind": "try",
-            "line": 50
+            "line": 49
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.wildcard.sources:DEFAULT_TEST_WILDCARD_TEXT",
         "kind": "static_from",
-        "line": 64,
+        "line": 63,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "wildcard_engine.py",
@@ -69942,16 +70566,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 62,
+            "handler_line": 61,
             "kind": "try",
-            "line": 50
+            "line": 49
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.wildcard.sources:WILDCARD_DIR_NAME",
         "kind": "static_from",
-        "line": 64,
+        "line": 63,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "wildcard_engine.py",
@@ -69965,16 +70589,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 62,
+            "handler_line": 61,
             "kind": "try",
-            "line": 50
+            "line": 49
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.wildcard.sources:WILDCARD_EXTENSIONS",
         "kind": "static_from",
-        "line": 64,
+        "line": 63,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "wildcard_engine.py",
@@ -69988,16 +70612,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 62,
+            "handler_line": 61,
             "kind": "try",
-            "line": 50
+            "line": 49
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.wildcard.sources:default_wildcard_root",
         "kind": "static_from",
-        "line": 64,
+        "line": 63,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "wildcard_engine.py",
@@ -70011,16 +70635,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 62,
+            "handler_line": 61,
             "kind": "try",
-            "line": 50
+            "line": 49
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.wildcard.sources:ensure_default_wildcard_root",
         "kind": "static_from",
-        "line": 64,
+        "line": 63,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "wildcard_engine.py",
@@ -70034,16 +70658,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 62,
+            "handler_line": 61,
             "kind": "try",
-            "line": 50
+            "line": 49
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.wildcard.sources:parse_wildcard_extra_paths",
         "kind": "static_from",
-        "line": 64,
+        "line": 63,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "wildcard_engine.py",
@@ -70057,16 +70681,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 62,
+            "handler_line": 61,
             "kind": "try",
-            "line": 50
+            "line": 49
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.wildcard.sources:resolve_wildcard_roots",
         "kind": "static_from",
-        "line": 64,
+        "line": 63,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "wildcard_engine.py",
@@ -70080,16 +70704,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 80,
+            "handler_line": 79,
             "kind": "try",
-            "line": 75
+            "line": 74
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.wildcard.snapshot:_WildcardSnapshot",
         "kind": "static_from",
-        "line": 81,
+        "line": 80,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "wildcard_engine.py",
@@ -70103,20 +70727,227 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 80,
+            "handler_line": 79,
             "kind": "try",
-            "line": 75
+            "line": 74
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.wildcard.snapshot:_build_wildcard_snapshot",
         "kind": "static_from",
-        "line": 81,
+        "line": 80,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "wildcard_engine.py",
         "target": "easyuse_anima/wildcard/snapshot.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 97,
+            "kind": "try",
+            "line": 85
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.wildcard.seed:MAX_SEED",
+        "kind": "static_from",
+        "line": 98,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "wildcard_engine.py",
+        "target": "easyuse_anima/wildcard/seed.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 97,
+            "kind": "try",
+            "line": 85
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.wildcard.seed:PUBLIC_MAX_SEED",
+        "kind": "static_from",
+        "line": 98,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "wildcard_engine.py",
+        "target": "easyuse_anima/wildcard/seed.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 97,
+            "kind": "try",
+            "line": 85
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.wildcard.seed:SEED_CONTROL_DECREMENT",
+        "kind": "static_from",
+        "line": 98,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "wildcard_engine.py",
+        "target": "easyuse_anima/wildcard/seed.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 97,
+            "kind": "try",
+            "line": 85
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.wildcard.seed:SEED_CONTROL_FIXED",
+        "kind": "static_from",
+        "line": 98,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "wildcard_engine.py",
+        "target": "easyuse_anima/wildcard/seed.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 97,
+            "kind": "try",
+            "line": 85
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.wildcard.seed:SEED_CONTROL_INCREMENT",
+        "kind": "static_from",
+        "line": 98,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "wildcard_engine.py",
+        "target": "easyuse_anima/wildcard/seed.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 97,
+            "kind": "try",
+            "line": 85
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.wildcard.seed:SEED_CONTROL_MODES",
+        "kind": "static_from",
+        "line": 98,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "wildcard_engine.py",
+        "target": "easyuse_anima/wildcard/seed.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 97,
+            "kind": "try",
+            "line": 85
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.wildcard.seed:SEED_CONTROL_RANDOMIZE",
+        "kind": "static_from",
+        "line": 98,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "wildcard_engine.py",
+        "target": "easyuse_anima/wildcard/seed.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 97,
+            "kind": "try",
+            "line": 85
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.wildcard.seed:next_seed",
+        "kind": "static_from",
+        "line": 98,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "wildcard_engine.py",
+        "target": "easyuse_anima/wildcard/seed.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 97,
+            "kind": "try",
+            "line": 85
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.wildcard.seed:normalize_seed",
+        "kind": "static_from",
+        "line": 98,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "wildcard_engine.py",
+        "target": "easyuse_anima/wildcard/seed.py"
       }
     ],
     "entry_modules": [
@@ -75543,13 +76374,35 @@
         "line": 3,
         "optional": false,
         "role": "ordinary",
+        "source": "easyuse_anima/wildcard/seed.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "random",
+        "kind": "static_import",
+        "line": 5,
+        "optional": false,
+        "role": "ordinary",
+        "source": "easyuse_anima/wildcard/seed.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "__future__:annotations",
+        "kind": "static_from",
+        "line": 3,
+        "optional": false,
+        "role": "ordinary",
         "source": "easyuse_anima/wildcard/snapshot.py"
       },
       {
         "branch_context": [],
         "classification": "external",
         "conditional": false,
-        "imported": "dataclasses:dataclass",
+        "imported": "collections.abc:Mapping",
         "kind": "static_from",
         "line": 5,
         "optional": false,
@@ -75560,7 +76413,7 @@
         "branch_context": [],
         "classification": "external",
         "conditional": false,
-        "imported": "types:MappingProxyType",
+        "imported": "dataclasses:dataclass",
         "kind": "static_from",
         "line": 6,
         "optional": false,
@@ -75571,7 +76424,7 @@
         "branch_context": [],
         "classification": "external",
         "conditional": false,
-        "imported": "typing:Mapping",
+        "imported": "types:MappingProxyType",
         "kind": "static_from",
         "line": 7,
         "optional": false,
@@ -75796,7 +76649,7 @@
         "branch_context": [],
         "classification": "external",
         "conditional": false,
-        "imported": "random",
+        "imported": "re",
         "kind": "static_import",
         "line": 8,
         "optional": false,
@@ -75807,7 +76660,7 @@
         "branch_context": [],
         "classification": "external",
         "conditional": false,
-        "imported": "re",
+        "imported": "threading",
         "kind": "static_import",
         "line": 9,
         "optional": false,
@@ -75818,20 +76671,9 @@
         "branch_context": [],
         "classification": "external",
         "conditional": false,
-        "imported": "threading",
-        "kind": "static_import",
-        "line": 10,
-        "optional": false,
-        "role": "ordinary",
-        "source": "wildcard_engine.py"
-      },
-      {
-        "branch_context": [],
-        "classification": "external",
-        "conditional": false,
         "imported": "dataclasses:dataclass",
         "kind": "static_from",
-        "line": 11,
+        "line": 10,
         "optional": false,
         "role": "ordinary",
         "source": "wildcard_engine.py"
@@ -75842,7 +76684,7 @@
         "conditional": false,
         "imported": "pathlib:Path",
         "kind": "static_from",
-        "line": 12,
+        "line": 11,
         "optional": false,
         "role": "ordinary",
         "source": "wildcard_engine.py"
@@ -75853,7 +76695,7 @@
         "conditional": false,
         "imported": "typing:Iterable",
         "kind": "static_from",
-        "line": 13,
+        "line": 12,
         "optional": false,
         "role": "ordinary",
         "source": "wildcard_engine.py"
@@ -75864,7 +76706,7 @@
         "conditional": false,
         "imported": "typing:Sequence",
         "kind": "static_from",
-        "line": 13,
+        "line": 12,
         "optional": false,
         "role": "ordinary",
         "source": "wildcard_engine.py"
@@ -75875,7 +76717,7 @@
         "conditional": false,
         "imported": "numpy",
         "kind": "static_import",
-        "line": 17,
+        "line": 16,
         "optional": false,
         "role": "ordinary",
         "source": "wildcard_engine.py"
@@ -76965,6 +77807,7 @@
       "easyuse_anima/translation/service.py",
       "easyuse_anima/wildcard/__init__.py",
       "easyuse_anima/wildcard/models.py",
+      "easyuse_anima/wildcard/seed.py",
       "easyuse_anima/wildcard/snapshot.py",
       "easyuse_anima/wildcard/sources.py",
       "easyuse_anima/workflow.py",
@@ -77096,6 +77939,7 @@
       "easyuse_anima/translation/service.py",
       "easyuse_anima/wildcard/__init__.py",
       "easyuse_anima/wildcard/models.py",
+      "easyuse_anima/wildcard/seed.py",
       "easyuse_anima/wildcard/snapshot.py",
       "easyuse_anima/wildcard/sources.py",
       "easyuse_anima/workflow.py",
@@ -78726,7 +79570,7 @@
         "column": 13,
         "context": "assign:COMMENT_RE",
         "kind": "import_time_call",
-        "line": 131,
+        "line": 142,
         "module": "wildcard_engine.py",
         "scope": "<module>"
       },
@@ -78735,7 +79579,7 @@
         "column": 13,
         "context": "assign:DYNAMIC_RE",
         "kind": "import_time_call",
-        "line": 132,
+        "line": 143,
         "module": "wildcard_engine.py",
         "scope": "<module>"
       },
@@ -78744,7 +79588,7 @@
         "column": 14,
         "context": "assign:WILDCARD_RE",
         "kind": "import_time_call",
-        "line": 133,
+        "line": 144,
         "module": "wildcard_engine.py",
         "scope": "<module>"
       },
@@ -78753,7 +79597,7 @@
         "column": 19,
         "context": "assign:WILDCARD_FULL_RE",
         "kind": "import_time_call",
-        "line": 134,
+        "line": 145,
         "module": "wildcard_engine.py",
         "scope": "<module>"
       },
@@ -78762,7 +79606,7 @@
         "column": 25,
         "context": "assign:WILDCARD_QUANTIFIER_RE",
         "kind": "import_time_call",
-        "line": 135,
+        "line": 146,
         "module": "wildcard_engine.py",
         "scope": "<module>"
       },
@@ -78771,7 +79615,7 @@
         "column": 16,
         "context": "assign:COUNT_SPEC_RE",
         "kind": "import_time_call",
-        "line": 139,
+        "line": 150,
         "module": "wildcard_engine.py",
         "scope": "<module>"
       },
@@ -78780,7 +79624,7 @@
         "column": 22,
         "context": "assign:_SNAPSHOT_CONDITION",
         "kind": "import_time_call",
-        "line": 144,
+        "line": 155,
         "module": "wildcard_engine.py",
         "scope": "<module>"
       },
@@ -78789,7 +79633,7 @@
         "column": 57,
         "context": "assign:_SNAPSHOT_CACHE",
         "kind": "import_time_call",
-        "line": 145,
+        "line": 156,
         "module": "wildcard_engine.py",
         "scope": "<module>"
       },
@@ -78798,7 +79642,7 @@
         "column": 33,
         "context": "assign:_SNAPSHOT_BUILDING",
         "kind": "import_time_call",
-        "line": 146,
+        "line": 157,
         "module": "wildcard_engine.py",
         "scope": "<module>"
       },
@@ -78807,7 +79651,7 @@
         "column": 1,
         "context": "decorator:_ExpansionSegment",
         "kind": "import_time_call",
-        "line": 164,
+        "line": 175,
         "module": "wildcard_engine.py",
         "scope": "<module>"
       },
@@ -78816,7 +79660,7 @@
         "column": 1,
         "context": "decorator:_Replacement",
         "kind": "import_time_call",
-        "line": 237,
+        "line": 248,
         "module": "wildcard_engine.py",
         "scope": "<module>"
       }
@@ -79198,19 +80042,19 @@
       },
       {
         "kind": "dict",
-        "line": 104,
+        "line": 128,
         "module": "wildcard_engine.py",
         "name": "WILDCARD_MODE_ALIASES"
       },
       {
         "kind": "set",
-        "line": 146,
+        "line": 157,
         "module": "wildcard_engine.py",
         "name": "_SNAPSHOT_BUILDING"
       },
       {
         "kind": "dict",
-        "line": 145,
+        "line": 156,
         "module": "wildcard_engine.py",
         "name": "_SNAPSHOT_CACHE"
       }
@@ -79375,7 +80219,7 @@
           "single_flight"
         ],
         "initializer": "set",
-        "line": 146,
+        "line": 157,
         "module": "wildcard_engine.py",
         "name": "_SNAPSHOT_BUILDING"
       },
@@ -79385,7 +80229,7 @@
           "mutable_container"
         ],
         "initializer": "OrderedDict",
-        "line": 145,
+        "line": 156,
         "module": "wildcard_engine.py",
         "name": "_SNAPSHOT_CACHE"
       }

--- a/tests/test_python_backend_analyzer.py
+++ b/tests/test_python_backend_analyzer.py
@@ -691,9 +691,9 @@ ignored/
 
         self.assertEqual(analyzer.render_json(report), expected_text)
         self.assertEqual(report["schema_version"], 2)
-        self.assertEqual(report["inventory"]["module_count"], 129)
-        self.assertEqual(len(report["registry"]["shipped_python_modules"]), 129)
-        self.assertEqual(len(report["registry"]["runtime_import_closure"]), 129)
+        self.assertEqual(report["inventory"]["module_count"], 130)
+        self.assertEqual(len(report["registry"]["shipped_python_modules"]), 130)
+        self.assertEqual(len(report["registry"]["runtime_import_closure"]), 130)
         self.assertEqual(
             report["registry"]["entry_modules"],
             [
@@ -969,6 +969,13 @@ ignored/
         )
         self.assertIn(
             {
+                "from": "wildcard_engine.py",
+                "to": "easyuse_anima/wildcard/seed.py",
+            },
+            report["imports"]["module_graph"],
+        )
+        self.assertIn(
+            {
                 "from": "easyuse_anima/wildcard/snapshot.py",
                 "to": "easyuse_anima/wildcard/models.py",
             },
@@ -991,6 +998,7 @@ ignored/
         for module in (
             "easyuse_anima/wildcard/__init__.py",
             "easyuse_anima/wildcard/models.py",
+            "easyuse_anima/wildcard/seed.py",
             "easyuse_anima/wildcard/snapshot.py",
             "easyuse_anima/wildcard/sources.py",
         ):
@@ -1063,7 +1071,11 @@ ignored/
         )
         self.assertFalse(
             any(
-                module == "easyuse_anima/wildcard/snapshot.py"
+                module
+                in {
+                    "easyuse_anima/wildcard/seed.py",
+                    "easyuse_anima/wildcard/snapshot.py",
+                }
                 for module, _name in mutable_by_name
             )
         )

--- a/tests/test_python_package_skeleton.py
+++ b/tests/test_python_package_skeleton.py
@@ -88,6 +88,7 @@ PACKAGE_MODULES = (
     "easyuse_anima.translation.service",
     "easyuse_anima.wildcard",
     "easyuse_anima.wildcard.models",
+    "easyuse_anima.wildcard.seed",
     "easyuse_anima.wildcard.snapshot",
     "easyuse_anima.wildcard.sources",
     "easyuse_anima.seed.execution_identity",
@@ -382,6 +383,19 @@ print(json.dumps({{
             "WildcardOption",
             "WildcardExpansionBudget",
             "WildcardExpansionResult",
+        ]
+        expected_all[
+            PACKAGE_MODULES.index("easyuse_anima.wildcard.seed")
+        ] = [
+            "SEED_CONTROL_FIXED",
+            "SEED_CONTROL_RANDOMIZE",
+            "SEED_CONTROL_INCREMENT",
+            "SEED_CONTROL_DECREMENT",
+            "SEED_CONTROL_MODES",
+            "MAX_SEED",
+            "PUBLIC_MAX_SEED",
+            "normalize_seed",
+            "next_seed",
         ]
         expected_all[
             PACKAGE_MODULES.index("easyuse_anima.wildcard.sources")

--- a/tests/test_registry_scanner_safety.py
+++ b/tests/test_registry_scanner_safety.py
@@ -83,6 +83,7 @@ EXPECTED_PYTHON_PACKAGE_FILES = {
     "easyuse_anima/settings/service.py",
     "easyuse_anima/wildcard/__init__.py",
     "easyuse_anima/wildcard/models.py",
+    "easyuse_anima/wildcard/seed.py",
     "easyuse_anima/wildcard/snapshot.py",
     "easyuse_anima/wildcard/sources.py",
     "easyuse_anima/registration.py",

--- a/tests/test_wildcards.py
+++ b/tests/test_wildcards.py
@@ -13,6 +13,7 @@ from easyuse_anima.nodes import wildcard_nodes
 from easyuse_anima.prompt import advanced as prompt_advanced
 from easyuse_anima.seed import compatibility as seed_compatibility
 from easyuse_anima.wildcard import models as wildcard_models
+from easyuse_anima.wildcard import seed as wildcard_seed
 from easyuse_anima.wildcard import snapshot as wildcard_snapshot
 from easyuse_anima.wildcard import sources as wildcard_sources
 from nodes import (
@@ -35,6 +36,26 @@ from wildcard_engine import (
 
 
 class WildcardEngineTests(unittest.TestCase):
+    def test_root_seed_surface_has_canonical_identity(self):
+        expected = (
+            "SEED_CONTROL_FIXED",
+            "SEED_CONTROL_RANDOMIZE",
+            "SEED_CONTROL_INCREMENT",
+            "SEED_CONTROL_DECREMENT",
+            "SEED_CONTROL_MODES",
+            "MAX_SEED",
+            "PUBLIC_MAX_SEED",
+            "normalize_seed",
+            "next_seed",
+        )
+        self.assertEqual(wildcard_seed.__all__, expected)
+        for name in expected:
+            with self.subTest(name=name):
+                self.assertIs(
+                    getattr(wildcard_engine, name),
+                    getattr(wildcard_seed, name),
+                )
+
     def test_root_snapshot_surface_has_canonical_identity(self):
         self.assertEqual(wildcard_snapshot.__all__, ())
         self.assertIs(
@@ -932,7 +953,7 @@ class WildcardSeedContractTests(unittest.TestCase):
             wildcard_engine.next_seed(public_max, "decrement"),
             public_max - 1,
         )
-        with patch("wildcard_engine.random.SystemRandom") as system_random:
+        with patch.object(wildcard_seed.random, "SystemRandom") as system_random:
             system_random.return_value.randrange.return_value = public_max
 
             self.assertEqual(
@@ -1184,7 +1205,7 @@ class WildcardNodeTests(unittest.TestCase):
 
     def test_prompt_studio_mode_and_seed_control_matrix_saves_current_seed_as_fixed(self):
         with (
-            patch("wildcard_engine.random.SystemRandom") as system_random,
+            patch.object(wildcard_seed.random, "SystemRandom") as system_random,
             patch(
                 "easyuse_anima.nodes.seed_adapters.get_runtime",
                 side_effect=RuntimeError,
@@ -1280,7 +1301,7 @@ class WildcardNodeTests(unittest.TestCase):
         }
 
         with (
-            patch("wildcard_engine.random.SystemRandom") as system_random,
+            patch.object(wildcard_seed.random, "SystemRandom") as system_random,
             patch(
                 "easyuse_anima.nodes.seed_adapters.get_runtime",
                 side_effect=RuntimeError,

--- a/wildcard_engine.py
+++ b/wildcard_engine.py
@@ -5,7 +5,6 @@ from collections import OrderedDict
 import fnmatch
 import hashlib
 import math
-import random
 import re
 import threading
 from dataclasses import dataclass
@@ -83,6 +82,31 @@ except ImportError:
         _WildcardSnapshot,
     )
 
+try:
+    from .easyuse_anima.wildcard.seed import (
+        MAX_SEED,
+        PUBLIC_MAX_SEED,
+        SEED_CONTROL_DECREMENT,
+        SEED_CONTROL_FIXED,
+        SEED_CONTROL_INCREMENT,
+        SEED_CONTROL_MODES,
+        SEED_CONTROL_RANDOMIZE,
+        next_seed,
+        normalize_seed,
+    )
+except ImportError:
+    from easyuse_anima.wildcard.seed import (
+        MAX_SEED,
+        PUBLIC_MAX_SEED,
+        SEED_CONTROL_DECREMENT,
+        SEED_CONTROL_FIXED,
+        SEED_CONTROL_INCREMENT,
+        SEED_CONTROL_MODES,
+        SEED_CONTROL_RANDOMIZE,
+        next_seed,
+        normalize_seed,
+    )
+
 
 WILDCARD_MODE_POPULATE = "populate"
 WILDCARD_MODE_FIXED = "fixed"
@@ -115,19 +139,6 @@ WILDCARD_MODE_ALIASES = {
     "재현": WILDCARD_MODE_REPRODUCE,
 }
 
-SEED_CONTROL_FIXED = "fixed"
-SEED_CONTROL_RANDOMIZE = "randomize"
-SEED_CONTROL_INCREMENT = "increment"
-SEED_CONTROL_DECREMENT = "decrement"
-SEED_CONTROL_MODES = (
-    SEED_CONTROL_FIXED,
-    SEED_CONTROL_RANDOMIZE,
-    SEED_CONTROL_INCREMENT,
-    SEED_CONTROL_DECREMENT,
-)
-
-MAX_SEED = 0xFFFFFFFFFFFFFFFF
-PUBLIC_MAX_SEED = (1 << 53) - 1
 COMMENT_RE = re.compile(r"^\s*#.*(?:\n|$)", re.MULTILINE)
 DYNAMIC_RE = re.compile(r"(?<![\\%])\{((?:[^{}]|(?<=\\)[{}])*?)(?<!\\)\}")
 WILDCARD_RE = re.compile(r"__(?P<keyword>[\w.\-+/*\\]+?)__", re.IGNORECASE)
@@ -383,37 +394,6 @@ def normalize_prompt_studio_wildcard_mode(mode: str) -> str:
         if normalize_wildcard_mode(mode) == WILDCARD_MODE_SEQUENTIAL
         else WILDCARD_MODE_POPULATE
     )
-
-
-def normalize_seed(value) -> int:
-    try:
-        seed = int(value)
-    except (TypeError, ValueError):
-        seed = 0
-    return max(0, min(MAX_SEED, seed))
-
-
-def next_seed(seed, control: str) -> int:
-    """Return the next public wildcard seed without breaking legacy inputs.
-
-    Existing workflows may contain uint64 values that JavaScript cannot
-    represent exactly.  The current generation still consumes that legacy
-    value, and ``fixed`` preserves it.  Controls that advance the state first
-    project the value onto the public JavaScript-safe range so every returned
-    non-fixed seed uses the same inclusive range in Python and JavaScript.
-    """
-    seed = normalize_seed(seed)
-    control = str(control or SEED_CONTROL_FIXED).strip()
-    if control == SEED_CONTROL_FIXED:
-        return seed
-    if control == SEED_CONTROL_RANDOMIZE:
-        return random.SystemRandom().randrange(0, PUBLIC_MAX_SEED + 1)
-    public_seed = min(seed, PUBLIC_MAX_SEED)
-    if control == SEED_CONTROL_INCREMENT:
-        return 0 if public_seed >= PUBLIC_MAX_SEED else public_seed + 1
-    if control == SEED_CONTROL_DECREMENT:
-        return PUBLIC_MAX_SEED if public_seed <= 0 else public_seed - 1
-    return seed
 
 
 def has_wildcard_syntax(text: str) -> bool:


### PR DESCRIPTION
## 작업

- Task: D-12d Wildcard seed-control canonical Move
- Parent: D-12 / owner #186
- Behavior prerequisites: #159, #160 complete
- Type: Move
- Base: `dev@e9adbe30ec8f7fdf251c515679b142942979f924`
- Behavior changes: forbidden

## 변경 요약

- seed-control 5개 name, backend/public seed range, `normalize_seed`, `next_seed`를 `easyuse_anima.wildcard.seed`로 이동했습니다.
- root의 9개 supported name은 identical canonical object에 직접 바인딩합니다.
- `SystemRandom` patch seam은 canonical owner로 이동했고 per-call 생성 및 inclusive public range는 유지됩니다.
- wildcard mode constants/alias normalization, `_Selector`, NumPy/PCG64, snapshot lifecycle, expansion, node/Prompt Studio/reservation consumer는 변경하지 않았습니다.
- canonical seed module에는 root/NumPy import나 mutable global이 없습니다.
- G-03 enrollment, API/node/bootstrap/frontend/workflow/Registry metadata 변경은 없습니다.

## 주요 파일

- `easyuse_anima/wildcard/seed.py`
- `wildcard_engine.py`
- wildcard/package/Registry/analyzer tests 및 analyzer baseline
- `docs/architecture/wildcard-seed-control-canonical-move.md`
- roadmap 및 compatibility-shim ledger

## 검증

- wildcard/seed behavior and identity: 75 passed
- package skeleton: 1 passed
- Registry scanner safety: 8 passed
- Python import boundaries: 16 passed
- backend analyzer: 18 passed
- canonical `seed.py` Ruff: 0 findings
- canonical `seed.py` Pyright 1.1.411: 0 diagnostics
- official full: Python 1,138 passed; frontend 112 files passed; G-03a 10 groups / 0 violations; existing Pyright baseline 14 errors passed
- `comfy node validate`: passed
- `comfy node pack`: 260 entries; root engine와 canonical wildcard `__init__.py`, `models.py`, `seed.py`, `sources.py`, `snapshot.py` 포함 확인
- `git diff --check`: passed

## 테스트 표면

- Repository-owned focused unittest and static contracts
- ComfyUI Codex test environment: official project full runner
- Live ComfyUI/server/browser smoke: not run (Move boundary상 불필요)

## 남은 위험 / 미확인

- wildcard mode와 mutable alias lookup은 root에 남아 있습니다.
- NumPy/PCG64 selector와 expansion 이동은 no-eager-NumPy gate를 고려한 후속 D-12 범위입니다.
- Prompt Studio/reservation consumer cutover는 mode/selector 경계가 확정된 뒤 별도 처리합니다.

상세 symbol/caller/alias/global-state inventory와 allowed-file boundary는 `docs/architecture/wildcard-seed-control-canonical-move.md`에 기록했습니다.