### PR TITLE
feat: locale 기반 autocomplete source 초기화 (#335)

### DIFF
--- a/easyuse_anima/autocomplete/dataset.py
+++ b/easyuse_anima/autocomplete/dataset.py
@@ -38,6 +38,7 @@ AUTOCOMPLETE_CSV = DBR_DANBOORU_AUTOCOMPLETE_CSV
 
 
 DEFAULT_AUTOCOMPLETE_SOURCE = "dbr_danbooru_2025_09_01"
+_KOREAN_AUTOCOMPLETE_SOURCE = "localsmile_kr_wiki"
 
 
 AUTOCOMPLETE_SOURCES = {
@@ -157,7 +158,11 @@ def resolve_autocomplete_source(source: str | None = None) -> tuple[str, Path]:
     key = str(source or "").strip() or DEFAULT_AUTOCOMPLETE_SOURCE
     if key not in AUTOCOMPLETE_SOURCES:
         key = DEFAULT_AUTOCOMPLETE_SOURCE
-    return key, Path(AUTOCOMPLETE_SOURCES[key]["path"])
+    path = Path(AUTOCOMPLETE_SOURCES[key]["path"])
+    if key == _KOREAN_AUTOCOMPLETE_SOURCE and not path.is_file():
+        key = DEFAULT_AUTOCOMPLETE_SOURCE
+        path = Path(AUTOCOMPLETE_SOURCES[key]["path"])
+    return key, path
 
 
 def available_autocomplete_sources(selected: str | None = None) -> list[dict]:

--- a/easyuse_anima/settings/repository.py
+++ b/easyuse_anima/settings/repository.py
@@ -19,6 +19,10 @@ from .schema import (
 
 SETTINGS_FILE = USER_DATA_DIR / "settings.json"
 LONG_TEXT_SETTINGS_FILE = USER_DATA_DIR / "long_text_settings.json"
+_AUTOCOMPLETE_SOURCE_KEY = "autocomplete.source"
+_COMFY_AUTOCOMPLETE_SOURCE_KEY = "EasyUseAnima.Prompt.AutocompleteSource"
+_COMFY_LOCALE_KEY = "Comfy.Locale"
+_KOREAN_AUTOCOMPLETE_SOURCE = "localsmile_kr_wiki"
 
 
 def _read_json_file(path: Path) -> dict:
@@ -101,6 +105,53 @@ def _load_comfy_settings() -> dict:
     return {}
 
 
+def _is_korean_locale(value) -> bool:
+    locale = str(value or "").strip().casefold()
+    return (
+        locale == "ko"
+        or locale.startswith("ko-")
+        or "korean" in locale
+        or "한국어" in locale
+    )
+
+
+def _initial_autocomplete_source(comfy_settings: dict) -> str:
+    if _is_korean_locale(comfy_settings.get(_COMFY_LOCALE_KEY)):
+        return _KOREAN_AUTOCOMPLETE_SOURCE
+    return DEFAULT_SETTINGS[_AUTOCOMPLETE_SOURCE_KEY]
+
+
+def _initialize_autocomplete_source(data: dict, comfy_settings: dict) -> dict:
+    if (
+        _AUTOCOMPLETE_SOURCE_KEY in data
+        or _COMFY_AUTOCOMPLETE_SOURCE_KEY in comfy_settings
+    ):
+        return data
+
+    source = _initial_autocomplete_source(comfy_settings)
+    initialized = dict(data)
+    initialized[_AUTOCOMPLETE_SOURCE_KEY] = source
+
+    def merge(current) -> dict:
+        if not isinstance(current, dict):
+            return initialized
+        if _AUTOCOMPLETE_SOURCE_KEY in current:
+            return current
+        current = dict(current)
+        current[_AUTOCOMPLETE_SOURCE_KEY] = source
+        return current
+
+    try:
+        persisted = AtomicJsonStore(SETTINGS_FILE).update(
+            merge,
+            default={},
+            trailing_newline=True,
+        )
+    except OSError:
+        return initialized
+    return persisted if isinstance(persisted, dict) else initialized
+
+
 def _stringify_setting_value(value) -> str:
     if value is None:
         return ""
@@ -139,8 +190,15 @@ def _apply_prompt_studio_color_settings(
         settings["prompt_studio.colors"] = json.dumps(colors, ensure_ascii=False)
 
 
-def _apply_comfy_settings(settings: dict) -> dict:
-    comfy_settings = _load_comfy_settings()
+def _apply_comfy_settings(
+    settings: dict,
+    comfy_settings: dict | None = None,
+) -> dict:
+    comfy_settings = (
+        _load_comfy_settings()
+        if comfy_settings is None
+        else comfy_settings
+    )
     for comfy_key, internal_key in COMFY_SETTING_KEYS.items():
         if comfy_key in comfy_settings and internal_key in DEFAULT_SETTINGS:
             settings[internal_key] = _stringify_setting_value(
@@ -156,14 +214,17 @@ def _apply_long_text_settings(settings: dict) -> dict:
 
 
 def get_settings() -> dict:
-    settings = dict(DEFAULT_SETTINGS)
     data = _read_json_file(SETTINGS_FILE)
-    if isinstance(data, dict):
-        for key in DEFAULT_SETTINGS:
-            if key in data:
-                value = data[key]
-                settings[key] = "" if value is None else str(value)
-    return _apply_long_text_settings(_apply_comfy_settings(settings))
+    comfy_settings = _load_comfy_settings()
+    data = _initialize_autocomplete_source(data, comfy_settings)
+    settings = dict(DEFAULT_SETTINGS)
+    for key in DEFAULT_SETTINGS:
+        if key in data:
+            value = data[key]
+            settings[key] = "" if value is None else str(value)
+    return _apply_long_text_settings(
+        _apply_comfy_settings(settings, comfy_settings)
+    )
 
 
 def save_setting(key: str, value) -> dict:

--- a/tests/fixtures/python_backend_baseline.json
+++ b/tests/fixtures/python_backend_baseline.json
@@ -26158,7 +26158,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 77
+            "line": 81
           }
         ],
         "classification": "external",
@@ -26166,7 +26166,7 @@
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 78,
+        "line": 82,
         "name": null,
         "optional": true,
         "requested": "folder_paths",
@@ -59722,14 +59722,14 @@
       },
       {
         "is_package": false,
-        "loc": 488,
+        "loc": 493,
         "module": "easyuse_anima.autocomplete.dataset",
-        "normalized_git_blob_sha1": "b0b29152a1cefb4e275431d5c418e51597e5235a",
+        "normalized_git_blob_sha1": "4544b4e59e500f0290db4172744347ce13c5f079",
         "path": "easyuse_anima/autocomplete/dataset.py",
         "top_level": {
           "class_count": 4,
           "function_count": 24,
-          "global_count": 21
+          "global_count": 22
         }
       },
       {
@@ -60502,14 +60502,14 @@
       },
       {
         "is_package": false,
-        "loc": 187,
+        "loc": 248,
         "module": "easyuse_anima.settings.repository",
-        "normalized_git_blob_sha1": "224d9bbfd66a3240fde2ef9d4c48ab042eb576df",
+        "normalized_git_blob_sha1": "7abffa760e12c495b4958c093c54dec2ac4da3d2",
         "path": "easyuse_anima/settings/repository.py",
         "top_level": {
           "class_count": 0,
-          "function_count": 12,
-          "global_count": 3
+          "function_count": 15,
+          "global_count": 7
         }
       },
       {
@@ -77292,14 +77292,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 77
+            "line": 81
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 78,
+        "line": 82,
         "optional": true,
         "role": "optional_dependency",
         "source": "easyuse_anima/settings/repository.py"
@@ -78876,14 +78876,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 77
+            "line": 81
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 78,
+        "line": 82,
         "optional": true,
         "role": "optional_dependency",
         "source": "easyuse_anima/settings/repository.py"
@@ -80197,7 +80197,7 @@
         "column": 19,
         "context": "assign:_INLINE_SPACE_RE",
         "kind": "import_time_call",
-        "line": 74,
+        "line": 75,
         "module": "easyuse_anima/autocomplete/dataset.py",
         "scope": "<module>"
       },
@@ -80206,7 +80206,7 @@
         "column": 25,
         "context": "assign:_DESCRIPTION_PREFIX_RE",
         "kind": "import_time_call",
-        "line": 106,
+        "line": 107,
         "module": "easyuse_anima/autocomplete/dataset.py",
         "scope": "<module>"
       },
@@ -80215,7 +80215,7 @@
         "column": 1,
         "context": "decorator:AutocompleteEntry",
         "kind": "import_time_call",
-        "line": 118,
+        "line": 119,
         "module": "easyuse_anima/autocomplete/dataset.py",
         "scope": "<module>"
       },
@@ -80224,7 +80224,7 @@
         "column": 1,
         "context": "decorator:_AutocompleteCacheKey",
         "kind": "import_time_call",
-        "line": 128,
+        "line": 129,
         "module": "easyuse_anima/autocomplete/dataset.py",
         "scope": "<module>"
       },
@@ -80233,7 +80233,7 @@
         "column": 1,
         "context": "decorator:_AutocompleteSnapshot",
         "kind": "import_time_call",
-        "line": 136,
+        "line": 137,
         "module": "easyuse_anima/autocomplete/dataset.py",
         "scope": "<module>"
       },
@@ -80242,7 +80242,7 @@
         "column": 14,
         "context": "assign:_CACHE_LOCK",
         "kind": "import_time_call",
-        "line": 147,
+        "line": 148,
         "module": "easyuse_anima/autocomplete/dataset.py",
         "scope": "<module>"
       },
@@ -81008,37 +81008,37 @@
       },
       {
         "kind": "dict",
-        "line": 43,
+        "line": 44,
         "module": "easyuse_anima/autocomplete/dataset.py",
         "name": "AUTOCOMPLETE_SOURCES"
       },
       {
         "kind": "dict",
-        "line": 150,
+        "line": 151,
         "module": "easyuse_anima/autocomplete/dataset.py",
         "name": "_CACHE"
       },
       {
         "kind": "dict",
-        "line": 77,
+        "line": 78,
         "module": "easyuse_anima/autocomplete/dataset.py",
         "name": "_DANBOORU_CATEGORY_NAMES"
       },
       {
         "kind": "dict",
-        "line": 86,
+        "line": 87,
         "module": "easyuse_anima/autocomplete/dataset.py",
         "name": "_E621_CATEGORY_NAMES"
       },
       {
         "kind": "dict",
-        "line": 153,
+        "line": 154,
         "module": "easyuse_anima/autocomplete/dataset.py",
         "name": "_INFLIGHT"
       },
       {
         "kind": "dict",
-        "line": 97,
+        "line": 98,
         "module": "easyuse_anima/autocomplete/dataset.py",
         "name": "_MERGED_E621_CATEGORY_NAMES"
       },
@@ -81389,7 +81389,7 @@
           "mutable_container"
         ],
         "initializer": "Dict",
-        "line": 150,
+        "line": 151,
         "module": "easyuse_anima/autocomplete/dataset.py",
         "name": "_CACHE"
       },
@@ -81398,7 +81398,7 @@
           "lock"
         ],
         "initializer": "threading.Lock",
-        "line": 147,
+        "line": 148,
         "module": "easyuse_anima/autocomplete/dataset.py",
         "name": "_CACHE_LOCK"
       },
@@ -81409,7 +81409,7 @@
           "single_flight"
         ],
         "initializer": "Dict",
-        "line": 153,
+        "line": 154,
         "module": "easyuse_anima/autocomplete/dataset.py",
         "name": "_INFLIGHT"
       },

--- a/tests/frontend_settings_definitions_smoke.mjs
+++ b/tests/frontend_settings_definitions_smoke.mjs
@@ -9,10 +9,27 @@ function dataModule(relativePath, replacements = {}) {
   return "data:text/javascript;base64," + Buffer.from(source).toString("base64");
 }
 
+const settingValues = { "Comfy.Locale": "" };
+globalThis.window = {};
+globalThis.__easyuseAnimaI18nTestApp = {
+  ui: {
+    settings: {
+      getSettingValue(id) {
+        return settingValues[id];
+      },
+    },
+  },
+};
+const i18nModuleUrl = dataModule("../web/js/easyuse_anima_i18n.js", {
+  'import { app } from "../../../scripts/app.js";':
+    "const app = globalThis.__easyuseAnimaI18nTestApp;",
+});
+const i18nModule = await import(i18nModuleUrl);
 const definitionDataUrl = dataModule("../web/js/settings/definition_data.js");
 const definitionsModule = await import(
   dataModule("../web/js/settings/definitions.js", {
     "./definition_data.js": definitionDataUrl,
+    "../easyuse_anima_i18n.js": i18nModuleUrl,
   })
 );
 
@@ -36,7 +53,7 @@ const createWildcardExtraPathsEditor = renderer("wildcard");
 const createNaiaResolutionModeEditor = renderer("resolution-mode");
 const createNaiaResolutionScaleEditor = renderer("resolution-scale");
 
-const settings = definitionsModule.createEasyUseAnimaSettings({
+const dependencies = {
   text(key) {
     textCalls.push(key);
     return key === "autocompleteLimitTip" ? "" : "t:" + key;
@@ -53,7 +70,8 @@ const settings = definitionsModule.createEasyUseAnimaSettings({
   createWildcardExtraPathsEditor,
   createNaiaResolutionModeEditor,
   createNaiaResolutionScaleEditor,
-});
+};
+const settings = definitionsModule.createEasyUseAnimaSettings(dependencies);
 
 assert.equal(updateCalls.length, 0, "Building descriptors must not update settings");
 assert.equal(renderCalls.length, 0, "Building descriptors must not render DOM");
@@ -126,6 +144,12 @@ assert.ok(
 
 const byId = new Map(settings.map((item) => [item.id, item]));
 const autocompleteMode = byId.get("EasyUseAnima.Prompt.AutocompleteMode");
+const autocompleteSource = byId.get("EasyUseAnima.Prompt.AutocompleteSource");
+assert.equal(typeof autocompleteSource.defaultValue, "function");
+assert.equal(
+  autocompleteSource.defaultValue(),
+  "dbr_danbooru_2025_09_01",
+);
 assert.deepEqual(autocompleteMode, {
   id: "EasyUseAnima.Prompt.AutocompleteMode",
   name: "t:autocompleteMode",
@@ -180,7 +204,7 @@ const expectedRegularSchemas = new Map([
   ],
   [
     "EasyUseAnima.Prompt.AutocompleteSource",
-    schema("combo", "dbr_danbooru_2025_09_01", [
+    schema("combo", autocompleteSource.defaultValue, [
       "dbr_danbooru_2025_09_01",
       "dbr_e621_2025_09_01",
       "dbr_danbooru_e621_merged_2025_09_01",
@@ -311,5 +335,43 @@ assert.equal(
 );
 assert.ok(textCalls.includes("autocomplete"));
 assert.ok(textCalls.includes("preprocessingOptions"));
+
+for (const locale of ["ko", "ko-KR", "Korean", "한국어"]) {
+  settingValues["Comfy.Locale"] = locale;
+  assert.equal(
+    i18nModule.easyuseAnimaInitialAutocompleteSource(),
+    "localsmile_kr_wiki",
+  );
+}
+for (const locale of ["", "en", "ja-JP", "unknown"]) {
+  settingValues["Comfy.Locale"] = locale;
+  assert.equal(
+    i18nModule.easyuseAnimaInitialAutocompleteSource(),
+    "dbr_danbooru_2025_09_01",
+  );
+}
+
+settingValues["Comfy.Locale"] = "ko-KR";
+const koreanSettings =
+  definitionsModule.createEasyUseAnimaSettings(dependencies);
+const koreanAutocompleteSource = koreanSettings.find(
+  (item) => item.id === "EasyUseAnima.Prompt.AutocompleteSource",
+);
+assert.equal(koreanAutocompleteSource.defaultValue(), "localsmile_kr_wiki");
+
+globalThis.window.__easyuseAnimaSettings = {
+  "autocomplete.source": "dbr_danbooru_2025_09_01",
+};
+assert.equal(
+  koreanAutocompleteSource.defaultValue(),
+  "dbr_danbooru_2025_09_01",
+  "backend-loaded explicit internal source must replace the provisional locale default",
+);
+settingValues["Comfy.Locale"] = "en";
+assert.equal(
+  koreanAutocompleteSource.defaultValue(),
+  "dbr_danbooru_2025_09_01",
+  "locale changes must not replace the backend-loaded source",
+);
 
 console.log("Settings definitions smoke passed.");

--- a/tests/test_autocomplete_locale_settings.py
+++ b/tests/test_autocomplete_locale_settings.py
@@ -1,0 +1,284 @@
+from __future__ import annotations
+
+import json
+import shutil
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from easyuse_anima.autocomplete import dataset
+from easyuse_anima.settings import repository
+
+
+ROOT = Path(__file__).resolve().parents[1]
+TEST_ROOT = ROOT / "__pycache__" / "rel_feat_01_locale_settings"
+DANBOORU_SOURCE = "dbr_danbooru_2025_09_01"
+E621_SOURCE = "dbr_e621_2025_09_01"
+MERGED_SOURCE = "dbr_danbooru_e621_merged_2025_09_01"
+KOREAN_SOURCE = "localsmile_kr_wiki"
+
+
+class AutocompleteLocaleSettingsTests(unittest.TestCase):
+    def setUp(self):
+        shutil.rmtree(TEST_ROOT, ignore_errors=True)
+        TEST_ROOT.mkdir(parents=True, exist_ok=True)
+
+    def tearDown(self):
+        shutil.rmtree(TEST_ROOT, ignore_errors=True)
+
+    def _case_paths(self, name: str) -> tuple[Path, Path]:
+        root = TEST_ROOT / name
+        root.mkdir(parents=True, exist_ok=True)
+        return root / "settings.json", root / "long_text_settings.json"
+
+    def _get_settings(
+        self,
+        name: str,
+        comfy_settings: dict,
+    ) -> tuple[dict, Path]:
+        settings_file, long_text_file = self._case_paths(name)
+        with (
+            patch.object(repository, "SETTINGS_FILE", settings_file),
+            patch.object(
+                repository,
+                "LONG_TEXT_SETTINGS_FILE",
+                long_text_file,
+            ),
+            patch.object(
+                repository,
+                "_load_comfy_settings",
+                return_value=comfy_settings,
+            ),
+        ):
+            settings = repository.get_settings()
+        return settings, settings_file
+
+    def test_missing_source_initializes_from_locale_and_persists(self):
+        settings, settings_file = self._get_settings("missing-locale", {})
+        self.assertEqual(settings["autocomplete.source"], DANBOORU_SOURCE)
+        self.assertEqual(
+            json.loads(settings_file.read_text(encoding="utf-8")),
+            {"autocomplete.source": DANBOORU_SOURCE},
+        )
+
+        cases = (
+            ("ko", KOREAN_SOURCE),
+            ("ko-KR", KOREAN_SOURCE),
+            ("Korean", KOREAN_SOURCE),
+            ("한국어", KOREAN_SOURCE),
+            ("", DANBOORU_SOURCE),
+            ("en-US", DANBOORU_SOURCE),
+            ("unknown", DANBOORU_SOURCE),
+        )
+        for index, (locale, expected) in enumerate(cases):
+            with self.subTest(locale=locale):
+                settings, settings_file = self._get_settings(
+                    f"missing-{index}",
+                    {"Comfy.Locale": locale},
+                )
+                persisted = json.loads(settings_file.read_text(encoding="utf-8"))
+
+                self.assertEqual(settings["autocomplete.source"], expected)
+                self.assertEqual(
+                    persisted,
+                    {"autocomplete.source": expected},
+                )
+
+    def test_explicit_internal_sources_are_preserved(self):
+        sources = (
+            DANBOORU_SOURCE,
+            E621_SOURCE,
+            MERGED_SOURCE,
+            KOREAN_SOURCE,
+        )
+        for index, source in enumerate(sources):
+            with self.subTest(source=source):
+                settings_file, long_text_file = self._case_paths(
+                    f"explicit-internal-{index}"
+                )
+                stored = {
+                    "autocomplete.source": source,
+                    "autocomplete.limit": "17",
+                }
+                settings_file.write_text(
+                    json.dumps(stored),
+                    encoding="utf-8",
+                )
+                with (
+                    patch.object(repository, "SETTINGS_FILE", settings_file),
+                    patch.object(
+                        repository,
+                        "LONG_TEXT_SETTINGS_FILE",
+                        long_text_file,
+                    ),
+                    patch.object(
+                        repository,
+                        "_load_comfy_settings",
+                        return_value={"Comfy.Locale": "ko"},
+                    ),
+                ):
+                    settings = repository.get_settings()
+
+                self.assertEqual(settings["autocomplete.source"], source)
+                self.assertEqual(
+                    json.loads(settings_file.read_text(encoding="utf-8")),
+                    stored,
+                )
+
+    def test_explicit_comfy_sources_are_preserved_without_internal_write(self):
+        sources = (
+            DANBOORU_SOURCE,
+            E621_SOURCE,
+            MERGED_SOURCE,
+            KOREAN_SOURCE,
+        )
+        for index, source in enumerate(sources):
+            with self.subTest(source=source):
+                settings, settings_file = self._get_settings(
+                    f"explicit-comfy-{index}",
+                    {
+                        "Comfy.Locale": "ko",
+                        "EasyUseAnima.Prompt.AutocompleteSource": source,
+                    },
+                )
+
+                self.assertEqual(settings["autocomplete.source"], source)
+                self.assertFalse(settings_file.exists())
+
+    def test_explicit_comfy_source_precedes_internal_source(self):
+        settings_file, long_text_file = self._case_paths("precedence")
+        stored = {"autocomplete.source": KOREAN_SOURCE}
+        settings_file.write_text(json.dumps(stored), encoding="utf-8")
+        with (
+            patch.object(repository, "SETTINGS_FILE", settings_file),
+            patch.object(
+                repository,
+                "LONG_TEXT_SETTINGS_FILE",
+                long_text_file,
+            ),
+            patch.object(
+                repository,
+                "_load_comfy_settings",
+                return_value={
+                    "Comfy.Locale": "ko",
+                    "EasyUseAnima.Prompt.AutocompleteSource": MERGED_SOURCE,
+                },
+            ),
+        ):
+            settings = repository.get_settings()
+
+        self.assertEqual(settings["autocomplete.source"], MERGED_SOURCE)
+        self.assertEqual(
+            json.loads(settings_file.read_text(encoding="utf-8")),
+            stored,
+        )
+
+    def test_persisted_initial_source_survives_locale_change(self):
+        settings_file, long_text_file = self._case_paths("locale-change")
+        comfy_settings = {"Comfy.Locale": "ko"}
+        with (
+            patch.object(repository, "SETTINGS_FILE", settings_file),
+            patch.object(
+                repository,
+                "LONG_TEXT_SETTINGS_FILE",
+                long_text_file,
+            ),
+            patch.object(
+                repository,
+                "_load_comfy_settings",
+                side_effect=lambda: dict(comfy_settings),
+            ),
+        ):
+            first = repository.get_settings()
+            comfy_settings["Comfy.Locale"] = "en"
+            second = repository.get_settings()
+
+        self.assertEqual(first["autocomplete.source"], KOREAN_SOURCE)
+        self.assertEqual(second["autocomplete.source"], KOREAN_SOURCE)
+        self.assertEqual(
+            json.loads(settings_file.read_text(encoding="utf-8")),
+            {"autocomplete.source": KOREAN_SOURCE},
+        )
+
+    def test_persistence_failure_keeps_locale_derived_runtime_value(self):
+        settings_file, long_text_file = self._case_paths("write-failure")
+        with (
+            patch.object(repository, "SETTINGS_FILE", settings_file),
+            patch.object(
+                repository,
+                "LONG_TEXT_SETTINGS_FILE",
+                long_text_file,
+            ),
+            patch.object(
+                repository,
+                "_load_comfy_settings",
+                return_value={"Comfy.Locale": "ko"},
+            ),
+            patch.object(
+                repository.AtomicJsonStore,
+                "update",
+                side_effect=OSError("read-only"),
+            ),
+        ):
+            settings = repository.get_settings()
+
+        self.assertEqual(settings["autocomplete.source"], KOREAN_SOURCE)
+        self.assertFalse(settings_file.exists())
+
+    def test_missing_korean_csv_falls_back_without_changing_setting(self):
+        settings_file, long_text_file = self._case_paths("missing-korean")
+        default_csv = settings_file.parent / "danbooru.csv"
+        missing_korean_csv = settings_file.parent / "missing-korean.csv"
+        default_csv.write_text("sample_tag,0,1,\n", encoding="utf-8")
+        stored = {"autocomplete.source": KOREAN_SOURCE}
+        settings_file.write_text(json.dumps(stored), encoding="utf-8")
+        sources = {
+            DANBOORU_SOURCE: {
+                "label": "Danbooru",
+                "path": default_csv,
+                "entry_count": 1,
+            },
+            KOREAN_SOURCE: {
+                "label": "Korean",
+                "path": missing_korean_csv,
+                "entry_count": 1,
+            },
+        }
+
+        with (
+            patch.object(repository, "SETTINGS_FILE", settings_file),
+            patch.object(
+                repository,
+                "LONG_TEXT_SETTINGS_FILE",
+                long_text_file,
+            ),
+            patch.object(
+                repository,
+                "_load_comfy_settings",
+                return_value={},
+            ),
+            patch.object(dataset, "AUTOCOMPLETE_SOURCES", sources),
+        ):
+            settings = repository.get_settings()
+            source_key, source_path = dataset.resolve_autocomplete_source(
+                settings["autocomplete.source"]
+            )
+            available = dataset.available_autocomplete_sources(
+                settings["autocomplete.source"]
+            )
+
+        self.assertEqual(settings["autocomplete.source"], KOREAN_SOURCE)
+        self.assertEqual((source_key, source_path), (DANBOORU_SOURCE, default_csv))
+        self.assertTrue(
+            next(item for item in available if item["key"] == DANBOORU_SOURCE)[
+                "selected"
+            ]
+        )
+        self.assertEqual(
+            json.loads(settings_file.read_text(encoding="utf-8")),
+            stored,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/web/js/easyuse_anima_i18n.js
+++ b/web/js/easyuse_anima_i18n.js
@@ -4,6 +4,7 @@ import { app } from "../../../scripts/app.js";
 let localeWatchInstalled = false;
 let lastLanguage = null;
 const localeListeners = new Set();
+const AUTOCOMPLETE_SOURCE_KEY = "autocomplete.source";
 
 export function easyuseAnimaReadSettingValue(id) {
   try {
@@ -46,6 +47,34 @@ export function easyuseAnimaLanguage() {
 
 export function easyuseAnimaIsKorean() {
   return easyuseAnimaLanguage() === "ko";
+}
+
+function easyuseAnimaInternalAutocompleteSource() {
+  try {
+    const settingsWindow =
+      /** @type {Window & { __easyuseAnimaSettings?: Record<string, unknown> }} */ (
+        window
+      );
+    const settings = settingsWindow.__easyuseAnimaSettings;
+    if (
+      settings
+      && Object.prototype.hasOwnProperty.call(settings, AUTOCOMPLETE_SOURCE_KEY)
+    ) {
+      const value = settings[AUTOCOMPLETE_SOURCE_KEY];
+      return value == null ? "" : String(value);
+    }
+  } catch {}
+  return undefined;
+}
+
+export function easyuseAnimaInitialAutocompleteSource() {
+  const internalSource = easyuseAnimaInternalAutocompleteSource();
+  if (internalSource !== undefined) {
+    return internalSource;
+  }
+  return easyuseAnimaIsKorean()
+    ? "localsmile_kr_wiki"
+    : "dbr_danbooru_2025_09_01";
 }
 
 export function easyuseAnimaText(map, key) {

--- a/web/js/settings/definitions.js
+++ b/web/js/settings/definitions.js
@@ -6,6 +6,7 @@ import {
   NAIA_RESOLUTION_BUCKET_OPTIONS,
   ROOT_CATEGORY,
 } from "./definition_data.js";
+import { easyuseAnimaInitialAutocompleteSource } from "../easyuse_anima_i18n.js";
 
 /**
  * @typedef {object} EasyUseAnimaSettingsDependencies
@@ -121,7 +122,7 @@ export function createEasyUseAnimaSettings(dependencies) {
       name: t("autocompleteCsv"),
       tooltip: t("autocompleteCsvTip"),
       type: "combo",
-      defaultValue: "dbr_danbooru_2025_09_01",
+      defaultValue: easyuseAnimaInitialAutocompleteSource,
       options: [
         "dbr_danbooru_2025_09_01",
         "dbr_e621_2025_09_01",


### PR DESCRIPTION
## 변경 요약

- `autocomplete.source`가 내부 설정과 Comfy 설정 양쪽에 모두 없을 때만 현재 Comfy locale로 최초값을 정합니다.
  - Korean (`ko`, `ko-*`, `Korean`, `한국어`) → `localsmile_kr_wiki`
  - 그 외 → `dbr_danbooru_2025_09_01`
- 최초값은 EasyUse Anima 사용자 설정에 원자적으로 1회 저장합니다.
- 우선순위를 `Comfy 명시값 > 내부 명시값/초기화값 > locale 기본값`으로 유지합니다.
- Korean CSV가 설치본에서 누락된 경우 저장값은 유지하고 런타임 dataset만 Danbooru로 fallback합니다.
- Comfy 설정 UI의 source 기본값을 backend 설정 로드 이후 동적으로 다시 평가하게 해 frontend/backend 불일치를 막습니다.

Closes #335

## 기준과 범위

- base: `537f1b832994b7f2dde5f547d509c7b027a8cbdf` (`origin/dev`)
- tested head: `822821573effa08686e44715bef9a0ef35eedcee`
- 포함: locale 기반 최초 source, 기존 명시값 provenance, Korean CSV 누락 fallback, focused tests/analyzer fixture
- 제외: autocomplete 검색/랭킹/API schema 변경, artist prefix #64, scrollbar #267, AiO Hook, D/E/G/H, 별도 리팩터링

## 주요 파일

- `easyuse_anima/settings/repository.py`
- `easyuse_anima/autocomplete/dataset.py`
- `web/js/easyuse_anima_i18n.js`
- `web/js/settings/definitions.js`
- `tests/test_autocomplete_locale_settings.py`
- `tests/frontend_settings_definitions_smoke.mjs`
- `tests/fixtures/python_backend_baseline.json`

## 원인

기존 source 기본값은 backend schema와 frontend setting descriptor 모두 Danbooru로 고정되어 있어, 새 사용자도 Korean locale을 최초값 결정에 사용할 수 없었습니다. 또한 frontend descriptor가 backend 사용자 설정 fetch 전에 정적 기본값을 고정하면 backend가 보존한 명시값과 UI 표시가 달라질 수 있었습니다.

## 검증

- focused unittest: `tests.test_autocomplete_locale_settings.AutocompleteLocaleSettingsTests` — 7 passed
- focused analyzer fixture test — 1 passed
- frontend settings definitions smoke + 변경 모듈 `node --check` — passed
- 공식 full runner — Python 1,147 passed; frontend JavaScript 113 passed
- Python compile, Pyright baseline ratchet, import boundary, TypeScript, `git diff --check` — passed
- Ruff 119 findings — 기존 G-01 report-only baseline, blocking failure 아님

## Live ComfyUI smoke

ComfyUI 0.27.0 / frontend 1.45.20의 전역 Settings UI와 API에서 확인했습니다.

- fresh `ko-KR`, 양쪽 source 누락 → Korean source가 API/디스크/UI에 1회 초기화
- Korean locale + 내부 Danbooru 명시 + Comfy source 누락 → Danbooru 유지
- locale `ko → en` 변경/reload → 초기화된 내부 source 유지
- fresh English, primary/backup source 모두 누락 → Danbooru 1회 초기화
- Comfy e621 명시 + 내부 Danbooru → API/UI는 e621, 내부 파일은 Danbooru로 보존

이 변경은 canvas/node widget이 아닌 전역 Settings 표면이므로 Legacy/Node 2.0 렌더링 분기가 없습니다.

## 호환성

- 기존 Danbooru/e621/merged/Korean 명시값은 변경하지 않습니다.
- Comfy 설정의 명시값이 계속 최우선입니다.
- locale 변경은 이미 저장된 source를 재초기화하지 않습니다.
- Korean CSV 누락 시 저장 설정을 자동 수정하지 않아 파일 복구 후 선택을 되살릴 수 있습니다.
- settings API schema 및 기존 source key/값은 유지합니다.

## 롤백 경계

이 PR의 squash commit 하나를 revert하면 됩니다. 별도 migration이나 사용자 데이터 rewrite가 없으므로 rollback 시 기존에 저장된 `autocomplete.source` 값은 그대로 남고, 이전 고정 Danbooru 기본 동작으로 돌아갑니다.

## 다음 release task

#335 병합 후 #64의 configurable artist-only prefix를 별도 브랜치/PR로 진행합니다.