### PR TITLE
test: autocomplete edit range contract 정의 (#64)

### DIFF
--- a/tests/fixtures/autocomplete_edit_contract.v1.json
+++ b/tests/fixtures/autocomplete_edit_contract.v1.json
@@ -1,0 +1,30 @@
+{
+  "schema_version": 1,
+  "settings": {
+    "artist_prefix": {
+      "internal_key": "autocomplete.artist_prefix",
+      "comfy_key": "EasyUseAnima.Prompt.AutocompleteArtistPrefix",
+      "default": "@",
+      "max_length": 32
+    },
+    "commit_mode": {
+      "internal_key": "autocomplete.commit_mode",
+      "comfy_key": "EasyUseAnima.Prompt.AutocompleteCommitMode",
+      "default": "smart",
+      "accepted_values": [
+        "smart",
+        "insert",
+        "replace"
+      ]
+    },
+    "selection_parenthesis_weight": {
+      "internal_key": "prompt_studio.selection_parenthesis_weight",
+      "comfy_key": "EasyUseAnima.Prompt.SelectionParenthesisWeight",
+      "default": "false",
+      "accepted_values": [
+        "false",
+        "true"
+      ]
+    }
+  }
+}

--- a/tests/frontend_autocomplete_text_model_smoke.mjs
+++ b/tests/frontend_autocomplete_text_model_smoke.mjs
@@ -10,6 +10,7 @@ const textModel = await import(dataModule("../web/js/autocomplete/text_model.js"
 
 assert.deepEqual(Object.keys(textModel).sort(), [
   "autocompleteQuery",
+  "completionEditRangeContract",
   "currentToken",
   "currentWildcardToken",
   "isCaretInComment",
@@ -22,6 +23,7 @@ assert.deepEqual(Object.keys(textModel).sort(), [
 
 const {
   autocompleteQuery,
+  completionEditRangeContract,
   currentToken,
   currentWildcardToken,
   isCaretInComment,
@@ -31,6 +33,16 @@ const {
   planAutocompleteInsertion,
   wildcardAutocompleteQuery,
 } = textModel;
+
+function contractRanges(value, marker, options = {}) {
+  const caret = value.indexOf(marker);
+  assert.notEqual(caret, -1);
+  const text = value.replace(marker, "");
+  return completionEditRangeContract(text, caret, {
+    detectNaturalSentences: false,
+    ...options,
+  });
+}
 
 function appliedPlan(token, insert, options = {}) {
   const plan = planAutocompleteInsertion(token, insert, options);
@@ -43,6 +55,153 @@ function appliedPlan(token, insert, options = {}) {
     caret: plan.start + plan.caretOffset,
   };
 }
+
+const whitespaceSuffix = contractRanges("blue ha|ir solo", "|");
+assert.deepEqual(
+  {
+    query: [
+      whitespaceSuffix.queryStart,
+      whitespaceSuffix.queryEnd,
+    ],
+    insert: [
+      whitespaceSuffix.insertStart,
+      whitespaceSuffix.insertEnd,
+    ],
+    replace: [
+      whitespaceSuffix.replaceStart,
+      whitespaceSuffix.replaceEnd,
+    ],
+    protectedSuffix: whitespaceSuffix.value.slice(
+      whitespaceSuffix.protectedSuffixStart,
+    ),
+    item: [whitespaceSuffix.itemStart, whitespaceSuffix.itemEnd],
+    group: [
+      whitespaceSuffix.groupKind,
+      whitespaceSuffix.groupStart,
+      whitespaceSuffix.groupEnd,
+    ],
+  },
+  {
+    query: [0, "blue ha".length],
+    insert: [0, "blue ha".length],
+    replace: [0, "blue hair".length],
+    protectedSuffix: " solo",
+    item: [0, "blue hair solo".length],
+    group: ["root", 0, "blue hair solo".length],
+  },
+);
+
+for (const [value, expectedSuffix] of [
+  ["foo|, bar", ", bar"],
+  ["foo|\nbar", "\nbar"],
+]) {
+  const ranges = contractRanges(value, "|");
+  assert.equal(ranges.replaceEnd, "foo".length);
+  assert.equal(ranges.value.slice(ranges.protectedSuffixStart), expectedSuffix);
+}
+
+const parenthesisGroup = contractRanges("(foo|, bar:1.2)", "|");
+assert.deepEqual(
+  {
+    range: [
+      parenthesisGroup.replaceStart,
+      parenthesisGroup.replaceEnd,
+    ],
+    suffix: parenthesisGroup.value.slice(
+      parenthesisGroup.protectedSuffixStart,
+    ),
+    item: [parenthesisGroup.itemStart, parenthesisGroup.itemEnd],
+    group: [
+      parenthesisGroup.groupKind,
+      parenthesisGroup.groupStart,
+      parenthesisGroup.groupEnd,
+    ],
+  },
+  {
+    range: [1, 4],
+    suffix: ", bar:1.2)",
+    item: [1, 4],
+    group: ["parenthesis", 1, "(foo, bar:1.2".length],
+  },
+);
+
+const artistGroup = contractRanges(
+  "[[artist_a, art|ist_b:0.7]]",
+  "|",
+);
+assert.deepEqual(
+  {
+    query: [artistGroup.queryStart, artistGroup.queryEnd],
+    replace: [artistGroup.replaceStart, artistGroup.replaceEnd],
+    suffix: artistGroup.value.slice(artistGroup.protectedSuffixStart),
+    item: [artistGroup.itemStart, artistGroup.itemEnd],
+    group: [
+      artistGroup.groupKind,
+      artistGroup.groupStart,
+      artistGroup.groupEnd,
+    ],
+  },
+  {
+    query: [12, 15],
+    replace: [12, 20],
+    suffix: ":0.7]]",
+    item: [11, 24],
+    group: ["double-bracket", 2, 24],
+  },
+);
+
+const escapedGroup = contractRanges("\\(foo| bar\\)", "|");
+assert.equal(escapedGroup.groupKind, "root");
+assert.equal(escapedGroup.replaceEnd, "\\(foo".length);
+assert.equal(
+  escapedGroup.value.slice(escapedGroup.protectedSuffixStart),
+  " bar\\)",
+);
+
+const braceChoice = contractRanges("{choice_a|cho^ice_b}", "^");
+assert.deepEqual(
+  {
+    query: [braceChoice.queryStart, braceChoice.queryEnd],
+    replace: [braceChoice.replaceStart, braceChoice.replaceEnd],
+    suffix: braceChoice.value.slice(braceChoice.protectedSuffixStart),
+    item: [braceChoice.itemStart, braceChoice.itemEnd],
+    groupKind: braceChoice.groupKind,
+  },
+  {
+    query: ["{choice_a|".length, "{choice_a|cho".length],
+    replace: ["{choice_a|".length, "{choice_a|choice_b".length],
+    suffix: "}",
+    item: ["{choice_a|".length, "{choice_a|choice_b".length],
+    groupKind: "brace",
+  },
+);
+
+const selectedRange = completionEditRangeContract(
+  "(first, second)",
+  "(first, second".length,
+  {
+    selectionStart: "(first, ".length,
+    selectionEnd: "(first, second".length,
+  },
+);
+assert.deepEqual(
+  {
+    query: [selectedRange.queryStart, selectedRange.queryEnd],
+    insert: [selectedRange.insertStart, selectedRange.insertEnd],
+    replace: [selectedRange.replaceStart, selectedRange.replaceEnd],
+    group: [
+      selectedRange.groupKind,
+      selectedRange.groupStart,
+      selectedRange.groupEnd,
+    ],
+  },
+  {
+    query: [8, 14],
+    insert: [8, 14],
+    replace: [8, 14],
+    group: ["parenthesis", 1, 14],
+  },
+);
 
 const segmented = currentToken(
   "first tag, second tag\nthird tag",

--- a/tests/test_autocomplete_edit_contract.py
+++ b/tests/test_autocomplete_edit_contract.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import json
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+CONTRACT_FIXTURE = ROOT / "tests" / "fixtures" / "autocomplete_edit_contract.v1.json"
+
+
+class AutocompleteEditContractTests(unittest.TestCase):
+    def test_versioned_setting_keys_defaults_and_accepted_values_are_fixed(self):
+        self.assertEqual(
+            json.loads(CONTRACT_FIXTURE.read_text(encoding="utf-8")),
+            {
+                "schema_version": 1,
+                "settings": {
+                    "artist_prefix": {
+                        "internal_key": "autocomplete.artist_prefix",
+                        "comfy_key": (
+                            "EasyUseAnima.Prompt.AutocompleteArtistPrefix"
+                        ),
+                        "default": "@",
+                        "max_length": 32,
+                    },
+                    "commit_mode": {
+                        "internal_key": "autocomplete.commit_mode",
+                        "comfy_key": "EasyUseAnima.Prompt.AutocompleteCommitMode",
+                        "default": "smart",
+                        "accepted_values": ["smart", "insert", "replace"],
+                    },
+                    "selection_parenthesis_weight": {
+                        "internal_key": (
+                            "prompt_studio.selection_parenthesis_weight"
+                        ),
+                        "comfy_key": (
+                            "EasyUseAnima.Prompt.SelectionParenthesisWeight"
+                        ),
+                        "default": "false",
+                        "accepted_values": ["false", "true"],
+                    },
+                },
+            },
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_autocomplete_frontend.py
+++ b/tests/test_autocomplete_frontend.py
@@ -580,6 +580,7 @@ class AutocompleteFrontendBoundaryTests(unittest.TestCase):
         entry_source = AUTOCOMPLETE_ENTRY.read_text(encoding="utf-8")
         expected_exports = {
             "autocompleteQuery",
+            "completionEditRangeContract",
             "currentToken",
             "currentWildcardToken",
             "isCaretInComment",

--- a/web/js/autocomplete/text_model.js
+++ b/web/js/autocomplete/text_model.js
@@ -92,6 +92,221 @@ function trimPromptSyntaxSuffix(value, start, end) {
   return Math.max(start, cursor);
 }
 
+function syntaxOpeningAt(value, index) {
+  if (isEscaped(value, index)) {
+    return null;
+  }
+  if (value.slice(index, index + 2) === "[[") {
+    return { kind: "double-bracket", length: 2, closing: "]]" };
+  }
+  if (value[index] === "(") {
+    return { kind: "parenthesis", length: 1, closing: ")" };
+  }
+  if (value[index] === "{") {
+    return { kind: "brace", length: 1, closing: "}" };
+  }
+  return null;
+}
+
+function syntaxClosingAt(value, index) {
+  if (isEscaped(value, index)) {
+    return null;
+  }
+  if (value.slice(index, index + 2) === "]]") {
+    return { value: "]]", length: 2 };
+  }
+  if (value[index] === ")" || value[index] === "}") {
+    return { value: value[index], length: 1 };
+  }
+  return null;
+}
+
+function syntaxGroups(value) {
+  const groups = [];
+  const stack = [];
+  for (let index = 0; index < value.length; index += 1) {
+    const opening = syntaxOpeningAt(value, index);
+    if (opening) {
+      const group = {
+        kind: opening.kind,
+        openStart: index,
+        contentStart: index + opening.length,
+        closeStart: value.length,
+        contentEnd: value.length,
+      };
+      groups.push(group);
+      stack.push({ group, closing: opening.closing });
+      index += opening.length - 1;
+      continue;
+    }
+    const closing = syntaxClosingAt(value, index);
+    const active = stack[stack.length - 1];
+    if (!closing || !active || closing.value !== active.closing) {
+      continue;
+    }
+    active.group.closeStart = index;
+    active.group.contentEnd = index;
+    stack.pop();
+    index += closing.length - 1;
+  }
+  return groups;
+}
+
+function activeSyntaxGroup(value, caret) {
+  let selected = null;
+  for (const group of syntaxGroups(value)) {
+    if (caret < group.contentStart || caret > group.contentEnd) {
+      continue;
+    }
+    if (!selected || group.contentStart >= selected.contentStart) {
+      selected = group;
+    }
+  }
+  return selected || {
+    kind: "root",
+    openStart: -1,
+    contentStart: 0,
+    closeStart: value.length,
+    contentEnd: value.length,
+  };
+}
+
+function itemBoundsAtCaret(value, caret, groupKind, groupStart, groupEnd) {
+  let itemStart = groupStart;
+  let itemEnd = groupEnd;
+  const stack = [];
+  for (let index = groupStart; index < groupEnd; index += 1) {
+    const opening = syntaxOpeningAt(value, index);
+    if (opening) {
+      stack.push(opening.closing);
+      index += opening.length - 1;
+      continue;
+    }
+    const closing = syntaxClosingAt(value, index);
+    if (closing && stack[stack.length - 1] === closing.value) {
+      stack.pop();
+      index += closing.length - 1;
+      continue;
+    }
+    const itemDelimiter = value[index] === ","
+      || value[index] === "\n"
+      || (groupKind === "brace" && value[index] === "|");
+    if (stack.length > 0 || !itemDelimiter) {
+      continue;
+    }
+    if (index < caret) {
+      itemStart = index + 1;
+      continue;
+    }
+    itemEnd = index;
+    break;
+  }
+  return { itemStart, itemEnd };
+}
+
+function contiguousTailEnd(value, caret, itemEnd) {
+  let end = caret;
+  while (end < itemEnd) {
+    const closing = syntaxClosingAt(value, end);
+    if (closing || /[\s,\n]/.test(value[end])) {
+      break;
+    }
+    end += 1;
+  }
+  const tail = value.slice(caret, end);
+  const weight = /:\s*[+-]?(?:\d+(?:\.\d*)?|\.\d+)\s*$/.exec(tail);
+  return weight ? caret + weight.index : end;
+}
+
+export function completionEditRangeContract(value, caret, options = {}) {
+  const text = String(value || "");
+  const safeCaret = clamp(
+    caret == null ? text.length : Number(caret),
+    0,
+    text.length,
+  );
+  const rawSelectionStart = options.selectionStart == null
+    ? safeCaret
+    : Number(options.selectionStart);
+  const rawSelectionEnd = options.selectionEnd == null
+    ? safeCaret
+    : Number(options.selectionEnd);
+  const selectionStart = clamp(
+    Math.min(rawSelectionStart, rawSelectionEnd),
+    0,
+    text.length,
+  );
+  const selectionEnd = clamp(
+    Math.max(rawSelectionStart, rawSelectionEnd),
+    0,
+    text.length,
+  );
+  const selectionActive = selectionEnd > selectionStart;
+  const contextCaret = selectionActive ? selectionStart : safeCaret;
+  const group = activeSyntaxGroup(text, contextCaret);
+  const { itemStart, itemEnd } = itemBoundsAtCaret(
+    text,
+    contextCaret,
+    group.kind,
+    group.contentStart,
+    group.contentEnd,
+  );
+
+  if (selectionActive) {
+    return {
+      value: text,
+      caret: safeCaret,
+      selectionStart,
+      selectionEnd,
+      queryStart: selectionStart,
+      queryEnd: selectionEnd,
+      insertStart: selectionStart,
+      insertEnd: selectionEnd,
+      replaceStart: selectionStart,
+      replaceEnd: selectionEnd,
+      protectedSuffixStart: selectionEnd,
+      groupKind: group.kind,
+      groupStart: group.contentStart,
+      groupEnd: group.contentEnd,
+      itemStart,
+      itemEnd,
+    };
+  }
+
+  const naturalStart = naturalSentenceStart(
+    text,
+    itemStart,
+    safeCaret,
+    options.detectNaturalSentences !== false,
+  );
+  const sentenceDelimited = naturalStart > itemStart;
+  const activeItemEnd = sentenceDelimited
+    ? naturalSentenceEnd(text, safeCaret, itemEnd)
+    : itemEnd;
+  const rangeStart = trimPromptSyntaxPrefix(text, naturalStart, activeItemEnd);
+  const queryEnd = clamp(safeCaret, rangeStart, activeItemEnd);
+  const replaceEnd = contiguousTailEnd(text, queryEnd, activeItemEnd);
+
+  return {
+    value: text,
+    caret: safeCaret,
+    selectionStart,
+    selectionEnd,
+    queryStart: rangeStart,
+    queryEnd,
+    insertStart: rangeStart,
+    insertEnd: queryEnd,
+    replaceStart: rangeStart,
+    replaceEnd,
+    protectedSuffixStart: replaceEnd,
+    groupKind: group.kind,
+    groupStart: group.contentStart,
+    groupEnd: group.contentEnd,
+    itemStart,
+    itemEnd,
+  };
+}
+
 export function currentToken(value, caret, options = {}) {
   const text = String(value || "");
   const safeCaret = caret == null ? text.length : Number(caret);


### PR DESCRIPTION
## 요약

- Refs #64 — REL-FEAT-03A Completion edit Contract
- 현재 destructive completion을 재현하고, 03C가 소비할 query/insert/replace range 계약을 pure text model에 추가합니다.
- 세 setting의 이름/default/accepted value는 versioned test fixture로 고정하되, 03B~03D 전에는 persistence/public settings를 활성화하지 않습니다.
- 기존 `planAutocompleteInsertion()`은 새 계약을 소비하지 않으므로 production commit 동작은 이 PR에서 바뀌지 않습니다.

## 재현과 원인

수정 전 `blue ha|ir solo`에서 completion `blue hair`를 commit하면:

- token: `start=0, end=14`
- plan: 전체 `blue hair solo` range 교체
- 결과: `blue hair`
- 삭제됨: caret 오른쪽 `ir solo`

원인은 search query range와 실제 edit range가 동일한 `start/end` 하나로 결합돼 있기 때문입니다.

## Contract

- `queryStart/queryEnd`
- `insertStart/insertEnd`
- `replaceStart/replaceEnd`
- `protectedSuffixStart`
- root / `()` / `{}` / `[[ ]]` group boundary
- same-level comma/newline, brace `|` item boundary
- contiguous right tail만 replace 후보
- whitespace suffix, numeric weight, closing syntax 보호
- explicit selection 우선 및 escaped bracket literal 처리

Setting fixture:

- `autocomplete.artist_prefix` / `EasyUseAnima.Prompt.AutocompleteArtistPrefix` / default `@` / max 32
- `autocomplete.commit_mode` / `smart|insert|replace` / default `smart`
- `prompt_studio.selection_parenthesis_weight` / `false|true` / default `false`

## 변경 파일

- `web/js/autocomplete/text_model.js`
- `tests/frontend_autocomplete_text_model_smoke.mjs`
- `tests/test_autocomplete_frontend.py`
- `tests/fixtures/autocomplete_edit_contract.v1.json`
- `tests/test_autocomplete_edit_contract.py`

## 검증

- baseline quick: 통과
- focused frontend text-model smoke: 통과
- focused Python setting-contract: 1 test 통과
- focused frontend boundary: 1 test 통과
- official full runner: Python 1,149 tests 통과; frontend 115 JavaScript files, TypeScript 6.0.3, pyright baseline, import boundary, git diff gate 통과
- Ruff: 기존 report-only 119 findings
- 첫 full은 canonical schema의 조기 public export 때문에 4개 boundary/analyzer test가 실패했습니다. production schema 변경을 제거하고 versioned test fixture로 옮긴 뒤 최종 full을 통과했습니다.
- Legacy Canvas / Node 2.0 live smoke: 미실행. 이 PR은 planner/DOM/runtime behavior를 변경하지 않으며 실제 동작 gate는 03C/03D에서 수행합니다.

## 호환성 및 금지 범위

- `planAutocompleteInsertion()`, popup commit, preview, ranking/source API, IME/cache lifecycle은 변경하지 않습니다.
- #401 textarea autosize와 #394 resolution behavior를 변경하지 않습니다.
- 03B artist-prefix persistence/UI, 03C commit-mode behavior, 03D bracket key UX를 포함하지 않습니다.
- root settings shim과 analyzer baseline을 변경하지 않습니다.

## SHA / rollback

- base: `9c19d74490db7fe7b07d48e2256132d76b68e3f2`
- head: `ec7909386ff5345f825c45bc133269ee536c2765`
- rollback: head 단일 커밋 revert. 저장 데이터/API migration 없음.

## 다음 unit

- REL-FEAT-03B — configurable artist prefix setting