### PR TITLE
docs: revise queue UI hotfix around two-phase correlation

### DIFF
--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -21,9 +21,12 @@ section, owning Issue, direct owner files, and direct tests.
   is the current implementation and release owner for the queue/live-UI
   regressions in [#413](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/413)
   and [#414](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/414).
-  While #415 is open, read
-  [`queue-ui-execution-state-hotfix.md`](queue-ui-execution-state-hotfix.md)
-  **before** the ordinary backend roadmap or any AiO advanced-integration plan.
+  QSTATE-01 is merged. QSTATE-02A proved that backend `list_index` does not exist
+  at frontend submission-capture time. While #415 remains open, read
+  [`queue-ui-two-phase-correlation-addendum.md`](queue-ui-two-phase-correlation-addendum.md)
+  **before** the original
+  [`queue-ui-execution-state-hotfix.md`](queue-ui-execution-state-hotfix.md),
+  the ordinary backend roadmap, or an AiO advanced-integration plan.
 - Issue [#395](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/395)
   separately tracks the external Comfy Registry activation checkpoint for the
   immutable 0.5.5 release. Waiting for that external approval does not block
@@ -45,11 +48,17 @@ section, owning Issue, direct owner files, and direct tests.
   cross-roadmap Codex context budget, work-packet format, test ladder, invalidation
   rules, compact evidence format, and scoped test maps for #413/#414, #409/#410/#411,
   and ordinary backend work.
+- [`queue-ui-two-phase-correlation-addendum.md`](queue-ui-two-phase-correlation-addendum.md):
+  active correction after QSTATE-02A. It separates provisional submission,
+  accepted `promptId`, and the executed-event envelope; removes mandatory
+  `listIndex` from the node-level stale-result critical path; defines cache,
+  subgraph, mapped-result, transaction-core, and envelope-bridge boundaries; and
+  provides the current Codex start instruction.
 - [`queue-ui-execution-state-hotfix.md`](queue-ui-execution-state-hotfix.md):
-  active queue-first runbook for stale LoRA/Prompt Studio execution results
-  (#413), rgthree-compatible AiO special-seed display semantics (#414), the
-  shared transaction/revision Contract, integrated validation, and the patch
-  release gate owned by #415.
+  base runbook for stale LoRA/Prompt Studio execution results (#413),
+  rgthree-compatible AiO special-seed display semantics (#414), integrated
+  validation, and the patch release gate owned by #415. Its exact-identity-at-
+  submission assumptions are superseded by the two-phase addendum.
 - [`python-backend.md`](python-backend.md): living architecture, ownership,
   execution phases, validation gates, and overall Definition of Done.
 - [`python-backend-execution-roadmap.md`](python-backend-execution-roadmap.md):

--- a/docs/architecture/queue-ui-two-phase-correlation-addendum.md
+++ b/docs/architecture/queue-ui-two-phase-correlation-addendum.md
@@ -1,0 +1,392 @@
+# Queue UI Two-Phase Correlation Addendum
+
+## Status and authority
+
+- Status: active sequencing correction for Issues #413 and #415
+- Snapshot branch: `dev`
+- Snapshot commit: `0caf4e7cd79f01ab5f65bd9c6171b8bdfe31ec7f`
+- Completed prerequisites:
+  - PR #412 merged as `c3d97ccf9a390220c887542b3249315a12fe6284`
+  - PR #417 merged as `0caf4e7cd79f01ab5f65bd9c6171b8bdfe31ec7f`
+- Supersedes: the exact-identity-at-submission assumption in the QSTATE-01/QSTATE-02 sections of `queue-ui-execution-state-hotfix.md`
+- Does not supersede: the stale-result preservation rule, feature ownership boundaries, hotfix release gate, or test-escalation policy
+
+QSTATE-02A correctly stopped before production changes. It proved that ComfyUI does
+not know the effective `list_index` when the frontend captures the user's queue
+snapshot. `list_index` is created later inside the backend node invocation. The
+previous Contract therefore required information before the host could produce it.
+
+This addendum removes that false dependency without weakening stale-result safety.
+
+## 1. Verified host facts
+
+The following facts were checked against the current Easy Use Anima `dev` tree and
+the inspected ComfyUI/ComfyUI_frontend versions.
+
+1. The frontend knows the local node instance and edit revisions before queueing.
+2. `queuePrompt()` returns an accepted `prompt_id` only after the server accepts the
+   submission.
+3. The ComfyUI backend creates `list_index` inside `CurrentNodeContext` while mapping
+   one effective node invocation.
+4. The websocket `executed` event carries the current `prompt_id`, execution node id,
+   display node id, and output object.
+5. ComfyUI core passes only `detail.output` to `node.onExecuted()` and drops the outer
+   envelope at that boundary.
+6. `ComfyApi` is an `EventTarget`; its `addEventListener()` forwards capture options.
+7. UI output is cacheable. A volatile `prompt_id` or provisional submission token
+   must not be stamped into cacheable UI output merely to recover frontend identity.
+8. Mapped UI values are flattened in invocation order. An output array with multiple
+   items is ambiguous for an editable next-state commit unless a feature explicitly
+   defines aggregation.
+9. For subgraphs, the backend execution node id and the frontend display node may be
+   different. Core routing to the frontend node is authoritative for local UI
+   ownership.
+
+## 2. Corrected identity model
+
+The hotfix uses two required identity phases and one optional invocation phase.
+
+### 2.1 Provisional submission
+
+Created before `queuePrompt()` calls the host.
+
+```text
+local transaction id
+frontend node object / node epoch
+opaque feature surface tokens
+captured edit revisions
+local queue sequence
+```
+
+This phase does not contain `prompt_id` or `list_index`.
+
+### 2.2 Accepted submission
+
+Created only after `queuePrompt()` succeeds.
+
+```text
+provisional transaction
++ accepted promptId
+```
+
+A rejected queue cancels the provisional transaction. A result without a matching
+accepted `promptId` cannot mutate editable state.
+
+### 2.3 Executed-event envelope
+
+Recovered from the outer ComfyUI `executed` event rather than from cacheable feature
+payloads.
+
+```text
+promptId
+executionNodeId
+optional displayNodeId
+exact output object passed to node.onExecuted()
+```
+
+A narrow capture-phase listener records the envelope in a `WeakMap` keyed by the
+output object. `node.onExecuted(message)` consumes that envelope synchronously. The
+entry is removed on consume and by bounded fallback cleanup.
+
+### 2.4 Optional per-invocation identity
+
+`listIndex` is required only when a feature intends to commit one specific mapped
+invocation to editable state.
+
+For this hotfix:
+
+- one feature payload item may use the accepted submission identity;
+- zero payload items perform no commit;
+- multiple payload items are history/diagnostic only by default;
+- mapped editable commit remains fail-closed until that feature defines and tests an
+  aggregation or backend invocation-stamp Contract.
+
+The critical path therefore does not require backend `list_index` stamping.
+
+## 3. Cache, subgraph, and compatibility rules
+
+### Cache
+
+- The executed-event envelope `promptId` is authoritative for the current run.
+- Do not place `promptId`, a random frontend transaction token, or another volatile
+  submission id in cacheable UI output.
+- A cached result may update preview/history when its current event envelope matches.
+- A cached result may update editable next state only when the accepted transaction,
+  feature revision, and single-item policy all pass.
+
+### Subgraph and display routing
+
+- Key editable ownership by the actual frontend node object and a node lifecycle
+  epoch, not by assuming that its id equals the backend execution node id.
+- Preserve `executionNodeId` and `displayNodeId` as diagnostics and optional feature
+  checks.
+- When ComfyUI cannot route an output to the intended frontend node, do not search the
+  whole graph and guess a target.
+
+### Missing host data
+
+- Missing event envelope, missing `promptId`, cloned output identity, or disposed node
+  means no editable commit.
+- These paths may still publish safe global diagnostics that do not reference a live
+  node.
+- Do not add public sockets, workflow fields, a generic event bus, or a backend server
+  patch to recover identity in this hotfix.
+
+## 4. Revised critical path
+
+```text
+DONE: QSTATE-01   characterization and original Contract fixtures (PR #417)
+DONE: QSTATE-02A  host feasibility probe; exact listIndex-at-capture rejected
+  -> READY: QSTATE-02B  two-phase submission/envelope Contract amendment
+  -> QSTATE-02C  shared transaction core
+       +
+     QSTATE-02D  narrow executed-event envelope bridge
+  -> QSTATE-03  LoRA execution-result replay retirement
+       +
+     QSTATE-04  Prompt Studio feature-owned cutover
+  -> AIO-SEED-UI-01/02/03
+  -> HOTFIX-RC-01
+  -> 0.5.6 preparation/publication
+```
+
+After QSTATE-02B is merged, QSTATE-03 may proceed in parallel with QSTATE-02C/D if it
+removes live profile replay and does not introduce a second transaction framework.
+QSTATE-04 and AIO frontend compare-and-commit wait for QSTATE-02C/D.
+
+## 5. QSTATE-02B — Two-phase Contract amendment
+
+### Type
+
+`CONTRACT`. No production behavior change.
+
+### Required changes
+
+Update the reference transaction fixture so it proves:
+
+- provisional capture does not require host-generated identity;
+- successful queue acceptance binds an exact `promptId`;
+- rejection cancels provisional state;
+- the executed envelope is matched by `promptId` and frontend node ownership;
+- edit revision, latest queue ordering, settlement, and node disposal remain intact;
+- multiple mapped payload items cannot commit editable state by default;
+- missing envelope and cloned/unknown output fail closed;
+- terminal transactions and ordering references are bounded and released.
+
+Add a focused executed-event context fixture that models this ordering:
+
+```text
+ComfyUI core registers a normal executed listener
+Easy Use Anima later registers a capture listener
+executed event dispatch
+capture listener records detail.output -> envelope
+core listener invokes node.onExecuted(detail.output)
+node adapter consumes the exact envelope
+entry is released
+```
+
+### Candidate files
+
+```text
+tests/frontend_queue_ui_transaction_smoke.mjs
+tests/frontend_executed_event_context_smoke.mjs
+tools/check_frontend.ps1                 # only when registering the new smoke
+```
+
+### Focused validation
+
+```powershell
+node --check tests/frontend_queue_ui_transaction_smoke.mjs
+node --check tests/frontend_executed_event_context_smoke.mjs
+node tests/frontend_queue_ui_transaction_smoke.mjs
+node tests/frontend_executed_event_context_smoke.mjs
+git diff --check
+```
+
+Run the official full runner once on the final Contract PR SHA. Package and live
+ComfyUI checks are not triggered.
+
+### Exit gate
+
+- the fixture no longer requires `listIndex` during provisional capture;
+- event-envelope and output-object correlation is deterministic in the fixture;
+- mapped/multiple-result behavior is explicitly fail-closed;
+- no production module or feature adapter is implemented;
+- QSTATE-02C/D file boundaries and stop conditions are frozen.
+
+## 6. QSTATE-02C — Shared transaction core
+
+### Candidate owner
+
+```text
+web/js/lifecycle/queue_ui_transaction.js
+```
+
+### Minimum responsibilities
+
+```text
+captureProvisional(node, surfaces)
+acceptPrompt(transaction, promptId)
+markEdited(node, surfaces)
+canCommit(transaction, envelope, surface)
+settle(transaction)
+cancel(transaction, reason)
+finishPrompt(promptId)
+disposeNode(node)
+```
+
+Names may change, but responsibilities may not expand.
+
+The core owns only:
+
+- local node lifecycle epoch;
+- opaque surface revisions;
+- prompt acceptance;
+- latest submission ordering;
+- compare eligibility;
+- terminal cleanup and bounded retention.
+
+It does not own feature fields, profile data, prompt schemas, payload parsing, or DOM
+mutation.
+
+### Focused validation
+
+```powershell
+node --check web/js/lifecycle/queue_ui_transaction.js
+node tests/frontend_queue_ui_transaction_smoke.mjs
+git diff --check
+```
+
+No browser smoke is required before a feature adapter consumes the core. Run the
+full runner once on the final PR SHA.
+
+## 7. QSTATE-02D — Executed-event envelope bridge
+
+### Candidate owner
+
+```text
+web/js/lifecycle/executed_event_context.js
+```
+
+### Responsibilities
+
+- idempotently install one `executed` capture listener on the Comfy API host;
+- record only the current event envelope keyed by the exact output object;
+- expose synchronous consume/peek behavior to node adapters;
+- delete entries on consume and bounded fallback cleanup;
+- publish prompt terminal cleanup for `execution_success`, `execution_error`, and
+  `execution_interrupted` when available;
+- remove listeners on runtime retirement.
+
+It is not a generic event bus and does not register feature callbacks.
+
+### Focused validation
+
+```powershell
+node --check web/js/lifecycle/executed_event_context.js
+node tests/frontend_executed_event_context_smoke.mjs
+node tests/frontend_queue_ui_transaction_smoke.mjs
+git diff --check
+```
+
+Add `frontend_host_hook_registry_smoke.mjs` only if that existing owner is modified.
+Live validation waits for QSTATE-03/04.
+
+### Stop conditions
+
+Stop and record a blocker if:
+
+- the supported frontend does not run a later-registered capture listener before the
+  core normal listener;
+- core clones `detail.output` before calling `node.onExecuted()`;
+- the bridge requires patching ComfyUI core or replacing `api.dispatchEvent`;
+- a public workflow field or node socket becomes necessary;
+- the implementation starts collecting feature-specific payloads.
+
+Only these conditions justify another PRO-level review.
+
+## 8. Feature cutover corrections
+
+### QSTATE-03 — LoRA Preset
+
+The backend `profile_index` result is execution metadata, not authority over the
+current profile editor.
+
+Default implementation:
+
+- retire execution-result calls to `saveProfile`, `setProfileIndex`, `loadProfile`,
+  profile scrolling, and editable rerender;
+- optionally store the executed index in a non-editable history/status field;
+- do not add transaction complexity unless a real editable next-state requirement is
+  demonstrated.
+
+This task can proceed after QSTATE-02B without waiting for the envelope bridge when it
+only removes live replay.
+
+### QSTATE-04 — Prompt Studio
+
+Classify result fields before wiring the transaction owner.
+
+Never replay these submitted snapshots into current editable state:
+
+```text
+advanced_fields / field_inputs
+base resolution selection
+Artist Mix settings
+Classic/Extend widget and slot state
+current profile-like editor structure
+```
+
+Feature-owned compare-and-commit is reserved for intentional next state such as:
+
+```text
+accepted NAIA fill result
+wildcard next seed/control where still current
+non-editable previous-execution history
+linked-input execution presentation
+```
+
+A payload containing multiple mapped items performs no editable commit unless a
+separate feature Contract defines aggregation.
+
+### AiO seed
+
+- special tokens `-1/-2/-3` never require `listIndex` to remain visible;
+- concrete execution seed stays history/last-seed state;
+- only a concrete editable after-generate update uses prompt transaction revision;
+- use the executed-event envelope for `promptId`; do not stamp it into cacheable UI
+  payloads.
+
+## 9. Terminal cleanup and practical bounds
+
+Deterministic host signals should be used when available, but the hotfix does not wrap
+every queue-management API merely to observe pending-job deletion.
+
+Required cleanup:
+
+- queue rejection cancels provisional state;
+- node remove/reconfigure/workflow reload disposes node state;
+- execution success/error/interrupted finishes accepted prompt state;
+- settlement removes completed transactions;
+- a small per-node/per-prompt cap evicts superseded transactions that receive no
+  terminal host event.
+
+Do not introduce polling, long-lived timers, or an unbounded history map.
+
+## 10. Codex continuation instruction
+
+```text
+Use the existing clean branch/worktree codex/qstate-02-transaction-owner.
+Read only this addendum, Issues #413/#415 latest decisions, the merged QSTATE-01
+fixture, ComfyUI executed-event adapter, and the direct tests.
+
+Start QSTATE-02B only. Amend the reference Contract from exact identity at provisional
+capture to provisional -> accepted promptId -> executed envelope. Add the narrow
+EventTarget ordering/output-object fixture. Do not implement production modules.
+
+Run changed-file syntax, the two focused smokes, and git diff --check during the edit
+loop. Run the official full runner once on the final candidate SHA. Push and open a
+dev-targeting Draft PR with compact evidence.
+
+After QSTATE-02B review/merge, continue with QSTATE-02C and QSTATE-02D as separate PRs.
+Request another PRO review only if a listed QSTATE-02D stop condition is observed.
+```

--- a/docs/development/README.md
+++ b/docs/development/README.md
@@ -11,12 +11,16 @@ conversation.
    - use focused edit-loop tests;
    - run the official full runner once per final candidate SHA;
    - escalate to package, live, and benchmark evidence only when triggered.
-3. Python backend architecture or migration work:
+3. While Issue #415 owns the active hotfix, read
+   [`docs/architecture/queue-ui-two-phase-correlation-addendum.md`](../architecture/queue-ui-two-phase-correlation-addendum.md)
+   and only the current task section. It supersedes the original exact-identity-
+   at-submission assumption after the QSTATE-02A blocker.
+4. Python backend architecture or migration work:
    [`docs/architecture/README.md`](../architecture/README.md)
-4. Active frontend maintenance execution plan:
+5. Active frontend maintenance execution plan:
    `docs/development/frontend-maintenance-execution-plan.md`
-5. Current release candidate: `docs/development/0.5.5.md`
-6. Relevant topic guide:
+6. Current released baseline: `docs/development/0.5.5.md`
+7. Relevant topic guide:
    - Registry publish or flagged-version prevention:
      `docs/development/registry-scanner-safety.md`
    - workflow docs or release templates: `docs/Anima AiO/Workflow_Management.md`
@@ -31,8 +35,8 @@ conversation.
    - deferred Node 2.0 DOM widget resize investigation:
      `docs/development/node2-dom-widget-resize-limitation.md`
    - language or locale work: `docs/development/language-management.md`
-7. `git status --short`
-8. Relevant source and tests for the target area.
+8. `git status --short`
+9. Relevant source and tests for the target area.
 
 Do not read every roadmap or historical document by default. The efficiency
 protocol defines the maximum initial context and the conditions that justify
@@ -43,11 +47,13 @@ expanding it.
 - Current policy baseline: `docs/development/current-policies.md`
 - Codex work-packet, test-escalation, evidence-reuse, and token policy:
   [`docs/development/codex-execution-efficiency.md`](codex-execution-efficiency.md)
+- Active queue/live-UI correlation correction:
+  [`docs/architecture/queue-ui-two-phase-correlation-addendum.md`](../architecture/queue-ui-two-phase-correlation-addendum.md)
 - Python backend architecture and compatibility-shim registry:
   [`docs/architecture/README.md`](../architecture/README.md)
 - Active frontend maintenance execution ledger:
   `docs/development/frontend-maintenance-execution-plan.md`
-- Current release candidate: `docs/development/0.5.5.md`
+- Current released baseline: `docs/development/0.5.5.md`
 - Registry scanner safety: `docs/development/registry-scanner-safety.md`
 - Older implementation history: `docs/version-plans/`
 - Public workflow JSON templates and preview/source images: `docs/example_workflows/`
@@ -116,7 +122,7 @@ targeted symbol search; do not automatically read every listed file.
 ### Edit loop
 
 Use only changed-file syntax checks and the task-specific focused tests listed in
-`codex-execution-efficiency.md` or the owning Issue.
+`codex-execution-efficiency.md`, the active two-phase addendum, or the owning Issue.
 
 ```text
 node --check web/js/<changed-file>.js


### PR DESCRIPTION
## 요약

QSTATE-02A가 확인한 `listIndex` 생성 시점 blocker를 반영해, queue/live-UI hotfix의 identity와 실행 순서를 수정합니다.

기존 Contract는 frontend submission capture 시점에 `promptId + nodeId + listIndex`를 요구했지만, `listIndex`는 backend invocation 안에서만 생성됩니다. 이번 문서는 해당 가정을 다음 구조로 교체합니다.

```text
provisional local capture
  -> queue acceptance / promptId
  -> executed-event envelope
  -> optional per-invocation listIndex only when a feature needs it
```

## 핵심 결정

- node-level stale-result 보호에는 accepted `promptId`, frontend node lifecycle, surface revision을 사용합니다.
- ComfyUI `executed` event의 outer envelope가 current `promptId`의 source of truth입니다.
- `node.onExecuted(output)` 경계에서 사라지는 envelope는 capture-phase listener와 output-object `WeakMap`으로 좁게 전달합니다.
- volatile `promptId`나 random transaction token을 cacheable UI payload에 넣지 않습니다.
- mapped result가 여러 개인 경우 editable commit은 기본 fail-closed입니다.
- `listIndex`는 실제로 per-invocation editable commit이 필요한 feature의 후속 Contract에서만 사용합니다.
- shared owner는 identity/revision/order/settlement/cleanup만 소유하고 feature field schema를 알지 않습니다.

## 수정된 실행 순서

```text
DONE QSTATE-01
DONE QSTATE-02A feasibility probe
  -> READY QSTATE-02B two-phase Contract amendment
  -> QSTATE-02C transaction core
       + QSTATE-02D executed-event envelope bridge
  -> QSTATE-03 LoRA result replay retirement
       + QSTATE-04 Prompt Studio feature cutover
  -> AIO-SEED-UI
  -> integrated hotfix / 0.5.6
```

QSTATE-03은 live profile replay만 제거하는 경우 QSTATE-02C/D와 병렬 진행할 수 있습니다. QSTATE-04와 AiO frontend compare-and-commit은 shared core/bridge 이후 진행합니다.

## 변경 파일

- `docs/architecture/queue-ui-two-phase-correlation-addendum.md`
- `docs/architecture/README.md`
- `docs/development/README.md`

## 검증

- GitHub compare 기준 docs 3개만 변경
- production Python/JavaScript, tests, workflow, version metadata 변경 없음
- docs-only이므로 project full/package/live 검증 미실행

## 다음 작업

기존 clean branch/worktree `codex/qstate-02-transaction-owner`에서 QSTATE-02B Contract fixture만 시작합니다. Production owner 구현은 QSTATE-02B review/merge 이후 별도 PR로 진행합니다.

Refs #413
Refs #414
Refs #415