### PR TITLE
QSTATE-03: preserve LoRA profile edits after execution

### DIFF
--- a/tests/frontend_lora_preset_node_runtime_smoke.mjs
+++ b/tests/frontend_lora_preset_node_runtime_smoke.mjs
@@ -193,37 +193,32 @@ animationFrames.shift()();
 
 events.length = 0;
 node.onExecuted({ lora_preset_profile: [{ profile_index: 2 }] });
-assert.deepEqual(events.slice(0, 6), [
-  "executed:node-a",
-  "save:node-a:1",
-  "set:2",
-  "load:node-a:2:false",
-  "scroll:node-a:2",
-  "profile:node-a",
-]);
+assert.deepEqual(events, ["executed:node-a"]);
+assert.equal(node.__easyuseAnimaActiveProfileIndex, 1);
+
+// Simulate a real user profile switch after the queued snapshot was captured.
+findWidget(node, "profile_index").value = 2;
+findWidget(node, "profile_index").callback();
 assert.equal(node.__easyuseAnimaActiveProfileIndex, 2);
-assert.ok(events.includes("loras:node-a"));
+findWidget(node, "style_prompt").value = "new unsaved style";
+findWidget(node, "loras").value = JSON.stringify([{
+  name: "styles/new.safetensors",
+  on: false,
+  strength: 0.25,
+}]);
+const preservedWidgets = node.widgets.map((widget) => widget.value);
 
 events.length = 0;
 node.onExecuted({ lora_preset_profile: [{ profile_index: 2 }] });
-assert.deepEqual(events, ["executed:node-a", "profile:node-a"]);
+assert.deepEqual(events, ["executed:node-a"]);
+assert.equal(node.__easyuseAnimaActiveProfileIndex, 2);
+assert.deepEqual(node.widgets.map((widget) => widget.value), preservedWidgets);
 
-// QSTATE-01 characterization fixture: this intentionally passes while the
-// production bug exists. Profile 1 was queued before the user switched to
-// profile 2, and the real applyExecutedProfile() path currently restores
-// profile 1 over that edit. QSTATE-03 must flip this to a preservation assertion.
+// Profile 1 was queued before the user switched to and edited profile 2. The
+// stale result remains execution metadata and cannot replay profile 1 into the
+// current editor.
 events.length = 0;
 node.onExecuted({ lora_preset_profile: [{ profile_index: 1 }] });
-assert.deepEqual(events.slice(0, 6), [
-  "executed:node-a",
-  "save:node-a:2",
-  "set:1",
-  "load:node-a:1:false",
-  "scroll:node-a:1",
-  "profile:node-a",
-]);
-assert.equal(
-  node.__easyuseAnimaActiveProfileIndex,
-  1,
-  "QSTATE-01 fixture did not reproduce the stale LoRA profile overwrite",
-);
+assert.deepEqual(events, ["executed:node-a"]);
+assert.equal(node.__easyuseAnimaActiveProfileIndex, 2);
+assert.deepEqual(node.widgets.map((widget) => widget.value), preservedWidgets);

--- a/tests/test_frontend_lora_preset.py
+++ b/tests/test_frontend_lora_preset.py
@@ -124,8 +124,6 @@ class LoraPresetFrontendTests(unittest.TestCase):
                 "profileCount",
                 "selectedProfileIndex",
                 "activeProfileIndex",
-                "wrapProfileIndex",
-                "setProfileIndex",
                 "lorasWidgetValue",
                 "saveProfile",
                 "saveCurrentProfile",
@@ -144,7 +142,6 @@ class LoraPresetFrontendTests(unittest.TestCase):
             "finalizeInternalWidgets",
             "ensureLoraStackInput",
             "wrapWidgetCallback",
-            "applyExecutedProfile",
             "initializeNode",
         ):
             with self.subTest(moved_declaration=moved_declaration):
@@ -156,6 +153,8 @@ class LoraPresetFrontendTests(unittest.TestCase):
                     module_source,
                     rf"\bfunction\s+{re.escape(moved_declaration)}\b",
                 )
+        self.assertNotIn("applyExecutedProfile", module_source)
+        self.assertNotIn("prototype.onExecuted", module_source)
         self.assertIn("nodeRuntime: loraPresetNodeRuntime,", entry_source)
         self.assertTrue(LORA_PRESET_NODE_RUNTIME_SMOKE.is_file())
         self.assertIn("web/js/lora_preset/**/*.js", config["include"])

--- a/web/js/easyuse_anima_lora_preset.js
+++ b/web/js/easyuse_anima_lora_preset.js
@@ -403,8 +403,6 @@ const loraPresetNodeRuntime = createLoraPresetNodeRuntime({
   profileCount,
   selectedProfileIndex,
   activeProfileIndex,
-  wrapProfileIndex,
-  setProfileIndex,
   lorasWidgetValue,
   saveProfile,
   saveCurrentProfile,

--- a/web/js/lora_preset/node_runtime.js
+++ b/web/js/lora_preset/node_runtime.js
@@ -19,8 +19,6 @@ export function createLoraPresetNodeRuntime({
   profileCount,
   selectedProfileIndex,
   activeProfileIndex,
-  wrapProfileIndex,
-  setProfileIndex,
   lorasWidgetValue,
   saveProfile,
   saveCurrentProfile,
@@ -220,30 +218,6 @@ export function createLoraPresetNodeRuntime({
     requestAnimationFrame(() => rehydrateNode(node));
   }
 
-  function applyExecutedProfile(node, message) {
-    const payload = Array.isArray(message?.lora_preset_profile)
-      ? message.lora_preset_profile[0]
-      : message?.lora_preset_profile;
-    const index = Number.parseInt(payload?.profile_index, 10);
-    if (!Number.isFinite(index)) {
-      return;
-    }
-    const nextIndex = wrapProfileIndex(index, profileCount(node));
-    const currentIndex = activeProfileIndex(node);
-    if (nextIndex === currentIndex) {
-      canvasWidgets.renderProfileBar(node);
-      return;
-    }
-    saveProfile(node, currentIndex);
-    setProfileIndex(node, nextIndex);
-    node.__easyuseAnimaActiveProfileIndex = nextIndex;
-    loadProfile(node, nextIndex);
-    scrollProfileBarTo(node, nextIndex);
-    canvasWidgets.renderProfileBar(node);
-    canvasWidgets.renderLoraWidgets(node);
-    node.setDirtyCanvas?.(true, true);
-  }
-
   function beforeRegisterNodeDef(nodeType, nodeData) {
     if (nodeData.name !== nodeTypeName) {
       return;
@@ -259,11 +233,6 @@ export function createLoraPresetNodeRuntime({
       const result = originalOnNodeCreated?.apply(this, args);
       initializeNode(this);
       return result;
-    };
-    const originalOnExecuted = nodeType.prototype.onExecuted;
-    nodeType.prototype.onExecuted = function (message) {
-      originalOnExecuted?.apply(this, arguments);
-      applyExecutedProfile(this, message);
     };
   }
 


### PR DESCRIPTION
## 목적과 경계

Task: QSTATE-03 / #413  
Class: UI  
Base -> Head: `9bd4dcacef0210dab262663204f75035d6925c7a -> aa410cbecfe225f64d2ae807e1d6a8e1415b4c34`

LoRA Preset의 execution-result profile replay만 제거합니다. `applyExecutedProfile()` 및 runtime의 `prototype.onExecuted` wrapper를 없애 현재 선택 profile, style/LoRA 편집과 unsaved state가 늦은 실행 결과로 덮이지 않게 합니다. 기존 profile API, provenance/CAS, 저장·직렬화, profile bar와 사용자 profile 전환 동작은 유지합니다.

Changed boundary:
- `web/js/lora_preset/node_runtime.js`
- `web/js/easyuse_anima_lora_preset.js`의 직접 runtime wiring
- LoRA runtime characterization 및 module-boundary tests

Preserved:
- feature field 해석이나 shared transaction owner 변경 없음
- Prompt Studio/AiO/seed/public socket/workflow schema 변경 없음

## Evidence

Focused:
- changed-file `node --check`: PASS
- `node tests/frontend_queue_ui_transaction_smoke.mjs`: PASS (10 scenarios)
- `node tests/frontend_lora_preset_node_runtime_smoke.mjs`: PASS
- `node tests/frontend_lora_preset_profile_mutations_smoke.mjs`: PASS
- focused unittest `tests.test_frontend_lora_preset.LoraPresetFrontendTests.test_node_runtime_module_boundary`: PASS (1/1)
- `git diff --check`: PASS

Full:
- command: workspace `check_custom_node.ps1 -Profile full`
- exact SHA: `aa410cbecfe225f64d2ae807e1d6a8e1415b4c34`
- result: PASS — 1151 Python tests, 117 frontend JS files, TypeScript 6.0.3
- Ruff: existing 119 report-only findings

Live — Codex test instance:
- Source/install/served changed files: exact match
- Legacy Canvas (Modern node off): Profile A batch queued, Profile B selected/edited before settlement; queue returned to 0 and B remained; save/reload preserved B; relevant console errors 0
- Node 2.0 (Modern node on): same stale-settlement, queue-idle, save/reload result; relevant console errors 0
- temporary profile marker, batch count, and starting Legacy mode restored
- user v0.27.0 instance: not run

Package: not triggered

Risk:
- execution-result-driven profile refresh is intentionally retired; runtime now leaves the host's original `onExecuted` behavior untouched.

Rollback:
- revert `aa410cbecfe225f64d2ae807e1d6a8e1415b4c34`

Next:
- QSTATE-04A after review and merge
