### PR TITLE
feat: add Torch Compile environment diagnostics

### DIFF
--- a/api.py
+++ b/api.py
@@ -61,6 +61,9 @@ from .api_contract import (
     json_uuid_string,
     parse_json_object,
 )
+from .easyuse_anima.aio.torch_compile_diagnostics import (
+    collect_torch_compile_diagnostics as _collect_torch_compile_diagnostics,
+)
 from .easyuse_anima.profiles import aio as _aio_profiles
 from .easyuse_anima.profiles import contract as _profile_contract
 from .easyuse_anima.profiles import lora as _lora_profiles
@@ -605,6 +608,14 @@ if web is not None:
         return web.json_response({"status": "ok", "text": translated})
 
     @_request_correlated
+    async def aio_torch_compile_recommend_handler(request):
+        try:
+            await parse_json_object(request)
+        except ApiContractError as exc:
+            return _contract_error_response(exc)
+        return web.json_response(_collect_torch_compile_diagnostics())
+
+    @_request_correlated
     async def lora_preview_handler(request):
         preview_path = await _run_file_io(
             _resolve_lora_preview_path,
@@ -831,6 +842,11 @@ if web is not None:
         ("get", "/easyuse_anima/autocomplete", autocomplete_handler),
         ("post", "/easyuse_anima/classify_prompt", classify_prompt_handler),
         ("post", "/easyuse_anima/translate_prompt", translate_prompt_handler),
+        (
+            "post",
+            "/easyuse_anima/aio/torch-compile/recommend",
+            aio_torch_compile_recommend_handler,
+        ),
         ("get", "/easyuse_anima/lora_preview", lora_preview_handler),
         ("get", "/easyuse_anima/loras", loras_handler),
         ("get", "/easyuse_anima/lora_profiles", lora_profiles_handler),

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -17,16 +17,12 @@ section, owning Issue, direct owner files, and direct tests.
   focused edit loop, final-full-once rule, package/live/benchmark triggers,
   evidence reuse, and current task-specific test maps. It reduces repeated work;
   it does not weaken an Issue or release gate.
-- Issue [#415](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/415)
-  is the current implementation and release owner for the queue/live-UI
-  regressions in [#413](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/413)
-  and [#414](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/414).
-  QSTATE-01 is merged. QSTATE-02A proved that backend `list_index` does not exist
-  at frontend submission-capture time. While #415 remains open, read
-  [`queue-ui-two-phase-correlation-addendum.md`](queue-ui-two-phase-correlation-addendum.md)
-  **before** the original
-  [`queue-ui-execution-state-hotfix.md`](queue-ui-execution-state-hotfix.md),
-  the ordinary backend roadmap, or an AiO advanced-integration plan.
+- Issues [#413](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/413),
+  [#414](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/414), and
+  [#415](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/415) completed the
+  queue/live-UI hotfix and release lane. Their two-phase correlation and seed
+  ownership contracts remain authoritative for later feature adapters, but no
+  longer block the AiO advanced-integration queue.
 - Before Prompt Studio wildcard next-seed publication or AiO seed cutover, read
   [`seed-ui-semantics-gate.md`](seed-ui-semantics-gate.md). Prompt Studio uses a
   concrete seed plus an after-generate transition; AiO special `-1/-2/-3` values
@@ -40,10 +36,11 @@ section, owning Issue, direct owner files, and direct tests.
 - The DAVE stage-scope, Torch Compile recommendation, and NegPip plans are
   recorded in
   [`aio-advanced-integrations-roadmap.md`](aio-advanced-integrations-roadmap.md).
-  Issues #409, #410, and #411 remain blocked until the #415 hotfix release exits
-  and the dependency order is re-audited against the then-current `dev` head.
-- New D/E/G/H, AiO Hook, opportunistic cleanup, and unrelated feature work also
-  remain paused while the hotfix lane is active.
+  Issue #409 is complete. The active queue is #410 AIO-COMPILE-01 through 04,
+  followed by #411; patch-specific #440/#441 follow-ups do not jump this queue.
+- New D/E/G/H, AiO Hook, opportunistic cleanup, and unrelated feature work remain
+  outside the active #410/#411 queue unless a separately recorded priority
+  decision changes it.
 - The former B-11 Comfy host-provider bridge is complete. Its document remains a
   historical sequencing record and no longer overrides the active queue.
 

--- a/docs/architecture/aio-advanced-integrations-roadmap.md
+++ b/docs/architecture/aio-advanced-integrations-roadmap.md
@@ -2,11 +2,12 @@
 
 ## 문서 상태
 
-- 상태: **PLANNED / BLOCKED**
-- 기준일: 2026-07-25
+- 상태: **IN PROGRESS — #410 AIO-COMPILE**
+- 기준일: 2026-07-27
 - 기준 브랜치: `dev`
-- 기준 커밋: `df74cf9f65d481936122245e90db269113340c78`
-- 외부 차단점: [#395](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/395) Registry 0.5.5 activation
+- 기준 커밋: `966d08fd148533fa52ed35c9ade9fd201b56741c`
+- 완료된 선행: [#395](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/395),
+  [#409](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/409)
 - 기능 이슈:
   - [#409](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/409): stage별 고급 MODEL patch 범위
   - [#410](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/410): KJNodes Torch Compile 자동 추천
@@ -20,9 +21,9 @@ rollback 단위와 검증 순서를 고정한다. 기능 이슈의 behavior 요�
 구체적이면 해당 이슈가 우선하며, 아키텍처 ADR과 `MAINTAINING.md`는 계속
 최상위 정책이다.
 
-`#395`가 닫히기 전에는 이 문서의 production implementation을 시작하지 않는다.
-문서, 조사, fixture 설계는 가능하지만 D/E/G/H 및 새 AiO behavior 구현을 병행하지
-않는다.
+`#395`의 Registry checkpoint와 `#409`의 stage-scope/precedence 구현은 완료됐다.
+현재 production queue는 `#410`의 네 단계를 직렬로 수행한 뒤 `#411`로 이동한다.
+`#440/#441`의 patch-specific 후속은 이 queue를 선행하지 않는다.
 
 ## 1. 현재 확인된 실행 구조
 
@@ -112,7 +113,7 @@ sampling stage effective CFG = 1
 ## 3. 확정 실행 순서
 
 ```text
-BLOCKED: #395 Registry activation 및 release lane 종료
+#395 Registry activation 및 release lane 종료 — COMPLETE
   ↓
 ADV-00 current-dev re-audit
   ↓
@@ -259,6 +260,21 @@ DAVE first-pass-only
 - PyTorch/CUDA/accelerator/GPU VRAM/KJ input contract 수집
 - 외부 network/telemetry/지속 저장 금지
 - 버튼이 compile 또는 benchmark를 실행하지 않는다는 gate
+
+직접 owner와 phase boundary는 다음과 같이 고정한다.
+
+```text
+POST /easyuse_anima/aio/torch-compile/recommend
+  -> bounded Python/PyTorch/accelerator device facts
+  -> loaded TorchCompileModelAdvanced INPUT_TYPES + patch signature
+  -> no compile, tensor allocation, network, telemetry, persistence
+```
+
+COMPILE-01에서 `supported`는 CUDA, `torch.compile`, KJ node schema와 현재 AiO
+positional call signature가 모두 호환되는지를 뜻한다. `profile`은
+`diagnostics_only` 또는 `unsupported`, `values`는 빈 object로 반환한다. 실제 추천
+profile/value와 workload 정책은 COMPILE-02가 소유하며 COMPILE-01에서 추측하지
+않는다. CUDA 이외 accelerator와 malformed/missing contract는 fail-closed다.
 
 응답은 값뿐 아니라 다음을 포함한다.
 
@@ -511,24 +527,16 @@ Queue: repeated / concurrent / cancelled / exception
 
 ## 13. Codex 시작 지시
 
-`#395`가 열려 있는 동안:
-
-```text
-이 문서와 #409/#410/#411을 읽되 production implementation을 시작하지 않는다.
-새 D/E/G/H 또는 AiO advanced feature branch를 만들지 않는다.
-외부 node contract 변화가 발견되면 issue와 문서만 갱신한다.
-```
-
-`#395`가 닫힌 뒤:
+현재 `#410` 실행:
 
 ```text
 1. 최신 origin/dev와 open PR/branch를 확인한다.
-2. ADV-00 재감사를 수행한다.
-3. #409 AIO-SCOPE-01 하나만 선택한다.
-4. stage id, migration, precedence, cache-key Contract와 golden fixtures만 만든다.
-5. StageModelVariantResolver, UI, Torch recommendation, NegPip behavior는 같은 PR에 넣지 않는다.
-6. quick/full/package gate와 exact base/head SHA를 기록한다.
-7. 다음 unit을 READY로 바꾸되 자동 merge/release는 수행하지 않는다.
+2. installed KJ input/signature와 직접 owner를 현재 단계에서만 재확인한다.
+3. AIO-COMPILE-01 diagnostics부터 04 live matrix까지 PR/rollback 단위를 분리한다.
+4. COMPILE-01은 fake environment만 사용하고 compile/benchmark/live를 실행하지 않는다.
+5. COMPILE-02 전에는 추천값을 추측하지 않는다.
+6. 각 최종 후보에서 focused/full/package/live trigger를 단계 계약대로 기록한다.
+7. #410 완료 후에만 #411을 시작한다.
 ```
 
 ## 14. 릴리스 정책

--- a/easyuse_anima/aio/torch_compile_diagnostics.py
+++ b/easyuse_anima/aio/torch_compile_diagnostics.py
@@ -1,0 +1,320 @@
+"""Read-only environment and KJNodes contract diagnostics for Torch Compile."""
+
+from __future__ import annotations
+
+import importlib
+import inspect
+import platform
+from collections.abc import Callable, Mapping, Sequence
+from typing import Any
+
+from ..infrastructure.comfy.capabilities import _find_loaded_node_class
+
+AIO_TORCH_COMPILE_DIAGNOSTICS_SCHEMA_VERSION = 1
+AIO_TORCH_COMPILE_DIAGNOSTICS_POLICY_VERSION = "diagnostics-v1"
+TORCH_COMPILE_NODE_ID = "TorchCompileModelAdvanced"
+
+_EXPECTED_PATCH_PARAMETERS = (
+    "model",
+    "backend",
+    "fullgraph",
+    "mode",
+    "dynamic",
+    "dynamo_cache_size_limit",
+    "compile_transformer_blocks_only",
+    "debug_compile_keys",
+    "disable_dynamic_vram",
+)
+_REQUIRED_NODE_INPUTS = _EXPECTED_PATCH_PARAMETERS[:-1]
+_OPTIONAL_NODE_INPUTS = (_EXPECTED_PATCH_PARAMETERS[-1],)
+_CHOICE_INPUTS = ("backend", "mode", "dynamic")
+_MAX_TEXT_LENGTH = 160
+_MAX_INPUT_NAMES = 64
+_MAX_CHOICES = 32
+
+
+def _bounded_text(value: object, *, fallback: str = "") -> str:
+    try:
+        text = str(value or fallback)
+    except Exception:
+        text = fallback
+    return text[:_MAX_TEXT_LENGTH]
+
+
+def _torch_module():
+    return importlib.import_module("torch")
+
+
+def _input_map(value: object) -> dict[str, object]:
+    if not isinstance(value, Mapping):
+        return {}
+    merged: dict[str, object] = {}
+    for section in ("required", "optional"):
+        inputs = value.get(section)
+        if not isinstance(inputs, Mapping):
+            continue
+        for name, spec in inputs.items():
+            if isinstance(name, str) and len(merged) < _MAX_INPUT_NAMES:
+                merged[name] = spec
+    return merged
+
+
+def _choice_values(spec: object) -> list[str]:
+    if not isinstance(spec, Sequence) or isinstance(spec, (str, bytes)) or not spec:
+        return []
+    source: object = spec[0]
+    if source == "COMBO" and len(spec) > 1 and isinstance(spec[1], Mapping):
+        source = spec[1].get("options")
+    if not isinstance(source, Sequence) or isinstance(source, (str, bytes)):
+        return []
+    values: list[str] = []
+    for value in source:
+        if not isinstance(value, (str, int, float, bool)):
+            continue
+        normalized = _bounded_text(value)
+        if normalized and normalized not in values:
+            values.append(normalized)
+        if len(values) >= _MAX_CHOICES:
+            break
+    return values
+
+
+def _patch_signature_compatible(node_class: type) -> bool:
+    patch = getattr(node_class, "patch", None)
+    if not callable(patch):
+        return False
+    try:
+        parameters = list(inspect.signature(patch).parameters.values())
+    except (TypeError, ValueError):
+        return False
+    if parameters and parameters[0].name in {"self", "cls"}:
+        parameters = parameters[1:]
+    positional = [
+        parameter
+        for parameter in parameters
+        if parameter.kind
+        in (inspect.Parameter.POSITIONAL_ONLY, inspect.Parameter.POSITIONAL_OR_KEYWORD)
+    ]
+    if tuple(parameter.name for parameter in positional[: len(_EXPECTED_PATCH_PARAMETERS)]) != (
+        _EXPECTED_PATCH_PARAMETERS
+    ):
+        return False
+    return not any(
+        parameter.default is inspect.Parameter.empty
+        and parameter.kind
+        in (
+            inspect.Parameter.POSITIONAL_ONLY,
+            inspect.Parameter.POSITIONAL_OR_KEYWORD,
+            inspect.Parameter.KEYWORD_ONLY,
+        )
+        for parameter in parameters[len(_EXPECTED_PATCH_PARAMETERS) :]
+    )
+
+
+def _kj_contract(
+    find_node_class: Callable[[str], Any],
+) -> dict[str, object]:
+    try:
+        node_class = find_node_class(TORCH_COMPILE_NODE_ID)
+    except Exception:
+        node_class = None
+    if node_class is None:
+        return {
+            "available": False,
+            "compatible": False,
+            "supported_inputs": [],
+            "input_options": {},
+            "missing_inputs": list(_REQUIRED_NODE_INPUTS + _OPTIONAL_NODE_INPUTS),
+            "unexpected_required_inputs": [],
+            "signature_compatible": False,
+            "inspection_error": False,
+        }
+
+    try:
+        input_types = node_class.INPUT_TYPES()
+        required = input_types.get("required", {}) if isinstance(input_types, Mapping) else {}
+        if not isinstance(required, Mapping):
+            required = {}
+        inputs = _input_map(input_types)
+        missing_inputs = [
+            name
+            for name in _REQUIRED_NODE_INPUTS + _OPTIONAL_NODE_INPUTS
+            if name not in inputs
+        ]
+        unexpected_required = sorted(
+            str(name)
+            for name in required
+            if isinstance(name, str) and name not in _EXPECTED_PATCH_PARAMETERS
+        )[:_MAX_INPUT_NAMES]
+        signature_compatible = _patch_signature_compatible(node_class)
+        return {
+            "available": True,
+            "compatible": not missing_inputs
+            and not unexpected_required
+            and signature_compatible,
+            "supported_inputs": sorted(inputs)[:_MAX_INPUT_NAMES],
+            "input_options": {
+                name: _choice_values(inputs.get(name)) for name in _CHOICE_INPUTS
+            },
+            "missing_inputs": missing_inputs,
+            "unexpected_required_inputs": unexpected_required,
+            "signature_compatible": signature_compatible,
+            "inspection_error": False,
+        }
+    except Exception:
+        return {
+            "available": True,
+            "compatible": False,
+            "supported_inputs": [],
+            "input_options": {},
+            "missing_inputs": list(_REQUIRED_NODE_INPUTS + _OPTIONAL_NODE_INPUTS),
+            "unexpected_required_inputs": [],
+            "signature_compatible": False,
+            "inspection_error": True,
+        }
+
+
+def _accelerator_environment(torch: Any) -> tuple[dict[str, object], list[str]]:
+    warnings: list[str] = []
+    version = getattr(torch, "version", None)
+    cuda_version = _bounded_text(getattr(version, "cuda", None)) or None
+    rocm_version = _bounded_text(getattr(version, "hip", None)) or None
+    cuda = getattr(torch, "cuda", None)
+    cuda_is_available = getattr(cuda, "is_available", None)
+    try:
+        cuda_available = bool(callable(cuda_is_available) and cuda_is_available())
+    except Exception:
+        cuda_available = False
+        warnings.append("accelerator_probe_failed")
+
+    accelerator = "cpu"
+    device_name = None
+    compute_capability = None
+    total_vram_mb = None
+    if cuda_available:
+        accelerator = "rocm" if rocm_version else "cuda"
+        try:
+            current_device = getattr(cuda, "current_device", None)
+            get_device_properties = getattr(cuda, "get_device_properties", None)
+            if not callable(current_device) or not callable(get_device_properties):
+                raise AttributeError("CUDA device property API is unavailable")
+            device_index = current_device()
+            if type(device_index) is not int:
+                raise TypeError("CUDA current_device() did not return an integer")
+            properties = get_device_properties(device_index)
+            device_name = _bounded_text(getattr(properties, "name", None)) or None
+            major = getattr(properties, "major", None)
+            minor = getattr(properties, "minor", None)
+            if accelerator == "cuda" and isinstance(major, int) and isinstance(minor, int):
+                compute_capability = f"{major}.{minor}"
+            total_memory = getattr(properties, "total_memory", None)
+            if isinstance(total_memory, int) and total_memory >= 0:
+                total_vram_mb = total_memory // (1024 * 1024)
+        except Exception:
+            warnings.append("device_properties_unavailable")
+    else:
+        mps = getattr(getattr(torch, "backends", None), "mps", None)
+        mps_is_available = getattr(mps, "is_available", None)
+        try:
+            if callable(mps_is_available) and bool(mps_is_available()):
+                accelerator = "mps"
+        except Exception:
+            warnings.append("accelerator_probe_failed")
+
+    return (
+        {
+            "accelerator": accelerator,
+            "cuda_runtime_version": cuda_version,
+            "rocm_runtime_version": rocm_version,
+            "device_name": device_name,
+            "compute_capability": compute_capability,
+            "total_vram_mb": total_vram_mb,
+        },
+        warnings,
+    )
+
+
+def collect_torch_compile_diagnostics(
+    *,
+    load_torch: Callable[[], Any] = _torch_module,
+    find_node_class: Callable[[str], Any] = _find_loaded_node_class,
+    python_version: Callable[[], str] = platform.python_version,
+) -> dict[str, object]:
+    """Return bounded facts only; this never compiles, benchmarks, or persists."""
+
+    reason_codes: list[str] = []
+    warnings: list[str] = ["recommendation_policy_pending"]
+    try:
+        torch = load_torch()
+    except Exception:
+        torch = None
+        reason_codes.append("torch_unavailable")
+
+    if torch is None:
+        accelerator = {
+            "accelerator": "unknown",
+            "cuda_runtime_version": None,
+            "rocm_runtime_version": None,
+            "device_name": None,
+            "compute_capability": None,
+            "total_vram_mb": None,
+        }
+        torch_version = None
+        torch_compile_available = False
+    else:
+        accelerator, accelerator_warnings = _accelerator_environment(torch)
+        warnings.extend(accelerator_warnings)
+        torch_version = _bounded_text(getattr(torch, "__version__", None)) or None
+        torch_compile_available = callable(getattr(torch, "compile", None))
+        if not torch_compile_available:
+            reason_codes.append("torch_compile_unavailable")
+
+    if accelerator["accelerator"] != "cuda":
+        reason_codes.append("cuda_unavailable")
+
+    kj = _kj_contract(find_node_class)
+    if not kj["available"]:
+        reason_codes.append("kj_torch_compile_missing")
+    elif kj["inspection_error"]:
+        reason_codes.append("kj_input_contract_unreadable")
+    else:
+        if kj["missing_inputs"] or kj["unexpected_required_inputs"]:
+            reason_codes.append("kj_input_contract_drift")
+        if not kj["signature_compatible"]:
+            reason_codes.append("kj_patch_signature_drift")
+
+    supported = bool(
+        torch is not None
+        and torch_compile_available
+        and accelerator["accelerator"] == "cuda"
+        and kj["compatible"]
+    )
+    if supported:
+        reason_codes.append("diagnostics_ready")
+
+    return {
+        "schema_version": AIO_TORCH_COMPILE_DIAGNOSTICS_SCHEMA_VERSION,
+        "policy_version": AIO_TORCH_COMPILE_DIAGNOSTICS_POLICY_VERSION,
+        "supported": supported,
+        "profile": "diagnostics_only" if supported else "unsupported",
+        "values": {},
+        "environment": {
+            "python_version": _bounded_text(python_version(), fallback="unknown"),
+            "torch_version": torch_version,
+            **accelerator,
+            "kj_node_available": kj["available"],
+            "kj_contract_compatible": kj["compatible"],
+            "supported_inputs": kj["supported_inputs"],
+            "input_options": kj["input_options"],
+        },
+        "reason_codes": reason_codes,
+        "warnings": list(dict.fromkeys(warnings)),
+    }
+
+
+__all__ = [
+    "AIO_TORCH_COMPILE_DIAGNOSTICS_POLICY_VERSION",
+    "AIO_TORCH_COMPILE_DIAGNOSTICS_SCHEMA_VERSION",
+    "TORCH_COMPILE_NODE_ID",
+    "collect_torch_compile_diagnostics",
+]

--- a/tests/fixtures/python_backend_baseline.json
+++ b/tests/fixtures/python_backend_baseline.json
@@ -1986,6 +1986,24 @@
         "target": "api_contract.py"
       },
       {
+        "alias": "_collect_torch_compile_diagnostics",
+        "bound_name": "_collect_torch_compile_diagnostics",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".easyuse_anima.aio.torch_compile_diagnostics:collect_torch_compile_diagnostics",
+        "kind": "static_from",
+        "line": 64,
+        "name": "collect_torch_compile_diagnostics",
+        "optional": false,
+        "requested": ".easyuse_anima.aio.torch_compile_diagnostics",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "api.py",
+        "target": "easyuse_anima/aio/torch_compile_diagnostics.py"
+      },
+      {
         "alias": "_aio_profiles",
         "bound_name": "_aio_profiles",
         "branch_context": [],
@@ -1994,7 +2012,7 @@
         "conditional": false,
         "imported": ".easyuse_anima.profiles:aio",
         "kind": "static_from",
-        "line": 64,
+        "line": 67,
         "name": "aio",
         "optional": false,
         "requested": ".easyuse_anima.profiles",
@@ -2012,7 +2030,7 @@
         "conditional": false,
         "imported": ".easyuse_anima.profiles:contract",
         "kind": "static_from",
-        "line": 65,
+        "line": 68,
         "name": "contract",
         "optional": false,
         "requested": ".easyuse_anima.profiles",
@@ -2030,7 +2048,7 @@
         "conditional": false,
         "imported": ".easyuse_anima.profiles:lora",
         "kind": "static_from",
-        "line": 66,
+        "line": 69,
         "name": "lora",
         "optional": false,
         "requested": ".easyuse_anima.profiles",
@@ -2048,7 +2066,7 @@
         "conditional": false,
         "imported": ".easyuse_anima.profiles:mutation",
         "kind": "static_from",
-        "line": 67,
+        "line": 70,
         "name": "mutation",
         "optional": false,
         "requested": ".easyuse_anima.profiles",
@@ -2066,7 +2084,7 @@
         "conditional": false,
         "imported": ".easyuse_anima.profiles:repository",
         "kind": "static_from",
-        "line": 68,
+        "line": 71,
         "name": "repository",
         "optional": false,
         "requested": ".easyuse_anima.profiles",
@@ -2084,7 +2102,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 324
+            "line": 327
           }
         ],
         "classification": "external",
@@ -2092,7 +2110,7 @@
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 325,
+        "line": 328,
         "name": null,
         "optional": true,
         "requested": "folder_paths",
@@ -12115,6 +12133,177 @@
         "scope": "<module>",
         "source": "easyuse_anima/aio/sampling.py",
         "target": "easyuse_anima/aio/generation_normalization.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "annotations",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "__future__:annotations",
+        "kind": "static_from",
+        "line": 3,
+        "name": "annotations",
+        "optional": false,
+        "requested": "__future__",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/aio/torch_compile_diagnostics.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "importlib",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "importlib",
+        "kind": "static_import",
+        "line": 5,
+        "name": null,
+        "optional": false,
+        "requested": "importlib",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/aio/torch_compile_diagnostics.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "inspect",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "inspect",
+        "kind": "static_import",
+        "line": 6,
+        "name": null,
+        "optional": false,
+        "requested": "inspect",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/aio/torch_compile_diagnostics.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "platform",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "platform",
+        "kind": "static_import",
+        "line": 7,
+        "name": null,
+        "optional": false,
+        "requested": "platform",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/aio/torch_compile_diagnostics.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "Callable",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "collections.abc:Callable",
+        "kind": "static_from",
+        "line": 8,
+        "name": "Callable",
+        "optional": false,
+        "requested": "collections.abc",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/aio/torch_compile_diagnostics.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "Mapping",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "collections.abc:Mapping",
+        "kind": "static_from",
+        "line": 8,
+        "name": "Mapping",
+        "optional": false,
+        "requested": "collections.abc",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/aio/torch_compile_diagnostics.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "Sequence",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "collections.abc:Sequence",
+        "kind": "static_from",
+        "line": 8,
+        "name": "Sequence",
+        "optional": false,
+        "requested": "collections.abc",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/aio/torch_compile_diagnostics.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "Any",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "typing:Any",
+        "kind": "static_from",
+        "line": 9,
+        "name": "Any",
+        "optional": false,
+        "requested": "typing",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/aio/torch_compile_diagnostics.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_find_loaded_node_class",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": "..infrastructure.comfy.capabilities:_find_loaded_node_class",
+        "kind": "static_from",
+        "line": 11,
+        "name": "_find_loaded_node_class",
+        "optional": false,
+        "requested": "..infrastructure.comfy.capabilities",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/aio/torch_compile_diagnostics.py",
+        "target": "easyuse_anima/infrastructure/comfy/capabilities.py"
+      },
+      {
+        "alias": null,
+        "bound_name": null,
+        "branch_context": [],
+        "classification": "external",
+        "column": 11,
+        "conditional": false,
+        "imported": "torch",
+        "kind": "literal_dynamic",
+        "line": 45,
+        "name": null,
+        "optional": false,
+        "requested": "torch",
+        "role": "ordinary",
+        "scope": "_torch_module",
+        "source": "easyuse_anima/aio/torch_compile_diagnostics.py"
       },
       {
         "alias": null,
@@ -57211,6 +57400,10 @@
       },
       {
         "from": "api.py",
+        "to": "easyuse_anima/aio/torch_compile_diagnostics.py"
+      },
+      {
+        "from": "api.py",
         "to": "easyuse_anima/autocomplete/dataset.py"
       },
       {
@@ -57756,6 +57949,10 @@
       {
         "from": "easyuse_anima/aio/sampling.py",
         "to": "easyuse_anima/seed/reservation.py"
+      },
+      {
+        "from": "easyuse_anima/aio/torch_compile_diagnostics.py",
+        "to": "easyuse_anima/infrastructure/comfy/capabilities.py"
       },
       {
         "from": "easyuse_anima/aio/usdu.py",
@@ -59068,6 +59265,12 @@
       {
         "cyclic": false,
         "modules": [
+          "easyuse_anima/aio/torch_compile_diagnostics.py"
+        ]
+      },
+      {
+        "cyclic": false,
+        "modules": [
           "easyuse_anima/aio/usdu.py"
         ]
       },
@@ -59597,7 +59800,7 @@
     ]
   },
   "inventory": {
-    "module_count": 132,
+    "module_count": 133,
     "modules": [
       {
         "is_package": true,
@@ -59697,9 +59900,9 @@
       },
       {
         "is_package": false,
-        "loc": 875,
+        "loc": 891,
         "module": "api",
-        "normalized_git_blob_sha1": "b10837e70d997f09d4f3ad17c78f5d331e71f997",
+        "normalized_git_blob_sha1": "c45c4a21c02bfe2e55638287dd25a962cbd48e33",
         "path": "api.py",
         "top_level": {
           "class_count": 1,
@@ -60113,6 +60316,18 @@
           "class_count": 0,
           "function_count": 14,
           "global_count": 1
+        }
+      },
+      {
+        "is_package": false,
+        "loc": 320,
+        "module": "easyuse_anima.aio.torch_compile_diagnostics",
+        "normalized_git_blob_sha1": "b8f8389432392a80f18f1022740c6d93a7b5e95d",
+        "path": "easyuse_anima/aio/torch_compile_diagnostics.py",
+        "top_level": {
+          "class_count": 0,
+          "function_count": 8,
+          "global_count": 11
         }
       },
       {
@@ -72974,14 +73189,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 324
+            "line": 327
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 325,
+        "line": 328,
         "optional": true,
         "role": "optional_dependency",
         "source": "api.py"
@@ -74672,6 +74887,105 @@
         "optional": false,
         "role": "ordinary",
         "source": "easyuse_anima/aio/sampling.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "__future__:annotations",
+        "kind": "static_from",
+        "line": 3,
+        "optional": false,
+        "role": "ordinary",
+        "source": "easyuse_anima/aio/torch_compile_diagnostics.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "importlib",
+        "kind": "static_import",
+        "line": 5,
+        "optional": false,
+        "role": "ordinary",
+        "source": "easyuse_anima/aio/torch_compile_diagnostics.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "inspect",
+        "kind": "static_import",
+        "line": 6,
+        "optional": false,
+        "role": "ordinary",
+        "source": "easyuse_anima/aio/torch_compile_diagnostics.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "platform",
+        "kind": "static_import",
+        "line": 7,
+        "optional": false,
+        "role": "ordinary",
+        "source": "easyuse_anima/aio/torch_compile_diagnostics.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "collections.abc:Callable",
+        "kind": "static_from",
+        "line": 8,
+        "optional": false,
+        "role": "ordinary",
+        "source": "easyuse_anima/aio/torch_compile_diagnostics.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "collections.abc:Mapping",
+        "kind": "static_from",
+        "line": 8,
+        "optional": false,
+        "role": "ordinary",
+        "source": "easyuse_anima/aio/torch_compile_diagnostics.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "collections.abc:Sequence",
+        "kind": "static_from",
+        "line": 8,
+        "optional": false,
+        "role": "ordinary",
+        "source": "easyuse_anima/aio/torch_compile_diagnostics.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "typing:Any",
+        "kind": "static_from",
+        "line": 9,
+        "optional": false,
+        "role": "ordinary",
+        "source": "easyuse_anima/aio/torch_compile_diagnostics.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "torch",
+        "kind": "literal_dynamic",
+        "line": 45,
+        "optional": false,
+        "role": "ordinary",
+        "source": "easyuse_anima/aio/torch_compile_diagnostics.py"
       },
       {
         "branch_context": [],
@@ -78529,14 +78843,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 324
+            "line": 327
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 325,
+        "line": 328,
         "optional": true,
         "role": "optional_dependency",
         "source": "api.py"
@@ -79467,6 +79781,7 @@
       "easyuse_anima/aio/preview.py",
       "easyuse_anima/aio/resources.py",
       "easyuse_anima/aio/sampling.py",
+      "easyuse_anima/aio/torch_compile_diagnostics.py",
       "easyuse_anima/aio/usdu.py",
       "easyuse_anima/autocomplete/__init__.py",
       "easyuse_anima/autocomplete/dataset.py",
@@ -79601,6 +79916,7 @@
       "easyuse_anima/aio/preview.py",
       "easyuse_anima/aio/resources.py",
       "easyuse_anima/aio/sampling.py",
+      "easyuse_anima/aio/torch_compile_diagnostics.py",
       "easyuse_anima/aio/usdu.py",
       "easyuse_anima/autocomplete/__init__.py",
       "easyuse_anima/autocomplete/dataset.py",
@@ -79872,7 +80188,7 @@
         "column": 10,
         "context": "assign:_LOGGER",
         "kind": "import_time_call",
-        "line": 148,
+        "line": 151,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -79881,7 +80197,7 @@
         "column": 25,
         "context": "assign:_FILE_IO_LIMITERS_LOCK",
         "kind": "import_time_call",
-        "line": 151,
+        "line": 154,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -79890,7 +80206,7 @@
         "column": 47,
         "context": "assign:_FILE_IO_LIMITERS",
         "kind": "import_time_call",
-        "line": 152,
+        "line": 155,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -79899,7 +80215,7 @@
         "column": 29,
         "context": "assign:_PROMPT_TRANSLATION_WORKER",
         "kind": "import_time_call",
-        "line": 201,
+        "line": 204,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -79908,7 +80224,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 202,
+        "line": 205,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -79917,7 +80233,7 @@
         "column": 36,
         "context": "assign:_SAFE_PROFILE_VALIDATION_MESSAGES",
         "kind": "import_time_call",
-        "line": 351,
+        "line": 354,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -79926,7 +80242,7 @@
         "column": 9,
         "context": "assign:routes",
         "kind": "route_registry_creation",
-        "line": 508,
+        "line": 511,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -79935,7 +80251,7 @@
         "column": 19,
         "context": "assign:_ROUTE_SIGNATURE",
         "kind": "route_registry_creation",
-        "line": 851,
+        "line": 867,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -79944,7 +80260,7 @@
         "column": 5,
         "context": "assign:_ROUTE_SIGNATURE",
         "kind": "route_registry_creation",
-        "line": 852,
+        "line": 868,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -81564,6 +81880,12 @@
         "name": "AIO_PREVIEW_STAGE_LABELS"
       },
       {
+        "kind": "list",
+        "line": 315,
+        "module": "easyuse_anima/aio/torch_compile_diagnostics.py",
+        "name": "__all__"
+      },
+      {
         "kind": "dict",
         "line": 44,
         "module": "easyuse_anima/autocomplete/dataset.py",
@@ -81894,7 +82216,7 @@
           "lock"
         ],
         "initializer": "threading.Lock",
-        "line": 151,
+        "line": 154,
         "module": "api.py",
         "name": "_FILE_IO_LIMITERS_LOCK"
       },
@@ -81903,7 +82225,7 @@
           "executor"
         ],
         "initializer": "_PromptTranslationWorker",
-        "line": 201,
+        "line": 204,
         "module": "api.py",
         "name": "_PROMPT_TRANSLATION_WORKER"
       },

--- a/tests/test_aio_torch_compile_diagnostics.py
+++ b/tests/test_aio_torch_compile_diagnostics.py
@@ -1,0 +1,271 @@
+from __future__ import annotations
+
+import types
+import unittest
+
+from easyuse_anima.aio.torch_compile_diagnostics import (
+    TORCH_COMPILE_NODE_ID,
+    collect_torch_compile_diagnostics,
+)
+
+
+def _input_types():
+    return {
+        "required": {
+            "model": ("MODEL",),
+            "backend": (["inductor", "cudagraphs"], {"default": "inductor"}),
+            "fullgraph": ("BOOLEAN", {"default": False}),
+            "mode": (
+                [
+                    "default",
+                    "max-autotune",
+                    "max-autotune-no-cudagraphs",
+                    "reduce-overhead",
+                ],
+                {"default": "default"},
+            ),
+            "dynamic": (["auto", "true", "false"], {"default": "auto"}),
+            "compile_transformer_blocks_only": ("BOOLEAN", {"default": True}),
+            "dynamo_cache_size_limit": ("INT", {"default": 64}),
+            "debug_compile_keys": ("BOOLEAN", {"default": False}),
+        },
+        "optional": {
+            "disable_dynamic_vram": ("BOOLEAN", {"default": False}),
+        },
+    }
+
+
+class CompatibleTorchCompile:
+    @classmethod
+    def INPUT_TYPES(cls):
+        return _input_types()
+
+    def patch(
+        self,
+        model,
+        backend,
+        fullgraph,
+        mode,
+        dynamic,
+        dynamo_cache_size_limit,
+        compile_transformer_blocks_only,
+        debug_compile_keys,
+        disable_dynamic_vram=False,
+    ):
+        raise AssertionError("diagnostics must not invoke patch()")
+
+
+class FakeCuda:
+    def __init__(self, *, available: bool):
+        self.available = available
+        self.property_calls = 0
+
+    def is_available(self):
+        return self.available
+
+    def current_device(self):
+        if not self.available:
+            raise AssertionError("unavailable CUDA must not inspect a device")
+        return 0
+
+    def get_device_properties(self, index):
+        self.property_calls += 1
+        if index != 0:
+            raise AssertionError("unexpected device index")
+        return types.SimpleNamespace(
+            name="Fake CUDA Device",
+            major=9,
+            minor=0,
+            total_memory=24 * 1024 * 1024 * 1024,
+        )
+
+
+class CompileSentinel:
+    def __call__(self, *args, **kwargs):
+        raise AssertionError("diagnostics must not invoke torch.compile")
+
+
+def _fake_torch(*, cuda_available=True, include_compile=True):
+    cuda = FakeCuda(available=cuda_available)
+    values = {
+        "__version__": "2.12.0+cu132",
+        "version": types.SimpleNamespace(cuda="13.2", hip=None),
+        "cuda": cuda,
+        "backends": types.SimpleNamespace(
+            mps=types.SimpleNamespace(is_available=lambda: False),
+        ),
+    }
+    if include_compile:
+        values["compile"] = CompileSentinel()
+    return types.SimpleNamespace(**values), cuda
+
+
+class TorchCompileDiagnosticsTests(unittest.TestCase):
+    def _collect(self, torch, node_class=CompatibleTorchCompile):
+        requested = []
+
+        def find_node_class(node_id):
+            requested.append(node_id)
+            return node_class
+
+        payload = collect_torch_compile_diagnostics(
+            load_torch=lambda: torch,
+            find_node_class=find_node_class,
+            python_version=lambda: "3.13.5",
+        )
+        self.assertEqual(requested, [TORCH_COMPILE_NODE_ID])
+        return payload
+
+    def test_supported_fake_cuda_inventory_is_bounded_and_deterministic(self):
+        torch, cuda = _fake_torch()
+
+        first = self._collect(torch)
+        second = self._collect(torch)
+
+        self.assertEqual(first, second)
+        self.assertTrue(first["supported"])
+        self.assertEqual(first["profile"], "diagnostics_only")
+        self.assertEqual(first["values"], {})
+        self.assertEqual(first["reason_codes"], ["diagnostics_ready"])
+        self.assertEqual(first["warnings"], ["recommendation_policy_pending"])
+        self.assertEqual(
+            first["environment"],
+            {
+                "python_version": "3.13.5",
+                "torch_version": "2.12.0+cu132",
+                "accelerator": "cuda",
+                "cuda_runtime_version": "13.2",
+                "rocm_runtime_version": None,
+                "device_name": "Fake CUDA Device",
+                "compute_capability": "9.0",
+                "total_vram_mb": 24576,
+                "kj_node_available": True,
+                "kj_contract_compatible": True,
+                "supported_inputs": sorted(
+                    [
+                        "model",
+                        "backend",
+                        "fullgraph",
+                        "mode",
+                        "dynamic",
+                        "compile_transformer_blocks_only",
+                        "dynamo_cache_size_limit",
+                        "debug_compile_keys",
+                        "disable_dynamic_vram",
+                    ]
+                ),
+                "input_options": {
+                    "backend": ["inductor", "cudagraphs"],
+                    "mode": [
+                        "default",
+                        "max-autotune",
+                        "max-autotune-no-cudagraphs",
+                        "reduce-overhead",
+                    ],
+                    "dynamic": ["auto", "true", "false"],
+                },
+            },
+        )
+        self.assertEqual(cuda.property_calls, 2)
+
+    def test_cuda_unavailable_fails_closed_without_device_probe(self):
+        torch, cuda = _fake_torch(cuda_available=False)
+
+        payload = self._collect(torch)
+
+        self.assertFalse(payload["supported"])
+        self.assertEqual(payload["profile"], "unsupported")
+        self.assertEqual(payload["reason_codes"], ["cuda_unavailable"])
+        self.assertEqual(payload["environment"]["accelerator"], "cpu")
+        self.assertIsNone(payload["environment"]["device_name"])
+        self.assertEqual(cuda.property_calls, 0)
+
+    def test_missing_kj_node_fails_closed_with_installable_identity(self):
+        torch, _cuda = _fake_torch()
+
+        payload = collect_torch_compile_diagnostics(
+            load_torch=lambda: torch,
+            find_node_class=lambda _node_id: None,
+            python_version=lambda: "3.13.5",
+        )
+
+        self.assertFalse(payload["supported"])
+        self.assertEqual(payload["reason_codes"], ["kj_torch_compile_missing"])
+        self.assertFalse(payload["environment"]["kj_node_available"])
+        self.assertEqual(payload["environment"]["supported_inputs"], [])
+
+    def test_old_torch_without_compile_fails_closed_without_calling_any_compile(self):
+        torch, _cuda = _fake_torch(include_compile=False)
+
+        payload = self._collect(torch)
+
+        self.assertFalse(payload["supported"])
+        self.assertEqual(payload["reason_codes"], ["torch_compile_unavailable"])
+
+    def test_kj_input_contract_drift_is_reported_without_importing_private_source(self):
+        class InputDrift(CompatibleTorchCompile):
+            @classmethod
+            def INPUT_TYPES(cls):
+                inputs = _input_types()
+                del inputs["required"]["debug_compile_keys"]
+                inputs["required"]["new_required"] = ("BOOLEAN", {"default": False})
+                return inputs
+
+        torch, _cuda = _fake_torch()
+        payload = self._collect(torch, InputDrift)
+
+        self.assertFalse(payload["supported"])
+        self.assertEqual(payload["reason_codes"], ["kj_input_contract_drift"])
+        self.assertFalse(payload["environment"]["kj_contract_compatible"])
+
+    def test_kj_patch_signature_drift_is_fail_closed_even_with_matching_schema(self):
+        class SignatureDrift:
+            @classmethod
+            def INPUT_TYPES(cls):
+                return _input_types()
+
+            def patch(
+                self,
+                model,
+                backend,
+                fullgraph,
+                mode,
+                dynamic,
+                compile_transformer_blocks_only,
+                dynamo_cache_size_limit,
+                debug_compile_keys,
+            ):
+                raise AssertionError("diagnostics must not invoke patch()")
+
+        torch, _cuda = _fake_torch()
+        payload = self._collect(torch, SignatureDrift)
+
+        self.assertFalse(payload["supported"])
+        self.assertEqual(payload["reason_codes"], ["kj_patch_signature_drift"])
+
+    def test_unreadable_node_contract_and_missing_torch_remain_serializable(self):
+        class Unreadable:
+            @classmethod
+            def INPUT_TYPES(cls):
+                raise RuntimeError(r"C:\Users\alice\private-token")
+
+        def missing_torch():
+            raise ImportError("torch is unavailable")
+
+        payload = collect_torch_compile_diagnostics(
+            load_torch=missing_torch,
+            find_node_class=lambda _node_id: Unreadable,
+            python_version=lambda: "3.13.5",
+        )
+
+        self.assertFalse(payload["supported"])
+        self.assertEqual(
+            payload["reason_codes"],
+            ["torch_unavailable", "cuda_unavailable", "kj_input_contract_unreadable"],
+        )
+        self.assertNotIn("alice", str(payload))
+        self.assertNotIn("private-token", str(payload))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_api_contract.py
+++ b/tests/test_api_contract.py
@@ -162,6 +162,7 @@ class ApiRequestCorrelationTests(unittest.TestCase):
         ("GET", "/easyuse_anima/autocomplete"),
         ("POST", "/easyuse_anima/classify_prompt"),
         ("POST", "/easyuse_anima/translate_prompt"),
+        ("POST", "/easyuse_anima/aio/torch-compile/recommend"),
         ("GET", "/easyuse_anima/lora_preview"),
         ("GET", "/easyuse_anima/loras"),
         ("GET", "/easyuse_anima/lora_profiles"),
@@ -184,6 +185,7 @@ class ApiRequestCorrelationTests(unittest.TestCase):
         "/easyuse_anima/autocomplete",
         "/easyuse_anima/classify_prompt",
         "/easyuse_anima/translate_prompt",
+        "/easyuse_anima/aio/torch-compile/recommend",
         "/easyuse_anima/lora_preview",
         "/easyuse_anima/loras",
         "/easyuse_anima/lora_profiles",
@@ -422,12 +424,53 @@ class ApiRequestCorrelationTests(unittest.TestCase):
         self.assertIn("X-Request-ID", found.headers)
 
 
+class ApiTorchCompileDiagnosticsTests(unittest.TestCase):
+    def test_route_returns_exact_read_only_diagnostics_with_request_correlation(self):
+        api, routes = load_api_routes()
+        payload = {
+            "schema_version": 1,
+            "policy_version": "diagnostics-v1",
+            "supported": False,
+            "profile": "unsupported",
+            "values": {},
+            "environment": {"accelerator": "cpu"},
+            "reason_codes": ["cuda_unavailable"],
+            "warnings": ["recommendation_policy_pending"],
+        }
+        handler = routes.handlers["/easyuse_anima/aio/torch-compile/recommend"]
+        request = JsonRequest(
+            {
+                "generation_settings": {"prompt": "must not be reflected"},
+                "resolution": {"width": 1024, "height": 1024},
+                "batch_size": 1,
+            }
+        )
+
+        with (
+            patch.object(
+                api,
+                "_collect_torch_compile_diagnostics",
+                return_value=payload,
+            ) as collect,
+            patch.object(api, "_run_file_io") as file_io,
+        ):
+            response = asyncio.run(handler(request))
+
+        self.assertEqual(response["status"], 200)
+        self.assertEqual(response["payload"], payload)
+        self.assertIn("X-Request-ID", response.headers)
+        collect.assert_called_once_with()
+        file_io.assert_not_called()
+        self.assertNotIn("must not be reflected", json.dumps(response["payload"]))
+
+
 class ApiRequestContractTests(unittest.TestCase):
     POST_ROUTES = (
         "/easyuse_anima/set_setting",
         "/easyuse_anima/long_text_settings/save",
         "/easyuse_anima/classify_prompt",
         "/easyuse_anima/translate_prompt",
+        "/easyuse_anima/aio/torch-compile/recommend",
         "/easyuse_anima/lora_profiles/save",
         "/easyuse_anima/aio_profiles/save",
         "/easyuse_anima/aio_profiles/delete",

--- a/tests/test_python_backend_analyzer.py
+++ b/tests/test_python_backend_analyzer.py
@@ -691,9 +691,9 @@ ignored/
 
         self.assertEqual(analyzer.render_json(report), expected_text)
         self.assertEqual(report["schema_version"], 2)
-        self.assertEqual(report["inventory"]["module_count"], 132)
-        self.assertEqual(len(report["registry"]["shipped_python_modules"]), 132)
-        self.assertEqual(len(report["registry"]["runtime_import_closure"]), 132)
+        self.assertEqual(report["inventory"]["module_count"], 133)
+        self.assertEqual(len(report["registry"]["shipped_python_modules"]), 133)
+        self.assertEqual(len(report["registry"]["runtime_import_closure"]), 133)
         self.assertEqual(
             report["registry"]["entry_modules"],
             [
@@ -739,6 +739,7 @@ ignored/
                 "easyuse_anima/aio/preview.py",
                 "easyuse_anima/aio/resources.py",
                 "easyuse_anima/aio/sampling.py",
+                "easyuse_anima/aio/torch_compile_diagnostics.py",
                 "easyuse_anima/aio/usdu.py",
                 "easyuse_anima/bootstrap.py",
                 "easyuse_anima/common/__init__.py",
@@ -822,6 +823,7 @@ ignored/
                 "easyuse_anima/aio/preview.py",
                 "easyuse_anima/aio/resources.py",
                 "easyuse_anima/aio/sampling.py",
+                "easyuse_anima/aio/torch_compile_diagnostics.py",
                 "easyuse_anima/common/serialization.py",
                 "easyuse_anima/common/values.py",
                 "easyuse_anima/image/detailer.py",


### PR DESCRIPTION
## 목적과 변경 경계

- Task: AIO-COMPILE-01 / #410
- Class: CONTRACT / READ-ONLY RUNTIME
- Base -> Head: `966d08fd148533fa52ed35c9ade9fd201b56741c` -> `f814be9290af873e147fea4343b3cd2c7285b35c`
- Production boundary:
  - `easyuse_anima/aio/torch_compile_diagnostics.py`
  - correlated `POST /easyuse_anima/aio/torch-compile/recommend` route in `api.py`
- Direct tests/analyzer fixture and architecture status/contract docs only
- No frontend UI, settings/profile mutation, recommendation policy, model compile, benchmark, stage-scope, public socket, or workflow change

## Contract

- Lazy inventory: Python/PyTorch version, CUDA/ROCm/MPS/CPU classification, bounded device facts
- Installed-node inventory: loaded `TorchCompileModelAdvanced.INPUT_TYPES()` plus exact current AiO positional `patch()` signature
- Fail-closed: missing CUDA, missing KJ node, missing `torch.compile`, unreadable/schema/signature drift
- Stable response: schema/policy version, `supported`, `profile`, empty `values`, bounded environment, reason codes, warnings
- COMPILE-01 uses `diagnostics_only` or `unsupported`; COMPILE-02 exclusively owns actual recommendation profile/values
- Request payload, exceptions, paths, prompt/user data are not reflected; no network/telemetry/persistence
- Roadmap/index status was corrected because #395/#409 are complete and #410 is active; sequencing is unchanged

Installed audit evidence: isolated KJNodes `bb131be9e83d2f773c90f1d6f1e4b248a498c8c5` exposes the compatible node id, INPUT_TYPES, and patch signature.

## 검증

- Changed Python compile: PASS
- Focused diagnostics owner: 7 tests PASS
- Focused API route: 1 test PASS
- Route signature/correlation: 13 tests PASS
- POST request fail-closed contract: 15 tests PASS
- Backend analyzer: 18 tests PASS
- Import boundary: 0 violations
- Focused Pyright 1.1.411 for new owner: 0 diagnostics
- Diff: `git diff --check` PASS
- Full: exact SHA `f814be9290af873e147fea4343b3cd2c7285b35c` — PASS (Python 1,180 tests; frontend 118 JS files; TypeScript 6.0.3; Pyright baseline 116 files/14 reviewed errors; import boundary 0)
- Package: `comfy node validate` PASS; `comfy node pack` PASS; 270 entries; diagnostics module included; tests/docs/real Git metadata excluded
- Live/GPU compile/benchmark: not triggered by COMPILE-01 contract

A prior candidate `0cf016e…` stopped at the Pyright ratchet on two new optional-member diagnostics. Callable/type fail-closed checks were added, focused Pyright reached 0, the analyzer fixture was regenerated, and the final candidate/full above passed.

## 위험과 rollback

- The endpoint intentionally returns no recommendation values until COMPILE-02; no UI consumes it in this PR.
- CUDA device-property probe failures return bounded warning codes and no exception details.
- Rollback: this single COMPILE-01 squash commit.

## Next

After review and squash merge, continue from latest `dev` with AIO-COMPILE-02 pure workload/recommendation policy and bounded evidence. No UI is started first.
