### PR TITLE
fix: hand off executed envelopes within one turn

### DIFF
--- a/tests/frontend_executed_event_context_smoke.mjs
+++ b/tests/frontend_executed_event_context_smoke.mjs
@@ -21,7 +21,7 @@ assert.deepEqual(
     addEventListener() {},
     removeEventListener() {},
   })).sort(),
-  ["consume", "dispose", "install", "peek"],
+  ["consume", "consumeWithinTurn", "dispose", "install", "peek"],
 );
 assert.throws(() => createExecutedEventContext(null), /Comfy API/);
 assert.throws(
@@ -38,11 +38,17 @@ assert.throws(
   }, { finishPrompt: "invalid" }),
   /finishPrompt/,
 );
+assert.throws(
+  () => createExecutedEventContext({
+    addEventListener() {},
+    removeEventListener() {},
+  }, { scheduleMicrotask: "invalid" }),
+  /scheduleMicrotask/,
+);
 
-// Node's flat EventTarget does not model a browser capture phase. This fixture
-// preserves supported DOM target ordering: capture listeners run before normal
-// listeners even when the core normal listener was registered first.
-class BrowserPhaseEventTargetFixture {
+// ComfyApi is one EventTarget. Listeners on that same target run in registration
+// order even when a later listener requests capture.
+class OrderedEventTargetFixture {
   constructor() {
     this.listeners = new Map();
   }
@@ -75,15 +81,29 @@ class BrowserPhaseEventTargetFixture {
 
   dispatchEvent(event) {
     const listeners = [...(this.listeners.get(event.type) || [])];
-    for (const capture of [true, false]) {
-      for (const listener of listeners) {
-        if (listener.capture === capture) {
-          listener.callback.call(this, event);
-        }
-      }
+    for (const listener of listeners) {
+      listener.callback.call(this, event);
     }
     return true;
   }
+}
+
+function createMicrotaskFixture() {
+  const callbacks = [];
+  return {
+    schedule(callback) {
+      callbacks.push(callback);
+    },
+    get size() {
+      return callbacks.length;
+    },
+    flush() {
+      const queued = callbacks.splice(0);
+      for (const callback of queued) {
+        callback();
+      }
+    },
+  };
 }
 
 function event(type, detail) {
@@ -91,28 +111,25 @@ function event(type, detail) {
 }
 
 {
-  const api = new BrowserPhaseEventTargetFixture();
+  const api = new OrderedEventTargetFixture();
   const trace = [];
-  let bridge;
-  let consumedEnvelope = null;
+  let delivery;
+  const bridge = createExecutedEventContext(api);
+  assert.equal(bridge.install(), true);
+  assert.equal(bridge.install(), false);
   const node = {
     onExecuted(message) {
       trace.push("node-onExecuted");
-      consumedEnvelope = bridge.consume(message);
+      delivery = bridge.consumeWithinTurn(message);
     },
   };
 
-  // Mirrors current ComfyUI app.ts: core registers first and passes the exact
-  // detail.output object to node.onExecuted().
+  // Bridge-first ordering consumes synchronously through the existing API.
   api.addEventListener("executed", ({ detail }) => {
     trace.push(bridge.peek(detail.output) ? "captured-before-core" : "missing");
     trace.push("core-listener");
     node.onExecuted(detail.output);
   });
-
-  bridge = createExecutedEventContext(api);
-  assert.equal(bridge.install(), true);
-  assert.equal(bridge.install(), false);
 
   const output = { feature_payload: [{ value: "accepted" }] };
   api.dispatchEvent(event("executed", {
@@ -127,6 +144,7 @@ function event(type, detail) {
     "core-listener",
     "node-onExecuted",
   ]);
+  const consumedEnvelope = await delivery;
   assert(consumedEnvelope);
   assert.equal(Object.isFrozen(consumedEnvelope), true);
   assert.equal(consumedEnvelope.promptId, "prompt-a");
@@ -139,20 +157,67 @@ function event(type, detail) {
 }
 
 {
-  const api = new BrowserPhaseEventTargetFixture();
+  const api = new OrderedEventTargetFixture();
+  const microtasks = createMicrotaskFixture();
+  const trace = [];
   let bridge;
-  const clonedConsumes = [];
+  let delivery;
+  const node = {
+    onExecuted(message) {
+      trace.push("node-onExecuted");
+      delivery = bridge.consumeWithinTurn(message);
+    },
+  };
+
+  // Mirrors the supported live order: core registered first, then the bridge.
+  api.addEventListener("executed", ({ detail }) => {
+    trace.push("core-listener");
+    node.onExecuted(detail.output);
+  });
+  bridge = createExecutedEventContext(api, {
+    scheduleMicrotask: microtasks.schedule,
+  });
+  bridge.install();
+
+  const output = { feature_payload: [{ value: "accepted-late" }] };
+  api.dispatchEvent(event("executed", {
+    prompt_id: "prompt-node-first",
+    node: "backend-node",
+    display_node: "frontend-node",
+    output,
+  }));
+
+  assert.deepEqual(trace, ["core-listener", "node-onExecuted"]);
+  assert.equal(microtasks.size, 1);
+  const envelope = await delivery;
+  assert(envelope);
+  assert.equal(envelope.promptId, "prompt-node-first");
+  assert.equal(envelope.output, output);
+  assert.equal(bridge.peek(output), null);
+  assert.equal(bridge.consume(output), null);
+  microtasks.flush();
+  assert.equal(microtasks.size, 0);
+}
+
+{
+  const api = new OrderedEventTargetFixture();
+  const microtasks = createMicrotaskFixture();
+  let bridge;
+  const clonedDeliveries = [];
   const originalOutputs = [];
   const node = {
     onExecuted(message) {
-      clonedConsumes.push(bridge.consume(message));
+      clonedDeliveries.push(bridge.consumeWithinTurn(message));
     },
   };
 
   api.addEventListener("executed", ({ detail }) => {
     node.onExecuted({ ...detail.output });
   });
-  bridge = createExecutedEventContext(api, { maxPendingOutputs: 2 });
+  bridge = createExecutedEventContext(api, {
+    maxPendingOutputs: 2,
+    scheduleMicrotask: microtasks.schedule,
+  });
   bridge.install();
 
   for (let index = 0; index < 3; index += 1) {
@@ -165,7 +230,9 @@ function event(type, detail) {
     }));
   }
 
-  assert.deepEqual(clonedConsumes, [null, null, null]);
+  assert.equal(microtasks.size, 3);
+  microtasks.flush();
+  assert.deepEqual(await Promise.all(clonedDeliveries), [null, null, null]);
   assert.equal(bridge.peek(originalOutputs[0]), null);
   assert.equal(bridge.peek(originalOutputs[1])?.promptId, "prompt-clone-1");
   assert.equal(bridge.consume(originalOutputs[2])?.promptId, "prompt-clone-2");
@@ -173,7 +240,7 @@ function event(type, detail) {
 }
 
 {
-  const api = new BrowserPhaseEventTargetFixture();
+  const api = new OrderedEventTargetFixture();
   const owner = createQueueUiTransactionOwner();
   const bridge = createExecutedEventContext(api, {
     finishPrompt: owner.finishPrompt,
@@ -224,35 +291,129 @@ function event(type, detail) {
 }
 
 {
-  const api = new BrowserPhaseEventTargetFixture();
+  const api = new OrderedEventTargetFixture();
+  const microtasks = createMicrotaskFixture();
   let bridge;
-  const consumes = [];
+  const deliveries = [];
   const node = {
     onExecuted(message) {
-      consumes.push(bridge.consume(message));
+      deliveries.push(bridge.consumeWithinTurn(message));
     },
   };
   api.addEventListener("executed", ({ detail }) => {
     node.onExecuted(detail.output);
   });
-  bridge = createExecutedEventContext(api);
+  bridge = createExecutedEventContext(api, {
+    scheduleMicrotask: microtasks.schedule,
+  });
   bridge.install();
 
   api.dispatchEvent(event("executed", {
     node: "backend-node",
     output: { missing: "prompt-id" },
   }));
-  assert.deepEqual(consumes, [null]);
+  microtasks.flush();
+  assert.deepEqual(await Promise.all(deliveries), [null]);
+  assert.equal(bridge.dispose(), true);
+}
 
+{
+  const api = new OrderedEventTargetFixture();
+  const microtasks = createMicrotaskFixture();
+  const bridge = createExecutedEventContext(api, {
+    scheduleMicrotask: microtasks.schedule,
+  });
+  bridge.install();
+
+  const output = { expires: true };
+  const delivery = bridge.consumeWithinTurn(output);
+  assert.equal(microtasks.size, 1);
+  microtasks.flush();
+  assert.equal(await delivery, null);
+
+  api.dispatchEvent(event("executed", {
+    prompt_id: "prompt-after-expiry",
+    node: "backend-node",
+    output,
+  }));
+  assert.equal(bridge.consume(output)?.promptId, "prompt-after-expiry");
+  assert.equal(bridge.consume(output), null);
+  assert.equal(bridge.dispose(), true);
+}
+
+{
+  const api = new OrderedEventTargetFixture();
+  const microtasks = createMicrotaskFixture();
+  const bridge = createExecutedEventContext(api, {
+    scheduleMicrotask: microtasks.schedule,
+  });
+  bridge.install();
+
+  const output = { duplicate: true };
+  const first = bridge.consumeWithinTurn(output);
+  const duplicate = bridge.consumeWithinTurn(output);
+  assert.equal(await duplicate, null);
+  api.dispatchEvent(event("executed", {
+    prompt_id: "prompt-duplicate",
+    node: "backend-node",
+    output,
+  }));
+  assert.equal((await first)?.promptId, "prompt-duplicate");
+  assert.equal(bridge.consume(output), null);
+  microtasks.flush();
+  assert.equal(bridge.dispose(), true);
+}
+
+{
+  const api = new OrderedEventTargetFixture();
+  const microtasks = createMicrotaskFixture();
+  const bridge = createExecutedEventContext(api, {
+    scheduleMicrotask: microtasks.schedule,
+  });
+  bridge.install();
+
+  const output = { disposed: true };
+  const delivery = bridge.consumeWithinTurn(output);
   assert.equal(bridge.dispose(), true);
   assert.equal(bridge.dispose(), false);
+  assert.equal(await delivery, null);
+  microtasks.flush();
   api.dispatchEvent(event("executed", {
     prompt_id: "prompt-after-dispose",
     node: "backend-node",
-    output: {},
+    output,
   }));
-  assert.deepEqual(consumes, [null, null]);
+  assert.equal(bridge.peek(output), null);
   assert.equal(bridge.install(), true);
+  assert.equal(bridge.dispose(), true);
+}
+
+{
+  const api = new OrderedEventTargetFixture();
+  const microtasks = createMicrotaskFixture();
+  const bridge = createExecutedEventContext(api, {
+    maxPendingOutputs: 2,
+    scheduleMicrotask: microtasks.schedule,
+  });
+  bridge.install();
+
+  const outputs = [{ index: 0 }, { index: 1 }, { index: 2 }];
+  const deliveries = outputs.map(
+    (output) => bridge.consumeWithinTurn(output),
+  );
+  assert.equal(await deliveries[0], null);
+  for (let index = 1; index < outputs.length; index += 1) {
+    api.dispatchEvent(event("executed", {
+      prompt_id: `prompt-bounded-${index}`,
+      node: "backend-node",
+      output: outputs[index],
+    }));
+  }
+  assert.equal((await deliveries[1])?.promptId, "prompt-bounded-1");
+  assert.equal((await deliveries[2])?.promptId, "prompt-bounded-2");
+  assert.equal(bridge.peek(outputs[1]), null);
+  assert.equal(bridge.peek(outputs[2]), null);
+  microtasks.flush();
   assert.equal(bridge.dispose(), true);
 }
 

--- a/web/js/lifecycle/executed_event_context.js
+++ b/web/js/lifecycle/executed_event_context.js
@@ -60,8 +60,9 @@ function positiveInteger(value) {
 
 /**
  * Preserve the outer ComfyUI executed envelope until the exact output object is
- * synchronously consumed by a node adapter. This owner does not inspect feature
- * payloads or register feature callbacks.
+ * consumed by a node adapter. When the node adapter runs before this listener,
+ * one pending consumer may wait for the remainder of the current event turn.
+ * This owner does not inspect feature payloads or register feature callbacks.
  *
  * @param {{
  *   addEventListener: Function,
@@ -70,6 +71,7 @@ function positiveInteger(value) {
  * @param {{
  *   maxPendingOutputs?: number,
  *   finishPrompt?: ((promptId: string) => unknown) | null,
+ *   scheduleMicrotask?: ((callback: () => void) => unknown) | null,
  * }} [options]
  */
 export function createExecutedEventContext(api, options = {}) {
@@ -87,11 +89,18 @@ export function createExecutedEventContext(api, options = {}) {
   if (finishPrompt != null && typeof finishPrompt !== "function") {
     throw new TypeError("finishPrompt must be a function when provided.");
   }
+  const scheduleMicrotask = options.scheduleMicrotask ?? globalThis.queueMicrotask;
+  if (typeof scheduleMicrotask !== "function") {
+    throw new TypeError("scheduleMicrotask must be a function when provided.");
+  }
 
   let installed = false;
   let envelopesByOutput = new WeakMap();
+  let consumersByOutput = new WeakMap();
   /** @type {object[]} */
   const pendingOutputs = [];
+  /** @type {object[]} */
+  const pendingConsumerOutputs = [];
 
   /** @param {object} output */
   function removePending(output) {
@@ -99,6 +108,25 @@ export function createExecutedEventContext(api, options = {}) {
     if (index >= 0) {
       pendingOutputs.splice(index, 1);
     }
+  }
+
+  /** @param {object} output */
+  function removePendingConsumer(output) {
+    const index = pendingConsumerOutputs.indexOf(output);
+    if (index >= 0) {
+      pendingConsumerOutputs.splice(index, 1);
+    }
+  }
+
+  /** @param {object} output @param {any} expected */
+  function expireConsumer(output, expected) {
+    if (consumersByOutput.get(output) !== expected) {
+      return false;
+    }
+    consumersByOutput.delete(output);
+    removePendingConsumer(output);
+    expected.resolve(null);
+    return true;
   }
 
   /** @param {string} promptId */
@@ -117,6 +145,13 @@ export function createExecutedEventContext(api, options = {}) {
   function captureExecuted({ detail }) {
     const envelope = envelopeFromDetail(detail);
     if (!envelope) {
+      return;
+    }
+    const consumer = consumersByOutput.get(envelope.output);
+    if (consumer) {
+      consumersByOutput.delete(envelope.output);
+      removePendingConsumer(envelope.output);
+      consumer.resolve(envelope);
       return;
     }
     removePending(envelope.output);
@@ -174,6 +209,60 @@ export function createExecutedEventContext(api, options = {}) {
     return envelope;
   }
 
+  /**
+   * Consume an already-captured envelope or wait for a later listener in the
+   * current event turn to capture the exact same output object. An unmatched
+   * consumer expires after one injected microtask and duplicate consumers fail
+   * closed.
+   *
+   * @param {unknown} output
+   * @returns {Promise<any | null>}
+   */
+  function consumeWithinTurn(output) {
+    if (!isReference(output)) {
+      return Promise.resolve(null);
+    }
+    const envelope = consume(output);
+    if (envelope) {
+      return Promise.resolve(envelope);
+    }
+    if (consumersByOutput.has(output)) {
+      return Promise.resolve(null);
+    }
+
+    let resolveConsumer;
+    const promise = new Promise((resolve) => {
+      resolveConsumer = resolve;
+    });
+    const consumer = { resolve: resolveConsumer };
+    consumersByOutput.set(output, consumer);
+    pendingConsumerOutputs.push(output);
+
+    while (pendingConsumerOutputs.length > maxPendingOutputs) {
+      const expiredOutput = pendingConsumerOutputs[0];
+      const expiredConsumer = consumersByOutput.get(expiredOutput);
+      if (!expiredConsumer) {
+        pendingConsumerOutputs.shift();
+        continue;
+      }
+      expireConsumer(expiredOutput, expiredConsumer);
+    }
+
+    scheduleMicrotask(() => expireConsumer(output, consumer));
+    return promise;
+  }
+
+  function releaseConsumers() {
+    for (const output of [...pendingConsumerOutputs]) {
+      const consumer = consumersByOutput.get(output);
+      if (consumer) {
+        expireConsumer(output, consumer);
+      }
+    }
+    consumersByOutput = new WeakMap();
+    pendingConsumerOutputs.length = 0;
+  }
+
   function dispose() {
     if (!installed) {
       return false;
@@ -185,6 +274,7 @@ export function createExecutedEventContext(api, options = {}) {
     installed = false;
     envelopesByOutput = new WeakMap();
     pendingOutputs.length = 0;
+    releaseConsumers();
     return true;
   }
 
@@ -192,6 +282,7 @@ export function createExecutedEventContext(api, options = {}) {
     install,
     peek,
     consume,
+    consumeWithinTurn,
     dispose,
   });
 }


### PR DESCRIPTION
## 목적

QSTATE-02D1은 ComfyUI `executed` listener 등록 순서와 무관하게 exact output-object envelope를 한 event turn 안에서 feature adapter에 전달합니다.

## 변경 경계

```text
Base -> Head:
0346d61e3e56db1d5c0fa9c3862c3d4800dc9681
->
2f7296923446f229fec632ad48b67da190095e71
```

- `web/js/lifecycle/executed_event_context.js`
  - 기존 synchronous `consume()` 유지
  - feature-agnostic `consumeWithinTurn(output)` 추가
  - bridge-first는 이미 저장된 envelope를 즉시 consume
  - node-adapter-first는 exact object consumer 하나를 등록하고 한 injected microtask 뒤 폐기
  - duplicate consumer, missing/cloned output, dispose는 fail-closed
  - pending envelope/consumer retention은 기존 bound를 공유
- `tests/frontend_executed_event_context_smoke.mjs`
  - 실제 same-target registration order fixture
  - 양 listener 순서, clone/missing, one-microtask expiry, duplicate consume, dispose, bounded cleanup 고정

Shared bridge는 feature payload, Wildcard seed, AiO seed, DOM mutation을 해석하지 않습니다. Prompt Studio/QSTATE-04B production 파일, ComfyUI core, `api.dispatchEvent`, workflow/public socket은 변경하지 않습니다.

## 검증

```text
Focused:
node --check web/js/lifecycle/executed_event_context.js
node --check tests/frontend_executed_event_context_smoke.mjs
node tests/frontend_executed_event_context_smoke.mjs
git diff --check
Result: PASS

Official full:
powershell -ExecutionPolicy Bypass -File D:\ComfyUI\custom_nodes_workplace\tools\check_custom_node.ps1 -Project <QSTATE-02D1 worktree> -Profile full
Exact SHA: 2f7296923446f229fec632ad48b67da190095e71
Result: PASS
Python: 1151
Frontend: 117 JavaScript files
TypeScript: 6.0.3
Ruff: 119 existing report-only findings

Package: not triggered
Live: not triggered for lifecycle-only PR
```

## 위험과 rollback

위험은 기존 synchronous consumer 대신 새 one-turn API를 선택하는 feature adapter에 한정됩니다. 이 PR은 아직 feature cutover를 하지 않습니다. Rollback은 이 lifecycle commit 하나입니다.

## Next

Review/merge 후 기존 `codex/qstate-04b-wildcard-seed-commit`을 최신 `dev`에 rebase하고, Wildcard adapter가 `consumeWithinTurn()`을 최소 사용하도록 수정한 뒤 Legacy Canvas와 Node 2.0 changed flow를 재검증합니다.

Refs #413
Refs #415