### PR TITLE
docs: define technical PRO review and localize QSTATE-04B

### DIFF
--- a/docs/development/codex-blocker-escalation.md
+++ b/docs/development/codex-blocker-escalation.md
@@ -1,24 +1,59 @@
-# Codex Blocker Triage and PRO Escalation
+# Codex Blocker Triage and Technical PRO Review
 
 ## Status and purpose
 
 - Status: active cross-roadmap policy
-- Read only when a task reaches a documented stop condition or a final live gate fails.
-- Complements `codex-execution-efficiency.md`; it does not replace task-specific correctness or release gates.
+- Read only when a documented stop condition, repeated final live failure, or
+  predeclared technical review gate is reached.
+- Complements `codex-execution-efficiency.md`; it does not replace task correctness,
+  compatibility, or release gates.
 
-A stop condition starts **bounded triage**. It does not automatically stop the whole
-roadmap, request PRO review, open another planning issue, or ask the user to choose an
-implementation detail that Codex can resolve safely.
+A stop condition starts **bounded triage**. It is not an automatic whole-roadmap stop
+or PRO request.
 
-## 1. Default rule
+## 1. PRO review definition
 
-Codex continues the current task when all required behavior can still be achieved by a
-small change inside the existing ownership and compatibility boundaries.
+PRO review is a **technical-depth escalation**. Use it when the remaining problem
+requires one or more of the following:
+
+- comparison of multiple primary implementations or host contracts;
+- deep event-ordering, concurrency, lifecycle, cache, graph, or serialization reasoning;
+- discrimination among several technically credible root causes;
+- proof of a cross-layer invariant that direct focused tests cannot establish;
+- security, licensing, untrusted execution, destructive migration, or release-critical
+  runtime analysis.
+
+PRO review is not:
+
+- a request for the user to choose an internal implementation;
+- a substitute for reading direct owner code;
+- an approval ritual after every failed test;
+- a whole-repository re-audit;
+- a reason to stop when Codex can safely diagnose and correct the task locally.
+
+Product ambiguity is handled separately through the accepted Issue, roadmap, and
+compatibility baseline. An irreducible product choice may be returned to the user, but
+it is not labelled a PRO review.
+
+A focused PRO review must return an executable result:
+
+```text
+verified facts
+ranked hypotheses
+discriminating evidence
+selected minimum correction boundary
+rejected alternatives
+focused/full/live proof
+resume point or hard blocker
+```
+
+## 2. Default flow
 
 ```text
 observed mismatch
   -> classify
-  -> try the smallest contract-preserving correction
+  -> localize the first divergent phase
+  -> apply the smallest contract-preserving correction
   -> focused test
   -> rerun only the failed live path
   -> continue when green
@@ -26,224 +61,266 @@ observed mismatch
 
 Do not escalate merely because:
 
-- a test fixture assumed the wrong host callback order;
-- Legacy Canvas and Node 2.0 expose the same data at different points in one event turn;
-- one optional host signal is missing but a deterministic local handoff exists;
-- an allowed file or helper name must change without widening behavior;
-- a sandbox/process-spawn failure requires one approved rerun;
-- the first implementation attempt fails while the contract remains satisfiable.
+- a fixture assumed the wrong host callback order;
+- Legacy and Node 2.0 expose the same data at different points;
+- one host signal is missing but a deterministic local handoff exists;
+- an allowed helper/file boundary needs a small adjustment;
+- an environment failure requires one approved rerun;
+- the first implementation attempt fails;
+- two attempts failed but the failing phase has not been localized.
 
-## 2. Triage levels
+## 3. Triage levels
 
 ### Level 0 — Environment or evidence issue
 
-Examples:
+Examples: stale installed files, browser cache, server lifecycle, process permission,
+or a fixture that does not model the supported host.
 
-- sandbox process creation or permission error;
-- stale installed node-pack copy;
-- browser cache or server lifecycle mismatch;
-- test harness differs from the supported browser event model.
-
-Action:
-
-- correct the environment or fixture;
-- rerun the exact failed command or live path once;
-- do not change production behavior or request PRO review.
+Action: correct the environment/fixture and rerun the exact failed path once. Do not
+change product behavior or request PRO review.
 
 ### Level 1 — Local implementation mismatch
 
-The observed host behavior differs from an implementation assumption, but all of the
-following remain true:
-
-- required user behavior and compatibility invariants are unchanged;
-- the fix stays in the current owner or one already-approved adjacent lifecycle owner;
-- no public socket, workflow/profile/settings schema, package contract, or ComfyUI core
-  patch is required;
-- fail-closed behavior remains available;
-- rollback remains one bounded PR.
+Use when the fix remains inside the current owner or an approved adjacent owner, public
+contracts stay unchanged, fail-closed remains possible, and rollback remains one bounded
+PR.
 
 Action:
 
-- amend the task card locally;
-- implement the smallest deterministic correction;
-- update the direct fixture;
-- run focused validation and the failed live scenario;
-- continue to the normal PR gate when it passes.
-
-This level does not require a new roadmap document, a new issue, or PRO review.
+- amend the task card;
+- implement the minimum deterministic correction;
+- update direct tests;
+- rerun focused checks and the failed live flow;
+- continue to the normal PR gate.
 
 ### Level 2 — Bounded contract amendment
 
-One task-local contract assumption is false, but the accepted product semantics and
-public compatibility can still be preserved without expanding to a new subsystem.
-
-Action:
-
-- Codex may amend the direct contract and implementation in the same branch when the
-  correction is inseparable and remains one rollback boundary;
-- otherwise create one small contract PR followed by the implementation PR;
-- record the changed assumption and evidence once in the owning Issue or PR;
-- continue without PRO review after focused/full/live gates pass.
+Use when one task-local assumption is false but accepted product semantics and public
+compatibility remain preservable without a new subsystem.
 
 Examples:
 
-- replacing synchronous consumption with one deterministic microtask handoff;
-- changing an internal callback return shape;
-- moving cleanup to the existing lifecycle owner;
-- adding one opaque surface token while keeping feature semantics outside the shared
-  owner.
+- one deterministic event-turn handoff;
+- an internal callback shape change;
+- cleanup moved to its existing lifecycle owner;
+- an opaque surface token;
+- a broad rerender replaced by a narrow feature-owned synchronizer.
 
-### Level 3 — Hard blocker requiring PRO review
+Codex may amend contract and implementation together only when inseparable and still one
+rollback boundary. Otherwise split one small contract PR from one implementation PR.
 
-Request focused PRO review only when at least one of these conditions is evidenced:
+### Level 3 — Focused technical PRO review
 
-1. The fix requires changing a public node socket, workflow/profile/settings schema,
-   external API, Registry/package contract, or ComfyUI core.
-2. Backward compatibility or data migration has more than one credible policy choice.
-3. The change crosses feature semantics that must remain independent, such as Prompt
-   Studio Wildcard concrete next-seed behavior and AiO special-token behavior.
-4. Security, credentials, privacy, destructive data loss, licensing, or untrusted code
-   execution is involved.
-5. Two distinct bounded corrections have both failed the same supported live gate and
-   no third correction stays inside the approved boundary.
-6. Legacy Canvas and Node 2.0 require incompatible persistent behavior rather than a
-   local adapter difference.
-7. The required invariant conflicts with another frozen invariant and there is no safe
-   fail-closed behavior.
-8. A release-blocking package/runtime failure cannot be isolated to the current owner.
+Request it only when evidence shows routine bounded work is insufficient:
 
-PRO review remains focused on the exact blocker and direct owners. Do not request a
-whole-repository re-audit.
+1. The failure spans multiple technical layers and needs primary-source comparison,
+   event/concurrency reasoning, or discriminating instrumentation.
+2. Multiple credible root causes remain after direct tests and a localization pass.
+3. Progress requires ComfyUI core, public node socket, workflow/profile/settings schema,
+   external API, Registry/package contract, or unstable external integration changes.
+4. Security, privacy, destructive data loss, licensing, or untrusted execution is
+   involved.
+5. Legacy and Node 2.0 appear to require incompatible persistent behavior.
+6. Frozen invariants conflict and no safe fail-closed behavior remains.
+7. A release-blocking package/runtime failure cannot be isolated.
+8. A predeclared cross-layer review gate is reached, such as `AIO-SEED-UI-01`.
 
-## 3. Self-resolution budget
+Two failed corrections are evidence, not an automatic trigger. Perform one bounded
+diagnostic-localization pass first unless that pass would cross a public, security, or
+destructive boundary.
 
-Before Level 3 escalation, Codex may try at most **two distinct bounded corrections**.
+PRO stays limited to the exact blocker and direct owners. It selects a technical
+resolution; it does not ask the user to choose among internal designs.
 
-For each attempt record only:
+## 4. Diagnostic-localization checkpoint
+
+When a live result is wrong but its layer is unclear, do not make another speculative
+behavior change. Record the first divergence:
+
+```text
+queue capture
+prompt acceptance
+backend payload
+executed envelope
+transaction selection
+canCommit result and reason
+feature commit callback
+canonical widget state
+visible DOM/summary state
+history/metadata state
+terminal cleanup
+```
+
+Rules:
+
+- prefer injected diagnostic callbacks or test-only traces over permanent logging;
+- record reason codes at the owner making the decision;
+- never log prompt text, credentials, tokens, or user data;
+- inspect one exact queue before expanding the matrix;
+- remove temporary diagnostics before the reviewable PR;
+- return to Level 1/2 once the failing phase is proven.
+
+## 5. Self-resolution budget
+
+Codex may try up to two materially different bounded corrections before localization.
+
+Record only:
 
 ```text
 hypothesis
 changed boundary
 focused proof
-failed live path result
-why the next attempt is materially different
+failed live result
+why the next attempt is different
 ```
 
-Rules:
+Do not run official full between failed attempts, retain multiple experiments, or add
+unrelated cleanup. If two attempts fail without locating the phase, localize instead of
+declaring a hard blocker by count.
 
-- do not run the official full suite between failed attempts;
-- do not broaden the task to unrelated cleanup;
-- do not keep multiple experimental implementations;
-- use the first correction that satisfies the frozen contract;
-- after production/test changes stabilize, run official full once on the final SHA;
-- rerun only the affected Legacy/Node 2.0 flow before the integrated release matrix.
-
-If the first bounded correction passes, do not explore a second design for theoretical
-completeness.
-
-## 4. Reporting policy
-
-Do not report `PRO review requested` at the first stop-condition observation.
-
-Use these states:
+## 6. Reporting states
 
 ```text
 LOCAL TRIAGE
-  A contract-preserving correction is available and is being tested.
+  An owner-local correction or localization pass is available.
+
+TECHNICAL PRO REVIEW
+  A technical-depth criterion is named and bounded evidence is attached.
 
 HARD BLOCKER
-  The Level 3 criterion is named, two bounded attempts are exhausted when applicable,
-  and production expansion has stopped.
+  Focused review proves that progress needs a forbidden/public/incompatible boundary
+  or no viable correction remains.
 ```
 
-Issue/PR updates are required only when:
+Update an Issue/PR only when the critical path changes, a review candidate is ready, a
+technical review starts/completes, a hard blocker is confirmed, or work is handed off.
 
-- the critical path or frozen contract changes;
-- a candidate is ready for review;
-- a hard blocker is confirmed;
-- a task is completed or handed off.
+## 7. QSTATE-04B focused technical review
 
-Do not add a new checkpoint comment for every local test failure.
-
-## 5. Current QSTATE-04B application
-
-Observed live behavior:
+### 7.1 What the current run proves
 
 ```text
-ComfyUI core normal `executed` listener
-  -> node.onExecuted(detail.output)
-  -> later Easy Use Anima `executed` listener captures the envelope
+backend produced the next Wildcard seed
+previous-execution/history publication occurred
+visible Advanced Wildcard UI still showed the previous seed/control
 ```
 
-This invalidates the earlier same-target capture-order fixture, but it does not require
-ComfyUI core changes and does not invalidate the two-phase transaction model.
+QSTATE-02D1 already supports exact-output `consumeWithinTurn()` for either listener
+order. The failed Node 2.0 run does not by itself prove that envelope delivery or the
+transaction gate failed.
 
-Treat it as Level 1/2 local correction.
+QSTATE-04B's commit callback currently changes the hidden canonical `wildcard_seed`
+widget. The visible Advanced UI is a separately rendered summary/popup. Historical
+working code changed the widget and rerendered the editor, but QSTATE-04A now forbids
+broad executed-result rerenders because they can disturb prompt fields and caret state.
 
-### Preferred correction
-
-Use one microtask handoff owned by the existing executed-event context or transaction
-adapter:
+Strongest current hypothesis:
 
 ```text
-node.onExecuted(message)
-  -> schedule exactly one microtask for editable-result correlation
-  -> remaining listeners in the current `executed` dispatch run
-  -> envelope is stored for the exact output object
-  -> microtask consumes it and runs the existing revision/ordering gate
+transaction succeeds and hidden widget changes
+  -> feature-owned visible Wildcard presentation remains stale
 ```
 
-Requirements:
+Other credible hypotheses:
 
-- use `queueMicrotask` or an injected equivalent;
-- no `setTimeout`, polling, repeated animation frames, or retry loop;
-- keep the exact output-object identity contract;
-- consume at most once;
-- if the envelope is still missing after the one microtask, fail closed;
-- user edit, node disposal, prompt finish, duplicate callback, and mapped multi-result
-  checks still run at commit time;
-- the shared owner remains seed- and feature-agnostic;
-- reuse the bridge for later AiO publication rather than adding a Prompt-Studio-only
-  global event mechanism.
+1. `canCommit` rejects because a programmatic callback increments the edit revision.
+2. Captured and executed Node 2.0 node objects differ.
+3. Queue acceptance, envelope delivery, or terminal cleanup still races.
+4. Mapped-count or duplicate protection rejects the commit.
 
-### Required focused scenarios
+This qualifies for a focused technical PRO review because the observed output does not
+identify the first divergent phase. It does not require user input.
+
+### 7.2 Required one-run trace
+
+Before another behavior correction, record:
 
 ```text
-bridge listener before node adapter -> consumes once
-node adapter before bridge listener -> one microtask consumes once
-cloned output -> no commit
-missing envelope after one microtask -> no commit
-user edit before microtask -> no commit
-node dispose before microtask -> no commit
-duplicate callback -> one commit maximum
-multiple mapped payload items -> no editable commit
-Legacy Canvas and Node 2.0 live changed flow -> pass
+transaction state/promptId
+captured node === onExecuted node
+message === executed detail.output
+mapped item count
+envelope delivered
+canCommit + reason
+commit callback invoked
+hidden wildcard_seed before/after
+visible summary before/after
+open non-dirty popup input before/after
+revision origin
+terminal event order
 ```
 
-### Escalate only if
+Decision table:
 
-- the exact output object is unavailable even after the current event dispatch;
-- the supported frontend does not provide a deterministic microtask boundary;
-- solving the mismatch requires replacing `api.dispatchEvent`, patching ComfyUI core,
-  or adding a public workflow/socket field;
-- two bounded bridge corrections fail in both supported canvases;
-- feature-specific payload parsing must move into the shared bridge.
+| First divergence | Resume action |
+| --- | --- |
+| hidden widget changes; visible view stays old | add a narrow Wildcard view synchronizer; leave bridge unchanged |
+| commit is not invoked; canCommit rejects | correct the named node/revision/acceptance reason |
+| envelope missing for exact output | review bridge/event integration |
+| terminal cleanup wins | correct queue/terminal ordering |
+| mapped count is not one | stay fail-closed; add aggregation only through a separate contract |
 
-The current observation alone is not a PRO blocker.
+### 7.3 Preferred correction if view sync is confirmed
 
-## 6. Planned mandatory review remains
-
-The planned focused PRO review after `AIO-SEED-UI-01` remains mandatory because it
-validates cross-layer seed semantics, not because of a routine implementation mismatch.
-
-Its scope stays limited to:
+A Prompt Studio-owned adapter should atomically:
 
 ```text
-AiO -1/-2/-3 x stored after_generate matrix
-AiO concrete seed x after_generate matrix
+set canonical wildcard_seed
+update only the Wildcard summary
+update an open, non-dirty Wildcard seed input
+preserve prompt fields, caret, resolution, Artist Mix, and layout
+avoid renderAdvancedEditor()
+avoid user-edit callbacks and revision increments
+```
+
+Candidate owners:
+
+```text
+web/js/prompt_studio/advanced_controls.js
+web/js/prompt_studio/advanced_values.js
+web/js/prompt_studio/extension_runtime.js
+direct Wildcard view-sync smoke
+```
+
+### 7.4 Validation and stop point
+
+Focused checks:
+
+```text
+executed-event context smoke
+queue UI transaction smoke
+Prompt Studio Wildcard transaction smoke
+Advanced executed-values smoke
+narrow Wildcard view-sync smoke
+git diff --check
+```
+
+Run Node 2.0 first. Run Legacy after Node 2.0 passes. Run official full once on the final
+candidate, then create the Draft PR.
+
+Stop again only if localization proves:
+
+- exact output/prompt correlation is unavailable;
+- Node 2.0 routes to a different node with no stable mapping;
+- ComfyUI core or a public workflow/socket change is required;
+- safe view sync requires a broad rerender that violates QSTATE-04A;
+- Wildcard and AiO seed semantics must be merged;
+- the bounded reason-coded trace still cannot locate the failure.
+
+Otherwise Codex continues with the proven owner-local correction.
+
+## 8. Planned AiO seed review
+
+The focused PRO review after `AIO-SEED-UI-01` remains mandatory because it validates a
+cross-layer semantic matrix:
+
+```text
+AiO -1/-2/-3 x stored after_generate
+AiO concrete seed x after_generate
 backend reservation advancement
-frontend special-token / last-seed / serialization behavior
-non-sharing with Prompt Studio Wildcard concrete next-seed behavior
+frontend special-token / last-seed / serialization
+non-sharing with Prompt Studio Wildcard
 ```
 
-All other tasks continue under the Level 0-3 policy above.
+It selects or rejects the technical implementation from evidence. It does not ask the
+user to choose among equivalent internal designs.


### PR DESCRIPTION
## 목적

PRO review를 사용자 결정 요청이나 실패 횟수 기반 승인 절차가 아니라, 여러 기술 계층·레퍼런스·동시성/수명주기 추론이 필요한 경우의 **focused technical-depth review**로 재정의합니다.

또한 QSTATE-04B의 두 live 실패를 분석해, 세 번째 speculative correction 전에 실패 계층을 한 번의 reason-coded trace로 국소화하도록 실행 경계를 고정합니다.

## 기술 검토 결론

현재 관측은 다음만 증명합니다.

```text
backend next Wildcard seed 생성
previous-execution/history 갱신
visible Advanced Wildcard UI는 이전 seed/control 표시
```

이는 envelope bridge 실패를 직접 증명하지 않습니다. QSTATE-04B commit callback은 hidden canonical `wildcard_seed`만 변경하고, visible summary/popup은 별도 custom UI입니다. 과거 구현은 widget 변경 후 전체 editor를 rerender했지만, QSTATE-04A 이후 broad executed-result rerender는 prompt/caret 보존 계약과 충돌합니다.

가장 강한 현재 가설은 `hidden widget은 갱신됐지만 narrow visible publication이 누락`된 경우입니다. 다만 revision, node identity, acceptance/terminal timing, mapped-count도 직접 trace로 구분합니다.

## 정책 변경

- PRO는 깊은 기술 조사·다중 primary source 비교·동시성/수명주기 추론이 필요한 경우에만 사용
- 사용자에게 내부 구현을 선택시키는 행위는 PRO가 아님
- bounded correction 2회 실패는 증거일 뿐 자동 승격 조건이 아님
- 실패 계층이 불명확하면 reason-coded diagnostic-localization pass를 먼저 수행
- PRO 결과는 ranked hypotheses, discriminating evidence, minimum correction, 검증 및 resume point를 제공

## QSTATE-04B 재개점

한 Node 2.0 실행에서 다음을 기록합니다.

```text
transaction/prompt acceptance
envelope delivery
captured node identity
mapped count
canCommit + rejection reason
commit callback invocation
hidden widget before/after
visible summary/input before/after
revision origin
terminal order
```

- hidden widget만 갱신되면 Prompt Studio-owned narrow Wildcard view synchronizer를 구현합니다.
- canCommit이 거부되면 reason code가 지목한 node/revision/acceptance 경계만 수정합니다.
- exact envelope 자체가 없을 때만 bridge integration을 다시 검토합니다.

## 변경 파일

- `docs/development/codex-blocker-escalation.md`

Production, tests, workflow, schema, version metadata는 변경하지 않았습니다. Docs-only이므로 full/package/live 검증은 트리거되지 않습니다.

Refs #413
Refs #414
Refs #415