### PR TITLE
AIO-COMPILE-02B: preserve known variable stages

### DIFF
--- a/docs/architecture/aio-advanced-integrations-roadmap.md
+++ b/docs/architecture/aio-advanced-integrations-roadmap.md
@@ -335,7 +335,8 @@ variable_shapes / unknown:
 Highres, Detailer와 USDU는 `variable_shapes`다. ResShift-only upscale는 sampling
 MODEL을 사용하지 않으므로 그 자체로 shape variation을 만들지 않는다. 해상도,
 batch, stage enable contract 또는 upscale backend가 불확실하면 `unknown`으로
-닫는다.
+닫는다. 단, Highres/Detailer/USDU 중 하나가 명시적으로 활성화되어 shape variation이
+이미 확정된 경우에는 누락된 base resolution이나 batch보다 그 신호가 우선한다.
 
 VRAM tier는 `<8192 MiB=low`, `8192..15359 MiB=medium`, `>=15360 MiB=high`,
 그 외는 `unknown`이다. low/unknown은 공격적인 mode나 dynamic-VRAM override를

--- a/easyuse_anima/aio/torch_compile_recommendation.py
+++ b/easyuse_anima/aio/torch_compile_recommendation.py
@@ -86,10 +86,10 @@ def classify_torch_compile_workload(
     if not stage_contract_known:
         reasons.append("stage_shape_contract_unknown")
 
-    if not resolution_known or not batch_known or not stage_contract_known:
-        shape_class = "unknown"
-    elif active_shape_stages:
+    if active_shape_stages:
         shape_class = "variable_shapes"
+    elif not resolution_known or not batch_known or not stage_contract_known:
+        shape_class = "unknown"
     else:
         shape_class = "fixed_shapes"
 

--- a/tests/fixtures/python_backend_baseline.json
+++ b/tests/fixtures/python_backend_baseline.json
@@ -60413,7 +60413,7 @@
         "is_package": false,
         "loc": 283,
         "module": "easyuse_anima.aio.torch_compile_recommendation",
-        "normalized_git_blob_sha1": "c6270c6c1e78fb0c043d0c689f3b6bba4da89a92",
+        "normalized_git_blob_sha1": "8b0d9652cea43f7d1d44f49db01c5e9b7af0e7bd",
         "path": "easyuse_anima/aio/torch_compile_recommendation.py",
         "top_level": {
           "class_count": 0,

--- a/tests/test_aio_torch_compile_recommendation.py
+++ b/tests/test_aio_torch_compile_recommendation.py
@@ -85,6 +85,13 @@ class TorchCompileWorkloadClassificationTests(unittest.TestCase):
                 ["highres"],
             ),
             (
+                "highres with missing base resolution",
+                _settings(highres=True),
+                {},
+                "variable_shapes",
+                ["highres"],
+            ),
+            (
                 "detailer",
                 _settings(detailer=True),
                 {"width": 1024, "height": 1024},
@@ -147,6 +154,15 @@ class TorchCompileWorkloadClassificationTests(unittest.TestCase):
         self.assertEqual(workload["shape_class"], "unknown")
         self.assertIsNone(workload["batch_size"])
         self.assertIn("batch_size_unknown", workload["reason_codes"])
+
+        variable = classify_torch_compile_workload(
+            _settings(detailer=True),
+            {"width": 1024, "height": 1024},
+            0,
+        )
+        self.assertEqual(variable["shape_class"], "variable_shapes")
+        self.assertEqual(variable["active_shape_stages"], ["detailer"])
+        self.assertIn("batch_size_unknown", variable["reason_codes"])
 
     def test_vram_tiers_have_explicit_practical_boundaries(self):
         cases = (


### PR DESCRIPTION
## 목적과 변경 경계

COMPILE-03 feasibility에서 확인된 production request 경계를 반영하는 AIO-COMPILE-02B / #410 correction입니다. AiO Generator는 base resolution을 generation settings에 저장하지 않으므로 frontend는 이를 안전하게 unknown으로 보냅니다. 이때 이미 활성화된 Highres/Detailer/USDU의 확실한 variable signal이 missing resolution/batch에 의해 unknown으로 덮이지 않도록 classifier precedence만 수정합니다.

## Base -> Head

`a56c0415567a37b4f7b06b26424c498bb8be3515` -> `535588846ad6755a3f3a0d27938819080aff51d8`

## 보존 계약

- fixed는 계속 known positive resolution + batch + complete stage contract를 요구
- ResShift-only, unknown upscale backend, no-variable malformed stage는 기존 fail-closed 유지
- selected values, policy version, route, UI, workflow/public contract, prompt-data parsing은 변경하지 않음
- known variable stage는 missing base context보다 논리적으로 우선하며 reason codes는 누락 context도 계속 기록

## Evidence

- changed Python compile: PASS
- focused policy: 10 PASS — Highres missing resolution, Detailer missing batch, fixed/ResShift/unknown regression
- analyzer closure: 1 PASS
- focused Pyright: 0 diagnostics
- diff check: PASS
- official full exact head: PASS — Python 1,191; frontend 118; TypeScript 6.0.3; Pyright baseline 117 files/14 reviewed errors; import boundary 0
- package validate/pack: PASS, 271 entries, recommendation module included, tests/docs/Git metadata excluded, SHA-256 `FE7F1AE6764FD673969B5F58F6AD6B55A81E003C10AD3E196F51CC54144E96A4`
- benchmark: not retriggered; recommendation values/evidence revision unchanged
- live: not triggered

Rollback은 이 correction commit 단위입니다. Next: merge 후 latest dev에서 AIO-COMPILE-03 UI를 재생성합니다.

Refs #410
