### PR TITLE
QSTATE-04B: gate Prompt Studio Wildcard seed commits

### DIFF
--- a/tests/frontend_prompt_studio_advanced_values_smoke.mjs
+++ b/tests/frontend_prompt_studio_advanced_values_smoke.mjs
@@ -74,6 +74,8 @@ const node = {
 };
 let dirtyCount = 0;
 let renderCount = 0;
+let consumedMappedItemCount = null;
+let wildcardViewCommitCount = 0;
 publishAdvancedWildcardExecution(
   node,
   {
@@ -88,6 +90,15 @@ publishAdvancedWildcardExecution(
   },
   {
     advancedWidget: (target) => target.widgets[0],
+    commitAdvancedWildcardSeedView: (target, seed) => {
+      wildcardViewCommitCount += 1;
+      target.widgets.find((widget) => widget.name === "wildcard_seed").value = seed;
+    },
+    consumeWildcardSeedExecution: (_target, _message, mappedItemCount, commit) => {
+      consumedMappedItemCount = mappedItemCount;
+      commit();
+      return true;
+    },
     markNodeDirty: () => { dirtyCount += 1; },
     parseAdvancedFields: () => [],
     renderAdvancedEditor: () => { renderCount += 1; },
@@ -98,6 +109,8 @@ assert(
   node.widgets.find((widget) => widget.name === "wildcard_seed").value === 42,
   "Advanced did not apply the backend next seed",
 );
+assert(consumedMappedItemCount === 1, "Advanced did not report one mapped payload");
+assert(wildcardViewCommitCount === 1, "Advanced did not delegate the next seed to the narrow view owner");
 const previous = JSON.parse(
   node.properties.easyuse_anima_previous_wildcard_execution,
 );
@@ -147,6 +160,7 @@ publishAdvancedWildcardExecution(
       resolution_custom_width: 1024,
       resolution_custom_height: 1024,
       wildcard_mode: "순차",
+      wildcard_execution_seed: 40,
       wildcard_seed: 41,
       wildcard_seed_after_generate: "increment",
       artist_mix_mode: "average",
@@ -155,6 +169,7 @@ publishAdvancedWildcardExecution(
   },
   {
     advancedWidget: (target) => target.widgets[0],
+    consumeWildcardSeedExecution: () => false,
     parseAdvancedFields: (target) => JSON.parse(target.widgets[0].value),
     renderAdvancedEditor: () => {},
   },
@@ -189,13 +204,67 @@ assert(
   "stale Advanced wildcard settings replaced the current mode/control",
 );
 assert(
-  staleWidgetValue("wildcard_seed") === 41,
-  "QSTATE-04A must preserve the existing next-seed publication for QSTATE-04B",
+  staleWidgetValue("wildcard_seed") === 900,
+  "stale Advanced execution replaced the current editable next seed",
+);
+const stalePrevious = JSON.parse(
+  staleNode.properties.easyuse_anima_previous_wildcard_execution,
+);
+assert(
+  stalePrevious.seed === 40 && stalePrevious.mode === "sequential",
+  "stale execution must still update non-editable wildcard history",
 );
 assert(
   staleWidgetValue("artist_mix_mode") === "exact"
     && staleWidgetValue("artist_mix_start_percent") === 0.75,
   "stale Advanced Artist Mix state replaced the current atomic group",
+);
+
+const missingIdentityNode = {
+  properties: {},
+  widgets: [{ name: "wildcard_seed", value: 50 }],
+};
+publishAdvancedWildcardExecution(
+  missingIdentityNode,
+  {
+    prompt_studio_advanced: [{
+      wildcard_execution_seed: 50,
+      wildcard_seed: 51,
+      wildcard_mode: "일반",
+    }],
+  },
+  { markNodeDirty: () => {} },
+);
+assert(
+  missingIdentityNode.widgets[0].value === 50,
+  "missing transaction identity must fail closed for next-seed publication",
+);
+
+let mappedCount = null;
+const mappedNode = {
+  properties: {},
+  widgets: [{ name: "wildcard_seed", value: 60 }],
+};
+publishAdvancedWildcardExecution(
+  mappedNode,
+  {
+    prompt_studio_advanced: [
+      { wildcard_execution_seed: 60, wildcard_seed: 61, wildcard_mode: "일반" },
+      { wildcard_execution_seed: 70, wildcard_seed: 71, wildcard_mode: "일반" },
+    ],
+  },
+  {
+    consumeWildcardSeedExecution: (_target, _message, count) => {
+      mappedCount = count;
+      return false;
+    },
+    markNodeDirty: () => {},
+  },
+);
+assert(mappedCount === 2, "Advanced did not expose multiple mapped payloads");
+assert(
+  mappedNode.widgets[0].value === 60,
+  "multiple mapped payloads must not publish an editable next seed",
 );
 
 console.log("Prompt Studio Advanced executed values smoke passed.");

--- a/tests/frontend_prompt_studio_resolution_orientation_smoke.mjs
+++ b/tests/frontend_prompt_studio_resolution_orientation_smoke.mjs
@@ -94,6 +94,7 @@ const widgetsUrl = inlineModule(`
 const wildcardSeedContractUrl = inlineModule(`
   export function bindWildcardSeedInput() {}
   export function normalizeWildcardSeedControl(value) { return String(value || "fixed"); }
+  export function syncBoundWildcardSeedInput() { return false; }
 `);
 const wildcardSeedHistoryUrl = inlineModule(`
   export function readPreviousWildcardExecution() { return null; }

--- a/tests/frontend_prompt_studio_wildcard_transaction_smoke.mjs
+++ b/tests/frontend_prompt_studio_wildcard_transaction_smoke.mjs
@@ -1,0 +1,259 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+function dataModule(relativePath) {
+  const source = readFileSync(new URL(relativePath, import.meta.url), "utf8");
+  return `data:text/javascript;base64,${Buffer.from(source).toString("base64")}`;
+}
+
+const ownerModule = await import(dataModule(
+  "../web/js/lifecycle/queue_ui_transaction.js",
+));
+const contextModule = await import(dataModule(
+  "../web/js/lifecycle/executed_event_context.js",
+));
+const transactionModule = await import(dataModule(
+  "../web/js/prompt_studio/wildcard_seed_transaction.js",
+));
+
+assert.deepEqual(
+  Object.keys(transactionModule).sort(),
+  [
+    "WILDCARD_HISTORY_SURFACE",
+    "WILDCARD_SEED_CONTROL_SURFACE",
+    "createPromptStudioWildcardSeedTransaction",
+  ],
+);
+assert.equal(
+  transactionModule.WILDCARD_SEED_CONTROL_SURFACE,
+  "prompt.wildcard_seed_control",
+);
+assert.equal(
+  transactionModule.WILDCARD_HISTORY_SURFACE,
+  "prompt.wildcard_history",
+);
+
+class FakeApi {
+  constructor() {
+    this.listeners = new Map();
+  }
+
+  addEventListener(type, listener) {
+    const listeners = this.listeners.get(type) || [];
+    listeners.push(listener);
+    this.listeners.set(type, listeners);
+  }
+
+  removeEventListener(type, listener) {
+    this.listeners.set(
+      type,
+      (this.listeners.get(type) || []).filter((candidate) => candidate !== listener),
+    );
+  }
+
+  emit(type, detail) {
+    for (const listener of this.listeners.get(type) || []) {
+      listener({ detail });
+    }
+  }
+}
+
+function createNode(id) {
+  const callbackLog = [];
+  const widgets = [
+    {
+      name: "wildcard_seed",
+      value: 7,
+      callback(value) { callbackLog.push(["seed", value]); },
+    },
+    {
+      name: "wildcard_seed_after_generate",
+      value: "fixed",
+      callback(value) { callbackLog.push(["control", value]); },
+    },
+  ];
+  return { id, widgets, callbackLog };
+}
+
+function createHarness() {
+  const api = new FakeApi();
+  const owner = ownerModule.createQueueUiTransactionOwner();
+  let runtime;
+  const executedContext = contextModule.createExecutedEventContext(api, {
+    finishPrompt: (promptId) => runtime.finishPrompt(promptId),
+  });
+  runtime = transactionModule.createPromptStudioWildcardSeedTransaction({
+    owner,
+    executedContext,
+    findWidget: (node, name) => node.widgets.find((widget) => widget.name === name),
+  });
+  executedContext.install();
+  return { api, executedContext, runtime };
+}
+
+function accepted(runtime, node, promptId) {
+  const captured = runtime.captureQueue([node]);
+  assert.equal(captured.length, 1);
+  assert.equal(
+    runtime.acceptQueue(captured, { ok: true, result: { prompt_id: promptId } }),
+    1,
+  );
+  return captured[0].transaction;
+}
+
+function captureEnvelope(api, promptId, node, output) {
+  api.emit("executed", {
+    prompt_id: promptId,
+    node: String(node.id),
+    output,
+  });
+}
+
+{
+  const { api, runtime } = createHarness();
+  const node = createNode(7);
+  const transaction = accepted(runtime, node, "prompt-current");
+  const output = { prompt_studio_advanced: [{ wildcard_seed: 8 }] };
+  let commitCount = 0;
+  captureEnvelope(api, "prompt-current", node, output);
+  assert.equal(
+    await runtime.consumeExecution(node, output, 1, () => { commitCount += 1; }),
+    true,
+  );
+  assert.equal(commitCount, 1);
+  assert.equal(transaction.state, "settled");
+  assert.equal(transaction.reason, "executed");
+  assert.equal(
+    await runtime.consumeExecution(node, output, 1),
+    false,
+    "duplicate must fail closed",
+  );
+}
+
+{
+  const { api, runtime } = createHarness();
+  const node = createNode("node-first");
+  const transaction = accepted(runtime, node, "prompt-node-first");
+  const output = { prompt_studio_advanced: [{ wildcard_seed: 8 }] };
+  let commitCount = 0;
+  const delivery = runtime.consumeExecution(
+    node,
+    output,
+    1,
+    () => { commitCount += 1; },
+  );
+  captureEnvelope(api, "prompt-node-first", node, output);
+  assert.equal(await delivery, true, "node-first delivery must wait within the event turn");
+  assert.equal(commitCount, 1);
+  assert.equal(transaction.state, "settled");
+}
+
+for (const widgetName of ["wildcard_seed", "wildcard_seed_after_generate"]) {
+  const { api, runtime } = createHarness();
+  const node = createNode(widgetName);
+  const transaction = accepted(runtime, node, `prompt-edited-${widgetName}`);
+  const widget = node.widgets.find((candidate) => candidate.name === widgetName);
+  widget.callback(widget.value);
+  assert.equal(node.callbackLog.length, 1, "wrapped callback must preserve the feature callback");
+  const output = { prompt_studio_advanced: [{ wildcard_seed: 9 }] };
+  let commitCount = 0;
+  captureEnvelope(api, transaction.promptId, node, output);
+  assert.equal(
+    await runtime.consumeExecution(node, output, 1, () => { commitCount += 1; }),
+    false,
+    `${widgetName} edit must invalidate the atomic seed/control surface`,
+  );
+  assert.equal(commitCount, 0);
+  assert.equal(transaction.state, "settled");
+}
+
+{
+  const { api, runtime } = createHarness();
+  const node = createNode(8);
+  accepted(runtime, node, "prompt-clone");
+  const output = { prompt_studio_advanced: [{ wildcard_seed: 10 }] };
+  captureEnvelope(api, "prompt-clone", node, output);
+  assert.equal(
+    await runtime.consumeExecution(node, structuredClone(output), 1),
+    false,
+    "cloned output must fail closed",
+  );
+  assert.equal(await runtime.consumeExecution(node, output, 1, () => {}), true);
+}
+
+{
+  const { api, runtime } = createHarness();
+  const node = createNode(9);
+  const transaction = accepted(runtime, node, "prompt-mapped");
+  const output = {
+    prompt_studio_advanced: [
+      { wildcard_seed: 11 },
+      { wildcard_seed: 12 },
+    ],
+  };
+  captureEnvelope(api, "prompt-mapped", node, output);
+  assert.equal(
+    await runtime.consumeExecution(node, output, 2, () => {}),
+    false,
+    "multiple mapped payloads must not publish editable state",
+  );
+  assert.equal(transaction.state, "settled");
+}
+
+{
+  const { api, runtime } = createHarness();
+  const node = createNode(10);
+  const captured = runtime.captureQueue([node]);
+  const transaction = captured[0].transaction;
+  const output = { prompt_studio_advanced: [{ wildcard_seed: 14 }] };
+  let commitCount = 0;
+  captureEnvelope(api, "prompt-out-of-order", node, output);
+  assert.equal(
+    await runtime.consumeExecution(node, output, 1, () => { commitCount += 1; }),
+    false,
+    "executed-before-accept must defer editable publication",
+  );
+  assert.equal(transaction.state, "provisional");
+  assert.equal(commitCount, 0);
+  assert.equal(
+    runtime.acceptQueue(captured, {
+      ok: true,
+      result: { prompt_id: "prompt-out-of-order" },
+    }),
+    1,
+  );
+  assert.equal(commitCount, 1, "acceptance must finalize the deferred commit once");
+  assert.equal(transaction.state, "settled");
+}
+
+{
+  const { runtime } = createHarness();
+  const node = createNode(11);
+  const captured = runtime.captureQueue([node]);
+  assert.equal(runtime.acceptQueue(captured, { ok: true, result: {} }), 0);
+  assert.equal(captured[0].transaction.state, "cancelled");
+  assert.equal(captured[0].transaction.reason, "reject");
+}
+
+{
+  const { api, runtime } = createHarness();
+  const node = createNode(12);
+  const transaction = accepted(runtime, node, "prompt-disposed");
+  assert.equal(runtime.disposeNode(node, "remove"), true);
+  const output = { prompt_studio_advanced: [{ wildcard_seed: 13 }] };
+  captureEnvelope(api, "prompt-disposed", node, output);
+  assert.equal(await runtime.consumeExecution(node, output, 1), false);
+  assert.equal(transaction.state, "cancelled");
+  assert.equal(transaction.reason, "remove");
+}
+
+{
+  const { api, runtime } = createHarness();
+  const node = createNode(13);
+  const transaction = accepted(runtime, node, "prompt-terminal");
+  api.emit("execution_error", { prompt_id: "prompt-terminal" });
+  assert.equal(transaction.state, "finished");
+  assert.equal(transaction.reason, "prompt-terminal");
+}
+
+console.log("Prompt Studio wildcard transaction smoke passed.");

--- a/tests/frontend_prompt_studio_wildcard_view_sync_smoke.mjs
+++ b/tests/frontend_prompt_studio_wildcard_view_sync_smoke.mjs
@@ -1,0 +1,155 @@
+import { readFileSync } from "node:fs";
+import { createFakeDocument } from "./frontend_support/fake_dom.mjs";
+
+function dataModule(relativePath, replacements = {}) {
+  let source = readFileSync(new URL(relativePath, import.meta.url), "utf8");
+  for (const [specifier, replacement] of Object.entries(replacements)) {
+    source = source.replaceAll(`"${specifier}"`, `"${replacement}"`);
+  }
+  return `data:text/javascript;base64,${Buffer.from(source).toString("base64")}`;
+}
+
+function inlineModule(source) {
+  return `data:text/javascript;base64,${Buffer.from(source).toString("base64")}`;
+}
+
+function assertEqual(actual, expected, message) {
+  if (actual !== expected) {
+    throw new Error(`${message}: expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`);
+  }
+}
+
+const appUrl = inlineModule(`
+  export const app = {
+    graph: {
+      dirtyCount: 0,
+      setDirtyCanvas() { this.dirtyCount += 1; },
+    },
+  };
+`);
+const constantsUrl = inlineModule(`
+  export const ADVANCED_CONTROL_WIDGETS = [];
+  export const ADVANCED_WILDCARD_DEFAULT_MODE = "일반";
+  export const ADVANCED_WILDCARD_MODES = ["일반", "순차"];
+  export const ADVANCED_WILDCARD_SEED_CONTROLS = ["fixed", "randomize", "increment"];
+  export const ADVANCED_RESOLUTION_BUCKETS = {};
+  export const ARTIST_MIX_MODES = ["off"];
+  export const CUSTOM_ADVANCED_RESOLUTION_BUCKET = "Custom";
+  export const NAIA_ADVANCED_RESOLUTION_BUCKET = "NAIA";
+`);
+const domUrl = inlineModule(`
+  export function stopAdvancedControlEvent(event) { event.stopPropagation(); }
+  export function protectAdvancedNativeControl(element) { return element; }
+  export function updateAdvancedSummary(node, groupId, text) {
+    node.__summaries ||= {};
+    node.__summaries[groupId] = text;
+  }
+  export function closeAdvancedHelpPopovers() {}
+  export function openAdvancedHelpPopover() {}
+`);
+const styleUrl = inlineModule("export function ensureAdvancedStyle() {}");
+const textUrl = inlineModule("export function psText(key) { return key; }");
+const widgetsUrl = inlineModule(`
+  export function findWidget(node, name) {
+    return node.widgets?.find((widget) => widget.name === name) || null;
+  }
+  export function findInputEl() { return null; }
+  export function isWidgetInputLinked() { return false; }
+`);
+const historyUrl = inlineModule(`
+  export function readPreviousWildcardExecution() { return null; }
+  export function wildcardModeWidgetValue(value) { return value; }
+`);
+const schemaUrl = inlineModule(`
+  export function advancedResolutionOptions() { return []; }
+  export function normalizeAdvancedResolutionBucket(value) { return value; }
+  export function normalizeAdvancedResolutionSize(_bucket, value) { return value; }
+  export function normalizeAdvancedWidgetQueueValue(name, value) {
+    return name === "wildcard_seed" ? Math.trunc(Number(value)) : value;
+  }
+  export function normalizeArtistMixMode(value) { return value; }
+`);
+const utilsUrl = inlineModule(`
+  export function advancedResolutionLabel(width, height) { return width + " * " + height; }
+  export function clampAdvancedNumber(value) { return Number(value); }
+  export function snapResolution32(value) { return Number(value); }
+`);
+const orientationUrl = inlineModule(`
+  export function advancedResolutionOrientationPlan() { return { enabled: false }; }
+  export function advancedResolutionOrientationTitleKey() { return ""; }
+`);
+const wildcardContractUrl = new URL(
+  "../web/js/prompt_studio/wildcard_seed_contract.js",
+  import.meta.url,
+).href;
+const advancedControlsUrl = dataModule(
+  "../web/js/prompt_studio/advanced_controls.js",
+  {
+    "../../../../scripts/app.js": appUrl,
+    "./constants.js": constantsUrl,
+    "./dom.js": domUrl,
+    "./schema.js": schemaUrl,
+    "./style.js": styleUrl,
+    "./text.js": textUrl,
+    "./utils.js": utilsUrl,
+    "./advanced_resolution_orientation.js": orientationUrl,
+    "./widgets.js": widgetsUrl,
+    "./wildcard_seed_contract.js": wildcardContractUrl,
+    "./wildcard_seed_history.js": historyUrl,
+  },
+);
+
+globalThis.document = createFakeDocument();
+globalThis.HTMLElement = Object;
+globalThis.HTMLInputElement = Object;
+globalThis.HTMLTextAreaElement = Object;
+
+const {
+  commitAdvancedWildcardSeedView,
+  createAdvancedWildcardSettingsBody,
+} = await import(advancedControlsUrl);
+
+let callbackCount = 0;
+const node = {
+  dirtyCount: 0,
+  properties: {},
+  setDirtyCanvas() { this.dirtyCount += 1; },
+  widgets: [
+    { name: "wildcard_mode", value: "일반" },
+    {
+      name: "wildcard_seed",
+      value: 1,
+      callback() { callbackCount += 1; },
+    },
+    { name: "wildcard_seed_after_generate", value: "increment" },
+    { name: "resolution_size", value: "1344 * 768" },
+    { name: "artist_mix_mode", value: "exact" },
+    { name: "advanced_fields", value: "current prompt fields" },
+  ],
+};
+
+const body = createAdvancedWildcardSettingsBody(node);
+document.body.append(body);
+const seedInput = body.querySelector("input");
+seedInput.isConnected = true;
+assertEqual(seedInput.value, "1", "open seed input baseline");
+
+assertEqual(commitAdvancedWildcardSeedView(node, 2), true, "next seed commit");
+assertEqual(node.widgets[1].value, 2, "canonical hidden seed");
+assertEqual(node.__summaries.wildcard.includes("seed 2"), true, "Wildcard summary");
+assertEqual(seedInput.value, "2", "untouched open seed input");
+assertEqual(callbackCount, 0, "user widget callback count");
+assertEqual(node.dirtyCount, 0, "node layout/dirty mutation count");
+assertEqual(node.widgets[3].value, "1344 * 768", "resolution preservation");
+assertEqual(node.widgets[4].value, "exact", "Artist Mix preservation");
+assertEqual(node.widgets[5].value, "current prompt fields", "prompt field preservation");
+
+seedInput.value = "77";
+seedInput.emit("input");
+assertEqual(commitAdvancedWildcardSeedView(node, 3), true, "dirty-input seed commit");
+assertEqual(node.widgets[1].value, 3, "canonical seed with dirty popup");
+assertEqual(node.__summaries.wildcard.includes("seed 3"), true, "summary with dirty popup");
+assertEqual(seedInput.value, "77", "dirty popup input ownership");
+assertEqual(callbackCount, 0, "callback count after dirty popup");
+
+console.log("Prompt Studio narrow Wildcard view-sync smoke passed.");

--- a/tests/test_frontend_modules.py
+++ b/tests/test_frontend_modules.py
@@ -13,6 +13,9 @@ HOST_HOOK_REGISTRY_SMOKE = ROOT / "tests" / "frontend_host_hook_registry_smoke.m
 PROMPT_STUDIO_ADVANCED_VALUES_SMOKE = (
     ROOT / "tests" / "frontend_prompt_studio_advanced_values_smoke.mjs"
 )
+PROMPT_STUDIO_WILDCARD_TRANSACTION_SMOKE = (
+    ROOT / "tests" / "frontend_prompt_studio_wildcard_transaction_smoke.mjs"
+)
 PROMPT_STUDIO_RESOLUTION_ORIENTATION_SMOKE = (
     ROOT / "tests" / "frontend_prompt_studio_resolution_orientation_smoke.mjs"
 )
@@ -150,22 +153,24 @@ class FrontendModuleStructureTests(unittest.TestCase):
         self.assertIn('../../lifecycle/host_hook_registry.js"', regional_extension_source)
         self.assertIn('../lifecycle/host_hook_registry.js"', extension_runtime_source)
 
-        for source, owner, lease in (
+        for source, owner, lease, disposer in (
             (
                 extension_runtime_source,
                 "PROMPT_STUDIO_GLOBAL_HOOK_RUNTIME_OWNER",
                 '"advanced-save-sync"',
+                "dispose: disposeRuntime",
             ),
             (
                 regional_extension_source,
                 "REGIONAL_GLOBAL_HOOK_RUNTIME_OWNER",
                 '"regional-save-sync"',
+                "dispose: disposeGlobalHooks",
             ),
         ):
             self.assertIn("createHostHookRuntimeLifecycle(", source)
             self.assertIn(owner, source)
             self.assertIn(lease, source)
-            self.assertIn("dispose: disposeGlobalHooks", source)
+            self.assertIn(disposer, source)
 
         for source in (node_hooks_source, regional_extension_source):
             self.assertIn("registerHostHookCallbacks({", source)
@@ -2268,7 +2273,8 @@ class FrontendModuleStructureTests(unittest.TestCase):
         ).read_text(encoding="utf-8")
 
         self.assertIn("app.registerExtension", source)
-        self.assertNotIn('../../../scripts/api.js"', source)
+        self.assertIn('../../../scripts/api.js"', source)
+        self.assertIn("createPromptStudioExtensionRuntime(app, api)", source)
         self.assertIn('./prompt_studio/extension_runtime.js"', source)
         self.assertIn("./constants.js", extension_runtime_source)
         self.assertIn('./advanced_controls.js"', advanced_node_ui_source)
@@ -2276,6 +2282,11 @@ class FrontendModuleStructureTests(unittest.TestCase):
         self.assertIn('./advanced_fields_ui.js"', advanced_node_ui_source)
         self.assertIn("./advanced_fields_state.js", extension_runtime_source)
         self.assertIn("./advanced_values.js", extension_runtime_source)
+        self.assertIn("./wildcard_seed_transaction.js", extension_runtime_source)
+        self.assertIn("../lifecycle/queue_ui_transaction.js", extension_runtime_source)
+        self.assertIn("../lifecycle/executed_event_context.js", extension_runtime_source)
+        self.assertIn('"advanced-wildcard-seed-transaction"', extension_runtime_source)
+        self.assertIn("queueHost: api", extension_runtime_source)
         self.assertNotIn("./advanced_queue_seed_runtime.js", extension_runtime_source)
         self.assertNotIn("./queue_seed_bridge.js", extension_runtime_source)
         self.assertNotIn("installAdvancedQueueSeedQueueHook", extension_runtime_source)
@@ -2303,6 +2314,11 @@ class FrontendModuleStructureTests(unittest.TestCase):
         self.assertTrue(PROMPT_STUDIO_ADVANCED_VALUES_SMOKE.is_file())
         self.assertIn(
             r'node "tests\frontend_prompt_studio_advanced_values_smoke.mjs"',
+            FRONTEND_CHECK_SCRIPT.read_text(encoding="utf-8"),
+        )
+        self.assertTrue(PROMPT_STUDIO_WILDCARD_TRANSACTION_SMOKE.is_file())
+        self.assertIn(
+            r'node "tests\frontend_prompt_studio_wildcard_transaction_smoke.mjs"',
             FRONTEND_CHECK_SCRIPT.read_text(encoding="utf-8"),
         )
         self.assertTrue(PROMPT_STUDIO_RESOLUTION_ORIENTATION_SMOKE.is_file())
@@ -2626,7 +2642,7 @@ class FrontendModuleStructureTests(unittest.TestCase):
         self.assertIn("normalizeWildcardSeedControl", contract_source)
         self.assertIn("globalThis.requestAnimationFrame", contract_source)
         self.assertIn("input.isConnected !== true", contract_source)
-        self.assertIn("!dirty", contract_source)
+        self.assertIn("!state.dirty", contract_source)
         extension_source = (
             PROMPT_STUDIO_MODULES / "extension_runtime.js"
         ).read_text(encoding="utf-8")

--- a/tools/check_frontend.ps1
+++ b/tools/check_frontend.ps1
@@ -174,6 +174,16 @@ try {
         throw "Frontend Prompt Studio Advanced executed values smoke failed with exit code $LASTEXITCODE."
     }
 
+    & node "tests\frontend_prompt_studio_wildcard_transaction_smoke.mjs"
+    if ($LASTEXITCODE -ne 0) {
+        throw "Frontend Prompt Studio wildcard transaction smoke failed with exit code $LASTEXITCODE."
+    }
+
+    & node "tests\frontend_prompt_studio_wildcard_view_sync_smoke.mjs"
+    if ($LASTEXITCODE -ne 0) {
+        throw "Frontend Prompt Studio narrow Wildcard view-sync smoke failed with exit code $LASTEXITCODE."
+    }
+
     & node "tests\frontend_prompt_studio_classic_values_smoke.mjs"
     if ($LASTEXITCODE -ne 0) {
         throw "Frontend Prompt Studio Classic/Extend executed values smoke failed with exit code $LASTEXITCODE."

--- a/web/js/easyuse_anima_prompt_studio.js
+++ b/web/js/easyuse_anima_prompt_studio.js
@@ -1,10 +1,12 @@
 // @ts-expect-error ComfyUI provides this host module at runtime.
 import { app } from "../../../scripts/app.js";
+// @ts-expect-error ComfyUI provides this host module at runtime.
+import { api } from "../../../scripts/api.js";
 import {
   createPromptStudioExtensionRuntime,
 } from "./prompt_studio/extension_runtime.js";
 
 app.registerExtension({
   name: "easyuse-anima.prompt-studio",
-  ...createPromptStudioExtensionRuntime(app),
+  ...createPromptStudioExtensionRuntime(app, api),
 });

--- a/web/js/prompt_studio/advanced_controls.js
+++ b/web/js/prompt_studio/advanced_controls.js
@@ -45,11 +45,14 @@ import {
 import {
   bindWildcardSeedInput,
   normalizeWildcardSeedControl,
+  syncBoundWildcardSeedInput,
 } from "./wildcard_seed_contract.js";
 import {
   readPreviousWildcardExecution,
   wildcardModeWidgetValue,
 } from "./wildcard_seed_history.js";
+
+const ADVANCED_WILDCARD_SEED_INPUTS = new WeakMap();
 
 function setAdvancedControlValue(node, name, value) {
   const widget = findWidget(node, name);
@@ -581,6 +584,22 @@ function advancedWildcardSummary(node) {
   return `${modeValue} · seed ${Math.max(0, Math.trunc(Number(seedWidget?.value) || 0))} · ${advancedWildcardSeedControlLabel(controlValue)}`;
 }
 
+function commitAdvancedWildcardSeedView(node, value) {
+  const seedWidget = findWidget(node, "wildcard_seed");
+  if (!seedWidget) {
+    return false;
+  }
+  seedWidget.value = normalizeAdvancedWidgetQueueValue("wildcard_seed", value);
+  updateAdvancedSummary(node, "wildcard", advancedWildcardSummary(node));
+  const seedInput = ADVANCED_WILDCARD_SEED_INPUTS.get(node);
+  if (seedInput?.isConnected === true) {
+    syncBoundWildcardSeedInput(seedInput);
+  } else if (seedInput) {
+    ADVANCED_WILDCARD_SEED_INPUTS.delete(node);
+  }
+  return true;
+}
+
 function createAdvancedSummaryButtonRow(className, buttonLabelKey, titleKey, summaryId, summaryText, onClick) {
   const row = document.createElement("div");
   row.className = className;
@@ -717,6 +736,7 @@ function createAdvancedWildcardSettingsBody(node) {
     (seed) => setAdvancedWidgetValue(node, "wildcard_seed", seed),
     refreshSummary,
   );
+  ADVANCED_WILDCARD_SEED_INPUTS.set(node, seedInput);
   body.append(
     modeRow,
     createAdvancedControlRow("advanced.wildcardSeed", seedInput),
@@ -753,7 +773,7 @@ function createAdvancedWildcardBar(node, hooks = {}) {
       "advanced.wildcardSeed",
       "advanced.wildcardTitle",
       () => createAdvancedWildcardSettingsBody(node),
-      null,
+      () => ADVANCED_WILDCARD_SEED_INPUTS.delete(node),
       hooks,
       {
         headerHelpKey: "advanced.wildcardHelp",
@@ -1053,10 +1073,12 @@ export {
   advancedModGuidanceSummary,
   advancedResolutionSummary,
   advancedWildcardSummary,
+  commitAdvancedWildcardSeedView,
   createAdvancedControlBar,
   createAdvancedResolutionBar,
   createAdvancedResolutionSettingsBody,
   createAdvancedWildcardBar,
+  createAdvancedWildcardSettingsBody,
   setAdvancedControlValue,
   setAdvancedCustomResolution,
   setAdvancedWidgetValue,

--- a/web/js/prompt_studio/advanced_values.js
+++ b/web/js/prompt_studio/advanced_values.js
@@ -63,14 +63,27 @@ function syncAdvancedValues(node, serialized = null, hooks = {}) {
 }
 
 function publishAdvancedWildcardExecution(node, message, hooks = {}) {
-  const payload = firstValue(message?.prompt_studio_advanced, null);
+  const mappedPayload = message?.prompt_studio_advanced;
+  const payload = firstValue(mappedPayload, null);
   if (!payload || typeof payload !== "object") {
     return;
   }
+  const mappedItemCount = Array.isArray(mappedPayload) ? mappedPayload.length : 1;
   const wildcardSeed = findWidget(node, "wildcard_seed");
-  if (wildcardSeed && payload.wildcard_seed != null) {
-    wildcardSeed.value = payload.wildcard_seed;
-  }
+  hooks.consumeWildcardSeedExecution?.(
+    node,
+    message,
+    mappedItemCount,
+    wildcardSeed && payload.wildcard_seed != null
+      ? () => {
+        if (typeof hooks.commitAdvancedWildcardSeedView === "function") {
+          hooks.commitAdvancedWildcardSeedView(node, payload.wildcard_seed);
+        } else {
+          wildcardSeed.value = payload.wildcard_seed;
+        }
+      }
+      : null,
+  );
   if (writePreviousWildcardExecution(node, {
     seed: payload.wildcard_execution_seed,
     mode: payload.wildcard_mode,

--- a/web/js/prompt_studio/extension_runtime.js
+++ b/web/js/prompt_studio/extension_runtime.js
@@ -122,18 +122,45 @@ import {
 } from "./runtime_canvas.js";
 import {
   createHostHookRuntimeLifecycle,
+  registerHostHookCallbacks,
 } from "../lifecycle/host_hook_registry.js";
+import {
+  createQueueUiTransactionOwner,
+} from "../lifecycle/queue_ui_transaction.js";
+import {
+  createExecutedEventContext,
+} from "../lifecycle/executed_event_context.js";
+import {
+  createPromptStudioWildcardSeedTransaction,
+} from "./wildcard_seed_transaction.js";
+import {
+  commitAdvancedWildcardSeedView,
+} from "./advanced_controls.js";
 
 const PROMPT_STUDIO_GLOBAL_HOOK_RUNTIME_OWNER = Symbol.for(
   "easyuse-anima.prompt-studio.global-hook-runtime-owner",
 );
+const PROMPT_STUDIO_WILDCARD_SEED_TRANSACTION_OWNER = Symbol.for(
+  "easyuse-anima.prompt-studio.wildcard-seed-transaction",
+);
 
-function createPromptStudioExtensionRuntime(app) {
+function createPromptStudioExtensionRuntime(app, api) {
   const globalHookLifecycle = createHostHookRuntimeLifecycle(
     app,
     PROMPT_STUDIO_GLOBAL_HOOK_RUNTIME_OWNER,
   );
+  const queueUiTransactionOwner = createQueueUiTransactionOwner();
+  let wildcardSeedTransaction;
+  const executedEventContext = createExecutedEventContext(api, {
+    finishPrompt: (promptId) => wildcardSeedTransaction.finishPrompt(promptId),
+  });
+  wildcardSeedTransaction = createPromptStudioWildcardSeedTransaction({
+    owner: queueUiTransactionOwner,
+    executedContext: executedEventContext,
+    findWidget,
+  });
   let advancedSaveSyncSerializeHost;
+  let wildcardSeedTransactionGraphHost;
 
   function markNodeDirty(node) {
     markNodeDirtyWithApp(app, node);
@@ -163,6 +190,8 @@ function createPromptStudioExtensionRuntime(app) {
   function advancedValuesHooks() {
     return {
       advancedWidget,
+      commitAdvancedWildcardSeedView,
+      consumeWildcardSeedExecution: wildcardSeedTransaction.consumeExecution,
       markNodeDirty,
       parseAdvancedFields,
       repairAdvancedInternalWidgetValues,
@@ -367,13 +396,53 @@ function createPromptStudioExtensionRuntime(app) {
     return installed;
   }
 
+  function installAdvancedWildcardSeedTransactionForApp() {
+    const graphHost = app?.graph || null;
+    const replace = wildcardSeedTransactionGraphHost !== undefined
+      && graphHost != null
+      && graphHost !== wildcardSeedTransactionGraphHost;
+    const installed = globalHookLifecycle.install(
+      "advanced-wildcard-seed-transaction",
+      () => registerHostHookCallbacks({
+        owner: PROMPT_STUDIO_WILDCARD_SEED_TRANSACTION_OWNER,
+        // ComfyApp.queuePrompt resolves to a boolean after draining its local
+        // batch. ComfyApi.queuePrompt is the per-submission host call whose
+        // successful result owns the accepted prompt_id.
+        queueHost: api,
+        graphHost,
+        beforeQueue: () => wildcardSeedTransaction.captureQueue(
+          (app.graph?._nodes || []).filter(isAdvancedNode),
+        ),
+        afterQueue: (context) => wildcardSeedTransaction.acceptQueue(
+          context.callbackState,
+          context,
+        ),
+        onGraphClear: () => wildcardSeedTransaction.clear(),
+      }),
+      { replace },
+    );
+    if (installed) {
+      wildcardSeedTransactionGraphHost = graphHost;
+    }
+    return installed;
+  }
+
   function installGlobalHooks() {
     installAdvancedSaveSyncForApp();
+    installAdvancedWildcardSeedTransactionForApp();
   }
 
   function disposeGlobalHooks() {
     advancedSaveSyncSerializeHost = undefined;
+    wildcardSeedTransactionGraphHost = undefined;
     return globalHookLifecycle.dispose();
+  }
+
+  function disposeRuntime() {
+    let changed = disposeGlobalHooks();
+    changed = executedEventContext.dispose() || changed;
+    changed = wildcardSeedTransaction.dispose() || changed;
+    return changed;
   }
 
   function advancedNodeUiHooks() {
@@ -411,10 +480,11 @@ function createPromptStudioExtensionRuntime(app) {
   }
 
   return {
-    dispose: disposeGlobalHooks,
+    dispose: disposeRuntime,
     async setup() {
       installAdvancedWheelForwarder();
       installMiddlePanForwarder();
+      executedEventContext.install();
       installGlobalHooks();
       installPromptHighlightOverlayRefresh(app, applyPromptStudioTextStyle);
       await loadPromptStudioSettings({
@@ -451,7 +521,9 @@ function createPromptStudioExtensionRuntime(app) {
         ),
         disconnectAdvancedEditorWidthObserver,
         disposeAdvancedAutocompleteInputs,
+        disposeAdvancedWildcardSeedNode: wildcardSeedTransaction.disposeNode,
         hookWildcardSeedWidget,
+        hookAdvancedWildcardSeedNode: wildcardSeedTransaction.hookNode,
         hookStudioNode,
         isExtendNode,
         layoutExtendPromptWidgets,

--- a/web/js/prompt_studio/node_hooks.js
+++ b/web/js/prompt_studio/node_hooks.js
@@ -55,6 +55,7 @@ function registerPromptStudioNodeHooks(nodeType, nodeData, hooks) {
   nodeType.prototype.onNodeCreated = function () {
     onNodeCreated?.apply(this, arguments);
     if (isAdvanced) {
+      hooks.hookAdvancedWildcardSeedNode?.(this);
       hooks.scheduleHookAdvancedNode(this);
     } else if (isWildcard) {
       hooks.hookWildcardSeedWidget?.(this, { resetSeedControl: false });
@@ -65,9 +66,13 @@ function registerPromptStudioNodeHooks(nodeType, nodeData, hooks) {
 
   const onConfigure = nodeType.prototype.onConfigure;
   nodeType.prototype.onConfigure = function (serialized) {
+    if (isAdvanced) {
+      hooks.disposeAdvancedWildcardSeedNode?.(this, "reconfigure");
+    }
     const result = onConfigure?.apply(this, arguments);
     if (isAdvanced) {
       hooks.captureAdvancedConfigure(this, serialized);
+      hooks.hookAdvancedWildcardSeedNode?.(this);
       hooks.scheduleHookAdvancedNode(this);
     } else if (isWildcard) {
       hooks.hookWildcardSeedWidget?.(this, { resetSeedControl: true });
@@ -128,6 +133,11 @@ function registerPromptStudioNodeHooks(nodeType, nodeData, hooks) {
         hooks.disposeAdvancedAutocompleteInputs?.(this);
       } catch {
         // Autocomplete cleanup remains isolated from other node removal handlers.
+      }
+      try {
+        hooks.disposeAdvancedWildcardSeedNode?.(this, "remove");
+      } catch {
+        // Transaction cleanup remains isolated from other node removal handlers.
       }
     }
     if (didThrow) {

--- a/web/js/prompt_studio/wildcard_seed_contract.js
+++ b/web/js/prompt_studio/wildcard_seed_contract.js
@@ -18,6 +18,7 @@ const LEGACY_FIXED_WILDCARD_MODES = new Set([
   "reproduce",
   "재현",
 ]);
+const WILDCARD_SEED_INPUT_STATES = new WeakMap();
 
 /**
  * Normalize Prompt Studio's independent next-seed policy. Legacy Fixed and
@@ -93,15 +94,19 @@ function bindWildcardSeedInput(input, getCurrentSeed, publishSeed, afterPublish)
   input.step = "1";
   // An untouched open control must yield to queue/executed widget updates,
   // while any real input event keeps ownership of the user's pending edit.
-  let baselineValue = String(input.value ?? "");
-  let dirty = false;
+  const state = {
+    baselineValue: String(input.value ?? ""),
+    dirty: false,
+    getCurrentSeed,
+  };
+  WILDCARD_SEED_INPUT_STATES.set(input, state);
   const restoreCurrentSeed = () => {
     input.value = String(getCurrentSeed() ?? "0");
-    baselineValue = input.value;
-    dirty = false;
+    state.baselineValue = input.value;
+    state.dirty = false;
   };
   const syncSeed = () => {
-    if (!dirty && input.value === baselineValue) {
+    if (!state.dirty && input.value === state.baselineValue) {
       restoreCurrentSeed();
       return false;
     }
@@ -113,12 +118,12 @@ function bindWildcardSeedInput(input, getCurrentSeed, publishSeed, afterPublish)
     input.value = String(seed);
     publishSeed(seed);
     afterPublish?.(seed);
-    baselineValue = input.value;
-    dirty = false;
+    state.baselineValue = input.value;
+    state.dirty = false;
     return true;
   };
   input.addEventListener("input", () => {
-    dirty = true;
+    state.dirty = true;
   });
   input.addEventListener("change", syncSeed);
   input.addEventListener("blur", syncSeed);
@@ -128,13 +133,35 @@ function bindWildcardSeedInput(input, getCurrentSeed, publishSeed, afterPublish)
       if (input.isConnected !== true) {
         return;
       }
-      if (!dirty && String(input.value ?? "") !== String(getCurrentSeed() ?? "0")) {
-        restoreCurrentSeed();
-      }
+      syncBoundWildcardSeedInput(input);
       requestFrame(syncVisibleSeed);
     });
   }
   return syncSeed;
+}
+
+/**
+ * Reflect a canonical seed into an already-open input only while that input
+ * still represents its untouched baseline. Pending user text keeps ownership.
+ *
+ * @param {any} input
+ */
+function syncBoundWildcardSeedInput(input) {
+  const state = WILDCARD_SEED_INPUT_STATES.get(input);
+  if (
+    !state
+    || state.dirty
+    || String(input.value ?? "") !== state.baselineValue
+  ) {
+    return false;
+  }
+  const currentValue = String(state.getCurrentSeed() ?? "0");
+  if (String(input.value ?? "") === currentValue) {
+    return false;
+  }
+  input.value = currentValue;
+  state.baselineValue = currentValue;
+  return true;
 }
 
 /**
@@ -173,4 +200,5 @@ export {
   normalizeWildcardSeedInput,
   optionalWildcardSeed,
   randomWildcardSeed,
+  syncBoundWildcardSeedInput,
 };

--- a/web/js/prompt_studio/wildcard_seed_transaction.js
+++ b/web/js/prompt_studio/wildcard_seed_transaction.js
@@ -1,0 +1,313 @@
+// @ts-check
+
+const WILDCARD_SEED_CONTROL_SURFACE = "prompt.wildcard_seed_control";
+const WILDCARD_HISTORY_SURFACE = "prompt.wildcard_history";
+const EDITABLE_WIDGET_NAMES = Object.freeze([
+  "wildcard_seed",
+  "wildcard_seed_after_generate",
+]);
+const WIDGET_CALLBACK_OWNER = Symbol.for(
+  "easyuse-anima.prompt-studio.wildcard-seed-callback-owner",
+);
+const MAX_TRACKED_TRANSACTIONS_PER_NODE = 8;
+
+/** @param {unknown} value */
+function isReference(value) {
+  return value !== null && (
+    typeof value === "object"
+    || typeof value === "function"
+  );
+}
+
+/**
+ * Bind Prompt Studio's concrete next-seed publication to the shared queue UI
+ * transaction contract. Seed values and controls remain feature-owned; the
+ * shared owner sees only an opaque surface token and its revision.
+ *
+ * @param {{
+ *   owner: ReturnType<import("../lifecycle/queue_ui_transaction.js").createQueueUiTransactionOwner>,
+ *   executedContext: ReturnType<import("../lifecycle/executed_event_context.js").createExecutedEventContext>,
+ *   findWidget: (node: any, name: string) => any,
+ * }} options
+ */
+function createPromptStudioWildcardSeedTransaction(options) {
+  const { owner, executedContext, findWidget } = options || {};
+  if (
+    !owner
+    || !executedContext
+    || typeof findWidget !== "function"
+  ) {
+    throw new TypeError("Prompt Studio wildcard transaction dependencies are required.");
+  }
+
+  let disposed = false;
+  const transactionsByNode = new WeakMap();
+  const pendingExecutions = new WeakMap();
+  const activeNodes = new Set();
+
+  /** @param {any} node */
+  function activeTransactions(node) {
+    const current = transactionsByNode.get(node) || [];
+    const active = current.filter(
+      (transaction) => transaction?.state === "provisional"
+        || transaction?.state === "accepted",
+    );
+    if (active.length === 0) {
+      transactionsByNode.delete(node);
+      activeNodes.delete(node);
+    } else if (active.length !== current.length) {
+      transactionsByNode.set(node, active);
+    }
+    return active;
+  }
+
+  /** @param {any} node @param {any} transaction */
+  function remember(node, transaction) {
+    const active = activeTransactions(node);
+    while (active.length >= MAX_TRACKED_TRANSACTIONS_PER_NODE) {
+      owner.cancel(active.shift(), "cancel");
+    }
+    active.push(transaction);
+    transactionsByNode.set(node, active);
+    activeNodes.add(node);
+  }
+
+  /** @param {any} node @param {any} transaction */
+  function forget(node, transaction) {
+    const active = activeTransactions(node).filter(
+      (candidate) => candidate !== transaction,
+    );
+    if (active.length === 0) {
+      transactionsByNode.delete(node);
+      activeNodes.delete(node);
+    } else {
+      transactionsByNode.set(node, active);
+    }
+  }
+
+  /** @param {any} node */
+  function hookNode(node) {
+    if (disposed || !isReference(node)) {
+      return false;
+    }
+    let changed = false;
+    for (const name of EDITABLE_WIDGET_NAMES) {
+      const widget = findWidget(node, name);
+      if (!widget || typeof widget !== "object") {
+        continue;
+      }
+      const current = widget.callback;
+      const callbackState = current?.[WIDGET_CALLBACK_OWNER];
+      if (callbackState?.runtime === runtime) {
+        continue;
+      }
+      const original = callbackState?.original ?? current;
+      const wrapped = function (...args) {
+        try {
+          return typeof original === "function"
+            ? original.apply(this, args)
+            : undefined;
+        } finally {
+          if (!disposed) {
+            owner.markEdited(node, [WILDCARD_SEED_CONTROL_SURFACE]);
+          }
+        }
+      };
+      Object.defineProperty(wrapped, WIDGET_CALLBACK_OWNER, {
+        value: { runtime, original },
+      });
+      widget.callback = wrapped;
+      changed = true;
+    }
+    return changed;
+  }
+
+  /** @param {any[]} nodes */
+  function captureQueue(nodes) {
+    if (disposed || !Array.isArray(nodes)) {
+      return [];
+    }
+    const captured = [];
+    for (const node of nodes) {
+      if (!isReference(node)) {
+        continue;
+      }
+      hookNode(node);
+      const transaction = owner.captureProvisional({
+        node,
+        surfaces: [WILDCARD_SEED_CONTROL_SURFACE],
+      });
+      if (transaction) {
+        remember(node, transaction);
+        captured.push({ node, transaction });
+      }
+    }
+    return captured;
+  }
+
+  /**
+   * @param {{ node: any, transaction: any }[]} captured
+   * @param {{ ok?: boolean, result?: any }} outcome
+   */
+  function acceptQueue(captured, outcome = {}) {
+    if (!Array.isArray(captured)) {
+      return 0;
+    }
+    const promptId = outcome.ok === true ? outcome.result?.prompt_id : null;
+    let accepted = 0;
+    for (const entry of captured) {
+      if (
+        !disposed
+        && owner.acceptPrompt(entry.transaction, promptId)
+      ) {
+        accepted += 1;
+        const pending = pendingExecutions.get(entry.transaction);
+        if (pending) {
+          pendingExecutions.delete(entry.transaction);
+          finishExecution(entry.node, entry.transaction, pending);
+        }
+      } else {
+        pendingExecutions.delete(entry.transaction);
+        owner.cancel(entry.transaction, "reject");
+        forget(entry.node, entry.transaction);
+      }
+    }
+    return accepted;
+  }
+
+  /**
+   * @param {any} node
+   * @param {any} transaction
+   * @param {{ envelope: any, mappedItemCount: number, commit?: (() => unknown) | null }} pending
+   */
+  function finishExecution(node, transaction, pending) {
+    if (transaction.promptId !== pending.envelope.promptId) {
+      owner.cancel(transaction, "reject");
+      forget(node, transaction);
+      return false;
+    }
+    const canCommit = owner.canCommit(transaction, {
+      envelope: pending.envelope,
+      node,
+      surface: WILDCARD_SEED_CONTROL_SURFACE,
+      mappedItemCount: pending.mappedItemCount,
+    });
+    let committed = canCommit;
+    if (canCommit && typeof pending.commit === "function") {
+      try {
+        pending.commit();
+      } catch {
+        committed = false;
+      }
+    }
+    owner.settle(transaction, pending.envelope);
+    forget(node, transaction);
+    return committed;
+  }
+
+  /**
+   * Consume only the exact output object captured from ComfyUI's outer
+   * `executed` event. Multiple mapped payloads settle the transaction but are
+   * never allowed to publish an editable next seed.
+   *
+   * @param {any} node
+   * @param {unknown} output
+   * @param {number} mappedItemCount
+   * @param {(() => unknown) | null} [commit]
+   */
+  async function consumeExecution(node, output, mappedItemCount, commit = null) {
+    if (disposed || !isReference(node)) {
+      return false;
+    }
+    const envelope = await executedContext.consumeWithinTurn(output);
+    if (!envelope || disposed || !isReference(node)) {
+      return false;
+    }
+    const active = activeTransactions(node);
+    const matches = active.filter(
+      (transaction) => transaction.state === "accepted"
+        && transaction.promptId === envelope.promptId,
+    );
+    if (matches.length === 1) {
+      return finishExecution(node, matches[0], {
+        envelope,
+        mappedItemCount,
+        commit,
+      });
+    }
+    const provisional = active.filter(
+      (transaction) => transaction.state === "provisional",
+    );
+    if (matches.length !== 0 || provisional.length !== 1) {
+      return false;
+    }
+    pendingExecutions.set(provisional[0], {
+      envelope,
+      mappedItemCount,
+      commit,
+    });
+    return false;
+  }
+
+  /** @param {unknown} promptId */
+  function finishPrompt(promptId) {
+    const finished = owner.finishPrompt(promptId);
+    for (const node of [...activeNodes]) {
+      activeTransactions(node);
+    }
+    return finished;
+  }
+
+  /** @param {any} node @param {"remove" | "reconfigure" | "dispose"} [reason] */
+  function disposeNode(node, reason = "dispose") {
+    for (const transaction of activeTransactions(node)) {
+      pendingExecutions.delete(transaction);
+    }
+    const changed = owner.disposeNode(node, reason);
+    transactionsByNode.delete(node);
+    activeNodes.delete(node);
+    return changed;
+  }
+
+  function clear() {
+    let cancelled = 0;
+    for (const node of [...activeNodes]) {
+      for (const transaction of activeTransactions(node)) {
+        pendingExecutions.delete(transaction);
+        if (owner.cancel(transaction, "clear")) {
+          cancelled += 1;
+        }
+      }
+      transactionsByNode.delete(node);
+      activeNodes.delete(node);
+    }
+    return cancelled;
+  }
+
+  function dispose() {
+    if (disposed) {
+      return false;
+    }
+    clear();
+    disposed = true;
+    return true;
+  }
+
+  const runtime = Object.freeze({
+    acceptQueue,
+    captureQueue,
+    clear,
+    consumeExecution,
+    dispose,
+    disposeNode,
+    finishPrompt,
+    hookNode,
+  });
+  return runtime;
+}
+
+export {
+  WILDCARD_HISTORY_SURFACE,
+  WILDCARD_SEED_CONTROL_SURFACE,
+  createPromptStudioWildcardSeedTransaction,
+};


### PR DESCRIPTION
## 목적과 변경 경계

- Task: QSTATE-04B / #413
- Base -> Head: `1d41635ffc0f7b41a07c7c535c87f59314a3a1c1 -> cc3eabed790cfec7adc0834a4662e62ab16d30ce`
- Prompt Studio Advanced/AdvancedV2 Wildcard next-seed commit을 queue transaction의 exact execution correlation 뒤에서만 허용합니다.
- 첫 divergent phase에 따라 Prompt Studio-owned narrow Wildcard view sync만 추가했습니다.
- backend, ComfyUI core/api.dispatchEvent/public socket/workflow schema, AiO seed semantics, Prompt Studio broad rerender는 변경하지 않았습니다.

## Reason-coded diagnostic

실제 queue trace에서 다음을 확인했습니다.

- provisional transaction이 queue acceptance 뒤 accepted prompt identity로 bind됨
- captured node와 onExecuted node가 동일함
- node message가 outer executed detail.output과 동일한 object임
- mapped item count 1, envelope delivered
- canCommit: allowed
- commit callback invoked
- hidden wildcard_seed: 1 -> 2
- edit revision 변경 없음
- terminal order: execution_success -> finishPrompt
- 최초 결함: hidden widget은 진행했지만 Wildcard summary와 열린 non-dirty popup input이 stale

따라서 identity/bridge/terminal owner는 수정하지 않았습니다.

## 구현 계약

- canonical wildcard_seed를 먼저 갱신
- Wildcard summary만 갱신
- 열린 input은 untouched baseline일 때만 갱신
- dirty popup input은 사용자 편집 소유권을 유지
- widget callback, edit revision, dirty/layout mutation을 발생시키지 않음
- prompt fields/caret, resolution, Artist Mix를 보존
- `renderAdvancedEditor()`를 호출하지 않음

## 검증

- Changed-file `node --check`: PASS
- `frontend_executed_event_context_smoke.mjs`: PASS
- `frontend_queue_ui_transaction_smoke.mjs`: PASS, 10 scenarios
- `frontend_prompt_studio_wildcard_transaction_smoke.mjs`: PASS
- `frontend_prompt_studio_advanced_values_smoke.mjs`: PASS
- `frontend_prompt_studio_wildcard_view_sync_smoke.mjs`: PASS
- direct source-contract unittest: PASS
- `frontend_prompt_studio_resolution_orientation_smoke.mjs`: PASS
- `git diff --check`: PASS
- Node 2.0 changed flow: PASS; returned next seed가 summary와 다시 연 non-dirty popup input에 동일 반영, 새 console error 없음
- Legacy Canvas changed flow: PASS; returned next seed가 summary와 다시 연 non-dirty popup input에 동일 반영, 새 console error 없음
- Official full: `check_custom_node.ps1 -Project <QSTATE worktree> -Profile full`
  - exact SHA: `cc3eabed790cfec7adc0834a4662e62ab16d30ce`
  - PASS: 1,151 unittests, frontend 118 files
- Package: not triggered
- 추가 live/package: not triggered

## 위험, rollback, next

- 남은 위험: ComfyUI seed reservation에 의해 next seed 숫자는 이전 accepted execution history를 따르지만, feature UI는 backend가 반환한 canonical next seed만 반영합니다.
- Rollback: `cc3eabed790cfec7adc0834a4662e62ab16d30ce` revert
- Next: QSTATE-04B review/merge 후 AIO-SEED-UI-01. 예정된 final matrix 뒤 focused PRO review에서 중단합니다.
