### PR TITLE
test: amend queue UI two-phase correlation contract

### DIFF
--- a/tests/frontend_executed_event_context_smoke.mjs
+++ b/tests/frontend_executed_event_context_smoke.mjs
@@ -1,0 +1,276 @@
+import assert from "node:assert/strict";
+
+// QSTATE-02B contract-only fixture. Node's flat EventTarget does not model a
+// browser capture phase, so this test-local host preserves the DOM ordering the
+// ComfyUI adapter relies on: capture listeners run before normal listeners at
+// the target, even when the capture listener was registered later.
+class BrowserPhaseEventTargetFixture {
+  constructor() {
+    this.listeners = new Map();
+  }
+
+  addEventListener(type, callback, options = {}) {
+    const capture = typeof options === "boolean"
+      ? options
+      : Boolean(options?.capture);
+    const listeners = this.listeners.get(type) || [];
+    if (!listeners.some(
+      (listener) => listener.callback === callback && listener.capture === capture,
+    )) {
+      listeners.push({ callback, capture });
+      this.listeners.set(type, listeners);
+    }
+  }
+
+  removeEventListener(type, callback, options = {}) {
+    const capture = typeof options === "boolean"
+      ? options
+      : Boolean(options?.capture);
+    const listeners = this.listeners.get(type) || [];
+    this.listeners.set(
+      type,
+      listeners.filter(
+        (listener) => listener.callback !== callback || listener.capture !== capture,
+      ),
+    );
+  }
+
+  dispatchEvent(event) {
+    const listeners = [...(this.listeners.get(event.type) || [])];
+    for (const capture of [true, false]) {
+      for (const listener of listeners) {
+        if (listener.capture === capture) {
+          listener.callback.call(this, event);
+        }
+      }
+    }
+    return true;
+  }
+}
+
+function createExecutedEventContext(
+  api,
+  { maxPendingOutputs = 2, onCapture = null } = {},
+) {
+  assert(Number.isInteger(maxPendingOutputs) && maxPendingOutputs > 0);
+
+  let installed = false;
+  let envelopesByOutput = new WeakMap();
+  const pendingOutputs = [];
+
+  function normalizedId(value) {
+    if (typeof value === "string" && value.trim() !== "") {
+      return value.trim();
+    }
+    if (typeof value === "number" && Number.isInteger(value)) {
+      return String(value);
+    }
+    return null;
+  }
+
+  function envelopeFromDetail(detail) {
+    const promptId = normalizedId(detail?.prompt_id);
+    const executionNodeId = normalizedId(detail?.node);
+    const displayNodeId = detail?.display_node == null
+      ? null
+      : normalizedId(detail.display_node);
+    const output = detail?.output;
+    if (
+      promptId == null
+      || executionNodeId == null
+      || (detail?.display_node != null && displayNodeId == null)
+      || output === null
+      || (typeof output !== "object" && typeof output !== "function")
+    ) {
+      return null;
+    }
+    return { promptId, executionNodeId, displayNodeId, output };
+  }
+
+  function removePending(output) {
+    const index = pendingOutputs.indexOf(output);
+    if (index >= 0) {
+      pendingOutputs.splice(index, 1);
+    }
+  }
+
+  function captureExecuted({ detail }) {
+    const envelope = envelopeFromDetail(detail);
+    if (!envelope) {
+      return;
+    }
+    removePending(envelope.output);
+    envelopesByOutput.set(envelope.output, envelope);
+    pendingOutputs.push(envelope.output);
+    onCapture?.(envelope);
+
+    while (pendingOutputs.length > maxPendingOutputs) {
+      const expiredOutput = pendingOutputs.shift();
+      envelopesByOutput.delete(expiredOutput);
+    }
+  }
+
+  function install() {
+    if (installed) {
+      return false;
+    }
+    api.addEventListener("executed", captureExecuted, { capture: true });
+    installed = true;
+    return true;
+  }
+
+  function consume(output) {
+    if (
+      output === null
+      || (typeof output !== "object" && typeof output !== "function")
+    ) {
+      return null;
+    }
+    const envelope = envelopesByOutput.get(output) || null;
+    if (!envelope) {
+      return null;
+    }
+    envelopesByOutput.delete(output);
+    removePending(output);
+    return envelope;
+  }
+
+  function dispose() {
+    if (installed) {
+      api.removeEventListener("executed", captureExecuted, { capture: true });
+    }
+    installed = false;
+    envelopesByOutput = new WeakMap();
+    pendingOutputs.length = 0;
+  }
+
+  return {
+    install,
+    consume,
+    dispose,
+    inspect: () => ({ installed, pendingCount: pendingOutputs.length }),
+  };
+}
+
+function executedEvent(detail) {
+  return { type: "executed", detail };
+}
+
+{
+  const api = new BrowserPhaseEventTargetFixture();
+  const trace = [];
+  let bridge;
+  let consumedEnvelope = null;
+  const node = {
+    onExecuted(message) {
+      trace.push("node-onExecuted");
+      consumedEnvelope = bridge.consume(message);
+    },
+  };
+
+  // Mirrors current ComfyUI app.ts: the normal core listener is registered
+  // first and passes the same detail.output object to node.onExecuted().
+  api.addEventListener("executed", ({ detail }) => {
+    trace.push("core-listener");
+    node.onExecuted(detail.output);
+  });
+
+  bridge = createExecutedEventContext(api, {
+    onCapture: () => trace.push("capture-listener"),
+  });
+  assert.equal(bridge.install(), true);
+  assert.equal(bridge.install(), false);
+
+  const output = { prompt_studio_inputs: [{ text: "accepted" }] };
+  api.dispatchEvent(executedEvent({
+    prompt_id: "prompt-a",
+    node: "backend-node",
+    display_node: "frontend-node",
+    output,
+  }));
+
+  assert.deepEqual(trace, [
+    "capture-listener",
+    "core-listener",
+    "node-onExecuted",
+  ]);
+  assert(consumedEnvelope);
+  assert.equal(consumedEnvelope.promptId, "prompt-a");
+  assert.equal(consumedEnvelope.executionNodeId, "backend-node");
+  assert.equal(consumedEnvelope.displayNodeId, "frontend-node");
+  assert.equal(consumedEnvelope.output, output);
+  assert.deepEqual(bridge.inspect(), { installed: true, pendingCount: 0 });
+  assert.equal(bridge.consume(output), null);
+  assert.equal(bridge.consume({ ...output }), null);
+}
+
+{
+  const api = new BrowserPhaseEventTargetFixture();
+  let bridge;
+  const clonedConsumes = [];
+  const originalOutputs = [];
+  const node = {
+    onExecuted(message) {
+      clonedConsumes.push(bridge.consume(message));
+    },
+  };
+
+  api.addEventListener("executed", ({ detail }) => {
+    node.onExecuted({ ...detail.output });
+  });
+  bridge = createExecutedEventContext(api, { maxPendingOutputs: 2 });
+  bridge.install();
+
+  for (let index = 0; index < 3; index += 1) {
+    const output = { index };
+    originalOutputs.push(output);
+    api.dispatchEvent(executedEvent({
+      prompt_id: `prompt-clone-${index}`,
+      node: "backend-node",
+      output,
+    }));
+  }
+
+  assert.deepEqual(clonedConsumes, [null, null, null]);
+  assert.deepEqual(bridge.inspect(), { installed: true, pendingCount: 2 });
+  assert.equal(bridge.consume(originalOutputs[0]), null);
+  assert.equal(bridge.consume(originalOutputs[2])?.promptId, "prompt-clone-2");
+  assert.deepEqual(bridge.inspect(), { installed: true, pendingCount: 1 });
+  bridge.dispose();
+  assert.deepEqual(bridge.inspect(), { installed: false, pendingCount: 0 });
+}
+
+{
+  const api = new BrowserPhaseEventTargetFixture();
+  let bridge;
+  const consumes = [];
+  const node = {
+    onExecuted(message) {
+      consumes.push(bridge.consume(message));
+    },
+  };
+
+  api.addEventListener("executed", ({ detail }) => {
+    node.onExecuted(detail.output);
+  });
+  bridge = createExecutedEventContext(api);
+  bridge.install();
+
+  api.dispatchEvent(executedEvent({
+    node: "backend-node",
+    output: { missing: "prompt-id" },
+  }));
+  assert.deepEqual(consumes, [null]);
+  assert.deepEqual(bridge.inspect(), { installed: true, pendingCount: 0 });
+
+  bridge.dispose();
+  api.dispatchEvent(executedEvent({
+    prompt_id: "prompt-after-dispose",
+    node: "backend-node",
+    output: {},
+  }));
+  assert.deepEqual(consumes, [null, null]);
+  assert.deepEqual(bridge.inspect(), { installed: false, pendingCount: 0 });
+}
+
+console.log("Executed event context contract smoke passed.");

--- a/tests/frontend_queue_ui_transaction_smoke.mjs
+++ b/tests/frontend_queue_ui_transaction_smoke.mjs
@@ -1,31 +1,30 @@
 import assert from "node:assert/strict";
 
-// QSTATE-01 contract-only fixture. This reference owner is deliberately local
-// to the test. QSTATE-02 replaces it with an import from
-// web/js/lifecycle/queue_ui_transaction.js and must keep this scenario table.
+// QSTATE-02B contract-only fixture. The reference owner remains test-local;
+// QSTATE-02C will replace it with the production transaction core.
 //
-// Direct-owner identity evidence:
-// - app.queuePrompt's afterQueue callback can observe result.prompt_id.
-// - a captured frontend node supplies node_id, but the queue result does not
-//   supply the mapped/subgraph list_index component.
-// - current onExecuted(message) adapters receive feature UI payloads without
-//   prompt_id, node_id, or list_index.
-// - the backend seed execution context distinguishes invocations with
-//   prompt_id + node_id + list_index.
-//
-// Therefore a live commit requires the exact three-part identity below.
-// Missing host correlation is a QSTATE-02 blocker and always fails closed; it
-// does not authorize broader production wiring.
+// Shared ownership stops at frontend-node lifecycle, opaque surface revisions,
+// prompt ordering, settlement, and cleanup. Feature adapters retain ownership
+// of field catalogs, payload parsing, and actual editable mutations.
 const IDENTITY_DECISION = Object.freeze({
-  components: Object.freeze(["promptId", "nodeId", "listIndex"]),
-  queueResult: Object.freeze(["promptId"]),
-  executedUiPayload: Object.freeze([]),
+  provisional: Object.freeze([
+    "frontendNode",
+    "nodeEpoch",
+    "surfaceRevisions",
+    "localSequence",
+  ]),
+  accepted: Object.freeze(["promptId"]),
+  executedEnvelope: Object.freeze([
+    "promptId",
+    "executionNodeId",
+    "displayNodeId",
+    "output",
+  ]),
+  listIndexPolicy: "feature-contract-only",
+  mappedEditableCommitPolicy: "single-item-only",
   unavailableIdentityPolicy: "fail-closed",
 });
 
-// Shared ownership ends at opaque surface tokens and their revisions. QSTATE-03
-// and QSTATE-04 feature adapters own atomic field catalogs, commit allowlists,
-// and actual commit payload validation.
 const TERMINAL_REASONS = new Set([
   "cancel",
   "reject",
@@ -35,17 +34,30 @@ const TERMINAL_REASONS = new Set([
   "dispose",
 ]);
 
-function createReferenceHarness() {
+function createReferenceHarness({ maxTransactionsPerNode = 3 } = {}) {
+  assert(Number.isInteger(maxTransactionsPerNode) && maxTransactionsPerNode > 0);
+
   let sequence = 0;
   const transactions = new Map();
-  const revisionsByNode = new Map();
-  const latestByNodeSurface = new Map();
+  const nodeEpochs = new WeakMap();
+  const nodeStates = new Map();
+  const transactionsByPrompt = new Map();
+
+  function validNode(node) {
+    return (
+      node !== null
+      && (typeof node === "object" || typeof node === "function")
+    );
+  }
+
+  function normalizedPromptId(promptId) {
+    return typeof promptId === "string" && promptId.trim() !== ""
+      ? promptId.trim()
+      : null;
+  }
 
   function normalizedNodeId(nodeId) {
-    if (
-      typeof nodeId === "string"
-      && nodeId.trim() !== ""
-    ) {
+    if (typeof nodeId === "string" && nodeId.trim() !== "") {
       return nodeId.trim();
     }
     if (typeof nodeId === "number" && Number.isInteger(nodeId)) {
@@ -54,47 +66,23 @@ function createReferenceHarness() {
     return null;
   }
 
-  function normalizedIdentity(identity) {
-    const promptId = typeof identity?.promptId === "string"
-      ? identity.promptId.trim()
-      : "";
-    const nodeId = normalizedNodeId(identity?.nodeId);
-    const hasListIndex = Object.prototype.hasOwnProperty.call(
-      identity || {},
-      "listIndex",
-    );
-    const listIndex = identity?.listIndex;
-    const validListIndex = listIndex === null
-      || (
-        typeof listIndex === "number"
-        && Number.isInteger(listIndex)
-        && listIndex >= 0
-      );
-    if (!promptId || nodeId == null || !hasListIndex || !validListIndex) {
+  function normalizedEnvelope(envelope) {
+    const promptId = normalizedPromptId(envelope?.promptId);
+    const executionNodeId = normalizedNodeId(envelope?.executionNodeId);
+    const displayNodeId = envelope?.displayNodeId == null
+      ? null
+      : normalizedNodeId(envelope.displayNodeId);
+    const output = envelope?.output;
+    if (
+      promptId == null
+      || executionNodeId == null
+      || (envelope?.displayNodeId != null && displayNodeId == null)
+      || output === null
+      || (typeof output !== "object" && typeof output !== "function")
+    ) {
       return null;
     }
-    return { promptId, nodeId, listIndex };
-  }
-
-  function identityMatches(captured, result) {
-    const normalizedResult = normalizedIdentity(result);
-    return normalizedResult != null
-      && captured.promptId === normalizedResult.promptId
-      && captured.nodeId === normalizedResult.nodeId
-      && captured.listIndex === normalizedResult.listIndex;
-  }
-
-  function nodeRevisions(nodeId) {
-    let revisions = revisionsByNode.get(nodeId);
-    if (!revisions) {
-      revisions = new Map();
-      revisionsByNode.set(nodeId, revisions);
-    }
-    return revisions;
-  }
-
-  function revision(nodeId, surface) {
-    return revisionsByNode.get(nodeId)?.get(surface) || 0;
+    return { promptId, executionNodeId, displayNodeId, output };
   }
 
   function validSurfaces(surfaces) {
@@ -105,310 +93,607 @@ function createReferenceHarness() {
       );
   }
 
+  function nodeState(node) {
+    let state = nodeStates.get(node);
+    if (!state) {
+      const epoch = (nodeEpochs.get(node) || 0) + 1;
+      nodeEpochs.set(node, epoch);
+      state = {
+        epoch,
+        revisions: new Map(),
+        latestBySurface: new Map(),
+        transactionIds: [],
+      };
+      nodeStates.set(node, state);
+    }
+    return state;
+  }
+
+  function revision(state, surface) {
+    return state.revisions.get(surface) || 0;
+  }
+
   function tracked(transaction) {
     return Boolean(
       transaction
       && transactions.get(transaction.id) === transaction
-      && transaction.state === "pending",
+      && ["provisional", "accepted"].includes(transaction.state),
     );
+  }
+
+  function releasePromptReference(transaction) {
+    if (transaction.promptId == null) {
+      return;
+    }
+    const promptTransactions = transactionsByPrompt.get(transaction.promptId);
+    promptTransactions?.delete(transaction.id);
+    if (promptTransactions?.size === 0) {
+      transactionsByPrompt.delete(transaction.promptId);
+    }
   }
 
   function releaseTransaction(transaction) {
     transactions.delete(transaction.id);
+    releasePromptReference(transaction);
+
+    const state = nodeStates.get(transaction.node);
+    if (state?.epoch !== transaction.nodeEpoch) {
+      return;
+    }
+    state.transactionIds = state.transactionIds.filter(
+      (transactionId) => transactionId !== transaction.id,
+    );
     for (const surface of transaction.surfaces) {
-      const key = `${transaction.nodeId}:${surface}`;
-      if (latestByNodeSurface.get(key) === transaction.id) {
-        latestByNodeSurface.delete(key);
+      if (state.latestBySurface.get(surface) === transaction.id) {
+        state.latestBySurface.delete(surface);
       }
     }
   }
 
-  function capture({ identity, surfaces }) {
-    const normalized = normalizedIdentity(identity);
-    if (normalized == null || !validSurfaces(surfaces)) {
-      return null;
-    }
-    const id = `qstate-${++sequence}`;
-    const transaction = {
-      id,
-      identity: normalized,
-      nodeId: normalized.nodeId,
-      surfaces: [...new Set(surfaces.map((surface) => surface.trim()))],
-      revisions: {},
-      state: "pending",
-      reason: null,
-    };
-    for (const surface of transaction.surfaces) {
-      transaction.revisions[surface] = revision(transaction.nodeId, surface);
-      latestByNodeSurface.set(`${transaction.nodeId}:${surface}`, id);
-    }
-    transactions.set(id, transaction);
-    return transaction;
-  }
-
-  function markEdited(nodeId, surfaces) {
-    const normalized = normalizedNodeId(nodeId);
-    if (normalized == null || !validSurfaces(surfaces)) {
+  function terminate(transaction, state, reason) {
+    if (!tracked(transaction)) {
       return false;
     }
-    const revisions = nodeRevisions(normalized);
-    for (const surface of new Set(surfaces.map((value) => value.trim()))) {
-      revisions.set(surface, revision(normalized, surface) + 1);
-    }
-    return true;
-  }
-
-  function canCommit(transaction, resultIdentity, surface) {
-    if (!tracked(transaction) || !identityMatches(transaction.identity, resultIdentity)) {
-      return false;
-    }
-    if (!transaction.surfaces.includes(surface)) {
-      return false;
-    }
-    if (latestByNodeSurface.get(`${transaction.nodeId}:${surface}`) !== transaction.id) {
-      return false;
-    }
-    return revision(transaction.nodeId, surface) === transaction.revisions[surface];
-  }
-
-  function settle(transaction, resultIdentity) {
-    if (!tracked(transaction) || !identityMatches(transaction.identity, resultIdentity)) {
-      return false;
-    }
-    transaction.state = "settled";
-    releaseTransaction(transaction);
-    return true;
-  }
-
-  function cancel(transaction, reason = "cancel") {
-    if (!tracked(transaction) || !TERMINAL_REASONS.has(reason)) {
-      return false;
-    }
-    transaction.state = "cancelled";
+    transaction.state = state;
     transaction.reason = reason;
     releaseTransaction(transaction);
     return true;
   }
 
-  function disposeNode(nodeId, reason = "dispose") {
-    const normalized = normalizedNodeId(nodeId);
+  function enforceNodeRetention(state) {
+    while (state.transactionIds.length > maxTransactionsPerNode) {
+      const oldest = transactions.get(state.transactionIds[0]);
+      if (!oldest) {
+        state.transactionIds.shift();
+        continue;
+      }
+      terminate(oldest, "cancelled", "retention");
+    }
+  }
+
+  function captureProvisional({ node, surfaces }) {
+    if (!validNode(node) || !validSurfaces(surfaces)) {
+      return null;
+    }
+
+    const state = nodeState(node);
+    const id = `qstate-${++sequence}`;
+    const normalizedSurfaces = [
+      ...new Set(surfaces.map((surface) => surface.trim())),
+    ];
+    const transaction = {
+      id,
+      localSequence: sequence,
+      node,
+      nodeEpoch: state.epoch,
+      promptId: null,
+      surfaces: normalizedSurfaces,
+      revisions: {},
+      state: "provisional",
+      reason: null,
+    };
+
+    for (const surface of normalizedSurfaces) {
+      transaction.revisions[surface] = revision(state, surface);
+      state.latestBySurface.set(surface, id);
+    }
+    transactions.set(id, transaction);
+    state.transactionIds.push(id);
+    enforceNodeRetention(state);
+    return transaction;
+  }
+
+  function acceptPrompt(transaction, promptId) {
+    const normalized = normalizedPromptId(promptId);
     if (
-      normalized == null
-      || !["remove", "reconfigure", "dispose"].includes(reason)
+      !tracked(transaction)
+      || transaction.state !== "provisional"
+      || normalized == null
     ) {
       return false;
     }
-    for (const transaction of [...transactions.values()]) {
-      if (transaction.nodeId === normalized) {
-        cancel(transaction, reason);
-      }
+
+    const promptTransactions = transactionsByPrompt.get(normalized) || new Set();
+    const ambiguousNodePrompt = [...promptTransactions].some(
+      (transactionId) => transactions.get(transactionId)?.node === transaction.node,
+    );
+    if (ambiguousNodePrompt) {
+      terminate(transaction, "cancelled", "ambiguous-prompt");
+      return false;
     }
-    revisionsByNode.delete(normalized);
-    const prefix = `${normalized}:`;
-    for (const key of [...latestByNodeSurface.keys()]) {
-      if (key.startsWith(prefix)) {
-        latestByNodeSurface.delete(key);
-      }
+
+    transaction.promptId = normalized;
+    transaction.state = "accepted";
+    promptTransactions.add(transaction.id);
+    transactionsByPrompt.set(normalized, promptTransactions);
+    return true;
+  }
+
+  function markEdited(node, surfaces) {
+    const state = validNode(node) ? nodeStates.get(node) : null;
+    if (!state || !validSurfaces(surfaces)) {
+      return false;
+    }
+    for (const surface of new Set(surfaces.map((value) => value.trim()))) {
+      state.revisions.set(surface, revision(state, surface) + 1);
     }
     return true;
   }
 
+  function canCommit(
+    transaction,
+    { envelope, node, surface, mappedItemCount = 1 } = {},
+  ) {
+    const normalized = normalizedEnvelope(envelope);
+    if (
+      !tracked(transaction)
+      || transaction.state !== "accepted"
+      || normalized == null
+      || transaction.promptId !== normalized.promptId
+      || node !== transaction.node
+      || mappedItemCount !== 1
+    ) {
+      return false;
+    }
+
+    const state = nodeStates.get(node);
+    if (state?.epoch !== transaction.nodeEpoch) {
+      return false;
+    }
+    if (!transaction.surfaces.includes(surface)) {
+      return false;
+    }
+    if (state.latestBySurface.get(surface) !== transaction.id) {
+      return false;
+    }
+    return revision(state, surface) === transaction.revisions[surface];
+  }
+
+  function settle(transaction, envelope) {
+    const normalized = normalizedEnvelope(envelope);
+    if (
+      !tracked(transaction)
+      || transaction.state !== "accepted"
+      || normalized == null
+      || transaction.promptId !== normalized.promptId
+    ) {
+      return false;
+    }
+    return terminate(transaction, "settled", "executed");
+  }
+
+  function cancel(transaction, reason = "cancel") {
+    if (!TERMINAL_REASONS.has(reason)) {
+      return false;
+    }
+    return terminate(transaction, "cancelled", reason);
+  }
+
+  function finishPrompt(promptId) {
+    const normalized = normalizedPromptId(promptId);
+    const promptTransactions = normalized == null
+      ? null
+      : transactionsByPrompt.get(normalized);
+    if (!promptTransactions) {
+      return 0;
+    }
+    let finished = 0;
+    for (const transactionId of [...promptTransactions]) {
+      const transaction = transactions.get(transactionId);
+      if (transaction && terminate(transaction, "finished", "prompt-terminal")) {
+        finished += 1;
+      }
+    }
+    return finished;
+  }
+
+  function disposeNode(node, reason = "dispose") {
+    if (
+      !validNode(node)
+      || !["remove", "reconfigure", "dispose"].includes(reason)
+    ) {
+      return false;
+    }
+    const state = nodeStates.get(node);
+    if (!state) {
+      return false;
+    }
+    for (const transactionId of [...state.transactionIds]) {
+      const transaction = transactions.get(transactionId);
+      if (transaction) {
+        terminate(transaction, "cancelled", reason);
+      }
+    }
+    state.revisions.clear();
+    state.latestBySurface.clear();
+    state.transactionIds.length = 0;
+    nodeStates.delete(node);
+    return true;
+  }
+
   const owner = {
-    capture,
+    captureProvisional,
+    acceptPrompt,
     markEdited,
     canCommit,
     settle,
     cancel,
+    finishPrompt,
     disposeNode,
   };
   const inspect = () => ({
     transactionCount: transactions.size,
-    revisionNodeCount: revisionsByNode.size,
-    orderingReferenceCount: latestByNodeSurface.size,
+    nodeStateCount: nodeStates.size,
+    promptReferenceCount: [...transactionsByPrompt.values()].reduce(
+      (count, promptTransactions) => count + promptTransactions.size,
+      0,
+    ),
+    orderingReferenceCount: [...nodeStates.values()].reduce(
+      (count, state) => count + state.latestBySurface.size,
+      0,
+    ),
   });
   return { owner, inspect };
 }
 
 const expectedApi = [
-  "capture",
+  "captureProvisional",
+  "acceptPrompt",
   "markEdited",
   "canCommit",
   "settle",
   "cancel",
+  "finishPrompt",
   "disposeNode",
 ].sort();
 assert.deepEqual(Object.keys(createReferenceHarness().owner).sort(), expectedApi);
 
+function envelope(promptId, output = {}) {
+  return {
+    promptId,
+    executionNodeId: "backend-node",
+    displayNodeId: "frontend-node",
+    output,
+  };
+}
+
 const scenarios = [
   {
-    name: "identity is exact and unavailable components fail closed",
+    name: "provisional capture requires only local node and surfaces",
     run({ owner }) {
-      const surfaces = ["surface-a"];
-      for (const identity of [
-        { nodeId: "7", listIndex: null },
-        { promptId: "prompt-a", nodeId: "7" },
-        { promptId: "prompt-a", nodeId: "7", listIndex: -1 },
-      ]) {
-        assert.equal(owner.capture({ identity, surfaces }), null);
-      }
-      const identity = {
-        promptId: "prompt-a",
-        nodeId: "7",
-        listIndex: null,
-      };
-      const transaction = owner.capture({ identity, surfaces });
-      assert(transaction);
-      assert.equal(owner.canCommit(transaction, identity, "surface-a"), true);
-      assert.equal(
-        owner.canCommit(
-          transaction,
-          { promptId: "prompt-a", nodeId: "7" },
-          "surface-a",
-        ),
-        false,
-      );
-      assert.equal(
-        owner.canCommit(
-          transaction,
-          { promptId: "prompt-b", nodeId: "7", listIndex: null },
-          "surface-a",
-        ),
-        false,
-      );
-    },
-  },
-  {
-    name: "list index distinguishes mapped and subgraph invocations",
-    run({ owner }) {
-      const identity = {
-        promptId: "prompt-list",
-        nodeId: "8",
-        listIndex: 0,
-      };
-      const transaction = owner.capture({
-        identity,
+      const node = {};
+      assert.equal(owner.captureProvisional({ node: null, surfaces: ["surface-a"] }), null);
+      assert.equal(owner.captureProvisional({ node, surfaces: [] }), null);
+
+      const transaction = owner.captureProvisional({
+        node,
         surfaces: ["surface-a"],
       });
       assert(transaction);
+      assert.equal(transaction.promptId, null);
+      assert.equal(transaction.state, "provisional");
       assert.equal(
-        owner.canCommit(
-          transaction,
-          { ...identity, listIndex: 1 },
-          "surface-a",
-        ),
+        owner.canCommit(transaction, {
+          envelope: envelope("prompt-a"),
+          node,
+          surface: "surface-a",
+        }),
         false,
       );
-      assert.equal(owner.canCommit(transaction, identity, "surface-a"), true);
+      assert.equal(owner.acceptPrompt(transaction, ""), false);
+      assert.equal(owner.acceptPrompt(transaction, "prompt-a"), true);
+      assert.equal(owner.acceptPrompt(transaction, "prompt-a"), false);
     },
   },
   {
-    name: "feature-defined surface revisions invalidate one atomic token",
+    name: "queue rejection cancels provisional state and references",
+    run({ owner, inspect }) {
+      const node = {};
+      const transaction = owner.captureProvisional({
+        node,
+        surfaces: ["surface-a"],
+      });
+      assert(transaction);
+      assert.equal(owner.cancel(transaction, "reject"), true);
+      assert.equal(owner.acceptPrompt(transaction, "prompt-rejected"), false);
+      assert.deepEqual(inspect(), {
+        transactionCount: 0,
+        nodeStateCount: 1,
+        promptReferenceCount: 0,
+        orderingReferenceCount: 0,
+      });
+    },
+  },
+  {
+    name: "accepted prompt and frontend node ownership gate editable commit",
     run({ owner }) {
-      const identity = {
-        promptId: "prompt-edit",
-        nodeId: "9",
-        listIndex: null,
-      };
-      const transaction = owner.capture({
-        identity,
+      const node = {};
+      const transaction = owner.captureProvisional({
+        node,
+        surfaces: ["surface-a"],
+      });
+      assert(transaction);
+      assert.equal(owner.acceptPrompt(transaction, "prompt-a"), true);
+
+      const executedEnvelope = envelope("prompt-a");
+      assert.equal(
+        owner.canCommit(transaction, {
+          envelope: executedEnvelope,
+          node,
+          surface: "surface-a",
+        }),
+        true,
+      );
+      assert.equal(
+        owner.canCommit(transaction, {
+          envelope: null,
+          node,
+          surface: "surface-a",
+        }),
+        false,
+      );
+      assert.equal(
+        owner.canCommit(transaction, {
+          envelope: envelope("prompt-other"),
+          node,
+          surface: "surface-a",
+        }),
+        false,
+      );
+      assert.equal(
+        owner.canCommit(transaction, {
+          envelope: executedEnvelope,
+          node: {},
+          surface: "surface-a",
+        }),
+        false,
+      );
+    },
+  },
+  {
+    name: "multiple mapped payloads cannot commit editable state",
+    run({ owner }) {
+      const node = {};
+      const transaction = owner.captureProvisional({
+        node,
+        surfaces: ["surface-a"],
+      });
+      assert(transaction);
+      assert.equal(owner.acceptPrompt(transaction, "prompt-mapped"), true);
+      const executedEnvelope = envelope("prompt-mapped");
+
+      for (const mappedItemCount of [0, 2, 3]) {
+        assert.equal(
+          owner.canCommit(transaction, {
+            envelope: executedEnvelope,
+            node,
+            surface: "surface-a",
+            mappedItemCount,
+          }),
+          false,
+        );
+      }
+      assert.equal(
+        owner.canCommit(transaction, {
+          envelope: executedEnvelope,
+          node,
+          surface: "surface-a",
+          mappedItemCount: 1,
+        }),
+        true,
+      );
+    },
+  },
+  {
+    name: "opaque surface revisions invalidate only the edited surface",
+    run({ owner }) {
+      const node = {};
+      const transaction = owner.captureProvisional({
+        node,
         surfaces: ["surface-a", "surface-b"],
       });
       assert(transaction);
-      assert.equal(owner.markEdited("9", ["surface-a"]), true);
-      assert.equal(owner.canCommit(transaction, identity, "surface-a"), false);
-      assert.equal(owner.canCommit(transaction, identity, "surface-b"), true);
-      assert.equal(owner.canCommit(transaction, identity, "unknown-surface"), false);
+      assert.equal(owner.acceptPrompt(transaction, "prompt-edit"), true);
+      assert.equal(owner.markEdited(node, ["surface-a"]), true);
+
+      const executedEnvelope = envelope("prompt-edit");
+      assert.equal(
+        owner.canCommit(transaction, {
+          envelope: executedEnvelope,
+          node,
+          surface: "surface-a",
+        }),
+        false,
+      );
+      assert.equal(
+        owner.canCommit(transaction, {
+          envelope: executedEnvelope,
+          node,
+          surface: "surface-b",
+        }),
+        true,
+      );
+      assert.equal(
+        owner.canCommit(transaction, {
+          envelope: executedEnvelope,
+          node,
+          surface: "unknown-surface",
+        }),
+        false,
+      );
     },
   },
   {
-    name: "latest capture wins while older diagnostic settlement remains valid",
+    name: "latest capture wins while older settlement remains valid",
     run({ owner, inspect }) {
-      const olderIdentity = {
-        promptId: "prompt-old",
-        nodeId: "10",
-        listIndex: null,
-      };
-      const newerIdentity = {
-        promptId: "prompt-new",
-        nodeId: "10",
-        listIndex: null,
-      };
-      const older = owner.capture({
-        identity: olderIdentity,
-        surfaces: ["surface-a"],
-      });
-      const newer = owner.capture({
-        identity: newerIdentity,
-        surfaces: ["surface-a"],
-      });
+      const node = {};
+      const older = owner.captureProvisional({ node, surfaces: ["surface-a"] });
+      const newer = owner.captureProvisional({ node, surfaces: ["surface-a"] });
       assert(older && newer);
-      assert.equal(owner.canCommit(older, olderIdentity, "surface-a"), false);
-      assert.equal(owner.canCommit(newer, newerIdentity, "surface-a"), true);
-      assert.equal(owner.settle(older, olderIdentity), true);
+      assert.equal(owner.acceptPrompt(older, "prompt-old"), true);
+      assert.equal(owner.acceptPrompt(newer, "prompt-new"), true);
+
+      const olderEnvelope = envelope("prompt-old");
+      const newerEnvelope = envelope("prompt-new");
+      assert.equal(
+        owner.canCommit(older, {
+          envelope: olderEnvelope,
+          node,
+          surface: "surface-a",
+        }),
+        false,
+      );
+      assert.equal(
+        owner.canCommit(newer, {
+          envelope: newerEnvelope,
+          node,
+          surface: "surface-a",
+        }),
+        true,
+      );
+      assert.equal(owner.settle(older, olderEnvelope), true);
       assert.equal(inspect().transactionCount, 1);
-      assert.equal(owner.canCommit(newer, newerIdentity, "surface-a"), true);
-      assert.equal(owner.settle(newer, newerIdentity), true);
-      assert.equal(owner.settle(newer, newerIdentity), false);
+      assert.equal(owner.settle(newer, newerEnvelope), true);
+      assert.equal(owner.settle(newer, newerEnvelope), false);
       assert.equal(inspect().transactionCount, 0);
+      assert.equal(inspect().promptReferenceCount, 0);
       assert.equal(inspect().orderingReferenceCount, 0);
     },
   },
   {
-    name: "cancel reject and clear remove terminal transaction references",
+    name: "cancel clear and prompt terminal signals release transactions",
     run({ owner, inspect }) {
-      for (const [index, reason] of ["cancel", "reject", "clear"].entries()) {
-        const identity = {
-          promptId: `prompt-${reason}`,
-          nodeId: `11-${index}`,
-          listIndex: null,
-        };
-        const transaction = owner.capture({
-          identity,
+      for (const reason of ["cancel", "clear"]) {
+        const node = {};
+        const transaction = owner.captureProvisional({
+          node,
           surfaces: ["surface-a"],
         });
         assert(transaction);
+        assert.equal(owner.acceptPrompt(transaction, `prompt-${reason}`), true);
         assert.equal(owner.cancel(transaction, reason), true);
-        assert.equal(owner.canCommit(transaction, identity, "surface-a"), false);
         assert.equal(owner.cancel(transaction, reason), false);
-        assert.equal(inspect().transactionCount, 0);
-        assert.equal(inspect().orderingReferenceCount, 0);
       }
+
+      const firstNode = {};
+      const secondNode = {};
+      const first = owner.captureProvisional({
+        node: firstNode,
+        surfaces: ["surface-a"],
+      });
+      const second = owner.captureProvisional({
+        node: secondNode,
+        surfaces: ["surface-b"],
+      });
+      assert(first && second);
+      assert.equal(owner.acceptPrompt(first, "prompt-terminal"), true);
+      assert.equal(owner.acceptPrompt(second, "prompt-terminal"), true);
+      assert.equal(owner.finishPrompt("prompt-terminal"), 2);
+      assert.equal(owner.finishPrompt("prompt-terminal"), 0);
+      assert.equal(inspect().transactionCount, 0);
+      assert.equal(inspect().promptReferenceCount, 0);
+      assert.equal(inspect().orderingReferenceCount, 0);
     },
   },
   {
     name: "remove reconfigure and dispose release every node reference",
     run({ owner, inspect }) {
-      for (const [index, reason] of ["remove", "reconfigure", "dispose"].entries()) {
-        const nodeId = `12-${index}`;
-        const firstIdentity = {
-          promptId: `prompt-${reason}-0`,
-          nodeId,
-          listIndex: 0,
-        };
-        const secondIdentity = {
-          promptId: `prompt-${reason}-1`,
-          nodeId,
-          listIndex: 1,
-        };
-        const first = owner.capture({
-          identity: firstIdentity,
+      for (const reason of ["remove", "reconfigure", "dispose"]) {
+        const node = {};
+        const first = owner.captureProvisional({
+          node,
           surfaces: ["surface-a"],
         });
-        const second = owner.capture({
-          identity: secondIdentity,
+        const second = owner.captureProvisional({
+          node,
           surfaces: ["surface-b"],
         });
         assert(first && second);
-        assert.equal(owner.markEdited(nodeId, ["surface-a"]), true);
-        assert.equal(owner.disposeNode(nodeId, reason), true);
-        assert.equal(owner.canCommit(first, firstIdentity, "surface-a"), false);
-        assert.equal(owner.canCommit(second, secondIdentity, "surface-b"), false);
-        assert.deepEqual(inspect(), {
-          transactionCount: 0,
-          revisionNodeCount: 0,
-          orderingReferenceCount: 0,
-        });
+        assert.equal(owner.acceptPrompt(first, `prompt-${reason}-a`), true);
+        assert.equal(owner.acceptPrompt(second, `prompt-${reason}-b`), true);
+        assert.equal(owner.markEdited(node, ["surface-a"]), true);
+        assert.equal(owner.disposeNode(node, reason), true);
+        assert.equal(
+          owner.canCommit(first, {
+            envelope: envelope(`prompt-${reason}-a`),
+            node,
+            surface: "surface-a",
+          }),
+          false,
+        );
+        assert.equal(
+          owner.canCommit(second, {
+            envelope: envelope(`prompt-${reason}-b`),
+            node,
+            surface: "surface-b",
+          }),
+          false,
+        );
       }
+      assert.deepEqual(inspect(), {
+        transactionCount: 0,
+        nodeStateCount: 0,
+        promptReferenceCount: 0,
+        orderingReferenceCount: 0,
+      });
+    },
+  },
+  {
+    name: "superseded in-flight retention is bounded per node",
+    run() {
+      const { owner, inspect } = createReferenceHarness({
+        maxTransactionsPerNode: 2,
+      });
+      const node = {};
+      const first = owner.captureProvisional({ node, surfaces: ["surface-a"] });
+      const second = owner.captureProvisional({ node, surfaces: ["surface-a"] });
+      assert(first && second);
+      assert.equal(owner.acceptPrompt(first, "prompt-retained-a"), true);
+      assert.equal(owner.acceptPrompt(second, "prompt-retained-b"), true);
+
+      const third = owner.captureProvisional({ node, surfaces: ["surface-a"] });
+      assert(third);
+      assert.equal(owner.acceptPrompt(third, "prompt-retained-c"), true);
+      assert.equal(first.state, "cancelled");
+      assert.equal(first.reason, "retention");
+      assert.equal(inspect().transactionCount, 2);
+      assert.equal(inspect().promptReferenceCount, 2);
+      assert.equal(inspect().orderingReferenceCount, 1);
+      assert.equal(
+        owner.canCommit(first, {
+          envelope: envelope("prompt-retained-a"),
+          node,
+          surface: "surface-a",
+        }),
+        false,
+      );
+      assert.equal(owner.disposeNode(node), true);
+      assert.deepEqual(inspect(), {
+        transactionCount: 0,
+        nodeStateCount: 0,
+        promptReferenceCount: 0,
+        orderingReferenceCount: 0,
+      });
     },
   },
 ];
@@ -420,9 +705,21 @@ for (const scenario of scenarios) {
 assert.deepEqual(
   IDENTITY_DECISION,
   {
-    components: ["promptId", "nodeId", "listIndex"],
-    queueResult: ["promptId"],
-    executedUiPayload: [],
+    provisional: [
+      "frontendNode",
+      "nodeEpoch",
+      "surfaceRevisions",
+      "localSequence",
+    ],
+    accepted: ["promptId"],
+    executedEnvelope: [
+      "promptId",
+      "executionNodeId",
+      "displayNodeId",
+      "output",
+    ],
+    listIndexPolicy: "feature-contract-only",
+    mappedEditableCommitPolicy: "single-item-only",
     unavailableIdentityPolicy: "fail-closed",
   },
 );

--- a/tools/check_frontend.ps1
+++ b/tools/check_frontend.ps1
@@ -164,6 +164,11 @@ try {
         throw "Frontend queue UI transaction contract smoke failed with exit code $LASTEXITCODE."
     }
 
+    & node "tests\frontend_executed_event_context_smoke.mjs"
+    if ($LASTEXITCODE -ne 0) {
+        throw "Frontend executed event context contract smoke failed with exit code $LASTEXITCODE."
+    }
+
     & node "tests\frontend_prompt_studio_advanced_values_smoke.mjs"
     if ($LASTEXITCODE -ne 0) {
         throw "Frontend Prompt Studio Advanced executed values smoke failed with exit code $LASTEXITCODE."


### PR DESCRIPTION
## 목적과 변경 경계

QSTATE-02A에서 확인한 `listIndex` 생성 시점 blocker를 반영해 QSTATE-02B Contract fixture를 two-phase correlation으로 수정합니다.

Production JavaScript/Python은 변경하지 않았습니다. 변경 경계는 transaction Contract fixture, executed-event context fixture, frontend runner 등록뿐입니다.

## Base -> Head

```text
2379faba841853422fe34ef194b9bbeb2bc6372d
->
6c254f1999f69d91c5307d89954c0f6ede93daba
```

## 주요 파일

- `tests/frontend_queue_ui_transaction_smoke.mjs`
- `tests/frontend_executed_event_context_smoke.mjs`
- `tools/check_frontend.ps1`

## 고정한 Contract

- provisional capture는 frontend node lifecycle, node epoch, opaque surface revision, local ordering만 요구
- queue success 뒤 accepted `promptId` bind
- ComfyUI executed outer envelope를 정확한 `detail.output` object로 `node.onExecuted(message)`에서 동기 consume
- `listIndex`는 특정 mapped invocation을 editable state에 반영하는 후속 feature Contract에서만 사용
- multiple mapped payload는 editable commit 기본 금지
- missing envelope, cloned output, prompt mismatch, 다른/disposed node는 fail-closed
- settle/cancel/prompt terminal/node disposal이 transaction, prompt, ordering reference를 해제
- terminal signal이 누락된 superseded transaction은 작은 per-node cap으로 bounded retention
- shared owner는 identity/revision/ordering/settlement/cleanup만 소유하며 field catalog와 commit payload는 QSTATE-03/04 adapter 책임

## 검증

Focused:

```text
node --check tests/frontend_queue_ui_transaction_smoke.mjs
PASS

node --check tests/frontend_executed_event_context_smoke.mjs
PASS

node tests/frontend_queue_ui_transaction_smoke.mjs
PASS - 9 scenarios

node tests/frontend_executed_event_context_smoke.mjs
PASS

git diff --check
git diff --cached --check
PASS
```

Official full:

```text
powershell -ExecutionPolicy Bypass -File tools/check_custom_node.ps1 -Project <worktree> -Profile full
Exact SHA: 6c254f1999f69d91c5307d89954c0f6ede93daba
PASS - 1151 Python tests, 115 frontend JS files, TypeScript 6.0.3
```

- Package: not triggered
- Live: not triggered
- PRO review: not triggered; QSTATE-02D stop condition은 실제로 관측되지 않음

## 위험과 rollback

EventTarget fixture는 supported browser의 capture-before-normal phase ordering을 test-local로 모델링합니다. 실제 production bridge와 host gate는 QSTATE-02D에서 별도로 검증합니다.

Rollback boundary: `6c254f1999f69d91c5307d89954c0f6ede93daba`

## Next

Review/merge 후 별도 PR로 QSTATE-02C transaction core와 QSTATE-02D executed-event envelope bridge를 진행합니다. 이 PR에는 LoRA/Prompt Studio cutover, AiO seed 변경, production owner 구현이 없습니다.

Refs #413
Refs #415