### PR TITLE
AIO-SEED-UI-01: define special seed intent contract matrix

### DIFF
--- a/tests/frontend_aio_executed_seed_runtime_smoke.mjs
+++ b/tests/frontend_aio_executed_seed_runtime_smoke.mjs
@@ -10,13 +10,225 @@ const seedModule = await import(dataModule(
   "../web/js/aio/executed_seed_runtime.js",
 ));
 
+const SPECIAL_SELECTION_BY_TOKEN = new Map([
+  [-1, "randomize"],
+  [-2, "increment"],
+  [-3, "decrement"],
+]);
+const STORED_AFTER_GENERATE_CONTROLS = [
+  "fixed",
+  "randomize",
+  "increment",
+  "decrement",
+];
+const AIO_EDITABLE_MAXIMUM = 100;
+const AIO_PAYLOAD_FIELDS = Object.freeze([
+  "requested_seed",
+  "selection",
+  "effective_after_generate",
+  "execution_seed",
+  "next_seed",
+]);
+const AIO_SEED_INTENT_CONTRACT = Object.freeze({
+  payloadFields: AIO_PAYLOAD_FIELDS,
+  ownership: Object.freeze({
+    seedSelection: Object.freeze({
+      name: "aio.seed_selection",
+      role: "only-editable-revision-surface",
+      owns: Object.freeze(["requested-seed", "stored-after-generate"]),
+    }),
+    lastSeed: Object.freeze({
+      name: "aio.last_seed",
+      role: "monotonic-execution-history",
+      editableRevisionSurface: false,
+    }),
+    concreteNextSeed: Object.freeze({
+      name: "aio.concrete_next_seed",
+      role: "publication-class",
+      consumesRevision: "aio.seed_selection",
+    }),
+  }),
+  specialEffectiveAfterGenerate: "fixed",
+  specialDisplayPolicy: "never-publish-editable-result",
+  concreteDisplayPolicy: "publish-next-seed-if-revision-current",
+  lastSeedPolicy:
+    "highest-local-queue-sequence-among-successfully-correlated-executed-results",
+  queueAcceptancePolicy: "correlation-prerequisite-not-execution-success",
+  randomEachPolicy: "one-random-source-call-per-queue-no-uniqueness-retry",
+  workflowPolicy: "serialize-requested-seed-and-stored-control",
+  useLastPolicy: "execution-seed-to-concrete-fixed",
+  newFixedRandomPolicy: "one-random-seed-to-concrete-fixed",
+});
+
+function contractPayload({
+  requestedSeed,
+  storedAfterGenerate,
+  executionSeed,
+  nextSeed,
+}) {
+  const selection = SPECIAL_SELECTION_BY_TOKEN.get(requestedSeed) ?? "concrete";
+  return {
+    requested_seed: String(requestedSeed),
+    selection,
+    effective_after_generate:
+      selection === "concrete" ? storedAfterGenerate : "fixed",
+    execution_seed: String(executionSeed),
+    next_seed: String(nextSeed),
+  };
+}
+
+function parseContractSeed(value, { allowSpecial = false, maximum }) {
+  if (typeof value !== "string") {
+    return null;
+  }
+  if (allowSpecial && /^-[123]$/.test(value)) {
+    return Number(value);
+  }
+  if (!/^(?:0|[1-9]\d*)$/.test(value)) {
+    return null;
+  }
+  const parsed = BigInt(value);
+  if (parsed > BigInt(maximum)) {
+    return null;
+  }
+  return Number(parsed);
+}
+
+function validateContractPayload(
+  payload,
+  { maximum = AIO_EDITABLE_MAXIMUM, mappedItemCount = 1 } = {},
+) {
+  if (
+    !payload
+    || mappedItemCount !== 1
+    || Object.keys(payload).length !== AIO_PAYLOAD_FIELDS.length
+    || !AIO_PAYLOAD_FIELDS.every((field) => Object.hasOwn(payload, field))
+  ) {
+    return null;
+  }
+  const requestedSeed = parseContractSeed(
+    payload.requested_seed,
+    { allowSpecial: true, maximum },
+  );
+  const executionSeed = parseContractSeed(payload.execution_seed, { maximum });
+  const nextSeed = parseContractSeed(payload.next_seed, { maximum });
+  if (requestedSeed === null || executionSeed === null || nextSeed === null) {
+    return null;
+  }
+  const selection = SPECIAL_SELECTION_BY_TOKEN.get(requestedSeed) ?? "concrete";
+  if (payload.selection !== selection) {
+    return null;
+  }
+  if (
+    selection !== "concrete"
+    && payload.effective_after_generate !== "fixed"
+  ) {
+    return null;
+  }
+  if (
+    selection === "concrete"
+    && !STORED_AFTER_GENERATE_CONTROLS.includes(
+      payload.effective_after_generate,
+    )
+  ) {
+    return null;
+  }
+  return {
+    requestedSeed,
+    selection,
+    effectiveAfterGenerate: payload.effective_after_generate,
+    executionSeed,
+    nextSeed,
+  };
+}
+
+function contractSeedDecision({
+  payload,
+  storedAfterGenerate,
+  currentDisplaySeed,
+  revisionCurrent,
+  maximum = AIO_EDITABLE_MAXIMUM,
+  mappedItemCount = 1,
+}) {
+  const parsed = validateContractPayload(
+    payload,
+    { maximum, mappedItemCount },
+  );
+  if (
+    parsed === null
+    || !STORED_AFTER_GENERATE_CONTROLS.includes(storedAfterGenerate)
+    || (
+      parsed.selection === "concrete"
+      && parsed.effectiveAfterGenerate !== storedAfterGenerate
+    )
+  ) {
+    return null;
+  }
+  const special = parsed.selection !== "concrete";
+  const shouldPublishEditable =
+    !special
+    && revisionCurrent === true
+    && parsed.nextSeed !== currentDisplaySeed;
+  return {
+    ...parsed,
+    storedAfterGenerate,
+    shouldPublishEditable,
+    editablePublicationSeed: shouldPublishEditable ? parsed.nextSeed : null,
+    workflowSeed: parsed.requestedSeed,
+    workflowAfterGenerate: storedAfterGenerate,
+  };
+}
+
+function contractExplicitConcreteTransition(
+  action,
+  seed,
+  maximum = AIO_EDITABLE_MAXIMUM,
+) {
+  if (
+    !["use-last", "new-fixed-random"].includes(action)
+    || !Number.isSafeInteger(seed)
+    || seed < 0
+    || seed > maximum
+  ) {
+    return null;
+  }
+  return { seed, afterGenerate: "fixed" };
+}
+
+function recordLastExecutedSeed(state, {
+  localQueueSequence,
+  executionSeed,
+  queueAccepted,
+  executionSucceeded,
+  correlationSucceeded,
+  maximum = AIO_EDITABLE_MAXIMUM,
+}) {
+  if (
+    queueAccepted !== true
+    || executionSucceeded !== true
+    || correlationSucceeded !== true
+    || !Number.isSafeInteger(localQueueSequence)
+    || localQueueSequence <= state.localQueueSequence
+    || !Number.isSafeInteger(executionSeed)
+    || executionSeed < 0
+    || executionSeed > maximum
+  ) {
+    return false;
+  }
+  state.localQueueSequence = localQueueSequence;
+  state.executionSeed = executionSeed;
+  return true;
+}
+
 assert.deepEqual(
   Object.keys(seedModule),
   ["aioApplyExecutedSeedDisplay"],
 );
 
 {
-  const node = {};
+  // Characterization: the current production path destructively replaces a
+  // persistent special selection token with the backend concrete next seed.
+  const node = { seed: -1 };
   const updates = [];
   assert.equal(seedModule.aioApplyExecutedSeedDisplay(
     node,
@@ -30,10 +242,12 @@ assert.deepEqual(
       maximum: 100,
       updateSeed(candidate, seed, options) {
         updates.push([candidate, seed, options]);
+        candidate.seed = seed;
       },
     },
   ), true);
   assert.equal(node.__easyuseAnimaLastExecutedSeed, 41);
+  assert.equal(node.seed, 42, "current production replaces the -1 selection intent");
   assert.deepEqual(updates, [[node, 42, { markDirty: false }]]);
 }
 
@@ -105,5 +319,204 @@ for (const message of [
     },
   ), false);
 }
+
+for (const [requestedSeed, selection] of SPECIAL_SELECTION_BY_TOKEN) {
+  for (const storedAfterGenerate of STORED_AFTER_GENERATE_CONTROLS) {
+    const payload = contractPayload({
+      requestedSeed,
+      storedAfterGenerate,
+      executionSeed: 41,
+      nextSeed: 41,
+    });
+    const decision = contractSeedDecision({
+      payload,
+      storedAfterGenerate,
+      currentDisplaySeed: requestedSeed,
+      revisionCurrent: true,
+    });
+    assert.equal(decision.selection, selection);
+    assert.equal(decision.effectiveAfterGenerate, "fixed");
+    assert.equal(decision.shouldPublishEditable, false);
+    assert.equal(decision.editablePublicationSeed, null);
+    assert.equal(decision.workflowSeed, requestedSeed);
+    assert.equal(decision.workflowAfterGenerate, storedAfterGenerate);
+
+    const differentCurrentDisplay = contractSeedDecision({
+      payload,
+      storedAfterGenerate,
+      currentDisplaySeed: 99,
+      revisionCurrent: true,
+    });
+    assert.equal(differentCurrentDisplay.shouldPublishEditable, false);
+    assert.equal(differentCurrentDisplay.editablePublicationSeed, null);
+
+    const stale = contractSeedDecision({
+      payload,
+      storedAfterGenerate,
+      currentDisplaySeed: 99,
+      revisionCurrent: false,
+    });
+    assert.equal(stale.shouldPublishEditable, false);
+  }
+}
+
+const concreteNextByControl = new Map([
+  ["fixed", 7],
+  ["randomize", 91],
+  ["increment", 8],
+  ["decrement", 6],
+]);
+for (const [storedAfterGenerate, nextSeed] of concreteNextByControl) {
+  const payload = contractPayload({
+    requestedSeed: 7,
+    storedAfterGenerate,
+    executionSeed: 7,
+    nextSeed,
+  });
+  const current = contractSeedDecision({
+    payload,
+    storedAfterGenerate,
+    currentDisplaySeed: 7,
+    revisionCurrent: true,
+  });
+  assert.equal(current.selection, "concrete");
+  assert.equal(current.effectiveAfterGenerate, storedAfterGenerate);
+  assert.equal(current.shouldPublishEditable, nextSeed !== 7);
+  assert.equal(
+    current.editablePublicationSeed,
+    nextSeed !== 7 ? nextSeed : null,
+  );
+  assert.equal(current.workflowSeed, 7);
+  assert.equal(current.workflowAfterGenerate, storedAfterGenerate);
+
+  const stale = contractSeedDecision({
+    payload,
+    storedAfterGenerate,
+    currentDisplaySeed: 99,
+    revisionCurrent: false,
+  });
+  assert.equal(stale.shouldPublishEditable, false);
+}
+
+{
+  const validSpecial = contractPayload({
+    requestedSeed: -1,
+    storedAfterGenerate: "randomize",
+    executionSeed: 7,
+    nextSeed: 7,
+  });
+  const invalidPayloads = [
+    { ...validSpecial, selection: "increment" },
+    { ...validSpecial, effective_after_generate: "randomize" },
+    { ...validSpecial, requested_seed: "-4", selection: "concrete" },
+    { ...validSpecial, requested_seed: "7.0", selection: "concrete" },
+    { ...validSpecial, execution_seed: "7.0" },
+    { ...validSpecial, execution_seed: "101" },
+    { ...validSpecial, next_seed: "101" },
+    { ...validSpecial, next_display_seed: "-1" },
+  ];
+  for (const payload of invalidPayloads) {
+    assert.equal(contractSeedDecision({
+      payload,
+      storedAfterGenerate: "randomize",
+      currentDisplaySeed: -1,
+      revisionCurrent: true,
+    }), null);
+  }
+  assert.equal(contractSeedDecision({
+    payload: validSpecial,
+    storedAfterGenerate: "randomize",
+    currentDisplaySeed: -1,
+    revisionCurrent: true,
+    mappedItemCount: 2,
+  }), null);
+}
+
+assert.deepEqual(
+  contractExplicitConcreteTransition("use-last", 20),
+  { seed: 20, afterGenerate: "fixed" },
+);
+assert.deepEqual(
+  contractExplicitConcreteTransition("new-fixed-random", 30),
+  { seed: 30, afterGenerate: "fixed" },
+);
+assert.equal(contractExplicitConcreteTransition("automatic-result", 404), null);
+assert.equal(contractExplicitConcreteTransition("use-last", -1), null);
+assert.equal(contractExplicitConcreteTransition("use-last", 101), null);
+
+{
+  const state = { localQueueSequence: 0, executionSeed: null };
+  const result = (overrides) => ({
+    localQueueSequence: 2,
+    executionSeed: 20,
+    queueAccepted: true,
+    executionSucceeded: true,
+    correlationSucceeded: true,
+    ...overrides,
+  });
+  assert.equal(recordLastExecutedSeed(state, result()), true);
+  assert.equal(recordLastExecutedSeed(state, result({
+    localQueueSequence: 1,
+    executionSeed: 10,
+  })), false);
+  assert.equal(recordLastExecutedSeed(state, result()), false);
+  assert.equal(recordLastExecutedSeed(state, result({
+    localQueueSequence: 3,
+    executionSeed: 30,
+    executionSucceeded: false,
+  })), false);
+  assert.equal(recordLastExecutedSeed(state, result({
+    localQueueSequence: 3,
+    executionSeed: 30,
+    correlationSucceeded: false,
+  })), false);
+  assert.equal(recordLastExecutedSeed(state, result({
+    localQueueSequence: 3,
+    executionSeed: 101,
+  })), false);
+  assert.deepEqual(state, { localQueueSequence: 2, executionSeed: 20 });
+  assert.equal(recordLastExecutedSeed(state, result({
+    localQueueSequence: 3,
+    executionSeed: 30,
+  })), true);
+  assert.deepEqual(state, { localQueueSequence: 3, executionSeed: 30 });
+}
+
+assert.deepEqual(AIO_SEED_INTENT_CONTRACT, {
+  payloadFields: [
+    "requested_seed",
+    "selection",
+    "effective_after_generate",
+    "execution_seed",
+    "next_seed",
+  ],
+  ownership: {
+    seedSelection: {
+      name: "aio.seed_selection",
+      role: "only-editable-revision-surface",
+      owns: ["requested-seed", "stored-after-generate"],
+    },
+    lastSeed: {
+      name: "aio.last_seed",
+      role: "monotonic-execution-history",
+      editableRevisionSurface: false,
+    },
+    concreteNextSeed: {
+      name: "aio.concrete_next_seed",
+      role: "publication-class",
+      consumesRevision: "aio.seed_selection",
+    },
+  },
+  specialEffectiveAfterGenerate: "fixed",
+  specialDisplayPolicy: "never-publish-editable-result",
+  concreteDisplayPolicy: "publish-next-seed-if-revision-current",
+  lastSeedPolicy:
+    "highest-local-queue-sequence-among-successfully-correlated-executed-results",
+  queueAcceptancePolicy: "correlation-prerequisite-not-execution-success",
+  randomEachPolicy: "one-random-source-call-per-queue-no-uniqueness-retry",
+  workflowPolicy: "serialize-requested-seed-and-stored-control",
+  useLastPolicy: "execution-seed-to-concrete-fixed",
+  newFixedRandomPolicy: "one-random-seed-to-concrete-fixed",
+});
 
 console.log("AiO executed seed runtime smoke passed.");

--- a/tests/test_aio_seed_cutover.py
+++ b/tests/test_aio_seed_cutover.py
@@ -8,6 +8,46 @@ from easyuse_anima.nodes import aio_nodes
 from easyuse_anima.nodes.seed_adapters import AioSeedExecution
 
 
+SPECIAL_SELECTION_BY_SEED = {
+    -1: "randomize",
+    -2: "increment",
+    -3: "decrement",
+}
+STORED_AFTER_GENERATE_CONTROLS = (
+    "fixed",
+    "randomize",
+    "increment",
+    "decrement",
+)
+AIO_SEED_RESULT_CONTRACT_FIELDS = (
+    "requested_seed",
+    "selection",
+    "effective_after_generate",
+    "execution_seed",
+    "next_seed",
+)
+
+
+def _contract_seed_payload(
+    *,
+    requested_seed: int,
+    stored_after_generate: str,
+    execution_seed: int,
+    next_seed: int,
+) -> dict[str, str]:
+    selection = SPECIAL_SELECTION_BY_SEED.get(requested_seed, "concrete")
+    special = selection != "concrete"
+    return {
+        "requested_seed": str(requested_seed),
+        "selection": selection,
+        "effective_after_generate": (
+            "fixed" if special else stored_after_generate
+        ),
+        "execution_seed": str(execution_seed),
+        "next_seed": str(next_seed),
+    }
+
+
 class AioSeedCutoverTests(unittest.TestCase):
     def test_generate_uses_reserved_seed_and_publishes_backend_display(self):
         settings = {
@@ -88,6 +128,57 @@ class AioSeedCutoverTests(unittest.TestCase):
             output["ui"]["easyuse_anima_aio_seed"],
             [{"execution_seed": "17", "next_seed": "18"}],
         )
+
+    def test_result_contract_uses_five_canonical_backend_fields(self):
+        for requested_seed, selection in SPECIAL_SELECTION_BY_SEED.items():
+            for stored_after_generate in STORED_AFTER_GENERATE_CONTROLS:
+                with self.subTest(
+                    requested_seed=requested_seed,
+                    stored_after_generate=stored_after_generate,
+                ):
+                    payload = _contract_seed_payload(
+                        requested_seed=requested_seed,
+                        stored_after_generate=stored_after_generate,
+                        execution_seed=17,
+                        next_seed=17,
+                    )
+                    self.assertEqual(
+                        tuple(payload),
+                        AIO_SEED_RESULT_CONTRACT_FIELDS,
+                    )
+                    self.assertEqual(payload["selection"], selection)
+                    self.assertEqual(
+                        payload["effective_after_generate"],
+                        "fixed",
+                    )
+                    self.assertEqual(
+                        payload["next_seed"],
+                        payload["execution_seed"],
+                    )
+
+        concrete_next_by_control = {
+            "fixed": 7,
+            "randomize": 91,
+            "increment": 8,
+            "decrement": 6,
+        }
+        for stored_after_generate, next_seed in concrete_next_by_control.items():
+            with self.subTest(stored_after_generate=stored_after_generate):
+                payload = _contract_seed_payload(
+                    requested_seed=7,
+                    stored_after_generate=stored_after_generate,
+                    execution_seed=7,
+                    next_seed=next_seed,
+                )
+                self.assertEqual(payload["selection"], "concrete")
+                self.assertEqual(
+                    payload["effective_after_generate"],
+                    stored_after_generate,
+                )
+                self.assertEqual(
+                    payload["next_seed"],
+                    str(next_seed),
+                )
 
 
 if __name__ == "__main__":

--- a/tests/test_seed_adapters.py
+++ b/tests/test_seed_adapters.py
@@ -1,49 +1,131 @@
 from __future__ import annotations
 
 import unittest
+from dataclasses import replace
 from types import SimpleNamespace
 from unittest.mock import Mock, patch
 
 from easyuse_anima.nodes.seed_adapters import (
+    AioSeedExecution,
     aio_seed_execution,
     prompt_studio_seed_execution,
 )
 from easyuse_anima.seed.execution_identity import SeedExecutionIdentity
 from easyuse_anima.seed.reservation import (
+    SEED_CONTROL_FIXED,
+    SEED_OVERFLOW_CLAMP,
+    SEED_SELECTION_CONCRETE,
     SEED_SETTLEMENT_ACCEPTED,
     SeedReservation,
+    parse_legacy_seed_reservation_request,
 )
 from easyuse_anima.seed.service import InMemorySeedReservationService
 
 
+AIO_CONTRACT_MAX_SEED = 1 << 50
+AIO_SPECIAL_SELECTIONS = {
+    -1: "randomize",
+    -2: "increment",
+    -3: "decrement",
+}
+AIO_STORED_AFTER_GENERATE_CONTROLS = (
+    "fixed",
+    "randomize",
+    "increment",
+    "decrement",
+)
+AIO_CONTRACT_NORMALIZATION_OWNER = "aio_seed_execution"
+AIO_MISSING_IDENTITY_SPECIAL_POLICY = (
+    "one-concrete-seed-per-invocation-no-persistent-stream-or-double-advance"
+)
+
+
+def _aio_contract_request(
+    *,
+    stream_id: str,
+    request_id: str,
+    normalized_seed: int,
+    stored_after_generate: str,
+):
+    request = parse_legacy_seed_reservation_request(
+        stream_id=stream_id,
+        request_id=request_id,
+        normalized_seed=normalized_seed,
+        after_generate=stored_after_generate,
+        next_seed_max=AIO_CONTRACT_MAX_SEED,
+        overflow=SEED_OVERFLOW_CLAMP,
+    )
+    if request.selection != SEED_SELECTION_CONCRETE:
+        return replace(request, after_generate=SEED_CONTROL_FIXED)
+    return request
+
+
+def _aio_contract_missing_identity_execution(
+    *,
+    invocation_id: str,
+    normalized_seed: int,
+    stored_after_generate: str,
+    select_concrete_seed,
+):
+    """Model aio_seed_execution normalization before its branch decision."""
+    request = _aio_contract_request(
+        stream_id="compatibility:isolated",
+        request_id=invocation_id,
+        normalized_seed=normalized_seed,
+        stored_after_generate=stored_after_generate,
+    )
+    if request.selection == SEED_SELECTION_CONCRETE:
+        raise AssertionError("missing-identity fixture only models special intent")
+    execution_seed = select_concrete_seed()
+    return request, AioSeedExecution(
+        execution_seed=execution_seed,
+        next_seed=execution_seed,
+    )
+
+
 class SeedAdapterTests(unittest.TestCase):
-    def test_aio_missing_identity_uses_isolated_legacy_selection(self):
-        fallback_execution_seed = Mock(return_value=7)
-        random_next_seed = Mock(return_value=11)
-        with (
-            patch(
-                "easyuse_anima.nodes.seed_adapters.resolve_seed_execution_identity",
-                return_value=None,
+    def test_aio_missing_identity_contract_normalizes_before_fallback(self):
+        self.assertEqual(
+            AIO_CONTRACT_NORMALIZATION_OWNER,
+            "aio_seed_execution",
+        )
+        self.assertEqual(
+            AIO_MISSING_IDENTITY_SPECIAL_POLICY,
+            (
+                "one-concrete-seed-per-invocation-"
+                "no-persistent-stream-or-double-advance"
             ),
-            patch("easyuse_anima.nodes.seed_adapters.get_runtime") as get_runtime,
-        ):
-            with aio_seed_execution(
-                unique_id=None,
-                normalized_seed=-1,
-                after_generate="randomize",
-                fallback_execution_seed=fallback_execution_seed,
-                random_next_seed=random_next_seed,
-            ) as execution:
-                self.assertEqual(
-                    (execution.execution_seed, execution.next_seed),
-                    (7, 11),
-                )
+        )
+        for normalized_seed, selection in AIO_SPECIAL_SELECTIONS.items():
+            for stored_after_generate in AIO_STORED_AFTER_GENERATE_CONTROLS:
+                with self.subTest(
+                    normalized_seed=normalized_seed,
+                    stored_after_generate=stored_after_generate,
+                ):
+                    select_concrete_seed = Mock(side_effect=(7, 7))
+                    observed = []
+                    for invocation_index in range(2):
+                        request, execution = (
+                            _aio_contract_missing_identity_execution(
+                                invocation_id=f"invocation:{invocation_index}",
+                                normalized_seed=normalized_seed,
+                                stored_after_generate=stored_after_generate,
+                                select_concrete_seed=select_concrete_seed,
+                            )
+                        )
+                        self.assertEqual(request.selection, selection)
+                        self.assertEqual(
+                            request.after_generate,
+                            SEED_CONTROL_FIXED,
+                        )
+                        observed.append(
+                            (execution.execution_seed, execution.next_seed)
+                        )
 
-        get_runtime.assert_not_called()
-        fallback_execution_seed.assert_called_once_with()
-        random_next_seed.assert_called_once_with()
+                    self.assertEqual(observed, [(7, 7), (7, 7)])
+                    self.assertEqual(select_concrete_seed.call_count, 2)
 
-    def test_aio_installed_runtime_translates_legacy_selection_and_domain(self):
+    def test_current_aio_runtime_characterizes_pre_cutover_control(self):
         service = Mock()
         service.reserve.return_value = SeedReservation(
             version=2,
@@ -80,6 +162,8 @@ class SeedAdapterTests(unittest.TestCase):
         request = service.reserve.call_args.args[0]
         self.assertEqual(request.selection, "increment")
         self.assertIsNone(request.seed)
+        # Current production characterization for AIO-SEED-UI-02: the adapter
+        # still forwards the stored control instead of the Contract's fixed.
         self.assertEqual(request.after_generate, "increment")
         self.assertEqual(request.next_seed_max, 1 << 50)
         self.assertEqual(request.overflow, "clamp")
@@ -120,6 +204,111 @@ class SeedAdapterTests(unittest.TestCase):
                     )
 
         self.assertEqual(observed, [(4, 4), (5, 5)])
+
+    def test_aio_special_selection_and_stored_control_golden_matrix(self):
+        expected_execution_seeds = {
+            -1: [10, 10, 30],
+            -2: [10, 11, 12],
+            -3: [10, 9, 8],
+        }
+        expected_random_draws = {-1: 3, -2: 1, -3: 1}
+
+        for normalized_seed, selection in AIO_SPECIAL_SELECTIONS.items():
+            for stored_after_generate in AIO_STORED_AFTER_GENERATE_CONTROLS:
+                with self.subTest(
+                    normalized_seed=normalized_seed,
+                    stored_after_generate=stored_after_generate,
+                ):
+                    draws = iter((10, 10, 30))
+                    random_calls = []
+                    reservation_ids = iter(
+                        f"reservation:{index}" for index in range(3)
+                    )
+
+                    def random_seed(upper_bound):
+                        random_calls.append(upper_bound)
+                        return next(draws)
+
+                    service = InMemorySeedReservationService(
+                        random_seed=random_seed,
+                        reservation_id_factory=lambda: next(reservation_ids),
+                    )
+                    observed = []
+                    stream_id = (
+                        f"stream:{normalized_seed}:{stored_after_generate}"
+                    )
+                    for index in range(3):
+                        request = _aio_contract_request(
+                            stream_id=stream_id,
+                            request_id=f"request:{index}",
+                            normalized_seed=normalized_seed,
+                            stored_after_generate=stored_after_generate,
+                        )
+                        self.assertEqual(request.selection, selection)
+                        self.assertEqual(
+                            request.after_generate,
+                            SEED_CONTROL_FIXED,
+                        )
+                        reservation = service.reserve(request)
+                        observed.append(
+                            (
+                                reservation.execution_seed,
+                                reservation.next_seed,
+                            )
+                        )
+                        service.settle(
+                            reservation.reservation_id,
+                            SEED_SETTLEMENT_ACCEPTED,
+                        )
+
+                    execution_seeds = expected_execution_seeds[normalized_seed]
+                    self.assertEqual(
+                        observed,
+                        [(seed, seed) for seed in execution_seeds],
+                    )
+                    self.assertEqual(
+                        len(random_calls),
+                        expected_random_draws[normalized_seed],
+                    )
+
+    def test_aio_concrete_seed_and_after_generate_golden_matrix(self):
+        expected_next_seed = {
+            "fixed": 7,
+            "randomize": 91,
+            "increment": 8,
+            "decrement": 6,
+        }
+        for stored_after_generate, next_seed in expected_next_seed.items():
+            with self.subTest(stored_after_generate=stored_after_generate):
+                random_calls = []
+
+                def random_seed(upper_bound):
+                    random_calls.append(upper_bound)
+                    return 91
+
+                service = InMemorySeedReservationService(
+                    random_seed=random_seed,
+                    reservation_id_factory=lambda: "reservation:concrete",
+                )
+                request = _aio_contract_request(
+                    stream_id=f"stream:concrete:{stored_after_generate}",
+                    request_id="request:concrete",
+                    normalized_seed=7,
+                    stored_after_generate=stored_after_generate,
+                )
+                self.assertEqual(request.selection, SEED_SELECTION_CONCRETE)
+                self.assertEqual(request.seed, 7)
+                self.assertEqual(
+                    request.after_generate,
+                    stored_after_generate,
+                )
+                reservation = service.reserve(request)
+                self.assertEqual(reservation.execution_seed, 7)
+                self.assertEqual(reservation.next_seed, next_seed)
+                self.assertEqual(
+                    len(random_calls),
+                    1 if stored_after_generate == "randomize" else 0,
+                )
 
     def test_missing_identity_uses_compatibility_values_without_runtime_lookup(self):
         with (


### PR DESCRIPTION
## 목적과 경계

- Task: AIO-SEED-UI-01 / #414
- Class: CONTRACT
- Base -> Head: `9b0e2ddb3d7c43af75808da2eed44337c098d949 -> c6e1d782394f173739812d12d3d8ed748251a6b3`
- Changed boundary: Contract fixture 3개만
- Production JavaScript/Python, shared queue transaction owner, public socket/workflow schema는 변경하지 않았습니다.
- AIO-SEED-UI-02/03 구현은 포함하지 않았습니다.

## Current production characterization

`frontend_aio_executed_seed_runtime_smoke.mjs`는 실제 production `aioApplyExecutedSeedDisplay()`를 호출합니다.

```text
live seed intent -1
+ execution_seed 41 / next_seed 42
-> last executed seed 41
-> current production updateSeed(42)
-> live special intent가 concrete 42로 파괴됨
```

이는 현재 destructive mutation을 의도적으로 고정하는 characterization입니다. 새 desired Contract는 test-local fixture이며 production 경로를 변경하지 않습니다.

## Focused PRO 반영 Contract

Backend payload는 다음 5개 canonical field만 소유합니다.

```text
requested_seed
selection
effective_after_generate
execution_seed
next_seed
```

- `next_display_seed`는 제거했습니다. Special은 editable write 없음, concrete만 current revision에서 `next_seed`를 publish합니다.
- normalization owner는 `aio_seed_execution()` adapter입니다. requested seed -> selection -> effective after-generate를 runtime/fallback 분기 전에 한 번 계산합니다.
- 모든 special selection의 effective control은 `fixed`이며 stored control은 workflow intent로 보존합니다.
- missing identity fallback은 invocation당 concrete seed를 한 번만 선택하고 `next_seed == execution_seed`입니다.
- identity 없는 `-2/-3`은 persistent stream 증감을 보장하지 않으며 이중 advance하지 않습니다.
- identity가 있는 service path의 `-2/-3` stream matrix와 compatibility-only fallback을 구분합니다.
- Random Each는 queue당 random source 호출 1회만 요구합니다. duplicate draw를 허용하며 uniqueness retry/state는 요구하지 않습니다.

Ownership:

```text
aio.seed_selection
  seed + stored seed_after_generate의 유일한 editable revision surface

aio.last_seed
  monotonic execution history
  markEdited/canCommit surface가 아님

aio.concrete_next_seed
  별도 revision surface가 아닌 publication class
  aio.seed_selection revision을 소비
```

Frontend fail-closed Contract:

- special `-1/-2/-3` result는 current display가 달라도 editable seed를 자동 publish하지 않습니다.
- requested seed/selection 불일치, special + non-fixed effective control, invalid negative token, malformed decimal string을 거부합니다.
- editable maximum을 넘는 execution/next seed와 multiple mapped payload를 거부합니다.
- out-of-domain execution result는 기존 valid `aio.last_seed`를 지우거나 Use Last를 활성화하지 않습니다.
- Last ordering은 `highest local queue sequence among successfully correlated executed results`입니다.
- queue acceptance는 correlation prerequisite이며 execution success와 구분합니다. 오래된 result, duplicate, reject/cancel, correlation failure는 history를 rollback하지 않습니다.

Explicit `Use Last`와 `New Fixed Random`만 concrete + fixed로 전환합니다. Wildcard seed 의미나 helper는 공유하지 않습니다.

## 검증

Focused:

- `node --check tests/frontend_aio_executed_seed_runtime_smoke.mjs`: PASS
- `node tests/frontend_aio_executed_seed_runtime_smoke.mjs`: PASS
- focused `tests.test_aio_seed_cutover`: PASS (2)
- focused `tests.test_seed_adapters`: PASS (7)
- `git diff --check`: PASS

Official full:

- Command: repository official full profile
- Exact SHA: `c6e1d782394f173739812d12d3d8ed748251a6b3`
- Result: PASS
- Python unittest: 1,154
- Frontend: 118 JavaScript files, TypeScript 6.0.3
- Ruff: 119 report-only findings
- Package: not triggered
- Live: not triggered

Rollback: Contract fixture commit `c6e1d782394f173739812d12d3d8ed748251a6b3` revert

Next: focused PRO re-review 승인 후에만 AIO-SEED-UI-02/03.