### PR TITLE
fix: reset concrete seed after special selection

### DIFF
--- a/easyuse_anima/seed/service.py
+++ b/easyuse_anima/seed/service.py
@@ -467,7 +467,11 @@ class InMemorySeedReservationService:
             reservation = record.reservation
             state.committed_execution_seed = reservation.execution_seed
             state.committed_seed = reservation.next_seed
-            state.observed_seed = record.observed_seed_after
+            state.observed_seed = (
+                record.observed_seed_after
+                if record.request.selection == SEED_SELECTION_CONCRETE
+                else None
+            )
             identity = (reservation.stream_id, reservation.request_id)
             self._request_records.pop(identity, None)
             self._accepted_records[identity] = _AcceptedRecord(

--- a/tests/fixtures/python_backend_baseline.json
+++ b/tests/fixtures/python_backend_baseline.json
@@ -60661,9 +60661,9 @@
       },
       {
         "is_package": false,
-        "loc": 497,
+        "loc": 501,
         "module": "easyuse_anima.seed.service",
-        "normalized_git_blob_sha1": "489d63544dc9acf1ee0a65306188f41a9f06f672",
+        "normalized_git_blob_sha1": "b8ef428d579f3f65984d505a7937f33153c94161",
         "path": "easyuse_anima/seed/service.py",
         "top_level": {
           "class_count": 7,

--- a/tests/test_seed_adapters.py
+++ b/tests/test_seed_adapters.py
@@ -277,6 +277,49 @@ class SeedAdapterTests(unittest.TestCase):
 
         self.assertEqual(observed, [(4, 4), (5, 5)])
 
+    def test_aio_concrete_selection_resets_after_completed_special_selection(self):
+        ids = iter(
+            (
+                "reservation:concrete",
+                "reservation:special",
+                "reservation:reset",
+            )
+        )
+        service = InMemorySeedReservationService(
+            reservation_id_factory=lambda: next(ids),
+        )
+        identities = [
+            SeedExecutionIdentity("stream:aio", "request:concrete"),
+            SeedExecutionIdentity("stream:aio", "request:special"),
+            SeedExecutionIdentity("stream:aio", "request:reset"),
+        ]
+        with (
+            patch(
+                "easyuse_anima.nodes.seed_adapters.resolve_seed_execution_identity",
+                side_effect=identities,
+            ),
+            patch(
+                "easyuse_anima.nodes.seed_adapters.get_runtime",
+                return_value=SimpleNamespace(seed_reservations=service),
+            ),
+        ):
+            observed = []
+            for normalized_seed, after_generate in (
+                (7, "increment"),
+                (-2, "fixed"),
+                (7, "increment"),
+            ):
+                with aio_seed_execution(
+                    unique_id="8",
+                    normalized_seed=normalized_seed,
+                    after_generate=after_generate,
+                ) as execution:
+                    observed.append(
+                        (execution.execution_seed, execution.next_seed)
+                    )
+
+        self.assertEqual(observed, [(7, 8), (8, 8), (7, 8)])
+
     def test_aio_special_selection_and_stored_control_golden_matrix(self):
         expected_execution_seeds = {
             -1: [10, 10, 30],

--- a/tests/test_seed_reservation_service.py
+++ b/tests/test_seed_reservation_service.py
@@ -185,6 +185,44 @@ class SeedReservationServiceTests(unittest.TestCase):
             (20, 21),
         )
 
+    def test_accepted_special_selection_drops_stale_concrete_observation(self):
+        service = InMemorySeedReservationService(
+            reservation_id_factory=sequential_ids(),
+        )
+        concrete = service.reserve(
+            make_request(
+                "q1",
+                seed=7,
+                after_generate=SEED_SELECTION_INCREMENT,
+            )
+        )
+        service.settle(concrete.reservation_id, SEED_SETTLEMENT_ACCEPTED)
+        special = service.reserve(
+            make_request(
+                "q2",
+                selection=SEED_SELECTION_INCREMENT,
+            )
+        )
+        service.settle(special.reservation_id, SEED_SETTLEMENT_ACCEPTED)
+
+        reset = service.reserve(
+            make_request(
+                "q3",
+                seed=7,
+                after_generate=SEED_SELECTION_INCREMENT,
+            )
+        )
+
+        self.assertEqual(
+            (concrete.execution_seed, concrete.next_seed),
+            (7, 8),
+        )
+        self.assertEqual(
+            (special.execution_seed, special.next_seed),
+            (8, 8),
+        )
+        self.assertEqual((reset.execution_seed, reset.next_seed), (7, 8))
+
     def test_random_selection_and_after_generate_use_explicit_domain(self):
         draws = DrawSequence(3, 7)
         service = InMemorySeedReservationService(


### PR DESCRIPTION
## 목적과 변경 경계

Fixes #432. HOTFIX-RC package-installed Node 2.0 검증에서 발견한 AiO seed selection 전환 회귀를 수정한다.

accepted special selection 뒤에는 이전 concrete `observed_seed`가 더 이상 현재 UI 관찰값이 아니므로 폐기한다. reservation의 `committed_execution_seed`/`committed_seed`는 유지해 `-2/-3` 실행 stream 연속성은 보존한다.

## Base -> Head

`cbf3f96f1aac194e066235677b2126742f313987` -> `fc0a947bd8d3279f8e0c7c5a1cb41ab3b3b3bdc8`

## 변경 파일

- `easyuse_anima/seed/service.py`
- service/AiO adapter regression tests
- analyzer 파생 baseline

Frontend, public socket, workflow schema, payload 의미는 변경하지 않았다. concrete FIFO, pending-edit defer, Prompt Studio concrete 경로도 유지한다.

## 관찰된 회귀와 assertion

- concrete 7 + increment accepted
- 같은 stream에서 special increment accepted
- idle 상태에서 concrete 7 재입력
- 수정 전: execution/next = 8/9
- 수정 후: execution/next = 7/8
- AiO adapter 실제 normalization/runtime reservation 경로에서도 같은 전환을 고정

## 검증

- changed Python `py_compile`: PASS
- `tests.test_seed_reservation_service`: 26 PASS
- `tests.test_seed_adapters`: 10 PASS
- analyzer fixture focused: PASS
- `git diff --check`: PASS
- official full at `fc0a947bd8d3279f8e0c7c5a1cb41ab3b3b3bdc8`: PASS
  - Python unittest 1159
  - frontend 118 JavaScript files
  - TypeScript 6.0.3
- Package: not triggered for this Fix PR
- Live: not triggered for this Fix PR

## 위험과 rollback

shared seed reservation service의 accepted-selection 상태 전환 한 곳만 변경한다. rollback은 이 squash commit 단위다.

## Next

review 후 dev squash merge하고, 새 dev SHA에서 HOTFIX-RC package/live matrix의 영향을 받은 seed transition 행을 다시 검증한다.