### PR TITLE
feat: correlate AiO seed UI results

### DIFF
--- a/tests/frontend_aio_executed_seed_runtime_smoke.mjs
+++ b/tests/frontend_aio_executed_seed_runtime_smoke.mjs
@@ -9,6 +9,12 @@ function dataModule(relativePath) {
 const seedModule = await import(dataModule(
   "../web/js/aio/executed_seed_runtime.js",
 ));
+const queueModule = await import(dataModule(
+  "../web/js/lifecycle/queue_ui_transaction.js",
+));
+const contextModule = await import(dataModule(
+  "../web/js/lifecycle/executed_event_context.js",
+));
 
 const SPECIAL_SELECTION_BY_TOKEN = new Map([
   [-1, "randomize"],
@@ -222,102 +228,354 @@ function recordLastExecutedSeed(state, {
 
 assert.deepEqual(
   Object.keys(seedModule),
-  ["aioApplyExecutedSeedDisplay"],
+  ["AIO_SEED_SELECTION_SURFACE", "createAioSeedTransaction"],
 );
 
-{
-  // Characterization: the current production path destructively replaces a
-  // persistent special selection token with the backend concrete next seed.
-  const node = { seed: -1 };
-  const updates = [];
-  assert.equal(seedModule.aioApplyExecutedSeedDisplay(
+class FakeApi {
+  constructor() {
+    this.listeners = new Map();
+  }
+
+  addEventListener(type, handler) {
+    const handlers = this.listeners.get(type) || [];
+    handlers.push(handler);
+    this.listeners.set(type, handlers);
+  }
+
+  removeEventListener(type, handler) {
+    this.listeners.set(
+      type,
+      (this.listeners.get(type) || []).filter((candidate) => candidate !== handler),
+    );
+  }
+
+  dispatch(type, detail) {
+    for (const handler of [...(this.listeners.get(type) || [])]) {
+      handler({ detail });
+    }
+  }
+}
+
+function runtimePayload({
+  requestedSeed,
+  storedAfterGenerate,
+  executionSeed,
+  nextSeed,
+  overrides = {},
+}) {
+  return {
+    easyuse_anima_aio_seed: [{
+      ...contractPayload({
+        requestedSeed,
+        storedAfterGenerate,
+        executionSeed,
+        nextSeed,
+      }),
+      ...overrides,
+    }],
+  };
+}
+
+function createRuntimeFixture({
+  requestedSeed = 7,
+  storedAfterGenerate = "increment",
+} = {}) {
+  const api = new FakeApi();
+  const owner = queueModule.createQueueUiTransactionOwner();
+  let runtime = null;
+  const context = contextModule.createExecutedEventContext(api, {
+    finishPrompt: (promptId) => runtime.finishPrompt(promptId),
+  });
+  const selection = { requestedSeed, storedAfterGenerate };
+  const node = {
+    widgets: [
+      { name: "seed", callback() {} },
+      { name: "generation_settings", callback() {} },
+    ],
+  };
+  const lastPublications = [];
+  const editablePublications = [];
+  runtime = seedModule.createAioSeedTransaction({
+    owner,
+    executedContext: context,
+    maximum: AIO_EDITABLE_MAXIMUM,
+    findWidget(candidate, name) {
+      return candidate.widgets.find((widget) => widget.name === name);
+    },
+    readSelection() {
+      return selection;
+    },
+    publishLastSeed(_candidate, seed) {
+      lastPublications.push(seed);
+      return true;
+    },
+    publishConcreteNextSeed(candidate, seed) {
+      editablePublications.push(seed);
+      selection.requestedSeed = seed;
+      candidate.widgets[0].callback(seed);
+      candidate.widgets[1].callback();
+      return true;
+    },
+  });
+  context.install();
+
+  function capture(promptId, { accept = true } = {}) {
+    const captured = runtime.captureQueue([node]);
+    assert.equal(captured.length, 1);
+    if (accept) {
+      assert.equal(runtime.acceptQueue(captured, {
+        ok: true,
+        result: { prompt_id: promptId },
+      }), 1);
+    }
+    return captured;
+  }
+
+  async function execute(promptId, output, { dispatch = true } = {}) {
+    if (dispatch) {
+      api.dispatch("executed", {
+        prompt_id: promptId,
+        node: "41",
+        output,
+      });
+    }
+    return runtime.consumeExecution(node, output);
+  }
+
+  function edit({ seed = selection.requestedSeed, control = selection.storedAfterGenerate }) {
+    selection.requestedSeed = seed;
+    selection.storedAfterGenerate = control;
+    node.widgets[1].callback();
+  }
+
+  return {
+    api,
+    capture,
+    context,
+    edit,
+    editablePublications,
+    execute,
+    lastPublications,
     node,
-    {
-      easyuse_anima_aio_seed: [{
-        execution_seed: "41",
-        next_seed: "42",
-      }],
-    },
-    {
-      maximum: 100,
-      updateSeed(candidate, seed, options) {
-        updates.push([candidate, seed, options]);
-        candidate.seed = seed;
-      },
-    },
-  ), true);
-  assert.equal(node.__easyuseAnimaLastExecutedSeed, 41);
-  assert.equal(node.seed, 42, "current production replaces the -1 selection intent");
-  assert.deepEqual(updates, [[node, 42, { markDirty: false }]]);
+    owner,
+    runtime,
+    selection,
+  };
 }
 
 {
-  const node = {};
-  const updates = [];
-  assert.equal(seedModule.aioApplyExecutedSeedDisplay(
-    node,
-    {
-      easyuse_anima_aio_seed: [{
-        execution_seed: "18446744073709551615",
-        next_seed: "100",
-      }],
-    },
-    {
-      maximum: 100,
-      updateSeed(_candidate, seed) {
-        updates.push(seed);
-      },
-    },
-  ), true);
-  assert.equal(node.__easyuseAnimaLastExecutedSeed, undefined);
-  assert.deepEqual(updates, [100]);
+  const fixture = createRuntimeFixture({
+    requestedSeed: -1,
+    storedAfterGenerate: "increment",
+  });
+  fixture.capture("special");
+  const output = runtimePayload({
+    requestedSeed: -1,
+    storedAfterGenerate: "increment",
+    executionSeed: 41,
+    nextSeed: 41,
+  });
+  assert.equal(await fixture.execute("special", output), true);
+  assert.deepEqual(fixture.lastPublications, [41]);
+  assert.deepEqual(fixture.editablePublications, []);
+  assert.deepEqual(fixture.selection, {
+    requestedSeed: -1,
+    storedAfterGenerate: "increment",
+  });
 }
 
 {
-  const node = {};
-  assert.equal(seedModule.aioApplyExecutedSeedDisplay(
-    node,
-    {
-      easyuse_anima_aio_seed: [{
-        execution_seed: "7",
-        next_seed: "8",
-      }],
-    },
-    {
-      maximum: 100,
-      updateSeed() {
-        throw new Error("disposed panel");
-      },
-    },
-  ), true);
-  assert.equal(
-    node.__easyuseAnimaLastExecutedSeed,
-    7,
-    "backend acceptance remains visible after next-seed publication fails",
+  const fixture = createRuntimeFixture();
+  fixture.capture("concrete");
+  const output = runtimePayload({
+    requestedSeed: 7,
+    storedAfterGenerate: "increment",
+    executionSeed: 7,
+    nextSeed: 8,
+  });
+  assert.equal(await fixture.execute("concrete", output), true);
+  assert.deepEqual(fixture.lastPublications, [7]);
+  assert.deepEqual(fixture.editablePublications, [8]);
+  assert.deepEqual(fixture.selection, {
+    requestedSeed: 8,
+    storedAfterGenerate: "increment",
+  });
+}
+
+{
+  const fixture = createRuntimeFixture();
+  fixture.capture("unrelated-settings-edit");
+  fixture.node.widgets[1].callback();
+  const output = runtimePayload({
+    requestedSeed: 7,
+    storedAfterGenerate: "increment",
+    executionSeed: 7,
+    nextSeed: 8,
+  });
+  assert.equal(await fixture.execute("unrelated-settings-edit", output), true);
+  assert.deepEqual(fixture.lastPublications, [7]);
+  assert.deepEqual(
+    fixture.editablePublications,
+    [8],
+    "only the atomic seed/control pair owns the editable revision",
   );
 }
 
-for (const message of [
-  null,
-  {},
-  { easyuse_anima_aio_seed: [] },
+{
+  const fixture = createRuntimeFixture();
+  fixture.capture("stale");
+  fixture.edit({ seed: 23, control: "fixed" });
+  const output = runtimePayload({
+    requestedSeed: 7,
+    storedAfterGenerate: "increment",
+    executionSeed: 7,
+    nextSeed: 8,
+  });
+  assert.equal(await fixture.execute("stale", output), true);
+  assert.deepEqual(fixture.lastPublications, [7]);
+  assert.deepEqual(fixture.editablePublications, []);
+  assert.deepEqual(fixture.selection, {
+    requestedSeed: 23,
+    storedAfterGenerate: "fixed",
+  });
+}
+
+{
+  const fixture = createRuntimeFixture();
+  fixture.capture("older");
+  fixture.capture("newer");
+  const newer = runtimePayload({
+    requestedSeed: 7,
+    storedAfterGenerate: "increment",
+    executionSeed: 20,
+    nextSeed: 21,
+  });
+  const older = runtimePayload({
+    requestedSeed: 7,
+    storedAfterGenerate: "increment",
+    executionSeed: 10,
+    nextSeed: 11,
+  });
+  assert.equal(await fixture.execute("newer", newer), true);
+  assert.equal(await fixture.execute("older", older), false);
+  assert.deepEqual(fixture.lastPublications, [20]);
+  assert.deepEqual(fixture.editablePublications, [21]);
+}
+
+{
+  const fixture = createRuntimeFixture();
+  const captured = fixture.capture("adapter-first", { accept: false });
+  const output = runtimePayload({
+    requestedSeed: 7,
+    storedAfterGenerate: "increment",
+    executionSeed: 7,
+    nextSeed: 8,
+  });
+  const pending = fixture.execute("adapter-first", output, { dispatch: false });
+  fixture.api.dispatch("executed", {
+    prompt_id: "adapter-first",
+    node: "41",
+    output,
+  });
+  assert.equal(await pending, false);
+  assert.deepEqual(fixture.lastPublications, []);
+  assert.equal(fixture.runtime.acceptQueue(captured, {
+    ok: true,
+    result: { prompt_id: "adapter-first" },
+  }), 1);
+  assert.deepEqual(fixture.lastPublications, [7]);
+  assert.deepEqual(fixture.editablePublications, [8]);
+}
+
+for (const output of [
+  runtimePayload({
+    requestedSeed: 7,
+    storedAfterGenerate: "increment",
+    executionSeed: 101,
+    nextSeed: 8,
+  }),
+  runtimePayload({
+    requestedSeed: 7,
+    storedAfterGenerate: "increment",
+    executionSeed: 7,
+    nextSeed: 8,
+    overrides: { next_display_seed: "8" },
+  }),
   {
-    easyuse_anima_aio_seed: [{
-      execution_seed: "-1",
-      next_seed: "not-a-seed",
-    }],
+    easyuse_anima_aio_seed: [
+      contractPayload({
+        requestedSeed: 7,
+        storedAfterGenerate: "increment",
+        executionSeed: 7,
+        nextSeed: 8,
+      }),
+      contractPayload({
+        requestedSeed: 7,
+        storedAfterGenerate: "increment",
+        executionSeed: 7,
+        nextSeed: 8,
+      }),
+    ],
   },
 ]) {
-  assert.equal(seedModule.aioApplyExecutedSeedDisplay(
-    {},
-    message,
-    {
-      maximum: 100,
-      updateSeed() {
-        throw new Error("must not update");
-      },
-    },
+  const fixture = createRuntimeFixture();
+  fixture.capture("invalid");
+  assert.equal(await fixture.execute("invalid", output), false);
+  assert.deepEqual(fixture.lastPublications, []);
+  assert.deepEqual(fixture.editablePublications, []);
+}
+
+{
+  const fixture = createRuntimeFixture();
+  fixture.capture("clone");
+  const output = runtimePayload({
+    requestedSeed: 7,
+    storedAfterGenerate: "increment",
+    executionSeed: 7,
+    nextSeed: 8,
+  });
+  fixture.api.dispatch("executed", {
+    prompt_id: "clone",
+    node: "41",
+    output,
+  });
+  assert.equal(await fixture.runtime.consumeExecution(
+    fixture.node,
+    structuredClone(output),
   ), false);
+  assert.deepEqual(fixture.lastPublications, []);
+  assert.deepEqual(fixture.editablePublications, []);
+  fixture.runtime.disposeNode(fixture.node, "dispose");
+}
+
+{
+  const fixture = createRuntimeFixture();
+  fixture.capture("duplicate");
+  const output = runtimePayload({
+    requestedSeed: 7,
+    storedAfterGenerate: "increment",
+    executionSeed: 7,
+    nextSeed: 8,
+  });
+  assert.equal(await fixture.execute("duplicate", output), true);
+  assert.equal(await fixture.execute("duplicate", output), false);
+  assert.deepEqual(fixture.lastPublications, [7]);
+  assert.deepEqual(fixture.editablePublications, [8]);
+}
+
+{
+  const fixture = createRuntimeFixture();
+  fixture.capture("disposed");
+  assert.equal(fixture.runtime.disposeNode(fixture.node, "remove"), true);
+  const output = runtimePayload({
+    requestedSeed: 7,
+    storedAfterGenerate: "increment",
+    executionSeed: 7,
+    nextSeed: 8,
+  });
+  assert.equal(await fixture.execute("disposed", output), false);
+  assert.deepEqual(fixture.lastPublications, []);
+  assert.deepEqual(fixture.editablePublications, []);
 }
 
 for (const [requestedSeed, selection] of SPECIAL_SELECTION_BY_TOKEN) {

--- a/tests/frontend_aio_extension_runtime_smoke.mjs
+++ b/tests/frontend_aio_extension_runtime_smoke.mjs
@@ -87,6 +87,14 @@ function createFixture(options = {}) {
       handleDenoisePreviewEvent: callbacks.handleDenoisePreviewEvent,
       handleExecutingEvent: callbacks.handleExecutingEvent,
       clearDenoisePreviews: callbacks.clearDenoisePreviews,
+      installSeedRuntime() {
+        trace.push("installSeedRuntime");
+        return true;
+      },
+      disposeSeedRuntime() {
+        trace.push("disposeSeedRuntime");
+        return false;
+      },
       loadSamplerOptions() {
         trace.push("loadSamplerOptions");
         if (samplerSetupFailures > 0) {
@@ -125,6 +133,9 @@ function createFixture(options = {}) {
       hookGeneratorNode() {
         trace.push("hookGeneratorNode");
       },
+      hookSeedNode() {
+        trace.push("hookSeedNode");
+      },
       syncSerializedWidgets(_node, serialized) {
         trace.push(`syncSerializedWidgets:${serialized.marker}`);
       },
@@ -146,6 +157,9 @@ function createFixture(options = {}) {
         if (options.panelError) {
           throw options.panelError;
         }
+      },
+      disposeSeedNode(_node, reason) {
+        trace.push(`disposeSeedNode:${reason}`);
       },
       disposeNativePreviewLifecycle() {
         trace.push("disposeNativePreviewLifecycle");
@@ -226,7 +240,7 @@ function createNodeType(trace, options = {}) {
   );
   await Promise.resolve();
 
-  assert.deepEqual(fixture.trace.slice(0, 13), [
+  assert.deepEqual(fixture.trace.slice(0, 14), [
     "ensureStyle",
     "installWheelForwarder",
     "watchLocale",
@@ -238,6 +252,7 @@ function createNodeType(trace, options = {}) {
     "event:execution_error:false",
     "event:execution_interrupted:false",
     "event:execution_success:false",
+    "installSeedRuntime",
     "loadSamplerOptions",
     "loadUserProfiles",
   ]);
@@ -642,6 +657,7 @@ function createNodeType(trace, options = {}) {
     "suppressDefaultPreview:markDirty=false",
     "original:onNodeCreated:retry",
     "hookGeneratorNode",
+    "hookSeedNode",
   ]);
 }
 
@@ -712,14 +728,17 @@ function createNodeType(trace, options = {}) {
     "suppressDefaultPreview:markDirty=false",
     "original:onNodeCreated:new",
     "hookGeneratorNode",
+    "hookSeedNode",
   ]);
 
   fixture.trace.length = 0;
   assert.equal(node.onConfigure("saved"), returns.configured);
   assert.deepEqual(fixture.trace, [
     "suppressDefaultPreview:markDirty=false",
+    "disposeSeedNode:reconfigure",
     "original:onConfigure:saved",
     "hookGeneratorNode",
+    "hookSeedNode",
   ]);
 
   fixture.trace.length = 0;
@@ -748,6 +767,7 @@ function createNodeType(trace, options = {}) {
   assert.equal(node.onRemoved("delete"), returns.removed);
   assert.deepEqual(fixture.trace, [
     "original:onRemoved:delete",
+    "disposeSeedNode:remove",
     "disposePanel",
     "disposeNativePreviewLifecycle",
   ]);
@@ -769,6 +789,7 @@ for (const hookCase of [
     args: ["saved"],
     expectedTrace: [
       "suppressDefaultPreview:markDirty=false",
+      "disposeSeedNode:reconfigure",
       "original:onConfigure:saved",
     ],
   },
@@ -825,6 +846,7 @@ for (const hookCase of [
   assert.equal(caught, removedError, "the original removal error identity must be preserved");
   assert.deepEqual(fixture.trace, [
     "original:onRemoved:delete",
+    "disposeSeedNode:remove",
     "disposePanel",
     "disposeNativePreviewLifecycle",
   ]);
@@ -845,6 +867,7 @@ for (const hookCase of [
   assert.equal(caught, panelError, "the panel disposal error identity must be preserved");
   assert.deepEqual(fixture.trace, [
     "original:onRemoved:delete",
+    "disposeSeedNode:remove",
     "disposePanel",
     "disposeNativePreviewLifecycle",
   ]);
@@ -871,6 +894,7 @@ for (const hookCase of [
   );
   assert.deepEqual(fixture.trace, [
     "original:onRemoved:delete",
+    "disposeSeedNode:remove",
     "disposePanel",
     "disposeNativePreviewLifecycle",
   ]);

--- a/tests/frontend_aio_generator_panel_runtime_smoke.mjs
+++ b/tests/frontend_aio_generator_panel_runtime_smoke.mjs
@@ -121,11 +121,13 @@ assert.deepEqual(
     "findWidget",
     "GENERATOR_SETTINGS_WIDGET",
     "generatorSettings",
+    "normalizeSeedControl",
     `"use strict";\n${entrySource.slice(functionStart, functionEnd)}\nreturn commitGeneratorSeedValue;`,
   )(
     (node, name) => node.widgets.find((widget) => widget.name === name),
     "generation_settings",
     (node) => clone(node.settings),
+    (value) => String(value || "fixed"),
   );
   const seedCallbackError = new Error("seed callback failed");
   const settingsCallbackError = new Error("settings callback failed");
@@ -156,6 +158,19 @@ assert.deepEqual(
   assert.equal(seedWidget.value, 11);
   assert.equal(atomicNode.__easyuseAnimaGeneratorUiValues.seed, 11);
   assert.equal(JSON.parse(settingsWidget.value).sampler.seed, 11);
+  assert.equal(
+    atomicNode.settings.sampler.seed_after_generate,
+    "increment",
+    "ordinary seed updates must preserve the stored workflow control",
+  );
+  callbackTrace.length = 0;
+  assert.doesNotThrow(() => commitGeneratorSeedValue(atomicNode, 12, "fixed"));
+  assert.deepEqual(callbackTrace, ["seed", "settings"]);
+  assert.equal(seedWidget.value, 12);
+  assert.deepEqual(JSON.parse(settingsWidget.value).sampler, {
+    seed: 12,
+    seed_after_generate: "fixed",
+  });
 }
 
 function createFixture() {
@@ -391,7 +406,7 @@ function createFixture() {
       trace.push("set-widget:" + name + ":" + value);
       node.widgetValues[name] = value;
     },
-    commitSeedValue(node, seed) {
+    commitSeedValue(node, seed, afterGenerate = null) {
       dependencyCalls += 1;
       trace.push("commit-seed:" + seed);
       if (node.failSeedCommit) {
@@ -399,6 +414,9 @@ function createFixture() {
       }
       node.widgetValues.seed = seed;
       node.settings.sampler.seed = seed;
+      if (afterGenerate != null) {
+        node.settings.sampler.seed_after_generate = afterGenerate;
+      }
     },
     markDirty(node) {
       dependencyCalls += 1;
@@ -1287,6 +1305,7 @@ assert.equal(
 assert.equal(node.__easyuseAnimaLastExecutedSeed, 777);
 assert.equal(node.widgetValues.seed, 776);
 assert.equal(node.settings.sampler.seed, 776);
+assert.equal(node.settings.sampler.seed_after_generate, "fixed");
 assert.equal(panel.querySelector("[data-aio-seed-input]").value, 776);
 assert.equal(
   fixture.trace.includes("dirty"),
@@ -1320,14 +1339,21 @@ fixture.trace.length = 0;
 findByText(panel, "text:button.newFixed").emit("click");
 assert.equal(node.widgetValues.seed, 123456);
 assert.equal(node.settings.sampler.seed, 123456);
+assert.equal(node.settings.sampler.seed_after_generate, "fixed");
 assert.equal(fixture.trace.includes("random-seed"), true);
 assert.ok(fixture.trace.indexOf("random-seed") < fixture.trace.indexOf("commit-seed:123456"));
 assert.ok(fixture.trace.indexOf("commit-seed:123456") < fixture.trace.indexOf("get-settings"));
 assert.ok(fixture.trace.indexOf("get-settings") < fixture.trace.lastIndexOf("dirty"));
 fixture.trace.length = 0;
+node.settings.sampler.seed_after_generate = "decrement";
 findByText(panel, "text:button.randomEach").emit("click");
 assert.equal(node.widgetValues.seed, -1);
 assert.equal(node.settings.sampler.seed, -1);
+assert.equal(
+  node.settings.sampler.seed_after_generate,
+  "decrement",
+  "Random Each must preserve the serialized workflow control",
+);
 assert.ok(fixture.trace.indexOf("commit-seed:-1") < fixture.trace.indexOf("get-settings"));
 const seedInput = panel.querySelector("[data-aio-seed-input]");
 seedInput.value = "314";
@@ -1342,6 +1368,7 @@ seedLast = panel.querySelector("[data-aio-seed-last]");
 seedLast.emit("click");
 assert.equal(node.widgetValues.seed, 777);
 assert.equal(node.settings.sampler.seed, 777);
+assert.equal(node.settings.sampler.seed_after_generate, "fixed");
 assert.equal(seedLast.disabled, true);
 
 const highresBlock = settingsScroll.children[1];

--- a/tests/test_aio_frontend.py
+++ b/tests/test_aio_frontend.py
@@ -614,7 +614,11 @@ class AIOFrontendSourceTests(unittest.TestCase):
                 )
 
         self.assertIn(
-            "export function aioApplyExecutedSeedDisplay(",
+            "export function createAioSeedTransaction(",
+            executed_seed_source,
+        )
+        self.assertIn(
+            'const AIO_SEED_SELECTION_SURFACE = "aio.seed_selection";',
             executed_seed_source,
         )
         for retired_queue_owner in (
@@ -631,10 +635,12 @@ class AIOFrontendSourceTests(unittest.TestCase):
         )
         setup_body = extension_source[setup_start:setup_end]
         self.assertIn("installWheelForwarder();", setup_body)
+        self.assertIn("installSeedRuntime();", setup_body)
         self.assertNotIn("installGlobalHooks();", setup_body)
         self.assertIn(
             "installWheelForwarder: installGeneratorWheelForwarder,", source
         )
+        self.assertIn("installSeedRuntime: installAioSeedRuntime,", source)
 
         for unchanged_adapter in (
             "specialSeedRandom: GENERATOR_SPECIAL_SEED_RANDOM,",

--- a/tests/test_frontend_modules.py
+++ b/tests/test_frontend_modules.py
@@ -792,7 +792,7 @@ class FrontendModuleStructureTests(unittest.TestCase):
             frontend_check_source,
         )
 
-    def test_aio_executed_seed_runtime_replaces_browser_queue_authority(self):
+    def test_aio_executed_seed_runtime_uses_shared_correlation_owners(self):
         source = AIO_EXECUTED_SEED_RUNTIME_JS.read_text(encoding="utf-8")
         entry_source = AIO_JS.read_text(encoding="utf-8")
         frontend_check_source = FRONTEND_CHECK_SCRIPT.read_text(encoding="utf-8")
@@ -800,29 +800,46 @@ class FrontendModuleStructureTests(unittest.TestCase):
         self.assertEqual(source.splitlines()[0], "// @ts-check")
         self.assertEqual(
             re.findall(r"export function ([A-Za-z0-9_]+)\(", source),
-            ["aioApplyExecutedSeedDisplay"],
+            ["createAioSeedTransaction"],
         )
         self.assertEqual(STATIC_IMPORT_RE.findall(source), [])
         self.assertNotRegex(source, r"\b(?:document|window|app)\b")
         self.assertNotIn("fetch(", source)
         self.assertNotIn("app.registerExtension", source)
         self.assertIn(
-            'import { aioApplyExecutedSeedDisplay } from '
+            'import { createAioSeedTransaction } from '
             '"./aio/executed_seed_runtime.js";',
             entry_source,
         )
         self.assertIn(
-            "aioApplyExecutedSeedDisplay(node, message, {",
+            "aioSeedTransaction = createAioSeedTransaction({",
             entry_source,
         )
         self.assertIn(
-            "node.__easyuseAnimaLastExecutedSeed = executionSeed;",
-            source,
+            "void aioSeedTransaction.consumeExecution(node, message);",
+            entry_source,
         )
         self.assertIn(
-            "dependencies.updateSeed(node, nextSeed, { markDirty: false });",
+            'const AIO_SEED_SELECTION_SURFACE = "aio.seed_selection";',
             source,
         )
+        for shared_contract_call in (
+            "owner.captureProvisional({",
+            "owner.acceptPrompt(entry.transaction, promptId)",
+            "owner.markEdited(node, [AIO_SEED_SELECTION_SURFACE])",
+            "owner.canCommit(transaction, {",
+            "owner.settle(transaction, pending.envelope)",
+            "executedContext.consumeWithinTurn(output)",
+        ):
+            with self.subTest(shared_contract_call=shared_contract_call):
+                self.assertIn(shared_contract_call, source)
+        for shared_import in (
+            '"./lifecycle/queue_ui_transaction.js";',
+            '"./lifecycle/executed_event_context.js";',
+            '"./lifecycle/host_hook_registry.js";',
+        ):
+            with self.subTest(shared_import=shared_import):
+                self.assertIn(shared_import, entry_source)
         for retired_symbol in (
             "generatorQueueRuntime",
             "aioCreateGeneratorQueueRuntime",

--- a/web/js/aio/executed_seed_runtime.js
+++ b/web/js/aio/executed_seed_runtime.js
@@ -1,12 +1,50 @@
 // @ts-check
 
+const AIO_SEED_SELECTION_SURFACE = "aio.seed_selection";
+const AIO_SEED_WIDGET_NAMES = Object.freeze(["seed", "generation_settings"]);
+const AIO_SEED_CONTROLS = new Set([
+  "fixed",
+  "randomize",
+  "increment",
+  "decrement",
+]);
+const SPECIAL_SELECTION_BY_TOKEN = new Map([
+  [-1, "randomize"],
+  [-2, "increment"],
+  [-3, "decrement"],
+]);
+const AIO_PAYLOAD_FIELDS = Object.freeze([
+  "requested_seed",
+  "selection",
+  "effective_after_generate",
+  "execution_seed",
+  "next_seed",
+]);
+const AIO_SEED_CALLBACK_OWNER = Symbol.for(
+  "easyuse-anima.aio.seed-transaction-callback-owner",
+);
+const MAX_TRACKED_TRANSACTIONS_PER_NODE = 8;
+
+/** @param {unknown} value */
+function isReference(value) {
+  return value !== null && (
+    typeof value === "object"
+    || typeof value === "function"
+  );
+}
+
+/** @param {unknown} value @returns {value is Record<string, unknown>} */
+function isRecord(value) {
+  return value !== null && typeof value === "object";
+}
+
+/** @param {unknown} value @param {number} maximum */
 function editableSeed(value, maximum) {
-  const text = String(value ?? "").trim();
-  if (!/^\d+$/.test(text)) {
+  if (typeof value !== "string" || !/^(?:0|[1-9]\d*)$/.test(value)) {
     return null;
   }
   try {
-    const parsed = BigInt(text);
+    const parsed = BigInt(value);
     if (parsed > BigInt(maximum)) {
       return null;
     }
@@ -16,41 +54,473 @@ function editableSeed(value, maximum) {
   }
 }
 
-/**
- * Publish backend-accepted AiO seed state without owning queue preparation.
- *
- * The backend sends decimal strings so uint64 compatibility values are not
- * silently rounded by JSON. Values outside the editable browser domain stay
- * authoritative in the backend result/metadata and are not written into the
- * smaller number widget.
- *
- * @param {any} node
- * @param {any} message
- * @param {{maximum: number, updateSeed: (node: any, seed: number, options: {markDirty: boolean}) => any}} dependencies
- */
-export function aioApplyExecutedSeedDisplay(node, message, dependencies) {
-  const payload = Array.isArray(message?.easyuse_anima_aio_seed)
-    ? message.easyuse_anima_aio_seed[0]
+/** @param {unknown} value @param {number} maximum */
+function requestedSeed(value, maximum) {
+  if (typeof value !== "string") {
+    return null;
+  }
+  if (/^-[123]$/.test(value)) {
+    return Number(value);
+  }
+  return editableSeed(value, maximum);
+}
+
+/** @param {unknown} value @param {number} maximum */
+function normalizeSelectionSnapshot(value, maximum) {
+  if (!isRecord(value)) {
+    return null;
+  }
+  const seed = Number(value?.requestedSeed);
+  const storedAfterGenerate = String(value?.storedAfterGenerate || "");
+  if (
+    !Number.isSafeInteger(seed)
+    || seed < -3
+    || seed > maximum
+    || !AIO_SEED_CONTROLS.has(storedAfterGenerate)
+  ) {
+    return null;
+  }
+  return { requestedSeed: seed, storedAfterGenerate };
+}
+
+/** @param {any} left @param {any} right */
+function sameSelection(left, right) {
+  return Boolean(
+    left
+    && right
+    && left.requestedSeed === right.requestedSeed
+    && left.storedAfterGenerate === right.storedAfterGenerate,
+  );
+}
+
+/** @param {unknown} message @param {number} maximum */
+function parsePayload(message, maximum) {
+  const items = isRecord(message) && Array.isArray(message.easyuse_anima_aio_seed)
+    ? message.easyuse_anima_aio_seed
     : null;
-  if (!node || !payload || typeof payload !== "object") {
+  if (items?.length !== 1) {
+    return null;
+  }
+  const payload = items[0];
+  if (
+    !payload
+    || typeof payload !== "object"
+    || Object.keys(payload).length !== AIO_PAYLOAD_FIELDS.length
+    || !AIO_PAYLOAD_FIELDS.every((field) => Object.hasOwn(payload, field))
+  ) {
+    return null;
+  }
+  const normalizedRequestedSeed = requestedSeed(payload.requested_seed, maximum);
+  const executionSeed = editableSeed(payload.execution_seed, maximum);
+  const nextSeed = editableSeed(payload.next_seed, maximum);
+  if (
+    normalizedRequestedSeed == null
+    || executionSeed == null
+    || nextSeed == null
+  ) {
+    return null;
+  }
+  const selection = SPECIAL_SELECTION_BY_TOKEN.get(normalizedRequestedSeed)
+    || "concrete";
+  const effectiveAfterGenerate = String(payload.effective_after_generate || "");
+  if (
+    payload.selection !== selection
+    || !AIO_SEED_CONTROLS.has(effectiveAfterGenerate)
+    || (
+      selection !== "concrete"
+      && (
+        effectiveAfterGenerate !== "fixed"
+        || nextSeed !== executionSeed
+      )
+    )
+  ) {
+    return null;
+  }
+  return {
+    requestedSeed: normalizedRequestedSeed,
+    selection,
+    effectiveAfterGenerate,
+    executionSeed,
+    nextSeed,
+  };
+}
+
+/**
+ * Bind AiO seed publication to the shared queue transaction and exact executed
+ * envelope owners. The shared owners receive only an opaque surface token;
+ * this feature adapter owns every seed field and editable mutation.
+ *
+ * @param {{
+ *   owner: ReturnType<import("../lifecycle/queue_ui_transaction.js").createQueueUiTransactionOwner>,
+ *   executedContext: ReturnType<import("../lifecycle/executed_event_context.js").createExecutedEventContext>,
+ *   maximum: number,
+ *   findWidget: (node: any, name: string) => any,
+ *   readSelection: (node: any) => unknown,
+ *   publishLastSeed: (node: any, seed: number) => unknown,
+ *   publishConcreteNextSeed: (node: any, seed: number) => unknown,
+ * }} options
+ */
+export function createAioSeedTransaction(options) {
+  const {
+    owner,
+    executedContext,
+    maximum,
+    findWidget,
+    readSelection,
+    publishLastSeed,
+    publishConcreteNextSeed,
+  } = options || {};
+  if (
+    !owner
+    || !executedContext
+    || !Number.isSafeInteger(maximum)
+    || maximum < 0
+    || typeof findWidget !== "function"
+    || typeof readSelection !== "function"
+    || typeof publishLastSeed !== "function"
+    || typeof publishConcreteNextSeed !== "function"
+  ) {
+    throw new TypeError("AiO seed transaction dependencies are required.");
+  }
+
+  let disposed = false;
+  const transactionsByNode = new WeakMap();
+  const snapshotsByTransaction = new WeakMap();
+  const pendingExecutions = new WeakMap();
+  const observedSelections = new WeakMap();
+  const lastSequenceByNode = new WeakMap();
+  const suppressedNodes = new WeakSet();
+  const activeNodes = new Set();
+
+  /** @param {any} node */
+  function currentSelection(node) {
+    return normalizeSelectionSnapshot(readSelection(node), maximum);
+  }
+
+  /** @param {any} node */
+  function observeSelection(node) {
+    const previousKnown = observedSelections.has(node);
+    const previous = observedSelections.get(node) || null;
+    const current = currentSelection(node);
+    if (current) {
+      observedSelections.set(node, current);
+    } else {
+      observedSelections.delete(node);
+    }
+    if (
+      previousKnown
+      && !suppressedNodes.has(node)
+      && !sameSelection(previous, current)
+    ) {
+      return owner.markEdited(node, [AIO_SEED_SELECTION_SURFACE]);
+    }
     return false;
   }
 
-  const executionSeed = editableSeed(payload.execution_seed, dependencies.maximum);
-  const nextSeed = editableSeed(payload.next_seed, dependencies.maximum);
-  let applied = false;
-  if (executionSeed != null) {
-    node.__easyuseAnimaLastExecutedSeed = executionSeed;
-    applied = true;
-  }
-  if (nextSeed != null) {
+  /** @param {any} node @param {() => unknown} callback */
+  function withoutRevision(node, callback) {
+    suppressedNodes.add(node);
     try {
-      dependencies.updateSeed(node, nextSeed, { markDirty: false });
-      applied = true;
-    } catch {
-      // Backend acceptance remains authoritative when a stale panel cannot
-      // publish the accepted next-run value.
+      return callback();
+    } finally {
+      observeSelection(node);
+      suppressedNodes.delete(node);
     }
   }
-  return applied;
+
+  /** @param {any} node */
+  function activeTransactions(node) {
+    const current = transactionsByNode.get(node) || [];
+    const active = current.filter(
+      (transaction) => transaction?.state === "provisional"
+        || transaction?.state === "accepted",
+    );
+    if (active.length === 0) {
+      transactionsByNode.delete(node);
+      activeNodes.delete(node);
+    } else if (active.length !== current.length) {
+      transactionsByNode.set(node, active);
+    }
+    return active;
+  }
+
+  /** @param {any} node @param {any} transaction */
+  function remember(node, transaction) {
+    const active = activeTransactions(node);
+    while (active.length >= MAX_TRACKED_TRANSACTIONS_PER_NODE) {
+      const expired = active.shift();
+      pendingExecutions.delete(expired);
+      snapshotsByTransaction.delete(expired);
+      owner.cancel(expired, "cancel");
+    }
+    active.push(transaction);
+    transactionsByNode.set(node, active);
+    activeNodes.add(node);
+  }
+
+  /** @param {any} node @param {any} transaction */
+  function forget(node, transaction) {
+    pendingExecutions.delete(transaction);
+    snapshotsByTransaction.delete(transaction);
+    const active = activeTransactions(node).filter(
+      (candidate) => candidate !== transaction,
+    );
+    if (active.length === 0) {
+      transactionsByNode.delete(node);
+      activeNodes.delete(node);
+    } else {
+      transactionsByNode.set(node, active);
+    }
+  }
+
+  /** @param {any} node */
+  function hookNode(node) {
+    if (disposed || !isReference(node)) {
+      return false;
+    }
+    observeSelection(node);
+    let changed = false;
+    for (const name of AIO_SEED_WIDGET_NAMES) {
+      const widget = findWidget(node, name);
+      if (!widget || typeof widget !== "object") {
+        continue;
+      }
+      const current = widget.callback;
+      const callbackState = current?.[AIO_SEED_CALLBACK_OWNER];
+      if (callbackState?.runtime === runtime) {
+        continue;
+      }
+      const original = callbackState?.original ?? current;
+      const wrapped = function (...args) {
+        try {
+          return typeof original === "function"
+            ? original.apply(this, args)
+            : undefined;
+        } finally {
+          if (!disposed) {
+            observeSelection(node);
+          }
+        }
+      };
+      Object.defineProperty(wrapped, AIO_SEED_CALLBACK_OWNER, {
+        value: { runtime, original },
+      });
+      widget.callback = wrapped;
+      changed = true;
+    }
+    return changed;
+  }
+
+  /** @param {any[]} nodes */
+  function captureQueue(nodes) {
+    if (disposed || !Array.isArray(nodes)) {
+      return [];
+    }
+    const captured = [];
+    for (const node of nodes) {
+      if (!isReference(node)) {
+        continue;
+      }
+      hookNode(node);
+      const snapshot = currentSelection(node);
+      if (!snapshot) {
+        continue;
+      }
+      const transaction = owner.captureProvisional({
+        node,
+        surfaces: [AIO_SEED_SELECTION_SURFACE],
+      });
+      if (transaction) {
+        snapshotsByTransaction.set(transaction, snapshot);
+        remember(node, transaction);
+        captured.push({ node, transaction });
+      }
+    }
+    return captured;
+  }
+
+  /**
+   * @param {{ node: any, transaction: any }[]} captured
+   * @param {{ ok?: boolean, result?: any }} outcome
+   */
+  function acceptQueue(captured, outcome = {}) {
+    if (!Array.isArray(captured)) {
+      return 0;
+    }
+    const promptId = outcome.ok === true ? outcome.result?.prompt_id : null;
+    let accepted = 0;
+    for (const entry of captured) {
+      if (!disposed && owner.acceptPrompt(entry.transaction, promptId)) {
+        accepted += 1;
+        const pending = pendingExecutions.get(entry.transaction);
+        if (pending) {
+          pendingExecutions.delete(entry.transaction);
+          finishExecution(entry.node, entry.transaction, pending);
+        }
+      } else {
+        owner.cancel(entry.transaction, "reject");
+        forget(entry.node, entry.transaction);
+      }
+    }
+    return accepted;
+  }
+
+  /** @param {any} node @param {any} transaction @param {any} pending */
+  function finishExecution(node, transaction, pending) {
+    if (transaction.promptId !== pending.envelope.promptId) {
+      owner.cancel(transaction, "reject");
+      forget(node, transaction);
+      return false;
+    }
+    const snapshot = snapshotsByTransaction.get(transaction) || null;
+    const payload = pending.mappedItemCount === 1
+      ? parsePayload(pending.envelope.output, maximum)
+      : null;
+    const matchesSnapshot = Boolean(
+      snapshot
+      && payload
+      && payload.requestedSeed === snapshot.requestedSeed
+      && payload.selection === (
+        SPECIAL_SELECTION_BY_TOKEN.get(snapshot.requestedSeed) || "concrete"
+      )
+      && (
+        payload.selection !== "concrete"
+        || payload.effectiveAfterGenerate === snapshot.storedAfterGenerate
+      ),
+    );
+    let lastPublished = false;
+    let editablePublished = false;
+    if (matchesSnapshot) {
+      const lastSequence = lastSequenceByNode.get(node) || 0;
+      if (transaction.localSequence > lastSequence) {
+        try {
+          lastPublished = publishLastSeed(node, payload.executionSeed) !== false;
+          if (lastPublished) {
+            lastSequenceByNode.set(node, transaction.localSequence);
+          }
+        } catch {
+          lastPublished = false;
+        }
+      }
+      if (
+        payload.selection === "concrete"
+        && owner.canCommit(transaction, {
+          envelope: pending.envelope,
+          node,
+          surface: AIO_SEED_SELECTION_SURFACE,
+          mappedItemCount: pending.mappedItemCount,
+        })
+      ) {
+        try {
+          editablePublished = withoutRevision(
+            node,
+            () => publishConcreteNextSeed(node, payload.nextSeed),
+          ) !== false;
+        } catch {
+          editablePublished = false;
+        }
+      }
+    }
+    owner.settle(transaction, pending.envelope);
+    forget(node, transaction);
+    return lastPublished || editablePublished;
+  }
+
+  /** @param {any} node @param {unknown} output */
+  async function consumeExecution(node, output) {
+    if (disposed || !isReference(node)) {
+      return false;
+    }
+    const envelope = await executedContext.consumeWithinTurn(output);
+    if (!envelope || disposed || !isReference(node)) {
+      return false;
+    }
+    const active = activeTransactions(node);
+    const matches = active.filter(
+      (transaction) => transaction.state === "accepted"
+        && transaction.promptId === envelope.promptId,
+    );
+    const mappedItemCount = isRecord(output) && Array.isArray(output.easyuse_anima_aio_seed)
+      ? output.easyuse_anima_aio_seed.length
+      : 0;
+    if (matches.length === 1) {
+      return finishExecution(node, matches[0], {
+        envelope,
+        mappedItemCount,
+      });
+    }
+    const provisional = active.filter(
+      (transaction) => transaction.state === "provisional",
+    );
+    if (matches.length !== 0 || provisional.length !== 1) {
+      return false;
+    }
+    pendingExecutions.set(provisional[0], {
+      envelope,
+      mappedItemCount,
+    });
+    return false;
+  }
+
+  /** @param {unknown} promptId */
+  function finishPrompt(promptId) {
+    const finished = owner.finishPrompt(promptId);
+    for (const node of [...activeNodes]) {
+      activeTransactions(node);
+    }
+    return finished;
+  }
+
+  /** @param {any} node @param {"remove" | "reconfigure" | "dispose"} [reason] */
+  function disposeNode(node, reason = "dispose") {
+    for (const transaction of activeTransactions(node)) {
+      pendingExecutions.delete(transaction);
+      snapshotsByTransaction.delete(transaction);
+    }
+    const changed = owner.disposeNode(node, reason);
+    transactionsByNode.delete(node);
+    observedSelections.delete(node);
+    lastSequenceByNode.delete(node);
+    activeNodes.delete(node);
+    return changed;
+  }
+
+  function clear() {
+    let cancelled = 0;
+    for (const node of [...activeNodes]) {
+      for (const transaction of activeTransactions(node)) {
+        pendingExecutions.delete(transaction);
+        snapshotsByTransaction.delete(transaction);
+        if (owner.cancel(transaction, "clear")) {
+          cancelled += 1;
+        }
+      }
+      transactionsByNode.delete(node);
+      activeNodes.delete(node);
+    }
+    return cancelled;
+  }
+
+  function dispose() {
+    if (disposed) {
+      return false;
+    }
+    clear();
+    disposed = true;
+    return true;
+  }
+
+  const runtime = Object.freeze({
+    acceptQueue,
+    captureQueue,
+    clear,
+    consumeExecution,
+    dispose,
+    disposeNode,
+    finishPrompt,
+    hookNode,
+  });
+  return runtime;
 }
+
+export { AIO_SEED_SELECTION_SURFACE };

--- a/web/js/aio/extension_runtime.js
+++ b/web/js/aio/extension_runtime.js
@@ -98,6 +98,8 @@ export function aioCreateExtensionRuntime(dependencies) {
       loadSamplerOptions,
       loadUserProfiles,
       warnUserProfiles,
+      installSeedRuntime,
+      disposeSeedRuntime,
     },
     nodes: {
       suppressDefaultPreview,
@@ -109,6 +111,8 @@ export function aioCreateExtensionRuntime(dependencies) {
       scheduleLayout,
       disposePanel,
       disposeNativePreviewLifecycle,
+      hookSeedNode,
+      disposeSeedNode,
     },
   } = dependencies;
 
@@ -117,11 +121,12 @@ export function aioCreateExtensionRuntime(dependencies) {
       hookInputNode(node);
     } else if (nodeData.name === GENERATOR_NODE_TYPE) {
       hookGeneratorNode(node);
+      hookSeedNode(node);
     }
   }
 
   return {
-    dispose: () => false,
+    dispose: () => disposeSeedRuntime(),
     async setup() {
       const setupState = extensionSetupState(api);
       if (!setupState || setupState.inProgress) {
@@ -162,6 +167,9 @@ export function aioCreateExtensionRuntime(dependencies) {
         });
         runExtensionSetupStep(setupState, "execution-success-listener", () => {
           api.addEventListener("execution_success", clearDenoisePreviews);
+        });
+        runExtensionSetupStep(setupState, "seed-runtime", () => {
+          installSeedRuntime();
         });
         runExtensionSetupStep(setupState, "sampler-options-load", () => {
           loadSamplerOptions().then(refreshPanels);
@@ -217,6 +225,7 @@ export function aioCreateExtensionRuntime(dependencies) {
         nodeType.prototype.onConfigure = function () {
           if (nodeData.name === GENERATOR_NODE_TYPE) {
             suppressDefaultPreview(this, { markDirty: false });
+            disposeSeedNode(this, "reconfigure");
           }
           const result = onConfigure?.apply(this, arguments);
           hookNode(this, nodeData);
@@ -247,9 +256,13 @@ export function aioCreateExtensionRuntime(dependencies) {
               return onRemoved?.apply(this, arguments);
             } finally {
               try {
-                disposePanel(this);
+                disposeSeedNode(this, "remove");
               } finally {
-                disposeNativePreviewLifecycle(this);
+                try {
+                  disposePanel(this);
+                } finally {
+                  disposeNativePreviewLifecycle(this);
+                }
               }
             }
           };

--- a/web/js/aio/generator_panel_runtime.js
+++ b/web/js/aio/generator_panel_runtime.js
@@ -69,7 +69,7 @@ function closeGeneratorInfoTooltipOwner(document) {
  * @property {(node: any, name: string, fallback: any) => any} widgetValue
  * @property {(node: any, name: string, fallback: any[]) => any[]} widgetOptions
  * @property {(node: any, name: string, value: any) => void} setWidgetValueIfChanged
- * @property {(node: any, seed: number) => void} commitSeedValue
+ * @property {(node: any, seed: number, afterGenerate?: string | null) => void} commitSeedValue
  * @property {(node: any) => void} markDirty
  * @property {() => void} ensureStyle
  * @property {(node: any, options?: Record<string, any>) => void} suppressDefaultPreview
@@ -1080,7 +1080,7 @@ export function aioCreateGeneratorPanelRuntime(dependencies) {
 
   function updateGeneratorSeed(node, value, options = {}) {
     const seed = normalizeSeedValue(value, GENERATOR_SPECIAL_SEED_RANDOM);
-    commitSeedValue(node, seed);
+    commitSeedValue(node, seed, options.afterGenerate ?? null);
     const panel = node?.__easyuseAnimaGeneratorPanelEl;
     const seedInput = panel?.querySelector?.("[data-aio-seed-input]");
     if (seedInput) {
@@ -1506,7 +1506,7 @@ export function aioCreateGeneratorPanelRuntime(dependencies) {
     );
     const seedNewFixed = makeButton(
       aioText("button.newFixed"),
-      () => setGeneratorSeedFromUi(node, randomSeed()),
+      () => updateGeneratorSeed(node, randomSeed(), { afterGenerate: "fixed" }),
       "",
       "tip.newFixed",
     );
@@ -1516,7 +1516,11 @@ export function aioCreateGeneratorPanelRuntime(dependencies) {
         if (node.__easyuseAnimaLastExecutedSeed == null) {
           return;
         }
-        setGeneratorSeedFromUi(node, node.__easyuseAnimaLastExecutedSeed);
+        updateGeneratorSeed(
+          node,
+          node.__easyuseAnimaLastExecutedSeed,
+          { afterGenerate: "fixed" },
+        );
       },
       "",
       "tip.useLast",

--- a/web/js/easyuse_anima_aio.js
+++ b/web/js/easyuse_anima_aio.js
@@ -21,7 +21,7 @@ import { createAioProfileApiClient } from "./aio/profile_api_client.js";
 import { aioCreateProfileDialogs } from "./aio/profile_dialogs.js";
 import { aioCreateProfileSettingsRuntime } from "./aio/profile_settings_runtime.js";
 import { aioCreateGeneratorPanelRuntime } from "./aio/generator_panel_runtime.js";
-import { aioApplyExecutedSeedDisplay } from "./aio/executed_seed_runtime.js";
+import { createAioSeedTransaction } from "./aio/executed_seed_runtime.js";
 import { aioCreateStageSettingsDialogs } from "./aio/stage_settings_dialogs.js";
 import { aioCreateDetailerSettingsDialog } from "./aio/detailer_settings_dialog.js";
 import { aioCreateSamplerSettingsDialog } from "./aio/sampler_settings_dialog.js";
@@ -33,6 +33,16 @@ import {
   aioCreateExtensionRuntime,
   aioListAttachedGeneratorNodes,
 } from "./aio/extension_runtime.js";
+import {
+  createExecutedEventContext,
+} from "./lifecycle/executed_event_context.js";
+import {
+  createHostHookRuntimeLifecycle,
+  registerHostHookCallbacks,
+} from "./lifecycle/host_hook_registry.js";
+import {
+  createQueueUiTransactionOwner,
+} from "./lifecycle/queue_ui_transaction.js";
 import {
   AIO_BACKEND_DEPENDENCIES,
   AIO_OPTIONAL_DEPENDENCY_SPECS,
@@ -105,6 +115,9 @@ const INPUT_SETTINGS_WIDGET = "input_settings";
 const GENERATOR_SETTINGS_WIDGET = "generation_settings";
 const GENERATOR_PROFILE_CUSTOM_VALUE = "custom";
 const GENERATOR_PREVIEW_EVENT = "easyuse-anima-aio-preview";
+const AIO_SEED_TRANSACTION_OWNER = Symbol.for(
+  "easyuse-anima.aio.seed-transaction",
+);
 const GENERATOR_PANEL_MIN_HEIGHT = 430;
 const GENERATOR_SPECIAL_SEEDS = [
   GENERATOR_SPECIAL_SEED_RANDOM,
@@ -3435,11 +3448,14 @@ function setWidgetValueIfChanged(node, name, value) {
   setWidgetValue(node, name, value);
 }
 
-function commitGeneratorSeedValue(node, seed) {
+function commitGeneratorSeedValue(node, seed, afterGenerate = null) {
   const seedWidget = findWidget(node, "seed");
   const settingsWidget = findWidget(node, GENERATOR_SETTINGS_WIDGET);
   const settings = generatorSettings(node);
   settings.sampler.seed = seed;
+  if (afterGenerate != null) {
+    settings.sampler.seed_after_generate = normalizeSeedControl(afterGenerate);
+  }
   const serializedSettings = JSON.stringify(settings);
 
   if (seedWidget) {
@@ -4176,12 +4192,7 @@ function updateGeneratorExecutedStatus(node, message) {
   if (!node) {
     return;
   }
-  aioApplyExecutedSeedDisplay(node, message, {
-    maximum: GENERATOR_MAX_SEED,
-    updateSeed: (candidate, seed, options) => (
-      generatorPanelRuntime.updateSeed(candidate, seed, options)
-    ),
-  });
+  void aioSeedTransaction.consumeExecution(node, message);
   const nextImages = aioPreviewImages(message);
   const runId = aioPreviewRunId(message);
   addGeneratorPreviewImagesToNode(node, nextImages, runId, { replaceCurrentRun: true });
@@ -4193,6 +4204,75 @@ function updateGeneratorExecutedStatus(node, message) {
     sampler_backend: String(firstValue(message?.sampler_backend, "")),
   };
   updateGeneratorDomSummary(node);
+}
+
+const aioSeedQueueOwner = createQueueUiTransactionOwner();
+let aioSeedTransaction;
+const aioExecutedEventContext = createExecutedEventContext(api, {
+  finishPrompt: (promptId) => aioSeedTransaction.finishPrompt(promptId),
+});
+aioSeedTransaction = createAioSeedTransaction({
+  owner: aioSeedQueueOwner,
+  executedContext: aioExecutedEventContext,
+  maximum: GENERATOR_MAX_SEED,
+  findWidget,
+  readSelection: (node) => {
+    const settings = generatorSettings(node);
+    return {
+      requestedSeed: settings.sampler.seed,
+      storedAfterGenerate: settings.sampler.seed_after_generate,
+    };
+  },
+  publishLastSeed: (node, seed) => {
+    node.__easyuseAnimaLastExecutedSeed = seed;
+    refreshGeneratorSeedButtons(node);
+    return true;
+  },
+  publishConcreteNextSeed: (node, seed) => (
+    generatorPanelRuntime.updateSeed(node, seed, { markDirty: false })
+  ),
+});
+const aioSeedHookLifecycle = createHostHookRuntimeLifecycle(
+  app,
+  AIO_SEED_TRANSACTION_OWNER,
+);
+let aioSeedTransactionGraphHost;
+
+function installAioSeedRuntime() {
+  aioExecutedEventContext.install();
+  const graphHost = app?.graph || null;
+  const replace = aioSeedTransactionGraphHost !== undefined
+    && graphHost != null
+    && graphHost !== aioSeedTransactionGraphHost;
+  const installed = aioSeedHookLifecycle.install(
+    "aio-seed-transaction",
+    () => registerHostHookCallbacks({
+      owner: AIO_SEED_TRANSACTION_OWNER,
+      queueHost: api,
+      graphHost,
+      beforeQueue: () => aioSeedTransaction.captureQueue(
+        aioListAttachedGeneratorNodes(app.graph, isGeneratorGraphNode),
+      ),
+      afterQueue: (context) => aioSeedTransaction.acceptQueue(
+        context.callbackState,
+        context,
+      ),
+      onGraphClear: () => aioSeedTransaction.clear(),
+    }),
+    { replace },
+  );
+  if (installed) {
+    aioSeedTransactionGraphHost = graphHost;
+  }
+  return installed;
+}
+
+function disposeAioSeedRuntime() {
+  aioSeedTransactionGraphHost = undefined;
+  let changed = aioSeedHookLifecycle.dispose();
+  changed = aioExecutedEventContext.dispose() || changed;
+  changed = aioSeedTransaction.dispose() || changed;
+  return changed;
 }
 
 const aioExtensionRuntime = aioCreateExtensionRuntime({
@@ -4215,6 +4295,8 @@ const aioExtensionRuntime = aioCreateExtensionRuntime({
     clearDenoisePreviews: clearGeneratorDenoisePreviews,
     loadSamplerOptions: loadGeneratorSamplerOptions,
     loadUserProfiles: loadGeneratorUserProfiles,
+    installSeedRuntime: installAioSeedRuntime,
+    disposeSeedRuntime: disposeAioSeedRuntime,
     warnUserProfiles(error) {
       console.warn("[EasyUseAnima] Failed to load AiO user profiles.", error);
     },
@@ -4229,6 +4311,8 @@ const aioExtensionRuntime = aioCreateExtensionRuntime({
     scheduleLayout: scheduleGeneratorLayout,
     disposePanel: disposeGeneratorPanel,
     disposeNativePreviewLifecycle: disposeGeneratorNativePreviewLifecycle,
+    hookSeedNode: aioSeedTransaction.hookNode,
+    disposeSeedNode: aioSeedTransaction.disposeNode,
   },
 });
 


### PR DESCRIPTION
## 목적과 변경 경계

Task: AIO-SEED-UI-03 / #414
Class: UI
Base -> Head: `cdb8ef8418e1e63cbce246f09be74cb9acf2cf2b` -> `c9ba520866888fbbd33027c42b7cc21c8f203602`

- `queue_ui_transaction`과 `executed_event_context`를 재사용해 AiO seed result를 exact prompt/output identity에 연결합니다.
- 변경 경계는 AiO entry/runtime/panel/extension과 직접 Contract fixture입니다.
- public socket/workflow schema, backend, shared lifecycle owner, Wildcard 의미는 변경하지 않습니다.

## 보존 계약

- `aio.seed_selection`이 seed와 stored control의 atomic editable revision을 소유합니다.
- special result는 editable seed를 자동 변경하지 않습니다.
- successfully correlated result만 last seed를 갱신하며, 가장 높은 local queue sequence만 허용합니다.
- concrete result만 현재 revision에서 next seed를 publish합니다.
- malformed/mapped-multiple/duplicate/stale/disposed result는 fail-closed입니다.
- Use Last/New Fixed Random만 concrete + fixed를 원자적으로 적용합니다.

## 검증

- Focused: changed-file `node --check`, AiO executed/extension/panel smoke, shared queue/context smoke, 관련 unittest, TypeScript static, `git diff --check` — PASS
- Live Node 2.0: Random Each 3회 token 유지와 concrete history 갱신, Use Last/New Fixed Random, intervening edit stale-result 차단, workflow save/reload — PASS
- Live Legacy Canvas: 동일 changed flow — PASS
- Full: `check_custom_node.ps1 -Profile full`, exact SHA `c9ba520866888fbbd33027c42b7cc21c8f203602` — PASS (1157 unittest, 118 frontend JavaScript files, TypeScript 6.0.3)
- Package: not triggered

## 위험·롤백·다음

- 남은 위험: host queue/executed lifecycle 변화는 shared owner의 fail-closed 정책에 의존합니다.
- Rollback: 이 commit을 revert합니다.
- Next: review 후 `dev` merge. main/tag/release/Registry publish는 이 PR 범위가 아닙니다.
