### PR TITLE
QSTATE-04A: Prompt Studio submitted replay retirement

### DIFF
--- a/tests/frontend_prompt_studio_advanced_values_smoke.mjs
+++ b/tests/frontend_prompt_studio_advanced_values_smoke.mjs
@@ -60,7 +60,7 @@ const advancedValuesUrl = dataModule(
     "./wildcard_seed_history.js": wildcardSeedHistoryUrl,
   },
 );
-const { applyAdvancedExecutedInputs } = await import(advancedValuesUrl);
+const { publishAdvancedWildcardExecution } = await import(advancedValuesUrl);
 
 const node = {
   properties: {},
@@ -74,7 +74,7 @@ const node = {
 };
 let dirtyCount = 0;
 let renderCount = 0;
-applyAdvancedExecutedInputs(
+publishAdvancedWildcardExecution(
   node,
   {
     prompt_studio_advanced: [{
@@ -104,13 +104,12 @@ const previous = JSON.parse(
 assert(previous.seed === 41, "Advanced history did not store the execution seed");
 assert(previous.mode === "sequential", "Advanced history did not normalize the mode");
 assert(dirtyCount === 1, "Advanced history publication did not dirty once");
-assert(renderCount === 1, "Advanced editor was not refreshed once");
+assert(renderCount === 0, "execution publication must not rerender the Advanced editor");
 
-// QSTATE-01 characterization fixture: this intentionally passes while the
-// production bug exists. An Advanced/AdvancedV2 queue captured the submitted
-// values below, then the user edited every mutable surface group. The real
-// applyAdvancedExecutedInputs() path currently restores the submitted snapshot.
-// QSTATE-04 must flip this to a preservation assertion.
+// QSTATE-04A preservation fixture: an Advanced/AdvancedV2 queue captured the
+// submitted values below, then the user edited every mutable surface group.
+// Execution publication may retain wildcard history/next-seed behavior for the
+// QSTATE-04B cutover, but it must not replay submitted editor state.
 const submittedFields = JSON.stringify([
   { id: "positive_general", text: "queued old tags" },
 ]);
@@ -119,6 +118,9 @@ const editedFields = JSON.stringify([
 ]);
 const staleNode = {
   properties: {},
+  __easyuseAnimaAdvancedFieldInputValues: {
+    field_positive_general: "current socket edit",
+  },
   widgets: [
     { name: "advanced_fields", value: editedFields },
     { name: "use_naia", value: false },
@@ -133,7 +135,7 @@ const staleNode = {
     { name: "artist_mix_start_percent", value: 0.75 },
   ],
 };
-applyAdvancedExecutedInputs(
+publishAdvancedWildcardExecution(
   staleNode,
   {
     prompt_studio_advanced: [{
@@ -162,31 +164,38 @@ const staleWidgetValue = (name) => staleNode.widgets.find(
   (widget) => widget.name === name,
 )?.value;
 assert(
-  staleWidgetValue("advanced_fields") === submittedFields,
-  "QSTATE-01 fixture did not reproduce the stale Advanced field overwrite",
+  staleWidgetValue("advanced_fields") === editedFields,
+  "stale Advanced fields replaced the current editor state",
 );
 assert(
   staleNode.__easyuseAnimaAdvancedFieldInputValues.field_positive_general
-    === "queued socket value",
-  "QSTATE-01 fixture did not reproduce the stale Advanced field-input overwrite",
+    === "current socket edit",
+  "stale Advanced field inputs replaced the current socket state",
 );
 assert(
-  staleWidgetValue("resolution_bucket") === "1024"
-    && staleWidgetValue("resolution_size") === "1024 * 1024 (1:1)"
-    && staleWidgetValue("resolution_custom_width") === 1024
-    && staleWidgetValue("resolution_custom_height") === 1024,
-  "QSTATE-01 fixture did not reproduce the stale Advanced resolution overwrite",
+  staleWidgetValue("use_naia") === false,
+  "stale Advanced NAIA state replaced the current selection",
 );
 assert(
-  staleWidgetValue("wildcard_mode") === "순차"
-    && staleWidgetValue("wildcard_seed") === 41
-    && staleWidgetValue("wildcard_seed_after_generate") === "increment",
-  "QSTATE-01 fixture did not reproduce the stale Advanced wildcard overwrite",
+  staleWidgetValue("resolution_bucket") === "Custom"
+    && staleWidgetValue("resolution_size") === "1344 * 768"
+    && staleWidgetValue("resolution_custom_width") === 1344
+    && staleWidgetValue("resolution_custom_height") === 768,
+  "stale Advanced resolution replaced the current atomic group",
 );
 assert(
-  staleWidgetValue("artist_mix_mode") === "average"
-    && staleWidgetValue("artist_mix_start_percent") === 0.25,
-  "QSTATE-01 fixture did not reproduce the stale Advanced Artist Mix overwrite",
+  staleWidgetValue("wildcard_mode") === "일반"
+    && staleWidgetValue("wildcard_seed_after_generate") === "fixed",
+  "stale Advanced wildcard settings replaced the current mode/control",
+);
+assert(
+  staleWidgetValue("wildcard_seed") === 41,
+  "QSTATE-04A must preserve the existing next-seed publication for QSTATE-04B",
+);
+assert(
+  staleWidgetValue("artist_mix_mode") === "exact"
+    && staleWidgetValue("artist_mix_start_percent") === 0.75,
+  "stale Advanced Artist Mix state replaced the current atomic group",
 );
 
 console.log("Prompt Studio Advanced executed values smoke passed.");

--- a/tests/frontend_prompt_studio_classic_values_smoke.mjs
+++ b/tests/frontend_prompt_studio_classic_values_smoke.mjs
@@ -14,37 +14,14 @@ function inlineModule(source) {
 }
 
 const constantsUrl = inlineModule(`
-  export const EXTEND_ACTIVE_SLOTS_WIDGET = "active_slots";
-  export const EXTEND_VISIBLE_SLOTS_PROPERTY = "easyuse_anima_extend_visible_slots";
+  export const ADVANCED_NODE_TYPE = "EasyUseAnimaPromptStudioAdvanced";
+  export const ADVANCED_V2_NODE_TYPE = "EasyUseAnimaPromptStudioAdvancedV2";
+  export const EXTEND_NODE_TYPE = "EasyUseAnimaPromptStudioExtend";
+  export const NODE_TYPE = "EasyUseAnimaPromptStudio";
+  export const WILDCARD_NODE_TYPE = "EasyUseAnimaWildcard";
 `);
-const extendSlotsUrl = inlineModule(`
-  export function extendVisibleSlots(node) {
-    return node.__visibleSlots || new Set();
-  }
-  export function parseExtendSlots(value) {
-    if (Array.isArray(value)) return value;
-    if (typeof value !== "string") return [];
-    try {
-      const parsed = JSON.parse(value);
-      return Array.isArray(parsed) ? parsed : [];
-    } catch {
-      return [];
-    }
-  }
-  export function writeExtendVisibleSlots(node, slots) {
-    node.__visibleSlots = new Set(slots);
-  }
-`);
-const widgetsUrl = inlineModule(`
-  export function findInputEl(widget) {
-    return widget?.inputEl || null;
-  }
-  export function findWidget(node, name) {
-    return node?.widgets?.find((widget) => widget.name === name) || null;
-  }
-  export function firstValue(value, fallback) {
-    return Array.isArray(value) ? (value[0] ?? fallback) : (value ?? fallback);
-  }
+const hostHookRegistryUrl = inlineModule(`
+  export function registerHostHookCallbacks() { return () => {}; }
 `);
 const highlightUrl = inlineModule(`
   export function copyInputTextMetrics() {}
@@ -63,15 +40,14 @@ const highlightWidgetsUrl = inlineModule(`
     return node?.inputs?.some((input) => input?.name === name && input?.link != null) || false;
   }
 `);
-const studioValuesUrl = dataModule(
-  "../web/js/prompt_studio/studio_values.js",
+const nodeHooksUrl = dataModule(
+  "../web/js/prompt_studio/node_hooks.js",
   {
     "./constants.js": constantsUrl,
-    "./extend_slots.js": extendSlotsUrl,
-    "./widgets.js": widgetsUrl,
+    "../lifecycle/host_hook_registry.js": hostHookRegistryUrl,
   },
 );
-const { applyExecutedInputs } = await import(studioValuesUrl);
+const { registerPromptStudioNodeHooks } = await import(nodeHooksUrl);
 const highlightUiUrl = dataModule(
   "../web/js/prompt_studio/highlight_ui.js",
   {
@@ -90,78 +66,86 @@ function textWidget(name, value) {
   };
 }
 
-// QSTATE-01 Classic characterization fixture: this intentionally passes while
-// the production bug exists. The real applyExecutedInputs() path keeps the
-// stored edit but replaces the executed presentation state; the real
-// displayText() path then selects the stale result for a linked input.
-// QSTATE-04 must flip this to a preservation assertion.
+function executionFixture(nodeTypeName, state) {
+  function NodeType() {
+    Object.assign(this, state);
+    this.__originalExecutedMessages = [];
+  }
+  const originalOnExecuted = function (message) {
+    this.__originalExecutedMessages.push(message);
+  };
+  NodeType.prototype.onExecuted = originalOnExecuted;
+  assert.equal(
+    registerPromptStudioNodeHooks(NodeType, { name: nodeTypeName }, {}),
+    true,
+  );
+  assert.equal(
+    NodeType.prototype.onExecuted,
+    originalOnExecuted,
+    `${nodeTypeName} must retain the host's original onExecuted owner`,
+  );
+  return new NodeType();
+}
+
+// QSTATE-04A Classic preservation fixture: the production node hook keeps the
+// host's original onExecuted callback but no longer publishes submitted text
+// into current editor or linked-input presentation state.
 const classicPrompt = textWidget("prompt", "current classic edit");
-const classicNode = {
+const classicNode = executionFixture("EasyUseAnimaPromptStudio", {
   widgets: [classicPrompt],
   inputs: [{ name: "prompt", link: 17 }],
+});
+const classicMessage = {
+  prompt_studio_inputs: [{
+    prompt: "queued classic text",
+  }],
 };
-applyExecutedInputs(
-  classicNode,
-  {
-    prompt_studio_inputs: [{
-      prompt: "queued classic text",
-    }],
-  },
-  {
-    studioFieldNames: () => ["prompt"],
-    expandStudioInputToContent: () => {},
-    hookStudioNode: () => {},
-  },
-);
+classicNode.onExecuted(classicMessage);
+assert.deepEqual(classicNode.__originalExecutedMessages, [classicMessage]);
 assert.equal(classicPrompt.value, "current classic edit");
 assert.equal(classicPrompt.inputEl.value, "current classic edit");
 assert.equal(
   classicPrompt.__easyuseAnimaExecutedText,
-  "queued classic text",
-  "QSTATE-01 fixture did not reproduce the stale Classic executed-state overwrite",
+  undefined,
+  "stale Classic result created executed presentation state",
 );
 assert.equal(
   displayText(classicNode, classicPrompt),
-  "queued classic text",
-  "QSTATE-01 fixture did not reproduce the stale Classic linked-input presentation",
+  "current classic edit",
+  "stale Classic result replaced linked-input presentation",
 );
 
-// QSTATE-01 Extend characterization fixture: this intentionally passes while
-// the production bug exists. The real applyExecutedInputs() path directly
-// restores submitted text, visibility, and NAIA state over the user's edit.
-// QSTATE-04 must flip this to a preservation assertion.
+// QSTATE-04A Extend preservation fixture: submitted slot text, visibility, and
+// NAIA state are execution history, not current editor authority.
 const extendQuality = textWidget("quality_tags_1", "current extend edit");
 const extendFillNaia = { name: "fill_naia_prompt", value: false };
-const extendNode = {
+const extendNode = executionFixture("EasyUseAnimaPromptStudioExtend", {
   widgets: [extendQuality, extendFillNaia],
   __visibleSlots: new Set(["quality_tags_1", "general_tags_4"]),
+});
+const extendMessage = {
+  prompt_studio_slots: [{
+    quality_tags_1: "queued extend text",
+    active_slots: ["quality_tags_1"],
+    fill_naia_prompt: true,
+  }],
 };
-applyExecutedInputs(
-  extendNode,
-  {
-    prompt_studio_slots: [{
-      quality_tags_1: "queued extend text",
-      active_slots: ["quality_tags_1"],
-      fill_naia_prompt: true,
-    }],
-  },
-  {
-    studioFieldNames: () => ["quality_tags_1"],
-    expandStudioInputToContent: () => {},
-    hookStudioNode: () => {},
-  },
-);
+extendNode.onExecuted(extendMessage);
+assert.deepEqual(extendNode.__originalExecutedMessages, [extendMessage]);
 assert.equal(
   extendQuality.value,
-  "queued extend text",
-  "QSTATE-01 fixture did not reproduce the stale Extend widget overwrite",
+  "current extend edit",
+  "stale Extend result replaced the current widget value",
 );
 assert.equal(
   extendQuality.inputEl.value,
-  "queued extend text",
-  "QSTATE-01 fixture did not reproduce the stale Extend DOM overwrite",
+  "current extend edit",
+  "stale Extend result replaced the current DOM value",
 );
-assert.deepEqual([...extendNode.__visibleSlots], ["quality_tags_1"]);
-assert.equal(extendFillNaia.value, true);
+assert.deepEqual(
+  [...extendNode.__visibleSlots],
+  ["quality_tags_1", "general_tags_4"],
+);
+assert.equal(extendFillNaia.value, false);
 
-console.log("Prompt Studio Classic/Extend characterization smoke passed.");
+console.log("Prompt Studio Classic/Extend executed values smoke passed.");

--- a/tests/test_frontend_modules.py
+++ b/tests/test_frontend_modules.py
@@ -2290,7 +2290,14 @@ class FrontendModuleStructureTests(unittest.TestCase):
         advanced_values_source = (
             PROMPT_STUDIO_MODULES / "advanced_values.js"
         ).read_text(encoding="utf-8")
+        studio_values_source = (
+            PROMPT_STUDIO_MODULES / "studio_values.js"
+        ).read_text(encoding="utf-8")
         self.assertNotIn("shouldApplyExecutedSeed", advanced_values_source)
+        self.assertNotIn("applyAdvancedExecutedInputs", advanced_values_source)
+        self.assertNotIn("applyExecutedInputs", studio_values_source)
+        self.assertNotIn("hooks.applyExecutedInputs", node_hooks_source)
+        self.assertIn("publishAdvancedWildcardExecution", advanced_values_source)
         self.assertIn("wildcard_execution_seed", advanced_values_source)
         self.assertIn("writePreviousWildcardExecution", advanced_values_source)
         self.assertTrue(PROMPT_STUDIO_ADVANCED_VALUES_SMOKE.is_file())
@@ -2886,7 +2893,7 @@ class FrontendModuleStructureTests(unittest.TestCase):
                 self.assertIn(f"  {name},", advanced_fields_state_source)
 
         for name in (
-            "applyAdvancedExecutedInputs",
+            "publishAdvancedWildcardExecution",
             "syncAdvancedValues",
         ):
             with self.subTest(module="advanced_values", symbol=name):
@@ -3145,7 +3152,6 @@ class FrontendModuleStructureTests(unittest.TestCase):
                 self.assertIn(f"  {name},", studio_node_ui_source)
 
         for name in (
-            "applyExecutedInputs",
             "restoreInputFromWidget",
             "syncStudioValues",
             "syncWidgetValue",

--- a/tools/check_frontend.ps1
+++ b/tools/check_frontend.ps1
@@ -176,7 +176,7 @@ try {
 
     & node "tests\frontend_prompt_studio_classic_values_smoke.mjs"
     if ($LASTEXITCODE -ne 0) {
-        throw "Frontend Prompt Studio Classic/Extend characterization smoke failed with exit code $LASTEXITCODE."
+        throw "Frontend Prompt Studio Classic/Extend executed values smoke failed with exit code $LASTEXITCODE."
     }
 
     & node "tests\frontend_prompt_studio_resolution_orientation_smoke.mjs"

--- a/web/js/prompt_studio/advanced_values.js
+++ b/web/js/prompt_studio/advanced_values.js
@@ -9,11 +9,9 @@ import {
 } from "./schema.js";
 import {
   getAdvancedFields,
-  setAdvancedFields,
 } from "./state.js";
 import {
   collectAdvancedEditorFields,
-  mergeAdvancedFieldInputValues,
   syncAdvancedFieldsBackup,
 } from "./serialization.js";
 import {
@@ -64,39 +62,10 @@ function syncAdvancedValues(node, serialized = null, hooks = {}) {
   });
 }
 
-function applyAdvancedExecutedInputs(node, message, hooks = {}) {
+function publishAdvancedWildcardExecution(node, message, hooks = {}) {
   const payload = firstValue(message?.prompt_studio_advanced, null);
   if (!payload || typeof payload !== "object") {
     return;
-  }
-  node.__easyuseAnimaAdvancedFieldInputValues =
-    payload.field_inputs && typeof payload.field_inputs === "object" ? payload.field_inputs : {};
-  const widget = hooks.advancedWidget?.(node);
-  if (widget && payload.advanced_fields != null) {
-    widget.value = String(payload.advanced_fields);
-    syncAdvancedFieldsBackup(node, widget.value);
-  }
-  const fields = hooks.parseAdvancedFields?.(node) || [];
-  if (mergeAdvancedFieldInputValues(fields, node.__easyuseAnimaAdvancedFieldInputValues)) {
-    hooks.writeAdvancedFields?.(node, fields, { syncInputs: false });
-  } else {
-    setAdvancedFields(node, fields);
-  }
-  const useNaia = findWidget(node, "use_naia");
-  if (useNaia && payload.use_naia != null) {
-    useNaia.value = !!payload.use_naia;
-  }
-  for (const name of ["resolution_bucket", "resolution_size", "resolution_custom_width", "resolution_custom_height"]) {
-    const widget = findWidget(node, name);
-    if (widget && payload[name] != null) {
-      widget.value = payload[name];
-    }
-  }
-  for (const name of ["wildcard_mode", "wildcard_seed_after_generate"]) {
-    const widget = findWidget(node, name);
-    if (widget && payload[name] != null) {
-      widget.value = payload[name];
-    }
   }
   const wildcardSeed = findWidget(node, "wildcard_seed");
   if (wildcardSeed && payload.wildcard_seed != null) {
@@ -108,26 +77,9 @@ function applyAdvancedExecutedInputs(node, message, hooks = {}) {
   })) {
     hooks.markNodeDirty?.(node);
   }
-  for (const name of [
-    "artist_mix_mode",
-    "artist_mix_start_percent",
-    "artist_mix_strength_scale",
-    "artist_mix_style_gain",
-    "artist_mix_rms_scale_cap",
-    "artist_mix_exact_top_k",
-    "artist_mix_cluster_count",
-    "artist_mix_dominant_isolation",
-    "artist_mix_dominant_threshold",
-  ]) {
-    const widget = findWidget(node, name);
-    if (widget && payload[name] != null) {
-      widget.value = payload[name];
-    }
-  }
-  hooks.renderAdvancedEditor?.(node);
 }
 
 export {
-  applyAdvancedExecutedInputs,
+  publishAdvancedWildcardExecution,
   syncAdvancedValues,
 };

--- a/web/js/prompt_studio/extension_runtime.js
+++ b/web/js/prompt_studio/extension_runtime.js
@@ -86,7 +86,6 @@ import {
   enhanceResizableInput as enhanceResizableInputWithHooks,
 } from "./studio_resizable_input.js";
 import {
-  applyExecutedInputs as applyExecutedInputsWithHooks,
   restoreInputFromWidget,
   syncStudioValues as syncStudioValuesWithHooks,
   syncWidgetValue,
@@ -103,7 +102,7 @@ import {
   scheduleHookAdvancedNode as scheduleHookAdvancedNodeWithHooks,
 } from "./advanced_node_ui.js";
 import {
-  applyAdvancedExecutedInputs as applyAdvancedExecutedInputsWithHooks,
+  publishAdvancedWildcardExecution as publishAdvancedWildcardExecutionWithHooks,
   syncAdvancedValues as syncAdvancedValuesWithHooks,
 } from "./advanced_values.js";
 import {
@@ -176,8 +175,8 @@ function createPromptStudioExtensionRuntime(app) {
     syncAdvancedValuesWithHooks(node, serialized, advancedValuesHooks());
   }
 
-  function applyAdvancedExecutedInputs(node, message) {
-    applyAdvancedExecutedInputsWithHooks(node, message, advancedValuesHooks());
+  function publishAdvancedWildcardExecution(node, message) {
+    publishAdvancedWildcardExecutionWithHooks(node, message, advancedValuesHooks());
   }
 
   function applyWildcardExecutedInputs(node, message) {
@@ -230,10 +229,6 @@ function createPromptStudioExtensionRuntime(app) {
 
   function syncStudioValues(node, serialized = null) {
     syncStudioValuesWithHooks(node, serialized, studioValuesHooks());
-  }
-
-  function applyExecutedInputs(node, message) {
-    applyExecutedInputsWithHooks(node, message, studioValuesHooks());
   }
 
   function markCanvasDirty() {
@@ -449,8 +444,6 @@ function createPromptStudioExtensionRuntime(app) {
     },
     async beforeRegisterNodeDef(nodeType, nodeData) {
       registerPromptStudioNodeHooks(nodeType, nodeData, {
-        applyAdvancedExecutedInputs,
-        applyExecutedInputs,
         applyExtendSlotVisibility,
         applyWildcardExecutedInputs,
         captureAdvancedConfigure: (node, serialized) => (
@@ -463,6 +456,7 @@ function createPromptStudioExtensionRuntime(app) {
         isExtendNode,
         layoutExtendPromptWidgets,
         pruneDisconnectedAdvancedFieldInputValues,
+        publishAdvancedWildcardExecution,
         rebalanceStudioInputHeights,
         removeAdvancedInternalInputSockets,
         renderAdvancedEditor,

--- a/web/js/prompt_studio/node_hooks.js
+++ b/web/js/prompt_studio/node_hooks.js
@@ -168,17 +168,17 @@ function registerPromptStudioNodeHooks(nodeType, nodeData, hooks) {
     return result;
   };
 
-  const onExecuted = nodeType.prototype.onExecuted;
-  nodeType.prototype.onExecuted = function (message) {
-    onExecuted?.apply(this, arguments);
-    if (isAdvanced) {
-      hooks.applyAdvancedExecutedInputs(this, message);
-    } else if (isWildcard) {
-      hooks.applyWildcardExecutedInputs(this, message);
-    } else {
-      hooks.applyExecutedInputs(this, message);
-    }
-  };
+  if (isAdvanced || isWildcard) {
+    const onExecuted = nodeType.prototype.onExecuted;
+    nodeType.prototype.onExecuted = function (message) {
+      onExecuted?.apply(this, arguments);
+      if (isAdvanced) {
+        hooks.publishAdvancedWildcardExecution(this, message);
+      } else {
+        hooks.applyWildcardExecutedInputs(this, message);
+      }
+    };
+  }
 
   return true;
 }

--- a/web/js/prompt_studio/studio_values.js
+++ b/web/js/prompt_studio/studio_values.js
@@ -7,12 +7,10 @@ import {
 import {
   extendVisibleSlots,
   parseExtendSlots,
-  writeExtendVisibleSlots,
 } from "./extend_slots.js";
 import {
   findInputEl,
   findWidget,
-  firstValue,
 } from "./widgets.js";
 
 function syncWidgetValue(widget) {
@@ -74,42 +72,7 @@ function syncStudioValues(node, serialized = null, hooks = {}) {
   }
 }
 
-function applyExecutedInputs(node, message, hooks = {}) {
-  const slotPayload = firstValue(message?.prompt_studio_slots, null);
-  const payload = slotPayload || firstValue(message?.prompt_studio_inputs, null);
-  if (!payload || typeof payload !== "object") {
-    return;
-  }
-  const fieldNames = hooks.studioFieldNames?.(node) || [];
-  for (const name of fieldNames) {
-    const widget = findWidget(node, name);
-    if (!widget) {
-      continue;
-    }
-    if (slotPayload && Object.prototype.hasOwnProperty.call(payload, name)) {
-      widget.value = String(payload[name] ?? "");
-      restoreInputFromWidget(widget);
-      widget.__easyuseAnimaExecutedText = null;
-      hooks.expandStudioInputToContent?.(node, widget, true);
-    } else {
-      widget.__easyuseAnimaExecutedText = String(payload[name] ?? "");
-      hooks.expandStudioInputToContent?.(node, widget, true);
-    }
-  }
-  if (slotPayload) {
-    if (payload.active_slots != null) {
-      writeExtendVisibleSlots(node, parseExtendSlots(payload.active_slots));
-    }
-    const fillNaia = findWidget(node, "fill_naia_prompt");
-    if (fillNaia && payload.fill_naia_prompt != null) {
-      fillNaia.value = !!payload.fill_naia_prompt;
-    }
-  }
-  hooks.hookStudioNode?.(node);
-}
-
 export {
-  applyExecutedInputs,
   restoreInputFromWidget,
   syncStudioValues,
   syncWidgetValue,


### PR DESCRIPTION
Task: QSTATE-04A / #413
Class: BEHAVIOR
Base -> Head: 4e6f8b1c36fd84772f4577c9ea532d70e46f290f -> 5036441dee1af7fdff1cc5e796ce6f428bd517e4

Changed boundary:
- Prompt Studio Advanced/AdvancedV2 submitted field/resolution/Artist Mix/NAIA replay 제거
- Classic/Extend executed adapter 및 lifecycle wiring 제거
- 기존 wildcard execution history/next-seed publication은 QSTATE-04B 경계로 보존
- production 4 JS + 직접 frontend/source-boundary test + frontend runner label만 변경

Preserved:
- linking, autocomplete, highlighting, autosize, serialization, layout
- standalone Wildcard executed 경로
- AiO seed semantics 및 public socket/workflow schema

Focused:
- changed JS/MJS `node --check`: PASS
- `frontend_queue_ui_transaction_smoke.mjs`: PASS (10 scenarios)
- `frontend_prompt_studio_advanced_values_smoke.mjs`: PASS
- `frontend_prompt_studio_classic_values_smoke.mjs`: PASS
- `tests.test_frontend_modules.FrontendModuleTests.test_prompt_studio_entry_imports_phase_2_modules`: PASS
- `tests.test_frontend_modules.FrontendModuleTests.test_prompt_studio_phase_2_modules_export_expected_symbols`: PASS
- `git diff --check`: PASS

Full:
- `check_custom_node.ps1 -Profile full`
- exact SHA: 5036441dee1af7fdff1cc5e796ce6f428bd517e4
- PASS: Python 1151, frontend 117 files, TypeScript 6.0.3, diff gate; Ruff 119 existing report-only findings

Live (isolated ComfyUI_codex_test):
- source/install hashes matched for all 4 production JS files
- Legacy: actual backend execution settlement after Advanced field edit, resolution 1024->768 edit, Classic field edit; current values and caret retained; queue 0; relevant console errors 0
- Node 2.0: actual backend execution settlement after Advanced and Classic field edits; current values and caret retained; queue 0; relevant console errors 0
- batch restored to 1, VueNodes restored false, temporary workflow removed, server stopped

Package: not triggered
User/live instance: not touched
Rollback: squash commit for this PR
Next: QSTATE-04B concrete wildcard next-seed compare-and-commit after review and merge