### PR TITLE
docs: separate wildcard and AiO seed UI semantics

### DIFF
--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -27,6 +27,11 @@ section, owning Issue, direct owner files, and direct tests.
   **before** the original
   [`queue-ui-execution-state-hotfix.md`](queue-ui-execution-state-hotfix.md),
   the ordinary backend roadmap, or an AiO advanced-integration plan.
+- Before Prompt Studio wildcard next-seed publication or AiO seed cutover, read
+  [`seed-ui-semantics-gate.md`](seed-ui-semantics-gate.md). Prompt Studio uses a
+  concrete seed plus an after-generate transition; AiO special `-1/-2/-3` values
+  are persistent selection tokens. The shared transaction owner must not merge
+  those feature meanings.
 - Issue [#395](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/395)
   separately tracks the external Comfy Registry activation checkpoint for the
   immutable 0.5.5 release. Waiting for that external approval does not block
@@ -54,6 +59,10 @@ section, owning Issue, direct owner files, and direct tests.
   `listIndex` from the node-level stale-result critical path; defines cache,
   subgraph, mapped-result, transaction-core, and envelope-bridge boundaries; and
   provides the current Codex start instruction.
+- [`seed-ui-semantics-gate.md`](seed-ui-semantics-gate.md): feature boundary and
+  hard test gate separating Prompt Studio Wildcard concrete after-generate seed
+  publication from AiO rgthree-style persistent special-token selection, including
+  the special-token × stored-control no-double-advance matrix.
 - [`queue-ui-execution-state-hotfix.md`](queue-ui-execution-state-hotfix.md):
   base runbook for stale LoRA/Prompt Studio execution results (#413),
   rgthree-compatible AiO special-seed display semantics (#414), integrated

--- a/docs/architecture/seed-ui-semantics-gate.md
+++ b/docs/architecture/seed-ui-semantics-gate.md
@@ -29,10 +29,22 @@ The Prompt Studio adapter always submits a concrete non-negative seed.
 ```text
 selection = concrete
 seed = current wildcard seed
-after_generate = fixed | randomize | increment | decrement
+after_generate = fixed | randomize | increment
 overflow = wrap
 editable domain = 0 .. Number.MAX_SAFE_INTEGER
 ```
+
+The current custom UI, labels, and help expose exactly these three controls:
+
+```text
+Fixed
+Randomize every time
+Increment
+```
+
+Lower-level seed contracts currently recognize `decrement`, but Prompt Studio does
+not expose it as a public control. This hotfix must preserve the existing public
+surface rather than add a fourth mode incidentally.
 
 The executed payload distinguishes:
 
@@ -63,16 +75,22 @@ The rgthree Seed reference removes ComfyUI's separate
 `control_after_generate` widget and lets the special token own repeated queue-time
 selection. It changes only the submitted prompt copy and keeps the live token.
 
+Easy Use Anima may retain its existing stored `seed_after_generate` setting for
+concrete-seed compatibility, but that control cannot become a second transition
+while a special token is active.
+
 ## 2. Non-interchangeable behavior
 
 | Concern | Prompt Studio Wildcard | AiO special token | AiO concrete seed |
 | --- | --- | --- | --- |
 | Editable value | concrete integer | `-1`, `-2`, or `-3` | concrete integer |
 | Queue-time selection | current concrete value | token-defined stream selection | current concrete value |
-| `after_generate` role | computes the next concrete editable value | must not replace or advance the visible token | computes the next concrete editable value |
+| Public control set | fixed, randomize, increment | token itself owns repeated selection | fixed, randomize, increment, decrement |
+| `after_generate` role | computes the next concrete editable value | must not replace the token or create a second stream transition | computes the next concrete editable value |
 | Live value after accepted result | next concrete seed, if revision is current | same special token | next concrete seed, if revision is current |
 | Overflow domain | wrap | stream contract; no token mutation | current AiO concrete domain policy |
 | Execution seed | previous-execution history | last-seed/history only | last-seed/history and possible next-state basis |
+| Workflow reproducibility | previous accepted concrete execution may serialize as fixed | special token remains serialized | current concrete next-state contract |
 
 The following abstraction is forbidden:
 
@@ -97,10 +115,12 @@ shared transaction gate
 - `fixed` keeps the current concrete seed.
 - `randomize` chooses one new concrete next-run seed after an accepted execution.
   It is not a persistent random-mode token.
-- `increment` and `decrement` compute one concrete next-run seed using the existing
-  wrap domain.
+- `increment` computes one concrete next-run seed using the existing wrap domain.
+- The hotfix does not add a public decrement control or migration.
 - The next concrete seed is written to the live widget only when the accepted
   prompt transaction and `prompt.wildcard_seed` revision are still current.
+- The control and seed form one atomic editable next-state surface. Editing either
+  after queue prevents the old result from publishing its next seed.
 - A stale result may update non-editable previous-execution history but cannot
   overwrite a newer seed or control edit.
 - `wildcard_mode` (`populate/general` versus `sequential`) remains independent from
@@ -111,18 +131,20 @@ shared transaction gate
 ### 3.2 Required tests
 
 ```text
-seed 7 + fixed      -> execution 7, live next 7
-seed 7 + increment  -> execution 7, live next 8
+seed 7 + fixed       -> execution 7, live next 7
+seed 7 + increment   -> execution 7, live next 8
 seed MAX + increment -> live next 0
-seed 0 + decrement  -> live next MAX
-seed 7 + randomize  -> one concrete next value; following queue uses it
-queue seed 7 -> user edits 99 -> old result does not replace 99
+seed 7 + randomize   -> one concrete next value; following queue uses it
+queue seed 7 -> user edits seed 99 -> old result does not replace 99
+queue increment -> user changes control to fixed -> old result does not publish 8
 old result may record execution seed 7 in non-editable history
-workflow save/reload preserves the accepted reproducibility contract
+workflow save/reload preserves the accepted previous-execution reproducibility contract
+public control list remains fixed/randomize/increment
 ```
 
 Use deterministic random sources in tests. Do not copy AiO special-token logic
-into Prompt Studio.
+into Prompt Studio, and do not turn dormant lower-level decrement support into a
+new user-facing feature in this hotfix.
 
 ## 4. AiO special-token contract
 
@@ -199,6 +221,7 @@ QSTATE-02C/D 이후:
   -> QSTATE-04A Prompt Studio submitted-snapshot replay retirement
   -> QSTATE-04B Prompt Studio Wildcard concrete next-seed compare-and-commit
   -> AIO-SEED-UI-01 special/concrete intent-display Contract and full matrix
+  -> focused PRO review of the final seed matrix
   -> AIO-SEED-UI-02 backend payload/effective-control implementation
   -> AIO-SEED-UI-03 frontend publication and last-seed UX
 ```
@@ -207,14 +230,16 @@ QSTATE-04A and QSTATE-04B may share one PR only when their file ownership and
 rollback boundary remain small. They may not import AiO seed semantics.
 
 AIO-SEED-UI-01 may start after the shared transaction API is frozen, but
-AIO-SEED-UI-02/03 remain blocked until its full special-token matrix is reviewed.
+AIO-SEED-UI-02/03 remain blocked until its full special-token matrix passes and the
+focused review approves the separation.
 
 ## 6. Stop conditions
 
 Stop and record a blocker before implementation expands if:
 
 - the shared transaction core parses seed values or control names;
-- Prompt Studio requires negative sentinel values to implement next-seed control;
+- Prompt Studio introduces negative sentinel values or a new public seed control in
+  order to implement stale protection;
 - AiO special mode reuses Prompt Studio's concrete next-seed publication helper;
 - a special token plus non-fixed `seed_after_generate` advances the concrete stream
   more than once per accepted queue;
@@ -240,14 +265,22 @@ focused Python seed adapter tests when backend payload meaning changes
 git diff --check
 ```
 
+The Wildcard test matrix is limited to the current public controls. Lower-level
+`decrement` support may retain compatibility tests, but it is not a new UI acceptance
+criterion for this hotfix.
+
 ### AIO-SEED-UI-01
 
 ```text
 frontend AiO executed-seed Contract smoke
 Python seed adapter and reservation tests
-special-token x after_generate golden matrix
+special-token x stored-after_generate golden matrix
+concrete-seed x after_generate golden matrix
 git diff --check
 ```
+
+The final AIO-SEED-UI-01 Contract receives one focused PRO review before production
+implementation begins.
 
 ### AIO-SEED-UI-02/03
 
@@ -258,12 +291,12 @@ Contract edit loop.
 
 ## 8. Codex continuation rule
 
-QSTATE-02B, QSTATE-02C/D, and QSTATE-03 may continue without another seed review.
-Before QSTATE-04B or AIO-SEED-UI implementation, read this document and use separate
-feature task cards and separate surface tokens:
+QSTATE-02B, QSTATE-02C/D, QSTATE-03, and QSTATE-04A may continue without another
+seed review. Before QSTATE-04B or AIO-SEED-UI implementation, read this document and
+use separate feature task cards and separate surface tokens:
 
 ```text
-prompt.wildcard_seed
+prompt.wildcard_seed_control
 prompt.wildcard_history
 aio.seed_selection
 aio.last_seed

--- a/docs/architecture/seed-ui-semantics-gate.md
+++ b/docs/architecture/seed-ui-semantics-gate.md
@@ -1,0 +1,273 @@
+# Seed UI Semantics Gate
+
+## Status and authority
+
+- Status: active feature-semantics gate for Issues #413, #414, and #415
+- Snapshot branch: `dev`
+- Snapshot commit: `2379faba841853422fe34ef194b9bbeb2bc6372d`
+- Applies after: QSTATE-02B Contract review
+- Does not change: QSTATE-02 transaction identity, event-envelope correlation, or release priority
+
+This document prevents two different seed models from being collapsed into one
+frontend publication rule:
+
+1. Prompt Studio Wildcard uses a **concrete editable seed plus an after-generate
+   transition**.
+2. AiO uses rgthree-style **persistent special selection tokens** (`-1/-2/-3`)
+   in addition to an ordinary concrete-seed mode.
+
+The shared queue transaction owner decides only whether a feature may publish a
+next state. It never decides what a seed value means.
+
+## 1. Verified current contracts
+
+### 1.1 Prompt Studio Wildcard
+
+The Prompt Studio adapter always submits a concrete non-negative seed.
+`prompt_studio_seed_execution()` creates a reservation with:
+
+```text
+selection = concrete
+seed = current wildcard seed
+after_generate = fixed | randomize | increment | decrement
+overflow = wrap
+editable domain = 0 .. Number.MAX_SAFE_INTEGER
+```
+
+The executed payload distinguishes:
+
+```text
+wildcard_execution_seed = seed used by this execution
+wildcard_seed           = next concrete seed
+```
+
+The frontend also stores previous-execution history separately so a workflow can
+serialize the accepted execution seed with fixed control for reproducibility while
+the live editor remains on its next-run concrete seed.
+
+### 1.2 AiO Generator
+
+AiO accepts either a concrete seed or one of these persistent selection tokens:
+
+```text
+-1 = randomize every queue
+-2 = increment from the previous concrete execution seed
+-3 = decrement from the previous concrete execution seed
+```
+
+The backend translates these tokens into reservation `selection` values. The
+concrete execution seed is authoritative for sampling, cache keys, and metadata,
+but it is not the editable token shown to the user.
+
+The rgthree Seed reference removes ComfyUI's separate
+`control_after_generate` widget and lets the special token own repeated queue-time
+selection. It changes only the submitted prompt copy and keeps the live token.
+
+## 2. Non-interchangeable behavior
+
+| Concern | Prompt Studio Wildcard | AiO special token | AiO concrete seed |
+| --- | --- | --- | --- |
+| Editable value | concrete integer | `-1`, `-2`, or `-3` | concrete integer |
+| Queue-time selection | current concrete value | token-defined stream selection | current concrete value |
+| `after_generate` role | computes the next concrete editable value | must not replace or advance the visible token | computes the next concrete editable value |
+| Live value after accepted result | next concrete seed, if revision is current | same special token | next concrete seed, if revision is current |
+| Overflow domain | wrap | stream contract; no token mutation | current AiO concrete domain policy |
+| Execution seed | previous-execution history | last-seed/history only | last-seed/history and possible next-state basis |
+
+The following abstraction is forbidden:
+
+```text
+all seed results -> write payload.next_seed into the live widget
+```
+
+The following abstraction is accepted:
+
+```text
+shared transaction gate
+  -> feature adapter interprets its own seed contract
+  -> feature adapter publishes only the allowed next state
+```
+
+## 3. Prompt Studio Wildcard contract
+
+### 3.1 Required behavior
+
+- The editable seed remains a concrete integer; negative sentinel values are not
+  introduced.
+- `fixed` keeps the current concrete seed.
+- `randomize` chooses one new concrete next-run seed after an accepted execution.
+  It is not a persistent random-mode token.
+- `increment` and `decrement` compute one concrete next-run seed using the existing
+  wrap domain.
+- The next concrete seed is written to the live widget only when the accepted
+  prompt transaction and `prompt.wildcard_seed` revision are still current.
+- A stale result may update non-editable previous-execution history but cannot
+  overwrite a newer seed or control edit.
+- `wildcard_mode` (`populate/general` versus `sequential`) remains independent from
+  `wildcard_seed_after_generate`.
+- Existing previous-execution workflow serialization remains compatible unless a
+  separate migration is approved.
+
+### 3.2 Required tests
+
+```text
+seed 7 + fixed      -> execution 7, live next 7
+seed 7 + increment  -> execution 7, live next 8
+seed MAX + increment -> live next 0
+seed 0 + decrement  -> live next MAX
+seed 7 + randomize  -> one concrete next value; following queue uses it
+queue seed 7 -> user edits 99 -> old result does not replace 99
+old result may record execution seed 7 in non-editable history
+workflow save/reload preserves the accepted reproducibility contract
+```
+
+Use deterministic random sources in tests. Do not copy AiO special-token logic
+into Prompt Studio.
+
+## 4. AiO special-token contract
+
+### 4.1 Required observable behavior
+
+- `-1/-2/-3` remain visible after any number of accepted, rejected, cancelled, or
+  out-of-order queue results.
+- The backend reservation service remains the source of concrete execution seeds.
+- Actual execution seeds update only last-seed/history state.
+- `Use Last` is the explicit transition from a special token to one concrete fixed
+  seed.
+- `New Fixed Random` creates one concrete fixed seed and leaves special mode.
+- Workflow serialization stores the special token, not the concrete result.
+- No queue path temporarily mutates the live widget to a concrete seed.
+
+### 4.2 Interaction with `seed_after_generate`
+
+A special selection token already owns repeated queue-time selection. Therefore a
+second after-generate transition must not create another user-visible or stream
+advance.
+
+Required effective rule:
+
+```text
+seed in {-1, -2, -3}
+  -> special selection is authoritative
+  -> live token is preserved
+  -> effective after-generate behavior is fixed/no second transition
+```
+
+For compatibility, the stored `seed_after_generate` setting may be retained and
+become active again when the user switches to a concrete seed. It must not affect
+the special-mode execution sequence while a token is active.
+
+The implementation may normalize the effective reservation request to `fixed` or
+prove an equivalent backend-only result, but AIO-SEED-UI-02 cannot begin until the
+Contract fixture demonstrates that there is no double advancement.
+
+### 4.3 Required matrix
+
+```text
+-1 x every stored after_generate value
+  -> each queue uses a new concrete random seed
+  -> widget remains -1
+  -> exactly one queue-time selection occurs
+
+-2 x every stored after_generate value
+  -> concrete executions advance by exactly +1 per accepted queue
+  -> widget remains -2
+
+-3 x every stored after_generate value
+  -> concrete executions advance by exactly -1 per accepted queue
+  -> widget remains -3
+
+concrete seed x fixed/randomize/increment/decrement
+  -> after_generate computes a concrete next editable value
+  -> publication requires current transaction revision
+```
+
+This matrix is a hard gate, not an optional compatibility test.
+
+## 5. Revised feature sequence
+
+```text
+QSTATE-02B  two-phase Contract
+  -> QSTATE-02C transaction core
+       +
+     QSTATE-02D executed-event envelope bridge
+
+QSTATE-02B 이후 병렬 가능:
+  -> QSTATE-03 LoRA result replay retirement
+
+QSTATE-02C/D 이후:
+  -> QSTATE-04A Prompt Studio submitted-snapshot replay retirement
+  -> QSTATE-04B Prompt Studio Wildcard concrete next-seed compare-and-commit
+  -> AIO-SEED-UI-01 special/concrete intent-display Contract and full matrix
+  -> AIO-SEED-UI-02 backend payload/effective-control implementation
+  -> AIO-SEED-UI-03 frontend publication and last-seed UX
+```
+
+QSTATE-04A and QSTATE-04B may share one PR only when their file ownership and
+rollback boundary remain small. They may not import AiO seed semantics.
+
+AIO-SEED-UI-01 may start after the shared transaction API is frozen, but
+AIO-SEED-UI-02/03 remain blocked until its full special-token matrix is reviewed.
+
+## 6. Stop conditions
+
+Stop and record a blocker before implementation expands if:
+
+- the shared transaction core parses seed values or control names;
+- Prompt Studio requires negative sentinel values to implement next-seed control;
+- AiO special mode reuses Prompt Studio's concrete next-seed publication helper;
+- a special token plus non-fixed `seed_after_generate` advances the concrete stream
+  more than once per accepted queue;
+- workflow serialization replaces an AiO special token with an execution seed;
+- Prompt Studio previous-execution serialization must change to implement stale
+  protection;
+- a mapped payload with multiple items attempts an editable seed commit without a
+  separate aggregation Contract.
+
+The first three conditions require design correction. The double-advance or
+serialization conditions require another focused PRO-level review before AiO seed
+implementation continues.
+
+## 7. Focused validation ownership
+
+### QSTATE-04B
+
+```text
+frontend queue transaction smoke
+Prompt Studio Advanced executed-values smoke
+Prompt Studio wildcard seed/history/serialization smokes
+focused Python seed adapter tests when backend payload meaning changes
+git diff --check
+```
+
+### AIO-SEED-UI-01
+
+```text
+frontend AiO executed-seed Contract smoke
+Python seed adapter and reservation tests
+special-token x after_generate golden matrix
+git diff --check
+```
+
+### AIO-SEED-UI-02/03
+
+Add backend AiO node/generation tests only when their result construction changes.
+Add the generator-panel or extension-runtime smoke only when those owners change.
+Run dual-canvas live validation only on the final feature cutover, not during the
+Contract edit loop.
+
+## 8. Codex continuation rule
+
+QSTATE-02B, QSTATE-02C/D, and QSTATE-03 may continue without another seed review.
+Before QSTATE-04B or AIO-SEED-UI implementation, read this document and use separate
+feature task cards and separate surface tokens:
+
+```text
+prompt.wildcard_seed
+prompt.wildcard_history
+aio.seed_selection
+aio.last_seed
+aio.concrete_next_seed
+```
+
+Names may change, but the ownership split may not collapse.


### PR DESCRIPTION
## 목적

Prompt Studio Wildcard의 `생성 후 제어`와 AiO의 rgthree-style `-1/-2/-3` 특수 시드를 같은 publication 규칙으로 구현하지 않도록 active hotfix roadmap에 feature-semantics gate를 추가합니다.

## 핵심 구분

```text
Prompt Studio Wildcard
  concrete seed + after_generate transition
  current public controls: fixed / randomize / increment
  -> accepted result가 current일 때 next concrete seed를 live UI에 반영

AiO special seed
  persistent selection token -1/-2/-3
  -> backend가 concrete execution seed를 예약
  -> live token은 유지
  -> stored after_generate는 special mode에서 두 번째 transition을 만들지 않음
```

AiO concrete seed만 `after_generate`에 따른 next concrete value를 compare-and-commit합니다.

Lower-level seed 계층이 `decrement`를 인식하는 것과 별개로, Prompt Studio 현재 공개 UI·라벨·도움말은 세 control만 제공합니다. 이번 hotfix에서 새 Wildcard control을 추가하지 않습니다.

## 추가한 gate

- shared transaction core는 seed 값이나 control 이름을 해석하지 않음
- Prompt Studio `randomize`는 다음 concrete seed를 한 번 선택하는 transition이며 persistent random token이 아님
- Wildcard seed와 control은 하나의 atomic revision surface로 보호
- AiO special token은 queue-time selection을 소유하며 visible token을 concrete seed로 교체하지 않음
- special token × 모든 stored `after_generate` 조합에서 double advancement가 없는 golden matrix를 AIO-SEED-UI-01 hard gate로 지정
- AIO-SEED-UI-01 final matrix 뒤 focused PRO review를 필수 중단 지점으로 지정
- QSTATE-04를 submitted-snapshot retirement와 Wildcard concrete next-seed cutover로 구분
- multiple mapped payload의 editable seed commit은 계속 fail-closed

## 변경 파일

- `docs/architecture/seed-ui-semantics-gate.md`
- `docs/architecture/README.md`

## 검증

- GitHub compare 기준 docs 2개만 변경
- production Python/JavaScript, tests, workflow, version metadata 변경 없음
- docs-only이므로 full/package/live 검증 미실행

## 실행 관계

- PR #419 QSTATE-02B는 seed-agnostic Contract이므로 그대로 review/merge 가능
- QSTATE-02C/D와 QSTATE-03은 이 문서 병합 전후로 진행 가능
- QSTATE-04B와 AIO-SEED-UI 구현 전에는 이 gate를 반드시 적용
- AIO-SEED-UI-02/03은 final AIO-SEED-UI-01 matrix의 focused PRO review 승인 전까지 BLOCKED

Refs #413
Refs #414
Refs #415