### PR TITLE
AIO-COMPILE-02: add recommendation policy evidence

### DIFF
--- a/api.py
+++ b/api.py
@@ -64,6 +64,9 @@ from .api_contract import (
 from .easyuse_anima.aio.torch_compile_diagnostics import (
     collect_torch_compile_diagnostics as _collect_torch_compile_diagnostics,
 )
+from .easyuse_anima.aio.torch_compile_recommendation import (
+    recommend_torch_compile as _recommend_torch_compile,
+)
 from .easyuse_anima.profiles import aio as _aio_profiles
 from .easyuse_anima.profiles import contract as _profile_contract
 from .easyuse_anima.profiles import lora as _lora_profiles
@@ -610,10 +613,46 @@ if web is not None:
     @_request_correlated
     async def aio_torch_compile_recommend_handler(request):
         try:
-            await parse_json_object(request)
+            data = await parse_json_object(request)
+            generation_settings = (
+                json_object(data, "generation_settings")
+                if "generation_settings" in data
+                else {}
+            )
+            resolution = (
+                json_object(data, "resolution") if "resolution" in data else {}
+            )
+            width = json_integer(
+                resolution,
+                "width",
+                default=None,
+                minimum=1,
+                maximum=16384,
+            )
+            height = json_integer(
+                resolution,
+                "height",
+                default=None,
+                minimum=1,
+                maximum=16384,
+            )
+            batch_size = json_integer(
+                data,
+                "batch_size",
+                default=1,
+                minimum=1,
+                maximum=4096,
+            )
         except ApiContractError as exc:
             return _contract_error_response(exc)
-        return web.json_response(_collect_torch_compile_diagnostics())
+        return web.json_response(
+            _recommend_torch_compile(
+                _collect_torch_compile_diagnostics(),
+                generation_settings,
+                {"width": width, "height": height},
+                batch_size if batch_size is not None else 1,
+            )
+        )
 
     @_request_correlated
     async def lora_preview_handler(request):

--- a/docs/architecture/aio-advanced-integrations-roadmap.md
+++ b/docs/architecture/aio-advanced-integrations-roadmap.md
@@ -5,7 +5,7 @@
 - 상태: **IN PROGRESS — #410 AIO-COMPILE**
 - 기준일: 2026-07-27
 - 기준 브랜치: `dev`
-- 기준 커밋: `966d08fd148533fa52ed35c9ade9fd201b56741c`
+- 기준 커밋: `8c8555b6cdad54c8db10b1e5b41067b5ea106729`
 - 완료된 선행: [#395](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/395),
   [#409](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/409)
 - 기능 이슈:
@@ -22,7 +22,8 @@ rollback 단위와 검증 순서를 고정한다. 기능 이슈의 behavior 요�
 최상위 정책이다.
 
 `#395`의 Registry checkpoint와 `#409`의 stage-scope/precedence 구현은 완료됐다.
-현재 production queue는 `#410`의 네 단계를 직렬로 수행한 뒤 `#411`로 이동한다.
+`AIO-COMPILE-01` diagnostics도 완료됐다. 현재 production queue는 `#410`의
+나머지 세 단계를 직렬로 수행한 뒤 `#411`로 이동한다.
 `#440/#441`의 patch-specific 후속은 이 queue를 선행하지 않는다.
 
 ## 1. 현재 확인된 실행 구조
@@ -310,6 +311,43 @@ debug_compile_keys = false
 ```
 
 `mode`, `dynamic`, cache, dynamic-VRAM 정책은 evidence로 결정한다.
+
+`recommendation-v1`의 결정은 다음과 같다.
+
+```text
+common:
+  enabled = true
+  backend = inductor
+  fullgraph = false
+  mode = default
+  compile_transformer_blocks_only = true
+  dynamo_cache_size_limit = 64
+  debug_compile_keys = false
+  disable_dynamic_vram = false
+
+fixed_shapes:
+  dynamic = false
+
+variable_shapes / unknown:
+  dynamic = auto
+```
+
+Highres, Detailer와 USDU는 `variable_shapes`다. ResShift-only upscale는 sampling
+MODEL을 사용하지 않으므로 그 자체로 shape variation을 만들지 않는다. 해상도,
+batch, stage enable contract 또는 upscale backend가 불확실하면 `unknown`으로
+닫는다.
+
+VRAM tier는 `<8192 MiB=low`, `8192..15359 MiB=medium`, `>=15360 MiB=high`,
+그 외는 `unknown`이다. low/unknown은 공격적인 mode나 dynamic-VRAM override를
+선택하지 않고 보수적 profile과 경고를 사용한다. 고정 shape에서 `false` choice만
+사라진 경우
+지원되는 `auto`로만 보수적으로 fallback한다. variable/unknown의 `auto` 또는
+공통 안전 choice/input이 사라지면 recommendation을 fail-closed한다.
+
+대표 CUDA 환경에서 수행한 policy revision 1의 bounded synthetic benchmark는
+[recommendation evidence](../development/aio-torch-compile-recommendation-evidence.md)에
+기록한다. 이는 선택 profile의 graph/recompile 경향을 확인하는 증거이며, 전체 AiO
+모델이나 측정하지 않은 VRAM/stage/mode 조합의 최적성을 주장하지 않는다.
 
 ### AIO-COMPILE-03 — UI draft apply
 

--- a/docs/development/aio-torch-compile-recommendation-evidence.md
+++ b/docs/development/aio-torch-compile-recommendation-evidence.md
@@ -1,0 +1,67 @@
+# AiO Torch Compile Recommendation Evidence
+
+## Evidence identity
+
+- policy revision: `recommendation-v1`
+- date: 2026-07-27
+- scope: isolated synthetic transformer-block microbenchmark
+- environment: Python 3.12.13, PyTorch 2.12.1+cu130, CUDA 13.0
+- accelerator: CUDA, compute capability 12.0, 16,302 MiB total VRAM
+- installed KJ mapping: `dynamic=false -> False`, `dynamic=auto -> None`
+
+The device name was recorded in the local benchmark output, but the recommendation
+policy does not branch on product names. The benchmark allocated no user model or
+prompt data and did not start ComfyUI.
+
+## Policy decision
+
+The common safety axis is `inductor`, `fullgraph=false`, `mode=default`, transformer
+blocks only, cache limit 64, debug off, and `disable_dynamic_vram=false`. Fixed
+shapes use `dynamic=false`; variable or unknown shapes use KJ's `auto` choice.
+
+`default` is retained as the balanced, non-aggressive compiler mode. The policy
+does not claim that an autotune mode is faster for an AiO model because this bounded
+run did not compare such modes. PyTorch documents `default` as balancing performance
+and overhead, and describes automatic dynamic-shape behavior as preferable to
+forcing `dynamic=True` in the general case:
+
+- [torch.compile API](https://docs.pytorch.org/docs/stable/generated/torch.compile.html)
+- [Dynamic shapes](https://docs.pytorch.org/docs/stable/user_guide/torch_compiler/torch.compiler_dynamic_shapes.html)
+
+## One-run benchmark
+
+The single policy-revision run compiled a width-512 FP16 residual MLP block on CUDA.
+The fixed profile used 256 tokens repeatedly. The variable profile used 256 and 384
+tokens, then warmed both shapes. Both used `backend=inductor`, `mode=default`, and
+`fullgraph=false`.
+
+| Profile | Dynamic argument | Cold first call | Shape transition | Warm median | Peak allocated / reserved | Graph variants | Recompile estimate | Graph breaks |
+| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| fixed_shapes | `False` | 5698.251 ms | n/a | 0.246 ms | 83.252 / 104.000 MiB | 1 | 0 | 0 |
+| variable_shapes | `None` (`auto`) | 58.285 ms | 1268.072 ms | 0.248 ms | 84.127 / 106.000 MiB | 2 | 1 | 0 |
+
+`graph variants` is TorchDynamo's `unique_graphs` counter. `recompile estimate` is
+`max(unique_graphs - 1, 0)` for each newly compiled callable. No graph break was
+recorded in either profile.
+
+The fixed profile ran first in the same process and paid global compiler
+initialization. The variable profile could reuse initialized compiler state and the
+isolated Inductor cache. Therefore the two cold-first-call values are observations,
+not a valid cross-profile speed comparison. The useful result is narrower: the
+fixed selection remained one graph, while the automatic variable selection accepted
+one shape transition, produced one additional graph, and then served both shapes
+without a graph break in the bounded run.
+
+## Limits
+
+- This is not a full AiO model generation, output-parity, or artifact test.
+- Highres, Detailer, and USDU are represented only by a shape transition; their real
+  sampling paths remain AIO-COMPILE-04 live coverage.
+- Only the available high-VRAM environment was measured. Low, medium, and unknown
+  VRAM behavior is a conservative pure-policy contract, not benchmarked optimality.
+- LoRA, DAVE, SageAttention, dynamic VRAM, batch scaling, and other compile modes
+  were not measured here.
+- Cold timings are order-sensitive and should not be used as hardware rankings.
+
+The recommendation endpoint remains read-only and never executes this benchmark or
+calls `torch.compile`.

--- a/easyuse_anima/aio/torch_compile_recommendation.py
+++ b/easyuse_anima/aio/torch_compile_recommendation.py
@@ -1,0 +1,283 @@
+"""Pure Torch Compile workload classification and recommendation policy."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+
+AIO_TORCH_COMPILE_RECOMMENDATION_POLICY_VERSION = "recommendation-v1"
+
+_LOW_VRAM_LIMIT_MB = 8192
+_HIGH_VRAM_MINIMUM_MB = 15360
+_COMMON_VALUES = {
+    "enabled": True,
+    "backend": "inductor",
+    "fullgraph": False,
+    "mode": "default",
+    "dynamic": "auto",
+    "compile_transformer_blocks_only": True,
+    "dynamo_cache_size_limit": 64,
+    "debug_compile_keys": False,
+    "disable_dynamic_vram": False,
+}
+
+
+def _mapping(value: object) -> Mapping[str, object] | None:
+    return value if isinstance(value, Mapping) else None
+
+
+def _enabled_section(
+    settings: Mapping[str, object],
+    name: str,
+) -> tuple[bool | None, Mapping[str, object] | None]:
+    section = _mapping(settings.get(name))
+    if section is None or type(section.get("enabled")) is not bool:
+        return None, section
+    return bool(section["enabled"]), section
+
+
+def classify_torch_compile_workload(
+    generation_settings: Mapping[str, object],
+    resolution: Mapping[str, object],
+    batch_size: int,
+) -> dict[str, object]:
+    """Classify shape stability from the explicit AiO stage configuration."""
+
+    width = resolution.get("width")
+    height = resolution.get("height")
+    resolution_known = (
+        type(width) is int
+        and type(height) is int
+        and width > 0
+        and height > 0
+    )
+    batch_known = type(batch_size) is int and batch_size > 0
+    highres_enabled, _highres = _enabled_section(generation_settings, "highres")
+    detailer_enabled, _detailer = _enabled_section(generation_settings, "detailer")
+    upscale_enabled, upscale = _enabled_section(generation_settings, "upscale")
+
+    active_shape_stages: list[str] = []
+    reasons: list[str] = []
+    stage_contract_known = None not in (
+        highres_enabled,
+        detailer_enabled,
+        upscale_enabled,
+    )
+    if highres_enabled:
+        active_shape_stages.append("highres")
+        reasons.append("highres_changes_shape")
+    if detailer_enabled:
+        active_shape_stages.append("detailer")
+        reasons.append("detailer_uses_variable_crops")
+    if upscale_enabled:
+        backend = upscale.get("backend") if upscale is not None else None
+        if backend == "usdu":
+            active_shape_stages.append("upscale")
+            reasons.append("usdu_uses_tiles")
+        elif backend == "resshift":
+            reasons.append("resshift_has_no_sampling_model")
+        else:
+            stage_contract_known = False
+            reasons.append("upscale_backend_unknown")
+
+    if not resolution_known:
+        reasons.append("base_resolution_unknown")
+    if not batch_known:
+        reasons.append("batch_size_unknown")
+    if not stage_contract_known:
+        reasons.append("stage_shape_contract_unknown")
+
+    if not resolution_known or not batch_known or not stage_contract_known:
+        shape_class = "unknown"
+    elif active_shape_stages:
+        shape_class = "variable_shapes"
+    else:
+        shape_class = "fixed_shapes"
+
+    return {
+        "shape_class": shape_class,
+        "active_shape_stages": active_shape_stages,
+        "resolution": (
+            {"width": width, "height": height}
+            if resolution_known
+            else None
+        ),
+        "batch_size": batch_size if batch_known else None,
+        "reason_codes": reasons,
+    }
+
+
+def classify_torch_compile_vram(total_vram_mb: object) -> str:
+    if type(total_vram_mb) is not int or total_vram_mb <= 0:
+        return "unknown"
+    if total_vram_mb < _LOW_VRAM_LIMIT_MB:
+        return "low"
+    if total_vram_mb < _HIGH_VRAM_MINIMUM_MB:
+        return "medium"
+    return "high"
+
+
+def _choice_values(environment: Mapping[str, object], name: str) -> list[str]:
+    input_options = _mapping(environment.get("input_options"))
+    values = input_options.get(name) if input_options is not None else None
+    if not isinstance(values, Sequence) or isinstance(values, (str, bytes)):
+        return []
+    return [value for value in values if isinstance(value, str)]
+
+
+def _supported_input_names(environment: Mapping[str, object]) -> set[str]:
+    values = environment.get("supported_inputs")
+    if not isinstance(values, Sequence) or isinstance(values, (str, bytes)):
+        return set()
+    return {value for value in values if isinstance(value, str)}
+
+
+def _string_list(value: object) -> list[str]:
+    if not isinstance(value, Sequence) or isinstance(value, (str, bytes)):
+        return []
+    return [item for item in value if isinstance(item, str)]
+
+
+def _profile(shape_class: str, vram_tier: str) -> str:
+    if vram_tier == "low":
+        return "conservative_low_vram"
+    if vram_tier == "unknown":
+        return "conservative_unknown"
+    if shape_class == "fixed_shapes":
+        return "stable_fixed_shapes"
+    if shape_class == "variable_shapes":
+        return "stable_variable_shapes"
+    return "conservative_unknown"
+
+
+def recommend_torch_compile(
+    diagnostics: Mapping[str, object],
+    generation_settings: Mapping[str, object],
+    resolution: Mapping[str, object],
+    batch_size: int,
+) -> dict[str, object]:
+    """Return a deterministic recommendation without importing or invoking torch."""
+
+    environment = dict(_mapping(diagnostics.get("environment")) or {})
+    workload = classify_torch_compile_workload(
+        generation_settings,
+        resolution,
+        batch_size,
+    )
+    vram_tier = classify_torch_compile_vram(environment.get("total_vram_mb"))
+    workload["vram_tier"] = vram_tier
+
+    reason_codes = _string_list(diagnostics.get("reason_codes"))
+    warnings = [
+        value
+        for value in _string_list(diagnostics.get("warnings"))
+        if value != "recommendation_policy_pending"
+    ]
+    reason_codes.extend(_string_list(workload.get("reason_codes")))
+    reason_codes.extend((f"workload_{workload['shape_class']}", f"vram_{vram_tier}"))
+
+    payload = {
+        **diagnostics,
+        "policy_version": AIO_TORCH_COMPILE_RECOMMENDATION_POLICY_VERSION,
+        "environment": environment,
+        "workload": {
+            key: value for key, value in workload.items() if key != "reason_codes"
+        },
+        "reason_codes": list(dict.fromkeys(reason_codes)),
+        "warnings": warnings,
+    }
+    if diagnostics.get("supported") is not True:
+        payload.update(
+            {
+                "supported": False,
+                "profile": "unsupported",
+                "values": {},
+                "warnings": list(dict.fromkeys(warnings + ["recommendation_unavailable"])),
+            }
+        )
+        return payload
+
+    supported_inputs = _supported_input_names(environment)
+    required_inputs = set(_COMMON_VALUES) - {"enabled"}
+    if not required_inputs.issubset(supported_inputs):
+        payload.update(
+            {
+                "supported": False,
+                "profile": "unsupported",
+                "values": {},
+                "reason_codes": list(
+                    dict.fromkeys(reason_codes + ["kj_recommendation_input_drift"])
+                ),
+                "warnings": list(dict.fromkeys(warnings + ["recommendation_unavailable"])),
+            }
+        )
+        return payload
+
+    backend_options = _choice_values(environment, "backend")
+    mode_options = _choice_values(environment, "mode")
+    dynamic_options = _choice_values(environment, "dynamic")
+    if "inductor" not in backend_options or "default" not in mode_options:
+        payload.update(
+            {
+                "supported": False,
+                "profile": "unsupported",
+                "values": {},
+                "reason_codes": list(
+                    dict.fromkeys(reason_codes + ["kj_safe_choice_unavailable"])
+                ),
+                "warnings": list(dict.fromkeys(warnings + ["recommendation_unavailable"])),
+            }
+        )
+        return payload
+
+    values = dict(_COMMON_VALUES)
+    target_dynamic = "false" if workload["shape_class"] == "fixed_shapes" else "auto"
+    if target_dynamic not in dynamic_options:
+        if target_dynamic != "false" or "auto" not in dynamic_options:
+            payload.update(
+                {
+                    "supported": False,
+                    "profile": "unsupported",
+                    "values": {},
+                    "reason_codes": list(
+                        dict.fromkeys(reason_codes + ["kj_safe_choice_unavailable"])
+                    ),
+                    "warnings": list(
+                        dict.fromkeys(warnings + ["recommendation_unavailable"])
+                    ),
+                }
+            )
+            return payload
+        target_dynamic = "auto"
+        warnings.append("dynamic_choice_conservative_fallback")
+    values["dynamic"] = target_dynamic
+
+    if workload["shape_class"] == "variable_shapes":
+        warnings.append("shape_changes_may_recompile")
+    elif workload["shape_class"] == "unknown":
+        warnings.append("workload_shape_unknown")
+    if vram_tier == "low":
+        warnings.append("low_vram_peak_risk")
+    elif vram_tier == "unknown":
+        warnings.append("vram_unknown")
+    if isinstance(workload["batch_size"], int) and workload["batch_size"] > 1:
+        warnings.append("batch_size_increases_memory")
+    warnings.append("first_compile_may_be_slow")
+
+    payload.update(
+        {
+            "supported": True,
+            "profile": _profile(str(workload["shape_class"]), vram_tier),
+            "values": values,
+            "reason_codes": list(dict.fromkeys(reason_codes)),
+            "warnings": list(dict.fromkeys(warnings)),
+        }
+    )
+    return payload
+
+
+__all__ = [
+    "AIO_TORCH_COMPILE_RECOMMENDATION_POLICY_VERSION",
+    "classify_torch_compile_vram",
+    "classify_torch_compile_workload",
+    "recommend_torch_compile",
+]

--- a/tests/fixtures/python_backend_baseline.json
+++ b/tests/fixtures/python_backend_baseline.json
@@ -2004,6 +2004,24 @@
         "target": "easyuse_anima/aio/torch_compile_diagnostics.py"
       },
       {
+        "alias": "_recommend_torch_compile",
+        "bound_name": "_recommend_torch_compile",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".easyuse_anima.aio.torch_compile_recommendation:recommend_torch_compile",
+        "kind": "static_from",
+        "line": 67,
+        "name": "recommend_torch_compile",
+        "optional": false,
+        "requested": ".easyuse_anima.aio.torch_compile_recommendation",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "api.py",
+        "target": "easyuse_anima/aio/torch_compile_recommendation.py"
+      },
+      {
         "alias": "_aio_profiles",
         "bound_name": "_aio_profiles",
         "branch_context": [],
@@ -2012,7 +2030,7 @@
         "conditional": false,
         "imported": ".easyuse_anima.profiles:aio",
         "kind": "static_from",
-        "line": 67,
+        "line": 70,
         "name": "aio",
         "optional": false,
         "requested": ".easyuse_anima.profiles",
@@ -2030,7 +2048,7 @@
         "conditional": false,
         "imported": ".easyuse_anima.profiles:contract",
         "kind": "static_from",
-        "line": 68,
+        "line": 71,
         "name": "contract",
         "optional": false,
         "requested": ".easyuse_anima.profiles",
@@ -2048,7 +2066,7 @@
         "conditional": false,
         "imported": ".easyuse_anima.profiles:lora",
         "kind": "static_from",
-        "line": 69,
+        "line": 72,
         "name": "lora",
         "optional": false,
         "requested": ".easyuse_anima.profiles",
@@ -2066,7 +2084,7 @@
         "conditional": false,
         "imported": ".easyuse_anima.profiles:mutation",
         "kind": "static_from",
-        "line": 70,
+        "line": 73,
         "name": "mutation",
         "optional": false,
         "requested": ".easyuse_anima.profiles",
@@ -2084,7 +2102,7 @@
         "conditional": false,
         "imported": ".easyuse_anima.profiles:repository",
         "kind": "static_from",
-        "line": 71,
+        "line": 74,
         "name": "repository",
         "optional": false,
         "requested": ".easyuse_anima.profiles",
@@ -2102,7 +2120,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 327
+            "line": 330
           }
         ],
         "classification": "external",
@@ -2110,7 +2128,7 @@
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 328,
+        "line": 331,
         "name": null,
         "optional": true,
         "requested": "folder_paths",
@@ -12304,6 +12322,57 @@
         "role": "ordinary",
         "scope": "_torch_module",
         "source": "easyuse_anima/aio/torch_compile_diagnostics.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "annotations",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "__future__:annotations",
+        "kind": "static_from",
+        "line": 3,
+        "name": "annotations",
+        "optional": false,
+        "requested": "__future__",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/aio/torch_compile_recommendation.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "Mapping",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "collections.abc:Mapping",
+        "kind": "static_from",
+        "line": 5,
+        "name": "Mapping",
+        "optional": false,
+        "requested": "collections.abc",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/aio/torch_compile_recommendation.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "Sequence",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "collections.abc:Sequence",
+        "kind": "static_from",
+        "line": 5,
+        "name": "Sequence",
+        "optional": false,
+        "requested": "collections.abc",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/aio/torch_compile_recommendation.py"
       },
       {
         "alias": null,
@@ -57404,6 +57473,10 @@
       },
       {
         "from": "api.py",
+        "to": "easyuse_anima/aio/torch_compile_recommendation.py"
+      },
+      {
+        "from": "api.py",
         "to": "easyuse_anima/autocomplete/dataset.py"
       },
       {
@@ -59271,6 +59344,12 @@
       {
         "cyclic": false,
         "modules": [
+          "easyuse_anima/aio/torch_compile_recommendation.py"
+        ]
+      },
+      {
+        "cyclic": false,
+        "modules": [
           "easyuse_anima/aio/usdu.py"
         ]
       },
@@ -59800,7 +59879,7 @@
     ]
   },
   "inventory": {
-    "module_count": 133,
+    "module_count": 134,
     "modules": [
       {
         "is_package": true,
@@ -59900,9 +59979,9 @@
       },
       {
         "is_package": false,
-        "loc": 891,
+        "loc": 930,
         "module": "api",
-        "normalized_git_blob_sha1": "c45c4a21c02bfe2e55638287dd25a962cbd48e33",
+        "normalized_git_blob_sha1": "f479f7ce39163ef46d87dcbc6c2993138a06a7d8",
         "path": "api.py",
         "top_level": {
           "class_count": 1,
@@ -60328,6 +60407,18 @@
           "class_count": 0,
           "function_count": 8,
           "global_count": 11
+        }
+      },
+      {
+        "is_package": false,
+        "loc": 283,
+        "module": "easyuse_anima.aio.torch_compile_recommendation",
+        "normalized_git_blob_sha1": "c6270c6c1e78fb0c043d0c689f3b6bba4da89a92",
+        "path": "easyuse_anima/aio/torch_compile_recommendation.py",
+        "top_level": {
+          "class_count": 0,
+          "function_count": 9,
+          "global_count": 5
         }
       },
       {
@@ -73189,14 +73280,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 327
+            "line": 330
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 328,
+        "line": 331,
         "optional": true,
         "role": "optional_dependency",
         "source": "api.py"
@@ -74986,6 +75077,39 @@
         "optional": false,
         "role": "ordinary",
         "source": "easyuse_anima/aio/torch_compile_diagnostics.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "__future__:annotations",
+        "kind": "static_from",
+        "line": 3,
+        "optional": false,
+        "role": "ordinary",
+        "source": "easyuse_anima/aio/torch_compile_recommendation.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "collections.abc:Mapping",
+        "kind": "static_from",
+        "line": 5,
+        "optional": false,
+        "role": "ordinary",
+        "source": "easyuse_anima/aio/torch_compile_recommendation.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "collections.abc:Sequence",
+        "kind": "static_from",
+        "line": 5,
+        "optional": false,
+        "role": "ordinary",
+        "source": "easyuse_anima/aio/torch_compile_recommendation.py"
       },
       {
         "branch_context": [],
@@ -78843,14 +78967,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 327
+            "line": 330
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 328,
+        "line": 331,
         "optional": true,
         "role": "optional_dependency",
         "source": "api.py"
@@ -79782,6 +79906,7 @@
       "easyuse_anima/aio/resources.py",
       "easyuse_anima/aio/sampling.py",
       "easyuse_anima/aio/torch_compile_diagnostics.py",
+      "easyuse_anima/aio/torch_compile_recommendation.py",
       "easyuse_anima/aio/usdu.py",
       "easyuse_anima/autocomplete/__init__.py",
       "easyuse_anima/autocomplete/dataset.py",
@@ -79917,6 +80042,7 @@
       "easyuse_anima/aio/resources.py",
       "easyuse_anima/aio/sampling.py",
       "easyuse_anima/aio/torch_compile_diagnostics.py",
+      "easyuse_anima/aio/torch_compile_recommendation.py",
       "easyuse_anima/aio/usdu.py",
       "easyuse_anima/autocomplete/__init__.py",
       "easyuse_anima/autocomplete/dataset.py",
@@ -80188,7 +80314,7 @@
         "column": 10,
         "context": "assign:_LOGGER",
         "kind": "import_time_call",
-        "line": 151,
+        "line": 154,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -80197,7 +80323,7 @@
         "column": 25,
         "context": "assign:_FILE_IO_LIMITERS_LOCK",
         "kind": "import_time_call",
-        "line": 154,
+        "line": 157,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -80206,7 +80332,7 @@
         "column": 47,
         "context": "assign:_FILE_IO_LIMITERS",
         "kind": "import_time_call",
-        "line": 155,
+        "line": 158,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -80215,7 +80341,7 @@
         "column": 29,
         "context": "assign:_PROMPT_TRANSLATION_WORKER",
         "kind": "import_time_call",
-        "line": 204,
+        "line": 207,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -80224,7 +80350,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 205,
+        "line": 208,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -80233,7 +80359,7 @@
         "column": 36,
         "context": "assign:_SAFE_PROFILE_VALIDATION_MESSAGES",
         "kind": "import_time_call",
-        "line": 354,
+        "line": 357,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -80242,7 +80368,7 @@
         "column": 9,
         "context": "assign:routes",
         "kind": "route_registry_creation",
-        "line": 511,
+        "line": 514,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -80251,7 +80377,7 @@
         "column": 19,
         "context": "assign:_ROUTE_SIGNATURE",
         "kind": "route_registry_creation",
-        "line": 867,
+        "line": 906,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -80260,7 +80386,7 @@
         "column": 5,
         "context": "assign:_ROUTE_SIGNATURE",
         "kind": "route_registry_creation",
-        "line": 868,
+        "line": 907,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -81887,6 +82013,18 @@
       },
       {
         "kind": "dict",
+        "line": 11,
+        "module": "easyuse_anima/aio/torch_compile_recommendation.py",
+        "name": "_COMMON_VALUES"
+      },
+      {
+        "kind": "list",
+        "line": 278,
+        "module": "easyuse_anima/aio/torch_compile_recommendation.py",
+        "name": "__all__"
+      },
+      {
+        "kind": "dict",
         "line": 44,
         "module": "easyuse_anima/autocomplete/dataset.py",
         "name": "AUTOCOMPLETE_SOURCES"
@@ -82216,7 +82354,7 @@
           "lock"
         ],
         "initializer": "threading.Lock",
-        "line": 154,
+        "line": 157,
         "module": "api.py",
         "name": "_FILE_IO_LIMITERS_LOCK"
       },
@@ -82225,7 +82363,7 @@
           "executor"
         ],
         "initializer": "_PromptTranslationWorker",
-        "line": 204,
+        "line": 207,
         "module": "api.py",
         "name": "_PROMPT_TRANSLATION_WORKER"
       },

--- a/tests/test_aio_torch_compile_recommendation.py
+++ b/tests/test_aio_torch_compile_recommendation.py
@@ -1,0 +1,343 @@
+from __future__ import annotations
+
+import copy
+import unittest
+
+from easyuse_anima.aio.torch_compile_recommendation import (
+    AIO_TORCH_COMPILE_RECOMMENDATION_POLICY_VERSION,
+    classify_torch_compile_vram,
+    classify_torch_compile_workload,
+    recommend_torch_compile,
+)
+
+
+SUPPORTED_INPUTS = [
+    "model",
+    "backend",
+    "fullgraph",
+    "mode",
+    "dynamic",
+    "compile_transformer_blocks_only",
+    "dynamo_cache_size_limit",
+    "debug_compile_keys",
+    "disable_dynamic_vram",
+]
+
+
+def _diagnostics(*, vram=16302, supported=True):
+    return {
+        "schema_version": 1,
+        "policy_version": "diagnostics-v1",
+        "supported": supported,
+        "profile": "diagnostics_only" if supported else "unsupported",
+        "values": {},
+        "environment": {
+            "python_version": "3.13.5",
+            "torch_version": "2.12.1+cu130",
+            "accelerator": "cuda" if supported else "cpu",
+            "cuda_runtime_version": "13.0" if supported else None,
+            "rocm_runtime_version": None,
+            "device_name": "Fake Device",
+            "compute_capability": "12.0" if supported else None,
+            "total_vram_mb": vram,
+            "kj_node_available": supported,
+            "kj_contract_compatible": supported,
+            "supported_inputs": list(SUPPORTED_INPUTS) if supported else [],
+            "input_options": {
+                "backend": ["inductor", "cudagraphs"],
+                "mode": [
+                    "default",
+                    "max-autotune",
+                    "max-autotune-no-cudagraphs",
+                    "reduce-overhead",
+                ],
+                "dynamic": ["auto", "true", "false"],
+            },
+        },
+        "reason_codes": ["diagnostics_ready"] if supported else ["cuda_unavailable"],
+        "warnings": ["recommendation_policy_pending"],
+    }
+
+
+def _settings(*, highres=False, detailer=False, upscale=False, backend="usdu"):
+    return {
+        "highres": {"enabled": highres},
+        "detailer": {"enabled": detailer},
+        "upscale": {"enabled": upscale, "backend": backend},
+    }
+
+
+class TorchCompileWorkloadClassificationTests(unittest.TestCase):
+    def test_fixed_variable_unknown_and_resshift_boundaries(self):
+        cases = (
+            (
+                "fixed",
+                _settings(),
+                {"width": 1024, "height": 1024},
+                "fixed_shapes",
+                [],
+            ),
+            (
+                "highres",
+                _settings(highres=True),
+                {"width": 1024, "height": 1024},
+                "variable_shapes",
+                ["highres"],
+            ),
+            (
+                "detailer",
+                _settings(detailer=True),
+                {"width": 1024, "height": 1024},
+                "variable_shapes",
+                ["detailer"],
+            ),
+            (
+                "usdu",
+                _settings(upscale=True, backend="usdu"),
+                {"width": 1024, "height": 1024},
+                "variable_shapes",
+                ["upscale"],
+            ),
+            (
+                "resshift",
+                _settings(upscale=True, backend="resshift"),
+                {"width": 1024, "height": 1024},
+                "fixed_shapes",
+                [],
+            ),
+            (
+                "missing resolution",
+                _settings(),
+                {},
+                "unknown",
+                [],
+            ),
+            (
+                "unknown upscale backend",
+                _settings(upscale=True, backend="future"),
+                {"width": 1024, "height": 1024},
+                "unknown",
+                [],
+            ),
+            (
+                "missing stage contract",
+                {"highres": {}, "detailer": {"enabled": False}, "upscale": {"enabled": False}},
+                {"width": 1024, "height": 1024},
+                "unknown",
+                [],
+            ),
+        )
+        for name, settings, resolution, expected_class, expected_stages in cases:
+            with self.subTest(name=name):
+                workload = classify_torch_compile_workload(
+                    settings,
+                    resolution,
+                    1,
+                )
+                self.assertEqual(workload["shape_class"], expected_class)
+                self.assertEqual(workload["active_shape_stages"], expected_stages)
+
+    def test_non_positive_batch_is_unknown(self):
+        workload = classify_torch_compile_workload(
+            _settings(),
+            {"width": 1024, "height": 1024},
+            0,
+        )
+
+        self.assertEqual(workload["shape_class"], "unknown")
+        self.assertIsNone(workload["batch_size"])
+        self.assertIn("batch_size_unknown", workload["reason_codes"])
+
+    def test_vram_tiers_have_explicit_practical_boundaries(self):
+        cases = (
+            (None, "unknown"),
+            (0, "unknown"),
+            (8191, "low"),
+            (8192, "medium"),
+            (15359, "medium"),
+            (15360, "high"),
+        )
+        for value, expected in cases:
+            with self.subTest(value=value):
+                self.assertEqual(classify_torch_compile_vram(value), expected)
+
+
+class TorchCompileRecommendationPolicyTests(unittest.TestCase):
+    def test_fixed_high_vram_uses_balanced_static_safe_axis(self):
+        payload = recommend_torch_compile(
+            _diagnostics(),
+            _settings(),
+            {"width": 1024, "height": 1024},
+            1,
+        )
+
+        self.assertTrue(payload["supported"])
+        self.assertEqual(payload["policy_version"], AIO_TORCH_COMPILE_RECOMMENDATION_POLICY_VERSION)
+        self.assertEqual(payload["profile"], "stable_fixed_shapes")
+        self.assertEqual(
+            payload["values"],
+            {
+                "enabled": True,
+                "backend": "inductor",
+                "fullgraph": False,
+                "mode": "default",
+                "dynamic": "false",
+                "compile_transformer_blocks_only": True,
+                "dynamo_cache_size_limit": 64,
+                "debug_compile_keys": False,
+                "disable_dynamic_vram": False,
+            },
+        )
+        self.assertEqual(payload["workload"]["shape_class"], "fixed_shapes")
+        self.assertEqual(payload["workload"]["vram_tier"], "high")
+        self.assertIn("first_compile_may_be_slow", payload["warnings"])
+        self.assertNotIn("recommendation_policy_pending", payload["warnings"])
+
+    def test_variable_stage_profiles_use_automatic_dynamic_shapes(self):
+        cases = (
+            (_settings(highres=True), "highres_changes_shape"),
+            (_settings(detailer=True), "detailer_uses_variable_crops"),
+            (_settings(upscale=True, backend="usdu"), "usdu_uses_tiles"),
+        )
+        for settings, reason in cases:
+            with self.subTest(reason=reason):
+                payload = recommend_torch_compile(
+                    _diagnostics(vram=12288),
+                    settings,
+                    {"width": 1024, "height": 1024},
+                    1,
+                )
+                self.assertTrue(payload["supported"])
+                self.assertEqual(payload["profile"], "stable_variable_shapes")
+                self.assertEqual(payload["values"]["dynamic"], "auto")
+                self.assertEqual(payload["values"]["mode"], "default")
+                self.assertIn(reason, payload["reason_codes"])
+                self.assertIn("shape_changes_may_recompile", payload["warnings"])
+
+    def test_low_and_unknown_inputs_remain_conservative_without_forcing_dynamic_vram(self):
+        cases = (
+            (
+                4096,
+                _settings(),
+                {"width": 1024, "height": 1024},
+                "conservative_low_vram",
+                "false",
+                "low_vram_peak_risk",
+            ),
+            (
+                None,
+                _settings(),
+                {"width": 1024, "height": 1024},
+                "conservative_unknown",
+                "false",
+                "vram_unknown",
+            ),
+            (
+                16302,
+                _settings(),
+                {},
+                "conservative_unknown",
+                "auto",
+                "workload_shape_unknown",
+            ),
+        )
+        for vram, settings, resolution, profile, dynamic, warning in cases:
+            with self.subTest(profile=profile, warning=warning):
+                payload = recommend_torch_compile(
+                    _diagnostics(vram=vram),
+                    settings,
+                    resolution,
+                    1,
+                )
+                self.assertEqual(payload["profile"], profile)
+                self.assertEqual(payload["values"]["mode"], "default")
+                self.assertEqual(payload["values"]["dynamic"], dynamic)
+                self.assertFalse(payload["values"]["disable_dynamic_vram"])
+                self.assertIn(warning, payload["warnings"])
+
+    def test_batch_warning_and_resshift_no_sampling_model_contract(self):
+        payload = recommend_torch_compile(
+            _diagnostics(),
+            _settings(upscale=True, backend="resshift"),
+            {"width": 1024, "height": 1024},
+            2,
+        )
+
+        self.assertEqual(payload["workload"]["shape_class"], "fixed_shapes")
+        self.assertEqual(payload["workload"]["active_shape_stages"], [])
+        self.assertIn("resshift_has_no_sampling_model", payload["reason_codes"])
+        self.assertIn("batch_size_increases_memory", payload["warnings"])
+
+    def test_unsupported_diagnostics_and_contract_drift_fail_closed(self):
+        unsupported = recommend_torch_compile(
+            _diagnostics(supported=False),
+            _settings(),
+            {"width": 1024, "height": 1024},
+            1,
+        )
+        self.assertFalse(unsupported["supported"])
+        self.assertEqual(unsupported["values"], {})
+        self.assertIn("recommendation_unavailable", unsupported["warnings"])
+
+        missing_input = _diagnostics()
+        missing_input["environment"]["supported_inputs"].remove("debug_compile_keys")
+        drift = recommend_torch_compile(
+            missing_input,
+            _settings(),
+            {"width": 1024, "height": 1024},
+            1,
+        )
+        self.assertFalse(drift["supported"])
+        self.assertEqual(drift["values"], {})
+        self.assertIn("kj_recommendation_input_drift", drift["reason_codes"])
+
+    def test_missing_safe_choices_fail_closed_and_fixed_dynamic_has_bounded_fallback(self):
+        unsafe = _diagnostics()
+        unsafe["environment"]["input_options"]["backend"] = ["future"]
+        failed = recommend_torch_compile(
+            unsafe,
+            _settings(),
+            {"width": 1024, "height": 1024},
+            1,
+        )
+        self.assertFalse(failed["supported"])
+        self.assertIn("kj_safe_choice_unavailable", failed["reason_codes"])
+
+        fixed_fallback = _diagnostics()
+        fixed_fallback["environment"]["input_options"]["dynamic"] = ["auto"]
+        fixed = recommend_torch_compile(
+            fixed_fallback,
+            _settings(),
+            {"width": 1024, "height": 1024},
+            1,
+        )
+        self.assertEqual(fixed["values"]["dynamic"], "auto")
+        self.assertIn("dynamic_choice_conservative_fallback", fixed["warnings"])
+
+        variable_drift = _diagnostics()
+        variable_drift["environment"]["input_options"]["dynamic"] = ["false"]
+        variable = recommend_torch_compile(
+            variable_drift,
+            _settings(highres=True),
+            {"width": 1024, "height": 1024},
+            1,
+        )
+        self.assertFalse(variable["supported"])
+        self.assertEqual(variable["values"], {})
+        self.assertIn("kj_safe_choice_unavailable", variable["reason_codes"])
+
+    def test_policy_is_deterministic_and_does_not_mutate_inputs(self):
+        diagnostics = _diagnostics()
+        settings = _settings(highres=True)
+        resolution = {"width": 1024, "height": 1536}
+        originals = copy.deepcopy((diagnostics, settings, resolution))
+
+        first = recommend_torch_compile(diagnostics, settings, resolution, 1)
+        second = recommend_torch_compile(diagnostics, settings, resolution, 1)
+
+        self.assertEqual(first, second)
+        self.assertEqual((diagnostics, settings, resolution), originals)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_api_contract.py
+++ b/tests/test_api_contract.py
@@ -425,9 +425,9 @@ class ApiRequestCorrelationTests(unittest.TestCase):
 
 
 class ApiTorchCompileDiagnosticsTests(unittest.TestCase):
-    def test_route_returns_exact_read_only_diagnostics_with_request_correlation(self):
+    def test_route_composes_diagnostics_and_policy_with_request_correlation(self):
         api, routes = load_api_routes()
-        payload = {
+        diagnostics = {
             "schema_version": 1,
             "policy_version": "diagnostics-v1",
             "supported": False,
@@ -437,10 +437,16 @@ class ApiTorchCompileDiagnosticsTests(unittest.TestCase):
             "reason_codes": ["cuda_unavailable"],
             "warnings": ["recommendation_policy_pending"],
         }
+        recommendation = {
+            **diagnostics,
+            "policy_version": "recommendation-v1",
+            "warnings": ["recommendation_unavailable"],
+        }
         handler = routes.handlers["/easyuse_anima/aio/torch-compile/recommend"]
+        generation_settings = {"prompt": "must not be reflected"}
         request = JsonRequest(
             {
-                "generation_settings": {"prompt": "must not be reflected"},
+                "generation_settings": generation_settings,
                 "resolution": {"width": 1024, "height": 1024},
                 "batch_size": 1,
             }
@@ -450,18 +456,56 @@ class ApiTorchCompileDiagnosticsTests(unittest.TestCase):
             patch.object(
                 api,
                 "_collect_torch_compile_diagnostics",
-                return_value=payload,
+                return_value=diagnostics,
             ) as collect,
+            patch.object(
+                api,
+                "_recommend_torch_compile",
+                return_value=recommendation,
+            ) as recommend,
             patch.object(api, "_run_file_io") as file_io,
         ):
             response = asyncio.run(handler(request))
 
         self.assertEqual(response["status"], 200)
-        self.assertEqual(response["payload"], payload)
+        self.assertEqual(response["payload"], recommendation)
         self.assertIn("X-Request-ID", response.headers)
         collect.assert_called_once_with()
+        recommend.assert_called_once_with(
+            diagnostics,
+            generation_settings,
+            {"width": 1024, "height": 1024},
+            1,
+        )
         file_io.assert_not_called()
         self.assertNotIn("must not be reflected", json.dumps(response["payload"]))
+
+    def test_route_rejects_invalid_workload_contract_before_diagnostics(self):
+        api, routes = load_api_routes()
+        handler = routes.handlers["/easyuse_anima/aio/torch-compile/recommend"]
+        cases = (
+            ({"generation_settings": []}, "generation_settings"),
+            ({"resolution": []}, "resolution"),
+            ({"resolution": {"width": "1024"}}, "width"),
+            ({"resolution": {"width": 0}}, "width"),
+            ({"resolution": {"height": 16385}}, "height"),
+            ({"batch_size": "1"}, "batch_size"),
+            ({"batch_size": 0}, "batch_size"),
+        )
+
+        with (
+            patch.object(api, "_collect_torch_compile_diagnostics") as collect,
+            patch.object(api, "_recommend_torch_compile") as recommend,
+        ):
+            for payload, field in cases:
+                with self.subTest(payload=payload):
+                    response = asyncio.run(handler(JsonRequest(payload)))
+                    self.assertEqual(response["status"], 422)
+                    self.assertEqual(response["payload"]["code"], "invalid_request")
+                    self.assertEqual(response["payload"]["details"]["field"], field)
+
+        collect.assert_not_called()
+        recommend.assert_not_called()
 
 
 class ApiRequestContractTests(unittest.TestCase):

--- a/tests/test_python_backend_analyzer.py
+++ b/tests/test_python_backend_analyzer.py
@@ -691,9 +691,9 @@ ignored/
 
         self.assertEqual(analyzer.render_json(report), expected_text)
         self.assertEqual(report["schema_version"], 2)
-        self.assertEqual(report["inventory"]["module_count"], 133)
-        self.assertEqual(len(report["registry"]["shipped_python_modules"]), 133)
-        self.assertEqual(len(report["registry"]["runtime_import_closure"]), 133)
+        self.assertEqual(report["inventory"]["module_count"], 134)
+        self.assertEqual(len(report["registry"]["shipped_python_modules"]), 134)
+        self.assertEqual(len(report["registry"]["runtime_import_closure"]), 134)
         self.assertEqual(
             report["registry"]["entry_modules"],
             [
@@ -740,6 +740,7 @@ ignored/
                 "easyuse_anima/aio/resources.py",
                 "easyuse_anima/aio/sampling.py",
                 "easyuse_anima/aio/torch_compile_diagnostics.py",
+                "easyuse_anima/aio/torch_compile_recommendation.py",
                 "easyuse_anima/aio/usdu.py",
                 "easyuse_anima/bootstrap.py",
                 "easyuse_anima/common/__init__.py",
@@ -824,6 +825,7 @@ ignored/
                 "easyuse_anima/aio/resources.py",
                 "easyuse_anima/aio/sampling.py",
                 "easyuse_anima/aio/torch_compile_diagnostics.py",
+                "easyuse_anima/aio/torch_compile_recommendation.py",
                 "easyuse_anima/common/serialization.py",
                 "easyuse_anima/common/values.py",
                 "easyuse_anima/image/detailer.py",


### PR DESCRIPTION
## 목적과 변경 경계

AIO-COMPILE-02 / #410의 pure recommendation policy와 bounded benchmark evidence를 추가합니다. 변경 경계는 recommendation owner, 기존 correlated route composition, 직접 contract/analyzer fixture, roadmap/evidence 문서뿐입니다. UI, settings/profile 저장, model compile 호출, workflow/public socket은 변경하지 않습니다.

## Base -> Head

`8c8555b6cdad54c8db10b1e5b41067b5ea106729` -> `7d7eb28c6f26e008b506c808c33a823c15959acf`

## Contract

- workload: `fixed_shapes | variable_shapes | unknown`
- VRAM: low `<8192`, medium `8192..15359`, high `>=15360`, otherwise unknown
- common: `inductor`, `fullgraph=false`, `mode=default`, transformer blocks only, cache 64, debug off, dynamic VRAM override off
- dynamic: fixed=`false`, variable/unknown=`auto`
- Highres/Detailer/USDU는 variable; ResShift-only는 sampling MODEL shape variation으로 취급하지 않음
- missing/changed KJ input/choice는 fail-closed; fixed의 `false`만 없을 때 지원되는 `auto` fallback 허용
- no GPU product-name rule, no optimality claim, no input mutation/compile/tensor/network/telemetry/persistence/UI mutation

## Evidence

- changed Python compile: PASS
- focused policy: 10 PASS — shape/stage/VRAM/choice drift/determinism/no mutation
- focused API: 2 PASS — exact diagnostics-to-policy composition and malformed nested request fail-closed
- analyzer fixture: 1 PASS; shipped/runtime closure 134
- import boundary: 1 PASS, 0 enrolled violations
- focused Pyright 1.1.411: new owner 0 diagnostics
- `git diff --check`: PASS
- one isolated policy-revision benchmark: fixed `1 graph / 0 recompile / 0 break`; variable auto `2 graphs / 1 recompile estimate / 0 break`; cold/warm/peak VRAM and order limitation recorded in the evidence doc
- official full at exact head: PASS — Python 1,191; frontend 118; TypeScript 6.0.3; Pyright baseline 117 files / 14 reviewed errors; import boundary 0
- package: `comfy node validate` + `comfy node pack` PASS, 271 entries, new module included, tests/docs/Git metadata excluded, SHA-256 `00B6FD14B3BEE22F2E9B48C3A9048680EF534FBE455DD718378059EE39ABE7C9`
- live: not triggered by COMPILE-02

## 위험, rollback, next

Benchmark는 synthetic high-VRAM 환경의 selected-profile evidence이며 실제 AiO model 또는 미측정 조합의 최적성 증거가 아닙니다. Rollback은 이 Contract commit 단위입니다.

Next: review/merge 후 별도 AIO-COMPILE-03 PR에서 Advanced dialog의 loading/error/preview/draft apply를 구현합니다.

Refs #410
