### PR TITLE
fix: Prompt Studio 긴 paste 높이 안정화 (#401)

### DIFF
--- a/tests/frontend_prompt_studio_paste_autosize_smoke.mjs
+++ b/tests/frontend_prompt_studio_paste_autosize_smoke.mjs
@@ -1,0 +1,501 @@
+import { readFileSync } from "node:fs";
+import {
+  createFakeDocument,
+} from "./frontend_support/fake_dom.mjs";
+import {
+  createTextareaGrowStabilizer,
+  TEXTAREA_FIT_TOLERANCE,
+  TEXTAREA_STABILIZATION_FRAMES,
+} from "../web/js/prompt_studio/textarea_stabilization.js";
+
+function assert(condition, message) {
+  if (!condition) {
+    throw new Error(message);
+  }
+}
+
+function assertEqual(actual, expected, message) {
+  if (actual !== expected) {
+    throw new Error(`${message}: expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`);
+  }
+}
+
+function inlineModule(source) {
+  return `data:text/javascript;base64,${Buffer.from(source).toString("base64")}`;
+}
+
+function dataModule(relativePath, replacements = {}) {
+  let source = readFileSync(new URL(relativePath, import.meta.url), "utf8");
+  for (const [specifier, replacement] of Object.entries(replacements)) {
+    source = source.replaceAll(`"${specifier}"`, `"${replacement}"`);
+  }
+  return inlineModule(source);
+}
+
+let animationFrames = [];
+globalThis.requestAnimationFrame = (callback) => {
+  animationFrames.push(callback);
+  return animationFrames.length;
+};
+
+function flushFrame() {
+  const callback = animationFrames.shift();
+  assert(callback, "Expected a scheduled animation frame");
+  callback(0);
+}
+
+function resetFrames() {
+  animationFrames = [];
+}
+
+function heightValue(style) {
+  return Math.round(Number.parseFloat(style.height || "") || 0);
+}
+
+function createMeasuredTextarea(initialHeight, initialScrollHeight) {
+  return {
+    isConnected: true,
+    scrollHeight: initialScrollHeight,
+    style: {
+      height: `${initialHeight}px`,
+      overflowY: "auto",
+    },
+    get clientHeight() {
+      return heightValue(this.style);
+    },
+  };
+}
+
+assertEqual(TEXTAREA_FIT_TOLERANCE, 2, "Fit tolerance contract");
+assertEqual(TEXTAREA_STABILIZATION_FRAMES, 2, "Frame budget contract");
+
+for (const fixture of [
+  { type: "EasyUseAnimaPromptStudio", immediate: 150, first: 1680, post: 1728 },
+  { type: "EasyUseAnimaPromptStudioExtend", immediate: 120, first: 1812, post: 1860 },
+  { type: "EasyUseAnimaPromptStudioAdvanced", immediate: 120, first: 1920, post: 1968 },
+  { type: "EasyUseAnimaPromptStudioAdvancedV2", immediate: 120, first: 2040, post: 2088 },
+]) {
+  resetFrames();
+  const textarea = createMeasuredTextarea(fixture.immediate, fixture.immediate);
+  let storedHeight = fixture.immediate;
+  const stabilizer = createTextareaGrowStabilizer(textarea, () => {
+    const currentHeight = textarea.clientHeight;
+    const nextHeight = Math.max(currentHeight, textarea.scrollHeight);
+    if (nextHeight <= currentHeight + 1) {
+      return false;
+    }
+    textarea.style.height = `${nextHeight}px`;
+    storedHeight = nextHeight;
+    return true;
+  });
+
+  stabilizer.schedule();
+  textarea.scrollHeight = fixture.first;
+  flushFrame();
+  assertEqual(storedHeight, fixture.first, `${fixture.type} first-frame grow`);
+  textarea.scrollHeight = fixture.post;
+  flushFrame();
+  assertEqual(storedHeight, fixture.post, `${fixture.type} post-layout grow`);
+  assert(
+    textarea.scrollHeight <= textarea.clientHeight + TEXTAREA_FIT_TOLERANCE,
+    `${fixture.type} final content does not fit`,
+  );
+  assertEqual(textarea.style.overflowY, "hidden", `${fixture.type} final overflow`);
+}
+
+resetFrames();
+const manualTextarea = createMeasuredTextarea(480, 240);
+let manualHeight = 480;
+const manualStabilizer = createTextareaGrowStabilizer(manualTextarea, () => {
+  const nextHeight = Math.max(manualHeight, manualTextarea.scrollHeight);
+  if (nextHeight <= manualHeight + 1) {
+    return false;
+  }
+  manualHeight = nextHeight;
+  manualTextarea.style.height = `${manualHeight}px`;
+  return true;
+});
+manualStabilizer.schedule();
+flushFrame();
+assertEqual(manualHeight, 480, "Manual height must not shrink");
+manualTextarea.scrollHeight = 720;
+manualStabilizer.schedule();
+flushFrame();
+manualTextarea.scrollHeight = 768;
+flushFrame();
+assertEqual(manualHeight, 768, "Manual height must grow when content no longer fits");
+
+resetFrames();
+const rapidTextarea = createMeasuredTextarea(120, 120);
+let rapidGrowCalls = 0;
+const rapidStabilizer = createTextareaGrowStabilizer(rapidTextarea, () => {
+  rapidGrowCalls += 1;
+  rapidTextarea.style.height = `${rapidTextarea.scrollHeight}px`;
+  return true;
+});
+rapidStabilizer.schedule();
+rapidTextarea.scrollHeight = 900;
+rapidStabilizer.schedule();
+flushFrame();
+assertEqual(rapidGrowCalls, 0, "Stale revision must not grow");
+flushFrame();
+assertEqual(rapidGrowCalls, 1, "Latest revision must own growth");
+
+resetFrames();
+const removedTextarea = createMeasuredTextarea(120, 900);
+let removedGrowCalls = 0;
+const removedStabilizer = createTextareaGrowStabilizer(removedTextarea, () => {
+  removedGrowCalls += 1;
+  return true;
+});
+removedStabilizer.schedule();
+removedTextarea.isConnected = false;
+flushFrame();
+assertEqual(removedGrowCalls, 0, "Disconnected textarea must be a safe no-op");
+
+class ClassicTextarea {
+  constructor(height, scrollHeight) {
+    this.dataset = {};
+    this.isConnected = true;
+    this.listeners = new Map();
+    this.scrollHeight = scrollHeight;
+    this.style = {
+      boxSizing: "",
+      fontFamily: "",
+      fontSize: "",
+      height: `${height}px`,
+      minHeight: "0px",
+      overflowY: "hidden",
+      resize: "",
+    };
+    this.value = "";
+  }
+
+  addEventListener(type, callback) {
+    const callbacks = this.listeners.get(type) || [];
+    callbacks.push(callback);
+    this.listeners.set(type, callbacks);
+  }
+
+  emit(type) {
+    for (const callback of this.listeners.get(type) || []) {
+      callback({ target: this });
+    }
+  }
+
+  getAttribute(name) {
+    return name === "aria-label" ? (this.ariaLabel || null) : null;
+  }
+
+  get clientHeight() {
+    return heightValue(this.style);
+  }
+
+  get offsetHeight() {
+    return this.clientHeight;
+  }
+}
+
+globalThis.HTMLElement = ClassicTextarea;
+globalThis.HTMLTextAreaElement = ClassicTextarea;
+globalThis.HTMLInputElement = ClassicTextarea;
+globalThis.window = {};
+
+const fileUrl = (relativePath) => new URL(relativePath, import.meta.url).href;
+const classicResizableUrl = dataModule(
+  "../web/js/prompt_studio/studio_resizable_input.js",
+  {
+    "./constants.js": fileUrl("../web/js/prompt_studio/constants.js"),
+    "./highlight.js": inlineModule("export function requestOverlaySync() {}"),
+    "./settings.js": inlineModule("export function applyPromptStudioTextStyle() {}"),
+    "./studio_textareas.js": fileUrl("../web/js/prompt_studio/studio_textareas.js"),
+    "./textarea_stabilization.js": fileUrl("../web/js/prompt_studio/textarea_stabilization.js"),
+    "./widgets.js": fileUrl("../web/js/prompt_studio/widgets.js"),
+  },
+);
+const {
+  enhanceResizableInput,
+} = await import(classicResizableUrl);
+const classicOwners = await import("../web/js/prompt_studio/studio_textareas.js");
+const {
+  resolveStudioInput,
+} = await import("../web/js/prompt_studio/studio_input_resolver.js");
+
+const node2FieldNames = [
+  "lora_trigger_tags",
+  "quality_tags",
+  "trigger_and_artist_tags",
+  "prompt",
+  "trailing_quality_tags",
+];
+const node2Widgets = node2FieldNames.map((name) => ({ name, options: {} }));
+const node2Controls = node2FieldNames.map((name, index) => {
+  const control = new ClassicTextarea(64, 64);
+  if (index === 0) {
+    control.ariaLabel = name;
+  }
+  return control;
+});
+const node2NodeElement = {
+  dataset: { nodeId: "41" },
+  querySelectorAll() {
+    return node2Controls;
+  },
+};
+const node2Canvas = {
+  parentElement: {
+    querySelectorAll() {
+      return [node2NodeElement];
+    },
+  },
+};
+const node2Node = { id: 41, widgets: node2Widgets };
+assertEqual(
+  resolveStudioInput(node2Node, node2Widgets[0], node2FieldNames, node2Canvas),
+  node2Controls[0],
+  "Node 2.0 named field resolves inside owner node",
+);
+assertEqual(
+  resolveStudioInput(node2Node, node2Widgets[3], node2FieldNames, node2Canvas),
+  node2Controls[3],
+  "Node 2.0 anonymous textarea follows visible field order",
+);
+assertEqual(
+  node2Widgets[3].__easyuseAnimaStudioInput,
+  node2Controls[3],
+  "Node 2.0 resolver stores only the Prompt Studio-owned seam",
+);
+
+function classicFixture(type, name, initialHeight, manual = false, node2 = false) {
+  resetFrames();
+  const input = new ClassicTextarea(initialHeight, initialHeight);
+  const overlay = { style: { height: "" } };
+  const widget = {
+    name,
+    __easyuseAnimaHeight: initialHeight,
+    __easyuseAnimaManualHeight: manual,
+  };
+  if (node2) {
+    widget.element = {
+      querySelector(selector) {
+        return selector === "textarea, input" ? input : null;
+      },
+    };
+  } else {
+    widget.inputEl = input;
+  }
+  const ownerHooks = {
+    refreshNodeSize() {},
+    updateHighlight() {
+      overlay.style.height = input.style.height;
+    },
+  };
+  const hooks = {
+    expandStudioInputToContent(node, target, refresh) {
+      classicOwners.expandStudioInputToContent(node, target, refresh, ownerHooks);
+    },
+    growStudioManualHeightToContent(node, target, refresh) {
+      return classicOwners.growStudioManualHeightToContent(node, target, refresh, ownerHooks);
+    },
+    setStudioInputHeight(node, target, height, refresh) {
+      classicOwners.setStudioInputHeight(node, target, height, refresh, ownerHooks);
+    },
+    setStudioManualHeight(node, target) {
+      classicOwners.setStudioManualHeight(node, target, ownerHooks);
+    },
+    updateHighlight: ownerHooks.updateHighlight,
+  };
+  enhanceResizableInput({ type }, widget, hooks);
+  flushFrame();
+  resetFrames();
+  return { input, overlay, type, widget };
+}
+
+for (const fixture of [
+  classicFixture("EasyUseAnimaPromptStudio", "prompt", 150),
+  classicFixture("EasyUseAnimaPromptStudioExtend", "general_tags_4", 120),
+  classicFixture("EasyUseAnimaPromptStudioNode2", "prompt", 150, false, true),
+]) {
+  fixture.input.value = Array.from(
+    { length: 120 },
+    (_, index) => `태그_${index}, english_tag_${index}, (weight_${index}:1.2), [[artist_${index}]]`,
+  ).join("\n");
+  fixture.input.emit("input");
+  assertEqual(
+    fixture.widget.__easyuseAnimaHeight,
+    fixture.type.endsWith("Extend") ? 120 : 150,
+    `${fixture.type} immediate stale height`,
+  );
+  fixture.input.scrollHeight = 1440;
+  flushFrame();
+  fixture.input.scrollHeight = 1512;
+  flushFrame();
+  assertEqual(fixture.widget.__easyuseAnimaHeight, 1512, `${fixture.type} persisted height`);
+  assertEqual(fixture.overlay.style.height, fixture.input.style.height, `${fixture.type} overlay parity`);
+  assertEqual(fixture.input.style.overflowY, "hidden", `${fixture.type} overflow invariant`);
+}
+
+const manualClassic = classicFixture(
+  "EasyUseAnimaPromptStudio",
+  "prompt",
+  480,
+  true,
+);
+manualClassic.input.emit("input");
+manualClassic.input.scrollHeight = 840;
+flushFrame();
+manualClassic.input.scrollHeight = 888;
+flushFrame();
+assertEqual(manualClassic.widget.__easyuseAnimaHeight, 888, "Classic manual height grows");
+assertEqual(manualClassic.widget.__easyuseAnimaManualHeight, true, "Classic manual ownership persists");
+
+const advancedControlsUrl = inlineModule("export function setAdvancedControlValue() {}");
+const debounceUrl = inlineModule("export function debounce() { return () => {}; }");
+const highlightUrl = inlineModule("export function requestOverlaySync() {}");
+const textUrl = inlineModule("export function psText(key) { return key; }");
+const advancedFieldsUiUrl = dataModule(
+  "../web/js/prompt_studio/advanced_fields_ui.js",
+  {
+    "./advanced_controls.js": advancedControlsUrl,
+    "./constants.js": fileUrl("../web/js/prompt_studio/constants.js"),
+    "./fields.js": fileUrl("../web/js/prompt_studio/fields.js"),
+    "./highlight.js": highlightUrl,
+    "./layout.js": fileUrl("../web/js/prompt_studio/layout.js"),
+    "./schema.js": fileUrl("../web/js/prompt_studio/schema.js"),
+    "./serialization.js": fileUrl("../web/js/prompt_studio/serialization.js"),
+    "./state.js": fileUrl("../web/js/prompt_studio/state.js"),
+    "./textarea.js": fileUrl("../web/js/prompt_studio/textarea.js"),
+    "./textarea_stabilization.js": fileUrl("../web/js/prompt_studio/textarea_stabilization.js"),
+    "./text.js": textUrl,
+    "./utils.js": debounceUrl,
+    "./widgets.js": fileUrl("../web/js/prompt_studio/widgets.js"),
+  },
+);
+
+globalThis.document = createFakeDocument();
+const createElement = globalThis.document.createElement.bind(globalThis.document);
+globalThis.document.createElement = (tagName) => {
+  const element = createElement(tagName);
+  element.dataset = {};
+  return element;
+};
+globalThis.HTMLElement = Object;
+globalThis.HTMLTextAreaElement = Object;
+globalThis.HTMLInputElement = Object;
+globalThis.getComputedStyle = () => ({
+  borderBottomWidth: "0",
+  borderTopWidth: "0",
+  fontSize: "12",
+  lineHeight: "16",
+  paddingBottom: "0",
+  paddingTop: "0",
+});
+
+const {
+  createAdvancedFieldElement,
+} = await import(advancedFieldsUiUrl);
+
+function advancedFixture(type, manual = false) {
+  resetFrames();
+  const field = {
+    enabled: true,
+    height: manual ? 480 : 120,
+    heightMode: manual ? "manual" : "auto",
+    id: "positive_general_1",
+    label: "General Tags",
+    pane: "positive",
+    text: "",
+    type: "general",
+  };
+  const node = {
+    __easyuseAnimaAdvancedFields: [field],
+    inputs: [],
+    type,
+    widgets: [],
+  };
+  let overlayHeight = "";
+  const hooks = {
+    advancedFieldLabel: (target) => target.label,
+    applyAdvancedNaiaGeneralAutoToggle() {},
+    parseAdvancedFields: () => [field],
+    registerAdvancedAutocompleteInput() {},
+    scheduleAdvancedFieldHighlight() {},
+    scheduleAdvancedLayout() {},
+    syncAdvancedFieldInputs() {},
+    updateAdvancedFieldHighlight(_node, _field, textarea) {
+      overlayHeight = textarea.style.height;
+    },
+    writeAdvancedFields() {},
+  };
+  const block = createAdvancedFieldElement(node, field, hooks);
+  const textarea = block.querySelector("textarea");
+  let scrollHeight = field.height;
+  Object.defineProperties(textarea, {
+    clientHeight: {
+      configurable: true,
+      get() {
+        return heightValue(this.style);
+      },
+    },
+    offsetHeight: {
+      configurable: true,
+      get() {
+        return this.clientHeight;
+      },
+    },
+    scrollHeight: {
+      configurable: true,
+      get() {
+        return scrollHeight;
+      },
+      set(value) {
+        scrollHeight = Number(value);
+      },
+    },
+  });
+  textarea.isConnected = true;
+  flushFrame();
+  resetFrames();
+  return {
+    field,
+    get overlayHeight() {
+      return overlayHeight;
+    },
+    textarea,
+    type,
+  };
+}
+
+for (const fixture of [
+  advancedFixture("EasyUseAnimaPromptStudioAdvanced"),
+  advancedFixture("EasyUseAnimaPromptStudioAdvancedV2"),
+]) {
+  fixture.textarea.value = Array.from(
+    { length: 120 },
+    (_, index) => `태그_${index}, english_tag_${index}, (weight_${index}:1.2), [[artist_${index}]]`,
+  ).join("\n");
+  fixture.textarea.emit("input");
+  assertEqual(fixture.field.height, 120, `${fixture.type} immediate stale height`);
+  fixture.textarea.scrollHeight = 1560;
+  flushFrame();
+  fixture.textarea.scrollHeight = 1632;
+  flushFrame();
+  assertEqual(fixture.field.height, 1632, `${fixture.type} persisted height`);
+  assertEqual(fixture.overlayHeight, fixture.textarea.style.height, `${fixture.type} overlay parity`);
+  assertEqual(fixture.textarea.style.overflowY, "hidden", `${fixture.type} overflow invariant`);
+  assertEqual(fixture.field.text, fixture.textarea.value, `${fixture.type} save/reload value source`);
+}
+
+const manualAdvanced = advancedFixture(
+  "EasyUseAnimaPromptStudioAdvancedV2",
+  true,
+);
+manualAdvanced.textarea.emit("input");
+manualAdvanced.textarea.scrollHeight = 912;
+flushFrame();
+manualAdvanced.textarea.scrollHeight = 960;
+flushFrame();
+assertEqual(manualAdvanced.field.height, 960, "Advanced manual height grows");
+assertEqual(manualAdvanced.field.heightMode, "manual", "Advanced manual ownership persists");
+
+console.log("Prompt Studio paste autosize smoke passed.");

--- a/tests/test_frontend_modules.py
+++ b/tests/test_frontend_modules.py
@@ -3216,6 +3216,59 @@ class FrontendModuleStructureTests(unittest.TestCase):
             with self.subTest(module="extension_runtime", symbol=name):
                 self.assertIn(f"  {name},", extension_runtime_source)
 
+    def test_prompt_studio_paste_autosize_is_bounded_revision_owned_and_grow_only(self):
+        stabilizer_source = (
+            PROMPT_STUDIO_MODULES / "textarea_stabilization.js"
+        ).read_text(encoding="utf-8")
+        classic_source = (
+            PROMPT_STUDIO_MODULES / "studio_resizable_input.js"
+        ).read_text(encoding="utf-8")
+        advanced_source = (
+            PROMPT_STUDIO_MODULES / "advanced_fields_ui.js"
+        ).read_text(encoding="utf-8")
+        widgets_source = (
+            PROMPT_STUDIO_MODULES / "widgets.js"
+        ).read_text(encoding="utf-8")
+        runner_source = (
+            ROOT / "tools" / "check_frontend.ps1"
+        ).read_text(encoding="utf-8")
+
+        self.assertIn("const TEXTAREA_STABILIZATION_FRAMES = 2", stabilizer_source)
+        self.assertIn("let revision = 0", stabilizer_source)
+        self.assertIn("const ownedRevision = revision", stabilizer_source)
+        self.assertIn("textarea?.isConnected === false", stabilizer_source)
+        self.assertIn("remainingFrames > 0 && (grew || !fits)", stabilizer_source)
+        self.assertIn('textarea.style.overflowY = "hidden"', stabilizer_source)
+        self.assertNotIn("setInterval", stabilizer_source)
+        self.assertNotIn("setTimeout", stabilizer_source)
+
+        for source in (classic_source, advanced_source):
+            self.assertIn("createTextareaGrowStabilizer", source)
+            self.assertIn("heightStabilizer.schedule()", source)
+            self.assertIn("currentHeight", source)
+            self.assertIn("nextHeight", source)
+
+        self.assertIn("widget?.__easyuseAnimaStudioInput", widgets_source)
+        self.assertIn("widget?.inputEl", widgets_source)
+        self.assertIn("widget?.element", widgets_source)
+        self.assertIn('candidate?.querySelector?.("textarea, input")', widgets_source)
+        self.assertIn("input.isConnected !== false", widgets_source)
+
+        resolver_source = (
+            PROMPT_STUDIO_MODULES / "studio_input_resolver.js"
+        ).read_text(encoding="utf-8")
+        self.assertIn('".lg-node[data-node-id]"', resolver_source)
+        self.assertIn('"aria-label"', resolver_source)
+        self.assertIn("anonymousFieldNames.indexOf(widget.name)", resolver_source)
+        self.assertIn("widget.__easyuseAnimaStudioInput = input", resolver_source)
+        self.assertNotIn("addEventListener", resolver_source)
+        self.assertNotIn("MutationObserver", resolver_source)
+
+        self.assertIn(
+            'node "tests\\frontend_prompt_studio_paste_autosize_smoke.mjs"',
+            runner_source,
+        )
+
     def test_advanced_width_reflow_grows_content_without_owning_node_height(self):
         controller_source = (PROMPT_STUDIO_MODULES / "advanced_layout_controller.js").read_text(
             encoding="utf-8"

--- a/tools/check_frontend.ps1
+++ b/tools/check_frontend.ps1
@@ -169,6 +169,11 @@ try {
         throw "Frontend Prompt Studio resolution orientation smoke failed with exit code $LASTEXITCODE."
     }
 
+    & node "tests\frontend_prompt_studio_paste_autosize_smoke.mjs"
+    if ($LASTEXITCODE -ne 0) {
+        throw "Frontend Prompt Studio paste autosize smoke failed with exit code $LASTEXITCODE."
+    }
+
     & node "tests\frontend_wildcard_values_smoke.mjs"
     if ($LASTEXITCODE -ne 0) {
         throw "Frontend standalone Wildcard populated-text smoke failed with exit code $LASTEXITCODE."

--- a/web/js/prompt_studio/advanced_fields_ui.js
+++ b/web/js/prompt_studio/advanced_fields_ui.js
@@ -34,6 +34,9 @@ import {
   rememberAdvancedTextareaResizeStart,
   syncAdvancedTextareaLinkedInputValue,
 } from "./textarea.js";
+import {
+  createTextareaGrowStabilizer,
+} from "./textarea_stabilization.js";
 import { psText } from "./text.js";
 import {
   findWidget,
@@ -234,6 +237,7 @@ function createAdvancedFieldElement(node, field, hooks = {}) {
     } else {
       requestOverlaySync(textarea);
     }
+    return nextHeight;
   };
   const syncHeight = () => {
     if (field.heightMode === "manual") {
@@ -249,6 +253,24 @@ function createAdvancedFieldElement(node, field, hooks = {}) {
     field.heightMode = "auto";
     persistTextareaHeight(height, "auto");
   };
+  const growHeightToCurrentContent = () => {
+    const currentHeight = advancedTextareaCurrentHeight(textarea);
+    const contentHeight = advancedTextareaContentHeight(textarea);
+    const nextHeight = Math.max(currentHeight, contentHeight);
+    if (nextHeight <= currentHeight + 1) {
+      requestOverlaySync(textarea);
+      return false;
+    }
+    const persistedHeight = persistTextareaHeight(
+      nextHeight,
+      field.heightMode === "manual" ? "manual" : "auto",
+    );
+    return persistedHeight > currentHeight + 1;
+  };
+  const heightStabilizer = createTextareaGrowStabilizer(
+    textarea,
+    growHeightToCurrentContent,
+  );
   const rememberTextareaResizeStart = () => rememberAdvancedTextareaResizeStart(textarea);
   const captureTextareaManualResize = () => {
     const { changed, currentHeight } = captureAdvancedTextareaManualResize(textarea);
@@ -267,6 +289,7 @@ function createAdvancedFieldElement(node, field, hooks = {}) {
     field.text = textarea.value;
     updateFieldHighlight();
     syncHeight();
+    heightStabilizer.schedule();
   });
   textarea.addEventListener("change", () => {
     updateFieldHighlight();

--- a/web/js/prompt_studio/extension_runtime.js
+++ b/web/js/prompt_studio/extension_runtime.js
@@ -63,6 +63,9 @@ import {
   findWidget,
 } from "./widgets.js";
 import {
+  resolveStudioInput as resolveStudioInputWithCanvas,
+} from "./studio_input_resolver.js";
+import {
   updateAdvancedEditorWidth,
 } from "./layout.js";
 import {
@@ -257,6 +260,15 @@ function createPromptStudioExtensionRuntime(app) {
     return isExtendNode(node) ? EXTEND_FIELD_NAMES : FIELD_NAMES;
   }
 
+  function resolveStudioInput(node, widget) {
+    return resolveStudioInputWithCanvas(
+      node,
+      widget,
+      studioFieldNames(node),
+      app.canvas?.canvas,
+    );
+  }
+
   function promptHighlightHooks() {
     return {
       findWidget,
@@ -322,6 +334,7 @@ function createPromptStudioExtensionRuntime(app) {
       growStudioManualHeightToContent,
       setStudioInputHeight,
       setStudioManualHeight,
+      resolveStudioInput,
       updateHighlight,
     });
   }
@@ -335,6 +348,7 @@ function createPromptStudioExtensionRuntime(app) {
       isExtendNode,
       layoutExtendPromptWidgets,
       refreshNodeSize,
+      resolveStudioInput,
       restoreInputFromWidget,
       studioFieldNames,
       syncWidgetValue,

--- a/web/js/prompt_studio/studio_input_resolver.js
+++ b/web/js/prompt_studio/studio_input_resolver.js
@@ -1,0 +1,91 @@
+// @ts-check
+
+import {
+  findInputEl,
+  findWidget,
+} from "./widgets.js";
+
+function connectedStudioControl(candidate) {
+  if (
+    !(candidate instanceof HTMLTextAreaElement)
+    && !(candidate instanceof HTMLInputElement)
+  ) {
+    return null;
+  }
+  return candidate.isConnected === false ? null : candidate;
+}
+
+function nodeElementForCanvas(node, canvasElement) {
+  const root = canvasElement?.parentElement;
+  const nodeId = String(node?.id ?? "");
+  if (!root || !nodeId) {
+    return null;
+  }
+  return Array.from(root.querySelectorAll?.(".lg-node[data-node-id]") || [])
+    .find((element) => String(element?.dataset?.nodeId || "") === nodeId)
+    || null;
+}
+
+/**
+ * Resolve the current Prompt Studio field input without installing a global
+ * listener or registry. Legacy/custom DOM widgets keep their canonical
+ * inputEl/element seam. Vue Node 2.0 fields are matched only inside the owning
+ * node: named controls use aria-label, while anonymous multiline controls use
+ * the current visible Prompt Studio field order.
+ */
+function resolveStudioInput(node, widget, fieldNames, canvasElement) {
+  const current = findInputEl(widget);
+  if (current) {
+    return current;
+  }
+
+  const nodeElement = nodeElementForCanvas(node, canvasElement);
+  if (!nodeElement || !widget?.name) {
+    return null;
+  }
+  const controls = Array.from(
+    nodeElement.querySelectorAll?.('[data-testid="node-widget"] textarea, [data-testid="node-widget"] input')
+    || [],
+  );
+  const named = controls.find(
+    (control) => control?.getAttribute?.("aria-label") === widget.name,
+  );
+  const namedInput = connectedStudioControl(named);
+  if (namedInput) {
+    widget.__easyuseAnimaStudioInput = namedInput;
+    return namedInput;
+  }
+
+  const visibleFieldNames = fieldNames.filter((name) => {
+    const fieldWidget = findWidget(node, name);
+    return fieldWidget
+      && fieldWidget.hidden !== true
+      && fieldWidget.options?.hidden !== true
+      && fieldWidget.__easyuseAnimaExtendHidden !== true;
+  });
+  const namedFieldNames = new Set(
+    controls
+      .map((control) => control?.getAttribute?.("aria-label"))
+      .filter((name) => visibleFieldNames.includes(name)),
+  );
+  const anonymousFieldNames = visibleFieldNames.filter(
+    (name) => !namedFieldNames.has(name),
+  );
+  const fieldIndex = anonymousFieldNames.indexOf(widget.name);
+  if (fieldIndex < 0) {
+    return null;
+  }
+  const anonymousControls = controls.filter(
+    (control) => !control?.getAttribute?.("aria-label"),
+  );
+  const input = connectedStudioControl(anonymousControls[fieldIndex]);
+  if (!input) {
+    return null;
+  }
+  widget.__easyuseAnimaStudioInput = input;
+  return input;
+}
+
+export {
+  resolveStudioInput,
+};

--- a/web/js/prompt_studio/studio_node_ui.js
+++ b/web/js/prompt_studio/studio_node_ui.js
@@ -26,6 +26,7 @@ function hookStudioNode(node, attempt = 0, hooks = {}) {
     isExtendNode = () => false,
     layoutExtendPromptWidgets = () => {},
     refreshNodeSize = () => {},
+    resolveStudioInput = (_node, widget) => findInputEl(widget),
     restoreInputFromWidget = () => {},
     studioFieldNames = () => [],
     syncWidgetValue = () => {},
@@ -92,7 +93,7 @@ function hookStudioNode(node, attempt = 0, hooks = {}) {
     if (!widget) {
       continue;
     }
-    const input = findInputEl(widget);
+    const input = resolveStudioInput(node, widget);
     if (!input) {
       pendingInput = true;
       continue;
@@ -106,7 +107,7 @@ function hookStudioNode(node, attempt = 0, hooks = {}) {
     enhanceResizableInput(node, widget);
     const updateField = getUpdateField(name);
 
-    if (!widget.__easyuseAnimaStudioHooked) {
+    if (!widget.__easyuseAnimaStudioCallbackHooked) {
       const callback = widget.callback;
       widget.callback = function (_value) {
         const result = callback?.apply(this, arguments);
@@ -115,6 +116,9 @@ function hookStudioNode(node, attempt = 0, hooks = {}) {
         updateField();
         return result;
       };
+      widget.__easyuseAnimaStudioCallbackHooked = true;
+    }
+    if (widget.__easyuseAnimaStudioHookInput !== input) {
       input.addEventListener("input", () => {
         widget.value = input.value;
         widget.__easyuseAnimaExecutedText = null;
@@ -130,6 +134,7 @@ function hookStudioNode(node, attempt = 0, hooks = {}) {
       input.addEventListener("blur", () => syncWidgetValue(widget));
       input.addEventListener("click", () => updateHighlight(node, widget));
       input.addEventListener("keyup", () => updateHighlight(node, widget));
+      widget.__easyuseAnimaStudioHookInput = input;
       widget.__easyuseAnimaStudioHooked = true;
     }
     updateField();

--- a/web/js/prompt_studio/studio_resizable_input.js
+++ b/web/js/prompt_studio/studio_resizable_input.js
@@ -15,6 +15,9 @@ import {
   studioDefaultHeight,
 } from "./studio_textareas.js";
 import {
+  createTextareaGrowStabilizer,
+} from "./textarea_stabilization.js";
+import {
   findInputEl,
 } from "./widgets.js";
 
@@ -32,11 +35,12 @@ function enhanceResizableInput(node, widget, hooks = {}) {
   const {
     expandStudioInputToContent = () => {},
     growStudioManualHeightToContent = () => {},
+    resolveStudioInput = (_node, target) => findStudioInput(target),
     setStudioInputHeight = () => {},
     setStudioManualHeight = () => {},
     updateHighlight = () => {},
   } = hooks;
-  const input = findStudioInput(widget);
+  const input = resolveStudioInput(node, widget);
   if (!input) {
     return;
   }
@@ -73,6 +77,23 @@ function enhanceResizableInput(node, widget, hooks = {}) {
     const height = desiredTextareaHeight(input, 0, minimumHeight, { includeCurrent: false });
     setStudioInputHeight(node, widget, height, "immediate");
   };
+  const growHeightToCurrentContent = () => {
+    if (widget.__easyuseAnimaManualHeight) {
+      return growStudioManualHeightToContent(node, widget, "immediate") === true;
+    }
+    const currentHeight = studioCurrentHeight(widget, input);
+    const nextHeight = desiredTextareaHeight(input, currentHeight, minimumHeight);
+    if (nextHeight <= currentHeight + 1) {
+      requestOverlaySync(input);
+      return false;
+    }
+    setStudioInputHeight(node, widget, nextHeight, "immediate");
+    return true;
+  };
+  const heightStabilizer = createTextareaGrowStabilizer(
+    input,
+    growHeightToCurrentContent,
+  );
   const rememberResizeStart = () => {
     widget.__easyuseAnimaResizeStartHeight = studioCurrentHeight(widget, input);
   };
@@ -96,7 +117,10 @@ function enhanceResizableInput(node, widget, hooks = {}) {
   input.addEventListener("pointerdown", rememberResizeStart);
   input.addEventListener("mouseup", captureManualResize);
   input.addEventListener("pointerup", captureManualResize);
-  input.addEventListener("input", syncHeight);
+  input.addEventListener("input", () => {
+    syncHeight();
+    heightStabilizer.schedule();
+  });
   input.__easyuseAnimaStudioResizable = true;
 }
 

--- a/web/js/prompt_studio/textarea_stabilization.js
+++ b/web/js/prompt_studio/textarea_stabilization.js
@@ -1,0 +1,67 @@
+// @ts-check
+
+const TEXTAREA_FIT_TOLERANCE = 2;
+const TEXTAREA_STABILIZATION_FRAMES = 2;
+
+/**
+ * Schedule a small revision-owned post-input grow pass. Height calculation,
+ * persistence, and node layout remain owned by the caller.
+ *
+ * @param {HTMLTextAreaElement | HTMLInputElement} textarea
+ * @param {() => boolean} growToContent
+ * @param {{
+ *   frameBudget?: number,
+ *   requestFrame?: (callback: FrameRequestCallback) => number,
+ *   tolerance?: number,
+ * }} [options]
+ */
+function createTextareaGrowStabilizer(textarea, growToContent, options = {}) {
+  const frameBudget = Math.max(
+    1,
+    Math.round(Number(options.frameBudget) || TEXTAREA_STABILIZATION_FRAMES),
+  );
+  const tolerance = Math.max(
+    0,
+    Number(options.tolerance) || TEXTAREA_FIT_TOLERANCE,
+  );
+  const requestFrame = options.requestFrame
+    || ((callback) => globalThis.requestAnimationFrame(callback));
+  let revision = 0;
+
+  const schedule = () => {
+    revision += 1;
+    const ownedRevision = revision;
+    let remainingFrames = frameBudget;
+
+    const remeasure = () => {
+      if (ownedRevision !== revision || textarea?.isConnected === false) {
+        return;
+      }
+      const grew = growToContent() === true;
+      textarea.style.overflowY = "hidden";
+      remainingFrames -= 1;
+      const fits = Number(textarea.scrollHeight) <= Number(textarea.clientHeight) + tolerance;
+      if (remainingFrames > 0 && (grew || !fits)) {
+        requestFrame(remeasure);
+      }
+    };
+
+    requestFrame(remeasure);
+    return ownedRevision;
+  };
+
+  const invalidate = () => {
+    revision += 1;
+  };
+
+  return {
+    invalidate,
+    schedule,
+  };
+}
+
+export {
+  createTextareaGrowStabilizer,
+  TEXTAREA_FIT_TOLERANCE,
+  TEXTAREA_STABILIZATION_FRAMES,
+};

--- a/web/js/prompt_studio/widgets.js
+++ b/web/js/prompt_studio/widgets.js
@@ -10,9 +10,24 @@ function findWidget(node, name) {
 }
 
 function findInputEl(widget) {
-  const input = widget?.inputEl;
-  if (input instanceof HTMLTextAreaElement || input instanceof HTMLInputElement) {
-    return input;
+  for (const candidate of [
+    widget?.__easyuseAnimaStudioInput,
+    widget?.inputEl,
+    widget?.element,
+  ]) {
+    if (
+      (candidate instanceof HTMLTextAreaElement || candidate instanceof HTMLInputElement)
+      && candidate.isConnected !== false
+    ) {
+      return candidate;
+    }
+    const input = candidate?.querySelector?.("textarea, input");
+    if (
+      (input instanceof HTMLTextAreaElement || input instanceof HTMLInputElement)
+      && input.isConnected !== false
+    ) {
+      return input;
+    }
   }
   return null;
 }


### PR DESCRIPTION
## 요약

- Fixes #401
- Classic/Extend와 Advanced/AdvancedV2의 기존 즉시 높이 계산은 유지하고, 입력 revision이 소유하는 최대 2 frame grow-only 재측정을 추가했습니다.
- stale revision과 연결 해제된 textarea는 no-op이며, 최종 overflow는 hidden으로 고정합니다.
- Vue Node 2.0에서는 전역 listener/registry 없이 현재 노드 ID와 Prompt Studio field 순서 안에서만 native 입력을 연결합니다.

## 재현과 원인

수정 전 controlled browser-layout fixture에서 `scrollHeight/clientHeight`는 다음처럼 남았습니다.

| 변형 | input 직후 | 첫 frame | post-layout frame |
| --- | ---: | ---: | ---: |
| Classic | 84/84 | 1460/84 | 1460/84 |
| Extend | 84/84 | 1460/84 | 1460/84 |
| Advanced | 120/120 | 1536/120 | 1536/120 |
| AdvancedV2 | 120/120 | 1536/120 | 1536/120 |

원인은 input event 같은 turn의 측정만 저장하고, paste 뒤 browser layout에서 늦게 확정되는 scrollHeight를 다시 측정하는 입력 revision 소유자가 없었던 것입니다.

## 주요 변경 파일

- `web/js/prompt_studio/textarea_stabilization.js`
- `web/js/prompt_studio/studio_resizable_input.js`
- `web/js/prompt_studio/advanced_fields_ui.js`
- `web/js/prompt_studio/studio_input_resolver.js`
- `web/js/prompt_studio/studio_node_ui.js`
- `tests/frontend_prompt_studio_paste_autosize_smoke.mjs`

## 검증

- Focused frontend: `node tests\frontend_prompt_studio_paste_autosize_smoke.mjs` — 통과
- Focused unittest: `tests.test_frontend_modules.FrontendModuleStructureTests.test_prompt_studio_paste_autosize_is_bounded_revision_owned_and_grow_only` — 1 test 통과
- Full runner: Python 1,148 tests 통과, frontend 115 JavaScript files 통과, TypeScript 6.0.3 통과, pyright baseline/import boundary/git diff gate 통과
- Ruff: 기존 report-only 119 findings, blocking failure 없음
- ComfyUI 0.27.0 live paste smoke:
  - Legacy Classic 1577/1577, Advanced 8023/8023, AdvancedV2 3920/3920
  - Node 2.0 Classic 1964/1964, Advanced 8002/8002, AdvancedV2 3899/3899
  - 위 값은 각 표면의 input 직후 / 첫 frame / post-layout frame에서 동일했고 overflow는 hidden이었습니다.
- Extend backend node는 현재 live test surface에 등록되지 않아 live smoke는 미실행입니다. 동일 frontend owner 경로는 focused runtime smoke에서 input/first/post-layout, auto/manual, stale revision, disconnected no-op까지 통과했습니다.

## 호환성과 범위

- 자동 높이와 수동 높이 ownership을 유지하며 shrink하지 않습니다. 수동 높이도 내용이 넘칠 때만 grow합니다.
- frame budget은 2로 제한되고 새 입력 revision이 이전 callback을 무효화합니다.
- #394 해상도 production 파일과 #64 autocomplete production 파일은 변경하지 않았습니다.
- base SHA: `9a4f11593b5ea042d0883aa3ca325f6695a78bc2`
- head SHA: `61e64c0abbc42c083a7a5ceb885f816cec0faf10`

## Rollback

`61e64c0abbc42c083a7a5ceb885f816cec0faf10`을 revert하면 bounded 재측정, Node 2.0 Prompt Studio 입력 연결, 해당 focused test/runner 등록만 함께 제거됩니다. 저장 데이터/API migration은 없습니다.

## 다음 release task

- #64 REL-FEAT-03A