### PR TITLE
docs: lock AiO model patch scope policy

### DIFF
--- a/docs/architecture/aio-advanced-integrations-roadmap.md
+++ b/docs/architecture/aio-advanced-integrations-roadmap.md
@@ -242,6 +242,13 @@ DAVE first-pass-only
 - Safe PAG, FP16 accumulation, SageAttention, Torch Compile 각각의 stage 적용 가능성을 결정한다.
 - run-global torch setting과 stage-local MODEL wrapper를 구분한다.
 - 지원 근거가 없는 patch에 generic scope UI를 자동 추가하지 않는다.
+- 결정:
+  - DAVE만 현재 네 sampling stage scope를 지원한다.
+  - Safe PAG는 stage-local 후보지만 temporary shared-module mutation 검증을 #440으로 분리한다.
+  - SageAttention은 clone-local 후보지만 experimental/`allow_compile` 검증을 #441로 분리한다.
+  - FP16 accumulation과 Torch Compile은 현재 upstream의 process-global/shared-registry 계약 때문에
+    독립 stage scope를 지원하지 않는다.
+  - #440/#441은 현재 `#409 -> #410 -> #411` queue를 선행하지 않는다.
 
 ## 6. #410 실행 manifest
 

--- a/docs/architecture/aio-settings-contract.md
+++ b/docs/architecture/aio-settings-contract.md
@@ -50,8 +50,22 @@ execution은 기존 코드다.
 DAVE의 `stage_scope` stage id는 `first_pass`, `highres`, `detailer`, `upscale`로 고정한다. fresh v2 default는
 first pass만 true다. `upscale`은 sampling MODEL을 사용하는 USDU 계약이며 ResShift, postprocess, save는 이
 scope에 포함하지 않는다. patch-order revision 1은 KJ Torch Compile과 DAVE가 함께 선택된 stage에서
-`kj.torch_compile → dave` precedence edge만 승인한다. Safe PAG와 다른 KJ patch의 stage 지원/전체 순서는
-AIO-SCOPE-04 전까지 확장하지 않는다.
+`kj.torch_compile → dave` precedence edge만 승인한다.
+
+AIO-SCOPE-04 audit는 Anima Safe PAG `905b0107`과 KJNodes `e27a505b`의 public source,
+그리고 current ComfyUI `ModelPatcher.clone()`의 `model_options` deep-copy 계약을 기준으로 했다.
+generic scope UI는 승인하지 않고 patch별 owner를 다음처럼 고정했다.
+
+| patch | stage-scope 결정 | 근거와 후속 |
+| --- | --- | --- |
+| DAVE | 지원 | 네 sampling stage를 현재 schema/runtime/UI가 소유한다. |
+| Safe PAG | 후속 검증 필요 | MODEL clone과 sampler callback을 사용하지만 shared attention module을 일시적으로 바꾸므로 precedence/cleanup/live 증명을 [#440](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/440)에서 분리한다. |
+| KJ FP16 accumulation | stage scope 미지원 | pre-run/cleanup callback이 process-global torch flag를 바꾸므로 run-global 설정으로 유지한다. |
+| KJ SageAttention | 후속 검증 필요 | clone-local `model_options` override이지만 upstream experimental 계약과 `allow_compile`을 [#441](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/441)에서 검증한다. |
+| KJ Torch Compile | stage scope 미지원 | compiled module registry가 shared BaseModel을 key로 쓰고 Dynamo config도 process-global이므로 현재는 run-global 설정으로 유지한다. #410은 진단/추천만 소유하며 generic scope를 추가하지 않는다. |
+
+Safe PAG와 KJ 설정에 저장된 unknown `stage_scope`는 보존할 수 있지만 현재 patch selection을 부분 변경하지
+않는다. 지원되지 않은 field 때문에 기존 all-stage 실행 의미가 조용히 달라지지 않는 것이 rollback 계약이다.
 
 ## Python typed config 경계
 

--- a/easyuse_anima/aio/schemas/generation_settings.v2.json
+++ b/easyuse_anima/aio/schemas/generation_settings.v2.json
@@ -264,7 +264,32 @@
       "patch_order_revision": 1,
       "precedence_edges": [["kj.torch_compile", "dave"]],
       "dave_fresh_default": "first-pass-only",
-      "execution_cutover": "deferred-to-AIO-SCOPE-02/03"
+      "execution_cutover": "complete-through-AIO-SCOPE-03",
+      "stage_scope_policy": {
+        "generic_scope_ui": false,
+        "owners": {
+          "dave": {
+            "decision": "supported",
+            "stages": ["first_pass", "highres", "detailer", "upscale"]
+          },
+          "safe_pag": {
+            "decision": "follow-up-required",
+            "reason": "clone-local-wrapper-with-temporary-shared-module-mutation"
+          },
+          "kj.fp16_accumulation": {
+            "decision": "run-global-not-stage-scoped",
+            "reason": "process-global-torch-setting-callback"
+          },
+          "kj.sage_attention": {
+            "decision": "follow-up-required",
+            "reason": "experimental-clone-local-override"
+          },
+          "kj.torch_compile": {
+            "decision": "run-global-not-stage-scoped",
+            "reason": "shared-base-model-compile-registry-and-dynamo-config"
+          }
+        }
+      }
     },
     "persistence": {
       "write_on_read": false,

--- a/tests/frontend_aio_settings_core_smoke.mjs
+++ b/tests/frontend_aio_settings_core_smoke.mjs
@@ -708,9 +708,34 @@ assertJsonEqual(
     patch_order_revision: 1,
     precedence_edges: [["kj.torch_compile", "dave"]],
     dave_fresh_default: "first-pass-only",
-    execution_cutover: "deferred-to-AIO-SCOPE-02/03",
+    execution_cutover: "complete-through-AIO-SCOPE-03",
+    stage_scope_policy: {
+      generic_scope_ui: false,
+      owners: {
+        dave: {
+          decision: "supported",
+          stages: ["first_pass", "highres", "detailer", "upscale"],
+        },
+        safe_pag: {
+          decision: "follow-up-required",
+          reason: "clone-local-wrapper-with-temporary-shared-module-mutation",
+        },
+        "kj.fp16_accumulation": {
+          decision: "run-global-not-stage-scoped",
+          reason: "process-global-torch-setting-callback",
+        },
+        "kj.sage_attention": {
+          decision: "follow-up-required",
+          reason: "experimental-clone-local-override",
+        },
+        "kj.torch_compile": {
+          decision: "run-global-not-stage-scoped",
+          reason: "shared-base-model-compile-registry-and-dynamo-config",
+        },
+      },
+    },
   },
-  "The v2 manifest must freeze stage ids, precedence revision, and deferred cutover",
+  "The v2 manifest must freeze stage ids, precedence revision, cutover, and scope owners",
 );
 
 console.log("AiO settings core smoke passed.");

--- a/tests/test_aio_model_preparation.py
+++ b/tests/test_aio_model_preparation.py
@@ -194,6 +194,63 @@ class AIOModelPreparationMoveTests(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "Unknown AiO sampling stage"):
             model_preparation._aio_stage_model_patch_plan(first_only, "save")
 
+    def test_unapproved_scope_fields_do_not_partially_select_safe_pag_or_kj(self):
+        settings = {
+            "model_patches": {
+                "dave": {"enabled": False},
+                "safe_pag": {
+                    "enabled": True,
+                    "stage_scope": {
+                        "first_pass": True,
+                        "highres": False,
+                        "detailer": False,
+                        "upscale": False,
+                    },
+                },
+                "kj": {
+                    "fp16_accumulation": True,
+                    "sage_attention": "auto",
+                    "stage_scope": {
+                        "first_pass": True,
+                        "highres": False,
+                        "detailer": False,
+                        "upscale": False,
+                    },
+                    "torch_compile": {
+                        "enabled": True,
+                        "stage_scope": {
+                            "first_pass": True,
+                            "highres": False,
+                            "detailer": False,
+                            "upscale": False,
+                        },
+                    },
+                },
+            }
+        }
+        expected_patch_ids = (
+            "aura_flow",
+            "safe_pag",
+            "kj.fp16_accumulation",
+            "kj.sage_attention",
+            "kj.torch_compile",
+        )
+
+        plans = {
+            stage_id: model_preparation._aio_stage_model_patch_plan(settings, stage_id)
+            for stage_id in ("first_pass", "highres", "detailer", "upscale")
+        }
+
+        self.assertEqual(
+            {stage_id: plan.patch_ids for stage_id, plan in plans.items()},
+            {stage_id: expected_patch_ids for stage_id in plans},
+        )
+        self.assertEqual(
+            len({plan.signature for plan in plans.values()}),
+            1,
+            "Unsupported scope fields must not create partial stage variants",
+        )
+
     def test_stage_plan_moves_only_compile_before_dave_in_the_patch_chain(self):
         trace: list[tuple[str, object]] = []
 

--- a/tests/test_aio_schema_contract.py
+++ b/tests/test_aio_schema_contract.py
@@ -1032,7 +1032,44 @@ class AIOGenerationSettingsManifestTests(unittest.TestCase):
         self.assertEqual(patch_contract["dave_fresh_default"], "first-pass-only")
         self.assertEqual(
             patch_contract["execution_cutover"],
-            "deferred-to-AIO-SCOPE-02/03",
+            "complete-through-AIO-SCOPE-03",
+        )
+        self.assertEqual(
+            patch_contract["stage_scope_policy"],
+            {
+                "generic_scope_ui": False,
+                "owners": {
+                    "dave": {
+                        "decision": "supported",
+                        "stages": [
+                            "first_pass",
+                            "highres",
+                            "detailer",
+                            "upscale",
+                        ],
+                    },
+                    "safe_pag": {
+                        "decision": "follow-up-required",
+                        "reason": (
+                            "clone-local-wrapper-with-temporary-shared-module-mutation"
+                        ),
+                    },
+                    "kj.fp16_accumulation": {
+                        "decision": "run-global-not-stage-scoped",
+                        "reason": "process-global-torch-setting-callback",
+                    },
+                    "kj.sage_attention": {
+                        "decision": "follow-up-required",
+                        "reason": "experimental-clone-local-override",
+                    },
+                    "kj.torch_compile": {
+                        "decision": "run-global-not-stage-scoped",
+                        "reason": (
+                            "shared-base-model-compile-registry-and-dynamo-config"
+                        ),
+                    },
+                },
+            },
         )
         self.assertFalse(capabilities["owned_by_manifest"])
         self.assertEqual(


### PR DESCRIPTION
## 목적과 변경 경계

- Task: AIO-SCOPE-04 / #409
- Class: CONTRACT
- Base -> Head: `9c576f52f49ef5da9201b36104fc26648fd72a27` -> `de437b5ce07f97b2d758b3fc47c5b7ea9d8bb279`
- 변경 경계: v2 schema의 model patch scope 정책, architecture 문서, 직접 contract/negative fixture만 변경
- Production Python/JavaScript 동작 변경 없음

## 계약 결정

| Integration | 결정 | 경계 |
| --- | --- | --- |
| DAVE | 현재 stage scope 지원 | sampling stage 4개 |
| Safe PAG | 후보, 현재 UI 미노출 | lifecycle 검증은 #440 |
| SageAttention | 후보, 현재 UI 미노출 | clone/compile 격리는 #441 |
| FP16 accumulation | run-global | 독립 stage scope 금지 |
| Torch Compile | run-wide/shared runtime | generic stage scope 금지 |

알 수 없거나 지원되지 않는 Safe PAG/KJ `stage_scope` 값은 일부 stage만 변경하지 않고 기존 all-stage 의미를 유지하도록 characterization fixture로 고정했습니다. 공용 scope UI나 범용 patch dispatcher는 추가하지 않았습니다.

후속 조사 #440, #441은 기록했으며 현재 roadmap 순서 `#409 -> #410 -> #411`을 앞당기지 않습니다.

## 검증

- Focused: `python -m unittest tests.test_aio_schema_contract` — schema/manifest policy, 18 tests PASS
- Focused: `python -m unittest tests.test_aio_model_preparation` — patch scope characterization, 12 tests PASS
- Focused: `node --check tests/frontend_aio_settings_core_smoke.mjs` — syntax PASS
- Focused: `node tests/frontend_aio_settings_core_smoke.mjs` — exact frontend manifest contract PASS
- Diff: `git diff --check` — PASS
- Full: repository official full runner at exact SHA `de437b5ce07f97b2d758b3fc47c5b7ea9d8bb279` — PASS (Python 1,172 tests, frontend 118 JS files, TypeScript 6.0.3, import boundary 0 violations, reviewed Pyright baseline unchanged)
- Package: `comfy node validate` PASS; `comfy node pack` PASS; archive 269 entries, changed schema included, tests/docs/git metadata excluded
- Live: not triggered (contract/schema policy-only PR)

## 위험과 rollback

- 위험: Safe PAG/SageAttention의 stage-scoped production cutover는 아직 승인하지 않으며 후속 issue의 runtime 증거가 필요합니다.
- Rollback: 이 단일 SCOPE-04 contract commit을 되돌리면 됩니다.

## Next

검토 및 squash merge 후 #409를 evidence와 함께 닫고, 최신 `dev`에서 #410 AIO-COMPILE-01을 시작합니다.
