### PR TITLE
[REL-BUG-02] LoRA 프로필 스크롤바 host 폭 기준 보정

### DIFF
--- a/tests/frontend_lora_preset_canvas_widgets_smoke.mjs
+++ b/tests/frontend_lora_preset_canvas_widgets_smoke.mjs
@@ -290,6 +290,46 @@ assert.deepEqual(addWidget.computeSize(), [520, 36]);
 }
 
 {
+  // Both Legacy and Node 2.0 route pointer coordinates in the host-supplied
+  // custom-widget width, which can differ from the persisted node width.
+  const node = makeNode({ profileCount: 8, width: 640 });
+  const widget = new runtime.ProfileBarWidget();
+  let drawRequests = 0;
+  widget.triggerDraw = () => { drawRequests += 1; };
+  widget.draw(fakeContext(), node, 440, 73, 170);
+
+  assert.deepEqual(widget.listArea, [8, 107, 424, 132]);
+  assert.deepEqual(widget.listClientArea, [108, 307, 424, 132]);
+  assert.deepEqual(widget.scrollTrackArea, [421, 107, 12, 132]);
+  assert.ok(widget.scrollTrackArea[0] + widget.scrollTrackArea[2] <= 440);
+
+  const trackBottom = [
+    widget.scrollTrackArea[0] + widget.scrollTrackArea[2] / 2,
+    widget.scrollTrackArea[1] + widget.scrollTrackArea[3] - 1,
+  ];
+  assert.equal(widget.mouse({ type: "pointerdown", button: 0 }, trackBottom, node), true);
+  assert.equal(widget.scrollOffset, 2);
+  assert.equal(widget.scrollDragging, true);
+  assert.equal(widget.mouse({ type: "pointerup" }, trackBottom, node), true);
+  assert.equal(widget.scrollDragging, false);
+
+  widget.draw(fakeContext(), node, 440, 73, 170);
+  const thumb = widget.scrollThumbArea;
+  const thumbPos = [thumb[0] + thumb[2] / 2, thumb[1] + 1];
+  assert.equal(widget.mouse({ type: "pointerdown", button: 0 }, thumbPos, node), true);
+  assert.equal(widget.mouse(
+    { type: "pointermove" },
+    [thumbPos[0], widget.scrollTrackArea[1]],
+    node,
+  ), true);
+  assert.equal(widget.scrollOffset, 0);
+  assert.equal(widget.mouse({ type: "pointercancel" }, thumbPos, node), true);
+  assert.equal(widget.scrollDragging, false);
+  assert.equal(widget.scrollDragDelta, 0);
+  assert.equal(drawRequests, 2);
+}
+
+{
   const ctx = fakeContext();
   const narrow = makeNode({ width: 229 });
   const row = new runtime.LoraRowWidget(0);

--- a/web/js/lora_preset/canvas_widgets.js
+++ b/web/js/lora_preset/canvas_widgets.js
@@ -269,7 +269,10 @@ export function createLoraPresetCanvasWidgets(dependencies) {
     }
 
     draw(ctx, node, width, y, _height) {
-      const drawWidth = nodeWidgetWidth(node, width);
+      const drawWidth = Math.max(
+        1,
+        Number(width) || Number(node?.size?.[0]) || MIN_NODE_WIDTH,
+      );
       const canvas = getCanvas();
       const liteGraph = getLiteGraph();
       this.hitAreas = [];


### PR DESCRIPTION
## 변경 요약

LoRA Preset 프로필 바의 scrollbar draw/hit geometry가 ComfyUI host가 custom widget에 전달한 실제 `width`를 기준으로 계산되도록 수정합니다. persisted `node.size[0]`은 host width가 없을 때만 fallback으로 사용합니다.

Closes #267

## 원인

수정 전 `ProfileBarWidget.draw()`는 host가 전달한 widget `width`보다 `node.size[0]`을 우선했습니다. 실 UI 계측에서 다음 차이를 확인했습니다.

- Legacy Canvas: `width=440`, `node.size[0]=440`, `y=192`
- Node 2.0 초기 draw: `width=233`, `node.size[0]=440`, `y=1`
- Node 2.0 안정화 draw: `width=438`, `node.size[0]=440`, `y=1`

Node 2.0 초기·resize 구간처럼 두 폭이 다르면 보이는 custom-widget canvas 밖에 track/thumb geometry가 생성될 수 있고, host가 전달하는 local pointer 좌표와 hit area가 일치하지 않습니다.

## 변경 파일

- `web/js/lora_preset/canvas_widgets.js`
  - ProfileBar만 host widget width 우선으로 변경
- `tests/frontend_lora_preset_canvas_widgets_smoke.mjs`
  - persisted node width 640 / host width 440 / non-zero widget Y 73 조건 추가
  - track click, thumb drag, pointerup, pointercancel cleanup 검증

## 검증

- Focused frontend unittest: 19 passed
- Official full runner:
  - Python unittest: 1,140 passed
  - Frontend checks: 112 JavaScript files passed
  - Python compile, Pyright baseline ratchet, import boundary gate, `git diff --check` passed
  - Ruff G-01 기존 119건은 report-only baseline이며 신규 blocking failure 없음
- ComfyUI v0.27.0 / `comfyui_frontend_package` 1.45.20 live smoke:
  - Legacy Canvas: track click 및 thumb drag 통과
  - Node 2.0: track click 및 thumb drag 통과
  - pointerup/pointercancel 종료는 focused smoke로 통과

## 기준 SHA

- Base (`dev`): `48e35f2931bf9f1c2329031edb46727df307a37b`
- Head: `38511c8`

## 호환성 및 rollback 경계

- workflow serialization, profile data, backend/API 계약 변경 없음
- 다른 LoRA custom widget의 width 계산은 변경하지 않음
- 사용자 데이터 migration 없음
- rollback은 이 PR의 단일 commit revert로 제한되며 저장 데이터 복원 작업은 필요하지 않음

## 다음 release task

Issue #395 순서에 따라 REL-BUG-03(#335)과 REL-BUG-04(#394)를 각각 독립 production PR로 진행합니다.