### PR TITLE
docs: prioritize release fixes and Prompt Studio UX before refactor

### DIFF
--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -5,50 +5,66 @@ rules for ComfyUI EasyUse Anima.
 
 They are contracts for future work, not a claim that the target package layout
 already exists. Start with the current-state section in
-[`python-backend.md`](python-backend.md). While Issue #323 is open, read the
-active B-11 sequencing addendum in
-[`comfy-host-provider-bridge.md`](comfy-host-provider-bridge.md), then use the
-current executable queue in
-[`python-backend-execution-roadmap.md`](python-backend-execution-roadmap.md)
-before planning an implementation PR.
+[`python-backend.md`](python-backend.md).
 
-The bridge addendum overrides only the ordering between the final B-11 shim and
-the minimum E-02a/E-07a Comfy host-provider Contract. It does not mark Phase E
-complete or replace the architecture ADRs and normal validation gates.
+While Issue [#395](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/395)
+is open, read
+[`release-first-stabilization-lane.md`](release-first-stabilization-lane.md)
+**before** selecting a task from the normal executable queue. The release lane
+pauses new D/E/G/H and AiO Hook implementation, orders #266, #267, #335, #394,
+and #64, and requires an integrated release before structural work resumes.
+
+After the release lane exits, use the current executable queue in
+[`python-backend-execution-roadmap.md`](python-backend-execution-roadmap.md)
+and re-audit its next task against the then-current `dev` head.
+
+The former B-11 Comfy host-provider bridge is complete. Its document remains a
+historical sequencing record and no longer overrides the active queue.
 
 ## Documents
 
+- [`release-first-stabilization-lane.md`](release-first-stabilization-lane.md):
+  active cross-surface execution override for release-blocking LoRA bugs, required
+  autocomplete and Prompt Studio features, integrated release validation, and
+  the refactor resumption gate.
 - [`python-backend.md`](python-backend.md): living architecture, ownership,
   execution phases, validation gates, and overall Definition of Done.
-- [`comfy-host-provider-bridge.md`](comfy-host-provider-bridge.md): active,
-  narrowly scoped sequencing addendum for the seven blocked root Comfy
+- [`python-backend-execution-roadmap.md`](python-backend-execution-roadmap.md):
+  verified backend progress, Codex execution protocol, ordinary ordered work
+  units, stop conditions, and task-level validation gates. Its next-work ordering
+  is paused while #395 is open.
+- [`comfy-host-provider-bridge.md`](comfy-host-provider-bridge.md): completed
+  historical sequencing addendum for the seven former root Comfy
   capability/invocation wrappers and the minimum runtime-bound provider Contract
   required before the final B-11 shim.
-- [`python-backend-execution-roadmap.md`](python-backend-execution-roadmap.md):
-  current verified progress, Codex execution protocol, ordered work units,
-  stop conditions, and task-level validation gates.
 - [`aio-hook-extensibility-plan.md`](aio-hook-extensibility-plan.md): follow-on
-  AiO extension contract, stage/cache/lifecycle sequencing, and the 0.6.0
-  release gate after the required backend refactor exits are satisfied.
+  AiO extension contract and stage/cache/lifecycle sequencing. Its older 0.6.0
+  target does not block the active stabilization release; assign the Hook public
+  API to a later minor if the stabilization release uses 0.6.0.
 - [`adr-001-modular-monolith.md`](adr-001-modular-monolith.md): why the backend
-  will converge on a feature-oriented modular monolith under `easyuse_anima`.
+  converges on a feature-oriented modular monolith under `easyuse_anima`.
 - [`adr-002-compatibility-shims.md`](adr-002-compatibility-shims.md): policy for
   introducing, supporting, and retiring root compatibility shims.
 - [`python-compatibility-shims.md`](python-compatibility-shims.md): registry
-  schema and initial inventory of current root/module surfaces.
+  schema and inventory of root/module compatibility surfaces.
 
 ## Authority and scope
 
-- The current repository policy remains authoritative for branches, releases,
-  Registry publication, and validation: [`MAINTAINING.md`](../../MAINTAINING.md).
+- The repository policy remains authoritative for branches, releases, Registry
+  publication, and validation: [`MAINTAINING.md`](../../MAINTAINING.md).
 - The development-document entry point remains
   [`docs/development/README.md`](../development/README.md).
-- These documents cover the Python backend only. Frontend JavaScript,
-  TypeScript, DOM, canvas, resize, and visual UX work are explicitly excluded.
-- Implementation is tracked by
+- The architecture ADRs and ordinary backend roadmap cover Python backend
+  ownership. Frontend JavaScript, TypeScript, DOM, canvas, resize, and visual UX
+  work normally stays in development documents.
+- The release-first stabilization lane is intentionally cross-surface because a
+  release gate must order backend settings, frontend UX, workflow compatibility,
+  packaging, and live ComfyUI evidence together. It does not redefine feature
+  ownership or authorize unrelated refactoring.
+- Long-term implementation is tracked by
   [Issue #184](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/184),
-  the long-term parent
-  [Issue #185](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/185), the
-  runtime bridge [Issue #323](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/323),
-  and their related backend issues. An ADR or sequencing addendum does not
-  authorize a package move, behavior change, release, or shim removal by itself.
+  [Issue #185](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/185), and
+  their child issues. The active release override is tracked by
+  [Issue #395](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/395).
+- An ADR, roadmap, or sequencing addendum does not authorize a package move,
+  behavior change, merge, version bump, tag, or Registry publication by itself.

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -8,11 +8,16 @@ already exists. Start with the current-state section in
 [`python-backend.md`](python-backend.md).
 
 While Issue [#395](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/395)
-is open, read
-[`release-first-stabilization-lane.md`](release-first-stabilization-lane.md)
-**before** selecting a task from the normal executable queue. The release lane
-pauses new D/E/G/H and AiO Hook implementation, orders #266, #267, #335, #394,
-and #64, and requires an integrated release before structural work resumes.
+is open, read these active release documents in order before selecting any task:
+
+1. [`release-first-stabilization-lane.md`](release-first-stabilization-lane.md)
+2. [`prompt-studio-autocomplete-release-addendum.md`](prompt-studio-autocomplete-release-addendum.md)
+
+The base release lane pauses new D/E/G/H and AiO Hook implementation. The active
+addendum adds the Prompt Studio long-paste bug #401 and expands #64 into ordered
+completion-range, artist-prefix, safe mid-text, and bracket-editing work units.
+It overrides the affected queue, release-candidate matrix, and resumption gate in
+the base lane.
 
 After the release lane exits, use the current executable queue in
 [`python-backend-execution-roadmap.md`](python-backend-execution-roadmap.md)
@@ -24,9 +29,13 @@ historical sequencing record and no longer overrides the active queue.
 ## Documents
 
 - [`release-first-stabilization-lane.md`](release-first-stabilization-lane.md):
-  active cross-surface execution override for release-blocking LoRA bugs, required
-  autocomplete and Prompt Studio features, integrated release validation, and
-  the refactor resumption gate.
+  base active cross-surface execution override for release-blocking LoRA bugs,
+  required autocomplete and Prompt Studio features, integrated release
+  validation, and the refactor resumption gate.
+- [`prompt-studio-autocomplete-release-addendum.md`](prompt-studio-autocomplete-release-addendum.md):
+  active revision adding #401 long-paste textarea stabilization and the detailed
+  #64 dual-range completion, configurable artist prefix, right-text preservation,
+  bracket-group editing, and optional selected-text weight workflow.
 - [`python-backend.md`](python-backend.md): living architecture, ownership,
   execution phases, validation gates, and overall Definition of Done.
 - [`python-backend-execution-roadmap.md`](python-backend-execution-roadmap.md):
@@ -57,14 +66,17 @@ historical sequencing record and no longer overrides the active queue.
 - The architecture ADRs and ordinary backend roadmap cover Python backend
   ownership. Frontend JavaScript, TypeScript, DOM, canvas, resize, and visual UX
   work normally stays in development documents.
-- The release-first stabilization lane is intentionally cross-surface because a
-  release gate must order backend settings, frontend UX, workflow compatibility,
-  packaging, and live ComfyUI evidence together. It does not redefine feature
-  ownership or authorize unrelated refactoring.
+- The release-first stabilization lane and its active addendum are intentionally
+  cross-surface because a release gate must order backend settings, frontend UX,
+  workflow compatibility, packaging, and live ComfyUI evidence together. They do
+  not redefine feature ownership or authorize unrelated refactoring.
 - Long-term implementation is tracked by
   [Issue #184](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/184),
   [Issue #185](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/185), and
   their child issues. The active release override is tracked by
-  [Issue #395](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/395).
+  [Issue #395](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/395), with
+  [Issue #401](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/401) and
+  [Issue #64](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/64) owning the
+  added Prompt Studio/autocomplete work.
 - An ADR, roadmap, or sequencing addendum does not authorize a package move,
   behavior change, merge, version bump, tag, or Registry publication by itself.

--- a/docs/architecture/prompt-studio-autocomplete-release-addendum.md
+++ b/docs/architecture/prompt-studio-autocomplete-release-addendum.md
@@ -4,61 +4,110 @@
 
 - Status: active release-lane addendum
 - Snapshot date: 2026-07-24
-- Base branch: `dev`
+- Snapshot branch: `dev`
+- Snapshot commit: `9a4f11593b5ea042d0883aa3ca325f6695a78bc2`
 - Base release lane: [`release-first-stabilization-lane.md`](release-first-stabilization-lane.md)
 - Release owner: [#395](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/395)
 - Expanded autocomplete work: [#64](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/64)
 - New release-blocking textarea bug: [#401](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/401)
 
 This addendum records two user-facing requirements discovered after the original
-release-first lane was written. While #395 is open, it overrides the relevant
-queue, #64 manifest, release-candidate matrix, and resumption checklist in the
-base lane. All other freeze, validation, release, and ownership rules remain in
-force.
+release-first lane was written. While #395 is open, this file overrides the
+relevant queue, #64 manifest, release-candidate matrix, and resumption checklist
+in the base lane. All other freeze, validation, release, and ownership rules
+remain in force.
 
-## 1. Revised critical path
+## 1. Verified state and revised critical path
+
+The original first four implementation tasks are already integrated:
+
+- #266 profile provenance: PR #397;
+- #267 profile scrollbar pointer interaction: PR #398;
+- #394 resolution orientation switch: PR #399; and
+- #335 locale-aware initial autocomplete source: PR #400.
+
+Do not reopen or combine those completed scopes. The next release work is:
 
 ```text
-REL-BUG-01   #266 LoRA workflow profile provenance
-  -> REL-BUG-02   #267 LoRA scrollbar pointer interaction
-  -> REL-BUG-03   #401 Prompt Studio long-paste textarea autosize
-  -> REL-FEAT-01  #335 locale-aware initial autocomplete source
-       + REL-FEAT-02  #394 resolution orientation switch in parallel
-  -> REL-FEAT-03A #64 completion edit Contract
-  -> REL-FEAT-03B #64 configurable artist prefix
-  -> REL-FEAT-03C #64 safe mid-text completion
-  -> REL-FEAT-03D #64 bracket and weighted-selection UX
-  -> REL-RC-01 integrated release-candidate validation
-  -> REL-PREP-01 release preparation
-  -> REL-PUBLISH-01 main/tag/Registry publication
-  -> backend refactor re-audit and resume
+COMPLETE: #266 / PR #397
+COMPLETE: #267 / PR #398
+COMPLETE: #394 / PR #399
+COMPLETE: #335 / PR #400
+
+READY:    REL-BUG-03   #401 Prompt Studio long-paste textarea autosize
+  ->      REL-FEAT-03A #64 completion edit Contract
+  ->      REL-FEAT-03B #64 configurable artist prefix
+  ->      REL-FEAT-03C #64 safe mid-text completion
+  ->      REL-FEAT-03D #64 bracket and weighted-selection UX
+  ->      REL-RC-01 integrated release-candidate validation
+  ->      REL-PREP-01 release preparation
+  ->      REL-PUBLISH-01 main/tag/Registry publication
+  ->      backend refactor re-audit and resume
 ```
 
-The first READY task remains REL-BUG-01 / #266. This addendum does not authorize
-starting #401 or #64 ahead of their prerequisites.
+The first task Codex must select from this addendum is **REL-BUG-03 / #401**.
 
 ## 2. Revised executable queue
 
-| Order | Task ID | Owner | State at this snapshot | Type | Prerequisites |
+| Order | Task ID | Owner | State | Type | Prerequisites |
 | ---: | --- | --- | --- | --- | --- |
-| 1 | REL-BUG-01 | #266 | READY | Fix | latest `dev`; no overlapping PR |
-| 2 | REL-BUG-02 | #267 | BLOCKED | Fix | REL-BUG-01 merged |
-| 3 | REL-BUG-03 | #401 | BLOCKED | Fix | REL-BUG-02 merged; rebase Prompt Studio frontend |
-| 4A | REL-FEAT-01 | #335 | BLOCKED | Feature/Contract | REL-BUG-03 merged |
-| 4B | REL-FEAT-02 | #394 | BLOCKED | Feature | REL-BUG-03 merged; may run with 4A only when file ownership remains disjoint |
-| 5A | REL-FEAT-03A | #64 | BLOCKED | Contract/test | REL-FEAT-01 and REL-FEAT-02 merged |
-| 5B | REL-FEAT-03B | #64 | BLOCKED | Feature/Contract | REL-FEAT-03A merged |
-| 5C | REL-FEAT-03C | #64 | BLOCKED | Fix/Feature | REL-FEAT-03B merged |
-| 5D | REL-FEAT-03D | #64 | BLOCKED | Feature | REL-FEAT-03C merged |
-| 6 | REL-RC-01 | #395 | BLOCKED | Integration gate | six issues and all #64 units merged |
-| 7 | REL-PREP-01 | #395 | BLOCKED | Release-only | REL-RC-01 passed |
-| 8 | REL-PUBLISH-01 | #395 | BLOCKED | Release | release prep reviewed and merged |
+| 1 | REL-BUG-01 | #266 | COMPLETE | Fix | PR #397 merged |
+| 2 | REL-BUG-02 | #267 | COMPLETE | Fix | PR #398 merged |
+| 3 | REL-FEAT-02 | #394 | COMPLETE | Feature | PR #399 merged |
+| 4 | REL-FEAT-01 | #335 | COMPLETE | Feature/Contract | PR #400 merged |
+| 5 | REL-BUG-03 | #401 | READY | Fix | current `dev`; no overlapping implementation PR |
+| 6A | REL-FEAT-03A | #64 | BLOCKED | Contract/test | REL-BUG-03 merged and Prompt Studio frontend rebased |
+| 6B | REL-FEAT-03B | #64 | BLOCKED | Feature/Contract | REL-FEAT-03A merged |
+| 6C | REL-FEAT-03C | #64 | BLOCKED | Fix/Feature | REL-FEAT-03B merged |
+| 6D | REL-FEAT-03D | #64 | BLOCKED | Feature | REL-FEAT-03C merged |
+| 7 | REL-RC-01 | #395 | BLOCKED | Integration gate | #401 and all #64 units merged |
+| 8 | REL-PREP-01 | #395 | BLOCKED | Release-only | REL-RC-01 passed |
+| 9 | REL-PUBLISH-01 | #395 | BLOCKED | Release | release prep reviewed and merged |
 
 One issue may use several rollback-sized PRs when its accepted plan explicitly
-requires ordered Contract and Behavior units. Do not combine #401 with #394 or
-#64 merely because they touch Prompt Studio.
+requires ordered Contract and behavior units. Do not combine #401 with #64 or
+reopen #394 merely because all three touch Prompt Studio.
 
-## 3. Verified autocomplete failure surface
+## 3. Common execution protocol
+
+Before editing:
+
+```powershell
+git fetch origin
+git checkout -b codex/rel-<task-id>-<description> origin/dev
+git rev-parse HEAD
+powershell -ExecutionPolicy Bypass -File tools\check_project.ps1 -Profile quick
+```
+
+Then:
+
+1. read the base release lane, this addendum, #395, and the owning issue;
+2. verify current `dev` and search open PRs and branches for the task ID;
+3. reproduce the current behavior before editing;
+4. inventory the canonical owners, allowed files, and forbidden changes in the PR
+   body;
+5. implement one rollback-sized unit only; and
+6. record exact base/head SHA, focused/full/live evidence, rollback boundary, and
+   next task.
+
+Every implementation PR runs:
+
+```powershell
+powershell -ExecutionPolicy Bypass -File tools\check_project.ps1 -Profile full
+```
+
+UI-visible behavior additionally requires Legacy Canvas and Node 2.0 evidence.
+Package or public-surface changes additionally require:
+
+```powershell
+comfy node validate
+comfy node pack
+```
+
+An unavailable live scenario is recorded as unexecuted, not passed, and remains a
+REL-RC-01 gate.
+
+## 4. Verified autocomplete failure surface
 
 The current frontend has one search range and one replacement range.
 
@@ -69,30 +118,31 @@ The current frontend has one search range and one replacement range.
 3. returns one `start` and `end`; and
 4. lets `planAutocompleteInsertion()` replace that full range.
 
-This means that a caret in the middle of a comma-delimited segment can cause
-right-hand text in the same segment to be removed. Search context and edit
-ownership are incorrectly coupled.
+This couples search context to edit ownership. A caret in the middle of a
+comma-delimited segment can therefore cause right-hand text in the same segment
+to be removed.
 
-The accepted correction follows the editor model used by LSP
-`InsertReplaceEdit` and Monaco suggestion insert/replace modes, without adding an
+The accepted correction follows the editor model represented by LSP
+`InsertReplaceEdit` and Monaco suggestion insert/replace modes without adding an
 editor dependency:
 
 ```text
 query range   != insert range != replace range
 ```
 
-- query range may include a multi-word search prefix;
-- insert range ends at the caret and preserves right-hand text;
-- replace range may include only the proven contiguous tail of the active item;
+- the query range may include a multi-word search prefix;
+- the insert range ends at the caret and preserves right-hand text;
+- the replace range may include only the proven contiguous tail of the active
+  item; and
 - closing brackets, numeric weights, separators, and separate suffix tags are
   protected.
 
-Official design references:
+Design references:
 
 - https://microsoft.github.io/language-server-protocol/specifications/lsp/3.18/specification/#textDocument_completion
 - https://microsoft.github.io/monaco-editor/typedoc/interfaces/editor_editor_api.editor.ISuggestOptions.html
 
-## 4. REL-BUG-03 — Long-paste textarea autosize
+## 5. REL-BUG-03 — Long-paste textarea autosize
 
 ### Goal
 
@@ -112,8 +162,32 @@ Neither path verifies after browser wrapping, font/highlight work, node sizing,
 and the next layout frame that `scrollHeight` actually fits `clientHeight`.
 
 This is a confirmed missing stabilization guarantee. The implementation PR must
-still capture live values to prove which affected node variants reproduce the
-reported clipping.
+still capture live values to identify every affected node variant and the exact
+frame where the stale height occurs.
+
+### Required pre-fix evidence
+
+Test at least:
+
+```text
+100+ short lines
+one long wrapped line
+mixed Korean/English text
+brackets, weights, and Artist Mix syntax
+narrow node width
+paste before and after manual textarea resize
+Classic, Advanced, AdvancedV2, Legacy Canvas, Node 2.0
+```
+
+Record:
+
+```text
+paste/input-turn scrollHeight, clientHeight, offsetHeight
+first requestAnimationFrame values
+post-node-layout frame values
+stored field.height or widget.__easyuseAnimaHeight
+final overflowY
+```
 
 ### Required implementation
 
@@ -122,7 +196,7 @@ input or paste
   -> immediate grow
   -> bounded requestAnimationFrame remeasure
   -> optional one additional post-node-layout verification
-  -> stop when content fits or retry budget is exhausted
+  -> stop when content fits or the small fixed retry budget is exhausted
 ```
 
 Rules:
@@ -130,12 +204,13 @@ Rules:
 - use an input revision/epoch so stale callbacks cannot overwrite newer text;
 - post-layout corrections are grow-only;
 - use a small fixed retry budget, never an unbounded RAF or polling loop;
-- removed/disconnected inputs make scheduled work a safe no-op;
+- removed or disconnected inputs make scheduled work a safe no-op;
 - preserve the current auto/manual height distinction;
 - manual height remains user-owned but grows when content no longer fits;
 - keep `overflowY: hidden` on the textarea;
 - reuse existing Advanced and Classic height/layout owners;
-- do not create a document-level paste listener or global timer registry.
+- do not create a document-level paste listener or global timer registry; and
+- preserve the already merged #394 resolution component and its layout behavior.
 
 ### Exit invariant
 
@@ -169,26 +244,27 @@ Legacy Canvas and Node 2.0 live smoke
 - inner scrolling as a substitute for correct height;
 - prompt text truncation or normalization;
 - repeated node `setSize()` loops;
-- #394 resolution behavior;
+- changes to #394 resolution semantics or controls;
 - #64 completion behavior;
 - unrelated Prompt Studio refactoring.
 
 ### Rollback boundary
 
 Revert only bounded paste/input remeasurement and its tests. Existing manual
-resize, width reflow, highlight, and node-layout ownership remain intact.
+resize, width reflow, highlight, node-layout ownership, and #394 remain intact.
 
-## 5. REL-FEAT-03 — Expanded #64 execution plan
+## 6. REL-FEAT-03 — Expanded #64 execution plan
 
-Issue #64 now owns three connected user outcomes:
+Issue #64 owns three connected user outcomes:
 
 1. configurable artist-only autocomplete prefix;
 2. non-destructive completion in the middle of text; and
 3. bracket-group and selected-text editing ergonomics.
 
-It does not own textarea autosize; that remains #401.
+It does not own textarea autosize; that remains #401. The #335 canonical settings
+initialization contract is already integrated in PR #400 and must be reused.
 
-### 5.1 Settings contract
+### 6.1 Settings contract
 
 #### Artist prefix
 
@@ -199,10 +275,9 @@ default: @
 ```
 
 - trim surrounding whitespace;
-- reject newline, comma, control characters, and an excessive length;
+- reject newline, comma, control characters, and excessive length;
 - empty or invalid values fall back to `@`;
-- compare the prefix literally rather than building an unsafe dynamic regular
-  expression;
+- compare the prefix literally rather than building an unsafe dynamic regex;
 - apply it only to artist-only query and insertion;
 - do not rewrite existing prompt text.
 
@@ -237,11 +312,11 @@ default: false
 - an existing top-level numeric weight is not duplicated;
 - an empty selection retains normal `()` pair behavior.
 
-All keys must be owned by canonical `easyuse_anima.settings` and reflected in
-public settings, frontend definitions/runtime, localization, and setting parity
-tests. Root settings shims must not regain implementation.
+All keys are owned by canonical `easyuse_anima.settings` and reflected in public
+settings, frontend definitions/runtime, localization, and setting parity tests.
+Root settings shims must not regain implementation.
 
-### 5.2 Range contract
+### 6.2 Range contract
 
 The pure text model must expose enough information to keep search and editing
 separate:
@@ -265,10 +340,10 @@ Required parsing rules:
    range;
 6. allow only the caret-adjacent contiguous tail as a `smart` replace candidate;
 7. protect `:number`, `)`, `}`, and `]]` suffixes;
-8. allow query context to be wider than the edit range for multi-word tags;
+8. allow query context to be wider than the edit range for multi-word tags; and
 9. use the identical edit plan for inline preview and commit.
 
-### 5.3 Required non-destructive examples
+### 6.3 Required non-destructive examples
 
 ```text
 foo| bar + completion "foo tag"
@@ -281,7 +356,7 @@ foo| bar + completion "foo tag"
   -> artist_a and :0.7 remain
 
 old_t|ag
-  smart  -> only proven contiguous tail may be replaced
+  smart  -> only the proven contiguous tail may be replaced
   insert -> ag remains
 ```
 
@@ -289,7 +364,28 @@ At minimum, a complete recognized tag separated by whitespace to the right of
 the caret must never be deleted. The accepted default is stronger: every
 whitespace-separated suffix is protected in `smart` mode.
 
-### 5.4 Bracket editing contract
+### 6.4 Completion edit planner
+
+`planAutocompleteInsertion()` must choose a reviewed range according to the
+commit mode rather than use one segment-wide `start/end` pair.
+
+Return shape may evolve during 03A but must support:
+
+```text
+start/end
+replacement
+caretOffset or selectionStartOffset/selectionEndOffset
+preservedSuffix
+modeUsed
+```
+
+- `replaceInputRange()` may be extended to set a post-insert selection;
+- each command remains one undoable edit;
+- `execCommand("insertText")` and `setRangeText()` fallbacks produce the same
+  text and selection; and
+- IME composition never commits a suggestion.
+
+### 6.5 Bracket editing contract
 
 - support consistent selected-text wrapping for `()`, `{}`, and `[[ ]]`;
 - skip over an already auto-inserted closing delimiter when the user types it;
@@ -298,14 +394,17 @@ whitespace-separated suffix is protected in `smart` mode.
 - allow more than one autocomplete item inside one pair;
 - optional weighted wrapping inserts `(selection:1)` as one undoable edit and
   selects `1` for immediate replacement;
-- preserve nested and escaped delimiters;
+- preserve nested and escaped delimiters; and
 - define multiline selection behavior in pure tests before enabling it.
 
-### 5.5 Work units
+Backspace pair deletion and unrelated editor conveniences are not implicitly in
+scope. Add them only through a separately reviewed work unit.
+
+### 6.6 Work units
 
 #### REL-FEAT-03A — Completion edit Contract
 
-- freeze current destructive examples as failing/regression fixtures;
+- freeze current destructive examples as regression fixtures;
 - define dual ranges, syntax-group boundaries, settings names/defaults, and
   insertion result shape;
 - minimize production behavior changes.
@@ -330,11 +429,10 @@ whitespace-separated suffix is protected in `smart` mode.
 - complete Legacy Canvas, Node 2.0, keyboard, IME, undo, save/reload, and
   accessibility evidence.
 
-### 5.6 PR isolation
+### 6.7 Branch and PR isolation
 
-#64 may use four ordered PRs under one issue because Contract, settings, edit
-behavior, and bracket behavior have independent rollback boundaries. Each branch
-uses:
+#64 uses four ordered PRs because Contract, settings, edit behavior, and bracket
+behavior have independent rollback boundaries:
 
 ```text
 codex/rel-feat-03a-completion-contract
@@ -343,14 +441,51 @@ codex/rel-feat-03c-safe-midtext
 codex/rel-feat-03d-bracket-ux
 ```
 
-Do not combine #335, #401, or broad autocomplete refactoring into these PRs.
+Do not combine #401, reopen #335/#394, or perform broad autocomplete refactoring
+inside these PRs.
 
-## 6. Revised release-candidate matrix
+### 6.8 Existing behavior to preserve
 
-REL-RC-01 runs only after all six issues and all #64 units are integrated on one
-exact `dev` head.
+- source ranking, result order, category API, dataset/index format;
+- wildcard autocomplete;
+- natural-sentence period handling;
+- append-separator and no-comma-after-period settings;
+- inline preview enable/disable;
+- Shift+Enter line break;
+- Enter/Tab commit setting;
+- forced artist-only input scope;
+- workflow text and node/widget serialization; and
+- autocomplete cache, cancellation, and IME lifecycle.
 
-Automated gates remain:
+### 6.9 Required tests
+
+```text
+artist prefix default/custom/duplicate/persistence
+forced artist-only field with custom prefix
+non-artist categories unchanged
+mid-segment commit with whitespace-separated right tag preserved
+mid-segment commit with comma/newline suffix preserved
+contiguous tail smart replace
+always-insert mode preserves all right text
+weight and closing syntax preserved
+nested parentheses and [[ ]] active item only
+multiple comma-separated items in one group
+preview/commit range parity
+selection -> (), {}, [[ ]]
+selection + weight option -> (selection:1), numeric placeholder selected
+existing numeric weight -> no duplicate :1
+one undo step per edit
+IME composition and popup commit
+Legacy Canvas / Node 2.0 live smoke
+```
+
+## 7. Revised release-candidate matrix
+
+REL-RC-01 runs only after #401 and all four #64 units are integrated on one exact
+`dev` head. The already merged #266, #267, #335, and #394 behavior remains part
+of the regression matrix.
+
+Automated gates:
 
 ```powershell
 powershell -ExecutionPolicy Bypass -File tools\check_project.ps1 -Profile full
@@ -358,9 +493,10 @@ comfy node validate
 comfy node pack
 ```
 
-In addition to the base lane matrix, verify:
+Inspect the actual archive for required Python, JavaScript, locale, CSV,
+workflow, and changelog inputs.
 
-### #401
+### #401 flows
 
 - 100+ line paste and long wrapped-line paste;
 - auto and manual textarea height modes;
@@ -369,7 +505,7 @@ In addition to the base lane matrix, verify:
 - no stale scheduled resize after rapid input or node removal;
 - Classic, Advanced, AdvancedV2, Legacy Canvas, and Node 2.0 where applicable.
 
-### #64
+### #64 flows
 
 - default and custom artist prefix search/insertion/persistence;
 - no duplicate prefix and no non-artist category change;
@@ -383,44 +519,56 @@ In addition to the base lane matrix, verify:
 - optional `(selection:1)` with the numeric placeholder selected;
 - IME, keyboard, undo, save/reload, Legacy Canvas, and Node 2.0.
 
+### Previously merged regression flows
+
+- #266 cross-user profile provenance;
+- #267 track click and thumb drag;
+- #335 fresh locale default and explicit-value preservation; and
+- #394 preset/custom/NAIA orientation switching.
+
 A release candidate fails if any accepted completion deletes text outside its
 reviewed edit range, or if a long-paste textarea finishes with hidden overflow.
 
-## 7. Revised resumption gate
+## 8. Revised resumption gate
 
 The ordinary backend queue remains paused until:
 
-- #266, #267, #401, #335, #394, and #64 are complete;
+- #266, #267, #335, and #394 remain integrated and regression-clean;
+- #401 is complete;
 - #64 REL-FEAT-03A through REL-FEAT-03D are all integrated;
 - the revised REL-RC-01 passes at one exact `dev` head;
 - release preparation, `main` integration, immutable tag, Registry publication,
   and read-back complete; and
 - no immediate P0/P1 post-release regression remains open.
 
-## 8. Codex instructions
+## 9. Codex instructions
 
 ### Current first task
 
 ```text
-Read docs/architecture/release-first-stabilization-lane.md, then this addendum,
-and Issue #395. Select REL-BUG-01 / #266. Do not start #401 or #64 early.
-```
+Read docs/architecture/release-first-stabilization-lane.md, then
+prompt-studio-autocomplete-release-addendum.md, Issue #395, and Issue #401.
+Confirm PRs #397 through #400 are integrated and no open PR owns REL-BUG-03.
 
-### When REL-BUG-03 becomes READY
+Create codex/rel-bug-03-prompt-studio-paste from latest origin/dev. Reproduce the
+long-paste clipping in each Prompt Studio textarea family and record immediate,
+first-frame, and post-layout scrollHeight/clientHeight values. Implement only
+bounded revision-owned grow-only remeasurement. Preserve #394 and do not touch
+#64 completion behavior.
 
-```text
-Read Issue #401 and inspect both Prompt Studio textarea families. Reproduce and
-record immediate, first-frame, and post-layout scrollHeight/clientHeight values.
-Implement bounded revision-owned grow-only remeasurement. Do not touch #394 or
-#64. Run focused tests, the full project check, and Legacy/Node 2.0 paste smoke.
+Run focused tests, tools/check_project.ps1 -Profile full, and Legacy/Node 2.0
+paste smoke. Record exact base/head SHA, affected variants, final fit invariant,
+rollback boundary, and next task REL-FEAT-03A. Do not merge, version, tag, or
+publish from this implementation task.
 ```
 
 ### When REL-FEAT-03A becomes READY
 
 ```text
 Read the updated Issue #64. Start with Contract/tests only: reproduce right-text
-deletion, define query/insert/replace ranges, protected suffixes, bracket-group
-boundaries, and the three setting contracts. Do not jump directly to one broad
-implementation PR. Execute 03A, 03B, 03C, and 03D in order and record exact
-base/head SHA, rollback boundary, focused/full/live evidence, and next unit.
+deletion and define query/insert/replace ranges, protected suffixes,
+bracket-group boundaries, and all three setting contracts. Do not jump directly
+to one broad implementation PR. Execute 03A, 03B, 03C, and 03D in order and
+record exact base/head SHA, rollback boundary, focused/full/live evidence, and
+next unit.
 ```

--- a/docs/architecture/prompt-studio-autocomplete-release-addendum.md
+++ b/docs/architecture/prompt-studio-autocomplete-release-addendum.md
@@ -1,0 +1,426 @@
+# Prompt Studio and Autocomplete UX Release Addendum
+
+## Document status
+
+- Status: active release-lane addendum
+- Snapshot date: 2026-07-24
+- Base branch: `dev`
+- Base release lane: [`release-first-stabilization-lane.md`](release-first-stabilization-lane.md)
+- Release owner: [#395](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/395)
+- Expanded autocomplete work: [#64](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/64)
+- New release-blocking textarea bug: [#401](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/401)
+
+This addendum records two user-facing requirements discovered after the original
+release-first lane was written. While #395 is open, it overrides the relevant
+queue, #64 manifest, release-candidate matrix, and resumption checklist in the
+base lane. All other freeze, validation, release, and ownership rules remain in
+force.
+
+## 1. Revised critical path
+
+```text
+REL-BUG-01   #266 LoRA workflow profile provenance
+  -> REL-BUG-02   #267 LoRA scrollbar pointer interaction
+  -> REL-BUG-03   #401 Prompt Studio long-paste textarea autosize
+  -> REL-FEAT-01  #335 locale-aware initial autocomplete source
+       + REL-FEAT-02  #394 resolution orientation switch in parallel
+  -> REL-FEAT-03A #64 completion edit Contract
+  -> REL-FEAT-03B #64 configurable artist prefix
+  -> REL-FEAT-03C #64 safe mid-text completion
+  -> REL-FEAT-03D #64 bracket and weighted-selection UX
+  -> REL-RC-01 integrated release-candidate validation
+  -> REL-PREP-01 release preparation
+  -> REL-PUBLISH-01 main/tag/Registry publication
+  -> backend refactor re-audit and resume
+```
+
+The first READY task remains REL-BUG-01 / #266. This addendum does not authorize
+starting #401 or #64 ahead of their prerequisites.
+
+## 2. Revised executable queue
+
+| Order | Task ID | Owner | State at this snapshot | Type | Prerequisites |
+| ---: | --- | --- | --- | --- | --- |
+| 1 | REL-BUG-01 | #266 | READY | Fix | latest `dev`; no overlapping PR |
+| 2 | REL-BUG-02 | #267 | BLOCKED | Fix | REL-BUG-01 merged |
+| 3 | REL-BUG-03 | #401 | BLOCKED | Fix | REL-BUG-02 merged; rebase Prompt Studio frontend |
+| 4A | REL-FEAT-01 | #335 | BLOCKED | Feature/Contract | REL-BUG-03 merged |
+| 4B | REL-FEAT-02 | #394 | BLOCKED | Feature | REL-BUG-03 merged; may run with 4A only when file ownership remains disjoint |
+| 5A | REL-FEAT-03A | #64 | BLOCKED | Contract/test | REL-FEAT-01 and REL-FEAT-02 merged |
+| 5B | REL-FEAT-03B | #64 | BLOCKED | Feature/Contract | REL-FEAT-03A merged |
+| 5C | REL-FEAT-03C | #64 | BLOCKED | Fix/Feature | REL-FEAT-03B merged |
+| 5D | REL-FEAT-03D | #64 | BLOCKED | Feature | REL-FEAT-03C merged |
+| 6 | REL-RC-01 | #395 | BLOCKED | Integration gate | six issues and all #64 units merged |
+| 7 | REL-PREP-01 | #395 | BLOCKED | Release-only | REL-RC-01 passed |
+| 8 | REL-PUBLISH-01 | #395 | BLOCKED | Release | release prep reviewed and merged |
+
+One issue may use several rollback-sized PRs when its accepted plan explicitly
+requires ordered Contract and Behavior units. Do not combine #401 with #394 or
+#64 merely because they touch Prompt Studio.
+
+## 3. Verified autocomplete failure surface
+
+The current frontend has one search range and one replacement range.
+
+`web/js/autocomplete/text_model.js` currently:
+
+1. scans left and right to comma or newline;
+2. trims prompt-syntax prefixes and suffixes;
+3. returns one `start` and `end`; and
+4. lets `planAutocompleteInsertion()` replace that full range.
+
+This means that a caret in the middle of a comma-delimited segment can cause
+right-hand text in the same segment to be removed. Search context and edit
+ownership are incorrectly coupled.
+
+The accepted correction follows the editor model used by LSP
+`InsertReplaceEdit` and Monaco suggestion insert/replace modes, without adding an
+editor dependency:
+
+```text
+query range   != insert range != replace range
+```
+
+- query range may include a multi-word search prefix;
+- insert range ends at the caret and preserves right-hand text;
+- replace range may include only the proven contiguous tail of the active item;
+- closing brackets, numeric weights, separators, and separate suffix tags are
+  protected.
+
+Official design references:
+
+- https://microsoft.github.io/language-server-protocol/specifications/lsp/3.18/specification/#textDocument_completion
+- https://microsoft.github.io/monaco-editor/typedoc/interfaces/editor_editor_api.editor.ISuggestOptions.html
+
+## 4. REL-BUG-03 — Long-paste textarea autosize
+
+### Goal
+
+After a large paste or input mutation, each affected Prompt Studio textarea must
+grow until all text is visible without an internal vertical scrollbar.
+
+### Current code gap
+
+Both textarea families perform a same-turn content-height measurement:
+
+- Advanced/AdvancedV2: `advanced_fields_ui.js` calls
+  `advancedTextareaContentHeight()` during the `input` event;
+- Classic/Extend: `studio_resizable_input.js` calls
+  `desiredTextareaHeight()` during the `input` event.
+
+Neither path verifies after browser wrapping, font/highlight work, node sizing,
+and the next layout frame that `scrollHeight` actually fits `clientHeight`.
+
+This is a confirmed missing stabilization guarantee. The implementation PR must
+still capture live values to prove which affected node variants reproduce the
+reported clipping.
+
+### Required implementation
+
+```text
+input or paste
+  -> immediate grow
+  -> bounded requestAnimationFrame remeasure
+  -> optional one additional post-node-layout verification
+  -> stop when content fits or retry budget is exhausted
+```
+
+Rules:
+
+- use an input revision/epoch so stale callbacks cannot overwrite newer text;
+- post-layout corrections are grow-only;
+- use a small fixed retry budget, never an unbounded RAF or polling loop;
+- removed/disconnected inputs make scheduled work a safe no-op;
+- preserve the current auto/manual height distinction;
+- manual height remains user-owned but grows when content no longer fits;
+- keep `overflowY: hidden` on the textarea;
+- reuse existing Advanced and Classic height/layout owners;
+- do not create a document-level paste listener or global timer registry.
+
+### Exit invariant
+
+For every affected textarea after stabilization:
+
+```text
+textarea.scrollHeight <= textarea.clientHeight + 2
+textarea.style.overflowY == "hidden"
+```
+
+### Required tests
+
+```text
+long multiline paste
+long wrapped single line
+Korean and English mixed text
+prompt brackets and weights
+narrow node width
+paste followed by width change
+manual height followed by larger paste
+rapid consecutive paste; latest revision wins
+node/input removed before scheduled remeasure
+save/reload value and height parity
+highlight overlay height parity
+Legacy Canvas and Node 2.0 live smoke
+```
+
+### Forbidden changes
+
+- fixed oversized textarea defaults;
+- inner scrolling as a substitute for correct height;
+- prompt text truncation or normalization;
+- repeated node `setSize()` loops;
+- #394 resolution behavior;
+- #64 completion behavior;
+- unrelated Prompt Studio refactoring.
+
+### Rollback boundary
+
+Revert only bounded paste/input remeasurement and its tests. Existing manual
+resize, width reflow, highlight, and node-layout ownership remain intact.
+
+## 5. REL-FEAT-03 — Expanded #64 execution plan
+
+Issue #64 now owns three connected user outcomes:
+
+1. configurable artist-only autocomplete prefix;
+2. non-destructive completion in the middle of text; and
+3. bracket-group and selected-text editing ergonomics.
+
+It does not own textarea autosize; that remains #401.
+
+### 5.1 Settings contract
+
+#### Artist prefix
+
+```text
+internal key: autocomplete.artist_prefix
+Comfy key: EasyUseAnima.Prompt.AutocompleteArtistPrefix
+default: @
+```
+
+- trim surrounding whitespace;
+- reject newline, comma, control characters, and an excessive length;
+- empty or invalid values fall back to `@`;
+- compare the prefix literally rather than building an unsafe dynamic regular
+  expression;
+- apply it only to artist-only query and insertion;
+- do not rewrite existing prompt text.
+
+#### Completion commit mode
+
+```text
+internal key: autocomplete.commit_mode
+Comfy key: EasyUseAnima.Prompt.AutocompleteCommitMode
+accepted values: smart | insert | replace
+default: smart
+```
+
+- `smart`: replace only a proven contiguous active-item tail and preserve
+  whitespace/delimiter-separated suffix text;
+- `insert`: end the edit at the caret and unconditionally preserve everything to
+  the right;
+- `replace`: use the reviewed syntax-aware active-item replace range, never the
+  old whole comma segment.
+
+Ambiguity is resolved in favor of preserving text.
+
+#### Selected-parentheses weight
+
+```text
+internal key: prompt_studio.selection_parenthesis_weight
+Comfy key: EasyUseAnima.Prompt.SelectionParenthesisWeight
+default: false
+```
+
+- OFF: selected text plus `(` becomes `(selected)`;
+- ON: it becomes `(selected:1)` and the inserted `1` is selected;
+- an existing top-level numeric weight is not duplicated;
+- an empty selection retains normal `()` pair behavior.
+
+All keys must be owned by canonical `easyuse_anima.settings` and reflected in
+public settings, frontend definitions/runtime, localization, and setting parity
+tests. Root settings shims must not regain implementation.
+
+### 5.2 Range contract
+
+The pure text model must expose enough information to keep search and editing
+separate:
+
+```text
+queryStart/queryEnd
+insertStart/insertEnd
+replaceStart/replaceEnd
+caret and selection
+syntax group boundaries
+protected suffix start
+```
+
+Required parsing rules:
+
+1. honor an explicit non-empty selection;
+2. handle escaped brackets as literals;
+3. track `()`, `{}`, and `[[ ]]` nesting;
+4. treat comma/newline at the active nesting level as item boundaries;
+5. never include a whitespace-separated right suffix in the default replace
+   range;
+6. allow only the caret-adjacent contiguous tail as a `smart` replace candidate;
+7. protect `:number`, `)`, `}`, and `]]` suffixes;
+8. allow query context to be wider than the edit range for multi-word tags;
+9. use the identical edit plan for inline preview and commit.
+
+### 5.3 Required non-destructive examples
+
+```text
+foo| bar + completion "foo tag"
+  -> bar remains
+
+(foo|, bar:1.2)
+  -> (foo tag, bar:1.2)
+
+[[artist_a, art|ist_b:0.7]]
+  -> artist_a and :0.7 remain
+
+old_t|ag
+  smart  -> only proven contiguous tail may be replaced
+  insert -> ag remains
+```
+
+At minimum, a complete recognized tag separated by whitespace to the right of
+the caret must never be deleted. The accepted default is stronger: every
+whitespace-separated suffix is protected in `smart` mode.
+
+### 5.4 Bracket editing contract
+
+- support consistent selected-text wrapping for `()`, `{}`, and `[[ ]]`;
+- skip over an already auto-inserted closing delimiter when the user types it;
+- do not auto-close or rewrite the entire bracket group on completion commit;
+- preserve other comma-separated items in the same group;
+- allow more than one autocomplete item inside one pair;
+- optional weighted wrapping inserts `(selection:1)` as one undoable edit and
+  selects `1` for immediate replacement;
+- preserve nested and escaped delimiters;
+- define multiline selection behavior in pure tests before enabling it.
+
+### 5.5 Work units
+
+#### REL-FEAT-03A — Completion edit Contract
+
+- freeze current destructive examples as failing/regression fixtures;
+- define dual ranges, syntax-group boundaries, settings names/defaults, and
+  insertion result shape;
+- minimize production behavior changes.
+
+#### REL-FEAT-03B — Artist prefix setting
+
+- add canonical persistence and frontend UI;
+- parameterize query, insertion, inline preview, and forced artist-only fields;
+- preserve exact default `@` behavior.
+
+#### REL-FEAT-03C — Safe mid-text completion
+
+- implement `smart|insert|replace` edit planning;
+- preserve right suffix, weights, and closers;
+- make preview and commit use the same plan;
+- preserve separator, period, wildcard, cancellation, and IME behavior.
+
+#### REL-FEAT-03D — Bracket and weighted-selection UX
+
+- implement group-aware editing and selected wrapping;
+- add optional `(selection:1)` placeholder selection;
+- complete Legacy Canvas, Node 2.0, keyboard, IME, undo, save/reload, and
+  accessibility evidence.
+
+### 5.6 PR isolation
+
+#64 may use four ordered PRs under one issue because Contract, settings, edit
+behavior, and bracket behavior have independent rollback boundaries. Each branch
+uses:
+
+```text
+codex/rel-feat-03a-completion-contract
+codex/rel-feat-03b-artist-prefix
+codex/rel-feat-03c-safe-midtext
+codex/rel-feat-03d-bracket-ux
+```
+
+Do not combine #335, #401, or broad autocomplete refactoring into these PRs.
+
+## 6. Revised release-candidate matrix
+
+REL-RC-01 runs only after all six issues and all #64 units are integrated on one
+exact `dev` head.
+
+Automated gates remain:
+
+```powershell
+powershell -ExecutionPolicy Bypass -File tools\check_project.ps1 -Profile full
+comfy node validate
+comfy node pack
+```
+
+In addition to the base lane matrix, verify:
+
+### #401
+
+- 100+ line paste and long wrapped-line paste;
+- auto and manual textarea height modes;
+- narrow width and paste/resize ordering;
+- no textarea inner scrollbar;
+- no stale scheduled resize after rapid input or node removal;
+- Classic, Advanced, AdvancedV2, Legacy Canvas, and Node 2.0 where applicable.
+
+### #64
+
+- default and custom artist prefix search/insertion/persistence;
+- no duplicate prefix and no non-artist category change;
+- whitespace-, comma-, and newline-separated right suffix preservation;
+- complete right-hand tag preservation;
+- `smart`, `insert`, and `replace` modes;
+- numeric weight and closing-bracket preservation;
+- multiple items in one bracket group;
+- inline preview/commit parity;
+- `()`, `{}`, and `[[ ]]` selection wrapping;
+- optional `(selection:1)` with the numeric placeholder selected;
+- IME, keyboard, undo, save/reload, Legacy Canvas, and Node 2.0.
+
+A release candidate fails if any accepted completion deletes text outside its
+reviewed edit range, or if a long-paste textarea finishes with hidden overflow.
+
+## 7. Revised resumption gate
+
+The ordinary backend queue remains paused until:
+
+- #266, #267, #401, #335, #394, and #64 are complete;
+- #64 REL-FEAT-03A through REL-FEAT-03D are all integrated;
+- the revised REL-RC-01 passes at one exact `dev` head;
+- release preparation, `main` integration, immutable tag, Registry publication,
+  and read-back complete; and
+- no immediate P0/P1 post-release regression remains open.
+
+## 8. Codex instructions
+
+### Current first task
+
+```text
+Read docs/architecture/release-first-stabilization-lane.md, then this addendum,
+and Issue #395. Select REL-BUG-01 / #266. Do not start #401 or #64 early.
+```
+
+### When REL-BUG-03 becomes READY
+
+```text
+Read Issue #401 and inspect both Prompt Studio textarea families. Reproduce and
+record immediate, first-frame, and post-layout scrollHeight/clientHeight values.
+Implement bounded revision-owned grow-only remeasurement. Do not touch #394 or
+#64. Run focused tests, the full project check, and Legacy/Node 2.0 paste smoke.
+```
+
+### When REL-FEAT-03A becomes READY
+
+```text
+Read the updated Issue #64. Start with Contract/tests only: reproduce right-text
+deletion, define query/insert/replace ranges, protected suffixes, bracket-group
+boundaries, and the three setting contracts. Do not jump directly to one broad
+implementation PR. Execute 03A, 03B, 03C, and 03D in order and record exact
+base/head SHA, rollback boundary, focused/full/live evidence, and next unit.
+```

--- a/docs/architecture/release-first-stabilization-lane.md
+++ b/docs/architecture/release-first-stabilization-lane.md
@@ -1,0 +1,509 @@
+# Release-First Stabilization Lane Before Further Backend Refactor
+
+## Document status
+
+- Status: active execution-order override
+- Snapshot date: 2026-07-24
+- Snapshot branch: `dev`
+- Snapshot commit: `bf61d1eb5fb015a9ca21d011aa9809e4e20a8e00`
+- Primary execution issue: [#395](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/395)
+- Release-blocking bugs: [#266](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/266), [#267](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/267)
+- Required user features: [#335](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/335), [#394](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/394), [#64](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/64)
+- Scope: cross-surface release sequencing; it does not redefine Python package ownership
+
+While #395 is open, this document overrides the **next-work ordering** in
+[`python-backend-execution-roadmap.md`](python-backend-execution-roadmap.md).
+It does not roll back completed refactors, replace ADRs, or weaken their gates.
+It pauses new D/E/G/H and AiO Hook implementation so the repository can deliver
+user-visible fixes and features from a stable integration point.
+
+The active critical path is:
+
+```text
+#266 LoRA workflow profile provenance bug
+  -> #267 LoRA scrollbar pointer bug
+  -> #335 locale-aware initial autocomplete source
+       + #394 Prompt Studio resolution orientation switch in parallel
+  -> #64 configurable artist autocomplete prefix
+  -> integrated release-candidate validation
+  -> release preparation
+  -> main/tag/Registry publication
+  -> re-audit and resume backend refactor
+```
+
+## 1. Verified starting state
+
+At the snapshot:
+
+- B-11 final root shim work is complete.
+- The #167 seed series and #169 stage/cache series have completed their current
+  implementation path.
+- D-01, D-08, D-09, D-10, D-11a/b, and D-12a through D-12f2 have reached their
+  reviewed integration points; D-12f2 was merged in PR #393.
+- No open pull request owns #266, #267, #335, #394, or #64.
+- The package version remains `0.5.4`.
+- The open issues carrying the `bug` label are #266 and #267.
+
+The next structural D-12 lifecycle/expansion slice is deliberately no longer
+READY. Completed canonical owners remain authoritative and must be used by the
+release work; the release work must not reopen root implementation ownership.
+
+## 2. Priority and freeze rules
+
+### 2.1 Work that is READY or may become READY
+
+Only these categories may start while this lane is active:
+
+1. one of the release tasks listed in section 3;
+2. a new P0/P1 regression discovered while validating those tasks;
+3. documentation or test infrastructure strictly required to prove a release
+   task; or
+4. release preparation after the integrated release gate passes.
+
+### 2.2 Work that is paused
+
+Do not start a new implementation PR for:
+
+- additional D-series root consolidation;
+- E-series lifecycle or service migration;
+- G/H quality or shim-retirement work unless required to prevent a release
+  regression;
+- AiO Hook public API or extension work;
+- opportunistic package cleanup, file splitting, alias retirement, or formatting;
+- behavior changes outside #266, #267, #335, #394, and #64.
+
+An already completed refactor is not reverted. An urgent bug fix may use its
+canonical owner, but it may not bundle the next refactor milestone.
+
+### 2.3 Pull-request isolation
+
+- One issue per PR.
+- Do not combine #266 and #267 even though both affect LoRA Preset.
+- Do not combine #335 and #64 even though both affect settings/autocomplete.
+- Use `codex/rel-<task-id>-<description>` from the latest `origin/dev`.
+- Search open PRs and branches before editing.
+- Record exact base and head SHAs in every PR.
+- A release task is a Fix, Feature/Contract, or Release-only PR. It is not a Move
+  PR unless the owning issue explicitly proves that a missing owner blocks the
+  user behavior.
+
+## 3. Active executable queue
+
+| Order | Task ID | Owner | State | Type | Prerequisites |
+| ---: | --- | --- | --- | --- | --- |
+| 1 | REL-BUG-01 | #266 | READY | Fix | current `dev`; no overlapping PR |
+| 2 | REL-BUG-02 | #267 | BLOCKED | Fix | REL-BUG-01 merged; rebase LoRA frontend |
+| 3A | REL-FEAT-01 | #335 | BLOCKED | Feature/Contract | both bug fixes merged |
+| 3B | REL-FEAT-02 | #394 | BLOCKED | Feature | both bug fixes merged; may run parallel with 3A if files remain disjoint |
+| 4 | REL-FEAT-03 | #64 | BLOCKED | Feature/Contract | REL-FEAT-01 merged |
+| 5 | REL-RC-01 | #395 | BLOCKED | Integration gate | all five issue PRs merged |
+| 6 | REL-PREP-01 | #395 | BLOCKED | Release-only | REL-RC-01 passed |
+| 7 | REL-PUBLISH-01 | #395 | BLOCKED | Release | release prep reviewed and merged |
+
+The first task Codex must select is **REL-BUG-01 / #266**.
+
+## 4. Common implementation protocol
+
+Before editing:
+
+```powershell
+git fetch origin
+git checkout -b codex/rel-<task-id>-<description> origin/dev
+git rev-parse HEAD
+powershell -ExecutionPolicy Bypass -File tools\check_project.ps1 -Profile quick
+```
+
+Then:
+
+1. read this file and #395;
+2. read the owning issue and recent comments;
+3. inspect current canonical owners and open PRs;
+4. reproduce the current behavior before changing it;
+5. write an allowed-file and forbidden-change inventory in the PR body; and
+6. implement the smallest complete correction or feature.
+
+Every implementation PR must run:
+
+```powershell
+powershell -ExecutionPolicy Bypass -File tools\check_project.ps1 -Profile full
+```
+
+UI or workflow-visible changes additionally require the owning task's Legacy
+Canvas and Node 2.0 matrix. Package/public-surface changes additionally require:
+
+```powershell
+comfy node validate
+comfy node pack
+```
+
+A missing live environment is recorded as an unexecuted release gate. It is not
+reported as passed and must be completed in REL-RC-01.
+
+## 5. REL-BUG-01 — Local profile provenance for shared workflows
+
+### Goal
+
+A portable workflow must not make serialized author-local `saved_name` or
+`saved_snapshot` metadata appear to be verified current-user storage state.
+
+### Required behavior
+
+- Rehydrated workflow metadata begins unverified.
+- `saved` is shown only after the current profile store proves the relevant
+  profile exists and its identity/content contract matches.
+- Same-name but different local profiles are not treated as the same profile.
+- Workflow metadata never becomes an overwrite/CAS token by itself.
+- Reopening a workflow in the same local environment can restore `saved` after
+  current-store verification.
+
+### Allowed production surface
+
+Use the current LoRA Preset frontend profile-data, mutation, runtime, and API
+adapter owners discovered during preflight. Backend profile contracts may change
+only when required to expose an existing identity/content check; do not redesign
+profile persistence.
+
+### Forbidden changes
+
+- scrollbar geometry or event routing from #267;
+- profile naming rules or unrelated CRUD UI;
+- workflow node IDs, row contents, mapping, or public API shape;
+- implicit trust in serialized `saved_name`, snapshot text, or stale token;
+- unrelated profile repository refactor.
+
+### Required tests
+
+```text
+external workflow + empty local store -> not saved
+external workflow + same name/different identity or content -> not saved
+external workflow + verified matching local profile -> saved
+workflow metadata -> no overwrite/CAS token adoption
+same-local workflow reopen -> saved only after verification
+serialized workflow remains portable and contains no newly privileged token
+```
+
+### Live gate
+
+Create a workflow in one user-data environment, transfer it to another with an
+empty or conflicting profile store, and verify the displayed state and save flow.
+
+### Rollback boundary
+
+Revert only the profile-provenance verification and its tests. Do not revert
+canonical profile ownership or other LoRA UI fixes.
+
+## 6. REL-BUG-02 — LoRA profile scrollbar pointer interaction
+
+### Goal
+
+With at least seven profiles, the visible scrollbar track and thumb must respond
+to actual host pointer routing in both canvas modes.
+
+### Required pre-fix evidence
+
+Measure or otherwise prove:
+
+- the widget width passed to draw;
+- `node.size[0]`;
+- widget-local pointer coordinates;
+- track and thumb rectangles; and
+- whether pointerdown reaches the custom widget.
+
+Do not commit permanent diagnostic logging. The measurement belongs in the PR
+record or a deterministic host-routing test.
+
+### Required behavior
+
+- track click changes the offset predictably;
+- thumb drag updates offset continuously;
+- pointerup and pointercancel end drag state;
+- wheel scrolling and row selection continue to work;
+- resize recalculates geometry without leaving stale hit areas.
+
+### Forbidden changes
+
+- #266 profile-provenance logic;
+- global permanent listeners that leak after node removal;
+- speculative event-name replacement without host evidence;
+- list order, profile CRUD, or wheel ownership changes.
+
+### Required tests
+
+```text
+non-zero widget origin and host-supplied width
+track click
+thumb pointerdown/move/up
+pointercancel cleanup
+resize then hit-test
+wheel and row-click regression
+Legacy Canvas live interaction
+Node 2.0 live interaction
+```
+
+## 7. REL-FEAT-01 — Locale-aware initial autocomplete source
+
+### Goal
+
+Select a locale-derived autocomplete source only when neither settings store has
+an explicit source key.
+
+### Precedence
+
+```text
+explicit Comfy setting
+  > explicit EasyUse Anima setting
+  > locale-derived initial value
+```
+
+Locale-derived initial values:
+
+```text
+Korean locale -> localsmile_kr_wiki
+other/unknown -> dbr_danbooru_2025_09_01
+```
+
+### Current ownership
+
+Use the canonical `easyuse_anima.settings` and `easyuse_anima.autocomplete`
+owners plus frontend settings/i18n. Do not reintroduce implementation into root
+`settings.py` or `autocomplete_dataset.py` shims.
+
+### Required behavior
+
+- Key presence, not equality with the old default, identifies an explicit user
+  choice.
+- Existing Danbooru, e621, merged, or Korean selections remain unchanged.
+- Locale is consulted once for missing-value initialization, not on every read.
+- Later locale changes do not silently switch an initialized source.
+- A missing Korean CSV safely falls back to bundled Danbooru without damaging
+  stored settings.
+- Backend/public settings and frontend setting display agree.
+
+### Forbidden changes
+
+- source ranking, autocomplete query API, or index policy;
+- migration of existing explicit values;
+- a frontend-only default that disagrees with backend persistence;
+- unrelated D/E settings or autocomplete refactor.
+
+### Required tests
+
+```text
+missing/missing + ko and ko-KR -> Korean source
+missing/missing + en/ja/zh/unknown -> Danbooru
+explicit internal source + Korean locale -> preserve
+explicit Comfy source + Korean locale -> preserve
+explicit Danbooru + Korean locale -> preserve
+initialized value + later locale change -> preserve
+missing Korean CSV -> safe Danbooru
+frontend/backend parity and source-cache invalidation
+```
+
+## 8. REL-FEAT-02 — Prompt Studio resolution orientation switch
+
+### Goal
+
+Add a keyboard-accessible orientation switch to the Advanced and AdvancedV2
+resolution UI without changing backend resolution semantics.
+
+### Required behavior
+
+Preset bucket:
+
+- choose the exact inverse `height × width` option in the same bucket;
+- square values are a no-op;
+- if the exact inverse does not exist, preserve the current value and disable or
+  explain the action;
+- never choose an approximate aspect ratio.
+
+Custom resolution:
+
+- swap custom width and height;
+- update both number inputs, hidden widgets, `resolution_size`, summary,
+  callbacks, queue value, and serialization consistently;
+- preserve existing 32-pixel normalization and minimum rules.
+
+NAIA resolution:
+
+- do not silently change to Custom or break NAIA ownership;
+- initial implementation keeps the action disabled with localized explanation
+  unless current contracts prove a safe direct swap.
+
+### Forbidden changes
+
+- new resolution buckets or approximate selection;
+- Regional canvas/mask rotation;
+- image rotation or backend latent/sampling changes;
+- linked input overwrite;
+- node height or textarea-layout mutation.
+
+### Required tests
+
+```text
+portrait preset -> exact landscape
+landscape preset -> exact portrait
+square -> no-op
+missing inverse -> preserve
+custom swap -> all widgets/summary synchronized
+popup close/reopen and workflow reload
+linked input protection
+NAIA no silent Custom conversion
+Advanced/AdvancedV2 parity
+Legacy Canvas and Node 2.0
+```
+
+## 9. REL-FEAT-03 — Configurable artist autocomplete prefix
+
+### Goal
+
+Persist a user-selected prefix for artist-only autocomplete trigger and result
+insertion while preserving `@` as the default.
+
+### Required behavior
+
+- The setting persists through restart and browser reload.
+- The configured prefix starts artist-only search.
+- Selecting an artist result inserts exactly one configured prefix.
+- General, character, copyright, and other categories are unchanged.
+- Forced artist-only fields preserve their existing scope behavior.
+- The default configuration remains `@artist name`.
+- An empty or invalid value does not invent a new mode; until explicitly
+  specified otherwise, normalize it back to `@`.
+
+### Dependency on #335
+
+Reuse #335's canonical settings ownership and explicit/missing-value rules.
+Do not change locale-based source initialization while adding the artist-prefix
+setting.
+
+### Forbidden changes
+
+- autocomplete ranking, source API, or dataset format;
+- prefixes for non-artist categories;
+- migration or rewriting of existing prompt text;
+- combining #335 implementation into this PR;
+- broad autocomplete module refactor.
+
+### Required tests
+
+```text
+default @ search and insertion
+custom prefix artist-only search
+custom prefix insertion
+no duplicate prefix
+non-artist categories unchanged
+forced artist-only input parity
+settings save/read/reload
+IME composition and popup commit
+Legacy Canvas and Node 2.0
+```
+
+## 10. REL-RC-01 — Integrated release-candidate gate
+
+All five implementation PRs must be merged to the latest `dev` head before this
+gate runs. Issue closure alone is not sufficient.
+
+### Automated gates
+
+```powershell
+powershell -ExecutionPolicy Bypass -File tools\check_project.ps1 -Profile full
+comfy node validate
+comfy node pack
+```
+
+Inspect the actual archive and verify required Python, JavaScript, locale, CSV,
+workflow, and changelog inputs are present. Source-tree import success is not an
+archive-closure substitute.
+
+### Installation matrices
+
+1. clean user-data installation;
+2. update from 0.5.4 settings, profiles, and maintained workflows;
+3. Legacy Canvas;
+4. Node 2.0;
+5. Korean and non-Korean Comfy locale;
+6. sender/receiver user-data split for LoRA workflow provenance.
+
+### Required user flows
+
+- #266 cross-user workflow profile state;
+- #267 track click and thumb drag;
+- #335 fresh Korean/non-Korean source and explicit-value preservation;
+- #394 preset/custom/NAIA orientation action;
+- #64 default/custom artist prefix, IME, insertion, and reload;
+- no browser console error from EasyUse Anima;
+- no package import or optional-feature regression.
+
+If this gate finds a regression, create a separate `bug`/`type: fix` issue and
+insert it before REL-PREP-01. Do not patch production code inside the release-prep
+PR.
+
+## 11. REL-PREP-01 — Release preparation
+
+The release-prep PR is metadata/documentation only. It must not change production
+Python or JavaScript.
+
+Required work:
+
+- select a semantic version;
+- update `pyproject.toml` and aligned release metadata;
+- add a user-facing changelog section;
+- update maintained workflow package metadata where required;
+- align README summaries and release instructions;
+- run the full release validation again; and
+- record the exact candidate commit and tested ComfyUI/frontend versions.
+
+Because this lane contains backward-compatible UI and behavior additions,
+`MAINTAINING.md` classifies it as a minor release. From `0.5.4`, the default
+candidate is **0.6.0** unless the release PR records a different compliant
+choice.
+
+The older AiO Hook plan's 0.6.0 target is not a prerequisite for this release.
+If this stabilization release uses 0.6.0, assign the public Hook API to a later
+minor version in its next planning update.
+
+## 12. REL-PUBLISH-01 — Main, tag, and Registry
+
+Follow `MAINTAINING.md` exactly:
+
+1. merge the validated release candidate into protected `main`;
+2. create the immutable annotated tag from the released `main` commit;
+3. dispatch the manual Registry publish workflow with the exact version;
+4. read back Registry version, changelog, and download state;
+5. run metadata synchronization and prove the final dry-run is a no-op; and
+6. verify a normal user update from the published package.
+
+Do not tag `dev`, reuse an existing version, rewrite a published tag, or publish
+before the release candidate has live ComfyUI evidence.
+
+## 13. Refactor resumption gate
+
+The ordinary backend queue becomes selectable again only after:
+
+- #266, #267, #335, #394, and #64 are complete;
+- REL-RC-01 has passed at one exact integrated `dev` head;
+- release preparation and main integration are complete;
+- tag and Registry publication/read-back are complete; and
+- no immediate P0/P1 post-release regression remains open.
+
+At that point, re-run the backend analyzer, inspect open issues and PRs, and
+choose the next D/E/G/H task from current evidence. Do not automatically resume
+the task that was next before this freeze.
+
+## 14. Codex start instruction
+
+```text
+Read docs/architecture/release-first-stabilization-lane.md and Issue #395 before
+any other roadmap queue. While #395 is open, do not start a new D/E/G/H or AiO
+Hook implementation task.
+
+Select REL-BUG-01 / Issue #266. Create one branch from the latest origin/dev,
+reproduce the cross-user workflow profile-state bug, inventory current canonical
+LoRA profile owners, and implement only current-store provenance verification.
+Do not touch scrollbar behavior from #267 or perform unrelated refactoring.
+
+Run focused tests, tools/check_project.ps1 -Profile full, and the sender/receiver
+user-data live smoke. Record exact base/head SHA, reproduction, root cause,
+compatibility evidence, rollback boundary, and the next release task. Do not
+merge, version, tag, or publish from the implementation PR.
+```


### PR DESCRIPTION
## 요약

장기 backend refactor의 다음 구조 작업보다 사용자 체감 버그와 확정 기능을 먼저 완료하고 릴리스하도록 active execution ordering을 유지하며, 최신 `dev` 진행과 새 Prompt Studio 요구사항을 반영합니다.

- 현재 검증 기준: `dev@9a4f11593b5ea042d0883aa3ca325f6695a78bc2`
- 실행 owner: #395
- 새 release-blocking bug: #401
- 확장 기능 owner: #64

## 현재 통합 상태

- #266 / PR #397 완료
- #267 / PR #398 완료
- #394 / PR #399 완료
- #335 / PR #400 완료

따라서 현재 critical path는 다음과 같습니다.

```text
READY: #401 Prompt Studio long-paste textarea autosize
  -> #64 REL-FEAT-03A completion edit Contract
  -> #64 REL-FEAT-03B configurable artist prefix
  -> #64 REL-FEAT-03C safe mid-text completion
  -> #64 REL-FEAT-03D bracket and weighted-selection UX
  -> integrated RC validation
  -> release prep
  -> main/tag/Registry publish
  -> backend refactor re-audit/resume
```

#395가 열려 있는 동안 새 D/E/G/H 및 AiO Hook implementation PR은 시작하지 않습니다. 완료된 refactor와 PR #397~#400은 되돌리지 않으며, 각 사용자 이슈는 현재 canonical owner를 사용하되 별도 refactor scope를 결합하지 않습니다.

## 추가된 구체 계획

### #401

- Classic/Extend와 Advanced/AdvancedV2 long-paste 경로 계측
- 즉시 grow 뒤 bounded requestAnimationFrame 재측정
- input revision으로 stale callback 차단
- grow-only correction과 제거된 input safe no-op
- 최종 `scrollHeight <= clientHeight + 2`, `overflowY == hidden`
- Legacy Canvas / Node 2.0 live paste matrix

### #64

- LSP/Monaco 방식의 query / insert / replace range 분리
- 공백·쉼표·줄바꿈으로 구분된 커서 오른쪽 텍스트와 완전한 태그 보존
- `smart | insert | replace` completion commit mode
- configurable artist prefix와 기본 `@` parity
- 괄호 안 여러 autocomplete 항목과 weight/closing suffix 보존
- 선택 영역 `()`, `{}`, `[[ ]]` wrapping
- 설정으로 `(selection:1)` 삽입 및 숫자 `1` 선택
- 03A Contract → 03B prefix → 03C safe edit → 03D bracket UX 독립 PR 순서

## 변경 파일

- `docs/architecture/release-first-stabilization-lane.md`
- `docs/architecture/prompt-studio-autocomplete-release-addendum.md`
- `docs/architecture/README.md`

## 변경 유형

- [x] Documentation / execution-order update
- [ ] Production Python change
- [ ] Frontend JavaScript change
- [ ] Release/version change

## 검증

- 최신 `dev`와 compare한 결과 production/test/workflow/version 파일 변경 없음
- release-first base lane 509행과 Prompt Studio/autocomplete active addendum 574행
- architecture index가 Codex에게 base lane 다음 active addendum를 읽도록 연결
- 문서-only PR이므로 project full runner와 live ComfyUI smoke는 실행하지 않음
- 브랜치는 PR #397~#400 이전 기준에서 시작했으나 GitHub 기준 mergeable이며, 최종 병합 전 최신 `dev` diff가 문서 3개뿐인지 다시 확인해야 함

## 리뷰 포인트

1. #401을 현재 첫 READY release-blocking task로 두는 것이 맞는지
2. #64를 Contract/settings/edit/bracket 네 rollback 단위로 분리한 것이 충분한지
3. `smart` 기본값이 모호한 suffix를 삭제하지 않고 보존하는 정책이 적절한지
4. 선택 영역 `(text:1)`에서 `1`을 선택하는 편집기 동작이 원하는 조작감인지
5. revised RC matrix가 long paste, mid-text completion, IME, Legacy/Node 2.0을 충분히 검증하는지

Refs #64
Refs #170
Refs #185
Refs #186
Refs #188
Refs #266
Refs #267
Refs #335
Refs #394
Refs #395
Refs #401