### PR TITLE
feat: add queue UI transaction owner

### DIFF
--- a/tests/frontend_queue_ui_transaction_smoke.mjs
+++ b/tests/frontend_queue_ui_transaction_smoke.mjs
@@ -1,12 +1,21 @@
 import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
 
-// QSTATE-02B contract-only fixture. The reference owner remains test-local;
-// QSTATE-02C will replace it with the production transaction core.
-//
-// Shared ownership stops at frontend-node lifecycle, opaque surface revisions,
-// prompt ordering, settlement, and cleanup. Feature adapters retain ownership
-// of field catalogs, payload parsing, and actual editable mutations.
-const IDENTITY_DECISION = Object.freeze({
+function dataModule(relativePath) {
+  const source = readFileSync(new URL(relativePath, import.meta.url), "utf8");
+  return `data:text/javascript;base64,${Buffer.from(source).toString("base64")}`;
+}
+
+const transactionModule = await import(dataModule(
+  "../web/js/lifecycle/queue_ui_transaction.js",
+));
+const { createQueueUiTransactionOwner } = transactionModule;
+
+assert.deepEqual(Object.keys(transactionModule), [
+  "createQueueUiTransactionOwner",
+]);
+
+const CONTRACT_DECISIONS = Object.freeze({
   provisional: Object.freeze([
     "frontendNode",
     "nodeEpoch",
@@ -23,338 +32,8 @@ const IDENTITY_DECISION = Object.freeze({
   listIndexPolicy: "feature-contract-only",
   mappedEditableCommitPolicy: "single-item-only",
   unavailableIdentityPolicy: "fail-closed",
+  featureSemanticsPolicy: "adapter-owned",
 });
-
-const TERMINAL_REASONS = new Set([
-  "cancel",
-  "reject",
-  "clear",
-  "remove",
-  "reconfigure",
-  "dispose",
-]);
-
-function createReferenceHarness({ maxTransactionsPerNode = 3 } = {}) {
-  assert(Number.isInteger(maxTransactionsPerNode) && maxTransactionsPerNode > 0);
-
-  let sequence = 0;
-  const transactions = new Map();
-  const nodeEpochs = new WeakMap();
-  const nodeStates = new Map();
-  const transactionsByPrompt = new Map();
-
-  function validNode(node) {
-    return (
-      node !== null
-      && (typeof node === "object" || typeof node === "function")
-    );
-  }
-
-  function normalizedPromptId(promptId) {
-    return typeof promptId === "string" && promptId.trim() !== ""
-      ? promptId.trim()
-      : null;
-  }
-
-  function normalizedNodeId(nodeId) {
-    if (typeof nodeId === "string" && nodeId.trim() !== "") {
-      return nodeId.trim();
-    }
-    if (typeof nodeId === "number" && Number.isInteger(nodeId)) {
-      return String(nodeId);
-    }
-    return null;
-  }
-
-  function normalizedEnvelope(envelope) {
-    const promptId = normalizedPromptId(envelope?.promptId);
-    const executionNodeId = normalizedNodeId(envelope?.executionNodeId);
-    const displayNodeId = envelope?.displayNodeId == null
-      ? null
-      : normalizedNodeId(envelope.displayNodeId);
-    const output = envelope?.output;
-    if (
-      promptId == null
-      || executionNodeId == null
-      || (envelope?.displayNodeId != null && displayNodeId == null)
-      || output === null
-      || (typeof output !== "object" && typeof output !== "function")
-    ) {
-      return null;
-    }
-    return { promptId, executionNodeId, displayNodeId, output };
-  }
-
-  function validSurfaces(surfaces) {
-    return Array.isArray(surfaces)
-      && surfaces.length > 0
-      && surfaces.every(
-        (surface) => typeof surface === "string" && surface.trim() !== "",
-      );
-  }
-
-  function nodeState(node) {
-    let state = nodeStates.get(node);
-    if (!state) {
-      const epoch = (nodeEpochs.get(node) || 0) + 1;
-      nodeEpochs.set(node, epoch);
-      state = {
-        epoch,
-        revisions: new Map(),
-        latestBySurface: new Map(),
-        transactionIds: [],
-      };
-      nodeStates.set(node, state);
-    }
-    return state;
-  }
-
-  function revision(state, surface) {
-    return state.revisions.get(surface) || 0;
-  }
-
-  function tracked(transaction) {
-    return Boolean(
-      transaction
-      && transactions.get(transaction.id) === transaction
-      && ["provisional", "accepted"].includes(transaction.state),
-    );
-  }
-
-  function releasePromptReference(transaction) {
-    if (transaction.promptId == null) {
-      return;
-    }
-    const promptTransactions = transactionsByPrompt.get(transaction.promptId);
-    promptTransactions?.delete(transaction.id);
-    if (promptTransactions?.size === 0) {
-      transactionsByPrompt.delete(transaction.promptId);
-    }
-  }
-
-  function releaseTransaction(transaction) {
-    transactions.delete(transaction.id);
-    releasePromptReference(transaction);
-
-    const state = nodeStates.get(transaction.node);
-    if (state?.epoch !== transaction.nodeEpoch) {
-      return;
-    }
-    state.transactionIds = state.transactionIds.filter(
-      (transactionId) => transactionId !== transaction.id,
-    );
-    for (const surface of transaction.surfaces) {
-      if (state.latestBySurface.get(surface) === transaction.id) {
-        state.latestBySurface.delete(surface);
-      }
-    }
-  }
-
-  function terminate(transaction, state, reason) {
-    if (!tracked(transaction)) {
-      return false;
-    }
-    transaction.state = state;
-    transaction.reason = reason;
-    releaseTransaction(transaction);
-    return true;
-  }
-
-  function enforceNodeRetention(state) {
-    while (state.transactionIds.length > maxTransactionsPerNode) {
-      const oldest = transactions.get(state.transactionIds[0]);
-      if (!oldest) {
-        state.transactionIds.shift();
-        continue;
-      }
-      terminate(oldest, "cancelled", "retention");
-    }
-  }
-
-  function captureProvisional({ node, surfaces }) {
-    if (!validNode(node) || !validSurfaces(surfaces)) {
-      return null;
-    }
-
-    const state = nodeState(node);
-    const id = `qstate-${++sequence}`;
-    const normalizedSurfaces = [
-      ...new Set(surfaces.map((surface) => surface.trim())),
-    ];
-    const transaction = {
-      id,
-      localSequence: sequence,
-      node,
-      nodeEpoch: state.epoch,
-      promptId: null,
-      surfaces: normalizedSurfaces,
-      revisions: {},
-      state: "provisional",
-      reason: null,
-    };
-
-    for (const surface of normalizedSurfaces) {
-      transaction.revisions[surface] = revision(state, surface);
-      state.latestBySurface.set(surface, id);
-    }
-    transactions.set(id, transaction);
-    state.transactionIds.push(id);
-    enforceNodeRetention(state);
-    return transaction;
-  }
-
-  function acceptPrompt(transaction, promptId) {
-    const normalized = normalizedPromptId(promptId);
-    if (
-      !tracked(transaction)
-      || transaction.state !== "provisional"
-      || normalized == null
-    ) {
-      return false;
-    }
-
-    const promptTransactions = transactionsByPrompt.get(normalized) || new Set();
-    const ambiguousNodePrompt = [...promptTransactions].some(
-      (transactionId) => transactions.get(transactionId)?.node === transaction.node,
-    );
-    if (ambiguousNodePrompt) {
-      terminate(transaction, "cancelled", "ambiguous-prompt");
-      return false;
-    }
-
-    transaction.promptId = normalized;
-    transaction.state = "accepted";
-    promptTransactions.add(transaction.id);
-    transactionsByPrompt.set(normalized, promptTransactions);
-    return true;
-  }
-
-  function markEdited(node, surfaces) {
-    const state = validNode(node) ? nodeStates.get(node) : null;
-    if (!state || !validSurfaces(surfaces)) {
-      return false;
-    }
-    for (const surface of new Set(surfaces.map((value) => value.trim()))) {
-      state.revisions.set(surface, revision(state, surface) + 1);
-    }
-    return true;
-  }
-
-  function canCommit(
-    transaction,
-    { envelope, node, surface, mappedItemCount = 1 } = {},
-  ) {
-    const normalized = normalizedEnvelope(envelope);
-    if (
-      !tracked(transaction)
-      || transaction.state !== "accepted"
-      || normalized == null
-      || transaction.promptId !== normalized.promptId
-      || node !== transaction.node
-      || mappedItemCount !== 1
-    ) {
-      return false;
-    }
-
-    const state = nodeStates.get(node);
-    if (state?.epoch !== transaction.nodeEpoch) {
-      return false;
-    }
-    if (!transaction.surfaces.includes(surface)) {
-      return false;
-    }
-    if (state.latestBySurface.get(surface) !== transaction.id) {
-      return false;
-    }
-    return revision(state, surface) === transaction.revisions[surface];
-  }
-
-  function settle(transaction, envelope) {
-    const normalized = normalizedEnvelope(envelope);
-    if (
-      !tracked(transaction)
-      || transaction.state !== "accepted"
-      || normalized == null
-      || transaction.promptId !== normalized.promptId
-    ) {
-      return false;
-    }
-    return terminate(transaction, "settled", "executed");
-  }
-
-  function cancel(transaction, reason = "cancel") {
-    if (!TERMINAL_REASONS.has(reason)) {
-      return false;
-    }
-    return terminate(transaction, "cancelled", reason);
-  }
-
-  function finishPrompt(promptId) {
-    const normalized = normalizedPromptId(promptId);
-    const promptTransactions = normalized == null
-      ? null
-      : transactionsByPrompt.get(normalized);
-    if (!promptTransactions) {
-      return 0;
-    }
-    let finished = 0;
-    for (const transactionId of [...promptTransactions]) {
-      const transaction = transactions.get(transactionId);
-      if (transaction && terminate(transaction, "finished", "prompt-terminal")) {
-        finished += 1;
-      }
-    }
-    return finished;
-  }
-
-  function disposeNode(node, reason = "dispose") {
-    if (
-      !validNode(node)
-      || !["remove", "reconfigure", "dispose"].includes(reason)
-    ) {
-      return false;
-    }
-    const state = nodeStates.get(node);
-    if (!state) {
-      return false;
-    }
-    for (const transactionId of [...state.transactionIds]) {
-      const transaction = transactions.get(transactionId);
-      if (transaction) {
-        terminate(transaction, "cancelled", reason);
-      }
-    }
-    state.revisions.clear();
-    state.latestBySurface.clear();
-    state.transactionIds.length = 0;
-    nodeStates.delete(node);
-    return true;
-  }
-
-  const owner = {
-    captureProvisional,
-    acceptPrompt,
-    markEdited,
-    canCommit,
-    settle,
-    cancel,
-    finishPrompt,
-    disposeNode,
-  };
-  const inspect = () => ({
-    transactionCount: transactions.size,
-    nodeStateCount: nodeStates.size,
-    promptReferenceCount: [...transactionsByPrompt.values()].reduce(
-      (count, promptTransactions) => count + promptTransactions.size,
-      0,
-    ),
-    orderingReferenceCount: [...nodeStates.values()].reduce(
-      (count, state) => count + state.latestBySurface.size,
-      0,
-    ),
-  });
-  return { owner, inspect };
-}
 
 const expectedApi = [
   "captureProvisional",
@@ -366,7 +45,20 @@ const expectedApi = [
   "finishPrompt",
   "disposeNode",
 ].sort();
-assert.deepEqual(Object.keys(createReferenceHarness().owner).sort(), expectedApi);
+
+assert.equal(typeof createQueueUiTransactionOwner, "function");
+assert.deepEqual(
+  Object.keys(createQueueUiTransactionOwner()).sort(),
+  expectedApi,
+);
+assert.throws(
+  () => createQueueUiTransactionOwner({ maxTransactionsPerNode: 0 }),
+  /positive integer/,
+);
+assert.throws(
+  () => createQueueUiTransactionOwner({ maxTransactionsPerPrompt: 1.5 }),
+  /positive integer/,
+);
 
 function envelope(promptId, output = {}) {
   return {
@@ -379,17 +71,26 @@ function envelope(promptId, output = {}) {
 
 const scenarios = [
   {
-    name: "provisional capture requires only local node and surfaces",
-    run({ owner }) {
+    name: "provisional capture requires only local node and opaque surfaces",
+    run() {
+      const owner = createQueueUiTransactionOwner();
       const node = {};
-      assert.equal(owner.captureProvisional({ node: null, surfaces: ["surface-a"] }), null);
+      assert.equal(
+        owner.captureProvisional({ node: null, surfaces: ["surface-a"] }),
+        null,
+      );
       assert.equal(owner.captureProvisional({ node, surfaces: [] }), null);
+      assert.equal(
+        owner.captureProvisional({ node, surfaces: ["surface-a", 1] }),
+        null,
+      );
 
       const transaction = owner.captureProvisional({
         node,
-        surfaces: ["surface-a"],
+        surfaces: [" surface-a ", "surface-a"],
       });
       assert(transaction);
+      assert.equal(Object.isFrozen(transaction), true);
       assert.equal(transaction.promptId, null);
       assert.equal(transaction.state, "provisional");
       assert.equal(
@@ -401,32 +102,33 @@ const scenarios = [
         false,
       );
       assert.equal(owner.acceptPrompt(transaction, ""), false);
-      assert.equal(owner.acceptPrompt(transaction, "prompt-a"), true);
+      assert.equal(owner.acceptPrompt(transaction, " prompt-a "), true);
+      assert.equal(transaction.promptId, "prompt-a");
+      assert.equal(transaction.state, "accepted");
       assert.equal(owner.acceptPrompt(transaction, "prompt-a"), false);
     },
   },
   {
-    name: "queue rejection cancels provisional state and references",
-    run({ owner, inspect }) {
-      const node = {};
+    name: "queue rejection cancels provisional state",
+    run() {
+      const owner = createQueueUiTransactionOwner();
       const transaction = owner.captureProvisional({
-        node,
+        node: {},
         surfaces: ["surface-a"],
       });
       assert(transaction);
+      assert.equal(owner.cancel(transaction, "unknown"), false);
       assert.equal(owner.cancel(transaction, "reject"), true);
+      assert.equal(transaction.state, "cancelled");
+      assert.equal(transaction.reason, "reject");
       assert.equal(owner.acceptPrompt(transaction, "prompt-rejected"), false);
-      assert.deepEqual(inspect(), {
-        transactionCount: 0,
-        nodeStateCount: 1,
-        promptReferenceCount: 0,
-        orderingReferenceCount: 0,
-      });
+      assert.equal(owner.cancel(transaction, "reject"), false);
     },
   },
   {
-    name: "accepted prompt and frontend node ownership gate editable commit",
-    run({ owner }) {
+    name: "accepted prompt envelope and frontend node gate editable commit",
+    run() {
+      const owner = createQueueUiTransactionOwner();
       const node = {};
       const transaction = owner.captureProvisional({
         node,
@@ -436,43 +138,66 @@ const scenarios = [
       assert.equal(owner.acceptPrompt(transaction, "prompt-a"), true);
 
       const executedEnvelope = envelope("prompt-a");
-      assert.equal(
-        owner.canCommit(transaction, {
-          envelope: executedEnvelope,
+      assert.equal(owner.canCommit(transaction, {
+        envelope: executedEnvelope,
+        node,
+        surface: "surface-a",
+      }), true);
+      for (const invalidEnvelope of [
+        null,
+        { ...executedEnvelope, promptId: "" },
+        { ...executedEnvelope, promptId: "prompt-other" },
+        { ...executedEnvelope, executionNodeId: null },
+        { ...executedEnvelope, displayNodeId: {} },
+        { ...executedEnvelope, output: null },
+      ]) {
+        assert.equal(owner.canCommit(transaction, {
+          envelope: invalidEnvelope,
           node,
           surface: "surface-a",
-        }),
-        true,
-      );
-      assert.equal(
-        owner.canCommit(transaction, {
-          envelope: null,
-          node,
-          surface: "surface-a",
-        }),
-        false,
-      );
-      assert.equal(
-        owner.canCommit(transaction, {
-          envelope: envelope("prompt-other"),
-          node,
-          surface: "surface-a",
-        }),
-        false,
-      );
-      assert.equal(
-        owner.canCommit(transaction, {
-          envelope: executedEnvelope,
-          node: {},
-          surface: "surface-a",
-        }),
-        false,
-      );
+        }), false);
+      }
+      assert.equal(owner.canCommit(transaction, {
+        envelope: executedEnvelope,
+        node: {},
+        surface: "surface-a",
+      }), false);
+      assert.equal(owner.canCommit(transaction, {
+        envelope: executedEnvelope,
+        node,
+        surface: "unknown-surface",
+      }), false);
+    },
+  },
+  {
+    name: "ambiguous accepted identity fails closed",
+    run() {
+      const owner = createQueueUiTransactionOwner();
+      const node = {};
+      const first = owner.captureProvisional({
+        node,
+        surfaces: ["surface-a"],
+      });
+      const ambiguous = owner.captureProvisional({
+        node,
+        surfaces: ["surface-b"],
+      });
+      assert(first && ambiguous);
+      assert.equal(owner.acceptPrompt(first, "prompt-shared"), true);
+      assert.equal(owner.acceptPrompt(ambiguous, "prompt-shared"), false);
+      assert.equal(ambiguous.state, "cancelled");
+      assert.equal(ambiguous.reason, "ambiguous-prompt");
+      assert.equal(owner.canCommit(ambiguous, {
+        envelope: envelope("prompt-shared"),
+        node,
+        surface: "surface-b",
+      }), false);
     },
   },
   {
     name: "multiple mapped payloads cannot commit editable state",
-    run({ owner }) {
+    run() {
+      const owner = createQueueUiTransactionOwner();
       const node = {};
       const transaction = owner.captureProvisional({
         node,
@@ -483,30 +208,25 @@ const scenarios = [
       const executedEnvelope = envelope("prompt-mapped");
 
       for (const mappedItemCount of [0, 2, 3]) {
-        assert.equal(
-          owner.canCommit(transaction, {
-            envelope: executedEnvelope,
-            node,
-            surface: "surface-a",
-            mappedItemCount,
-          }),
-          false,
-        );
-      }
-      assert.equal(
-        owner.canCommit(transaction, {
+        assert.equal(owner.canCommit(transaction, {
           envelope: executedEnvelope,
           node,
           surface: "surface-a",
-          mappedItemCount: 1,
-        }),
-        true,
-      );
+          mappedItemCount,
+        }), false);
+      }
+      assert.equal(owner.canCommit(transaction, {
+        envelope: executedEnvelope,
+        node,
+        surface: "surface-a",
+        mappedItemCount: 1,
+      }), true);
     },
   },
   {
-    name: "opaque surface revisions invalidate only the edited surface",
-    run({ owner }) {
+    name: "opaque revisions invalidate only the edited surface",
+    run() {
+      const owner = createQueueUiTransactionOwner();
       const node = {};
       const transaction = owner.captureProvisional({
         node,
@@ -514,38 +234,26 @@ const scenarios = [
       });
       assert(transaction);
       assert.equal(owner.acceptPrompt(transaction, "prompt-edit"), true);
-      assert.equal(owner.markEdited(node, ["surface-a"]), true);
+      assert.equal(owner.markEdited(node, [" surface-a "]), true);
+      assert.equal(owner.markEdited(node, []), false);
 
       const executedEnvelope = envelope("prompt-edit");
-      assert.equal(
-        owner.canCommit(transaction, {
-          envelope: executedEnvelope,
-          node,
-          surface: "surface-a",
-        }),
-        false,
-      );
-      assert.equal(
-        owner.canCommit(transaction, {
-          envelope: executedEnvelope,
-          node,
-          surface: "surface-b",
-        }),
-        true,
-      );
-      assert.equal(
-        owner.canCommit(transaction, {
-          envelope: executedEnvelope,
-          node,
-          surface: "unknown-surface",
-        }),
-        false,
-      );
+      assert.equal(owner.canCommit(transaction, {
+        envelope: executedEnvelope,
+        node,
+        surface: "surface-a",
+      }), false);
+      assert.equal(owner.canCommit(transaction, {
+        envelope: executedEnvelope,
+        node,
+        surface: "surface-b",
+      }), true);
     },
   },
   {
     name: "latest capture wins while older settlement remains valid",
-    run({ owner, inspect }) {
+    run() {
+      const owner = createQueueUiTransactionOwner();
       const node = {};
       const older = owner.captureProvisional({ node, surfaces: ["surface-a"] });
       const newer = owner.captureProvisional({ node, surfaces: ["surface-a"] });
@@ -555,70 +263,64 @@ const scenarios = [
 
       const olderEnvelope = envelope("prompt-old");
       const newerEnvelope = envelope("prompt-new");
-      assert.equal(
-        owner.canCommit(older, {
-          envelope: olderEnvelope,
-          node,
-          surface: "surface-a",
-        }),
-        false,
-      );
-      assert.equal(
-        owner.canCommit(newer, {
-          envelope: newerEnvelope,
-          node,
-          surface: "surface-a",
-        }),
-        true,
-      );
+      assert.equal(owner.canCommit(older, {
+        envelope: olderEnvelope,
+        node,
+        surface: "surface-a",
+      }), false);
+      assert.equal(owner.canCommit(newer, {
+        envelope: newerEnvelope,
+        node,
+        surface: "surface-a",
+      }), true);
+      assert.equal(owner.settle(older, envelope("wrong-prompt")), false);
       assert.equal(owner.settle(older, olderEnvelope), true);
-      assert.equal(inspect().transactionCount, 1);
+      assert.equal(older.state, "settled");
+      assert.equal(older.reason, "executed");
       assert.equal(owner.settle(newer, newerEnvelope), true);
       assert.equal(owner.settle(newer, newerEnvelope), false);
-      assert.equal(inspect().transactionCount, 0);
-      assert.equal(inspect().promptReferenceCount, 0);
-      assert.equal(inspect().orderingReferenceCount, 0);
+      assert.equal(owner.finishPrompt("prompt-old"), 0);
     },
   },
   {
     name: "cancel clear and prompt terminal signals release transactions",
-    run({ owner, inspect }) {
+    run() {
+      const owner = createQueueUiTransactionOwner();
       for (const reason of ["cancel", "clear"]) {
-        const node = {};
         const transaction = owner.captureProvisional({
-          node,
+          node: {},
           surfaces: ["surface-a"],
         });
         assert(transaction);
         assert.equal(owner.acceptPrompt(transaction, `prompt-${reason}`), true);
         assert.equal(owner.cancel(transaction, reason), true);
-        assert.equal(owner.cancel(transaction, reason), false);
+        assert.equal(transaction.state, "cancelled");
+        assert.equal(transaction.reason, reason);
       }
 
-      const firstNode = {};
-      const secondNode = {};
       const first = owner.captureProvisional({
-        node: firstNode,
+        node: {},
         surfaces: ["surface-a"],
       });
       const second = owner.captureProvisional({
-        node: secondNode,
+        node: {},
         surfaces: ["surface-b"],
       });
       assert(first && second);
       assert.equal(owner.acceptPrompt(first, "prompt-terminal"), true);
       assert.equal(owner.acceptPrompt(second, "prompt-terminal"), true);
       assert.equal(owner.finishPrompt("prompt-terminal"), 2);
+      assert.equal(first.state, "finished");
+      assert.equal(second.state, "finished");
+      assert.equal(first.reason, "prompt-terminal");
       assert.equal(owner.finishPrompt("prompt-terminal"), 0);
-      assert.equal(inspect().transactionCount, 0);
-      assert.equal(inspect().promptReferenceCount, 0);
-      assert.equal(inspect().orderingReferenceCount, 0);
     },
   },
   {
-    name: "remove reconfigure and dispose release every node reference",
-    run({ owner, inspect }) {
+    name: "remove reconfigure and dispose invalidate node epochs",
+    run() {
       for (const reason of ["remove", "reconfigure", "dispose"]) {
+        const owner = createQueueUiTransactionOwner();
         const node = {};
         const first = owner.captureProvisional({
           node,
@@ -631,38 +333,28 @@ const scenarios = [
         assert(first && second);
         assert.equal(owner.acceptPrompt(first, `prompt-${reason}-a`), true);
         assert.equal(owner.acceptPrompt(second, `prompt-${reason}-b`), true);
-        assert.equal(owner.markEdited(node, ["surface-a"]), true);
         assert.equal(owner.disposeNode(node, reason), true);
-        assert.equal(
-          owner.canCommit(first, {
-            envelope: envelope(`prompt-${reason}-a`),
-            node,
-            surface: "surface-a",
-          }),
-          false,
-        );
-        assert.equal(
-          owner.canCommit(second, {
-            envelope: envelope(`prompt-${reason}-b`),
-            node,
-            surface: "surface-b",
-          }),
-          false,
-        );
+        assert.equal(first.state, "cancelled");
+        assert.equal(second.state, "cancelled");
+        assert.equal(first.reason, reason);
+        assert.equal(owner.disposeNode(node, reason), false);
+
+        const replacement = owner.captureProvisional({
+          node,
+          surfaces: ["surface-a"],
+        });
+        assert(replacement);
+        assert.equal(replacement.nodeEpoch, first.nodeEpoch + 1);
+        assert.equal(owner.disposeNode(node), true);
       }
-      assert.deepEqual(inspect(), {
-        transactionCount: 0,
-        nodeStateCount: 0,
-        promptReferenceCount: 0,
-        orderingReferenceCount: 0,
-      });
     },
   },
   {
-    name: "superseded in-flight retention is bounded per node",
+    name: "orphaned transaction retention is bounded by node and prompt",
     run() {
-      const { owner, inspect } = createReferenceHarness({
+      const owner = createQueueUiTransactionOwner({
         maxTransactionsPerNode: 2,
+        maxTransactionsPerPrompt: 2,
       });
       const node = {};
       const first = owner.captureProvisional({ node, surfaces: ["surface-a"] });
@@ -670,58 +362,59 @@ const scenarios = [
       assert(first && second);
       assert.equal(owner.acceptPrompt(first, "prompt-retained-a"), true);
       assert.equal(owner.acceptPrompt(second, "prompt-retained-b"), true);
-
       const third = owner.captureProvisional({ node, surfaces: ["surface-a"] });
       assert(third);
-      assert.equal(owner.acceptPrompt(third, "prompt-retained-c"), true);
       assert.equal(first.state, "cancelled");
       assert.equal(first.reason, "retention");
-      assert.equal(inspect().transactionCount, 2);
-      assert.equal(inspect().promptReferenceCount, 2);
-      assert.equal(inspect().orderingReferenceCount, 1);
-      assert.equal(
-        owner.canCommit(first, {
-          envelope: envelope("prompt-retained-a"),
-          node,
-          surface: "surface-a",
-        }),
-        false,
-      );
-      assert.equal(owner.disposeNode(node), true);
-      assert.deepEqual(inspect(), {
-        transactionCount: 0,
-        nodeStateCount: 0,
-        promptReferenceCount: 0,
-        orderingReferenceCount: 0,
+      assert.equal(owner.acceptPrompt(third, "prompt-retained-c"), true);
+      assert.equal(owner.canCommit(first, {
+        envelope: envelope("prompt-retained-a"),
+        node,
+        surface: "surface-a",
+      }), false);
+
+      const promptTransactions = [0, 1, 2].map((index) => {
+        const promptNode = {};
+        const transaction = owner.captureProvisional({
+          node: promptNode,
+          surfaces: ["surface-prompt"],
+        });
+        assert(transaction);
+        assert.equal(owner.acceptPrompt(transaction, "prompt-wide"), true);
+        return { promptNode, transaction };
       });
+      assert.equal(promptTransactions[0].transaction.state, "cancelled");
+      assert.equal(promptTransactions[0].transaction.reason, "retention");
+      assert.equal(owner.finishPrompt("prompt-wide"), 2);
+      assert.equal(promptTransactions[1].transaction.state, "finished");
+      assert.equal(promptTransactions[2].transaction.state, "finished");
+      assert.equal(owner.disposeNode(node), true);
     },
   },
 ];
 
 for (const scenario of scenarios) {
-  scenario.run(createReferenceHarness());
+  scenario.run();
 }
 
-assert.deepEqual(
-  IDENTITY_DECISION,
-  {
-    provisional: [
-      "frontendNode",
-      "nodeEpoch",
-      "surfaceRevisions",
-      "localSequence",
-    ],
-    accepted: ["promptId"],
-    executedEnvelope: [
-      "promptId",
-      "executionNodeId",
-      "displayNodeId",
-      "output",
-    ],
-    listIndexPolicy: "feature-contract-only",
-    mappedEditableCommitPolicy: "single-item-only",
-    unavailableIdentityPolicy: "fail-closed",
-  },
-);
+assert.deepEqual(CONTRACT_DECISIONS, {
+  provisional: [
+    "frontendNode",
+    "nodeEpoch",
+    "surfaceRevisions",
+    "localSequence",
+  ],
+  accepted: ["promptId"],
+  executedEnvelope: [
+    "promptId",
+    "executionNodeId",
+    "displayNodeId",
+    "output",
+  ],
+  listIndexPolicy: "feature-contract-only",
+  mappedEditableCommitPolicy: "single-item-only",
+  unavailableIdentityPolicy: "fail-closed",
+  featureSemanticsPolicy: "adapter-owned",
+});
 
-console.log(`Queue UI transaction contract smoke passed: ${scenarios.length} scenarios.`);
+console.log(`Queue UI transaction production smoke passed: ${scenarios.length} scenarios.`);

--- a/web/js/lifecycle/queue_ui_transaction.js
+++ b/web/js/lifecycle/queue_ui_transaction.js
@@ -1,0 +1,454 @@
+// @ts-check
+
+const DEFAULT_MAX_TRANSACTIONS_PER_NODE = 8;
+const DEFAULT_MAX_TRANSACTIONS_PER_PROMPT = 128;
+const ACTIVE_STATES = new Set(["provisional", "accepted"]);
+const CANCELLATION_REASONS = new Set([
+  "cancel",
+  "reject",
+  "clear",
+  "remove",
+  "reconfigure",
+  "dispose",
+]);
+
+/** @param {unknown} value @returns {value is object} */
+function isReference(value) {
+  return value !== null && (
+    typeof value === "object"
+    || typeof value === "function"
+  );
+}
+
+/** @param {unknown} value */
+function normalizePromptId(value) {
+  return typeof value === "string" && value.trim() !== ""
+    ? value.trim()
+    : null;
+}
+
+/** @param {unknown} value */
+function normalizeNodeId(value) {
+  if (typeof value === "string" && value.trim() !== "") {
+    return value.trim();
+  }
+  if (typeof value === "number" && Number.isInteger(value)) {
+    return String(value);
+  }
+  return null;
+}
+
+/** @param {unknown} value */
+function normalizeSurface(value) {
+  return typeof value === "string" && value.trim() !== ""
+    ? value.trim()
+    : null;
+}
+
+/** @param {unknown} surfaces @returns {string[] | null} */
+function normalizeSurfaces(surfaces) {
+  if (!Array.isArray(surfaces) || surfaces.length === 0) {
+    return null;
+  }
+  /** @type {string[]} */
+  const normalized = [];
+  for (const surface of surfaces) {
+    const token = normalizeSurface(surface);
+    if (token == null) {
+      return null;
+    }
+    normalized.push(token);
+  }
+  return [...new Set(normalized)];
+}
+
+/** @param {any} envelope */
+function normalizeEnvelope(envelope) {
+  if (!envelope || typeof envelope !== "object") {
+    return null;
+  }
+  const promptId = normalizePromptId(envelope.promptId);
+  const executionNodeId = normalizeNodeId(envelope.executionNodeId);
+  const displayNodeId = envelope.displayNodeId == null
+    ? null
+    : normalizeNodeId(envelope.displayNodeId);
+  const output = envelope.output;
+  if (
+    promptId == null
+    || executionNodeId == null
+    || (envelope.displayNodeId != null && displayNodeId == null)
+    || !isReference(output)
+  ) {
+    return null;
+  }
+  return { promptId, executionNodeId, displayNodeId, output };
+}
+
+/** @param {unknown} value @param {string} name @returns {number} */
+function positiveInteger(value, name) {
+  if (typeof value !== "number" || !Number.isInteger(value) || value <= 0) {
+    throw new TypeError(`${name} must be a positive integer.`);
+  }
+  return value;
+}
+
+/**
+ * Create one seed- and feature-agnostic queue UI transaction owner.
+ *
+ * Surface strings are opaque to this module. Callers retain ownership of field
+ * catalogs, payload parsing, editable mutations, and every feature-specific
+ * interpretation of a surface.
+ *
+ * @param {{
+ *   maxTransactionsPerNode?: number,
+ *   maxTransactionsPerPrompt?: number,
+ * }} [options]
+ */
+export function createQueueUiTransactionOwner(options = {}) {
+  const maxTransactionsPerNode = positiveInteger(
+    options.maxTransactionsPerNode ?? DEFAULT_MAX_TRANSACTIONS_PER_NODE,
+    "maxTransactionsPerNode",
+  );
+  const maxTransactionsPerPrompt = positiveInteger(
+    options.maxTransactionsPerPrompt ?? DEFAULT_MAX_TRANSACTIONS_PER_PROMPT,
+    "maxTransactionsPerPrompt",
+  );
+
+  let sequence = 0;
+  const records = new Map();
+  const transactionIds = new WeakMap();
+  const nodeEpochs = new WeakMap();
+  const nodeStates = new WeakMap();
+  const transactionsByPrompt = new Map();
+
+  /** @param {object | Function} node */
+  function stateForNode(node) {
+    let state = nodeStates.get(node);
+    if (!state) {
+      const epoch = (nodeEpochs.get(node) || 0) + 1;
+      nodeEpochs.set(node, epoch);
+      state = {
+        epoch,
+        revisions: new Map(),
+        latestBySurface: new Map(),
+        transactionIds: [],
+      };
+      nodeStates.set(node, state);
+    }
+    return state;
+  }
+
+  /** @param {any} state @param {string} surface */
+  function revisionFor(state, surface) {
+    return state.revisions.get(surface) || 0;
+  }
+
+  /** @param {unknown} transaction */
+  function recordFor(transaction) {
+    if (!isReference(transaction)) {
+      return null;
+    }
+    const id = transactionIds.get(transaction);
+    const record = id == null ? null : records.get(id);
+    return record?.token === transaction ? record : null;
+  }
+
+  /** @param {any} record */
+  function isTracked(record) {
+    return Boolean(
+      record
+      && records.get(record.id) === record
+      && ACTIVE_STATES.has(record.publicState.state),
+    );
+  }
+
+  /** @param {any} record */
+  function releasePromptReference(record) {
+    if (record.promptId == null) {
+      return;
+    }
+    const promptTransactions = transactionsByPrompt.get(record.promptId);
+    promptTransactions?.delete(record.id);
+    if (promptTransactions?.size === 0) {
+      transactionsByPrompt.delete(record.promptId);
+    }
+  }
+
+  /** @param {any} record */
+  function releaseTransaction(record) {
+    records.delete(record.id);
+    releasePromptReference(record);
+
+    const node = record.node;
+    const state = nodeStates.get(node);
+    if (state?.epoch === record.nodeEpoch) {
+      state.transactionIds = state.transactionIds.filter(
+        (transactionId) => transactionId !== record.id,
+      );
+      for (const surface of record.surfaces) {
+        if (state.latestBySurface.get(surface) === record.id) {
+          state.latestBySurface.delete(surface);
+        }
+      }
+    }
+    record.node = null;
+  }
+
+  /** @param {any} record @param {string} state @param {string} reason */
+  function terminate(record, state, reason) {
+    if (!isTracked(record)) {
+      return false;
+    }
+    record.publicState.state = state;
+    record.publicState.reason = reason;
+    releaseTransaction(record);
+    return true;
+  }
+
+  /** @param {any} state */
+  function enforceNodeRetention(state) {
+    while (state.transactionIds.length > maxTransactionsPerNode) {
+      const oldestId = state.transactionIds[0];
+      const oldest = records.get(oldestId);
+      if (!oldest) {
+        state.transactionIds.shift();
+        continue;
+      }
+      terminate(oldest, "cancelled", "retention");
+    }
+  }
+
+  /** @param {string} promptId */
+  function enforcePromptRetention(promptId) {
+    const promptTransactions = transactionsByPrompt.get(promptId);
+    while (promptTransactions?.size > maxTransactionsPerPrompt) {
+      const oldestId = promptTransactions.values().next().value;
+      const oldest = records.get(oldestId);
+      if (!oldest) {
+        promptTransactions.delete(oldestId);
+        continue;
+      }
+      terminate(oldest, "cancelled", "retention");
+    }
+  }
+
+  /** @param {any} record */
+  function createToken(record) {
+    const { id, localSequence, nodeEpoch, publicState } = record;
+    const token = {};
+    Object.defineProperties(token, {
+      id: { enumerable: true, value: id },
+      localSequence: { enumerable: true, value: localSequence },
+      nodeEpoch: { enumerable: true, value: nodeEpoch },
+      promptId: {
+        enumerable: true,
+        get: () => publicState.promptId,
+      },
+      state: {
+        enumerable: true,
+        get: () => publicState.state,
+      },
+      reason: {
+        enumerable: true,
+        get: () => publicState.reason,
+      },
+    });
+    return Object.freeze(token);
+  }
+
+  /** @param {{ node?: unknown, surfaces?: unknown }} [request] */
+  function captureProvisional({ node, surfaces } = {}) {
+    const normalizedSurfaces = normalizeSurfaces(surfaces);
+    if (!isReference(node) || normalizedSurfaces == null) {
+      return null;
+    }
+
+    const state = stateForNode(node);
+    const id = `qstate-${++sequence}`;
+    /** @type {any} */
+    const record = {
+      id,
+      localSequence: sequence,
+      node,
+      nodeEpoch: state.epoch,
+      promptId: null,
+      surfaces: normalizedSurfaces,
+      revisions: new Map(),
+      publicState: {
+        promptId: null,
+        state: "provisional",
+        reason: null,
+      },
+      token: null,
+    };
+    record.token = createToken(record);
+
+    for (const surface of normalizedSurfaces) {
+      record.revisions.set(surface, revisionFor(state, surface));
+      state.latestBySurface.set(surface, id);
+    }
+    records.set(id, record);
+    transactionIds.set(record.token, id);
+    state.transactionIds.push(id);
+    enforceNodeRetention(state);
+    return record.token;
+  }
+
+  /** @param {unknown} transaction @param {unknown} promptId */
+  function acceptPrompt(transaction, promptId) {
+    const record = recordFor(transaction);
+    const normalized = normalizePromptId(promptId);
+    if (
+      !isTracked(record)
+      || record.publicState.state !== "provisional"
+      || normalized == null
+    ) {
+      return false;
+    }
+
+    const promptTransactions = transactionsByPrompt.get(normalized) || new Set();
+    const ambiguousNodePrompt = [...promptTransactions].some(
+      (transactionId) => records.get(transactionId)?.node === record.node,
+    );
+    if (ambiguousNodePrompt) {
+      terminate(record, "cancelled", "ambiguous-prompt");
+      return false;
+    }
+
+    record.promptId = normalized;
+    record.publicState.promptId = normalized;
+    record.publicState.state = "accepted";
+    promptTransactions.add(record.id);
+    transactionsByPrompt.set(normalized, promptTransactions);
+    enforcePromptRetention(normalized);
+    return record.publicState.state === "accepted";
+  }
+
+  /** @param {unknown} node @param {unknown} surfaces */
+  function markEdited(node, surfaces) {
+    const normalizedSurfaces = normalizeSurfaces(surfaces);
+    const state = isReference(node) ? nodeStates.get(node) : null;
+    if (!state || normalizedSurfaces == null) {
+      return false;
+    }
+    for (const surface of normalizedSurfaces) {
+      state.revisions.set(surface, revisionFor(state, surface) + 1);
+    }
+    return true;
+  }
+
+  /**
+   * @param {unknown} transaction
+   * @param {{
+   *   envelope?: unknown,
+   *   node?: unknown,
+   *   surface?: unknown,
+   *   mappedItemCount?: number,
+   * }} [request]
+   */
+  function canCommit(transaction, request = {}) {
+    const record = recordFor(transaction);
+    const envelope = normalizeEnvelope(request.envelope);
+    const surface = normalizeSurface(request.surface);
+    if (
+      !isTracked(record)
+      || record.publicState.state !== "accepted"
+      || envelope == null
+      || record.promptId !== envelope.promptId
+      || request.node !== record.node
+      || (
+        request.mappedItemCount !== undefined
+        && request.mappedItemCount !== 1
+      )
+      || surface == null
+    ) {
+      return false;
+    }
+
+    const state = nodeStates.get(record.node);
+    return Boolean(
+      state?.epoch === record.nodeEpoch
+      && record.revisions.has(surface)
+      && state.latestBySurface.get(surface) === record.id
+      && revisionFor(state, surface) === record.revisions.get(surface),
+    );
+  }
+
+  /** @param {unknown} transaction @param {unknown} envelope */
+  function settle(transaction, envelope) {
+    const record = recordFor(transaction);
+    const normalized = normalizeEnvelope(envelope);
+    if (
+      !isTracked(record)
+      || record.publicState.state !== "accepted"
+      || normalized == null
+      || record.promptId !== normalized.promptId
+    ) {
+      return false;
+    }
+    return terminate(record, "settled", "executed");
+  }
+
+  /** @param {unknown} transaction @param {string} [reason] */
+  function cancel(transaction, reason = "cancel") {
+    if (!CANCELLATION_REASONS.has(reason)) {
+      return false;
+    }
+    return terminate(recordFor(transaction), "cancelled", reason);
+  }
+
+  /** @param {unknown} promptId */
+  function finishPrompt(promptId) {
+    const normalized = normalizePromptId(promptId);
+    const promptTransactions = normalized == null
+      ? null
+      : transactionsByPrompt.get(normalized);
+    if (!promptTransactions) {
+      return 0;
+    }
+    let finished = 0;
+    for (const transactionId of [...promptTransactions]) {
+      const record = records.get(transactionId);
+      if (record && terminate(record, "finished", "prompt-terminal")) {
+        finished += 1;
+      }
+    }
+    return finished;
+  }
+
+  /** @param {unknown} node @param {string} [reason] */
+  function disposeNode(node, reason = "dispose") {
+    if (
+      !isReference(node)
+      || !["remove", "reconfigure", "dispose"].includes(reason)
+    ) {
+      return false;
+    }
+    const state = nodeStates.get(node);
+    if (!state) {
+      return false;
+    }
+    for (const transactionId of [...state.transactionIds]) {
+      const record = records.get(transactionId);
+      if (record) {
+        terminate(record, "cancelled", reason);
+      }
+    }
+    state.revisions.clear();
+    state.latestBySurface.clear();
+    state.transactionIds.length = 0;
+    nodeStates.delete(node);
+    return true;
+  }
+
+  return Object.freeze({
+    captureProvisional,
+    acceptPrompt,
+    markEdited,
+    canCommit,
+    settle,
+    cancel,
+    finishPrompt,
+    disposeNode,
+  });
+}


### PR DESCRIPTION
## 목적과 변경 경계

QSTATE-02C shared queue UI transaction owner를 production module로 추가합니다. QSTATE-02B의 test-local reference owner를 제거하고 동일 Contract smoke가 실제 production module을 import하도록 전환했습니다.

QSTATE-02D executed-event bridge, feature adapter cutover, DOM mutation, payload parsing은 포함하지 않습니다.

## Base -> Head

```text
7888257da4154310161627091ee2d302b999130d
->
a38dc77c61b41f013fb8381e1aae481922a91e3f
```

## 변경 파일

- `web/js/lifecycle/queue_ui_transaction.js`
- `tests/frontend_queue_ui_transaction_smoke.mjs`

## Contract

- provisional capture: frontend node lifecycle, node epoch, opaque surface revision, local ordering
- queue success: accepted `promptId` bind
- commit gate: accepted prompt/envelope, exact frontend node, current surface revision/latest ordering
- mapped payload: single-item only; ambiguous/multiple identity는 fail-closed
- terminal paths: settle, cancel/reject/clear, prompt finish, remove/reconfigure/dispose
- bounded retention: configurable per-node and per-prompt caps
- node ownership: internal `WeakMap` lifecycle state; dispose 후 epoch 갱신
- shared owner는 seed 값/control, Wildcard/AiO/LoRA/Prompt Studio field catalog, feature payload, DOM을 해석하지 않음

## 검증

Focused:

```text
node --check web/js/lifecycle/queue_ui_transaction.js
PASS

node --check tests/frontend_queue_ui_transaction_smoke.mjs
PASS

node tests/frontend_queue_ui_transaction_smoke.mjs
PASS - 10 scenarios

git diff --check
git diff --cached --check
PASS
```

Official full:

```text
powershell -ExecutionPolicy Bypass -File tools/check_custom_node.ps1 -Project <worktree> -Profile full
Exact SHA: a38dc77c61b41f013fb8381e1aae481922a91e3f
PASS - 1151 Python tests, 116 frontend JS files, TypeScript 6.0.3
```

- Ruff G-01: 기존 report-only 119 findings
- Package: not triggered
- Live: not triggered

## 위험과 rollback

아직 QSTATE-02D event-envelope bridge와 feature wiring이 없으므로 production feature는 이 owner를 소비하지 않습니다. 이 PR 단독으로 사용자 UI 동작은 변경되지 않습니다.

Rollback boundary: `a38dc77c61b41f013fb8381e1aae481922a91e3f`

## Next

이 PR review/merge 후 별도 PR로 QSTATE-02D를 시작합니다. LoRA/Prompt Studio cutover와 AiO seed 변경은 이 PR에 없습니다.

AIO-SEED-UI-01 final matrix 뒤 focused PRO review 중단점과 승인 전 AIO-SEED-UI-02/03 금지는 그대로 유지합니다.

Refs #413
Refs #415