### PR TITLE
fix: 자동완성 중간 텍스트 편집 범위를 안전하게 보존

### DIFF
--- a/easyuse_anima/settings/schema.py
+++ b/easyuse_anima/settings/schema.py
@@ -15,6 +15,7 @@ DEFAULT_SETTINGS = {
     "autocomplete.mode": "compatible_global",
     "autocomplete.artist_prefix": "@",
     "autocomplete.commit_key": "enter",
+    "autocomplete.commit_mode": "smart",
     "autocomplete.append_separator": "false",
     "autocomplete.no_comma_after_period": "true",
     "autocomplete.detect_natural_sentences": "true",
@@ -77,6 +78,12 @@ AUTOCOMPLETE_COMMIT_KEYS = {
     "tab",
 }
 
+AUTOCOMPLETE_COMMIT_MODES = {
+    "smart",
+    "insert",
+    "replace",
+}
+
 NAIA_RESOLUTION_MODES = {
     "scale",
     "bucket",
@@ -134,6 +141,7 @@ COMFY_SETTING_KEYS = {
     "EasyUseAnima.Prompt.AutocompleteMode": "autocomplete.mode",
     "EasyUseAnima.Prompt.AutocompleteArtistPrefix": "autocomplete.artist_prefix",
     "EasyUseAnima.Prompt.AutocompleteCommitKey": "autocomplete.commit_key",
+    "EasyUseAnima.Prompt.AutocompleteCommitMode": "autocomplete.commit_mode",
     "EasyUseAnima.Prompt.AutocompleteAppendSeparator": "autocomplete.append_separator",
     "EasyUseAnima.Prompt.AutocompleteNoCommaAfterPeriod": "autocomplete.no_comma_after_period",
     "EasyUseAnima.Prompt.AutocompleteDetectNaturalSentences": "autocomplete.detect_natural_sentences",
@@ -204,6 +212,7 @@ LONG_TEXT_SETTING_ALIASES = {
 
 __all__ = (
     "AUTOCOMPLETE_COMMIT_KEYS",
+    "AUTOCOMPLETE_COMMIT_MODES",
     "AUTOCOMPLETE_MODES",
     "COMFY_COLOR_SETTING_KEYS",
     "COMFY_SETTING_KEYS",

--- a/easyuse_anima/settings/service.py
+++ b/easyuse_anima/settings/service.py
@@ -12,6 +12,7 @@ from ..translation.contracts import (
 from .repository import get_settings
 from .schema import (
     AUTOCOMPLETE_COMMIT_KEYS,
+    AUTOCOMPLETE_COMMIT_MODES,
     AUTOCOMPLETE_MODES,
     DEFAULT_SETTINGS,
     NAIA_PREPROCESSING_KEYS,
@@ -34,6 +35,7 @@ def public_settings() -> dict:
         "autocomplete.mode": resolve_autocomplete_mode(settings),
         "autocomplete.artist_prefix": _resolve_autocomplete_artist_prefix(settings),
         "autocomplete.commit_key": resolve_autocomplete_commit_key(settings),
+        "autocomplete.commit_mode": resolve_autocomplete_commit_mode(settings),
         "autocomplete.append_separator": settings.get(
             "autocomplete.append_separator",
             DEFAULT_SETTINGS["autocomplete.append_separator"],
@@ -200,6 +202,20 @@ def resolve_autocomplete_commit_key(settings: dict | None = None) -> str:
     if value in AUTOCOMPLETE_COMMIT_KEYS:
         return value
     return DEFAULT_SETTINGS["autocomplete.commit_key"]
+
+
+def resolve_autocomplete_commit_mode(settings: dict | None = None) -> str:
+    settings = settings or get_settings()
+    value = str(
+        settings.get(
+            "autocomplete.commit_mode",
+            DEFAULT_SETTINGS["autocomplete.commit_mode"],
+        )
+        or DEFAULT_SETTINGS["autocomplete.commit_mode"]
+    ).strip()
+    if value in AUTOCOMPLETE_COMMIT_MODES:
+        return value
+    return DEFAULT_SETTINGS["autocomplete.commit_mode"]
 
 
 def _resolve_lora_preset_strength_step(
@@ -450,6 +466,7 @@ def resolve_naia_settings() -> dict:
 __all__ = (
     "public_settings",
     "resolve_autocomplete_commit_key",
+    "resolve_autocomplete_commit_mode",
     "resolve_autocomplete_limit",
     "resolve_autocomplete_mode",
     "resolve_autocomplete_source",

--- a/settings.py
+++ b/settings.py
@@ -13,6 +13,7 @@ try:
     )
     from .easyuse_anima.settings.schema import (
         AUTOCOMPLETE_COMMIT_KEYS,
+        AUTOCOMPLETE_COMMIT_MODES,
         AUTOCOMPLETE_MODES,
         COMFY_COLOR_SETTING_KEYS,
         COMFY_SETTING_KEYS,
@@ -27,6 +28,7 @@ try:
     from .easyuse_anima.settings.service import (
         public_settings,
         resolve_autocomplete_commit_key,
+        resolve_autocomplete_commit_mode,
         resolve_autocomplete_limit,
         resolve_autocomplete_mode,
         resolve_autocomplete_source,
@@ -59,6 +61,7 @@ except ImportError:
     )
     from easyuse_anima.settings.schema import (
         AUTOCOMPLETE_COMMIT_KEYS,
+        AUTOCOMPLETE_COMMIT_MODES,
         AUTOCOMPLETE_MODES,
         COMFY_COLOR_SETTING_KEYS,
         COMFY_SETTING_KEYS,
@@ -73,6 +76,7 @@ except ImportError:
     from easyuse_anima.settings.service import (
         public_settings,
         resolve_autocomplete_commit_key,
+        resolve_autocomplete_commit_mode,
         resolve_autocomplete_limit,
         resolve_autocomplete_mode,
         resolve_autocomplete_source,
@@ -98,6 +102,7 @@ except ImportError:
 
 __all__ = (
     "AUTOCOMPLETE_COMMIT_KEYS",
+    "AUTOCOMPLETE_COMMIT_MODES",
     "AUTOCOMPLETE_MODES",
     "COMFY_COLOR_SETTING_KEYS",
     "COMFY_SETTING_KEYS",
@@ -114,6 +119,7 @@ __all__ = (
     "load_long_text_settings",
     "public_settings",
     "resolve_autocomplete_commit_key",
+    "resolve_autocomplete_commit_mode",
     "resolve_autocomplete_limit",
     "resolve_autocomplete_mode",
     "resolve_autocomplete_source",

--- a/tests/fixtures/python_backend_baseline.json
+++ b/tests/fixtures/python_backend_baseline.json
@@ -26390,6 +26390,24 @@
       },
       {
         "alias": null,
+        "bound_name": "AUTOCOMPLETE_COMMIT_MODES",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".schema:AUTOCOMPLETE_COMMIT_MODES",
+        "kind": "static_from",
+        "line": 13,
+        "name": "AUTOCOMPLETE_COMMIT_MODES",
+        "optional": false,
+        "requested": ".schema",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/settings/service.py",
+        "target": "easyuse_anima/settings/schema.py"
+      },
+      {
+        "alias": null,
         "bound_name": "AUTOCOMPLETE_MODES",
         "branch_context": [],
         "classification": "internal",
@@ -51054,6 +51072,37 @@
       },
       {
         "alias": null,
+        "bound_name": "AUTOCOMPLETE_COMMIT_MODES",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 5
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "AUTOCOMPLETE_COMMIT_MODES",
+          "target": "easyuse_anima/settings/schema.py",
+          "try_line": 5
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.settings.schema:AUTOCOMPLETE_COMMIT_MODES",
+        "kind": "static_from",
+        "line": 14,
+        "name": "AUTOCOMPLETE_COMMIT_MODES",
+        "optional": false,
+        "requested": ".easyuse_anima.settings.schema",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "settings.py",
+        "target": "easyuse_anima/settings/schema.py"
+      },
+      {
+        "alias": null,
         "bound_name": "AUTOCOMPLETE_MODES",
         "branch_context": [
           {
@@ -51384,7 +51433,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.settings.service:public_settings",
         "kind": "static_from",
-        "line": 27,
+        "line": 28,
         "name": "public_settings",
         "optional": false,
         "requested": ".easyuse_anima.settings.service",
@@ -51415,8 +51464,39 @@
         "conditional": true,
         "imported": ".easyuse_anima.settings.service:resolve_autocomplete_commit_key",
         "kind": "static_from",
-        "line": 27,
+        "line": 28,
         "name": "resolve_autocomplete_commit_key",
+        "optional": false,
+        "requested": ".easyuse_anima.settings.service",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "settings.py",
+        "target": "easyuse_anima/settings/service.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "resolve_autocomplete_commit_mode",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 5
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "resolve_autocomplete_commit_mode",
+          "target": "easyuse_anima/settings/service.py",
+          "try_line": 5
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.settings.service:resolve_autocomplete_commit_mode",
+        "kind": "static_from",
+        "line": 28,
+        "name": "resolve_autocomplete_commit_mode",
         "optional": false,
         "requested": ".easyuse_anima.settings.service",
         "role": "compatibility_primary",
@@ -51446,7 +51526,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.settings.service:resolve_autocomplete_limit",
         "kind": "static_from",
-        "line": 27,
+        "line": 28,
         "name": "resolve_autocomplete_limit",
         "optional": false,
         "requested": ".easyuse_anima.settings.service",
@@ -51477,7 +51557,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.settings.service:resolve_autocomplete_mode",
         "kind": "static_from",
-        "line": 27,
+        "line": 28,
         "name": "resolve_autocomplete_mode",
         "optional": false,
         "requested": ".easyuse_anima.settings.service",
@@ -51508,7 +51588,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.settings.service:resolve_autocomplete_source",
         "kind": "static_from",
-        "line": 27,
+        "line": 28,
         "name": "resolve_autocomplete_source",
         "optional": false,
         "requested": ".easyuse_anima.settings.service",
@@ -51539,7 +51619,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.settings.service:resolve_lora_preset_menu_mode",
         "kind": "static_from",
-        "line": 27,
+        "line": 28,
         "name": "resolve_lora_preset_menu_mode",
         "optional": false,
         "requested": ".easyuse_anima.settings.service",
@@ -51570,7 +51650,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.settings.service:resolve_lora_preset_strength_button_step",
         "kind": "static_from",
-        "line": 27,
+        "line": 28,
         "name": "resolve_lora_preset_strength_button_step",
         "optional": false,
         "requested": ".easyuse_anima.settings.service",
@@ -51601,7 +51681,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.settings.service:resolve_lora_preset_strength_drag_pixels",
         "kind": "static_from",
-        "line": 27,
+        "line": 28,
         "name": "resolve_lora_preset_strength_drag_pixels",
         "optional": false,
         "requested": ".easyuse_anima.settings.service",
@@ -51632,7 +51712,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.settings.service:resolve_lora_preset_strength_drag_step",
         "kind": "static_from",
-        "line": 27,
+        "line": 28,
         "name": "resolve_lora_preset_strength_drag_step",
         "optional": false,
         "requested": ".easyuse_anima.settings.service",
@@ -51663,7 +51743,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.settings.service:resolve_metadata_filter_words",
         "kind": "static_from",
-        "line": 27,
+        "line": 28,
         "name": "resolve_metadata_filter_words",
         "optional": false,
         "requested": ".easyuse_anima.settings.service",
@@ -51694,7 +51774,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.settings.service:resolve_naia_port",
         "kind": "static_from",
-        "line": 27,
+        "line": 28,
         "name": "resolve_naia_port",
         "optional": false,
         "requested": ".easyuse_anima.settings.service",
@@ -51725,7 +51805,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.settings.service:resolve_naia_resolution_bucket",
         "kind": "static_from",
-        "line": 27,
+        "line": 28,
         "name": "resolve_naia_resolution_bucket",
         "optional": false,
         "requested": ".easyuse_anima.settings.service",
@@ -51756,7 +51836,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.settings.service:resolve_naia_resolution_max_long_edge",
         "kind": "static_from",
-        "line": 27,
+        "line": 28,
         "name": "resolve_naia_resolution_max_long_edge",
         "optional": false,
         "requested": ".easyuse_anima.settings.service",
@@ -51787,7 +51867,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.settings.service:resolve_naia_resolution_mode",
         "kind": "static_from",
-        "line": 27,
+        "line": 28,
         "name": "resolve_naia_resolution_mode",
         "optional": false,
         "requested": ".easyuse_anima.settings.service",
@@ -51818,7 +51898,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.settings.service:resolve_naia_resolution_scale",
         "kind": "static_from",
-        "line": 27,
+        "line": 28,
         "name": "resolve_naia_resolution_scale",
         "optional": false,
         "requested": ".easyuse_anima.settings.service",
@@ -51849,7 +51929,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.settings.service:resolve_naia_settings",
         "kind": "static_from",
-        "line": 27,
+        "line": 28,
         "name": "resolve_naia_settings",
         "optional": false,
         "requested": ".easyuse_anima.settings.service",
@@ -51880,7 +51960,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.settings.service:resolve_prompt_studio_font_family",
         "kind": "static_from",
-        "line": 27,
+        "line": 28,
         "name": "resolve_prompt_studio_font_family",
         "optional": false,
         "requested": ".easyuse_anima.settings.service",
@@ -51911,7 +51991,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.settings.service:resolve_prompt_studio_font_size",
         "kind": "static_from",
-        "line": 27,
+        "line": 28,
         "name": "resolve_prompt_studio_font_size",
         "optional": false,
         "requested": ".easyuse_anima.settings.service",
@@ -51942,7 +52022,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.settings.service:resolve_prompt_translation_provider",
         "kind": "static_from",
-        "line": 27,
+        "line": 28,
         "name": "resolve_prompt_translation_provider",
         "optional": false,
         "requested": ".easyuse_anima.settings.service",
@@ -51973,7 +52053,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.settings.service:resolve_prompt_translation_settings",
         "kind": "static_from",
-        "line": 27,
+        "line": 28,
         "name": "resolve_prompt_translation_settings",
         "optional": false,
         "requested": ".easyuse_anima.settings.service",
@@ -52004,7 +52084,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.settings.service:resolve_prompt_translation_source",
         "kind": "static_from",
-        "line": 27,
+        "line": 28,
         "name": "resolve_prompt_translation_source",
         "optional": false,
         "requested": ".easyuse_anima.settings.service",
@@ -52035,7 +52115,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.settings.service:resolve_prompt_translation_target",
         "kind": "static_from",
-        "line": 27,
+        "line": 28,
         "name": "resolve_prompt_translation_target",
         "optional": false,
         "requested": ".easyuse_anima.settings.service",
@@ -52054,7 +52134,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 51,
+            "handler_line": 53,
             "kind": "try",
             "line": 5
           }
@@ -52069,7 +52149,7 @@
         "conditional": true,
         "imported": "easyuse_anima.settings.repository:LONG_TEXT_SETTINGS_FILE",
         "kind": "static_from",
-        "line": 52,
+        "line": 54,
         "name": "LONG_TEXT_SETTINGS_FILE",
         "optional": false,
         "requested": "easyuse_anima.settings.repository",
@@ -52088,7 +52168,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 51,
+            "handler_line": 53,
             "kind": "try",
             "line": 5
           }
@@ -52103,7 +52183,7 @@
         "conditional": true,
         "imported": "easyuse_anima.settings.repository:SETTINGS_FILE",
         "kind": "static_from",
-        "line": 52,
+        "line": 54,
         "name": "SETTINGS_FILE",
         "optional": false,
         "requested": "easyuse_anima.settings.repository",
@@ -52122,7 +52202,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 51,
+            "handler_line": 53,
             "kind": "try",
             "line": 5
           }
@@ -52137,7 +52217,7 @@
         "conditional": true,
         "imported": "easyuse_anima.settings.repository:get_settings",
         "kind": "static_from",
-        "line": 52,
+        "line": 54,
         "name": "get_settings",
         "optional": false,
         "requested": "easyuse_anima.settings.repository",
@@ -52156,7 +52236,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 51,
+            "handler_line": 53,
             "kind": "try",
             "line": 5
           }
@@ -52171,7 +52251,7 @@
         "conditional": true,
         "imported": "easyuse_anima.settings.repository:load_long_text_settings",
         "kind": "static_from",
-        "line": 52,
+        "line": 54,
         "name": "load_long_text_settings",
         "optional": false,
         "requested": "easyuse_anima.settings.repository",
@@ -52190,7 +52270,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 51,
+            "handler_line": 53,
             "kind": "try",
             "line": 5
           }
@@ -52205,7 +52285,7 @@
         "conditional": true,
         "imported": "easyuse_anima.settings.repository:save_long_text_settings",
         "kind": "static_from",
-        "line": 52,
+        "line": 54,
         "name": "save_long_text_settings",
         "optional": false,
         "requested": "easyuse_anima.settings.repository",
@@ -52224,7 +52304,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 51,
+            "handler_line": 53,
             "kind": "try",
             "line": 5
           }
@@ -52239,7 +52319,7 @@
         "conditional": true,
         "imported": "easyuse_anima.settings.repository:save_setting",
         "kind": "static_from",
-        "line": 52,
+        "line": 54,
         "name": "save_setting",
         "optional": false,
         "requested": "easyuse_anima.settings.repository",
@@ -52258,7 +52338,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 51,
+            "handler_line": 53,
             "kind": "try",
             "line": 5
           }
@@ -52273,8 +52353,42 @@
         "conditional": true,
         "imported": "easyuse_anima.settings.schema:AUTOCOMPLETE_COMMIT_KEYS",
         "kind": "static_from",
-        "line": 60,
+        "line": 62,
         "name": "AUTOCOMPLETE_COMMIT_KEYS",
+        "optional": false,
+        "requested": "easyuse_anima.settings.schema",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "settings.py",
+        "target": "easyuse_anima/settings/schema.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "AUTOCOMPLETE_COMMIT_MODES",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 53,
+            "kind": "try",
+            "line": 5
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "AUTOCOMPLETE_COMMIT_MODES",
+          "target": "easyuse_anima/settings/schema.py",
+          "try_line": 5
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.settings.schema:AUTOCOMPLETE_COMMIT_MODES",
+        "kind": "static_from",
+        "line": 62,
+        "name": "AUTOCOMPLETE_COMMIT_MODES",
         "optional": false,
         "requested": "easyuse_anima.settings.schema",
         "role": "compatibility_fallback",
@@ -52292,7 +52406,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 51,
+            "handler_line": 53,
             "kind": "try",
             "line": 5
           }
@@ -52307,7 +52421,7 @@
         "conditional": true,
         "imported": "easyuse_anima.settings.schema:AUTOCOMPLETE_MODES",
         "kind": "static_from",
-        "line": 60,
+        "line": 62,
         "name": "AUTOCOMPLETE_MODES",
         "optional": false,
         "requested": "easyuse_anima.settings.schema",
@@ -52326,7 +52440,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 51,
+            "handler_line": 53,
             "kind": "try",
             "line": 5
           }
@@ -52341,7 +52455,7 @@
         "conditional": true,
         "imported": "easyuse_anima.settings.schema:COMFY_COLOR_SETTING_KEYS",
         "kind": "static_from",
-        "line": 60,
+        "line": 62,
         "name": "COMFY_COLOR_SETTING_KEYS",
         "optional": false,
         "requested": "easyuse_anima.settings.schema",
@@ -52360,7 +52474,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 51,
+            "handler_line": 53,
             "kind": "try",
             "line": 5
           }
@@ -52375,7 +52489,7 @@
         "conditional": true,
         "imported": "easyuse_anima.settings.schema:COMFY_SETTING_KEYS",
         "kind": "static_from",
-        "line": 60,
+        "line": 62,
         "name": "COMFY_SETTING_KEYS",
         "optional": false,
         "requested": "easyuse_anima.settings.schema",
@@ -52394,7 +52508,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 51,
+            "handler_line": 53,
             "kind": "try",
             "line": 5
           }
@@ -52409,7 +52523,7 @@
         "conditional": true,
         "imported": "easyuse_anima.settings.schema:DEFAULT_SETTINGS",
         "kind": "static_from",
-        "line": 60,
+        "line": 62,
         "name": "DEFAULT_SETTINGS",
         "optional": false,
         "requested": "easyuse_anima.settings.schema",
@@ -52428,7 +52542,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 51,
+            "handler_line": 53,
             "kind": "try",
             "line": 5
           }
@@ -52443,7 +52557,7 @@
         "conditional": true,
         "imported": "easyuse_anima.settings.schema:LONG_TEXT_SETTING_ALIASES",
         "kind": "static_from",
-        "line": 60,
+        "line": 62,
         "name": "LONG_TEXT_SETTING_ALIASES",
         "optional": false,
         "requested": "easyuse_anima.settings.schema",
@@ -52462,7 +52576,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 51,
+            "handler_line": 53,
             "kind": "try",
             "line": 5
           }
@@ -52477,7 +52591,7 @@
         "conditional": true,
         "imported": "easyuse_anima.settings.schema:LONG_TEXT_SETTING_KEYS",
         "kind": "static_from",
-        "line": 60,
+        "line": 62,
         "name": "LONG_TEXT_SETTING_KEYS",
         "optional": false,
         "requested": "easyuse_anima.settings.schema",
@@ -52496,7 +52610,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 51,
+            "handler_line": 53,
             "kind": "try",
             "line": 5
           }
@@ -52511,7 +52625,7 @@
         "conditional": true,
         "imported": "easyuse_anima.settings.schema:NAIA_PREPROCESSING_KEYS",
         "kind": "static_from",
-        "line": 60,
+        "line": 62,
         "name": "NAIA_PREPROCESSING_KEYS",
         "optional": false,
         "requested": "easyuse_anima.settings.schema",
@@ -52530,7 +52644,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 51,
+            "handler_line": 53,
             "kind": "try",
             "line": 5
           }
@@ -52545,7 +52659,7 @@
         "conditional": true,
         "imported": "easyuse_anima.settings.schema:NAIA_RESOLUTION_BUCKETS",
         "kind": "static_from",
-        "line": 60,
+        "line": 62,
         "name": "NAIA_RESOLUTION_BUCKETS",
         "optional": false,
         "requested": "easyuse_anima.settings.schema",
@@ -52564,7 +52678,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 51,
+            "handler_line": 53,
             "kind": "try",
             "line": 5
           }
@@ -52579,7 +52693,7 @@
         "conditional": true,
         "imported": "easyuse_anima.settings.schema:NAIA_RESOLUTION_MODES",
         "kind": "static_from",
-        "line": 60,
+        "line": 62,
         "name": "NAIA_RESOLUTION_MODES",
         "optional": false,
         "requested": "easyuse_anima.settings.schema",
@@ -52598,7 +52712,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 51,
+            "handler_line": 53,
             "kind": "try",
             "line": 5
           }
@@ -52613,7 +52727,7 @@
         "conditional": true,
         "imported": "easyuse_anima.settings.schema:PROMPT_STUDIO_COLOR_KEYS",
         "kind": "static_from",
-        "line": 60,
+        "line": 62,
         "name": "PROMPT_STUDIO_COLOR_KEYS",
         "optional": false,
         "requested": "easyuse_anima.settings.schema",
@@ -52632,7 +52746,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 51,
+            "handler_line": 53,
             "kind": "try",
             "line": 5
           }
@@ -52647,7 +52761,7 @@
         "conditional": true,
         "imported": "easyuse_anima.settings.service:public_settings",
         "kind": "static_from",
-        "line": 73,
+        "line": 76,
         "name": "public_settings",
         "optional": false,
         "requested": "easyuse_anima.settings.service",
@@ -52666,7 +52780,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 51,
+            "handler_line": 53,
             "kind": "try",
             "line": 5
           }
@@ -52681,8 +52795,42 @@
         "conditional": true,
         "imported": "easyuse_anima.settings.service:resolve_autocomplete_commit_key",
         "kind": "static_from",
-        "line": 73,
+        "line": 76,
         "name": "resolve_autocomplete_commit_key",
+        "optional": false,
+        "requested": "easyuse_anima.settings.service",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "settings.py",
+        "target": "easyuse_anima/settings/service.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "resolve_autocomplete_commit_mode",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 53,
+            "kind": "try",
+            "line": 5
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "resolve_autocomplete_commit_mode",
+          "target": "easyuse_anima/settings/service.py",
+          "try_line": 5
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.settings.service:resolve_autocomplete_commit_mode",
+        "kind": "static_from",
+        "line": 76,
+        "name": "resolve_autocomplete_commit_mode",
         "optional": false,
         "requested": "easyuse_anima.settings.service",
         "role": "compatibility_fallback",
@@ -52700,7 +52848,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 51,
+            "handler_line": 53,
             "kind": "try",
             "line": 5
           }
@@ -52715,7 +52863,7 @@
         "conditional": true,
         "imported": "easyuse_anima.settings.service:resolve_autocomplete_limit",
         "kind": "static_from",
-        "line": 73,
+        "line": 76,
         "name": "resolve_autocomplete_limit",
         "optional": false,
         "requested": "easyuse_anima.settings.service",
@@ -52734,7 +52882,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 51,
+            "handler_line": 53,
             "kind": "try",
             "line": 5
           }
@@ -52749,7 +52897,7 @@
         "conditional": true,
         "imported": "easyuse_anima.settings.service:resolve_autocomplete_mode",
         "kind": "static_from",
-        "line": 73,
+        "line": 76,
         "name": "resolve_autocomplete_mode",
         "optional": false,
         "requested": "easyuse_anima.settings.service",
@@ -52768,7 +52916,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 51,
+            "handler_line": 53,
             "kind": "try",
             "line": 5
           }
@@ -52783,7 +52931,7 @@
         "conditional": true,
         "imported": "easyuse_anima.settings.service:resolve_autocomplete_source",
         "kind": "static_from",
-        "line": 73,
+        "line": 76,
         "name": "resolve_autocomplete_source",
         "optional": false,
         "requested": "easyuse_anima.settings.service",
@@ -52802,7 +52950,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 51,
+            "handler_line": 53,
             "kind": "try",
             "line": 5
           }
@@ -52817,7 +52965,7 @@
         "conditional": true,
         "imported": "easyuse_anima.settings.service:resolve_lora_preset_menu_mode",
         "kind": "static_from",
-        "line": 73,
+        "line": 76,
         "name": "resolve_lora_preset_menu_mode",
         "optional": false,
         "requested": "easyuse_anima.settings.service",
@@ -52836,7 +52984,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 51,
+            "handler_line": 53,
             "kind": "try",
             "line": 5
           }
@@ -52851,7 +52999,7 @@
         "conditional": true,
         "imported": "easyuse_anima.settings.service:resolve_lora_preset_strength_button_step",
         "kind": "static_from",
-        "line": 73,
+        "line": 76,
         "name": "resolve_lora_preset_strength_button_step",
         "optional": false,
         "requested": "easyuse_anima.settings.service",
@@ -52870,7 +53018,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 51,
+            "handler_line": 53,
             "kind": "try",
             "line": 5
           }
@@ -52885,7 +53033,7 @@
         "conditional": true,
         "imported": "easyuse_anima.settings.service:resolve_lora_preset_strength_drag_pixels",
         "kind": "static_from",
-        "line": 73,
+        "line": 76,
         "name": "resolve_lora_preset_strength_drag_pixels",
         "optional": false,
         "requested": "easyuse_anima.settings.service",
@@ -52904,7 +53052,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 51,
+            "handler_line": 53,
             "kind": "try",
             "line": 5
           }
@@ -52919,7 +53067,7 @@
         "conditional": true,
         "imported": "easyuse_anima.settings.service:resolve_lora_preset_strength_drag_step",
         "kind": "static_from",
-        "line": 73,
+        "line": 76,
         "name": "resolve_lora_preset_strength_drag_step",
         "optional": false,
         "requested": "easyuse_anima.settings.service",
@@ -52938,7 +53086,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 51,
+            "handler_line": 53,
             "kind": "try",
             "line": 5
           }
@@ -52953,7 +53101,7 @@
         "conditional": true,
         "imported": "easyuse_anima.settings.service:resolve_metadata_filter_words",
         "kind": "static_from",
-        "line": 73,
+        "line": 76,
         "name": "resolve_metadata_filter_words",
         "optional": false,
         "requested": "easyuse_anima.settings.service",
@@ -52972,7 +53120,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 51,
+            "handler_line": 53,
             "kind": "try",
             "line": 5
           }
@@ -52987,7 +53135,7 @@
         "conditional": true,
         "imported": "easyuse_anima.settings.service:resolve_naia_port",
         "kind": "static_from",
-        "line": 73,
+        "line": 76,
         "name": "resolve_naia_port",
         "optional": false,
         "requested": "easyuse_anima.settings.service",
@@ -53006,7 +53154,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 51,
+            "handler_line": 53,
             "kind": "try",
             "line": 5
           }
@@ -53021,7 +53169,7 @@
         "conditional": true,
         "imported": "easyuse_anima.settings.service:resolve_naia_resolution_bucket",
         "kind": "static_from",
-        "line": 73,
+        "line": 76,
         "name": "resolve_naia_resolution_bucket",
         "optional": false,
         "requested": "easyuse_anima.settings.service",
@@ -53040,7 +53188,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 51,
+            "handler_line": 53,
             "kind": "try",
             "line": 5
           }
@@ -53055,7 +53203,7 @@
         "conditional": true,
         "imported": "easyuse_anima.settings.service:resolve_naia_resolution_max_long_edge",
         "kind": "static_from",
-        "line": 73,
+        "line": 76,
         "name": "resolve_naia_resolution_max_long_edge",
         "optional": false,
         "requested": "easyuse_anima.settings.service",
@@ -53074,7 +53222,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 51,
+            "handler_line": 53,
             "kind": "try",
             "line": 5
           }
@@ -53089,7 +53237,7 @@
         "conditional": true,
         "imported": "easyuse_anima.settings.service:resolve_naia_resolution_mode",
         "kind": "static_from",
-        "line": 73,
+        "line": 76,
         "name": "resolve_naia_resolution_mode",
         "optional": false,
         "requested": "easyuse_anima.settings.service",
@@ -53108,7 +53256,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 51,
+            "handler_line": 53,
             "kind": "try",
             "line": 5
           }
@@ -53123,7 +53271,7 @@
         "conditional": true,
         "imported": "easyuse_anima.settings.service:resolve_naia_resolution_scale",
         "kind": "static_from",
-        "line": 73,
+        "line": 76,
         "name": "resolve_naia_resolution_scale",
         "optional": false,
         "requested": "easyuse_anima.settings.service",
@@ -53142,7 +53290,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 51,
+            "handler_line": 53,
             "kind": "try",
             "line": 5
           }
@@ -53157,7 +53305,7 @@
         "conditional": true,
         "imported": "easyuse_anima.settings.service:resolve_naia_settings",
         "kind": "static_from",
-        "line": 73,
+        "line": 76,
         "name": "resolve_naia_settings",
         "optional": false,
         "requested": "easyuse_anima.settings.service",
@@ -53176,7 +53324,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 51,
+            "handler_line": 53,
             "kind": "try",
             "line": 5
           }
@@ -53191,7 +53339,7 @@
         "conditional": true,
         "imported": "easyuse_anima.settings.service:resolve_prompt_studio_font_family",
         "kind": "static_from",
-        "line": 73,
+        "line": 76,
         "name": "resolve_prompt_studio_font_family",
         "optional": false,
         "requested": "easyuse_anima.settings.service",
@@ -53210,7 +53358,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 51,
+            "handler_line": 53,
             "kind": "try",
             "line": 5
           }
@@ -53225,7 +53373,7 @@
         "conditional": true,
         "imported": "easyuse_anima.settings.service:resolve_prompt_studio_font_size",
         "kind": "static_from",
-        "line": 73,
+        "line": 76,
         "name": "resolve_prompt_studio_font_size",
         "optional": false,
         "requested": "easyuse_anima.settings.service",
@@ -53244,7 +53392,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 51,
+            "handler_line": 53,
             "kind": "try",
             "line": 5
           }
@@ -53259,7 +53407,7 @@
         "conditional": true,
         "imported": "easyuse_anima.settings.service:resolve_prompt_translation_provider",
         "kind": "static_from",
-        "line": 73,
+        "line": 76,
         "name": "resolve_prompt_translation_provider",
         "optional": false,
         "requested": "easyuse_anima.settings.service",
@@ -53278,7 +53426,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 51,
+            "handler_line": 53,
             "kind": "try",
             "line": 5
           }
@@ -53293,7 +53441,7 @@
         "conditional": true,
         "imported": "easyuse_anima.settings.service:resolve_prompt_translation_settings",
         "kind": "static_from",
-        "line": 73,
+        "line": 76,
         "name": "resolve_prompt_translation_settings",
         "optional": false,
         "requested": "easyuse_anima.settings.service",
@@ -53312,7 +53460,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 51,
+            "handler_line": 53,
             "kind": "try",
             "line": 5
           }
@@ -53327,7 +53475,7 @@
         "conditional": true,
         "imported": "easyuse_anima.settings.service:resolve_prompt_translation_source",
         "kind": "static_from",
-        "line": 73,
+        "line": 76,
         "name": "resolve_prompt_translation_source",
         "optional": false,
         "requested": "easyuse_anima.settings.service",
@@ -53346,7 +53494,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 51,
+            "handler_line": 53,
             "kind": "try",
             "line": 5
           }
@@ -53361,7 +53509,7 @@
         "conditional": true,
         "imported": "easyuse_anima.settings.service:resolve_prompt_translation_target",
         "kind": "static_from",
-        "line": 73,
+        "line": 76,
         "name": "resolve_prompt_translation_target",
         "optional": false,
         "requested": "easyuse_anima.settings.service",
@@ -60514,25 +60662,25 @@
       },
       {
         "is_package": false,
-        "loc": 217,
+        "loc": 226,
         "module": "easyuse_anima.settings.schema",
-        "normalized_git_blob_sha1": "68ecb1cbfb728a3b2dab22b0dfc9a3816fd61924",
+        "normalized_git_blob_sha1": "fc547a31d088ec472e2b437db3293efca90e7e5f",
         "path": "easyuse_anima/settings/schema.py",
         "top_level": {
           "class_count": 0,
           "function_count": 0,
-          "global_count": 12
+          "global_count": 13
         }
       },
       {
         "is_package": false,
-        "loc": 473,
+        "loc": 490,
         "module": "easyuse_anima.settings.service",
-        "normalized_git_blob_sha1": "a92a5768ea6dfd3c34574e1ceeb7430dfbfbb1cb",
+        "normalized_git_blob_sha1": "7b3cdd24bfce1c8c7ad83622414cfa128b0878a7",
         "path": "easyuse_anima/settings/service.py",
         "top_level": {
           "class_count": 0,
-          "function_count": 25,
+          "function_count": 26,
           "global_count": 1
         }
       },
@@ -60730,9 +60878,9 @@
       },
       {
         "is_package": false,
-        "loc": 139,
+        "loc": 145,
         "module": "settings",
-        "normalized_git_blob_sha1": "1e5f5fe39e39ba930f7586bbe88ea84216f8e400",
+        "normalized_git_blob_sha1": "be72e4cd9020795d8fd7f5f0b0b9726f0034b25d",
         "path": "settings.py",
         "top_level": {
           "class_count": 0,
@@ -70145,7 +70293,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 51,
+            "handler_line": 53,
             "kind": "try",
             "line": 5
           }
@@ -70154,7 +70302,7 @@
         "conditional": true,
         "imported": "easyuse_anima.settings.repository:LONG_TEXT_SETTINGS_FILE",
         "kind": "static_from",
-        "line": 52,
+        "line": 54,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "settings.py",
@@ -70168,7 +70316,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 51,
+            "handler_line": 53,
             "kind": "try",
             "line": 5
           }
@@ -70177,7 +70325,7 @@
         "conditional": true,
         "imported": "easyuse_anima.settings.repository:SETTINGS_FILE",
         "kind": "static_from",
-        "line": 52,
+        "line": 54,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "settings.py",
@@ -70191,7 +70339,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 51,
+            "handler_line": 53,
             "kind": "try",
             "line": 5
           }
@@ -70200,7 +70348,7 @@
         "conditional": true,
         "imported": "easyuse_anima.settings.repository:get_settings",
         "kind": "static_from",
-        "line": 52,
+        "line": 54,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "settings.py",
@@ -70214,7 +70362,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 51,
+            "handler_line": 53,
             "kind": "try",
             "line": 5
           }
@@ -70223,7 +70371,7 @@
         "conditional": true,
         "imported": "easyuse_anima.settings.repository:load_long_text_settings",
         "kind": "static_from",
-        "line": 52,
+        "line": 54,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "settings.py",
@@ -70237,7 +70385,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 51,
+            "handler_line": 53,
             "kind": "try",
             "line": 5
           }
@@ -70246,7 +70394,7 @@
         "conditional": true,
         "imported": "easyuse_anima.settings.repository:save_long_text_settings",
         "kind": "static_from",
-        "line": 52,
+        "line": 54,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "settings.py",
@@ -70260,7 +70408,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 51,
+            "handler_line": 53,
             "kind": "try",
             "line": 5
           }
@@ -70269,7 +70417,7 @@
         "conditional": true,
         "imported": "easyuse_anima.settings.repository:save_setting",
         "kind": "static_from",
-        "line": 52,
+        "line": 54,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "settings.py",
@@ -70283,7 +70431,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 51,
+            "handler_line": 53,
             "kind": "try",
             "line": 5
           }
@@ -70292,7 +70440,7 @@
         "conditional": true,
         "imported": "easyuse_anima.settings.schema:AUTOCOMPLETE_COMMIT_KEYS",
         "kind": "static_from",
-        "line": 60,
+        "line": 62,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "settings.py",
@@ -70306,7 +70454,30 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 51,
+            "handler_line": 53,
+            "kind": "try",
+            "line": 5
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.settings.schema:AUTOCOMPLETE_COMMIT_MODES",
+        "kind": "static_from",
+        "line": 62,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "settings.py",
+        "target": "easyuse_anima/settings/schema.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 53,
             "kind": "try",
             "line": 5
           }
@@ -70315,7 +70486,7 @@
         "conditional": true,
         "imported": "easyuse_anima.settings.schema:AUTOCOMPLETE_MODES",
         "kind": "static_from",
-        "line": 60,
+        "line": 62,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "settings.py",
@@ -70329,7 +70500,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 51,
+            "handler_line": 53,
             "kind": "try",
             "line": 5
           }
@@ -70338,7 +70509,7 @@
         "conditional": true,
         "imported": "easyuse_anima.settings.schema:COMFY_COLOR_SETTING_KEYS",
         "kind": "static_from",
-        "line": 60,
+        "line": 62,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "settings.py",
@@ -70352,7 +70523,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 51,
+            "handler_line": 53,
             "kind": "try",
             "line": 5
           }
@@ -70361,7 +70532,7 @@
         "conditional": true,
         "imported": "easyuse_anima.settings.schema:COMFY_SETTING_KEYS",
         "kind": "static_from",
-        "line": 60,
+        "line": 62,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "settings.py",
@@ -70375,7 +70546,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 51,
+            "handler_line": 53,
             "kind": "try",
             "line": 5
           }
@@ -70384,7 +70555,7 @@
         "conditional": true,
         "imported": "easyuse_anima.settings.schema:DEFAULT_SETTINGS",
         "kind": "static_from",
-        "line": 60,
+        "line": 62,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "settings.py",
@@ -70398,7 +70569,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 51,
+            "handler_line": 53,
             "kind": "try",
             "line": 5
           }
@@ -70407,7 +70578,7 @@
         "conditional": true,
         "imported": "easyuse_anima.settings.schema:LONG_TEXT_SETTING_ALIASES",
         "kind": "static_from",
-        "line": 60,
+        "line": 62,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "settings.py",
@@ -70421,7 +70592,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 51,
+            "handler_line": 53,
             "kind": "try",
             "line": 5
           }
@@ -70430,7 +70601,7 @@
         "conditional": true,
         "imported": "easyuse_anima.settings.schema:LONG_TEXT_SETTING_KEYS",
         "kind": "static_from",
-        "line": 60,
+        "line": 62,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "settings.py",
@@ -70444,7 +70615,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 51,
+            "handler_line": 53,
             "kind": "try",
             "line": 5
           }
@@ -70453,7 +70624,7 @@
         "conditional": true,
         "imported": "easyuse_anima.settings.schema:NAIA_PREPROCESSING_KEYS",
         "kind": "static_from",
-        "line": 60,
+        "line": 62,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "settings.py",
@@ -70467,7 +70638,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 51,
+            "handler_line": 53,
             "kind": "try",
             "line": 5
           }
@@ -70476,7 +70647,7 @@
         "conditional": true,
         "imported": "easyuse_anima.settings.schema:NAIA_RESOLUTION_BUCKETS",
         "kind": "static_from",
-        "line": 60,
+        "line": 62,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "settings.py",
@@ -70490,7 +70661,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 51,
+            "handler_line": 53,
             "kind": "try",
             "line": 5
           }
@@ -70499,7 +70670,7 @@
         "conditional": true,
         "imported": "easyuse_anima.settings.schema:NAIA_RESOLUTION_MODES",
         "kind": "static_from",
-        "line": 60,
+        "line": 62,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "settings.py",
@@ -70513,7 +70684,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 51,
+            "handler_line": 53,
             "kind": "try",
             "line": 5
           }
@@ -70522,7 +70693,7 @@
         "conditional": true,
         "imported": "easyuse_anima.settings.schema:PROMPT_STUDIO_COLOR_KEYS",
         "kind": "static_from",
-        "line": 60,
+        "line": 62,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "settings.py",
@@ -70536,7 +70707,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 51,
+            "handler_line": 53,
             "kind": "try",
             "line": 5
           }
@@ -70545,7 +70716,7 @@
         "conditional": true,
         "imported": "easyuse_anima.settings.service:public_settings",
         "kind": "static_from",
-        "line": 73,
+        "line": 76,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "settings.py",
@@ -70559,7 +70730,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 51,
+            "handler_line": 53,
             "kind": "try",
             "line": 5
           }
@@ -70568,7 +70739,7 @@
         "conditional": true,
         "imported": "easyuse_anima.settings.service:resolve_autocomplete_commit_key",
         "kind": "static_from",
-        "line": 73,
+        "line": 76,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "settings.py",
@@ -70582,7 +70753,30 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 51,
+            "handler_line": 53,
+            "kind": "try",
+            "line": 5
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.settings.service:resolve_autocomplete_commit_mode",
+        "kind": "static_from",
+        "line": 76,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "settings.py",
+        "target": "easyuse_anima/settings/service.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 53,
             "kind": "try",
             "line": 5
           }
@@ -70591,7 +70785,7 @@
         "conditional": true,
         "imported": "easyuse_anima.settings.service:resolve_autocomplete_limit",
         "kind": "static_from",
-        "line": 73,
+        "line": 76,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "settings.py",
@@ -70605,7 +70799,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 51,
+            "handler_line": 53,
             "kind": "try",
             "line": 5
           }
@@ -70614,7 +70808,7 @@
         "conditional": true,
         "imported": "easyuse_anima.settings.service:resolve_autocomplete_mode",
         "kind": "static_from",
-        "line": 73,
+        "line": 76,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "settings.py",
@@ -70628,7 +70822,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 51,
+            "handler_line": 53,
             "kind": "try",
             "line": 5
           }
@@ -70637,7 +70831,7 @@
         "conditional": true,
         "imported": "easyuse_anima.settings.service:resolve_autocomplete_source",
         "kind": "static_from",
-        "line": 73,
+        "line": 76,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "settings.py",
@@ -70651,7 +70845,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 51,
+            "handler_line": 53,
             "kind": "try",
             "line": 5
           }
@@ -70660,7 +70854,7 @@
         "conditional": true,
         "imported": "easyuse_anima.settings.service:resolve_lora_preset_menu_mode",
         "kind": "static_from",
-        "line": 73,
+        "line": 76,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "settings.py",
@@ -70674,7 +70868,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 51,
+            "handler_line": 53,
             "kind": "try",
             "line": 5
           }
@@ -70683,7 +70877,7 @@
         "conditional": true,
         "imported": "easyuse_anima.settings.service:resolve_lora_preset_strength_button_step",
         "kind": "static_from",
-        "line": 73,
+        "line": 76,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "settings.py",
@@ -70697,7 +70891,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 51,
+            "handler_line": 53,
             "kind": "try",
             "line": 5
           }
@@ -70706,7 +70900,7 @@
         "conditional": true,
         "imported": "easyuse_anima.settings.service:resolve_lora_preset_strength_drag_pixels",
         "kind": "static_from",
-        "line": 73,
+        "line": 76,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "settings.py",
@@ -70720,7 +70914,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 51,
+            "handler_line": 53,
             "kind": "try",
             "line": 5
           }
@@ -70729,7 +70923,7 @@
         "conditional": true,
         "imported": "easyuse_anima.settings.service:resolve_lora_preset_strength_drag_step",
         "kind": "static_from",
-        "line": 73,
+        "line": 76,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "settings.py",
@@ -70743,7 +70937,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 51,
+            "handler_line": 53,
             "kind": "try",
             "line": 5
           }
@@ -70752,7 +70946,7 @@
         "conditional": true,
         "imported": "easyuse_anima.settings.service:resolve_metadata_filter_words",
         "kind": "static_from",
-        "line": 73,
+        "line": 76,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "settings.py",
@@ -70766,7 +70960,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 51,
+            "handler_line": 53,
             "kind": "try",
             "line": 5
           }
@@ -70775,7 +70969,7 @@
         "conditional": true,
         "imported": "easyuse_anima.settings.service:resolve_naia_port",
         "kind": "static_from",
-        "line": 73,
+        "line": 76,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "settings.py",
@@ -70789,7 +70983,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 51,
+            "handler_line": 53,
             "kind": "try",
             "line": 5
           }
@@ -70798,7 +70992,7 @@
         "conditional": true,
         "imported": "easyuse_anima.settings.service:resolve_naia_resolution_bucket",
         "kind": "static_from",
-        "line": 73,
+        "line": 76,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "settings.py",
@@ -70812,7 +71006,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 51,
+            "handler_line": 53,
             "kind": "try",
             "line": 5
           }
@@ -70821,7 +71015,7 @@
         "conditional": true,
         "imported": "easyuse_anima.settings.service:resolve_naia_resolution_max_long_edge",
         "kind": "static_from",
-        "line": 73,
+        "line": 76,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "settings.py",
@@ -70835,7 +71029,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 51,
+            "handler_line": 53,
             "kind": "try",
             "line": 5
           }
@@ -70844,7 +71038,7 @@
         "conditional": true,
         "imported": "easyuse_anima.settings.service:resolve_naia_resolution_mode",
         "kind": "static_from",
-        "line": 73,
+        "line": 76,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "settings.py",
@@ -70858,7 +71052,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 51,
+            "handler_line": 53,
             "kind": "try",
             "line": 5
           }
@@ -70867,7 +71061,7 @@
         "conditional": true,
         "imported": "easyuse_anima.settings.service:resolve_naia_resolution_scale",
         "kind": "static_from",
-        "line": 73,
+        "line": 76,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "settings.py",
@@ -70881,7 +71075,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 51,
+            "handler_line": 53,
             "kind": "try",
             "line": 5
           }
@@ -70890,7 +71084,7 @@
         "conditional": true,
         "imported": "easyuse_anima.settings.service:resolve_naia_settings",
         "kind": "static_from",
-        "line": 73,
+        "line": 76,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "settings.py",
@@ -70904,7 +71098,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 51,
+            "handler_line": 53,
             "kind": "try",
             "line": 5
           }
@@ -70913,7 +71107,7 @@
         "conditional": true,
         "imported": "easyuse_anima.settings.service:resolve_prompt_studio_font_family",
         "kind": "static_from",
-        "line": 73,
+        "line": 76,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "settings.py",
@@ -70927,7 +71121,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 51,
+            "handler_line": 53,
             "kind": "try",
             "line": 5
           }
@@ -70936,7 +71130,7 @@
         "conditional": true,
         "imported": "easyuse_anima.settings.service:resolve_prompt_studio_font_size",
         "kind": "static_from",
-        "line": 73,
+        "line": 76,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "settings.py",
@@ -70950,7 +71144,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 51,
+            "handler_line": 53,
             "kind": "try",
             "line": 5
           }
@@ -70959,7 +71153,7 @@
         "conditional": true,
         "imported": "easyuse_anima.settings.service:resolve_prompt_translation_provider",
         "kind": "static_from",
-        "line": 73,
+        "line": 76,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "settings.py",
@@ -70973,7 +71167,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 51,
+            "handler_line": 53,
             "kind": "try",
             "line": 5
           }
@@ -70982,7 +71176,7 @@
         "conditional": true,
         "imported": "easyuse_anima.settings.service:resolve_prompt_translation_settings",
         "kind": "static_from",
-        "line": 73,
+        "line": 76,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "settings.py",
@@ -70996,7 +71190,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 51,
+            "handler_line": 53,
             "kind": "try",
             "line": 5
           }
@@ -71005,7 +71199,7 @@
         "conditional": true,
         "imported": "easyuse_anima.settings.service:resolve_prompt_translation_source",
         "kind": "static_from",
-        "line": 73,
+        "line": 76,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "settings.py",
@@ -71019,7 +71213,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 51,
+            "handler_line": 53,
             "kind": "try",
             "line": 5
           }
@@ -71028,7 +71222,7 @@
         "conditional": true,
         "imported": "easyuse_anima.settings.service:resolve_prompt_translation_target",
         "kind": "static_from",
-        "line": 73,
+        "line": 76,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "settings.py",
@@ -81218,19 +81412,25 @@
       },
       {
         "kind": "set",
-        "line": 75,
+        "line": 76,
         "module": "easyuse_anima/settings/schema.py",
         "name": "AUTOCOMPLETE_COMMIT_KEYS"
       },
       {
         "kind": "set",
-        "line": 69,
+        "line": 81,
+        "module": "easyuse_anima/settings/schema.py",
+        "name": "AUTOCOMPLETE_COMMIT_MODES"
+      },
+      {
+        "kind": "set",
+        "line": 70,
         "module": "easyuse_anima/settings/schema.py",
         "name": "AUTOCOMPLETE_MODES"
       },
       {
         "kind": "dict",
-        "line": 130,
+        "line": 137,
         "module": "easyuse_anima/settings/schema.py",
         "name": "COMFY_SETTING_KEYS"
       },
@@ -81242,37 +81442,37 @@
       },
       {
         "kind": "dict",
-        "line": 189,
+        "line": 197,
         "module": "easyuse_anima/settings/schema.py",
         "name": "LONG_TEXT_SETTING_ALIASES"
       },
       {
         "kind": "set",
-        "line": 182,
+        "line": 190,
         "module": "easyuse_anima/settings/schema.py",
         "name": "LONG_TEXT_SETTING_KEYS"
       },
       {
         "kind": "list",
-        "line": 94,
+        "line": 101,
         "module": "easyuse_anima/settings/schema.py",
         "name": "NAIA_PREPROCESSING_KEYS"
       },
       {
         "kind": "set",
-        "line": 85,
+        "line": 92,
         "module": "easyuse_anima/settings/schema.py",
         "name": "NAIA_RESOLUTION_BUCKETS"
       },
       {
         "kind": "set",
-        "line": 80,
+        "line": 87,
         "module": "easyuse_anima/settings/schema.py",
         "name": "NAIA_RESOLUTION_MODES"
       },
       {
         "kind": "list",
-        "line": 112,
+        "line": 119,
         "module": "easyuse_anima/settings/schema.py",
         "name": "PROMPT_STUDIO_COLOR_KEYS"
       },

--- a/tests/frontend_autocomplete_text_model_smoke.mjs
+++ b/tests/frontend_autocomplete_text_model_smoke.mjs
@@ -17,6 +17,7 @@ assert.deepEqual(Object.keys(textModel).sort(), [
   "isCaretInComment",
   "isCaretInPromptTranslationMarker",
   "normalizeAutocompleteArtistPrefix",
+  "normalizeAutocompleteCommitMode",
   "normalizeWildcardSearchText",
   "parseAutocompleteText",
   "planAutocompleteInsertion",
@@ -32,6 +33,7 @@ const {
   isCaretInComment,
   isCaretInPromptTranslationMarker,
   normalizeAutocompleteArtistPrefix,
+  normalizeAutocompleteCommitMode,
   normalizeWildcardSearchText,
   parseAutocompleteText,
   planAutocompleteInsertion,
@@ -58,6 +60,17 @@ function appliedPlan(token, insert, options = {}) {
       + token.value.slice(plan.end),
     caret: plan.start + plan.caretOffset,
   };
+}
+
+function completionToken(value, marker, options = {}) {
+  const caret = value.indexOf(marker);
+  assert.notEqual(caret, -1);
+  const text = value.replace(marker, "");
+  return currentToken(text, caret, {
+    detectNaturalSentences: false,
+    previewCompletion: true,
+    ...options,
+  });
 }
 
 const whitespaceSuffix = contractRanges("blue ha|ir solo", "|");
@@ -207,6 +220,87 @@ assert.deepEqual(
   },
 );
 
+assert.equal(normalizeAutocompleteCommitMode("smart"), "smart");
+assert.equal(normalizeAutocompleteCommitMode("insert"), "insert");
+assert.equal(normalizeAutocompleteCommitMode("replace"), "replace");
+assert.equal(normalizeAutocompleteCommitMode("INVALID"), "smart");
+
+const smartWhitespace = appliedPlan(
+  completionToken("blue ha|ir solo", "|"),
+  "blue hair",
+  { commitMode: "smart" },
+);
+assert.equal(smartWhitespace.value, "blue hair solo");
+assert.equal(smartWhitespace.editRange, "replace");
+assert.equal(smartWhitespace.modeUsed, "smart");
+assert.equal(smartWhitespace.preservedSuffix, " solo");
+
+for (const [value, insert, expected] of [
+  ["foo|, bar", "foo tag", "foo tag, bar"],
+  ["foo|\nbar", "foo tag", "foo tag\nbar"],
+  ["(foo|, bar:1.2)", "foo tag", "(foo tag, bar:1.2)"],
+  [
+    "[[artist_a, art|ist_b:0.7]]",
+    "artist b",
+    "[[artist_a, artist b:0.7]]",
+  ],
+]) {
+  const plan = appliedPlan(
+    completionToken(value, "|"),
+    insert,
+    { commitMode: "smart" },
+  );
+  assert.equal(plan.value, expected);
+  assert.equal(plan.editRange, "replace");
+}
+
+const smartContiguousTail = appliedPlan(
+  completionToken("old_t|ag", "|"),
+  "old tag",
+  { commitMode: "smart" },
+);
+assert.equal(smartContiguousTail.value, "old tag");
+assert.equal(smartContiguousTail.editRange, "replace");
+
+const smartAmbiguousTail = appliedPlan(
+  completionToken("old_t|ail", "|"),
+  "old train",
+  { commitMode: "smart" },
+);
+assert.equal(smartAmbiguousTail.value, "old train, ail");
+assert.equal(smartAmbiguousTail.editRange, "insert");
+assert.equal(smartAmbiguousTail.preservedSuffix, "ail");
+
+const insertTail = appliedPlan(
+  completionToken("old_t|ag", "|"),
+  "old tag",
+  { commitMode: "insert" },
+);
+assert.equal(insertTail.value, "old tag, ag");
+assert.equal(insertTail.editRange, "insert");
+assert.equal(insertTail.preservedSuffix, "ag");
+
+const replaceTail = appliedPlan(
+  completionToken("old_t|ail", "|"),
+  "old train",
+  { commitMode: "replace" },
+);
+assert.equal(replaceTail.value, "old train");
+assert.equal(replaceTail.editRange, "replace");
+assert.equal(replaceTail.preservedSuffix, "");
+
+const previewPlan = planAutocompleteInsertion(
+  completionToken("(foo|, bar:1.2)", "|"),
+  "foo tag",
+  { commitMode: "smart" },
+);
+const commitPlan = planAutocompleteInsertion(
+  completionToken("(foo|, bar:1.2)", "|"),
+  "foo tag",
+  { commitMode: "smart" },
+);
+assert.deepEqual(previewPlan, commitPlan);
+
 const segmented = currentToken(
   "first tag, second tag\nthird tag",
   "first tag, second".length,
@@ -268,7 +362,7 @@ assert.equal(
     "beta tag",
     { appendSeparator: false, noCommaAfterPeriod: true },
   ).value,
-  "alpha. beta tag. delta",
+  "alpha. beta tag gamma. delta",
 );
 
 const weightedValue = "[[ @old_name:1.25]]";
@@ -322,7 +416,7 @@ for (const previewCompletion of [false, true]) {
   assert.equal(autocompleteQuery(token).query, "old");
   assert.equal(token.start, start);
   assert.equal(token.end, start + "old_tag".length);
-  assert.equal(appliedPlan(token, "new tag").value, "((new tag:1.2))");
+  assert.equal(appliedPlan(token, "new tag").value, "((new tag, _tag:1.2))");
 }
 
 const strictAtClosing = currentToken(
@@ -470,6 +564,9 @@ assert.deepEqual(
     suffix: ", ",
     consumeAfter: 0,
     caretExtra: 2,
+    preservedSuffix: "",
+    modeUsed: "smart",
+    editRange: "replace",
     value: "tag, ",
     caret: 5,
   },

--- a/tests/frontend_settings_definition_data_smoke.mjs
+++ b/tests/frontend_settings_definition_data_smoke.mjs
@@ -85,6 +85,7 @@ const expectedInternalKeys = {
   "EasyUseAnima.Prompt.AutocompleteLimit": "autocomplete.limit",
   "EasyUseAnima.Prompt.AutocompleteArtistPrefix": "autocomplete.artist_prefix",
   "EasyUseAnima.Prompt.AutocompleteCommitKey": "autocomplete.commit_key",
+  "EasyUseAnima.Prompt.AutocompleteCommitMode": "autocomplete.commit_mode",
   "EasyUseAnima.Prompt.AutocompleteAppendSeparator": "autocomplete.append_separator",
   "EasyUseAnima.Prompt.AutocompleteNoCommaAfterPeriod": "autocomplete.no_comma_after_period",
   "EasyUseAnima.Prompt.AutocompleteDetectNaturalSentences": "autocomplete.detect_natural_sentences",

--- a/tests/frontend_settings_definitions_smoke.mjs
+++ b/tests/frontend_settings_definitions_smoke.mjs
@@ -100,6 +100,7 @@ const expectedIds = [
   "EasyUseAnima.Prompt.AutocompleteLimit",
   "EasyUseAnima.Prompt.AutocompleteArtistPrefix",
   "EasyUseAnima.Prompt.AutocompleteCommitKey",
+  "EasyUseAnima.Prompt.AutocompleteCommitMode",
   "EasyUseAnima.Prompt.AutocompleteAppendSeparator",
   "EasyUseAnima.Prompt.AutocompleteNoCommaAfterPeriod",
   "EasyUseAnima.Prompt.AutocompleteDetectNaturalSentences",
@@ -136,7 +137,7 @@ const expectedIds = [
 ];
 
 assert.deepEqual(settings.map((item) => item.id), expectedIds);
-assert.equal(settings.length, 53);
+assert.equal(settings.length, 54);
 assert.equal(new Set(expectedIds).size, settings.length, "Setting IDs must be unique");
 assert.ok(
   settings.every((item) => item.category[0] === "EASY USE ANIMA"),
@@ -228,6 +229,10 @@ const expectedRegularSchemas = new Map([
   [
     "EasyUseAnima.Prompt.AutocompleteCommitKey",
     schema("combo", "enter", ["enter", "tab"]),
+  ],
+  [
+    "EasyUseAnima.Prompt.AutocompleteCommitMode",
+    schema("combo", "smart", ["smart", "insert", "replace"]),
   ],
   ["EasyUseAnima.Prompt.AutocompleteAppendSeparator", schema("boolean", false)],
   ["EasyUseAnima.Prompt.AutocompleteNoCommaAfterPeriod", schema("boolean", true)],

--- a/tests/test_autocomplete_frontend.py
+++ b/tests/test_autocomplete_frontend.py
@@ -587,6 +587,7 @@ class AutocompleteFrontendBoundaryTests(unittest.TestCase):
             "isCaretInComment",
             "isCaretInPromptTranslationMarker",
             "normalizeAutocompleteArtistPrefix",
+            "normalizeAutocompleteCommitMode",
             "normalizeWildcardSearchText",
             "parseAutocompleteText",
             "planAutocompleteInsertion",
@@ -603,6 +604,7 @@ class AutocompleteFrontendBoundaryTests(unittest.TestCase):
                 "as caretInPromptTranslationMarker"
             ),
             "normalizeAutocompleteArtistPrefix",
+            "normalizeAutocompleteCommitMode",
             "normalizeWildcardSearchText",
             "parseAutocompleteText",
             "planAutocompleteInsertion",
@@ -655,6 +657,7 @@ class AutocompleteFrontendBoundaryTests(unittest.TestCase):
             "autocompleteQuery",
             "isCaretInComment",
             "normalizeAutocompleteArtistPrefix",
+            "normalizeAutocompleteCommitMode",
             "normalizeWildcardSearchText",
             "parseAutocompleteText",
             "planAutocompleteInsertion",
@@ -728,6 +731,10 @@ class AutocompleteFrontendBoundaryTests(unittest.TestCase):
             self.assertIn("planAutocompleteInsertion(", plan_consumer)
             self.assertIn(
                 "appendSeparator: autocompleteAppendSeparator",
+                plan_consumer,
+            )
+            self.assertIn(
+                "commitMode: autocompleteCommitMode",
                 plan_consumer,
             )
             self.assertIn(

--- a/tests/test_prompt_corrector.py
+++ b/tests/test_prompt_corrector.py
@@ -81,6 +81,7 @@ from easyuse_anima.settings.schema import NAIA_PREPROCESSING_KEYS
 from easyuse_anima.settings.service import (
     public_settings,
     resolve_autocomplete_commit_key,
+    resolve_autocomplete_commit_mode,
     resolve_autocomplete_limit,
     resolve_autocomplete_mode,
     resolve_lora_preset_menu_mode,
@@ -2882,7 +2883,7 @@ class SettingsTests(unittest.TestCase):
             for name in owner.__all__
         }
 
-        self.assertEqual(len(root_settings.__all__), 39)
+        self.assertEqual(len(root_settings.__all__), 41)
         self.assertEqual(set(root_settings.__all__), expected)
         for name in root_settings.__all__:
             canonical_owners = [
@@ -3098,6 +3099,7 @@ class SettingsTests(unittest.TestCase):
                 "autocomplete.mode",
                 "autocomplete.artist_prefix",
                 "autocomplete.commit_key",
+                "autocomplete.commit_mode",
                 "autocomplete.append_separator",
                 "autocomplete.no_comma_after_period",
                 "autocomplete.detect_natural_sentences",
@@ -3195,6 +3197,22 @@ class SettingsTests(unittest.TestCase):
         self.assertEqual(
             resolve_autocomplete_commit_key({"autocomplete.commit_key": "bad"}),
             "enter",
+        )
+
+    def test_autocomplete_commit_mode_is_validated(self):
+        for value in ("smart", "insert", "replace"):
+            with self.subTest(value=value):
+                self.assertEqual(
+                    resolve_autocomplete_commit_mode(
+                        {"autocomplete.commit_mode": value}
+                    ),
+                    value,
+                )
+        self.assertEqual(
+            resolve_autocomplete_commit_mode(
+                {"autocomplete.commit_mode": "bad"}
+            ),
+            "smart",
         )
 
     def test_lora_preset_strength_drag_step_is_clamped(self):
@@ -3359,6 +3377,7 @@ class SettingsTests(unittest.TestCase):
                     "EasyUseAnima.Prompt.AutocompleteLimit": "7",
                     "EasyUseAnima.Prompt.AutocompleteArtistPrefix": "artist:",
                     "EasyUseAnima.Prompt.AutocompleteCommitKey": "tab",
+                    "EasyUseAnima.Prompt.AutocompleteCommitMode": "replace",
                     "EasyUseAnima.Prompt.AutocompleteAppendSeparator": "true",
                     "EasyUseAnima.Prompt.AutocompleteNoCommaAfterPeriod": "false",
                     "EasyUseAnima.Prompt.AutocompleteDetectNaturalSentences": "false",
@@ -3386,6 +3405,7 @@ class SettingsTests(unittest.TestCase):
         self.assertEqual(settings["autocomplete.limit"], 7)
         self.assertEqual(settings["autocomplete.artist_prefix"], "artist:")
         self.assertEqual(settings["autocomplete.commit_key"], "tab")
+        self.assertEqual(settings["autocomplete.commit_mode"], "replace")
         self.assertEqual(settings["autocomplete.append_separator"], "true")
         self.assertEqual(settings["autocomplete.no_comma_after_period"], "false")
         self.assertEqual(settings["autocomplete.detect_natural_sentences"], "false")

--- a/tests/test_python_package_skeleton.py
+++ b/tests/test_python_package_skeleton.py
@@ -281,6 +281,7 @@ print(json.dumps({{
             PACKAGE_MODULES.index("easyuse_anima.settings.schema")
         ] = [
             "AUTOCOMPLETE_COMMIT_KEYS",
+            "AUTOCOMPLETE_COMMIT_MODES",
             "AUTOCOMPLETE_MODES",
             "COMFY_COLOR_SETTING_KEYS",
             "COMFY_SETTING_KEYS",
@@ -297,6 +298,7 @@ print(json.dumps({{
         ] = [
             "public_settings",
             "resolve_autocomplete_commit_key",
+            "resolve_autocomplete_commit_mode",
             "resolve_autocomplete_limit",
             "resolve_autocomplete_mode",
             "resolve_autocomplete_source",

--- a/web/js/autocomplete/text_model.js
+++ b/web/js/autocomplete/text_model.js
@@ -1,6 +1,7 @@
 // @ts-check
 
 const SENTENCE_PERIODS = new Set([".", "。", "．", "｡"]);
+const AUTOCOMPLETE_COMMIT_MODES = new Set(["smart", "insert", "replace"]);
 
 function clamp(value, min, max) {
   return Math.min(max, Math.max(min, value));
@@ -310,6 +311,11 @@ export function completionEditRangeContract(value, caret, options = {}) {
 export function currentToken(value, caret, options = {}) {
   const text = String(value || "");
   const safeCaret = caret == null ? text.length : Number(caret);
+  const editRanges = completionEditRangeContract(text, safeCaret, {
+    selectionStart: options.selectionStart,
+    selectionEnd: options.selectionEnd,
+    detectNaturalSentences: options.detectNaturalSentences,
+  });
   let segmentStart = safeCaret;
   while (segmentStart > 0 && text[segmentStart - 1] !== "," && text[segmentStart - 1] !== "\n") {
     segmentStart -= 1;
@@ -350,6 +356,20 @@ export function currentToken(value, caret, options = {}) {
     sentenceDelimited,
     query: (useStrictToken ? strictRaw : legacyRaw).trim(),
     active: useStrictToken ? strictActive : legacyActive,
+    selectionStart: editRanges.selectionStart,
+    selectionEnd: editRanges.selectionEnd,
+    queryStart: editRanges.queryStart,
+    queryEnd: editRanges.queryEnd,
+    insertStart: editRanges.insertStart,
+    insertEnd: editRanges.insertEnd,
+    replaceStart: editRanges.replaceStart,
+    replaceEnd: editRanges.replaceEnd,
+    protectedSuffixStart: editRanges.protectedSuffixStart,
+    groupKind: editRanges.groupKind,
+    groupStart: editRanges.groupStart,
+    groupEnd: editRanges.groupEnd,
+    itemStart: editRanges.itemStart,
+    itemEnd: editRanges.itemEnd,
   };
 }
 
@@ -534,6 +554,9 @@ function insertSuffixForAfter(after, appendSeparator, noCommaAfterPeriod) {
   if (!after) {
     return appendSeparator ? ", " : "";
   }
+  if (/^[ \t]/.test(after)) {
+    return "";
+  }
   if (/^[ \t]*:\s*[+-]?(?:\d+(?:\.\d*)?|\.\d+)/.test(after) || /^[ \t]*(?:\)|\]\])/.test(after)) {
     return "";
   }
@@ -559,18 +582,65 @@ function insertSuffixPlanForAfter(after, appendSeparator, noCommaAfterPeriod) {
   return { suffix, consumeAfter: 0, caretExtra: 0 };
 }
 
+export function normalizeAutocompleteCommitMode(value) {
+  const mode = String(value || "").trim().toLocaleLowerCase();
+  return AUTOCOMPLETE_COMMIT_MODES.has(mode) ? mode : "smart";
+}
+
+function tokenRange(value, fallback, sourceLength) {
+  const range = Number(value);
+  return Number.isFinite(range)
+    ? clamp(range, 0, sourceLength)
+    : fallback;
+}
+
+function normalizedSmartMatchText(value) {
+  return String(value || "")
+    .trim()
+    .toLocaleLowerCase()
+    .replace(/[_\s]+/g, " ");
+}
+
+function smartUsesReplaceRange(
+  token,
+  sourceValue,
+  insertedText,
+  insertStart,
+  insertEnd,
+  replaceStart,
+  replaceEnd,
+) {
+  if (replaceEnd <= insertEnd) {
+    return true;
+  }
+  if (Number(token.selectionEnd) > Number(token.selectionStart)) {
+    return true;
+  }
+  const currentItem = normalizedSmartMatchText(
+    sourceValue.slice(replaceStart, replaceEnd),
+  );
+  const typedPrefix = normalizedSmartMatchText(
+    sourceValue.slice(insertStart, insertEnd),
+  );
+  const completion = normalizedSmartMatchText(insertedText);
+  return !!currentItem
+    && !!typedPrefix
+    && completion.startsWith(typedPrefix)
+    && completion.startsWith(currentItem);
+}
+
 export function planAutocompleteInsertion(token, insert, options = {}) {
   if (!token) {
     return null;
   }
   const sourceValue = String(token.value || "");
-  const start = Number(token.start) || 0;
-  const tokenEnd = Number(token.end) || start;
+  const fallbackStart = clamp(Number(token.start) || 0, 0, sourceValue.length);
+  const fallbackEnd = tokenRange(token.end, fallbackStart, sourceValue.length);
   const insertedText = String(insert || "");
   if (token.wildcard) {
     return {
-      start,
-      end: tokenEnd,
+      start: fallbackStart,
+      end: fallbackEnd,
       replacement: insertedText,
       caretOffset: insertedText.length,
       prefix: "",
@@ -580,6 +650,26 @@ export function planAutocompleteInsertion(token, insert, options = {}) {
     };
   }
 
+  const insertStart = tokenRange(token.insertStart, fallbackStart, sourceValue.length);
+  const insertEnd = tokenRange(token.insertEnd, fallbackEnd, sourceValue.length);
+  const replaceStart = tokenRange(token.replaceStart, fallbackStart, sourceValue.length);
+  const replaceEnd = tokenRange(token.replaceEnd, fallbackEnd, sourceValue.length);
+  const modeUsed = normalizeAutocompleteCommitMode(options.commitMode);
+  const useReplaceRange = modeUsed === "replace"
+    || (
+      modeUsed === "smart"
+      && smartUsesReplaceRange(
+        token,
+        sourceValue,
+        insertedText,
+        insertStart,
+        insertEnd,
+        replaceStart,
+        replaceEnd,
+      )
+    );
+  const start = useReplaceRange ? replaceStart : insertStart;
+  const tokenEnd = useReplaceRange ? replaceEnd : insertEnd;
   const before = sourceValue.slice(0, start);
   const after = sourceValue.slice(tokenEnd);
   const appendSeparator = options.appendSeparator === true;
@@ -597,5 +687,8 @@ export function planAutocompleteInsertion(token, insert, options = {}) {
     suffix,
     consumeAfter: suffixPlan.consumeAfter,
     caretExtra: suffixPlan.caretExtra,
+    preservedSuffix: sourceValue.slice(tokenEnd + suffixPlan.consumeAfter),
+    modeUsed,
+    editRange: useReplaceRange ? "replace" : "insert",
   };
 }

--- a/web/js/easyuse_anima_autocomplete.js
+++ b/web/js/easyuse_anima_autocomplete.js
@@ -26,6 +26,7 @@ import {
   isCaretInComment,
   isCaretInPromptTranslationMarker as caretInPromptTranslationMarker,
   normalizeAutocompleteArtistPrefix,
+  normalizeAutocompleteCommitMode,
   normalizeWildcardSearchText,
   parseAutocompleteText,
   planAutocompleteInsertion,
@@ -98,6 +99,7 @@ const DEFAULT_MAX_RESULTS = 20;
 const MAX_RESULT_LIMIT = 100;
 const DEFAULT_AUTOCOMPLETE_MODE = "compatible_global";
 const DEFAULT_AUTOCOMPLETE_COMMIT_KEY = "enter";
+const DEFAULT_AUTOCOMPLETE_COMMIT_MODE = "smart";
 const DEFAULT_AUTOCOMPLETE_ARTIST_PREFIX = "@";
 const AUTOCOMPLETE_MODES = new Set([
   "off",
@@ -182,6 +184,7 @@ const MIN_QUERY_LENGTH = 1;
 let maxResults = DEFAULT_MAX_RESULTS;
 let autocompleteMode = DEFAULT_AUTOCOMPLETE_MODE;
 let autocompleteCommitKey = DEFAULT_AUTOCOMPLETE_COMMIT_KEY;
+let autocompleteCommitMode = DEFAULT_AUTOCOMPLETE_COMMIT_MODE;
 let autocompleteArtistPrefix = DEFAULT_AUTOCOMPLETE_ARTIST_PREFIX;
 let autocompleteAppendSeparator = false;
 let autocompleteNoCommaAfterPeriod = true;
@@ -443,6 +446,9 @@ async function refreshAutocompleteSettings() {
       dataRequestsInvalidated = true;
     }
     setAutocompleteCommitKey(settings["autocomplete.commit_key"]);
+    autocompleteCommitMode = normalizeAutocompleteCommitMode(
+      settings["autocomplete.commit_mode"],
+    );
     setAutocompleteAppendSeparator(settings["autocomplete.append_separator"]);
     setAutocompleteNoCommaAfterPeriod(settings["autocomplete.no_comma_after_period"]);
     const previousDetectNaturalSentences = autocompleteDetectNaturalSentences;
@@ -739,6 +745,8 @@ function currentToken(input) {
     {
       detectNaturalSentences: autocompleteDetectNaturalSentences,
       previewCompletion: autocompletePreviewCompletion,
+      selectionStart: input?.selectionStart,
+      selectionEnd: input?.selectionEnd,
     },
   );
 }
@@ -774,6 +782,7 @@ function autocompleteStateSignature(token, context, state) {
     detectNaturalSentences: autocompleteDetectNaturalSentences,
     previewClosingBrackets: autocompletePreviewClosingBrackets,
     previewCompletion: autocompletePreviewCompletion,
+    commitMode: autocompleteCommitMode,
   });
 }
 
@@ -1132,6 +1141,7 @@ function commitSuggestion(state, entry, options = {}) {
   const insert = completionText(token, entry, state.forceArtistOnly);
   const plan = planAutocompleteInsertion(token, insert, {
     appendSeparator: autocompleteAppendSeparator,
+    commitMode: autocompleteCommitMode,
     noCommaAfterPeriod: autocompleteNoCommaAfterPeriod,
   });
   if (!plan) {
@@ -1240,6 +1250,7 @@ function completionPreviewPlan(state, entry) {
   const insert = completionText(token, entry, state.forceArtistOnly);
   const plan = planAutocompleteInsertion(token, insert, {
     appendSeparator: autocompleteAppendSeparator,
+    commitMode: autocompleteCommitMode,
     noCommaAfterPeriod: autocompleteNoCommaAfterPeriod,
   });
   if (!plan) {
@@ -1761,6 +1772,11 @@ function handleAutocompleteSettingsUpdated(event) {
   }
   if ("autocomplete.commit_key" in detail) {
     setAutocompleteCommitKey(detail["autocomplete.commit_key"]);
+  }
+  if ("autocomplete.commit_mode" in detail) {
+    autocompleteCommitMode = normalizeAutocompleteCommitMode(
+      detail["autocomplete.commit_mode"],
+    );
   }
   if ("autocomplete.artist_prefix" in detail) {
     const nextArtistPrefix = normalizeAutocompleteArtistPrefix(

--- a/web/js/easyuse_anima_settings.js
+++ b/web/js/easyuse_anima_settings.js
@@ -41,6 +41,9 @@ const TEXT = {
       "Literal prefix used to start artist-only autocomplete and insert artist results. Empty or invalid values use @.",
     autocompleteCommitKey: "Autocomplete commit key",
     autocompleteCommitKeyTip: "Choose whether Enter and Tab commit suggestions, or only Tab commits. Shift+Enter always inserts a line break.",
+    autocompleteCommitMode: "Completion edit mode",
+    autocompleteCommitModeTip:
+      "Smart replaces only a matching contiguous tail. Insert preserves all text to the right. Replace uses the syntax-aware active-item range.",
     autocompleteAppendSeparator: "Append comma after autocomplete",
     autocompleteAppendSeparatorTip: "After committing a suggestion, add ', ' and place the caret after it for the next tag.",
     autocompleteNoCommaAfterPeriod: "Do not comma-correct after period",
@@ -166,6 +169,9 @@ const TEXT = {
       "작가 전용 자동완성을 시작하고 작가 결과 앞에 붙이는 문자열입니다. 빈 값이나 잘못된 값은 @를 사용합니다.",
     autocompleteCommitKey: "자동완성 적용 키",
     autocompleteCommitKeyTip: "Enter와 Tab 모두 자동완성을 적용할지, Tab만 적용할지 선택합니다. Shift+Enter는 항상 줄바꿈입니다.",
+    autocompleteCommitMode: "자동완성 편집 모드",
+    autocompleteCommitModeTip:
+      "스마트는 일치가 확인된 연속 후행 텍스트만 교체합니다. 삽입은 오른쪽 텍스트를 모두 보존하고, 교체는 구문을 인식한 활성 항목 범위를 사용합니다.",
     autocompleteAppendSeparator: "자동완성 뒤 쉼표 추가",
     autocompleteAppendSeparatorTip: "자동완성 적용 후 ', '를 붙이고 다음 태그를 바로 입력할 수 있게 커서를 이동합니다.",
     autocompleteNoCommaAfterPeriod: "온점 뒤 쉼표 보정 안 함",
@@ -291,6 +297,9 @@ const TEXT = {
       "アーティスト専用候補の開始と挿入に使う文字列です。空または無効な値は @ を使います。",
     autocompleteCommitKey: "自動補完の確定キー",
     autocompleteCommitKeyTip: "Enter と Tab の両方で候補を確定するか、Tab のみで確定するかを選びます。Shift+Enter は常に改行です。",
+    autocompleteCommitMode: "補完編集モード",
+    autocompleteCommitModeTip:
+      "スマートは一致が確認された連続末尾だけを置換します。挿入は右側のテキストをすべて保持し、置換は構文対応のアクティブ項目範囲を使用します。",
     autocompleteAppendSeparator: "自動補完後にカンマを追加",
     autocompleteAppendSeparatorTip: "候補確定後に ', ' を追加し、次のタグを入力しやすい位置へキャレットを移動します。",
     autocompleteNoCommaAfterPeriod: "句点後はカンマ補正しない",
@@ -416,6 +425,9 @@ const TEXT = {
       "用于启动画师专用补全并插入到画师结果前的文字。空值或无效值会使用 @。",
     autocompleteCommitKey: "自动补全确认键",
     autocompleteCommitKeyTip: "选择 Enter 和 Tab 都确认建议，或仅 Tab 确认。Shift+Enter 始终插入换行。",
+    autocompleteCommitMode: "补全编辑模式",
+    autocompleteCommitModeTip:
+      "智能模式仅替换确认匹配的连续尾部。插入模式保留右侧全部文本，替换模式使用语法感知的当前项目范围。",
     autocompleteAppendSeparator: "自动补全后追加逗号",
     autocompleteAppendSeparatorTip: "确认建议后追加 ', '，并将光标移动到便于输入下一个标签的位置。",
     autocompleteNoCommaAfterPeriod: "句号后不做逗号修正",

--- a/web/js/settings/definition_data.js
+++ b/web/js/settings/definition_data.js
@@ -31,6 +31,7 @@ export const INTERNAL_KEYS = {
   "EasyUseAnima.Prompt.AutocompleteLimit": "autocomplete.limit",
   "EasyUseAnima.Prompt.AutocompleteArtistPrefix": "autocomplete.artist_prefix",
   "EasyUseAnima.Prompt.AutocompleteCommitKey": "autocomplete.commit_key",
+  "EasyUseAnima.Prompt.AutocompleteCommitMode": "autocomplete.commit_mode",
   "EasyUseAnima.Prompt.AutocompleteAppendSeparator": "autocomplete.append_separator",
   "EasyUseAnima.Prompt.AutocompleteNoCommaAfterPeriod": "autocomplete.no_comma_after_period",
   "EasyUseAnima.Prompt.AutocompleteDetectNaturalSentences": "autocomplete.detect_natural_sentences",

--- a/web/js/settings/definitions.js
+++ b/web/js/settings/definitions.js
@@ -161,6 +161,16 @@ export function createEasyUseAnimaSettings(dependencies) {
       options: ["enter", "tab"],
     }),
     setting({
+      id: "EasyUseAnima.Prompt.AutocompleteCommitMode",
+      section: "Autocomplete",
+      group: t("autocomplete"),
+      name: t("autocompleteCommitMode"),
+      tooltip: t("autocompleteCommitModeTip"),
+      type: "combo",
+      defaultValue: "smart",
+      options: ["smart", "insert", "replace"],
+    }),
+    setting({
       id: "EasyUseAnima.Prompt.AutocompleteAppendSeparator",
       section: "Autocomplete",
       group: t("autocomplete"),


### PR DESCRIPTION
## 변경 요약

REL-FEAT-03C로 자동완성 query/insert/replace 범위를 분리하고, 중간 텍스트 커밋 정책을 `smart`/`insert`/`replace`로 제공합니다.

- 기본 `smart`: 입력 중인 접두사와 후보가 연속해서 일치하는 경우에만 활성 항목의 후행 조각을 교체
- `insert`: caret 오른쪽 텍스트를 모두 보존
- `replace`: 구문 인식 활성 항목 범위를 명시적으로 교체
- 공백·쉼표·줄바꿈·가중치 suffix 보존 및 preview/commit 동일 계획 사용
- Comfy 설정 `EasyUseAnima.Prompt.AutocompleteCommitMode`와 backend public settings 계약 추가

원인은 기존 커밋 계획이 query/insert/replace 소유권을 구분하지 않고, 활성 comma segment의 끝을 곧바로 교체 끝으로 사용한 데 있습니다.

## 주요 파일

- `web/js/autocomplete/text_model.js`
- `web/js/easyuse_anima_autocomplete.js`
- `web/js/settings/definitions.js`
- `easyuse_anima/settings/schema.py`
- `easyuse_anima/settings/service.py`
- 관련 frontend/Python 회귀 테스트와 analyzer fixture

## 검증

- focused unittest: 설정 검증, frontend boundary, package skeleton, analyzer exact 모두 통과
- frontend semantic smoke: text model, settings definition/data, input binding 통과
- 공식 full runner 통과
  - Python compile
  - Ruff report-only 119건(기존 baseline)
  - Pyright 115 files / expected 14 errors
  - import boundary 10 groups / 0 violations
  - Python unittest 1,151 tests
  - frontend 115 JS / TypeScript 6.0.3
  - diff gate
- ComfyUI Codex test instance
  - Legacy: smart/insert/replace 설정→추천→Enter 커밋 smoke 통과
  - Node 2.0: smart/insert/replace 설정→추천→Enter 커밋 smoke 통과
  - source/installed/served frontend SHA 일치
  - 브라우저에서 EasyUse Anima 관련 오류 없음

## 호환성과 경계

- 새 설치와 잘못된 값은 `smart`로 귀결됩니다.
- 기존 wildcard 커밋, 자연어/구분자 정책, 적용 키, 작가 접두사 동작을 유지합니다.
- #394 해상도 동작, #401 paste 측정, 03D 괄호 선택 가중치 UX는 변경하지 않습니다.
- 롤백은 이 PR의 squash commit 한 개로 제한됩니다. 설정 저장값은 미인식 시 기존 기본값 처리 경로로 안전하게 귀결됩니다.

Base: `f9354c242ad1992f37d312537d399f4f390c2e2d`
Head: `a84d4c0`

다음 release task: REL-FEAT-03D (safe bracket selection-weight UX)