### PR TITLE
fix: publish normalized AiO seed results

### DIFF
--- a/easyuse_anima/nodes/aio_nodes.py
+++ b/easyuse_anima/nodes/aio_nodes.py
@@ -307,10 +307,12 @@ class EasyUseAnimaAIOGenerator:
                 extra_pnginfo,
                 unique_id,
             )
-            output["ui"]["easyuse_anima_aio_seed"] = [{
-                "execution_seed": str(seed_execution.execution_seed),
-                "next_seed": str(seed_execution.next_seed),
-            }]
+            payload_factory = getattr(seed_execution, "ui_payload", None)
+            seed_payload = (
+                payload_factory() if callable(payload_factory) else None
+            )
+            if seed_payload is not None:
+                output["ui"]["easyuse_anima_aio_seed"] = [seed_payload]
             return output
 
 

--- a/easyuse_anima/nodes/seed_adapters.py
+++ b/easyuse_anima/nodes/seed_adapters.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 import random
 from collections.abc import Callable, Generator
 from contextlib import contextmanager
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from typing import cast
 
 from ..aio.generation_defaults import (
@@ -28,6 +28,7 @@ from ..seed.reservation import (
     SEED_SELECTION_RANDOMIZE,
     SeedControl,
     SeedReservationRequest,
+    SeedSelection,
     parse_legacy_seed_reservation_request,
 )
 
@@ -43,6 +44,26 @@ class AioSeedExecution:
 
     execution_seed: int
     next_seed: int
+    requested_seed: int | None = None
+    selection: SeedSelection | None = None
+    effective_after_generate: SeedControl | None = None
+
+    def ui_payload(self) -> dict[str, str] | None:
+        """Return the canonical UI payload when intent identity is complete."""
+
+        if (
+            self.requested_seed is None
+            or self.selection is None
+            or self.effective_after_generate is None
+        ):
+            return None
+        return {
+            "requested_seed": str(self.requested_seed),
+            "selection": self.selection,
+            "effective_after_generate": self.effective_after_generate,
+            "execution_seed": str(self.execution_seed),
+            "next_seed": str(self.next_seed),
+        }
 
 
 @dataclass(frozen=True, slots=True)
@@ -84,23 +105,43 @@ def _aio_fallback_next_seed(
 
 
 def _aio_compatibility_execution(
-    normalized_seed: int,
-    after_generate: str,
+    requested_seed: int,
+    request: SeedReservationRequest,
     fallback_execution_seed: Callable[[], int],
     random_next_seed: Callable[[], int],
 ) -> AioSeedExecution:
     execution_seed = _aio_fallback_execution_seed(
-        normalized_seed,
+        requested_seed,
         fallback_execution_seed,
     )
     return AioSeedExecution(
         execution_seed=execution_seed,
         next_seed=_aio_fallback_next_seed(
             execution_seed,
-            after_generate,
+            request.after_generate,
             random_next_seed,
         ),
+        requested_seed=requested_seed,
+        selection=request.selection,
+        effective_after_generate=request.after_generate,
     )
+
+
+def _normalize_aio_seed_request(
+    normalized_seed: int,
+    after_generate: str,
+) -> SeedReservationRequest:
+    request = parse_legacy_seed_reservation_request(
+        stream_id="aio:pending",
+        request_id="aio:pending",
+        normalized_seed=normalized_seed,
+        after_generate=cast(SeedControl, after_generate),
+        next_seed_max=AIO_GENERATOR_MAX_EDITABLE_SEED,
+        overflow=SEED_OVERFLOW_CLAMP,
+    )
+    if request.selection != SEED_SELECTION_CONCRETE:
+        return replace(request, after_generate=SEED_CONTROL_FIXED)
+    return request
 
 
 @contextmanager
@@ -114,6 +155,7 @@ def aio_seed_execution(
 ) -> Generator[AioSeedExecution, None, None]:
     """Reserve AiO execution state, with an isolated compatibility fallback."""
 
+    request = _normalize_aio_seed_request(normalized_seed, after_generate)
     identity = resolve_seed_execution_identity(
         AIO_GENERATOR_SEED_FEATURE,
         unique_id=unique_id,
@@ -121,7 +163,7 @@ def aio_seed_execution(
     if identity is None:
         yield _aio_compatibility_execution(
             normalized_seed,
-            after_generate,
+            request,
             fallback_execution_seed,
             random_next_seed,
         )
@@ -132,24 +174,24 @@ def aio_seed_execution(
     except RuntimeError:
         yield _aio_compatibility_execution(
             normalized_seed,
-            after_generate,
+            request,
             fallback_execution_seed,
             random_next_seed,
         )
         return
 
-    request = parse_legacy_seed_reservation_request(
+    request = replace(
+        request,
         stream_id=identity.stream_id,
         request_id=identity.request_id,
-        normalized_seed=normalized_seed,
-        after_generate=cast(SeedControl, after_generate),
-        next_seed_max=AIO_GENERATOR_MAX_EDITABLE_SEED,
-        overflow=SEED_OVERFLOW_CLAMP,
     )
     with seed_execution_session(service, request) as reservation:
         yield AioSeedExecution(
             execution_seed=reservation.execution_seed,
             next_seed=reservation.next_seed,
+            requested_seed=normalized_seed,
+            selection=request.selection,
+            effective_after_generate=request.after_generate,
         )
 
 

--- a/tests/fixtures/aio_legacy_execution_trace.v1.json
+++ b/tests/fixtures/aio_legacy_execution_trace.v1.json
@@ -121,6 +121,9 @@
         "ui": {
           "easyuse_anima_aio_seed": [
             {
+              "requested_seed": "-1",
+              "selection": "randomize",
+              "effective_after_generate": "fixed",
               "execution_seed": "17",
               "next_seed": "17"
             }
@@ -292,6 +295,9 @@
         "ui": {
           "easyuse_anima_aio_seed": [
             {
+              "requested_seed": "-1",
+              "selection": "randomize",
+              "effective_after_generate": "fixed",
               "execution_seed": "17",
               "next_seed": "17"
             }

--- a/tests/fixtures/python_backend_baseline.json
+++ b/tests/fixtures/python_backend_baseline.json
@@ -20116,6 +20116,23 @@
       },
       {
         "alias": null,
+        "bound_name": "replace",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "dataclasses:replace",
+        "kind": "static_from",
+        "line": 9,
+        "name": "replace",
+        "optional": false,
+        "requested": "dataclasses",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/nodes/seed_adapters.py"
+      },
+      {
+        "alias": null,
         "bound_name": "cast",
         "branch_context": [],
         "classification": "external",
@@ -20412,6 +20429,24 @@
         "kind": "static_from",
         "line": 19,
         "name": "SeedReservationRequest",
+        "optional": false,
+        "requested": "..seed.reservation",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/nodes/seed_adapters.py",
+        "target": "easyuse_anima/seed/reservation.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "SeedSelection",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": "..seed.reservation:SeedSelection",
+        "kind": "static_from",
+        "line": 19,
+        "name": "SeedSelection",
         "optional": false,
         "requested": "..seed.reservation",
         "role": "ordinary",
@@ -60218,9 +60253,9 @@
       },
       {
         "is_package": false,
-        "loc": 317,
+        "loc": 319,
         "module": "easyuse_anima.nodes.aio_nodes",
-        "normalized_git_blob_sha1": "9e7e9aab3af2ec1f757c21c407b370df394676e1",
+        "normalized_git_blob_sha1": "3892e3023c49b82bf79f162f0836a3a3bbebf98e",
         "path": "easyuse_anima/nodes/aio_nodes.py",
         "top_level": {
           "class_count": 2,
@@ -60350,13 +60385,13 @@
       },
       {
         "is_package": false,
-        "loc": 210,
+        "loc": 252,
         "module": "easyuse_anima.nodes.seed_adapters",
-        "normalized_git_blob_sha1": "b7eab3b8c1adfb7a83fd113136736debdfd4e94c",
+        "normalized_git_blob_sha1": "9866598edb0cce9a53b27e5d38a04592e07cea25",
         "path": "easyuse_anima/nodes/seed_adapters.py",
         "top_level": {
           "class_count": 2,
-          "function_count": 6,
+          "function_count": 7,
           "global_count": 5
         }
       },
@@ -76322,6 +76357,17 @@
         "branch_context": [],
         "classification": "external",
         "conditional": false,
+        "imported": "dataclasses:replace",
+        "kind": "static_from",
+        "line": 9,
+        "optional": false,
+        "role": "ordinary",
+        "source": "easyuse_anima/nodes/seed_adapters.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
         "imported": "typing:cast",
         "kind": "static_from",
         "line": 10,
@@ -80652,7 +80698,7 @@
         "column": 1,
         "context": "decorator:AioSeedExecution",
         "kind": "import_time_call",
-        "line": 40,
+        "line": 41,
         "module": "easyuse_anima/nodes/seed_adapters.py",
         "scope": "<module>"
       },
@@ -80661,7 +80707,7 @@
         "column": 1,
         "context": "decorator:PromptStudioSeedExecution",
         "kind": "import_time_call",
-        "line": 48,
+        "line": 69,
         "module": "easyuse_anima/nodes/seed_adapters.py",
         "scope": "<module>"
       },

--- a/tests/test_aio_legacy_generation.py
+++ b/tests/test_aio_legacy_generation.py
@@ -1885,10 +1885,7 @@ class AIOGeneratorLegacyMoveTests(unittest.TestCase):
             )
 
         self.assertIs(result, forwarded)
-        self.assertEqual(
-            result["ui"]["easyuse_anima_aio_seed"],
-            [{"execution_seed": "7", "next_seed": "7"}],
-        )
+        self.assertNotIn("easyuse_anima_aio_seed", result["ui"])
         run.assert_called_once_with(
             generator,
             "input",

--- a/tests/test_aio_seed_cutover.py
+++ b/tests/test_aio_seed_cutover.py
@@ -75,7 +75,13 @@ class AioSeedCutoverTests(unittest.TestCase):
                 },
             )
             self.assertTrue(callable(fallback_execution_seed))
-            yield AioSeedExecution(execution_seed=17, next_seed=18)
+            yield AioSeedExecution(
+                execution_seed=17,
+                next_seed=17,
+                requested_seed=-1,
+                selection="randomize",
+                effective_after_generate="fixed",
+            )
 
         with (
             patch.object(
@@ -126,8 +132,59 @@ class AioSeedCutoverTests(unittest.TestCase):
         self.assertEqual(output["ui"]["status"], ["generated"])
         self.assertEqual(
             output["ui"]["easyuse_anima_aio_seed"],
-            [{"execution_seed": "17", "next_seed": "18"}],
+            [{
+                "requested_seed": "-1",
+                "selection": "randomize",
+                "effective_after_generate": "fixed",
+                "execution_seed": "17",
+                "next_seed": "17",
+            }],
         )
+
+    def test_generate_does_not_guess_missing_compatibility_identity(self):
+        settings = {
+            "sampler": {
+                "seed": 7,
+                "seed_after_generate": "increment",
+            },
+        }
+        output = {
+            "ui": {"status": ["generated"]},
+            "result": ("image", "latent", "metadata"),
+        }
+
+        @contextmanager
+        def compatibility_seed(**_kwargs):
+            yield AioSeedExecution(7, 8)
+
+        with (
+            patch.object(
+                aio_nodes,
+                "_normalize_aio_generation_settings",
+                return_value=settings,
+            ),
+            patch.object(
+                aio_nodes,
+                "_require_easy_use_anima_input",
+                return_value="normalized input",
+            ),
+            patch.object(
+                aio_nodes,
+                "aio_seed_execution",
+                compatibility_seed,
+            ),
+            patch.object(
+                aio_nodes,
+                "_run_aio_generation_pipeline",
+                return_value=output,
+            ),
+        ):
+            result = aio_nodes.EasyUseAnimaAIOGenerator().generate(
+                "input",
+                "serialized settings",
+            )
+
+        self.assertNotIn("easyuse_anima_aio_seed", result["ui"])
 
     def test_result_contract_uses_five_canonical_backend_fields(self):
         for requested_seed, selection in SPECIAL_SELECTION_BY_SEED.items():

--- a/tests/test_seed_adapters.py
+++ b/tests/test_seed_adapters.py
@@ -125,7 +125,7 @@ class SeedAdapterTests(unittest.TestCase):
                     self.assertEqual(observed, [(7, 7), (7, 7)])
                     self.assertEqual(select_concrete_seed.call_count, 2)
 
-    def test_current_aio_runtime_characterizes_pre_cutover_control(self):
+    def test_aio_runtime_normalizes_special_control_before_service_branch(self):
         service = Mock()
         service.reserve.return_value = SeedReservation(
             version=2,
@@ -162,15 +162,87 @@ class SeedAdapterTests(unittest.TestCase):
         request = service.reserve.call_args.args[0]
         self.assertEqual(request.selection, "increment")
         self.assertIsNone(request.seed)
-        # Current production characterization for AIO-SEED-UI-02: the adapter
-        # still forwards the stored control instead of the Contract's fixed.
-        self.assertEqual(request.after_generate, "increment")
+        self.assertEqual(request.after_generate, "fixed")
         self.assertEqual(request.next_seed_max, 1 << 50)
         self.assertEqual(request.overflow, "clamp")
         service.settle.assert_called_once_with(
             "reservation:aio",
             SEED_SETTLEMENT_ACCEPTED,
         )
+
+    def test_aio_runtime_result_carries_normalized_intent_identity(self):
+        service = Mock()
+        service.reserve.return_value = SeedReservation(
+            version=2,
+            reservation_id="reservation:aio",
+            stream_id="stream:aio",
+            request_id="request:aio",
+            execution_seed=12,
+            next_seed=12,
+        )
+        identity = SeedExecutionIdentity(
+            stream_id="stream:aio",
+            request_id="request:aio",
+        )
+        with (
+            patch(
+                "easyuse_anima.nodes.seed_adapters.resolve_seed_execution_identity",
+                return_value=identity,
+            ),
+            patch(
+                "easyuse_anima.nodes.seed_adapters.get_runtime",
+                return_value=SimpleNamespace(seed_reservations=service),
+            ),
+        ):
+            with aio_seed_execution(
+                unique_id="8",
+                normalized_seed=-3,
+                after_generate="randomize",
+            ) as execution:
+                self.assertEqual(
+                    execution.ui_payload(),
+                    {
+                        "requested_seed": "-3",
+                        "selection": "decrement",
+                        "effective_after_generate": "fixed",
+                        "execution_seed": "12",
+                        "next_seed": "12",
+                    },
+                )
+
+    def test_aio_missing_identity_selects_special_seed_once_per_invocation(self):
+        for normalized_seed in AIO_SPECIAL_SELECTIONS:
+            with self.subTest(normalized_seed=normalized_seed):
+                fallback_execution_seed = Mock(return_value=7)
+                random_next_seed = Mock(return_value=11)
+                with (
+                    patch(
+                        "easyuse_anima.nodes.seed_adapters.resolve_seed_execution_identity",
+                        return_value=None,
+                    ),
+                    patch(
+                        "easyuse_anima.nodes.seed_adapters.get_runtime"
+                    ) as get_runtime,
+                ):
+                    with aio_seed_execution(
+                        unique_id=None,
+                        normalized_seed=normalized_seed,
+                        after_generate="randomize",
+                        fallback_execution_seed=fallback_execution_seed,
+                        random_next_seed=random_next_seed,
+                    ) as execution:
+                        self.assertEqual(
+                            (execution.execution_seed, execution.next_seed),
+                            (7, 7),
+                        )
+                        self.assertEqual(
+                            execution.effective_after_generate,
+                            "fixed",
+                        )
+
+                fallback_execution_seed.assert_called_once_with()
+                random_next_seed.assert_not_called()
+                get_runtime.assert_not_called()
 
     def test_aio_increment_selection_advances_on_completed_backend_execution(self):
         ids = iter(("reservation:1", "reservation:2"))


### PR DESCRIPTION
## 목적과 변경 경계

AIO-SEED-UI-02 / #414 backend normalization 및 result payload만 구현합니다.

- `aio_seed_execution()`이 runtime/fallback 분기 전에 requested seed, selection, effective after-generate를 한 번 정규화
- special `-1/-2/-3`의 effective control은 fixed; stored workflow control은 변경하지 않음
- missing-identity special fallback은 invocation당 concrete seed 1회 선택, `execution_seed == next_seed`
- `AioSeedExecution(execution_seed, next_seed)` 2-field constructor 유지; incomplete compatibility 객체에서는 새 payload 의미를 추측하지 않음
- backend UI payload는 정확히 `requested_seed / selection / effective_after_generate / execution_seed / next_seed`만 decimal seed string으로 게시

## Evidence

```text
Task: AIO-SEED-UI-02 / #414
Base -> Head:
01e4d464d6f7a8ae1988004ab7a21045142d3458
->
8de2e8277811e6a326c3ac10ead1b9fe1989dd9a

Changed boundary:
easyuse_anima/nodes/seed_adapters.py
easyuse_anima/nodes/aio_nodes.py
direct Contract/tests and deterministic fixtures only

Preserved:
public node socket/workflow schema
sampling result
shared reservation service
frontend transaction/publication
stored seed_after_generate intent
```

Focused:

- changed Python compile: PASS
- `tests.test_seed_adapters`: PASS (9)
- `tests.test_aio_seed_cutover`: PASS (3)
- `tests.test_aio_nodes`: PASS (77)
- direct legacy forwarding and move-boundary fixtures: PASS
- backend analyzer baseline fixture: PASS
- `git diff --check`: PASS

Full:

```text
powershell -ExecutionPolicy Bypass -File D:\ComfyUI\custom_nodes_workplace\tools\check_custom_node.ps1 -Project <worktree> -Profile full
exact SHA: 8de2e8277811e6a326c3ac10ead1b9fe1989dd9a
PASS: Python unittest 1157; frontend 118; project checks full
```

- Package: not triggered
- Live: not triggered
- Rollback: squash commit
- Next: AIO-SEED-UI-03 after review/merge; reuse #413 shared queue transaction and executed-event context
