### PR TITLE
REL-FEAT-03D: Prompt Studio 선택 영역 괄호 래핑

### DIFF
--- a/easyuse_anima/settings/schema.py
+++ b/easyuse_anima/settings/schema.py
@@ -28,6 +28,7 @@ DEFAULT_SETTINGS = {
     "lora_preset.strength_drag_pixels": "8",
     "prompt_studio.typo_indicator": "true",
     "prompt_studio.weight_syntax_underline": "false",
+    "prompt_studio.selection_parenthesis_weight": "false",
     "prompt_studio.comment_italic": "true",
     "prompt_studio.font_override": "false",
     "prompt_studio.font_family": "",
@@ -149,6 +150,9 @@ COMFY_SETTING_KEYS = {
     "EasyUseAnima.Prompt.AutocompletePreviewClosingBrackets": "autocomplete.preview_closing_brackets",
     "EasyUseAnima.Prompt.TypoIndicator": "prompt_studio.typo_indicator",
     "EasyUseAnima.Prompt.WeightSyntaxUnderline": "prompt_studio.weight_syntax_underline",
+    "EasyUseAnima.Prompt.SelectionParenthesisWeight": (
+        "prompt_studio.selection_parenthesis_weight"
+    ),
     "EasyUseAnima.Prompt.CommentItalic": "prompt_studio.comment_italic",
     "EasyUseAnima.Prompt.FontOverride": "prompt_studio.font_override",
     "EasyUseAnima.Prompt.FontFamily": "prompt_studio.font_family",

--- a/easyuse_anima/settings/service.py
+++ b/easyuse_anima/settings/service.py
@@ -78,6 +78,10 @@ def public_settings() -> dict:
             "prompt_studio.weight_syntax_underline",
             DEFAULT_SETTINGS["prompt_studio.weight_syntax_underline"],
         ),
+        "prompt_studio.selection_parenthesis_weight": settings.get(
+            "prompt_studio.selection_parenthesis_weight",
+            DEFAULT_SETTINGS["prompt_studio.selection_parenthesis_weight"],
+        ),
         "prompt_studio.comment_italic": settings.get(
             "prompt_studio.comment_italic",
             DEFAULT_SETTINGS["prompt_studio.comment_italic"],

--- a/tests/fixtures/python_backend_baseline.json
+++ b/tests/fixtures/python_backend_baseline.json
@@ -60662,9 +60662,9 @@
       },
       {
         "is_package": false,
-        "loc": 226,
+        "loc": 230,
         "module": "easyuse_anima.settings.schema",
-        "normalized_git_blob_sha1": "fc547a31d088ec472e2b437db3293efca90e7e5f",
+        "normalized_git_blob_sha1": "1a0a9046f9e6c1d7dd79b594854b6b899c7d1278",
         "path": "easyuse_anima/settings/schema.py",
         "top_level": {
           "class_count": 0,
@@ -60674,9 +60674,9 @@
       },
       {
         "is_package": false,
-        "loc": 490,
+        "loc": 494,
         "module": "easyuse_anima.settings.service",
-        "normalized_git_blob_sha1": "7b3cdd24bfce1c8c7ad83622414cfa128b0878a7",
+        "normalized_git_blob_sha1": "19963faaba9203febba90cad7c71d06b3341c8c7",
         "path": "easyuse_anima/settings/service.py",
         "top_level": {
           "class_count": 0,
@@ -81412,25 +81412,25 @@
       },
       {
         "kind": "set",
-        "line": 76,
+        "line": 77,
         "module": "easyuse_anima/settings/schema.py",
         "name": "AUTOCOMPLETE_COMMIT_KEYS"
       },
       {
         "kind": "set",
-        "line": 81,
+        "line": 82,
         "module": "easyuse_anima/settings/schema.py",
         "name": "AUTOCOMPLETE_COMMIT_MODES"
       },
       {
         "kind": "set",
-        "line": 70,
+        "line": 71,
         "module": "easyuse_anima/settings/schema.py",
         "name": "AUTOCOMPLETE_MODES"
       },
       {
         "kind": "dict",
-        "line": 137,
+        "line": 138,
         "module": "easyuse_anima/settings/schema.py",
         "name": "COMFY_SETTING_KEYS"
       },
@@ -81442,37 +81442,37 @@
       },
       {
         "kind": "dict",
-        "line": 197,
+        "line": 201,
         "module": "easyuse_anima/settings/schema.py",
         "name": "LONG_TEXT_SETTING_ALIASES"
       },
       {
         "kind": "set",
-        "line": 190,
+        "line": 194,
         "module": "easyuse_anima/settings/schema.py",
         "name": "LONG_TEXT_SETTING_KEYS"
       },
       {
         "kind": "list",
-        "line": 101,
+        "line": 102,
         "module": "easyuse_anima/settings/schema.py",
         "name": "NAIA_PREPROCESSING_KEYS"
       },
       {
         "kind": "set",
-        "line": 92,
+        "line": 93,
         "module": "easyuse_anima/settings/schema.py",
         "name": "NAIA_RESOLUTION_BUCKETS"
       },
       {
         "kind": "set",
-        "line": 87,
+        "line": 88,
         "module": "easyuse_anima/settings/schema.py",
         "name": "NAIA_RESOLUTION_MODES"
       },
       {
         "kind": "list",
-        "line": 119,
+        "line": 120,
         "module": "easyuse_anima/settings/schema.py",
         "name": "PROMPT_STUDIO_COLOR_KEYS"
       },

--- a/tests/frontend_autocomplete_input_binding_smoke.mjs
+++ b/tests/frontend_autocomplete_input_binding_smoke.mjs
@@ -6,6 +6,8 @@ function dataModule(relativePath) {
   return "data:text/javascript;base64," + Buffer.from(source).toString("base64");
 }
 
+const textModel = await import(dataModule("../web/js/autocomplete/text_model.js"));
+
 function captureOf(options) {
   return options === true || !!options?.capture;
 }
@@ -444,13 +446,20 @@ const { createAutocompleteInputBinding } = bindingModule;
   const handleBracketPreviewKeydown = new Function(
     "replaceInputRange",
     "syncWidgetValue",
-    `"use strict";\nconst autocompletePreviewClosingBrackets = true;\n${entrySource.slice(bracketStart, bracketEnd)}\nreturn handleBracketPreviewKeydown;`,
+    "planBracketInsertion",
+    "selectionParenthesisWeight",
+    `"use strict";\nconst autocompletePreviewClosingBrackets = true;\nconst promptStudioSelectionParenthesisWeight = selectionParenthesisWeight;\n${entrySource.slice(bracketStart, bracketEnd)}\nreturn handleBracketPreviewKeydown;`,
   )(
-    (input, start, end, replacement, caretOffset) => {
+    (input, start, end, replacement, selectionStartOffset, selectionEndOffset) => {
       input.value = `${input.value.slice(0, start)}${replacement}${input.value.slice(end)}`;
-      input.setSelectionRange(start + caretOffset, start + caretOffset);
+      input.setSelectionRange(
+        start + selectionStartOffset,
+        start + selectionEndOffset,
+      );
     },
     (state) => { state.syncCalls += 1; },
+    textModel.planBracketInsertion,
+    true,
   );
 
   const input = {
@@ -465,16 +474,17 @@ const { createAutocompleteInputBinding } = bindingModule;
   const state = { input, syncCalls: 0 };
   const openEvent = createEvent({ key: "(" });
   assert.equal(handleBracketPreviewKeydown(state, openEvent), true);
-  assert.equal(input.value, "(tag)");
-  assert.equal(input.selectionStart, 4);
+  assert.equal(input.value, "(tag:1)");
+  assert.equal(input.selectionStart, 5);
+  assert.equal(input.selectionEnd, 6);
   assert.equal(state.syncCalls, 1);
 
-  input.selectionStart = 4;
-  input.selectionEnd = 4;
+  input.selectionStart = 6;
+  input.selectionEnd = 6;
   const closeEvent = createEvent({ key: ")" });
   assert.equal(handleBracketPreviewKeydown(state, closeEvent), true);
-  assert.equal(input.value, "(tag)", "typing an existing closer must not duplicate it");
-  assert.equal(input.selectionStart, 5);
+  assert.equal(input.value, "(tag:1)", "typing an existing closer must not duplicate it");
+  assert.equal(input.selectionStart, 7);
   assert.equal(state.syncCalls, 1, "skipping an existing closer must not rewrite widget state");
 }
 

--- a/tests/frontend_autocomplete_text_model_smoke.mjs
+++ b/tests/frontend_autocomplete_text_model_smoke.mjs
@@ -21,6 +21,7 @@ assert.deepEqual(Object.keys(textModel).sort(), [
   "normalizeWildcardSearchText",
   "parseAutocompleteText",
   "planAutocompleteInsertion",
+  "planBracketInsertion",
   "wildcardAutocompleteQuery",
 ].sort());
 
@@ -37,6 +38,7 @@ const {
   normalizeWildcardSearchText,
   parseAutocompleteText,
   planAutocompleteInsertion,
+  planBracketInsertion,
   wildcardAutocompleteQuery,
 } = textModel;
 
@@ -59,6 +61,25 @@ function appliedPlan(token, insert, options = {}) {
       + plan.replacement
       + token.value.slice(plan.end),
     caret: plan.start + plan.caretOffset,
+  };
+}
+
+function appliedBracketPlan(value, selectionStart, selectionEnd, key, options = {}) {
+  const plan = planBracketInsertion(
+    value,
+    selectionStart,
+    selectionEnd,
+    key,
+    options,
+  );
+  assert.ok(plan);
+  return {
+    ...plan,
+    value: value.slice(0, plan.start)
+      + plan.replacement
+      + value.slice(plan.end),
+    selectionStart: plan.start + plan.selectionStartOffset,
+    selectionEnd: plan.start + plan.selectionEndOffset,
   };
 }
 
@@ -219,6 +240,99 @@ assert.deepEqual(
     group: ["parenthesis", 1, 14],
   },
 );
+
+const unweightedSelection = appliedBracketPlan("tag", 0, 3, "(");
+assert.deepEqual(
+  {
+    value: unweightedSelection.value,
+    selection: [
+      unweightedSelection.selectionStart,
+      unweightedSelection.selectionEnd,
+    ],
+    insertedWeight: unweightedSelection.insertedWeight,
+  },
+  {
+    value: "(tag)",
+    selection: [4, 4],
+    insertedWeight: false,
+  },
+);
+
+const weightedSelection = appliedBracketPlan(
+  "tag",
+  0,
+  3,
+  "(",
+  { selectionParenthesisWeight: true },
+);
+assert.deepEqual(
+  {
+    value: weightedSelection.value,
+    selected: weightedSelection.value.slice(
+      weightedSelection.selectionStart,
+      weightedSelection.selectionEnd,
+    ),
+    insertedWeight: weightedSelection.insertedWeight,
+  },
+  {
+    value: "(tag:1)",
+    selected: "1",
+    insertedWeight: true,
+  },
+);
+
+for (const [selected, expected, selectedWeight] of [
+  ["tag:1.2", "(tag:1.2)", "1.2"],
+  ["(tag:1.2)", "((tag:1.2):1)", "1"],
+  ["tag\\:1.2", "(tag\\:1.2:1)", "1"],
+  ["first\nsecond", "(first\nsecond:1)", "1"],
+]) {
+  const plan = appliedBracketPlan(
+    selected,
+    0,
+    selected.length,
+    "(",
+    { selectionParenthesisWeight: true },
+  );
+  assert.equal(plan.value, expected);
+  assert.equal(
+    plan.value.slice(plan.selectionStart, plan.selectionEnd),
+    selectedWeight,
+  );
+}
+
+for (const [key, expected] of [
+  ["{", "{choice_a|choice_b}"],
+  ["[", "[[choice_a|choice_b]]"],
+]) {
+  const selected = "choice_a|choice_b";
+  const plan = appliedBracketPlan(selected, 0, selected.length, key);
+  assert.equal(plan.value, expected);
+  assert.equal(plan.selectionStart, expected.length - (key === "[" ? 2 : 1));
+  assert.equal(plan.selectionEnd, plan.selectionStart);
+}
+
+const emptyParenthesis = appliedBracketPlan("", 0, 0, "(", {
+  selectionParenthesisWeight: true,
+});
+assert.deepEqual(
+  {
+    value: emptyParenthesis.value,
+    selection: [emptyParenthesis.selectionStart, emptyParenthesis.selectionEnd],
+  },
+  { value: "()", selection: [1, 1] },
+);
+
+const doubleBracket = appliedBracketPlan("[", 1, 1, "[");
+assert.deepEqual(
+  {
+    value: doubleBracket.value,
+    selection: [doubleBracket.selectionStart, doubleBracket.selectionEnd],
+  },
+  { value: "[[]]", selection: [2, 2] },
+);
+assert.equal(planBracketInsertion("", 0, 0, "["), null);
+assert.equal(planBracketInsertion("", 0, 0, "x"), null);
 
 assert.equal(normalizeAutocompleteCommitMode("smart"), "smart");
 assert.equal(normalizeAutocompleteCommitMode("insert"), "insert");

--- a/tests/frontend_settings_definition_data_smoke.mjs
+++ b/tests/frontend_settings_definition_data_smoke.mjs
@@ -93,6 +93,7 @@ const expectedInternalKeys = {
   "EasyUseAnima.Prompt.AutocompletePreviewClosingBrackets": "autocomplete.preview_closing_brackets",
   "EasyUseAnima.Prompt.TypoIndicator": "prompt_studio.typo_indicator",
   "EasyUseAnima.Prompt.WeightSyntaxUnderline": "prompt_studio.weight_syntax_underline",
+  "EasyUseAnima.Prompt.SelectionParenthesisWeight": "prompt_studio.selection_parenthesis_weight",
   "EasyUseAnima.Prompt.CommentItalic": "prompt_studio.comment_italic",
   "EasyUseAnima.Prompt.FontOverride": "prompt_studio.font_override",
   "EasyUseAnima.Prompt.FontFamily": "prompt_studio.font_family",

--- a/tests/frontend_settings_definitions_smoke.mjs
+++ b/tests/frontend_settings_definitions_smoke.mjs
@@ -106,6 +106,7 @@ const expectedIds = [
   "EasyUseAnima.Prompt.AutocompleteDetectNaturalSentences",
   "EasyUseAnima.Prompt.AutocompletePreviewCompletion",
   "EasyUseAnima.Prompt.AutocompletePreviewClosingBrackets",
+  "EasyUseAnima.Prompt.SelectionParenthesisWeight",
   "EasyUseAnima.Prompt.TranslationProvider",
   "EasyUseAnima.Prompt.TranslationSource",
   "EasyUseAnima.Prompt.TranslationTarget",
@@ -137,7 +138,7 @@ const expectedIds = [
 ];
 
 assert.deepEqual(settings.map((item) => item.id), expectedIds);
-assert.equal(settings.length, 54);
+assert.equal(settings.length, 55);
 assert.equal(new Set(expectedIds).size, settings.length, "Setting IDs must be unique");
 assert.ok(
   settings.every((item) => item.category[0] === "EASY USE ANIMA"),
@@ -239,6 +240,7 @@ const expectedRegularSchemas = new Map([
   ["EasyUseAnima.Prompt.AutocompleteDetectNaturalSentences", schema("boolean", true)],
   ["EasyUseAnima.Prompt.AutocompletePreviewCompletion", schema("boolean", false)],
   ["EasyUseAnima.Prompt.AutocompletePreviewClosingBrackets", schema("boolean", false)],
+  ["EasyUseAnima.Prompt.SelectionParenthesisWeight", schema("boolean", false)],
   [
     "EasyUseAnima.Prompt.TranslationProvider",
     schema("combo", "off", ["off", "google"]),

--- a/tests/test_autocomplete_frontend.py
+++ b/tests/test_autocomplete_frontend.py
@@ -591,6 +591,7 @@ class AutocompleteFrontendBoundaryTests(unittest.TestCase):
             "normalizeWildcardSearchText",
             "parseAutocompleteText",
             "planAutocompleteInsertion",
+            "planBracketInsertion",
             "wildcardAutocompleteQuery",
         }
         expected_imports = {
@@ -608,6 +609,7 @@ class AutocompleteFrontendBoundaryTests(unittest.TestCase):
             "normalizeWildcardSearchText",
             "parseAutocompleteText",
             "planAutocompleteInsertion",
+            "planBracketInsertion",
             "wildcardAutocompleteQuery",
         }
 

--- a/tests/test_prompt_corrector.py
+++ b/tests/test_prompt_corrector.py
@@ -3112,6 +3112,7 @@ class SettingsTests(unittest.TestCase):
                 "lora_preset.strength_drag_pixels",
                 "prompt_studio.typo_indicator",
                 "prompt_studio.weight_syntax_underline",
+                "prompt_studio.selection_parenthesis_weight",
                 "prompt_studio.comment_italic",
                 "prompt_studio.font_override",
                 "prompt_studio.font_family",
@@ -3382,6 +3383,7 @@ class SettingsTests(unittest.TestCase):
                     "EasyUseAnima.Prompt.AutocompleteNoCommaAfterPeriod": "false",
                     "EasyUseAnima.Prompt.AutocompleteDetectNaturalSentences": "false",
                     "EasyUseAnima.Prompt.TypoIndicator": "false",
+                    "EasyUseAnima.Prompt.SelectionParenthesisWeight": "true",
                     "EasyUseAnima.Prompt.CommentItalic": "false",
                     "EasyUseAnima.Prompt.FontOverride": "true",
                     "EasyUseAnima.Prompt.FontFamily": "Arial",
@@ -3410,6 +3412,10 @@ class SettingsTests(unittest.TestCase):
         self.assertEqual(settings["autocomplete.no_comma_after_period"], "false")
         self.assertEqual(settings["autocomplete.detect_natural_sentences"], "false")
         self.assertEqual(settings["prompt_studio.typo_indicator"], "false")
+        self.assertEqual(
+            settings["prompt_studio.selection_parenthesis_weight"],
+            "true",
+        )
         self.assertEqual(settings["prompt_studio.comment_italic"], "false")
         self.assertEqual(settings["prompt_studio.font_override"], "true")
         self.assertEqual(settings["prompt_studio.font_family"], "Arial")

--- a/web/js/autocomplete/text_model.js
+++ b/web/js/autocomplete/text_model.js
@@ -122,6 +122,125 @@ function syntaxClosingAt(value, index) {
   return null;
 }
 
+function topLevelNumericWeightRange(value) {
+  const text = String(value ?? "");
+  const match = /:\s*([+-]?(?:\d+(?:\.\d*)?|\.\d+))\s*$/.exec(text);
+  if (!match || isEscaped(text, match.index)) {
+    return null;
+  }
+  const stack = [];
+  for (let index = 0; index < match.index; index += 1) {
+    const opening = syntaxOpeningAt(text, index);
+    if (opening) {
+      stack.push(opening.closing);
+      index += opening.length - 1;
+      continue;
+    }
+    const closing = syntaxClosingAt(text, index);
+    if (closing && stack[stack.length - 1] === closing.value) {
+      stack.pop();
+      index += closing.length - 1;
+    }
+  }
+  if (stack.length > 0) {
+    return null;
+  }
+  const numericStart = match.index + match[0].indexOf(match[1]);
+  return {
+    start: numericStart,
+    end: numericStart + match[1].length,
+  };
+}
+
+export function planBracketInsertion(
+  value,
+  selectionStart,
+  selectionEnd,
+  key,
+  options = {},
+) {
+  const text = String(value ?? "");
+  const rawStart = Number(selectionStart);
+  const rawEnd = Number(selectionEnd);
+  const safeStart = clamp(Number.isFinite(rawStart) ? rawStart : 0, 0, text.length);
+  const safeEnd = clamp(
+    Number.isFinite(rawEnd) ? rawEnd : safeStart,
+    0,
+    text.length,
+  );
+  const start = Math.min(safeStart, safeEnd);
+  const end = Math.max(safeStart, safeEnd);
+  const selected = text.slice(start, end);
+  const hasSelection = end > start;
+
+  if (key === "(") {
+    if (hasSelection && options.selectionParenthesisWeight === true) {
+      const existingWeight = topLevelNumericWeightRange(selected);
+      if (existingWeight) {
+        return {
+          start,
+          end,
+          replacement: `(${selected})`,
+          selectionStartOffset: 1 + existingWeight.start,
+          selectionEndOffset: 1 + existingWeight.end,
+          insertedWeight: false,
+        };
+      }
+      return {
+        start,
+        end,
+        replacement: `(${selected}:1)`,
+        selectionStartOffset: selected.length + 2,
+        selectionEndOffset: selected.length + 3,
+        insertedWeight: true,
+      };
+    }
+    const caretOffset = 1 + selected.length;
+    return {
+      start,
+      end,
+      replacement: `(${selected})`,
+      selectionStartOffset: caretOffset,
+      selectionEndOffset: caretOffset,
+      insertedWeight: false,
+    };
+  }
+
+  if (key === "{") {
+    const caretOffset = 1 + selected.length;
+    return {
+      start,
+      end,
+      replacement: `{${selected}}`,
+      selectionStartOffset: caretOffset,
+      selectionEndOffset: caretOffset,
+    };
+  }
+
+  if (key === "[" && hasSelection) {
+    const caretOffset = 2 + selected.length;
+    return {
+      start,
+      end,
+      replacement: `[[${selected}]]`,
+      selectionStartOffset: caretOffset,
+      selectionEndOffset: caretOffset,
+    };
+  }
+
+  if (key === "[" && text[start - 1] === "[") {
+    return {
+      start,
+      end,
+      replacement: "[]]",
+      selectionStartOffset: 1,
+      selectionEndOffset: 1,
+    };
+  }
+
+  return null;
+}
+
 function syntaxGroups(value) {
   const groups = [];
   const stack = [];

--- a/web/js/easyuse_anima_autocomplete.js
+++ b/web/js/easyuse_anima_autocomplete.js
@@ -30,6 +30,7 @@ import {
   normalizeWildcardSearchText,
   parseAutocompleteText,
   planAutocompleteInsertion,
+  planBracketInsertion,
   wildcardAutocompleteQuery,
 } from "./autocomplete/text_model.js";
 
@@ -191,6 +192,7 @@ let autocompleteNoCommaAfterPeriod = true;
 let autocompleteDetectNaturalSentences = true;
 let autocompletePreviewClosingBrackets = false;
 let autocompletePreviewCompletion = false;
+let promptStudioSelectionParenthesisWeight = false;
 let popup = null;
 let activeState = null;
 let activeRefreshFrame = null;
@@ -256,6 +258,10 @@ function setAutocompleteDetectNaturalSentences(value) {
 
 function setAutocompletePreviewClosingBrackets(value) {
   autocompletePreviewClosingBrackets = parseBooleanSetting(value, false);
+}
+
+function setPromptStudioSelectionParenthesisWeight(value) {
+  promptStudioSelectionParenthesisWeight = parseBooleanSetting(value, false);
 }
 
 function setAutocompletePreviewCompletion(value) {
@@ -457,6 +463,9 @@ async function refreshAutocompleteSettings() {
       dataRequestsInvalidated = true;
     }
     setAutocompletePreviewClosingBrackets(settings["autocomplete.preview_closing_brackets"]);
+    setPromptStudioSelectionParenthesisWeight(
+      settings["prompt_studio.selection_parenthesis_weight"],
+    );
     const previousPreviewCompletion = autocompletePreviewCompletion;
     setAutocompletePreviewCompletion(settings["autocomplete.preview_completion"]);
     if (autocompletePreviewCompletion !== previousPreviewCompletion) {
@@ -982,7 +991,14 @@ function resetVisibleAutocompleteMenuSoon(menu, input) {
   });
 }
 
-function replaceInputRange(input, start, end, replacement, caretOffset) {
+function replaceInputRange(
+  input,
+  start,
+  end,
+  replacement,
+  selectionStartOffset,
+  selectionEndOffset = selectionStartOffset,
+) {
   input.focus?.();
   input.setSelectionRange(start, end);
   const beforeValue = input.value;
@@ -994,8 +1010,10 @@ function replaceInputRange(input, start, end, replacement, caretOffset) {
     input.setRangeText(replacement, start, end, "end");
     input.dispatchEvent(new Event("input", { bubbles: true }));
   }
-  const caret = start + caretOffset;
-  input.setSelectionRange(caret, caret);
+  input.setSelectionRange(
+    start + selectionStartOffset,
+    start + selectionEndOffset,
+  );
 }
 
 function suppressAutocompleteUntilInputChanges(input) {
@@ -1326,21 +1344,23 @@ function updateAutocompletePreview() {
   refreshAutocompleteHighlightPreview(input);
 }
 
-function insertBracketPair(state, event, open, close, replacement = null, caretOffset = null) {
+function insertBracketPair(state, event, plan) {
   if (!autocompletePreviewClosingBrackets || event.defaultPrevented || event.ctrlKey || event.metaKey || event.altKey) {
     return false;
   }
   const input = state?.input;
-  if (!input || input.selectionStart == null || input.selectionEnd == null) {
+  if (!input || !plan) {
     return false;
   }
   event.preventDefault();
-  const start = input.selectionStart;
-  const end = input.selectionEnd;
-  const selected = input.value.slice(start, end);
-  const text = replacement ?? `${open}${selected}${close}`;
-  const offset = caretOffset ?? (open.length + selected.length);
-  replaceInputRange(input, start, end, text, offset);
+  replaceInputRange(
+    input,
+    plan.start,
+    plan.end,
+    plan.replacement,
+    plan.selectionStartOffset,
+    plan.selectionEndOffset,
+  );
   syncWidgetValue(state);
   return true;
 }
@@ -1352,14 +1372,17 @@ function handleBracketPreviewKeydown(state, event) {
   }
   const start = input.selectionStart ?? 0;
   const end = input.selectionEnd ?? start;
-  if (event.key === "(") {
-    return insertBracketPair(state, event, "(", ")");
-  }
-  if (event.key === "{") {
-    return insertBracketPair(state, event, "{", "}");
-  }
-  if (event.key === "[" && start === end && input.value[start - 1] === "[") {
-    return insertBracketPair(state, event, "[", "]]", "[]]", 1);
+  const plan = planBracketInsertion(
+    input.value,
+    start,
+    end,
+    event.key,
+    {
+      selectionParenthesisWeight: promptStudioSelectionParenthesisWeight,
+    },
+  );
+  if (plan) {
+    return insertBracketPair(state, event, plan);
   }
   if ((event.key === ")" || event.key === "]" || event.key === "}") && start === end && input.value[start] === event.key) {
     event.preventDefault();
@@ -1802,6 +1825,11 @@ function handleAutocompleteSettingsUpdated(event) {
   }
   if ("autocomplete.preview_closing_brackets" in detail) {
     setAutocompletePreviewClosingBrackets(detail["autocomplete.preview_closing_brackets"]);
+  }
+  if ("prompt_studio.selection_parenthesis_weight" in detail) {
+    setPromptStudioSelectionParenthesisWeight(
+      detail["prompt_studio.selection_parenthesis_weight"],
+    );
   }
   if ("autocomplete.preview_completion" in detail) {
     const previousPreviewCompletion = autocompletePreviewCompletion;

--- a/web/js/easyuse_anima_settings.js
+++ b/web/js/easyuse_anima_settings.js
@@ -56,6 +56,9 @@ const TEXT = {
     autocompletePreviewClosingBrackets: "Preview closing brackets",
     autocompletePreviewClosingBracketsTip:
       "When typing an opening prompt bracket, insert the closing bracket at the caret like an editor pair. Autocomplete previews may show closing brackets, but suggestions do not force-close multi-item groups.",
+    selectionParenthesisWeight: "Add weight when wrapping a selection",
+    selectionParenthesisWeightTip:
+      "When closing-bracket preview is enabled, wrapping selected text with ( inserts :1 and selects the weight. Existing top-level numeric weights are preserved.",
     autocompleteCsvTip: "Select which bundled CSV powers autocomplete and tag highlighting. The merged Danbooru+e621 source may have category merge issues.",
     autocompleteLimitTip: "",
     highlightBehavior: "Highlight behavior",
@@ -184,6 +187,9 @@ const TEXT = {
     autocompletePreviewClosingBrackets: "닫는 괄호 미리입력",
     autocompletePreviewClosingBracketsTip:
       "여는 프롬프트 괄호를 입력하면 IDE처럼 닫는 괄호를 커서 오른쪽에 넣습니다. 자동완성 미리보기에는 닫는 괄호가 보일 수 있지만, 여러 항목을 넣는 그룹을 후보 적용만으로 강제 종료하지는 않습니다.",
+    selectionParenthesisWeight: "선택 영역 괄호에 가중치 추가",
+    selectionParenthesisWeightTip:
+      "닫는 괄호 미리입력이 켜져 있을 때 선택한 텍스트를 (로 감싸면 :1을 추가하고 숫자를 선택합니다. 기존 최상위 숫자 가중치는 유지합니다.",
     autocompleteCsvTip: "자동완성과 태그 하이라이트에 사용할 번들 CSV를 선택합니다. Danbooru+e621 병합 소스는 카테고리 병합 오류 가능성이 있습니다.",
     autocompleteLimitTip: "",
     highlightBehavior: "하이라이트 동작",
@@ -312,6 +318,9 @@ const TEXT = {
     autocompletePreviewClosingBrackets: "閉じ括弧を先に入力",
     autocompletePreviewClosingBracketsTip:
       "プロンプトの開き括弧を入力したとき、エディタのペア入力のように閉じ括弧をキャレット右側へ入れます。自動補完プレビューには閉じ括弧を表示できますが、候補確定だけでは複数項目グループを強制終了しません。",
+    selectionParenthesisWeight: "選択範囲を括弧で囲むとき重みを追加",
+    selectionParenthesisWeightTip:
+      "閉じ括弧の先行入力が有効なとき、選択したテキストを ( で囲むと :1 を追加して数値を選択します。既存のトップレベル数値重みは維持します。",
     autocompleteCsvTip: "自動補完とタグハイライトに使用する同梱 CSV を選択します。Danbooru+e621 の統合ソースにはカテゴリ統合エラーの可能性があります。",
     autocompleteLimitTip: "",
     highlightBehavior: "ハイライト動作",
@@ -440,6 +449,9 @@ const TEXT = {
     autocompletePreviewClosingBrackets: "预填闭合括号",
     autocompletePreviewClosingBracketsTip:
       "输入提示词开括号时，像 IDE 一样在光标右侧插入闭合括号。自动补全预览可以显示闭合括号，但确认候选不会强制结束可包含多项的分组。",
+    selectionParenthesisWeight: "括起选区时添加权重",
+    selectionParenthesisWeightTip:
+      "启用预填闭合括号后，用 ( 包裹所选文本会追加 :1 并选中数值。已有的顶层数值权重会保留。",
     autocompleteCsvTip: "选择用于自动补全和标签高亮的内置 CSV。Danbooru+e621 合并来源可能存在分类合并错误。",
     autocompleteLimitTip: "",
     highlightBehavior: "高亮行为",

--- a/web/js/settings/definition_data.js
+++ b/web/js/settings/definition_data.js
@@ -39,6 +39,7 @@ export const INTERNAL_KEYS = {
   "EasyUseAnima.Prompt.AutocompletePreviewClosingBrackets": "autocomplete.preview_closing_brackets",
   "EasyUseAnima.Prompt.TypoIndicator": "prompt_studio.typo_indicator",
   "EasyUseAnima.Prompt.WeightSyntaxUnderline": "prompt_studio.weight_syntax_underline",
+  "EasyUseAnima.Prompt.SelectionParenthesisWeight": "prompt_studio.selection_parenthesis_weight",
   "EasyUseAnima.Prompt.CommentItalic": "prompt_studio.comment_italic",
   "EasyUseAnima.Prompt.FontOverride": "prompt_studio.font_override",
   "EasyUseAnima.Prompt.FontFamily": "prompt_studio.font_family",

--- a/web/js/settings/definitions.js
+++ b/web/js/settings/definitions.js
@@ -216,6 +216,15 @@ export function createEasyUseAnimaSettings(dependencies) {
       defaultValue: false,
     }),
     setting({
+      id: "EasyUseAnima.Prompt.SelectionParenthesisWeight",
+      section: "Autocomplete",
+      group: t("autocomplete"),
+      name: t("selectionParenthesisWeight"),
+      tooltip: t("selectionParenthesisWeightTip"),
+      type: "boolean",
+      defaultValue: false,
+    }),
+    setting({
       id: "EasyUseAnima.Prompt.TranslationProvider",
       section: "PromptStudio",
       group: t("promptTranslation"),


### PR DESCRIPTION
## 변경 요약

- Prompt Studio의 선택 영역을 `()`, `{}`, `[[ ]]`로 한 번의 편집으로 감싸는 bracket planner를 추가했습니다.
- 선택 영역을 `(`로 감쌀 때 `:1`을 추가하고 숫자만 선택하는 opt-in 설정을 추가했습니다.
- 기존 최상위 숫자 가중치는 그대로 유지하며, 빈 선택은 기존 `()` 동작을 유지합니다.
- Classic/Extend 및 Advanced/AdvancedV2가 공유하는 autocomplete 입력 바인딩에 같은 계약을 적용했습니다.

Closes #64

## 원인

기존 bracket handler는 입력 요소에서 선택 문자열을 바로 읽어 `(${selected})` 또는 `{${selected}}`로 치환했고, `[[ ]]` 선택 래핑 및 가중치 선택 계획을 별도 text-model 계약으로 소유하지 않았습니다. 그 결과 선택 래핑의 구문별 동작, 기존 가중치 보존, selection range를 순수 테스트로 고정할 수 없었습니다.

## 주요 파일

- `web/js/autocomplete/text_model.js`: `planBracketInsertion` 순수 planner
- `web/js/easyuse_anima_autocomplete.js`: planner 기반 단일 편집 및 설정 반영
- `easyuse_anima/settings/*`, `web/js/settings/*`, `web/js/easyuse_anima_settings.js`: 기본값 false인 설정과 4개 locale
- `tests/*`: 선택/빈 입력/다중행/중첩/escaped/기존 가중치 및 설정 계약

## 검증

기준/헤드:

- base: `5642484877bd6bdb7b8995e331514152520e86f0`
- head: `4094c4fc7e7212021ff7fc410ac1ec7ed5d56f80`

Focused:

- `node tests/frontend_autocomplete_text_model_smoke.mjs`
- `node tests/frontend_autocomplete_input_binding_smoke.mjs`
- `node tests/frontend_settings_definition_data_smoke.mjs`
- `node tests/frontend_settings_definitions_smoke.mjs`
- `node --check web/js/autocomplete/text_model.js`
- `node --check web/js/easyuse_anima_autocomplete.js`
- 설정 공개 키/Comfy override/frontend export/analyzer fixture exact unittest 각각 통과
- `git diff --check` 통과

Full runner:

- `tools/check_custom_node.ps1 -Project <PR worktree> -Profile full`
- 최종 결과: Python unittest 1,151개 통과, frontend 115개 JS 검사 통과, TypeScript 6.0.3, compile/Pyright/import boundary/diff check 통과
- 최초 실행은 새 export와 Python analyzer LOC의 의도된 fixture drift 2건으로 실패했고, exact export 기대값과 공식 analyzer fixture를 갱신한 뒤 최종 실행이 통과했습니다.

Live smoke:

- ComfyUI 0.27.0 / frontend 1.45.20 Codex test instance
- Classic/Legacy: 한국어 입력 보존, `()` grow 및 기존 closer skip 확인
- Node 2.0 Advanced/AdvancedV2 표면: `[[]]`, `{}` grow 및 closer skip 확인
- Legacy/Node 2.0 입력값 reload 복원 확인
- 새 설정의 접근 가능한 이름, 기본값 false, runtime toggle과 원복 확인
- 브라우저 제어 계층이 textarea의 기본 선택 단축키/드래그를 전달하지 않아 live selected-range 조작은 제한됐습니다. 선택 래핑 자체는 순수 planner와 실제 input binding smoke에서 `(tag:1)` 및 숫자 선택 범위까지 검증했습니다.
- 테스트 후 브라우저 탭과 8194 테스트 인스턴스 프로세스를 종료하고 임시 로그를 제거했습니다.

## 호환성 및 경계

- 새 설정 기본값은 false이며 `닫는 괄호 미리입력`이 켜진 경우에만 활성화됩니다.
- 기존 설정/워크플로우에 migration이 없고, 저장되지 않은 새 키는 기존 동작을 유지합니다.
- #394 해상도 동작, autocomplete 후보/그룹 확정 동작, Backspace pair-delete는 변경하지 않았습니다.
- #395가 열린 동안 D/E/G/H 및 AiO Hook 구현은 계속 동결합니다.

## Rollback

단일 커밋 `4094c4f`를 revert하면 planner, input binding, 설정 및 테스트가 함께 제거됩니다. 데이터 migration이나 backend 저장 형식 변경이 없어 rollback 경계는 이 커밋 하나입니다.

## 다음 작업

03D 통합 후 0.5.5 release candidate 검증과 `dev -> main` 릴리즈 PR을 진행합니다.