### PR TITLE
test: QSTATE-01 queue UI stale-result Contract fixture 고정

### DIFF
--- a/tests/frontend_lora_preset_node_runtime_smoke.mjs
+++ b/tests/frontend_lora_preset_node_runtime_smoke.mjs
@@ -207,3 +207,23 @@ assert.ok(events.includes("loras:node-a"));
 events.length = 0;
 node.onExecuted({ lora_preset_profile: [{ profile_index: 2 }] });
 assert.deepEqual(events, ["executed:node-a", "profile:node-a"]);
+
+// QSTATE-01 characterization fixture: this intentionally passes while the
+// production bug exists. Profile 1 was queued before the user switched to
+// profile 2, and the real applyExecutedProfile() path currently restores
+// profile 1 over that edit. QSTATE-03 must flip this to a preservation assertion.
+events.length = 0;
+node.onExecuted({ lora_preset_profile: [{ profile_index: 1 }] });
+assert.deepEqual(events.slice(0, 6), [
+  "executed:node-a",
+  "save:node-a:2",
+  "set:1",
+  "load:node-a:1:false",
+  "scroll:node-a:1",
+  "profile:node-a",
+]);
+assert.equal(
+  node.__easyuseAnimaActiveProfileIndex,
+  1,
+  "QSTATE-01 fixture did not reproduce the stale LoRA profile overwrite",
+);

--- a/tests/frontend_prompt_studio_advanced_values_smoke.mjs
+++ b/tests/frontend_prompt_studio_advanced_values_smoke.mjs
@@ -106,4 +106,87 @@ assert(previous.mode === "sequential", "Advanced history did not normalize the m
 assert(dirtyCount === 1, "Advanced history publication did not dirty once");
 assert(renderCount === 1, "Advanced editor was not refreshed once");
 
+// QSTATE-01 characterization fixture: this intentionally passes while the
+// production bug exists. An Advanced/AdvancedV2 queue captured the submitted
+// values below, then the user edited every mutable surface group. The real
+// applyAdvancedExecutedInputs() path currently restores the submitted snapshot.
+// QSTATE-04 must flip this to a preservation assertion.
+const submittedFields = JSON.stringify([
+  { id: "positive_general", text: "queued old tags" },
+]);
+const editedFields = JSON.stringify([
+  { id: "positive_general", text: "current edited tags" },
+]);
+const staleNode = {
+  properties: {},
+  widgets: [
+    { name: "advanced_fields", value: editedFields },
+    { name: "use_naia", value: false },
+    { name: "resolution_bucket", value: "Custom" },
+    { name: "resolution_size", value: "1344 * 768" },
+    { name: "resolution_custom_width", value: 1344 },
+    { name: "resolution_custom_height", value: 768 },
+    { name: "wildcard_mode", value: "일반" },
+    { name: "wildcard_seed", value: 900 },
+    { name: "wildcard_seed_after_generate", value: "fixed" },
+    { name: "artist_mix_mode", value: "exact" },
+    { name: "artist_mix_start_percent", value: 0.75 },
+  ],
+};
+applyAdvancedExecutedInputs(
+  staleNode,
+  {
+    prompt_studio_advanced: [{
+      advanced_fields: submittedFields,
+      field_inputs: { field_positive_general: "queued socket value" },
+      use_naia: true,
+      resolution_bucket: "1024",
+      resolution_size: "1024 * 1024 (1:1)",
+      resolution_custom_width: 1024,
+      resolution_custom_height: 1024,
+      wildcard_mode: "순차",
+      wildcard_seed: 41,
+      wildcard_seed_after_generate: "increment",
+      artist_mix_mode: "average",
+      artist_mix_start_percent: 0.25,
+    }],
+  },
+  {
+    advancedWidget: (target) => target.widgets[0],
+    parseAdvancedFields: (target) => JSON.parse(target.widgets[0].value),
+    renderAdvancedEditor: () => {},
+  },
+);
+
+const staleWidgetValue = (name) => staleNode.widgets.find(
+  (widget) => widget.name === name,
+)?.value;
+assert(
+  staleWidgetValue("advanced_fields") === submittedFields,
+  "QSTATE-01 fixture did not reproduce the stale Advanced field overwrite",
+);
+assert(
+  staleNode.__easyuseAnimaAdvancedFieldInputValues.field_positive_general
+    === "queued socket value",
+  "QSTATE-01 fixture did not reproduce the stale Advanced field-input overwrite",
+);
+assert(
+  staleWidgetValue("resolution_bucket") === "1024"
+    && staleWidgetValue("resolution_size") === "1024 * 1024 (1:1)"
+    && staleWidgetValue("resolution_custom_width") === 1024
+    && staleWidgetValue("resolution_custom_height") === 1024,
+  "QSTATE-01 fixture did not reproduce the stale Advanced resolution overwrite",
+);
+assert(
+  staleWidgetValue("wildcard_mode") === "순차"
+    && staleWidgetValue("wildcard_seed") === 41
+    && staleWidgetValue("wildcard_seed_after_generate") === "increment",
+  "QSTATE-01 fixture did not reproduce the stale Advanced wildcard overwrite",
+);
+assert(
+  staleWidgetValue("artist_mix_mode") === "average"
+    && staleWidgetValue("artist_mix_start_percent") === 0.25,
+  "QSTATE-01 fixture did not reproduce the stale Advanced Artist Mix overwrite",
+);
+
 console.log("Prompt Studio Advanced executed values smoke passed.");

--- a/tests/frontend_prompt_studio_classic_values_smoke.mjs
+++ b/tests/frontend_prompt_studio_classic_values_smoke.mjs
@@ -1,0 +1,167 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+function dataModule(relativePath, replacements = {}) {
+  let source = readFileSync(new URL(relativePath, import.meta.url), "utf8");
+  for (const [specifier, replacement] of Object.entries(replacements)) {
+    source = source.replaceAll(`"${specifier}"`, `"${replacement}"`);
+  }
+  return `data:text/javascript;base64,${Buffer.from(source).toString("base64")}`;
+}
+
+function inlineModule(source) {
+  return `data:text/javascript;base64,${Buffer.from(source).toString("base64")}`;
+}
+
+const constantsUrl = inlineModule(`
+  export const EXTEND_ACTIVE_SLOTS_WIDGET = "active_slots";
+  export const EXTEND_VISIBLE_SLOTS_PROPERTY = "easyuse_anima_extend_visible_slots";
+`);
+const extendSlotsUrl = inlineModule(`
+  export function extendVisibleSlots(node) {
+    return node.__visibleSlots || new Set();
+  }
+  export function parseExtendSlots(value) {
+    if (Array.isArray(value)) return value;
+    if (typeof value !== "string") return [];
+    try {
+      const parsed = JSON.parse(value);
+      return Array.isArray(parsed) ? parsed : [];
+    } catch {
+      return [];
+    }
+  }
+  export function writeExtendVisibleSlots(node, slots) {
+    node.__visibleSlots = new Set(slots);
+  }
+`);
+const widgetsUrl = inlineModule(`
+  export function findInputEl(widget) {
+    return widget?.inputEl || null;
+  }
+  export function findWidget(node, name) {
+    return node?.widgets?.find((widget) => widget.name === name) || null;
+  }
+  export function firstValue(value, fallback) {
+    return Array.isArray(value) ? (value[0] ?? fallback) : (value ?? fallback);
+  }
+`);
+const highlightUrl = inlineModule(`
+  export function copyInputTextMetrics() {}
+  export function ensureHighlightOverlay() { return null; }
+  export function highlightOverlayHtml() { return ""; }
+  export function syncOverlayBounds() {}
+`);
+const settingsUrl = inlineModule(`
+  export function applyPromptStudioTextStyle() {}
+`);
+const highlightWidgetsUrl = inlineModule(`
+  export function findInputEl(widget) {
+    return widget?.inputEl || null;
+  }
+  export function isWidgetInputLinked(node, name) {
+    return node?.inputs?.some((input) => input?.name === name && input?.link != null) || false;
+  }
+`);
+const studioValuesUrl = dataModule(
+  "../web/js/prompt_studio/studio_values.js",
+  {
+    "./constants.js": constantsUrl,
+    "./extend_slots.js": extendSlotsUrl,
+    "./widgets.js": widgetsUrl,
+  },
+);
+const { applyExecutedInputs } = await import(studioValuesUrl);
+const highlightUiUrl = dataModule(
+  "../web/js/prompt_studio/highlight_ui.js",
+  {
+    "./highlight.js": highlightUrl,
+    "./settings.js": settingsUrl,
+    "./widgets.js": highlightWidgetsUrl,
+  },
+);
+const { displayText } = await import(highlightUiUrl);
+
+function textWidget(name, value) {
+  return {
+    name,
+    value,
+    inputEl: { value },
+  };
+}
+
+// QSTATE-01 Classic characterization fixture: this intentionally passes while
+// the production bug exists. The real applyExecutedInputs() path keeps the
+// stored edit but replaces the executed presentation state; the real
+// displayText() path then selects the stale result for a linked input.
+// QSTATE-04 must flip this to a preservation assertion.
+const classicPrompt = textWidget("prompt", "current classic edit");
+const classicNode = {
+  widgets: [classicPrompt],
+  inputs: [{ name: "prompt", link: 17 }],
+};
+applyExecutedInputs(
+  classicNode,
+  {
+    prompt_studio_inputs: [{
+      prompt: "queued classic text",
+    }],
+  },
+  {
+    studioFieldNames: () => ["prompt"],
+    expandStudioInputToContent: () => {},
+    hookStudioNode: () => {},
+  },
+);
+assert.equal(classicPrompt.value, "current classic edit");
+assert.equal(classicPrompt.inputEl.value, "current classic edit");
+assert.equal(
+  classicPrompt.__easyuseAnimaExecutedText,
+  "queued classic text",
+  "QSTATE-01 fixture did not reproduce the stale Classic executed-state overwrite",
+);
+assert.equal(
+  displayText(classicNode, classicPrompt),
+  "queued classic text",
+  "QSTATE-01 fixture did not reproduce the stale Classic linked-input presentation",
+);
+
+// QSTATE-01 Extend characterization fixture: this intentionally passes while
+// the production bug exists. The real applyExecutedInputs() path directly
+// restores submitted text, visibility, and NAIA state over the user's edit.
+// QSTATE-04 must flip this to a preservation assertion.
+const extendQuality = textWidget("quality_tags_1", "current extend edit");
+const extendFillNaia = { name: "fill_naia_prompt", value: false };
+const extendNode = {
+  widgets: [extendQuality, extendFillNaia],
+  __visibleSlots: new Set(["quality_tags_1", "general_tags_4"]),
+};
+applyExecutedInputs(
+  extendNode,
+  {
+    prompt_studio_slots: [{
+      quality_tags_1: "queued extend text",
+      active_slots: ["quality_tags_1"],
+      fill_naia_prompt: true,
+    }],
+  },
+  {
+    studioFieldNames: () => ["quality_tags_1"],
+    expandStudioInputToContent: () => {},
+    hookStudioNode: () => {},
+  },
+);
+assert.equal(
+  extendQuality.value,
+  "queued extend text",
+  "QSTATE-01 fixture did not reproduce the stale Extend widget overwrite",
+);
+assert.equal(
+  extendQuality.inputEl.value,
+  "queued extend text",
+  "QSTATE-01 fixture did not reproduce the stale Extend DOM overwrite",
+);
+assert.deepEqual([...extendNode.__visibleSlots], ["quality_tags_1"]);
+assert.equal(extendFillNaia.value, true);
+
+console.log("Prompt Studio Classic/Extend characterization smoke passed.");

--- a/tests/frontend_queue_ui_transaction_smoke.mjs
+++ b/tests/frontend_queue_ui_transaction_smoke.mjs
@@ -1,0 +1,430 @@
+import assert from "node:assert/strict";
+
+// QSTATE-01 contract-only fixture. This reference owner is deliberately local
+// to the test. QSTATE-02 replaces it with an import from
+// web/js/lifecycle/queue_ui_transaction.js and must keep this scenario table.
+//
+// Direct-owner identity evidence:
+// - app.queuePrompt's afterQueue callback can observe result.prompt_id.
+// - a captured frontend node supplies node_id, but the queue result does not
+//   supply the mapped/subgraph list_index component.
+// - current onExecuted(message) adapters receive feature UI payloads without
+//   prompt_id, node_id, or list_index.
+// - the backend seed execution context distinguishes invocations with
+//   prompt_id + node_id + list_index.
+//
+// Therefore a live commit requires the exact three-part identity below.
+// Missing host correlation is a QSTATE-02 blocker and always fails closed; it
+// does not authorize broader production wiring.
+const IDENTITY_DECISION = Object.freeze({
+  components: Object.freeze(["promptId", "nodeId", "listIndex"]),
+  queueResult: Object.freeze(["promptId"]),
+  executedUiPayload: Object.freeze([]),
+  unavailableIdentityPolicy: "fail-closed",
+});
+
+// Shared ownership ends at opaque surface tokens and their revisions. QSTATE-03
+// and QSTATE-04 feature adapters own atomic field catalogs, commit allowlists,
+// and actual commit payload validation.
+const TERMINAL_REASONS = new Set([
+  "cancel",
+  "reject",
+  "clear",
+  "remove",
+  "reconfigure",
+  "dispose",
+]);
+
+function createReferenceHarness() {
+  let sequence = 0;
+  const transactions = new Map();
+  const revisionsByNode = new Map();
+  const latestByNodeSurface = new Map();
+
+  function normalizedNodeId(nodeId) {
+    if (
+      typeof nodeId === "string"
+      && nodeId.trim() !== ""
+    ) {
+      return nodeId.trim();
+    }
+    if (typeof nodeId === "number" && Number.isInteger(nodeId)) {
+      return String(nodeId);
+    }
+    return null;
+  }
+
+  function normalizedIdentity(identity) {
+    const promptId = typeof identity?.promptId === "string"
+      ? identity.promptId.trim()
+      : "";
+    const nodeId = normalizedNodeId(identity?.nodeId);
+    const hasListIndex = Object.prototype.hasOwnProperty.call(
+      identity || {},
+      "listIndex",
+    );
+    const listIndex = identity?.listIndex;
+    const validListIndex = listIndex === null
+      || (
+        typeof listIndex === "number"
+        && Number.isInteger(listIndex)
+        && listIndex >= 0
+      );
+    if (!promptId || nodeId == null || !hasListIndex || !validListIndex) {
+      return null;
+    }
+    return { promptId, nodeId, listIndex };
+  }
+
+  function identityMatches(captured, result) {
+    const normalizedResult = normalizedIdentity(result);
+    return normalizedResult != null
+      && captured.promptId === normalizedResult.promptId
+      && captured.nodeId === normalizedResult.nodeId
+      && captured.listIndex === normalizedResult.listIndex;
+  }
+
+  function nodeRevisions(nodeId) {
+    let revisions = revisionsByNode.get(nodeId);
+    if (!revisions) {
+      revisions = new Map();
+      revisionsByNode.set(nodeId, revisions);
+    }
+    return revisions;
+  }
+
+  function revision(nodeId, surface) {
+    return revisionsByNode.get(nodeId)?.get(surface) || 0;
+  }
+
+  function validSurfaces(surfaces) {
+    return Array.isArray(surfaces)
+      && surfaces.length > 0
+      && surfaces.every(
+        (surface) => typeof surface === "string" && surface.trim() !== "",
+      );
+  }
+
+  function tracked(transaction) {
+    return Boolean(
+      transaction
+      && transactions.get(transaction.id) === transaction
+      && transaction.state === "pending",
+    );
+  }
+
+  function releaseTransaction(transaction) {
+    transactions.delete(transaction.id);
+    for (const surface of transaction.surfaces) {
+      const key = `${transaction.nodeId}:${surface}`;
+      if (latestByNodeSurface.get(key) === transaction.id) {
+        latestByNodeSurface.delete(key);
+      }
+    }
+  }
+
+  function capture({ identity, surfaces }) {
+    const normalized = normalizedIdentity(identity);
+    if (normalized == null || !validSurfaces(surfaces)) {
+      return null;
+    }
+    const id = `qstate-${++sequence}`;
+    const transaction = {
+      id,
+      identity: normalized,
+      nodeId: normalized.nodeId,
+      surfaces: [...new Set(surfaces.map((surface) => surface.trim()))],
+      revisions: {},
+      state: "pending",
+      reason: null,
+    };
+    for (const surface of transaction.surfaces) {
+      transaction.revisions[surface] = revision(transaction.nodeId, surface);
+      latestByNodeSurface.set(`${transaction.nodeId}:${surface}`, id);
+    }
+    transactions.set(id, transaction);
+    return transaction;
+  }
+
+  function markEdited(nodeId, surfaces) {
+    const normalized = normalizedNodeId(nodeId);
+    if (normalized == null || !validSurfaces(surfaces)) {
+      return false;
+    }
+    const revisions = nodeRevisions(normalized);
+    for (const surface of new Set(surfaces.map((value) => value.trim()))) {
+      revisions.set(surface, revision(normalized, surface) + 1);
+    }
+    return true;
+  }
+
+  function canCommit(transaction, resultIdentity, surface) {
+    if (!tracked(transaction) || !identityMatches(transaction.identity, resultIdentity)) {
+      return false;
+    }
+    if (!transaction.surfaces.includes(surface)) {
+      return false;
+    }
+    if (latestByNodeSurface.get(`${transaction.nodeId}:${surface}`) !== transaction.id) {
+      return false;
+    }
+    return revision(transaction.nodeId, surface) === transaction.revisions[surface];
+  }
+
+  function settle(transaction, resultIdentity) {
+    if (!tracked(transaction) || !identityMatches(transaction.identity, resultIdentity)) {
+      return false;
+    }
+    transaction.state = "settled";
+    releaseTransaction(transaction);
+    return true;
+  }
+
+  function cancel(transaction, reason = "cancel") {
+    if (!tracked(transaction) || !TERMINAL_REASONS.has(reason)) {
+      return false;
+    }
+    transaction.state = "cancelled";
+    transaction.reason = reason;
+    releaseTransaction(transaction);
+    return true;
+  }
+
+  function disposeNode(nodeId, reason = "dispose") {
+    const normalized = normalizedNodeId(nodeId);
+    if (
+      normalized == null
+      || !["remove", "reconfigure", "dispose"].includes(reason)
+    ) {
+      return false;
+    }
+    for (const transaction of [...transactions.values()]) {
+      if (transaction.nodeId === normalized) {
+        cancel(transaction, reason);
+      }
+    }
+    revisionsByNode.delete(normalized);
+    const prefix = `${normalized}:`;
+    for (const key of [...latestByNodeSurface.keys()]) {
+      if (key.startsWith(prefix)) {
+        latestByNodeSurface.delete(key);
+      }
+    }
+    return true;
+  }
+
+  const owner = {
+    capture,
+    markEdited,
+    canCommit,
+    settle,
+    cancel,
+    disposeNode,
+  };
+  const inspect = () => ({
+    transactionCount: transactions.size,
+    revisionNodeCount: revisionsByNode.size,
+    orderingReferenceCount: latestByNodeSurface.size,
+  });
+  return { owner, inspect };
+}
+
+const expectedApi = [
+  "capture",
+  "markEdited",
+  "canCommit",
+  "settle",
+  "cancel",
+  "disposeNode",
+].sort();
+assert.deepEqual(Object.keys(createReferenceHarness().owner).sort(), expectedApi);
+
+const scenarios = [
+  {
+    name: "identity is exact and unavailable components fail closed",
+    run({ owner }) {
+      const surfaces = ["surface-a"];
+      for (const identity of [
+        { nodeId: "7", listIndex: null },
+        { promptId: "prompt-a", nodeId: "7" },
+        { promptId: "prompt-a", nodeId: "7", listIndex: -1 },
+      ]) {
+        assert.equal(owner.capture({ identity, surfaces }), null);
+      }
+      const identity = {
+        promptId: "prompt-a",
+        nodeId: "7",
+        listIndex: null,
+      };
+      const transaction = owner.capture({ identity, surfaces });
+      assert(transaction);
+      assert.equal(owner.canCommit(transaction, identity, "surface-a"), true);
+      assert.equal(
+        owner.canCommit(
+          transaction,
+          { promptId: "prompt-a", nodeId: "7" },
+          "surface-a",
+        ),
+        false,
+      );
+      assert.equal(
+        owner.canCommit(
+          transaction,
+          { promptId: "prompt-b", nodeId: "7", listIndex: null },
+          "surface-a",
+        ),
+        false,
+      );
+    },
+  },
+  {
+    name: "list index distinguishes mapped and subgraph invocations",
+    run({ owner }) {
+      const identity = {
+        promptId: "prompt-list",
+        nodeId: "8",
+        listIndex: 0,
+      };
+      const transaction = owner.capture({
+        identity,
+        surfaces: ["surface-a"],
+      });
+      assert(transaction);
+      assert.equal(
+        owner.canCommit(
+          transaction,
+          { ...identity, listIndex: 1 },
+          "surface-a",
+        ),
+        false,
+      );
+      assert.equal(owner.canCommit(transaction, identity, "surface-a"), true);
+    },
+  },
+  {
+    name: "feature-defined surface revisions invalidate one atomic token",
+    run({ owner }) {
+      const identity = {
+        promptId: "prompt-edit",
+        nodeId: "9",
+        listIndex: null,
+      };
+      const transaction = owner.capture({
+        identity,
+        surfaces: ["surface-a", "surface-b"],
+      });
+      assert(transaction);
+      assert.equal(owner.markEdited("9", ["surface-a"]), true);
+      assert.equal(owner.canCommit(transaction, identity, "surface-a"), false);
+      assert.equal(owner.canCommit(transaction, identity, "surface-b"), true);
+      assert.equal(owner.canCommit(transaction, identity, "unknown-surface"), false);
+    },
+  },
+  {
+    name: "latest capture wins while older diagnostic settlement remains valid",
+    run({ owner, inspect }) {
+      const olderIdentity = {
+        promptId: "prompt-old",
+        nodeId: "10",
+        listIndex: null,
+      };
+      const newerIdentity = {
+        promptId: "prompt-new",
+        nodeId: "10",
+        listIndex: null,
+      };
+      const older = owner.capture({
+        identity: olderIdentity,
+        surfaces: ["surface-a"],
+      });
+      const newer = owner.capture({
+        identity: newerIdentity,
+        surfaces: ["surface-a"],
+      });
+      assert(older && newer);
+      assert.equal(owner.canCommit(older, olderIdentity, "surface-a"), false);
+      assert.equal(owner.canCommit(newer, newerIdentity, "surface-a"), true);
+      assert.equal(owner.settle(older, olderIdentity), true);
+      assert.equal(inspect().transactionCount, 1);
+      assert.equal(owner.canCommit(newer, newerIdentity, "surface-a"), true);
+      assert.equal(owner.settle(newer, newerIdentity), true);
+      assert.equal(owner.settle(newer, newerIdentity), false);
+      assert.equal(inspect().transactionCount, 0);
+      assert.equal(inspect().orderingReferenceCount, 0);
+    },
+  },
+  {
+    name: "cancel reject and clear remove terminal transaction references",
+    run({ owner, inspect }) {
+      for (const [index, reason] of ["cancel", "reject", "clear"].entries()) {
+        const identity = {
+          promptId: `prompt-${reason}`,
+          nodeId: `11-${index}`,
+          listIndex: null,
+        };
+        const transaction = owner.capture({
+          identity,
+          surfaces: ["surface-a"],
+        });
+        assert(transaction);
+        assert.equal(owner.cancel(transaction, reason), true);
+        assert.equal(owner.canCommit(transaction, identity, "surface-a"), false);
+        assert.equal(owner.cancel(transaction, reason), false);
+        assert.equal(inspect().transactionCount, 0);
+        assert.equal(inspect().orderingReferenceCount, 0);
+      }
+    },
+  },
+  {
+    name: "remove reconfigure and dispose release every node reference",
+    run({ owner, inspect }) {
+      for (const [index, reason] of ["remove", "reconfigure", "dispose"].entries()) {
+        const nodeId = `12-${index}`;
+        const firstIdentity = {
+          promptId: `prompt-${reason}-0`,
+          nodeId,
+          listIndex: 0,
+        };
+        const secondIdentity = {
+          promptId: `prompt-${reason}-1`,
+          nodeId,
+          listIndex: 1,
+        };
+        const first = owner.capture({
+          identity: firstIdentity,
+          surfaces: ["surface-a"],
+        });
+        const second = owner.capture({
+          identity: secondIdentity,
+          surfaces: ["surface-b"],
+        });
+        assert(first && second);
+        assert.equal(owner.markEdited(nodeId, ["surface-a"]), true);
+        assert.equal(owner.disposeNode(nodeId, reason), true);
+        assert.equal(owner.canCommit(first, firstIdentity, "surface-a"), false);
+        assert.equal(owner.canCommit(second, secondIdentity, "surface-b"), false);
+        assert.deepEqual(inspect(), {
+          transactionCount: 0,
+          revisionNodeCount: 0,
+          orderingReferenceCount: 0,
+        });
+      }
+    },
+  },
+];
+
+for (const scenario of scenarios) {
+  scenario.run(createReferenceHarness());
+}
+
+assert.deepEqual(
+  IDENTITY_DECISION,
+  {
+    components: ["promptId", "nodeId", "listIndex"],
+    queueResult: ["promptId"],
+    executedUiPayload: [],
+    unavailableIdentityPolicy: "fail-closed",
+  },
+);
+
+console.log(`Queue UI transaction contract smoke passed: ${scenarios.length} scenarios.`);

--- a/tools/check_frontend.ps1
+++ b/tools/check_frontend.ps1
@@ -159,9 +159,19 @@ try {
         throw "Frontend host hook registry smoke failed with exit code $LASTEXITCODE."
     }
 
+    & node "tests\frontend_queue_ui_transaction_smoke.mjs"
+    if ($LASTEXITCODE -ne 0) {
+        throw "Frontend queue UI transaction contract smoke failed with exit code $LASTEXITCODE."
+    }
+
     & node "tests\frontend_prompt_studio_advanced_values_smoke.mjs"
     if ($LASTEXITCODE -ne 0) {
         throw "Frontend Prompt Studio Advanced executed values smoke failed with exit code $LASTEXITCODE."
+    }
+
+    & node "tests\frontend_prompt_studio_classic_values_smoke.mjs"
+    if ($LASTEXITCODE -ne 0) {
+        throw "Frontend Prompt Studio Classic/Extend characterization smoke failed with exit code $LASTEXITCODE."
     }
 
     & node "tests\frontend_prompt_studio_resolution_orientation_smoke.mjs"


### PR DESCRIPTION
## 변경 요약

Issue #413 / #415의 QSTATE-01 acceptance를 고정하는 test-only Contract PR입니다.

- LoRA Preset, Prompt Studio Advanced/AdvancedV2, Classic/Extend의 현재 stale-result destructive mutation을 실제 production 함수 경로로 재현합니다.
- characterization assertion은 **현재 버그가 실제 발생하므로 의도적으로 통과**합니다. 영구 preservation contract가 아니며 QSTATE-03/04 feature cutover에서 동일 시나리오를 stale-result 차단 assertion으로 전환해야 합니다.
- `frontend_queue_ui_transaction_smoke.mjs`에는 QSTATE-02 shared owner가 소유할 identity/revision/ordering/settlement/cancel/disposal 계약만 test-local reference fixture로 고정합니다.
- production 파일은 변경하지 않았습니다.

## 변경 파일

- `tests/frontend_lora_preset_node_runtime_smoke.mjs`
- `tests/frontend_prompt_studio_advanced_values_smoke.mjs`
- `tests/frontend_prompt_studio_classic_values_smoke.mjs`
- `tests/frontend_queue_ui_transaction_smoke.mjs`
- `tools/check_frontend.ps1`

## Characterization assertions

- **LoRA:** 실제 `createLoraPresetNodeRuntime()`의 `onExecuted` wrapper가 내부 `applyExecutedProfile()`을 호출합니다. 사용자가 profile 2로 바꾼 뒤 profile 1의 오래된 결과가 도착하면 active profile을 1로 되돌리고 profile 2 저장 및 profile 1 load를 수행하는 destructive mutation을 검증합니다.
- **Advanced/AdvancedV2:** 실제 `applyAdvancedExecutedInputs()`를 호출합니다. 오래된 결과가 현재 `advanced_fields`/`field_inputs`, resolution, wildcard, Artist Mix widget 값을 submitted snapshot으로 되돌리는 destructive mutation을 검증합니다.
- **Classic:** 실제 `applyExecutedInputs()`가 linked input의 `__easyuseAnimaExecutedText`를 오래된 결과로 교체하고, 실제 `highlight_ui.displayText()`가 최신 stored edit 대신 그 stale text를 표시 대상으로 선택함을 검증합니다.
- **Extend:** 실제 `applyExecutedInputs()`가 현재 widget/DOM text, visible slots, `fill_naia_prompt`를 오래된 slot payload로 되돌리는 destructive mutation을 검증합니다.

Mock은 module import를 가능하게 하는 host/dependency seam만 대체하며, 위 mutation assignment와 표시 선택을 수행하는 production 함수 본문은 대체하지 않습니다.

## Invocation identity 대조

- Frontend submission: 기존 `queuePrompt` wrapper의 `afterQueue`는 accepted result를 전달하므로 `result.prompt_id`를 관찰할 수 있고, capture 대상 frontend node에서 `node_id`를 알 수 있습니다. 그러나 queue result에는 mapped/subgraph invocation을 구분하는 `list_index`가 없습니다.
- Frontend execution result: 현재 node `onExecuted(message)` adapter와 backend UI payload에는 `prompt_id`, `node_id`, `list_index`가 포함되지 않습니다. 확인한 AiO seed UI payload는 `execution_seed`, `next_seed`만 전달합니다.
- Backend seed execution identity: `comfy_execution` context의 `prompt_id + node_id + list_index`를 사용하며, `list_index`의 `None`, `0`, `1`은 서로 다른 request identity입니다.
- 결정: shared Contract identity는 정확한 `promptId + nodeId + listIndex`입니다. `listIndex`는 `null` 또는 non-negative integer이며 누락은 허용하지 않습니다. 세 component를 frontend submission과 execution result 사이에서 결정적으로 연결할 수 없는 현재 경로는 live commit을 fail-closed로 거부합니다. QSTATE-02에서 host identity를 확인하지 못하면 production 범위를 넓히지 않고 blocker로 반환합니다.

## Contract decisions

- Shared owner scope: identity, per-surface edit revision, latest ordering, settlement, cancel, node disposal만 소유합니다.
- Surface: feature adapter가 전달하는 opaque atomic surface token의 revision만 shared owner가 추적합니다. shared owner에는 LoRA/Prompt Studio/AiO field catalog가 없습니다.
- Feature ownership: field allowlist, atomic field payload 검증, 실제 commit payload는 QSTATE-03/04 feature adapter 책임입니다.
- Ordering: 같은 node/surface의 latest capture만 live commit할 수 있습니다. duplicate/out-of-order 결과는 live commit할 수 없습니다.
- Settlement: 오래된 transaction은 live commit은 불가하지만 identity가 정확하면 history/diagnostic settlement는 가능합니다. `settle`은 terminal transaction 참조를 제거하며 duplicate settlement는 false입니다.
- Terminal state: cancel/reject/clear와 remove/reconfigure/dispose 이후에는 commit할 수 없습니다.

## QSTATE-02 handoff

```text
Candidate owner:
web/js/lifecycle/queue_ui_transaction.js

Minimum API:
capture
markEdited
canCommit
settle
cancel
disposeNode

Allowed production files:
공통 transaction owner와 필요한 최소 lifecycle wiring만

Forbidden:
LoRA/Prompt Studio feature cutover
AiO seed semantics 변경
generic event bus/service locator
workflow/public socket 변경
```

QSTATE-02 exit gate:

- exact `promptId + nodeId + listIndex` correlation을 실제 host lifecycle에서 확보하거나, 확보 불가를 blocker로 반환합니다.
- settled/cancelled transaction을 active lookup과 ordering reference에서 제거합니다.
- node remove/reconfigure/dispose 후 transaction, revision, ordering 참조를 모두 해제합니다.
- shared owner에 feature field catalog/allowlist/commit payload를 추가하지 않습니다.
- common owner와 최소 lifecycle wiring을 넘어 feature cutover가 필요하면 중단합니다.

## Compact evidence

```text
Task: QSTATE-01 / #413
Class: CONTRACT
Base -> Head: df74cf9f65d481936122245e90db269113340c78 -> a14de117601a0af3ba2a0ca0013d13a7a870f6cd
Changed boundary: fixture와 frontend runner만
Characterization assertions: applyExecutedProfile / applyAdvancedExecutedInputs / applyExecutedInputs의 현재 destructive mutation을 실제 production 경로로 관찰
Contract decisions: promptId+nodeId+listIndex exact identity, opaque surface revision, latest-only commit, ambiguous fail-closed, diagnostic settlement와 terminal cleanup, node disposal reference release; field allowlist/commit payload는 QSTATE-03/04 feature adapter 소유
Focused:
- node --check tests/frontend_queue_ui_transaction_smoke.mjs — 변경 fixture syntax; PASS
- node tests/frontend_queue_ui_transaction_smoke.mjs — identity/listIndex/revision/ordering/settlement/cleanup 6 scenarios; PASS (sandbox spawn access failure 후 승인된 non-sandbox 1회 재실행)
- git diff --check — patch hygiene; PASS
Full: powershell -ExecutionPolicy Bypass -File D:\ComfyUI\custom_nodes_workplace\tools\check_custom_node.ps1 -Project D:\ComfyUI\custom_nodes_workplace\worktrees\ComfyUI-EasyUseAnima\codex\qstate-01-stale-result-fixtures -Profile full; exact SHA a14de117601a0af3ba2a0ca0013d13a7a870f6cd; PASS, 1151 tests, frontend checks 115 JS files
Package: not triggered
Live: not triggered
Rollback: fixture/Contract commit a14de117601a0af3ba2a0ca0013d13a7a870f6cd
Next: QSTATE-02 after review and merge
```

검증 표면: repository full / frontend smoke. Package와 live ComfyUI는 실행하지 않았습니다.

## 남은 위험

- queue transaction owner는 아직 production에 존재하지 않습니다. 현재 reference contract는 test-local이며 QSTATE-02에서 candidate owner import로 교체해야 합니다.
- 현재 frontend execution result에는 exact identity가 없어 live commit은 fail-closed입니다. QSTATE-02는 이 identity를 최소 lifecycle wiring으로 확보하지 못하면 blocker로 반환해야 합니다.
- 이 PR은 stale mutation을 수정하지 않습니다. 실제 LoRA/Prompt Studio cutover 전까지 characterization assertion은 현재 결함을 재현하며 통과합니다.

라벨: `type: chore`, `area: frontend`, `status: draft`.