### PR TITLE
docs: prioritize hotfixes and define efficient Codex execution

### DIFF
--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -4,12 +4,19 @@ These documents define the target Python backend architecture, migration rules,
 and explicitly reviewed cross-surface execution plans for ComfyUI EasyUse Anima.
 
 They are contracts for future work, not a claim that every target package or
-feature already exists. Start with the current-state section in
-[`python-backend.md`](python-backend.md), then follow the active sequencing notes
-below before selecting work from the ordinary backend roadmap.
+feature already exists. Before selecting a task, read the bounded execution and
+test-escalation policy in
+[`../development/codex-execution-efficiency.md`](../development/codex-execution-efficiency.md).
+Then follow the active sequencing notes below and read only the current task
+section, owning Issue, direct owner files, and direct tests.
 
 ## Active sequencing notes
 
+- [`codex-execution-efficiency.md`](../development/codex-execution-efficiency.md)
+  applies to every active and ordinary roadmap. It defines the bounded task card,
+  focused edit loop, final-full-once rule, package/live/benchmark triggers,
+  evidence reuse, and current task-specific test maps. It reduces repeated work;
+  it does not weaken an Issue or release gate.
 - Issue [#415](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/415)
   is the current implementation and release owner for the queue/live-UI
   regressions in [#413](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/413)
@@ -34,6 +41,10 @@ below before selecting work from the ordinary backend roadmap.
 
 ## Documents
 
+- [`../development/codex-execution-efficiency.md`](../development/codex-execution-efficiency.md):
+  cross-roadmap Codex context budget, work-packet format, test ladder, invalidation
+  rules, compact evidence format, and scoped test maps for #413/#414, #409/#410/#411,
+  and ordinary backend work.
 - [`queue-ui-execution-state-hotfix.md`](queue-ui-execution-state-hotfix.md):
   active queue-first runbook for stale LoRA/Prompt Studio execution results
   (#413), rgthree-compatible AiO special-seed display semantics (#414), the
@@ -42,9 +53,10 @@ below before selecting work from the ordinary backend roadmap.
 - [`python-backend.md`](python-backend.md): living architecture, ownership,
   execution phases, validation gates, and overall Definition of Done.
 - [`python-backend-execution-roadmap.md`](python-backend-execution-roadmap.md):
-  verified backend progress, Codex execution protocol, ordered work units, stop
-  conditions, and task-level validation gates. Its next-work ordering is paused
-  while #415 is open.
+  verified backend progress, ordered work units, stop conditions, and task-level
+  validation gates. Its next-work ordering is paused while #415 is open. When it
+  resumes, apply the efficiency protocol instead of rerunning every historical
+  inventory and broad test after each edit.
 - [`aio-advanced-integrations-roadmap.md`](aio-advanced-integrations-roadmap.md):
   blocked follow-on plan for stage-scoped DAVE and other MODEL patches (#409),
   KJNodes Torch Compile environment recommendations (#410), and ComfyUI-ppm
@@ -70,6 +82,9 @@ below before selecting work from the ordinary backend roadmap.
   publication, and validation: [`MAINTAINING.md`](../../MAINTAINING.md).
 - The development-document entry point remains
   [`docs/development/README.md`](../development/README.md).
+- The efficiency protocol selects the smallest sufficient evidence and timing;
+  it does not permit skipping explicit correctness, compatibility, package, live,
+  or release gates owned by a task.
 - The architecture ADRs and ordinary backend roadmap own Python package and
   lifecycle boundaries.
 - Cross-surface bug and AiO plans may also cover frontend state, queue identity,

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -1,40 +1,58 @@
 # Python Backend Architecture
 
 These documents define the target Python backend architecture, migration rules,
-and explicitly reviewed follow-on integration plans for ComfyUI EasyUse Anima.
+and explicitly reviewed cross-surface execution plans for ComfyUI EasyUse Anima.
 
 They are contracts for future work, not a claim that every target package or
 feature already exists. Start with the current-state section in
-[`python-backend.md`](python-backend.md), then use the current executable queue in
-[`python-backend-execution-roadmap.md`](python-backend-execution-roadmap.md).
+[`python-backend.md`](python-backend.md), then follow the active sequencing notes
+below before selecting work from the ordinary backend roadmap.
 
 ## Active sequencing notes
 
+- Issue [#415](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/415)
+  is the current implementation and release owner for the queue/live-UI
+  regressions in [#413](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/413)
+  and [#414](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/414).
+  While #415 is open, read
+  [`queue-ui-execution-state-hotfix.md`](queue-ui-execution-state-hotfix.md)
+  **before** the ordinary backend roadmap or any AiO advanced-integration plan.
 - Issue [#395](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/395)
-  remains the active release checkpoint until Comfy Registry 0.5.5 activation is
-  confirmed. Do not start a new D/E/G/H or AiO advanced-feature implementation
-  while that issue remains open.
-- The post-0.5.5 DAVE stage-scope, Torch Compile recommendation, and NegPip plans
-  are recorded in
+  separately tracks the external Comfy Registry activation checkpoint for the
+  immutable 0.5.5 release. Waiting for that external approval does not block
+  confirmed P1 post-release bug fixes, and it does not authorize rewriting the
+  `v0.5.5` tag.
+- The DAVE stage-scope, Torch Compile recommendation, and NegPip plans are
+  recorded in
   [`aio-advanced-integrations-roadmap.md`](aio-advanced-integrations-roadmap.md).
-  That roadmap is PLANNED/BLOCKED and starts with Issue #409 only after #395 exits.
+  Issues #409, #410, and #411 remain blocked until the #415 hotfix release exits
+  and the dependency order is re-audited against the then-current `dev` head.
+- New D/E/G/H, AiO Hook, opportunistic cleanup, and unrelated feature work also
+  remain paused while the hotfix lane is active.
 - The former B-11 Comfy host-provider bridge is complete. Its document remains a
   historical sequencing record and no longer overrides the active queue.
 
 ## Documents
 
+- [`queue-ui-execution-state-hotfix.md`](queue-ui-execution-state-hotfix.md):
+  active queue-first runbook for stale LoRA/Prompt Studio execution results
+  (#413), rgthree-compatible AiO special-seed display semantics (#414), the
+  shared transaction/revision Contract, integrated validation, and the patch
+  release gate owned by #415.
 - [`python-backend.md`](python-backend.md): living architecture, ownership,
   execution phases, validation gates, and overall Definition of Done.
 - [`python-backend-execution-roadmap.md`](python-backend-execution-roadmap.md):
   verified backend progress, Codex execution protocol, ordered work units, stop
-  conditions, and task-level validation gates.
+  conditions, and task-level validation gates. Its next-work ordering is paused
+  while #415 is open.
 - [`aio-advanced-integrations-roadmap.md`](aio-advanced-integrations-roadmap.md):
-  blocked post-0.5.5 execution plan for stage-scoped DAVE and other MODEL patches
-  (#409), KJNodes Torch Compile environment recommendations (#410), and
-  ComfyUI-ppm NegPip Off/On/Turbo conditioning (#411).
+  blocked follow-on plan for stage-scoped DAVE and other MODEL patches (#409),
+  KJNodes Torch Compile environment recommendations (#410), and ComfyUI-ppm
+  NegPip Off/On/Turbo conditioning (#411).
 - [`aio-hook-extensibility-plan.md`](aio-hook-extensibility-plan.md): follow-on AiO
   extension contract and stage/cache/lifecycle sequencing. It does not authorize
-  implementation while a higher-priority release or integration gate is active.
+  implementation while a higher-priority bug, release, or integration gate is
+  active.
 - [`comfy-host-provider-bridge.md`](comfy-host-provider-bridge.md): completed
   historical sequencing addendum for the seven former root Comfy capability and
   invocation wrappers and the minimum runtime-bound provider Contract required
@@ -54,13 +72,18 @@ feature already exists. Start with the current-state section in
   [`docs/development/README.md`](../development/README.md).
 - The architecture ADRs and ordinary backend roadmap own Python package and
   lifecycle boundaries.
-- Cross-surface AiO plans may also cover frontend settings, optional custom-node
-  contracts, workflow/profile compatibility, packaging, and live ComfyUI evidence
-  when those surfaces are inseparable from the backend execution contract.
+- Cross-surface bug and AiO plans may also cover frontend state, queue identity,
+  workflow/profile compatibility, optional custom-node contracts, packaging,
+  and live ComfyUI evidence when those surfaces are inseparable from the backend
+  execution contract.
+- The active hotfix is tracked by
+  [#413](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/413),
+  [#414](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/414), and
+  [#415](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/415).
 - Long-term implementation is tracked by
-  [Issue #184](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/184),
-  [Issue #185](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/185), and
-  their child issues. The new advanced integrations are tracked independently by
+  [#184](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/184),
+  [#185](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/185), and their
+  child issues. The blocked advanced integrations are tracked independently by
   [#409](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/409),
   [#410](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/410), and
   [#411](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/411).

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -1,54 +1,68 @@
 # Python Backend Architecture
 
-These documents define the target Python backend architecture and migration
-rules for ComfyUI EasyUse Anima.
+These documents define the target Python backend architecture, migration rules,
+and explicitly reviewed follow-on integration plans for ComfyUI EasyUse Anima.
 
-They are contracts for future work, not a claim that the target package layout
-already exists. Start with the current-state section in
-[`python-backend.md`](python-backend.md). While Issue #323 is open, read the
-active B-11 sequencing addendum in
-[`comfy-host-provider-bridge.md`](comfy-host-provider-bridge.md), then use the
-current executable queue in
-[`python-backend-execution-roadmap.md`](python-backend-execution-roadmap.md)
-before planning an implementation PR.
+They are contracts for future work, not a claim that every target package or
+feature already exists. Start with the current-state section in
+[`python-backend.md`](python-backend.md), then use the current executable queue in
+[`python-backend-execution-roadmap.md`](python-backend-execution-roadmap.md).
 
-The bridge addendum overrides only the ordering between the final B-11 shim and
-the minimum E-02a/E-07a Comfy host-provider Contract. It does not mark Phase E
-complete or replace the architecture ADRs and normal validation gates.
+## Active sequencing notes
+
+- Issue [#395](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/395)
+  remains the active release checkpoint until Comfy Registry 0.5.5 activation is
+  confirmed. Do not start a new D/E/G/H or AiO advanced-feature implementation
+  while that issue remains open.
+- The post-0.5.5 DAVE stage-scope, Torch Compile recommendation, and NegPip plans
+  are recorded in
+  [`aio-advanced-integrations-roadmap.md`](aio-advanced-integrations-roadmap.md).
+  That roadmap is PLANNED/BLOCKED and starts with Issue #409 only after #395 exits.
+- The former B-11 Comfy host-provider bridge is complete. Its document remains a
+  historical sequencing record and no longer overrides the active queue.
 
 ## Documents
 
 - [`python-backend.md`](python-backend.md): living architecture, ownership,
   execution phases, validation gates, and overall Definition of Done.
-- [`comfy-host-provider-bridge.md`](comfy-host-provider-bridge.md): active,
-  narrowly scoped sequencing addendum for the seven blocked root Comfy
-  capability/invocation wrappers and the minimum runtime-bound provider Contract
-  required before the final B-11 shim.
 - [`python-backend-execution-roadmap.md`](python-backend-execution-roadmap.md):
-  current verified progress, Codex execution protocol, ordered work units,
-  stop conditions, and task-level validation gates.
-- [`aio-hook-extensibility-plan.md`](aio-hook-extensibility-plan.md): follow-on
-  AiO extension contract, stage/cache/lifecycle sequencing, and the 0.6.0
-  release gate after the required backend refactor exits are satisfied.
+  verified backend progress, Codex execution protocol, ordered work units, stop
+  conditions, and task-level validation gates.
+- [`aio-advanced-integrations-roadmap.md`](aio-advanced-integrations-roadmap.md):
+  blocked post-0.5.5 execution plan for stage-scoped DAVE and other MODEL patches
+  (#409), KJNodes Torch Compile environment recommendations (#410), and
+  ComfyUI-ppm NegPip Off/On/Turbo conditioning (#411).
+- [`aio-hook-extensibility-plan.md`](aio-hook-extensibility-plan.md): follow-on AiO
+  extension contract and stage/cache/lifecycle sequencing. It does not authorize
+  implementation while a higher-priority release or integration gate is active.
+- [`comfy-host-provider-bridge.md`](comfy-host-provider-bridge.md): completed
+  historical sequencing addendum for the seven former root Comfy capability and
+  invocation wrappers and the minimum runtime-bound provider Contract required
+  before the final B-11 shim.
 - [`adr-001-modular-monolith.md`](adr-001-modular-monolith.md): why the backend
-  will converge on a feature-oriented modular monolith under `easyuse_anima`.
+  converges on a feature-oriented modular monolith under `easyuse_anima`.
 - [`adr-002-compatibility-shims.md`](adr-002-compatibility-shims.md): policy for
   introducing, supporting, and retiring root compatibility shims.
-- [`python-compatibility-shims.md`](python-compatibility-shims.md): registry
-  schema and initial inventory of current root/module surfaces.
+- [`python-compatibility-shims.md`](python-compatibility-shims.md): registry schema
+  and inventory of root/module compatibility surfaces.
 
 ## Authority and scope
 
-- The current repository policy remains authoritative for branches, releases,
-  Registry publication, and validation: [`MAINTAINING.md`](../../MAINTAINING.md).
+- Repository policy remains authoritative for branches, releases, Registry
+  publication, and validation: [`MAINTAINING.md`](../../MAINTAINING.md).
 - The development-document entry point remains
   [`docs/development/README.md`](../development/README.md).
-- These documents cover the Python backend only. Frontend JavaScript,
-  TypeScript, DOM, canvas, resize, and visual UX work are explicitly excluded.
-- Implementation is tracked by
+- The architecture ADRs and ordinary backend roadmap own Python package and
+  lifecycle boundaries.
+- Cross-surface AiO plans may also cover frontend settings, optional custom-node
+  contracts, workflow/profile compatibility, packaging, and live ComfyUI evidence
+  when those surfaces are inseparable from the backend execution contract.
+- Long-term implementation is tracked by
   [Issue #184](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/184),
-  the long-term parent
-  [Issue #185](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/185), the
-  runtime bridge [Issue #323](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/323),
-  and their related backend issues. An ADR or sequencing addendum does not
-  authorize a package move, behavior change, release, or shim removal by itself.
+  [Issue #185](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/185), and
+  their child issues. The new advanced integrations are tracked independently by
+  [#409](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/409),
+  [#410](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/410), and
+  [#411](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/411).
+- An ADR, roadmap, or sequencing note does not authorize a behavior change,
+  package move, merge, version bump, tag, or Registry publication by itself.

--- a/docs/architecture/aio-advanced-integrations-roadmap.md
+++ b/docs/architecture/aio-advanced-integrations-roadmap.md
@@ -1,0 +1,540 @@
+# AiO Advanced Integrations Execution Roadmap
+
+## 문서 상태
+
+- 상태: **PLANNED / BLOCKED**
+- 기준일: 2026-07-25
+- 기준 브랜치: `dev`
+- 기준 커밋: `df74cf9f65d481936122245e90db269113340c78`
+- 외부 차단점: [#395](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/395) Registry 0.5.5 activation
+- 기능 이슈:
+  - [#409](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/409): stage별 고급 MODEL patch 범위
+  - [#410](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/410): KJNodes Torch Compile 자동 추천
+  - [#411](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/411): ComfyUI-ppm NegPip Off/On/Turbo
+- 관련 기반:
+  - [#169](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/169): AiO stage pipeline/cache
+  - [#187](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/187): runtime/provider lifecycle
+
+이 문서는 세 기능을 같은 대형 PR로 구현하지 않도록 선행 관계, 공통 소유권,
+rollback 단위와 검증 순서를 고정한다. 기능 이슈의 behavior 요구가 이 문서보다
+구체적이면 해당 이슈가 우선하며, 아키텍처 ADR과 `MAINTAINING.md`는 계속
+최상위 정책이다.
+
+`#395`가 닫히기 전에는 이 문서의 production implementation을 시작하지 않는다.
+문서, 조사, fixture 설계는 가능하지만 D/E/G/H 및 새 AiO behavior 구현을 병행하지
+않는다.
+
+## 1. 현재 확인된 실행 구조
+
+### 1.1 MODEL patch가 모든 stage에 전파됨
+
+현재 AiO는 다음 순서로 하나의 MODEL 계보를 만든다.
+
+```text
+base MODEL
+  -> LoRA
+  -> AuraFlow sampling
+  -> DAVE
+  -> Safe PAG
+  -> KJNodes FP16 / Sage / Torch Compile
+  -> first pass
+  -> Highres
+  -> Detailer
+  -> USDU
+```
+
+`ModelVariantResolver`는 Mod Guidance와 Spectrum용 variant만 추가하므로 DAVE,
+Safe PAG, KJNodes patch는 first pass뿐 아니라 이후 sampling stage에도 남는다.
+DAVE를 first pass에만 적용하고 Highres에서 제외하려면 이미 patch된 MODEL에서
+wrapper를 제거하는 것이 아니라, 깨끗한 LoRA 기준 MODEL에서 stage별 variant를
+만들어야 한다.
+
+### 1.2 DAVE와 Compile의 precedence가 명시되지 않음
+
+ComfyUI-Anima-DAVE upstream은 Anima Block Compile과 함께 사용할 때
+`Compile -> DAVE` 순서를 요구한다. 현재 Easy Use Anima의 함수 순서는 DAVE 뒤에
+KJ Torch Compile을 호출한다. #409는 stage scope와 함께 deterministic patch-order
+contract를 도입한다.
+
+### 1.3 Torch Compile은 수동 설정만 제공
+
+현재 Advanced Options는 KJNodes의 주요 compile 입력을 노출하지만 환경 진단이나
+추천 기능은 없다.
+
+```text
+backend
+fullgraph
+mode
+dynamic
+compile_transformer_blocks_only
+dynamo_cache_size_limit
+debug_compile_keys
+disable_dynamic_vram
+```
+
+#410은 compile을 실행하는 버튼이 아니라 현재 환경과 workload를 읽어 추천값,
+이유, 경고를 반환하고 dialog draft에 적용하는 기능을 추가한다.
+
+### 1.4 NegPip은 MODEL + CLIP + conditioning 경계에 걸침
+
+ComfyUI-ppm의 `CLIPNegPip`은 MODEL과 CLIP을 함께 patch한다. 따라서 일반 MODEL
+patch 목록에 단순히 한 항목을 추가해서는 안 된다. LoRA 이후, prompt encoding
+이전, stage MODEL variant 생성 이전에 명시적인 MODEL/CLIP integration boundary가
+필요하다.
+
+Turbo는 추가로 다음 behavior를 소유한다.
+
+```text
+negative prompt contribution × -1
+positive execution conditioning에 결합
+sampling stage effective CFG = 1
+원본 prompt와 저장 CFG는 보존
+```
+
+## 2. 공통 유지보수 원칙
+
+1. 세 기능은 각각 독립 이슈와 독립 rollback 단위를 가진다.
+2. settings/schema/migration 변경은 versioned contract와 golden fixture를 동반한다.
+3. 기존 workflow/profile의 누락 key를 새 기본 behavior로 조용히 해석하지 않는다.
+4. optional custom node는 해당 기능이 선택될 때만 요구한다.
+5. 외부 custom-node source를 복사하거나 private module을 직접 import하지 않는다.
+6. installed node mapping과 node-info contract를 call-time으로 확인한다.
+7. MODEL/CLIP clone, wrapper, compile variant는 run owner와 cleanup owner가 명확해야 한다.
+8. patch order는 dictionary 순서, UI 순서 또는 우연한 import 순서에 의존하지 않는다.
+9. first-pass cache key는 실제 first-pass execution plan만 반영한다.
+10. user-facing 원본 설정과 normalized/effective execution setting을 구분한다.
+11. UI에서 runtime override를 숨기지 않는다.
+12. disabled feature가 package import, 다른 stage 또는 Registry validation을 깨뜨리면 안 된다.
+13. 한 PR에서 Move, Contract, Behavior를 섞지 않는다.
+14. broad utility module이나 arbitrary plugin registry를 만들지 않는다.
+15. 기존 node id, socket, output, workflow serialization은 별도 breaking issue 없이 변경하지 않는다.
+
+## 3. 확정 실행 순서
+
+```text
+BLOCKED: #395 Registry activation 및 release lane 종료
+  ↓
+ADV-00 current-dev re-audit
+  ↓
+#409 AIO-SCOPE-01 Contract/migration
+  ↓
+#409 AIO-SCOPE-02 StageModelVariantResolver
+  ↓
+#409 AIO-SCOPE-03 DAVE UI/cutover
+  ↓
+#409 AIO-SCOPE-04 other-patch opt-in audit
+  ↓
+#410 AIO-COMPILE-01 diagnostics
+  ↓
+#410 AIO-COMPILE-02 recommendation evidence/policy
+  ↓
+#410 AIO-COMPILE-03 UI draft apply
+  ↓
+#410 AIO-COMPILE-04 live matrix
+  ↓
+#411 AIO-NEGPIP-01 external contract/license boundary
+  ↓
+#411 AIO-NEGPIP-02 On mode
+  ↓
+#411 AIO-NEGPIP-03 Turbo conditioning Contract
+  ↓
+#411 AIO-NEGPIP-04 Turbo implementation/UI/live matrix
+  ↓
+ADV-RC integrated compatibility gate
+  ↓
+별도 release planning
+```
+
+#410과 #411의 조사/fixture 작업은 #409 Contract 이후 파일 경계가 겹치지 않으면
+병렬로 수행할 수 있다. 그러나 production implementation은 다음 공통 파일 때문에
+기본적으로 직렬화한다.
+
+```text
+generation defaults/schema/migrations
+model preparation/lifecycle
+first-pass cache key
+Advanced Options dialog
+optional dependency discovery
+profile fixtures
+```
+
+병렬 PR을 열려면 allowed-file set이 겹치지 않고 앞 PR의 schema revision에 의존하지
+않음을 PR 본문에서 증명해야 한다.
+
+## 4. ADV-00 — 재개 전 재감사
+
+#395가 닫힌 직후 바로 구현하지 않고 최신 `origin/dev`에서 다음을 다시 확인한다.
+
+- #409/#410/#411과 겹치는 열린 PR/branch
+- AiO schema/version과 migration head
+- `ModelVariantResolver`와 `EphemeralModelRegistry` 변경
+- KJNodes `TorchCompileModelAdvanced` node input contract
+- ComfyUI-Anima-DAVE wrapper/order contract
+- ComfyUI-ppm `CLIPNegPip` input/output/license/version
+- current full runner와 package closure
+- 0.5.5 이후 새 P0/P1 bug
+
+재감사 결과 외부 node id나 signature가 달라졌으면 issue body와 fixture부터 수정한다.
+과거 조사 결과를 그대로 production contract로 사용하지 않는다.
+
+## 5. #409 실행 manifest
+
+### AIO-SCOPE-01 — Contract와 migration
+
+- 유형: Contract
+- 목표:
+  - stage id `first_pass/highres/detailer/upscale` 고정
+  - patch별 `stage_scope` schema
+  - legacy scope 누락 설정의 all-stage parity migration
+  - 신규 DAVE first-pass-only default
+  - patch precedence revision
+  - first-pass cache-key sensitivity 계약
+- production behavior 변경은 migration facade에 필요한 최소 범위로 제한한다.
+
+허용 후보:
+
+```text
+easyuse_anima/aio/generation_defaults.py
+easyuse_anima/aio/generation_migrations.py
+easyuse_anima/aio/generation_normalization.py
+easyuse_anima/aio/schemas/*
+tests/test_aio_generation_*.py
+settings/profile golden fixtures
+```
+
+금지:
+
+- stage MODEL 실제 cutover
+- DAVE UI
+- Torch recommendation
+- NegPip
+
+### AIO-SCOPE-02 — StageModelVariantResolver
+
+- 유형: Behavior/architecture
+- `model_with_lora`를 깨끗한 run 기준으로 보존한다.
+- stage별 patch plan을 lazy 적용한다.
+- 같은 signature는 run 안에서 재사용한다.
+- 다른 stage/patch signature는 격리한다.
+- cleanup을 `EphemeralModelRegistry` 또는 명시적 인접 owner가 담당한다.
+- disabled stage/patch는 dependency lookup을 하지 않는다.
+
+핵심 invariant:
+
+```text
+DAVE first-pass-only
+  -> first-pass MODEL has anima_dave
+  -> highres/detailer/upscale MODEL has no anima_dave
+```
+
+### AIO-SCOPE-03 — DAVE cutover/UI
+
+- 유형: Feature
+- First pass only / All sampling stages / Custom UI
+- fresh default는 first-pass-only
+- migrated legacy profile은 all-stage
+- Compile과 같은 stage에서 `Compile -> DAVE`
+- stage metadata와 live output comparison
+
+### AIO-SCOPE-04 — opt-in audit
+
+- 유형: Contract/docs/gate
+- Safe PAG, FP16 accumulation, SageAttention, Torch Compile 각각의 stage 적용 가능성을 결정한다.
+- run-global torch setting과 stage-local MODEL wrapper를 구분한다.
+- 지원 근거가 없는 patch에 generic scope UI를 자동 추가하지 않는다.
+
+## 6. #410 실행 manifest
+
+### AIO-COMPILE-01 — Environment diagnostics
+
+- 유형: Contract
+- read-only endpoint 또는 동일한 adapter 경계
+- PyTorch/CUDA/accelerator/GPU VRAM/KJ input contract 수집
+- 외부 network/telemetry/지속 저장 금지
+- 버튼이 compile 또는 benchmark를 실행하지 않는다는 gate
+
+응답은 값뿐 아니라 다음을 포함한다.
+
+```text
+supported
+profile id
+recommended values
+environment summary
+reason codes
+warnings
+policy version
+```
+
+### AIO-COMPILE-02 — Recommendation policy
+
+- 유형: Contract/evidence
+- pure recommendation function
+- workload 분류:
+  - fixed_shapes
+  - variable_shapes
+  - unknown
+- VRAM/shape/stage 조합 benchmark
+- cold/warm 시간, peak VRAM, recompile, graph break 기록
+- evidence 없는 조합을 최적이라고 표시하지 않는다.
+
+공통 안전축 후보:
+
+```text
+backend = inductor
+fullgraph = false
+compile_transformer_blocks_only = true
+debug_compile_keys = false
+```
+
+`mode`, `dynamic`, cache, dynamic-VRAM 정책은 evidence로 결정한다.
+
+### AIO-COMPILE-03 — UI draft apply
+
+- 유형: Feature
+- `[현재 환경에 맞게 자동 설정]`
+- loading/error/unsupported state
+- 추천 diff, 이유, 경고 표시
+- dialog control만 변경
+- Cancel 시 설정 불변
+- Apply 후에만 profile/settings 저장
+
+### AIO-COMPILE-04 — Live matrix
+
+- fixed resolution
+- Highres
+- Detailer crop
+- USDU tiles
+- LoRA
+- DAVE
+- SageAttention
+- Legacy Canvas
+- Node 2.0
+- KJNodes old/new input drift
+
+## 7. #411 실행 manifest
+
+### AIO-NEGPIP-01 — External contract/license boundary
+
+- 유형: Contract
+- node id `CLIPNegPip`
+- MODEL+CLIP input/output
+- V3 `execute()`/`NodeOutput` adapter fixture
+- repeated invocation/idempotency
+- optional dependency failure isolation
+- ComfyUI-ppm source direct-import/vendor 금지 gate
+
+### AIO-NEGPIP-02 — On mode
+
+- 유형: Feature
+- Off parity
+- On에서 PPM MODEL+CLIP patch 1회
+- 기존 positive/negative conditioning과 CFG 유지
+- first-pass cache mode separation
+- metadata mode 기록
+
+### AIO-NEGPIP-03 — Turbo Contract
+
+- 유형: Contract
+- negative prompt에 추가 -1 multiplier를 적용하는 pure transformer
+- top-level comma/newline/nesting/escape/weight 규칙
+- neutral negative conditioning shape/metadata
+- sampling stage effective CFG=1
+- 저장 CFG와 원본 prompt 보존
+- policy revision
+
+### AIO-NEGPIP-04 — Turbo implementation/UI
+
+- 유형: Feature
+- Off / On (standard) / Turbo selector
+- dependency UX
+- runtime CFG override 표시
+- first/highres/detailer/USDU integration
+- Artist Mix/Mod Guidance/Spectrum/DAVE/KJ compatibility matrix
+- Legacy/Node 2.0/live output comparison
+
+## 8. Patch 및 conditioning precedence
+
+최종 precedence는 #409와 #411 Contract에서 fixture로 고정한다. 초기 목표는 다음과
+같다.
+
+```text
+resource load
+  -> LoRA MODEL/CLIP
+  -> NegPip MODEL/CLIP (On/Turbo)
+  -> prompt execution conditioning encode
+  -> stage MODEL variant
+       -> KJ compile
+       -> DAVE
+       -> 검증된 나머지 stage MODEL patches
+  -> stage-specific Spectrum/Mod Guidance sampler patch
+  -> sample
+```
+
+실제 Comfy wrapper nesting 때문에 prompt encode보다 MODEL variant 생성이 먼저
+필요할 수 있다. 중요한 invariant는 다음과 같다.
+
+- NegPip은 patched CLIP으로 prompt를 encode한다.
+- DAVE는 Compile과 함께 사용할 때 compiled block을 대상으로 한다.
+- stage에서 제외된 patch는 해당 MODEL variant에 존재하지 않는다.
+- patch가 disabled이면 외부 node lookup도 하지 않는다.
+- 같은 wrapper key가 queue마다 누적되지 않는다.
+
+Contract PR에서 runtime trace로 실제 호출 순서를 증명한 뒤 위 도식을 필요에 따라
+정정한다.
+
+## 9. Settings와 migration 정책
+
+세 기능 모두 기존 user data를 보호한다.
+
+### #409
+
+```text
+기존 설정에 stage_scope 없음 -> legacy all-stage
+새 DAVE 설정 -> first-pass-only
+```
+
+### #410
+
+```text
+기존 수동 compile 설정 -> 그대로 유지
+추천 버튼 -> 명시적 클릭과 Apply가 있을 때만 변경
+```
+
+### #411
+
+```text
+기존/신규 기본 -> Off
+On/Turbo -> 사용자가 선택
+Turbo -> 저장 CFG를 덮어쓰지 않고 effective CFG만 1
+```
+
+각 migration은 다음을 가져야 한다.
+
+- versioned step
+- pure migration
+- no-write-on-read 정책과 현재 저장 owner 준수
+- profile/workflow golden fixture
+- downgrade/rollback 설명
+- frontend/backend default parity
+
+## 10. Cache 및 lifecycle 계약
+
+### Cache
+
+first-pass cache key는 다음 실제 first-pass behavior를 구분한다.
+
+- first-pass patch plan과 parameter
+- patch precedence revision
+- compile policy/variant signature
+- NegPip mode/policy
+- Turbo derived conditioning fingerprint
+- effective first-pass CFG
+
+Highres-only DAVE scope 변경처럼 first-pass 결과에 영향을 주지 않는 변경은 불필요한
+first-pass miss를 만들지 않는다.
+
+### Lifecycle
+
+run 종료와 exception path에서 다음을 정리한다.
+
+- stage MODEL clones
+- compiled variants
+- DAVE/Safe PAG wrappers
+- NegPip MODEL/CLIP clones
+- temporary sampler patches
+
+process-global torch setting은 MODEL clone과 같은 cleanup 정책으로 다루지 않는다.
+KJNodes callback contract를 사용해 pre-run/cleanup을 보장하거나, 별도 run-global
+ownership 결정을 기록한다.
+
+## 11. 공통 통합 검증
+
+자동 검증:
+
+```powershell
+powershell -ExecutionPolicy Bypass -File tools\check_project.ps1 -Profile full
+comfy node validate
+comfy node pack
+```
+
+실제 archive에서 다음을 확인한다.
+
+- 새 Python/JavaScript/locale/schema 파일
+- optional dependency 없이 package import
+- root shim 재확장 없음
+- workflow/profile fixtures
+
+Live matrix:
+
+```text
+Canvas: Legacy / Node 2.0
+DAVE scope: first only / all / custom
+Torch Compile: off / manual / recommended
+NegPip: off / on / turbo
+Stages: first / highres / detailer / USDU / ResShift
+Prompt: empty negative / normal / weighted / nested
+Patches: LoRA / Safe PAG / Sage / Spectrum / Mod Guidance
+Failure: missing DAVE / KJ / PPM
+Queue: repeated / concurrent / cancelled / exception
+```
+
+품질 비교:
+
+- DAVE first-only와 all-stage의 Highres 색감/구조 비교
+- compile off/on output tolerance와 artifact 확인
+- NegPip On/Turbo negative concept 억제 비교
+- Turbo CFG override가 모든 sampling stage에서 일관적인지 확인
+
+## 12. Stop conditions
+
+다음 상황에서는 현재 PR을 확장하지 않고 blocker를 기록한다.
+
+- #395가 아직 닫히지 않음
+- 최신 dev에서 동일 surface의 구현 PR이 열림
+- settings migration 없이 기존 결과가 바뀜
+- stage patch를 제거하려고 private MODEL dictionary를 수정해야 함
+- KJ/PPM/DAVE private source import가 필요함
+- 외부 node signature가 조사 fixture와 다름
+- Turbo prompt 변환이 원문을 손상하거나 parser가 모호함
+- compile 추천에 benchmark/evidence 없이 특정 GPU 강제값이 필요함
+- disabled optional feature가 package import를 깨뜨림
+- cleanup owner를 정의할 수 없음
+- 한 PR에서 Contract와 Behavior를 분리할 수 없음
+- full/package/live gate가 behavior regression과 구조 변경을 구분하지 못함
+
+## 13. Codex 시작 지시
+
+`#395`가 열려 있는 동안:
+
+```text
+이 문서와 #409/#410/#411을 읽되 production implementation을 시작하지 않는다.
+새 D/E/G/H 또는 AiO advanced feature branch를 만들지 않는다.
+외부 node contract 변화가 발견되면 issue와 문서만 갱신한다.
+```
+
+`#395`가 닫힌 뒤:
+
+```text
+1. 최신 origin/dev와 open PR/branch를 확인한다.
+2. ADV-00 재감사를 수행한다.
+3. #409 AIO-SCOPE-01 하나만 선택한다.
+4. stage id, migration, precedence, cache-key Contract와 golden fixtures만 만든다.
+5. StageModelVariantResolver, UI, Torch recommendation, NegPip behavior는 같은 PR에 넣지 않는다.
+6. quick/full/package gate와 exact base/head SHA를 기록한다.
+7. 다음 unit을 READY로 바꾸되 자동 merge/release는 수행하지 않는다.
+```
+
+## 14. 릴리스 정책
+
+이 문서는 다음 버전 번호를 미리 예약하지 않는다. 세 기능은 독립적으로 릴리스될
+수 있지만, #409의 stage/precedence contract가 안정되지 않은 상태에서 #410 또는
+#411만 부분 공개하지 않는다.
+
+release candidate를 만들 때 다음을 별도로 결정한다.
+
+- 세 기능을 한 minor release에 묶을지
+- #409/DAVE만 먼저 공개할지
+- optional dependency minimum version
+- workflow/profile migration note
+- Registry scanner/package evidence
+- 사용자에게 필요한 restart/hard-refresh 안내

--- a/docs/architecture/queue-ui-execution-state-hotfix.md
+++ b/docs/architecture/queue-ui-execution-state-hotfix.md
@@ -1,0 +1,487 @@
+# Queue Execution vs Live UI State Hotfix Lane
+
+## Document status
+
+- Status: active bug-fix execution override
+- Snapshot date: 2026-07-25
+- Snapshot branch: `dev`
+- Snapshot commit: `df74cf9f65d481936122245e90db269113340c78`
+- Release owner: [#415](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/415)
+- Live-state overwrite owner: [#413](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/413)
+- AiO special-seed owner: [#414](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/414)
+- Follow-on advanced integrations: [#409](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/409), [#410](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/410), and [#411](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/411)
+
+This runbook owns the next bug-fix ordering after two post-0.5.5 queue/UI
+ownership regressions were reproduced from the current code. It overrides the
+next-work ordering in the ordinary backend roadmap and the planned AiO advanced
+integrations roadmap until the hotfix release gate exits.
+
+It does not rewrite the immutable 0.5.5 release, undo the backend seed
+reservation service, or authorize unrelated frontend/backend refactoring.
+
+## 1. Problem statement
+
+The current code sometimes treats a result produced from an old queue snapshot
+as a command to mutate the user's current live node state.
+
+```text
+queue snapshot S0
+  -> backend execution
+  -> user edits live node to S1
+  -> S0 result arrives
+  -> current UI is mutated back toward S0
+```
+
+The accepted ownership rule is:
+
+```text
+submitted execution snapshot != current editable UI state
+```
+
+A queue result may publish preview, execution history, diagnostics, and an
+explicitly allowed next state. It may not overwrite current editable inputs
+unless it proves that the current relevant revision still equals the revision
+that submitted the result.
+
+## 2. Verified failure surfaces
+
+### 2.1 LoRA Preset
+
+`web/js/lora_preset/node_runtime.js` currently handles
+`lora_preset_profile.profile_index` in `applyExecutedProfile()` by:
+
+```text
+save current profile
+  -> set returned profile index
+  -> load returned profile
+  -> rerender profile and LoRA widgets
+```
+
+There is no queue request identity or edit-revision comparison. A user who
+switches profiles or edits rows while an older job runs can be forced back to
+the old queued profile. The stale path may also save the current profile before
+loading the old one.
+
+### 2.2 Prompt Studio Advanced / AdvancedV2
+
+`web/js/prompt_studio/advanced_values.js` currently applies an execution payload
+directly to the live node:
+
+```text
+advanced_fields
+use_naia
+resolution bucket/size/custom dimensions
+wildcard mode/seed/control
+Artist Mix settings
+```
+
+It then rerenders the editor. An older queue may therefore replace current text,
+selection, field structure, resolution, or seed controls.
+
+### 2.3 Classic / Extend Prompt Studio
+
+`web/js/prompt_studio/studio_values.js` applies returned slot values and active
+slot state directly to current widgets. This path requires the same stale-result
+protection.
+
+### 2.4 AiO special seed
+
+The backend returns:
+
+```json
+{
+  "execution_seed": "...",
+  "next_seed": "..."
+}
+```
+
+`web/js/aio/executed_seed_runtime.js` currently writes every editable
+`next_seed` into the live seed widget. For `seed=-1` and the default
+`seed_after_generate=fixed`, backend reservation resolves a concrete execution
+seed and returns it as `next_seed`. The frontend therefore converts the
+persistent `Random Each` intent into a fixed number after one completed job.
+
+The rgthree Seed node demonstrates the desired user contract:
+
+- keep `-1/-2/-3` in the live widget;
+- resolve a concrete seed only in the submitted prompt copy;
+- store the concrete last seed separately; and
+- replace the live widget only after an explicit `Use Last` action.
+
+Easy Use Anima keeps backend reservation as the authoritative execution source,
+but must adopt the same separation between editable intent and concrete
+execution value.
+
+## 3. Active critical path
+
+```text
+READY: QSTATE-01  #413 Contract and failure fixtures
+  ->   QSTATE-02  #413 shared queue UI transaction owner
+  ->   QSTATE-03  #413 LoRA Preset cutover
+       +
+       QSTATE-04  #413 Prompt Studio cutover
+  ->   AIO-SEED-UI-01  #414 seed intent/display Contract
+  ->   AIO-SEED-UI-02  #414 backend result identity
+  ->   AIO-SEED-UI-03  #414 frontend compare-and-commit
+  ->   HOTFIX-RC-01    integrated validation
+  ->   HOTFIX-PREP-01  patch release preparation
+  ->   HOTFIX-PUBLISH-01 main/tag/Registry
+  ->   re-audit and resume #409 -> #410 -> #411
+```
+
+QSTATE-03 and QSTATE-04 may run in parallel after QSTATE-02 if their shared
+transaction API is merged and their production file sets stay disjoint.
+AIO-SEED-UI-01/02 may be planned in parallel after QSTATE-02, but the frontend
+cutover must use the reviewed shared transaction API rather than introduce an
+AiO-only duplicate.
+
+## 4. Freeze and release rules
+
+While #415 is open:
+
+- new D/E/G/H, AiO Hook, #409, #410, and #411 implementation remains blocked;
+- completed refactors and 0.5.5 behavior outside the two bugs remain intact;
+- only #413/#414 fixes, tests required to prove them, release preparation, and
+  newly discovered P0/P1 regressions may start;
+- one PR owns one Contract, infrastructure, feature cutover, or release unit;
+- production code never changes in the release-preparation PR;
+- the immutable `v0.5.5` tag is never rewritten or reused; and
+- when the final scope remains bug fixes only, the default patch candidate is
+  `0.5.6`.
+
+Issue #395 may continue tracking external Registry activation of 0.5.5. Its
+external checkpoint does not prevent fixing confirmed post-release regressions.
+The advanced integration queue additionally remains blocked by #415 even after
+#395 closes.
+
+## 5. QSTATE-01 — Contract and failure fixtures
+
+### Type
+
+Contract/test only. Production behavior changes should be zero or limited to
+non-observable instrumentation required to freeze the contract.
+
+### Required fixtures
+
+```text
+LoRA Q1 profile A -> user edits profile B -> Q1 completes
+LoRA Q1 A -> Q2 B -> user edits C -> completion order Q2, Q1
+Advanced old fields -> user edits new fields -> old completion
+Advanced resolution/wildcard/Artist Mix edits after queue
+Classic/Extend old slot payload after current edit
+same execution callback delivered twice
+node removed/reconfigured before result
+queue rejected/cancelled/cleared before result
+```
+
+### Decisions to freeze
+
+1. Which submission identity is available in browser, backend, and compatibility
+   paths.
+2. Which fields are execution-history-only and which are allowed to commit a
+   next state.
+3. Atomic surface groups and their edit-revision sources.
+4. Behavior when identity is unavailable or ambiguous.
+5. Duplicate, out-of-order, cancellation, reload, and removal semantics.
+
+Ambiguity must preserve current user input rather than apply the old result.
+
+### Exit gate
+
+- every destructive case is represented by a deterministic failing fixture;
+- accepted transaction identity and revision shapes are documented;
+- exact QSTATE-02 allowed files and API are frozen; and
+- no feature adapter has yet been broadly rewritten.
+
+## 6. QSTATE-02 — Shared queue UI transaction owner
+
+### Candidate owner
+
+```text
+web/js/lifecycle/queue_ui_transaction.js
+```
+
+The final name may change in QSTATE-01, but it must remain a narrow owner rather
+than a generic event bus or service locator.
+
+### Minimum API responsibilities
+
+```text
+capture submission snapshot
+associate prompt/request identity
+mark relevant user edit revision
+compare-and-commit eligibility
+idempotent settlement
+reject/cancel/clear cleanup
+node removal/reconfigure/workflow reload disposal
+out-of-order protection
+```
+
+### Identity contract
+
+Prefer UI-only ephemeral identity from the call-time Comfy execution context:
+
+```text
+prompt_id
+node_id
+list_index or stable request_id
+```
+
+Do not serialize that identity into workflows or profiles. Do not change public
+node sockets. When a compatibility path cannot provide exact identity, use a
+submitted snapshot fingerprint and local monotonic transaction identifier only
+when it is sufficient. Otherwise do not mutate the live UI.
+
+### Revision groups
+
+Candidate atomic groups:
+
+```text
+lora.profile
+lora.rows
+prompt.fields
+prompt.resolution
+prompt.wildcard
+prompt.artist_mix
+aio.seed
+```
+
+A serialization read or queue snapshot capture is not a user edit. Actual DOM,
+widget, profile, row, field, or settings changes increment the relevant revision.
+Do not split fields that must be committed atomically.
+
+### Exit gate
+
+- QSTATE fixtures cover the owner without feature-specific mocks hiding behavior;
+- no document-level permanent listener or unbounded transaction history remains;
+- node disposal releases all references;
+- duplicate and out-of-order settlement is deterministic; and
+- adapters can ask `canCommit` without importing application globals through a
+  circular dependency.
+
+## 7. QSTATE-03 — LoRA Preset cutover
+
+### Required behavior
+
+- stale `profile_index` never changes the current selection;
+- stale completion never calls `saveProfile()`;
+- current rows, strengths, toggles, style prompt, profile identity, and unsaved
+  state stay intact;
+- no-edit compatible completion may refresh execution-only status without
+  unnecessarily loading a profile; and
+- provenance, profile API, CAS/revision token, workflow serialization, and
+  profile-bar interaction remain unchanged.
+
+### Stop conditions
+
+Stop and split the PR if the fix requires a profile storage schema migration,
+profile API redesign, or unrelated profile UI refactor.
+
+## 8. QSTATE-04 — Prompt Studio cutover
+
+### Required behavior
+
+- stale results cannot replace Advanced/AdvancedV2 fields;
+- stale results cannot change resolution, wildcard settings, Artist Mix, or NAIA
+  editable state;
+- stale results cannot replace Classic/Extend slots or visibility;
+- stale results cannot rerender the editor and destroy current caret/selection;
+- allowed one-shot NAIA or seed state uses compare-and-commit; and
+- field linking, autocomplete, highlighting, textarea autosize, workflow
+  serialization, and node layout remain intact.
+
+A result may retain previous-execution text or history in a non-editable field,
+but it must not silently become the current prompt input.
+
+## 9. AIO-SEED-UI-01 — Intent and display Contract
+
+### Required model
+
+```text
+requested selection intent
+concrete execution seed
+reservation next seed
+editable next display value
+queue transaction identity
+```
+
+The current two-field `execution_seed`/`next_seed` payload is insufficient for
+frontend display semantics.
+
+### Special modes
+
+```text
+-1 = randomize each queue
+-2 = increment the previous concrete stream seed each queue
+-3 = decrement the previous concrete stream seed each queue
+```
+
+The live widget keeps the special token. The backend reservation service
+continues producing the concrete execution seed. `seed_after_generate` may
+advance concrete seed state, but must not replace the special mode token.
+The interaction between a special token and non-fixed after-generate control is
+frozen by golden fixtures to prevent double advancement.
+
+### Concrete mode
+
+For a concrete editable seed, fixed/randomize/increment/decrement may publish the
+next concrete value only when the `aio.seed` transaction revision is still
+current.
+
+## 10. AIO-SEED-UI-02 — Backend result identity
+
+### Required result information
+
+Candidate shape:
+
+```json
+{
+  "request_id": "...",
+  "requested_seed": "-1",
+  "selection": "randomize",
+  "after_generate": "fixed",
+  "execution_seed": "123",
+  "next_seed": "456",
+  "next_display_seed": "-1",
+  "preserve_selection_intent": true
+}
+```
+
+Field names may change in the Contract PR. Meaning may not be collapsed again.
+The payload remains UI-only and decimal-string-safe for large seeds.
+
+### Required preservation
+
+- browser and headless execution use the same backend reservation semantics;
+- cache and sampling receive the concrete execution seed;
+- output metadata records the concrete execution seed;
+- workflow serialization retains the user's selection intent; and
+- special mode does not require frontend RNG.
+
+## 11. AIO-SEED-UI-03 — Frontend publication
+
+### Required behavior
+
+- `-1/-2/-3` remain in the live seed input after any number of completions;
+- each queue receives the correct concrete backend-reserved seed;
+- concrete seed is published to a separate last-seed state;
+- `Use Last` explicitly converts the live widget to a concrete fixed seed;
+- `New Fixed Random` explicitly creates one concrete fixed seed;
+- older completions do not rollback a newer last-seed record;
+- concrete after-generate updates pass the shared compare-and-commit gate; and
+- no queue path temporarily mutates the live widget.
+
+The Contract PR decides whether the button label is `Last Queued` or `Last
+Executed` based on the exact monotonic ownership available. The label and
+implementation must describe the same event.
+
+## 12. Integrated hotfix validation
+
+### Automated/package
+
+```powershell
+powershell -ExecutionPolicy Bypass -File tools\check_project.ps1 -Profile full
+comfy node validate
+comfy node pack
+```
+
+Inspect the actual archive for all changed Python, JavaScript, fixture, locale,
+and changelog files.
+
+### Queue/live matrix
+
+```text
+Legacy Canvas
+Node 2.0
+single queue
+rapid Q1/Q2/Q3
+out-of-order callback fixture
+user edit while running
+queue reject/cancel/clear
+node removal/reconfigure/workflow reload
+subgraph or attached graph where supported
+clean user-data
+0.5.5 update user-data
+```
+
+### LoRA/Prompt acceptance
+
+```text
+Q1 old state -> current user edit -> completion -> current edit preserved
+stale LoRA completion -> saveProfile not called
+stale Prompt completion -> no field/widget/editor mutation
+no-edit compatible result -> allowed update once
+duplicate callback -> no-op
+workflow save after stale result -> current state serialized
+```
+
+### AiO seed acceptance
+
+```text
+-1 Q1/Q2/Q3 -> distinct concrete seeds; widget remains -1
+-2 stream -> concrete increments; widget remains -2
+-3 stream -> concrete decrements; widget remains -3
+Use Last -> exact concrete fixed seed
+New Fixed Random -> concrete fixed seed
+concrete after-generate update with and without intervening user edit
+out-of-order and duplicate completion
+workflow save/reload
+headless/API parity
+```
+
+A release candidate fails if any stale execution mutates a newer editable state,
+or if a special AiO seed intent is replaced by a concrete result without an
+explicit user action.
+
+## 13. Release preparation and publication
+
+When #413 and #414 are complete and the integrated gate passes:
+
+1. choose the patch version; default candidate is `0.5.6`;
+2. create a release-only PR with no production Python/JavaScript changes;
+3. update version, user-facing changelog, Registry metadata, maintained workflow
+   metadata, and aligned release docs;
+4. record the exact tested candidate commit and ComfyUI/frontend versions;
+5. merge to `main` only after full/package/live evidence;
+6. create an immutable annotated tag from the released `main` commit;
+7. publish to Registry and read back version, changelog, and package state; and
+8. verify update from the public 0.5.5 installation.
+
+Do not rewrite `v0.5.5` or patch production code in the release-preparation PR.
+
+## 14. Resumption gate
+
+The advanced integration and ordinary backend queues become selectable only
+after:
+
+- #413 is complete;
+- #414 is complete;
+- HOTFIX-RC-01 passes at one exact integrated `dev` head;
+- patch release preparation, `main` integration, immutable tag, Registry publish,
+  and read-back complete; and
+- no immediate P0/P1 post-release regression remains open.
+
+At that point re-audit the then-current code and open PRs. The expected advanced
+sequence is #409 -> #410 -> #411, but do not start it automatically if new
+evidence changes the dependency graph.
+
+## 15. Codex start instruction
+
+```text
+Read docs/architecture/queue-ui-execution-state-hotfix.md and Issues #415 and
+#413 before selecting any ordinary backend or AiO advanced-feature task.
+
+Start QSTATE-01 only. Reproduce the LoRA Preset, Advanced/AdvancedV2, and
+Classic/Extend stale queue-result overwrites in deterministic frontend fixtures.
+Inventory the exact onExecuted payloads, user-edit mutation points, queue identity
+available from frontend/backend, atomic surface groups, cancellation/removal
+boundaries, and allowed execution-derived commits.
+
+Do not implement a broad feature cutover, modify AiO seed semantics, or refactor
+LoRA/Prompt Studio structure in QSTATE-01. Freeze the transaction/revision API,
+allowed files, stop conditions, and failing examples first.
+
+Run focused tests and tools/check_project.ps1 -Profile full. Record exact
+base/head SHA, failure evidence, Contract decisions, rollback boundary, and next
+task QSTATE-02. Do not merge, version, tag, or publish without normal review.
+```

--- a/docs/development/README.md
+++ b/docs/development/README.md
@@ -6,12 +6,17 @@ conversation.
 ## Read Order
 
 1. `docs/development/current-policies.md`
-2. Python backend architecture or migration work:
+2. [`docs/development/codex-execution-efficiency.md`](codex-execution-efficiency.md)
+   - create one bounded task card;
+   - use focused edit-loop tests;
+   - run the official full runner once per final candidate SHA;
+   - escalate to package, live, and benchmark evidence only when triggered.
+3. Python backend architecture or migration work:
    [`docs/architecture/README.md`](../architecture/README.md)
-3. Active frontend maintenance execution plan:
+4. Active frontend maintenance execution plan:
    `docs/development/frontend-maintenance-execution-plan.md`
-4. Current release candidate: `docs/development/0.5.5.md`
-5. Relevant topic guide:
+5. Current release candidate: `docs/development/0.5.5.md`
+6. Relevant topic guide:
    - Registry publish or flagged-version prevention:
      `docs/development/registry-scanner-safety.md`
    - workflow docs or release templates: `docs/Anima AiO/Workflow_Management.md`
@@ -26,12 +31,18 @@ conversation.
    - deferred Node 2.0 DOM widget resize investigation:
      `docs/development/node2-dom-widget-resize-limitation.md`
    - language or locale work: `docs/development/language-management.md`
-6. `git status --short`
-7. Relevant source and tests for the target area.
+7. `git status --short`
+8. Relevant source and tests for the target area.
+
+Do not read every roadmap or historical document by default. The efficiency
+protocol defines the maximum initial context and the conditions that justify
+expanding it.
 
 ## Source Map
 
 - Current policy baseline: `docs/development/current-policies.md`
+- Codex work-packet, test-escalation, evidence-reuse, and token policy:
+  [`docs/development/codex-execution-efficiency.md`](codex-execution-efficiency.md)
 - Python backend architecture and compatibility-shim registry:
   [`docs/architecture/README.md`](../architecture/README.md)
 - Active frontend maintenance execution ledger:
@@ -85,6 +96,9 @@ conversation.
   - `tests/test_aio_nodes.py`
   - `tests/test_workflows.py`
 
+Use this map only as an initial hint. Confirm the current canonical owner with a
+targeted symbol search; do not automatically read every listed file.
+
 ## Current Policy Notes
 
 - Do not keep duplicated workflow JSON outside `docs/example_workflows/`.
@@ -99,15 +113,33 @@ conversation.
 
 ## Validation Shortlist
 
-- PR-ready official full, once per final diff:
+### Edit loop
+
+Use only changed-file syntax checks and the task-specific focused tests listed in
+`codex-execution-efficiency.md` or the owning Issue.
+
+```text
+node --check web/js/<changed-file>.js
+node tests/<focused-frontend-smoke>.mjs
+python -m unittest <focused test modules>
+git diff --check
+```
+
+The repository `quick` profile is still broad: it runs repository-wide Python
+quality, all frontend syntax/smoke checks, TypeScript, and diff checks. Do not run
+it after every edit.
+
+### Final PR candidate
+
+- Official full, once per final code/test diff:
   `powershell -ExecutionPolicy Bypass -File tools\check_project.ps1 -Profile full`
-- Focused implementation checks as applicable:
-  `node --check web/js/<changed-file>.js`,
-  `node tests/<focused-frontend-smoke>.mjs`,
-  `python -m unittest <focused test modules>`, and `git diff --check`
+- Rerun only when an invalidating code, test, runner, shared fixture, or
+  configuration change occurs.
 - Frontend behavior changes: follow
-  `docs/development/browser-smoke-matrix.md` once per final diff
-- Registry scanner grep from `docs/development/registry-scanner-safety.md`
-- `comfy node validate` before Registry publish
+  `docs/development/browser-smoke-matrix.md` once per final diff.
+- `comfy node validate` and `comfy node pack` only when package/import/registration,
+  `.comfyignore`, dependency, release, or runtime closure can change.
+- Registry scanner grep from `docs/development/registry-scanner-safety.md` only
+  for scanner-sensitive or release work.
 - Workflow JSON parse and package-version checks for
-  `docs/example_workflows/*.json`
+  `docs/example_workflows/*.json` only when workflow/release metadata changes.

--- a/docs/development/codex-execution-efficiency.md
+++ b/docs/development/codex-execution-efficiency.md
@@ -1,0 +1,696 @@
+# Codex Execution Efficiency and Test Escalation Protocol
+
+## Status and authority
+
+- Status: active cross-roadmap execution policy
+- Applies to: all implementation, maintenance, bug-fix, migration, quality, and release work
+- Current active lane: `docs/architecture/queue-ui-execution-state-hotfix.md`
+- Follow-on lane: `docs/architecture/aio-advanced-integrations-roadmap.md`
+- Ordinary backend lane: `docs/architecture/python-backend-execution-roadmap.md`
+
+This document reduces unnecessary repository reading, agent reasoning, tool calls,
+and repeated validation without weakening correctness or release gates.
+
+Use the following authority order:
+
+1. repository policy in `MAINTAINING.md` and `docs/development/current-policies.md`;
+2. the current owning Issue and its latest accepted task manifest;
+3. the active sequencing document for that task;
+4. this execution-efficiency protocol;
+5. area-specific implementation documents and historical plans.
+
+A task-specific requirement may add tests or evidence. It may not silently remove a
+repository or release gate. When two documents disagree, use the newer explicit
+Issue decision and update the stale document before implementing.
+
+## 1. Core rule
+
+Use the smallest evidence set that can disprove the current change, then escalate
+only when the change is stable.
+
+```text
+inspect
+  -> syntax/static check for changed files
+  -> focused behavior/contract tests
+  -> adjacent-boundary tests only when shared ownership changed
+  -> official full once on the final PR candidate
+  -> package validation only when package closure can change
+  -> live ComfyUI only when host-visible behavior can change
+  -> benchmarks only when performance policy is the task
+```
+
+Do not use the official `quick` or `full` runner as an edit-loop command. The
+current `quick` profile still runs repository-wide Python quality, all frontend
+JavaScript syntax checks, all frontend smoke files, TypeScript, and diff checks.
+The `full` profile adds the complete Python unittest suite. They are promotion
+gates, not substitutes for focused tests.
+
+## 2. Bounded work packet
+
+Before editing, create one compact task card. Do not repeatedly reread every parent
+roadmap or issue comment after the card is grounded.
+
+```text
+Task ID:
+Owner Issue:
+Primary class:
+Base SHA:
+Goal:
+Prerequisites:
+Allowed production files:
+Allowed test/docs files:
+Forbidden changes:
+Behavior/invariants to preserve:
+Focused tests and purpose:
+Promotion gates:
+Stop conditions:
+Next task:
+```
+
+The card must be sufficient for a fresh Codex session to continue the work. Link
+to the detailed Issue instead of copying its full body into every PR or handoff.
+
+### 2.1 Default context budget
+
+Read only:
+
+1. this policy once per work session;
+2. the active sequencing document's current task section;
+3. the owning Issue and its latest completion/blocker comment;
+4. direct owner source files and their direct tests; and
+5. callers/imports found by targeted search.
+
+Do not read the full repository, all historical plans, all closed Issues, or every
+test file unless the task is explicitly an inventory/audit task.
+
+### 2.2 Search policy
+
+Prefer bounded commands and exact ranges:
+
+```powershell
+git diff --name-only <base>...HEAD
+rg -n "<symbol-or-payload>" <known-directories>
+git grep -n "<symbol>" -- <known-paths>
+```
+
+Avoid broad recursive file dumps and repeated searches that answer the same
+question. Record the discovered owner and callers once in the task card.
+
+### 2.3 Existing evidence reuse
+
+Reuse an inventory, golden fixture, browser result, package result, or benchmark
+when all of the following hold:
+
+- it was produced from the same commit SHA;
+- the relevant code, test, runner, and environment contract did not change;
+- the evidence states its command and purpose; and
+- no newly discovered failure invalidates it.
+
+Documentation, PR-body, label, and comment-only changes do not invalidate code,
+package, browser, or benchmark evidence.
+
+## 3. Primary change classes
+
+Every PR has one primary class. Split a PR when it would require two independent
+rollback boundaries.
+
+| Class | Meaning | Typical examples |
+| --- | --- | --- |
+| `DOC` | Documentation or task ordering only | roadmap, ADR, changelog draft |
+| `CONTRACT` | Fixtures/types/contracts with no intended production behavior change | schema fixture, failure reproduction, protocol |
+| `PURE` | Deterministic helper or domain logic | parser, normalization, recommendation policy |
+| `MOVE` | Mechanical ownership relocation with behavior parity | canonical module extraction, direct alias |
+| `ADAPTER` | ComfyUI/custom-node/API boundary | node result payload, provider invocation |
+| `UI` | DOM/canvas/editor/current-state behavior | Prompt Studio, LoRA Preset, AiO panel |
+| `SCHEMA` | Settings/profile/workflow migration or serialization | versioned generation settings |
+| `LIFECYCLE` | Runtime ownership, concurrency, cache, transaction state | queue transaction, provider lifetime |
+| `PERF` | Performance policy or benchmark-driven optimization | Torch Compile recommendation |
+| `RELEASE` | Version/package/publication metadata only | patch release prep |
+
+Do not mix `MOVE` with observable behavior. Do not mix `RELEASE` with production
+code. A `CONTRACT` PR may add a minimal test seam, but must not quietly complete
+the later behavior task.
+
+## 4. Test ladder
+
+### E0 — Inspection only
+
+**Purpose:** establish ownership, callers, current behavior, and exact diff.
+
+Required for every task. No command output needs to be pasted in full. Record only
+the relevant paths, symbols, and decisions.
+
+### E1 — Changed-file syntax/static sanity
+
+**Purpose:** catch syntax, import, and malformed-diff failures immediately.
+
+Typical commands:
+
+```powershell
+python -m py_compile <changed-python-files>
+node --check <changed-js-files>
+git diff --check
+```
+
+Use changed directories with `compileall -q` when several adjacent Python files
+changed. Do not compile the entire repository after every edit.
+
+Run targeted Ruff/Pyright only when the task explicitly adds or enrolls a strict
+module. Repository-wide quality ratchets remain part of the final official runner.
+
+### E2 — Focused contract/behavior tests
+
+**Purpose:** prove the exact requirement and its nearest regressions.
+
+Typical commands:
+
+```powershell
+python -m unittest tests.test_<owner>
+python -m unittest tests.test_<owner>.<Class>.<test>
+node tests/frontend_<owner>_smoke.mjs
+```
+
+A focused test must have a stated purpose. Do not run a test merely because its
+name is in the same broad feature area.
+
+### E3 — Adjacent-boundary tests
+
+**Purpose:** protect a shared contract changed by the task.
+
+Run only when the diff changes one of these boundaries:
+
+- shared lifecycle/transaction owner;
+- settings/schema/migration used by multiple surfaces;
+- API or custom-node invocation adapter;
+- registration/import/package boundary;
+- shared serialization or cache-key contract.
+
+Choose the direct consumers. Do not run every feature suite.
+
+### E4 — Official full runner
+
+**Purpose:** prove repository-wide integration after the final candidate diff is
+stable.
+
+```powershell
+powershell -ExecutionPolicy Bypass -File tools\check_project.ps1 -Profile full
+```
+
+Rules:
+
+- run once per final PR candidate SHA;
+- rerun only after production, tests, runners, shared fixtures, or configuration
+  changes that can affect the result;
+- do not rerun after PR text, labels, comments, or docs-only follow-up changes;
+- if the full runner fails, reproduce the first relevant failure with E2/E3 and
+  fix it before running full again;
+- do not repeatedly run full to gather the same failure log.
+
+### E5 — Package/import closure
+
+**Purpose:** prove the shipped archive and ComfyUI validation include the required
+runtime files and metadata.
+
+```powershell
+comfy node validate
+comfy node pack
+```
+
+Required only when the diff can affect:
+
+- Python package/import/registration closure;
+- `.comfyignore`;
+- `pyproject.toml`, dependencies, Registry metadata, or version;
+- runtime file paths or optional integration files;
+- release candidate publication.
+
+Not required for isolated frontend logic, test-only contracts, or ordinary docs.
+The integrated release candidate still runs E5 once.
+
+### E6 — Live ComfyUI
+
+**Purpose:** prove host behavior that repository tests cannot model reliably.
+
+Required only for changes to:
+
+- DOM/canvas/pointer/keyboard/focus lifecycle;
+- queue submission or execution-result UI behavior;
+- node sizing, hidden widgets, workflow serialization, or Node 2.0 compatibility;
+- real optional custom-node invocation;
+- GPU/model/sampler behavior or output quality.
+
+Run after the final diff is stable, once on Legacy Canvas and once on Node 2.0,
+using only the changed flow plus required persistence/queue assertions. Follow
+`docs/development/browser-smoke-matrix.md` and reuse evidence for the same SHA.
+
+Pure helpers, contract-only PRs, mechanical moves, and test infrastructure normally
+omit E6 with an explicit reason.
+
+### E7 — Benchmark or quality comparison
+
+**Purpose:** support a performance or output-quality policy.
+
+Run only for `PERF` work or when the Issue requires comparative evidence. Correctness
+must pass first. Separate cold and warm measurements, record environment, and do
+not repeat an expensive benchmark after docs-only changes.
+
+## 5. Promotion schedule
+
+### During implementation
+
+Run E1 and the smallest E2 test after a coherent edit. Stop at the first failure.
+Do not run E4, E5, or E6 while the design is still changing.
+
+### Before opening or updating a reviewable PR
+
+Run all required E2 tests and E3 only for changed shared boundaries. Review the
+final diff and remove diagnostics, temporary files, and accidental scope changes.
+
+### Final candidate
+
+Run E4 once. Then run E5 and E6 only when their trigger conditions apply. Record
+the exact tested SHA.
+
+### Issue-close or release checkpoint
+
+Do not repeat valid per-PR evidence. Run only the integrated checks that require
+all child PRs on one exact head. A release candidate runs E4, E5, and the stated
+integrated E6 matrix once.
+
+## 6. Test invalidation rules
+
+| Change after a pass | Focused evidence | Full | Package | Live | Benchmark |
+| --- | --- | --- | --- | --- | --- |
+| PR body, labels, comments | reuse | reuse | reuse | reuse | reuse |
+| docs only | reuse unless docs test changed | reuse | reuse | reuse | reuse |
+| test expectation/fixture | rerun affected test | rerun before merge | usually reuse | usually reuse | if fixture drives benchmark |
+| production in same owner | rerun owner tests | invalidated | if package trigger | if UI/host trigger | if perf logic |
+| shared lifecycle/schema/API | rerun direct consumers | invalidated | often invalidated for runtime paths | if host-visible | if perf logic |
+| runner/configuration | rerun affected ladder | invalidated | if packaging config | if environment contract | if benchmark harness |
+| rebase with disjoint upstream diff | reuse E2/E3; inspect merge | final E4 on rebased SHA | final E5 if required | reuse only if tested code identical | reuse only if code/env identical |
+| rebase with overlapping owner | rerun relevant E2/E3 | invalidated | as triggered | as triggered | as triggered |
+
+Evidence cache key:
+
+```text
+commit SHA + command + test purpose + relevant environment
+```
+
+## 7. Test-purpose record
+
+For each command in a task card or PR, record one line:
+
+```text
+<command> — proves <specific invariant>; required because <changed boundary>
+```
+
+Example:
+
+```text
+node tests/frontend_lora_preset_node_runtime_smoke.mjs
+— proves stale completion cannot save/load the current profile after LoRA runtime cutover.
+```
+
+Do not paste entire passing logs. Record pass/fail, test count when useful, and the
+first actionable failure. Preserve raw logs only when needed for CI/debugging.
+
+## 8. Active hotfix test map
+
+This section applies while Issue #415 owns the active queue.
+
+### QSTATE-01 — Contract and failure fixtures
+
+Primary class: `CONTRACT`.
+
+Edit loop:
+
+```powershell
+node --check <new-or-changed-contract-js>
+node tests/frontend_lora_preset_node_runtime_smoke.mjs
+node tests/frontend_prompt_studio_advanced_values_smoke.mjs
+node tests/<new-classic-extend-stale-result-smoke>.mjs
+git diff --check
+```
+
+Purpose:
+
+- reproduce the stale LoRA profile mutation;
+- reproduce Advanced/AdvancedV2 field and settings overwrite;
+- reproduce Classic/Extend slot overwrite;
+- freeze duplicate, out-of-order, removal, and cancellation decisions.
+
+Do not run live ComfyUI or package checks. Run E4 once when the contract PR is final
+because shared frontend test registration may change.
+
+### QSTATE-02 — Shared queue transaction owner
+
+Primary class: `LIFECYCLE`.
+
+Edit loop:
+
+```powershell
+node --check web/js/lifecycle/queue_ui_transaction.js
+node tests/<queue-ui-transaction-smoke>.mjs
+node tests/frontend_host_hook_registry_smoke.mjs  # only if host-hook wiring changes
+git diff --check
+```
+
+Purpose:
+
+- prove capture, revision, settlement, cancellation, disposal, duplicate, and
+  out-of-order semantics without feature-specific UI noise.
+
+No live browser test is required until a feature adapter uses the owner. Run E4
+once on the final PR candidate.
+
+### QSTATE-03 — LoRA Preset cutover
+
+Primary class: `UI`.
+
+Edit loop:
+
+```powershell
+node tests/<queue-ui-transaction-smoke>.mjs
+node tests/frontend_lora_preset_node_runtime_smoke.mjs
+node tests/frontend_lora_preset_profile_mutations_smoke.mjs
+git diff --check
+```
+
+Add entry-lifecycle or save-sync smoke only when those files change.
+
+Live purpose on each canvas:
+
+1. queue Profile A, edit/switch to B, finish A, verify B remains;
+2. queue A then B, edit C, deliver out-of-order fixture/result where supported,
+   verify C remains;
+3. save/reload and verify current profile data is serialized.
+
+Do not rerun unrelated Prompt Studio, AiO, autocomplete, or settings browser flows.
+
+### QSTATE-04 — Prompt Studio cutover
+
+Primary class: `UI`.
+
+Edit loop:
+
+```powershell
+node tests/<queue-ui-transaction-smoke>.mjs
+node tests/frontend_prompt_studio_advanced_values_smoke.mjs
+node tests/<classic-extend-executed-values-smoke>.mjs
+git diff --check
+```
+
+Run host-hook registry smoke only if hook registration changes. Run autosize,
+resolution, autocomplete, or regional tests only when their owners are touched.
+
+Live purpose on each canvas:
+
+1. queue old fields, edit current text/field structure, complete old queue;
+2. repeat for resolution/wildcard/Artist Mix atomic groups;
+3. verify Classic/Extend slot and visibility edits remain;
+4. save/reload and verify current state and caret-safe rerender behavior.
+
+### AIO-SEED-UI-01 — Intent/display Contract
+
+Primary class: `CONTRACT`.
+
+```powershell
+node tests/frontend_aio_executed_seed_runtime_smoke.mjs
+python -m unittest tests.test_aio_seed_cutover tests.test_seed_adapters
+git diff --check
+```
+
+Purpose: freeze `requested`, `execution`, `next reservation`, `next display`, and
+last-seed meanings for `-1/-2/-3` and concrete seeds. No live or package check.
+
+### AIO-SEED-UI-02 — Backend result identity
+
+Primary class: `ADAPTER`.
+
+```powershell
+python -m unittest tests.test_aio_seed_cutover tests.test_seed_adapters tests.test_aio_nodes
+node tests/frontend_aio_executed_seed_runtime_smoke.mjs  # when payload parsing changes
+git diff --check
+```
+
+Add `tests.test_aio_legacy_generation` only if generation-pipeline metadata or
+result construction outside the node adapter changes. E5 is not required unless
+registration/import/package closure changes.
+
+### AIO-SEED-UI-03 — Frontend compare-and-commit
+
+Primary class: `UI`.
+
+```powershell
+node tests/<queue-ui-transaction-smoke>.mjs
+node tests/frontend_aio_executed_seed_runtime_smoke.mjs
+node tests/frontend_aio_generator_panel_runtime_smoke.mjs
+git diff --check
+```
+
+Add extension-runtime smoke only if extension hook ownership changes.
+
+Live purpose on each canvas:
+
+1. `-1` across Q1/Q2/Q3: widget remains `-1`, concrete seeds differ;
+2. intervening user seed edit: old completion cannot overwrite it;
+3. `Use Last` and `New Fixed Random` are the only explicit concrete transitions;
+4. workflow save/reload preserves the special token.
+
+### HOTFIX-RC-01
+
+Run once on one exact integrated `dev` SHA:
+
+```powershell
+powershell -ExecutionPolicy Bypass -File tools\check_project.ps1 -Profile full
+comfy node validate
+comfy node pack
+```
+
+Then run the exact #413/#414 Legacy/Node 2.0 matrix. Do not repeat every child PR's
+manual steps if the integrated flow covers the same invariant.
+
+## 9. Follow-on AiO advanced integration test map
+
+This section becomes active only after the hotfix lane exits and the dependency
+order is re-audited.
+
+### #409 — Stage-scoped model patches
+
+#### AIO-SCOPE-01 Contract/migration
+
+```powershell
+python -m unittest tests.test_aio_generation_migrations tests.test_aio_generation_settings tests.test_aio_schema_contract
+python -m unittest tests.test_aio_first_pass_cache
+```
+
+Purpose: legacy missing-scope parity, new-default semantics, patch-order revision,
+and cache-key sensitivity. No live test.
+
+#### AIO-SCOPE-02 Variant owner
+
+```powershell
+python -m unittest tests.test_aio_generation_lifecycle tests.test_aio_stage_integration_matrix tests.test_aio_model_preparation
+```
+
+Add individual stage tests only for stages whose request/model wiring changes.
+Purpose: clean base lineage, lazy variant reuse, precedence, and cleanup. No UI
+browser test.
+
+#### AIO-SCOPE-03 DAVE UI/cutover
+
+```powershell
+node tests/frontend_aio_advanced_settings_dialog_smoke.mjs
+node tests/frontend_aio_profile_core_smoke.mjs
+python -m unittest tests.test_aio_model_preparation tests.test_aio_generation_settings
+```
+
+Live only the changed flows: first-pass-only, all-stage legacy parity, one custom
+scope, Compile-before-DAVE, save/reload, and both canvas surfaces. Output/color
+comparison is required because the user-visible defect is stage-dependent color
+degradation.
+
+#### AIO-SCOPE-04 Other patch audit
+
+Test only each patch whose stage support is being approved. Do not run an exhaustive
+Cartesian product of every optional integration.
+
+### #410 — Torch Compile recommendation
+
+#### AIO-COMPILE-01 Diagnostics
+
+Use fake host/environment fixtures. Do not allocate large GPU tensors or compile a
+model. Test missing CUDA/KJNodes, input-contract drift, and read-only environment
+reporting.
+
+#### AIO-COMPILE-02 Recommendation policy
+
+Use pure policy tests for fixed/variable/unknown shapes and VRAM tiers. Benchmark
+only after correctness is stable, on explicitly selected representative systems.
+Record cold compile time, warm time, peak VRAM, recompiles, and graph breaks once
+per policy revision/environment.
+
+#### AIO-COMPILE-03 UI
+
+Run the Advanced settings dialog smoke and a dedicated recommendation UI smoke.
+Live test only button loading/error/supported states, draft-only changes, Cancel,
+Apply, and persistence on both canvas modes. Clicking the button must not compile.
+
+#### AIO-COMPILE-04 Integration
+
+Use a risk-based matrix, not every parameter combination. Cover one fixed-shape,
+one Highres/variable-shape, one Detailer/USDU case, and the highest-risk approved
+patch combination.
+
+### #411 — NegPip Off/On/Turbo
+
+#### AIO-NEGPIP-01 External contract/license boundary
+
+Use fake `CLIPNegPip` node info and result objects. Test dependency absence, V3
+output adaptation, contract drift, no eager import, and no vendored upstream code.
+No real PPM live test yet.
+
+#### AIO-NEGPIP-02 On mode
+
+Test one adapter invocation, MODEL/CLIP lineage, unchanged positive/negative CFG,
+cache separation, metadata, repeat execution, and cleanup. Run one real Anima +
+ComfyUI-ppm live smoke after focused/full pass.
+
+#### AIO-NEGPIP-03 Turbo Contract
+
+Use pure parser/conditioning fixtures for top-level items, nesting, escapes,
+existing weights, empty input, malformed syntax, neutral negative conditioning,
+and stage CFG=1. No UI browser test.
+
+#### AIO-NEGPIP-04 UI/integration
+
+Run mode/persistence UI smoke and a selected compatibility matrix. Prefer pairwise
+highest-risk combinations over a full Cartesian product:
+
+- Turbo + Artist Mix;
+- Turbo + Mod Guidance;
+- Turbo + DAVE/Torch Compile approved order;
+- Turbo + Highres;
+- Turbo + Detailer;
+- Turbo + USDU.
+
+Run Off parity once, On once, and Turbo once per required canvas/model surface.
+
+## 10. Ordinary backend roadmap test map
+
+| Work type | Focused proof | Final additions | Normally omit |
+| --- | --- | --- | --- |
+| Contract-only | new fixture/contract tests | E4 once if runner/shared fixture changes | live, package |
+| Mechanical Move | identity, direct callers, import boundary, package skeleton | E4; E5 when runtime path changes | live |
+| Pure domain/service | owner unit tests, targeted syntax/type | E4 | live, package unless closure changes |
+| Behavior change | owner golden/error tests, direct consumers | E4; E6 if host-visible | unrelated feature suites |
+| Runtime/lifecycle | concurrency, cleanup, retry, fake provider/clock | E4; E6 only for actual host lifecycle | broad UI matrix |
+| Settings/schema | defaults, normalization, migration golden, frontend/backend parity | E4; E6 only when UI changes | unrelated model/sampler tests |
+| Quality ratchet | exact analyzer/ruff/pyright/import gate | E4 once | live |
+| Release-only | metadata/changelog/workflow/version checks | E4 + E5 + required release live/read-back | production edits |
+
+For ordinary roadmap tasks, do not repeat old Move inventories unless `dev` changed
+the same owner or the task's stop condition is triggered.
+
+## 11. Agent and token policy
+
+### Default single-agent execution
+
+Use one implementation agent by default. Parallel workers are justified only when:
+
+- file ownership is disjoint;
+- no worker depends on another worker's undecided contract;
+- each worker receives a bounded task card and exact output format; and
+- merging the results is cheaper than one sequential implementation.
+
+Do not spawn multiple agents to reread the same roadmap, independently rediscover
+the same owner, or produce overlapping design opinions for a small task.
+
+### Handoff size
+
+Worker handoff should contain only:
+
+```text
+finding/decision
+files and symbols inspected
+specific evidence
+patch or recommended change
+tests run/not run
+blocker or next action
+```
+
+Do not include hidden reasoning, full logs, or copied issue bodies.
+
+### External research
+
+Use external upstream research only when the task depends on a current external
+contract, version, license, or API. Pin the inspected commit. Do not repeatedly
+browse upstream after its contract is frozen unless a version drift is detected.
+
+### Output discipline
+
+- Summarize passing logs; do not paste them.
+- Report the first root cause before secondary cascades.
+- Link to existing decisions instead of rewriting them.
+- Keep one decision ledger per owner Issue.
+- Remove temporary diagnostics before final validation.
+- Do not create speculative tests for behavior outside the task's accepted scope.
+
+## 12. Compact evidence template
+
+Use this format in PRs and Issue completion comments:
+
+```text
+Task: <id / owner>
+Class: <primary class>
+Base -> Head: <sha> -> <sha>
+Changed boundary: <paths/owner>
+Preserved invariants: <short list>
+Focused: <commands and purpose; pass/fail>
+Adjacent: <commands and purpose | not required>
+Full: <command, tested SHA, result | not yet required>
+Package: <validate/pack result | not triggered>
+Live: <Legacy/Node 2.0 changed flow | not triggered>
+Benchmark: <environment/result | not triggered>
+Rollback: <single boundary>
+Next: <task or blocker>
+```
+
+The PR body should remain a review aid, not a duplicate architecture document.
+
+## 13. Stop conditions
+
+Stop and record a blocker instead of expanding the search or test scope when:
+
+- required changes exceed the task's allowed production files;
+- a shared contract is still undecided;
+- current `dev` or an open PR overlaps the same owner;
+- a focused failure shows the root cause belongs to another Issue;
+- the external custom-node/API contract differs from the frozen fixture;
+- package or live validation requires an unavailable dependency/environment;
+- a proposed test needs a generic framework larger than the behavior under test;
+- the change would combine Move, Behavior, and Release ownership.
+
+A blocker report must identify the missing decision and the smallest next Contract,
+not request a broad repository re-audit by default.
+
+## 14. Future scoped-runner automation
+
+The manual protocol above is immediately usable. A future maintenance task may add
+a scope-aware wrapper such as:
+
+```text
+tools/check_scope.ps1 -Scope <name> -ChangedFrom <sha> -List|-Run
+```
+
+A valid implementation must:
+
+- use a reviewed manifest mapping path globs to focused tests and purposes;
+- print the selected tests before running them;
+- include shared-boundary escalation rules;
+- fail closed on unknown runtime paths;
+- never claim to replace the final official full runner; and
+- keep results deterministic and reviewable.
+
+Do not delay current hotfix work waiting for that automation. Use the task-specific
+commands in this document now.

--- a/docs/development/current-policies.md
+++ b/docs/development/current-policies.md
@@ -72,6 +72,33 @@ This document records decisions that supersede earlier experimental notes.
 - Follow `docs/development/browser-smoke-matrix.md` for focused, full,
   dual-canvas, and final user-instance validation timing.
 
+## Codex Execution Efficiency
+
+- Follow [`codex-execution-efficiency.md`](codex-execution-efficiency.md) for
+  every roadmap and implementation task.
+- Start from one bounded task card. Read the active task section, owning Issue,
+  direct owner files, direct tests, and targeted callers; do not reread the full
+  repository or all historical plans by default.
+- During implementation, run changed-file syntax checks and focused tests only.
+- The `quick` project profile is a broad repository check, not a per-edit focused
+  command.
+- Run the official `full` project check once on the final candidate SHA. Rerun it
+  only after an invalidating code, test, runner, shared fixture, configuration,
+  or overlapping-rebase change.
+- Run package validation only when import/registration/archive/metadata closure
+  can change. Run live ComfyUI only for host-visible behavior. Run benchmarks
+  only for performance or output-quality policy work.
+- Reuse evidence for the same SHA and environment. Documentation, PR text,
+  labels, and comments do not invalidate code or live evidence.
+- Every test command must state the invariant it proves. Do not run broad suites
+  merely because they share a high-level feature name.
+- Stop at the first focused failure, identify the root cause, and do not rerun
+  the complete suite until the focused failure passes.
+- Use one implementation agent by default. Parallel workers require disjoint
+  file ownership, a frozen shared contract, and bounded handoff output.
+- PR and Issue completion records use the compact evidence template from the
+  efficiency protocol instead of duplicating full logs or roadmap bodies.
+
 ## Detailer and SAM3
 
 - Do not copy or reimplement Impact Pack `DetailerForEach` core logic in EasyUse Anima.


### PR DESCRIPTION
## 요약

0.5.5 이후 확인된 queue/live-UI 회귀를 고급 기능보다 먼저 수정하도록 순서를 정하고, **모든 현재·후속 로드맵에 적용되는 Codex 저비용 실행/검증 규약**을 추가합니다.

- #413: 과거 queue 결과가 LoRA Preset·Prompt Studio의 최신 편집값을 덮어씀
- #414: AiO `Random Each (-1)`가 실행 후 concrete 고정 시드로 변환됨
- #415: 두 버그의 Contract, 통합 검증, patch release owner
- #409/#410/#411: hotfix release 이후 고급 AiO 기능
- #416: hotfix 이후 scope-aware focused test runner 자동화

기준: `dev@df74cf9f65d481936122245e90db269113340c78`

## 현재 실행 순서

```text
QSTATE-01  #413 stale-overwrite Contract/failure fixtures
  -> QSTATE-02 shared queue UI transaction/revision owner
  -> QSTATE-03 LoRA Preset cutover
       + QSTATE-04 Prompt Studio cutover
  -> AIO-SEED-UI-01 #414 intent/display Contract
  -> AIO-SEED-UI-02 backend result identity
  -> AIO-SEED-UI-03 frontend compare-and-commit
  -> integrated hotfix RC
  -> patch release preparation/publication (default candidate 0.5.6)
  -> re-audit and resume #409 -> #410 -> #411
  -> optional #416 scoped-runner automation
```

#395는 immutable 0.5.5의 외부 Registry activation checkpoint를 별도로 추적합니다. 외부 승인을 기다리는 동안에도 확인된 P1 회귀는 수정할 수 있지만 `v0.5.5`를 수정하거나 재사용하지 않습니다.

## Codex 실행 효율 규약

신규 문서:

```text
docs/development/codex-execution-efficiency.md
```

핵심 규칙:

- 작업마다 1개의 bounded task card를 작성하고 전체 저장소·과거 문서를 반복해서 읽지 않음
- edit loop는 changed-file syntax + task-specific focused tests만 실행
- `quick`도 모든 frontend smoke와 repository-wide quality를 실행하므로 per-edit 명령으로 사용하지 않음
- 공식 `tools/check_project.ps1 -Profile full`은 최종 후보 SHA에서 1회
- package/live/benchmark는 변경 경계가 실제로 요구할 때만 승격
- SHA·command·purpose·environment가 같은 증거는 재사용
- docs/PR text/label/comment 변경은 code/package/live evidence를 무효화하지 않음
- 실패 시 focused root cause부터 수정하고 같은 full suite를 반복 실행하지 않음
- 기본 single-agent; 병렬은 disjoint file ownership과 frozen contract가 있을 때만 허용
- PR/Issue에는 compact evidence record만 남기고 전체 로그와 이슈 본문을 복제하지 않음

문서에는 현재 hotfix의 QSTATE-01~04, AIO-SEED-UI-01~03, #409/#410/#411, ordinary backend Move/Contract/Behavior/Lifecycle 작업별 **정확한 focused test 구간과 목적**, full/package/live/benchmark 승격 조건, invalidation matrix를 포함합니다.

## 문서 구조

- `docs/architecture/queue-ui-execution-state-hotfix.md`
  - #413/#414 shared transaction and seed-intent hotfix
- `docs/architecture/aio-advanced-integrations-roadmap.md`
  - #409 DAVE stage scope
  - #410 Torch Compile recommendation
  - #411 NegPip Off/On/Turbo
- `docs/development/codex-execution-efficiency.md`
  - bounded context/task card
  - E0~E7 test ladder
  - final-full-once and evidence reuse
  - changed-path invalidation
  - current/follow-on/ordinary task test map
  - compact handoff/evidence template
- `docs/development/README.md`, `current-policies.md`, `docs/architecture/README.md`
  - 모든 시작 경로에서 효율 규약을 먼저 읽도록 연결

## 자동화 후속

Issue #416은 다음을 별도 후속으로 설계합니다.

```text
tools/check_scope.ps1 -Scope <name> -ChangedFrom <sha> -List|-Run
tools/test_scopes.json
```

unknown runtime path는 fail-closed하고, 선택된 test와 목적을 먼저 출력하며, 공식 full runner를 대체하지 않습니다. #415 hotfix는 이 tooling을 기다리지 않고 문서의 focused 명령을 즉시 사용합니다.

## 변경 유형

- [x] Documentation / execution-order update
- [x] Codex context/test-efficiency policy
- [ ] Production Python
- [ ] Frontend JavaScript
- [ ] Test behavior
- [ ] Schema/version/release metadata

## 검증

- GitHub compare 기준 production/test/workflow/profile/version 파일 변경 없음
- 문서 entrypoint에서 efficiency protocol과 active hotfix/advanced roadmaps를 순서화
- 문서-only PR이므로 project full runner와 live ComfyUI smoke는 실행하지 않음
- 구현 PR은 각 task card의 focused tests를 먼저 실행하고 최종 SHA에서 full/package/live gate를 1회 수행

## 리뷰 포인트

1. `quick`/`full`을 promotion gate로 제한하고 edit loop를 focused test로 고정한 것이 적절한지
2. test invalidation과 evidence reuse 규칙이 불필요한 반복을 충분히 막는지
3. #413 shared transaction Contract를 #414보다 먼저 두는 것이 적절한지
4. hotfix의 기본 patch 후보를 0.5.6으로 두는 것이 맞는지
5. #409/#410/#411과 #416을 hotfix 이후로 미룬 순서가 안전한지

Refs #167
Refs #169
Refs #184
Refs #185
Refs #187
Refs #395
Refs #409
Refs #410
Refs #411
Refs #413
Refs #414
Refs #415
Refs #416