### PR TITLE
AIO-COMPILE-03: add Torch Compile recommendation draft UI

### DIFF
--- a/tests/frontend_aio_advanced_settings_dialog_smoke.mjs
+++ b/tests/frontend_aio_advanced_settings_dialog_smoke.mjs
@@ -72,11 +72,13 @@ function assertDisabled(entries, expected = true) {
 }
 
 async function flushPromises() {
-  await Promise.resolve();
-  await Promise.resolve();
+  for (let index = 0; index < 6; index += 1) {
+    await Promise.resolve();
+  }
 }
 
 const advancedDialogModule = await import(dataModule("../web/js/aio/advanced_settings_dialog.js"));
+const recommendationModule = await import(dataModule("../web/js/aio/torch_compile_recommendation.js"));
 const settingsModule = await import(dataModule("../web/js/aio/settings.js"));
 assert.deepEqual(
   Object.keys(advancedDialogModule),
@@ -151,7 +153,13 @@ function configuredSettings() {
   };
 }
 
-function createFixture({ settings = {}, available = {}, deferLoads = false } = {}) {
+function createFixture({
+  settings = {},
+  available = {},
+  deferLoads = false,
+  recommendationResults = [],
+  deferRecommendations = false,
+} = {}) {
   let dependencyCalls = 0;
   let currentDialog = null;
   const dialogs = [];
@@ -162,6 +170,8 @@ function createFixture({ settings = {}, available = {}, deferLoads = false } = {
   const clampCalls = [];
   const writes = [];
   const renders = [];
+  const recommendationCalls = [];
+  const recommendationResolvers = [];
   const document = createFakeDocument();
   const availabilityState = { ...available };
   const defaultSettings = clone(settingsModule.AIO_DEFAULT_GENERATION_SETTINGS);
@@ -305,6 +315,27 @@ function createFixture({ settings = {}, available = {}, deferLoads = false } = {
     currentDialog.trace.push("render");
   }
 
+  function recommend(settingsSnapshot, context) {
+    dependencyCalls += 1;
+    recommendationCalls.push({
+      settings: clone(settingsSnapshot),
+      context: clone(context),
+    });
+    if (deferRecommendations) {
+      return new Promise((resolve, reject) => {
+        recommendationResolvers.push({ resolve, reject });
+      });
+    }
+    const next = recommendationResults.shift();
+    if (next instanceof Error) {
+      throw next;
+    }
+    if (next === undefined) {
+      throw new Error("Missing fixture recommendation result");
+    }
+    return clone(next);
+  }
+
   const openAdvancedSettings = advancedDialogModule.aioCreateAdvancedSettingsDialog({
     document,
     controls: {
@@ -359,6 +390,10 @@ function createFixture({ settings = {}, available = {}, deferLoads = false } = {
         return new Promise((resolve) => loadResolvers.push(resolve));
       },
     },
+    recommendationAdapter: {
+      recommend,
+      diff: recommendationModule.aioTorchCompileRecommendationDiff,
+    },
   });
 
   return {
@@ -374,11 +409,22 @@ function createFixture({ settings = {}, available = {}, deferLoads = false } = {
     clampCalls,
     writes,
     renders,
+    recommendationCalls,
     dependencyCallCount: () => dependencyCalls,
     resolveLoads() {
       for (const resolve of loadResolvers.splice(0)) {
         resolve();
       }
+    },
+    resolveNextRecommendation(result) {
+      const pending = recommendationResolvers.shift();
+      assert.ok(pending, "missing deferred recommendation request");
+      pending.resolve(clone(result));
+    },
+    rejectNextRecommendation(error) {
+      const pending = recommendationResolvers.shift();
+      assert.ok(pending, "missing deferred recommendation request");
+      pending.reject(error);
     },
   };
 }
@@ -416,7 +462,8 @@ function createFixture({ settings = {}, available = {}, deferLoads = false } = {
   const torchDetails = subsectionByHeading(torch, "Torch Compile Parameters");
   const warning = find(
     modelPatches,
-    (element) => element.classList.contains("easyuse-anima-aio-warning"),
+    (element) => element.classList.contains("easyuse-anima-aio-warning")
+      && element.getAttribute?.("aria-live") !== "polite",
   );
   assert.ok(warning);
   assert.equal(warning.hidden, true);
@@ -736,7 +783,8 @@ for (const dependencyCase of [
   const torchDetails = subsectionByHeading(torch, "Torch Compile Parameters");
   const warning = find(
     modelPatches,
-    (element) => element.classList.contains("easyuse-anima-aio-warning"),
+    (element) => element.classList.contains("easyuse-anima-aio-warning")
+      && element.getAttribute?.("aria-live") !== "polite",
   );
   assert.ok(warning);
   const controlGroups = {
@@ -848,7 +896,8 @@ for (const dependencyCase of [
   const torchDetails = subsectionByHeading(torch, "Torch Compile Parameters");
   const warning = find(
     modelPatches,
-    (element) => element.classList.contains("easyuse-anima-aio-warning"),
+    (element) => element.classList.contains("easyuse-anima-aio-warning")
+      && element.getAttribute?.("aria-live") !== "polite",
   );
   assert.ok(warning);
   assert.equal(fixture.loadCalls.length, 1);
@@ -942,6 +991,223 @@ for (const dependencyCase of [
   assert.equal(fixture.node.settings.model_patches.kj.sage_allow_compile, false);
   assert.equal(fixture.node.settings.model_patches.kj.torch_compile.enabled, false);
   assert.deepEqual(JSON.parse(fixture.node.widgets[0].value), fixture.node.settings);
+}
+
+function supportedRecommendation() {
+  return {
+    supported: true,
+    profile: "stable_variable_shapes",
+    policyVersion: "recommendation-v1",
+    values: {
+      enabled: true,
+      backend: "inductor",
+      fullgraph: false,
+      mode: "default",
+      dynamic: "auto",
+      compile_transformer_blocks_only: true,
+      dynamo_cache_size_limit: 64,
+      debug_compile_keys: false,
+      disable_dynamic_vram: false,
+    },
+    reasonCodes: ["highres_changes_shape"],
+    warnings: ["first_compile_may_be_slow"],
+    environment: { accelerator: "cuda", totalVramMb: 16302 },
+  };
+}
+
+function torchRecommendationControls(dialog) {
+  const modelPatches = sectionByHeading(dialog.body, "Model Patch / Optimization");
+  const kj = subsectionByHeading(modelPatches, "KJNodes Optimization");
+  const torch = subsectionByHeading(kj, "Torch Compile (KJNodes)");
+  const details = subsectionByHeading(torch, "Torch Compile Parameters");
+  const button = findByText(torch, "text:button.torchCompileRecommend");
+  const status = find(torch, (element) => element.getAttribute?.("aria-live") === "polite");
+  assert.ok(button, "missing Torch Compile recommendation button");
+  assert.ok(status, "missing Torch Compile recommendation status");
+  return { torch, details, button, status };
+}
+
+{
+  const fixture = createFixture({
+    settings: configuredSettings(),
+    deferRecommendations: true,
+  });
+  const originalSettings = clone(fixture.node.settings);
+  const originalWidget = fixture.node.widgets[0].value;
+  fixture.openAdvancedSettings(fixture.node);
+  await flushPromises();
+  const dialog = fixture.dialogs[0];
+  const controls = torchRecommendationControls(dialog);
+
+  controls.button.emit("click");
+  assert.equal(controls.button.disabled, true);
+  assert.equal(controls.status.getAttribute("data-state"), "loading");
+  assert.equal(controls.status.textContent, "text:status.torchCompileLoading");
+  controls.button.emit("click");
+  await flushPromises();
+  assert.equal(fixture.recommendationCalls.length, 1, "A pending click must not duplicate requests");
+  assert.deepEqual(fixture.recommendationCalls[0], {
+    settings: originalSettings,
+    context: {},
+  });
+  assert.equal(fixture.writes.length, 0, "Recommendation loading must not write node settings");
+
+  fixture.resolveNextRecommendation(supportedRecommendation());
+  await flushPromises();
+  assert.equal(controls.button.disabled, false);
+  assert.equal(controls.status.getAttribute("data-state"), "supported");
+  assert.ok(controls.status.textContent.includes("text:status.torchCompileDraftApplied"));
+  assert.ok(controls.status.textContent.includes(
+    'format:status.torchCompileProfile:{"profile":"stable_variable_shapes"}',
+  ));
+  assert.ok(controls.status.textContent.includes(
+    'format:status.torchCompileEnvironment:{"accelerator":"cuda","vram":"16302 MiB"}',
+  ));
+  assert.ok(controls.status.textContent.includes(
+    'format:status.torchCompileReason:{"code":"highres_changes_shape"}',
+  ));
+  assert.ok(controls.status.textContent.includes(
+    'format:status.torchCompileWarning:{"code":"first_compile_may_be_slow"}',
+  ));
+  assertValues([
+    [controls.details, "Backend", "inductor"],
+    [controls.details, "Mode", "default"],
+    [controls.details, "Dynamic", "auto"],
+    [controls.details, "Dynamo cache limit", 64],
+  ]);
+  assertChecked([
+    [controls.torch, "Use Torch compile", true],
+    [controls.details, "Fullgraph", false],
+    [controls.details, "Transformer blocks only", true],
+    [controls.details, "Debug keys", false],
+    [controls.details, "Disable dynamic VRAM", false],
+  ]);
+  assert.deepEqual(fixture.node.settings, originalSettings, "Recommendation is draft-only");
+  assert.equal(fixture.node.widgets[0].value, originalWidget);
+  assert.equal(fixture.writes.length, 0);
+  assert.equal(fixture.renders.length, 0);
+
+  action(dialog, "button.cancel").emit("click");
+  assert.deepEqual(dialog.trace, ["remove"]);
+  assert.deepEqual(fixture.node.settings, originalSettings, "Cancel must discard recommendation draft");
+  assert.equal(fixture.node.widgets[0].value, originalWidget);
+}
+
+{
+  const fixture = createFixture({
+    settings: configuredSettings(),
+    recommendationResults: [supportedRecommendation()],
+  });
+  fixture.openAdvancedSettings(fixture.node);
+  await flushPromises();
+  const dialog = fixture.dialogs[0];
+  const controls = torchRecommendationControls(dialog);
+  controls.button.emit("click");
+  await flushPromises();
+  assert.equal(fixture.writes.length, 0);
+  action(dialog, "button.apply").emit("click");
+  assert.deepEqual(dialog.trace, ["merge", "write", "render", "remove"]);
+  assert.deepEqual(
+    {
+      enabled: fixture.node.settings.model_patches.kj.torch_compile.enabled,
+      backend: fixture.node.settings.model_patches.kj.torch_compile.backend,
+      fullgraph: fixture.node.settings.model_patches.kj.torch_compile.fullgraph,
+      mode: fixture.node.settings.model_patches.kj.torch_compile.mode,
+      dynamic: fixture.node.settings.model_patches.kj.torch_compile.dynamic,
+      compile_transformer_blocks_only: (
+        fixture.node.settings.model_patches.kj.torch_compile.compile_transformer_blocks_only
+      ),
+      dynamo_cache_size_limit: (
+        fixture.node.settings.model_patches.kj.torch_compile.dynamo_cache_size_limit
+      ),
+      debug_compile_keys: fixture.node.settings.model_patches.kj.torch_compile.debug_compile_keys,
+      disable_dynamic_vram: fixture.node.settings.model_patches.kj.torch_compile.disable_dynamic_vram,
+    },
+    supportedRecommendation().values,
+    "Only final Apply may persist a recommendation",
+  );
+  assert.equal(
+    fixture.node.settings.model_patches.kj.torch_compile.future_torch_key,
+    "keep-torch",
+    "Unknown Torch Compile settings must survive final Apply",
+  );
+}
+
+{
+  const unsupported = {
+    supported: false,
+    profile: "unsupported_environment",
+    policyVersion: "recommendation-v1",
+    values: null,
+    reasonCodes: ["unsupported_accelerator"],
+    warnings: [],
+    environment: { accelerator: "cpu", totalVramMb: null },
+  };
+  const fixture = createFixture({
+    settings: configuredSettings(),
+    recommendationResults: [unsupported],
+  });
+  fixture.openAdvancedSettings(fixture.node);
+  await flushPromises();
+  const dialog = fixture.dialogs[0];
+  const controls = torchRecommendationControls(dialog);
+  const before = {
+    backend: controlIn(controls.details, "Backend").value,
+    dynamic: controlIn(controls.details, "Dynamic").value,
+    enabled: controlIn(controls.torch, "Use Torch compile").checked,
+  };
+  controls.button.emit("click");
+  await flushPromises();
+  assert.equal(controls.status.getAttribute("data-state"), "unsupported");
+  assert.ok(controls.status.textContent.includes("text:status.torchCompileUnsupported"));
+  assert.deepEqual({
+    backend: controlIn(controls.details, "Backend").value,
+    dynamic: controlIn(controls.details, "Dynamic").value,
+    enabled: controlIn(controls.torch, "Use Torch compile").checked,
+  }, before, "Unsupported responses must not mutate controls");
+  assert.equal(fixture.writes.length, 0);
+}
+
+{
+  const fixture = createFixture({
+    settings: configuredSettings(),
+    recommendationResults: [new Error("policy unavailable")],
+  });
+  fixture.openAdvancedSettings(fixture.node);
+  await flushPromises();
+  const dialog = fixture.dialogs[0];
+  const controls = torchRecommendationControls(dialog);
+  const before = controlIn(controls.details, "Backend").value;
+  controls.button.emit("click");
+  await flushPromises();
+  assert.equal(controls.status.getAttribute("data-state"), "error");
+  assert.equal(
+    controls.status.textContent,
+    'format:status.torchCompileRequestFailed:{"message":"policy unavailable"}',
+  );
+  assert.equal(controlIn(controls.details, "Backend").value, before);
+  assert.equal(fixture.writes.length, 0);
+}
+
+{
+  const fixture = createFixture({
+    settings: configuredSettings(),
+    deferRecommendations: true,
+  });
+  const originalSettings = clone(fixture.node.settings);
+  fixture.openAdvancedSettings(fixture.node);
+  await flushPromises();
+  const dialog = fixture.dialogs[0];
+  const controls = torchRecommendationControls(dialog);
+  const before = controlIn(controls.details, "Backend").value;
+  controls.button.emit("click");
+  await flushPromises();
+  action(dialog, "button.cancel").emit("click");
+  fixture.resolveNextRecommendation(supportedRecommendation());
+  await flushPromises();
+  assert.equal(controlIn(controls.details, "Backend").value, before);
+  assert.deepEqual(fixture.node.settings, originalSettings);
+  assert.equal(fixture.writes.length, 0, "A late result after Cancel must be ignored");
 }
 
 console.log("AiO Advanced settings dialog smoke passed.");

--- a/tests/frontend_aio_torch_compile_recommendation_smoke.mjs
+++ b/tests/frontend_aio_torch_compile_recommendation_smoke.mjs
@@ -1,0 +1,243 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+function dataModule(relativePath) {
+  const source = readFileSync(new URL(relativePath, import.meta.url), "utf8");
+  return "data:text/javascript;base64," + Buffer.from(source).toString("base64");
+}
+
+function clone(value) {
+  return value == null ? value : JSON.parse(JSON.stringify(value));
+}
+
+const module = await import(dataModule("../web/js/aio/torch_compile_recommendation.js"));
+assert.deepEqual(Object.keys(module), [
+  "aioNormalizeTorchCompileRecommendation",
+  "aioTorchCompileRecommendationDiff",
+  "aioTorchCompileRecommendationRequest",
+  "createAioTorchCompileRecommendationClient",
+]);
+
+const settings = {
+  highres: { enabled: true, prompt: "must-not-leak" },
+  detailer: { enabled: false, user_data: { secret: true } },
+  upscale: { enabled: true, backend: "ultimate_sd_upscale", workflow: { id: 9 } },
+  prompt: "must-not-leak",
+  profile: { name: "must-not-leak" },
+  model: "must-not-leak",
+  future_root: "must-not-leak",
+};
+const originalSettings = clone(settings);
+assert.deepEqual(
+  module.aioTorchCompileRecommendationRequest(settings, {
+    resolution: { width: 1024, height: 1536, prompt: "must-not-leak" },
+    batchSize: 4,
+    user: "must-not-leak",
+  }),
+  {
+    generation_settings: {
+      highres: { enabled: true },
+      detailer: { enabled: false },
+      upscale: { enabled: true, backend: "ultimate_sd_upscale" },
+    },
+    resolution: { width: 1024, height: 1536 },
+    batch_size: 4,
+  },
+  "The request must contain only bounded workload facts",
+);
+assert.deepEqual(settings, originalSettings, "Building a request must not mutate settings");
+assert.deepEqual(
+  module.aioTorchCompileRecommendationRequest({
+    highres: { enabled: "true" },
+    detailer: null,
+    upscale: { enabled: true, backend: "x".repeat(100) },
+  }, {
+    resolution: { width: 0, height: 99999 },
+    batchSize: 0,
+  }),
+  {
+    generation_settings: {
+      highres: { enabled: null },
+      detailer: { enabled: null },
+      upscale: { enabled: true, backend: "x".repeat(80) },
+    },
+    resolution: {},
+    batch_size: 1,
+  },
+  "Invalid optional context must fall back without guessing",
+);
+
+const backendResponse = {
+  supported: true,
+  profile: "stable_variable_shapes",
+  policy_version: "recommendation-v1",
+  values: {
+    enabled: true,
+    backend: "inductor",
+    fullgraph: false,
+    mode: "default",
+    dynamic: "auto",
+    compile_transformer_blocks_only: true,
+    dynamo_cache_size_limit: 64,
+    debug_compile_keys: false,
+    disable_dynamic_vram: false,
+    future_backend_field: "ignored",
+  },
+  reason_codes: ["highres_changes_shape"],
+  warnings: ["first_compile_may_be_slow"],
+  environment: {
+    accelerator: "cuda",
+    total_vram_mb: 16302,
+    device_name: "must-not-propagate",
+  },
+  future_response_field: "ignored",
+};
+const expectedNormalized = {
+  supported: true,
+  profile: "stable_variable_shapes",
+  policyVersion: "recommendation-v1",
+  values: {
+    enabled: true,
+    backend: "inductor",
+    fullgraph: false,
+    mode: "default",
+    dynamic: "auto",
+    compile_transformer_blocks_only: true,
+    dynamo_cache_size_limit: 64,
+    debug_compile_keys: false,
+    disable_dynamic_vram: false,
+  },
+  reasonCodes: ["highres_changes_shape"],
+  warnings: ["first_compile_may_be_slow"],
+  environment: { accelerator: "cuda", totalVramMb: 16302 },
+};
+assert.deepEqual(
+  module.aioNormalizeTorchCompileRecommendation(backendResponse),
+  expectedNormalized,
+  "Only the canonical response allowlist may reach dialog controls",
+);
+assert.deepEqual(
+  module.aioNormalizeTorchCompileRecommendation({
+    supported: false,
+    profile: "unsupported_environment",
+    policy_version: "recommendation-v1",
+    values: { enabled: true },
+    reason_codes: ["unsupported_accelerator"],
+    warnings: [],
+    environment: { accelerator: 9, total_vram_mb: -1 },
+  }),
+  {
+    supported: false,
+    profile: "unsupported_environment",
+    policyVersion: "recommendation-v1",
+    values: null,
+    reasonCodes: ["unsupported_accelerator"],
+    warnings: [],
+    environment: { accelerator: "unknown", totalVramMb: null },
+  },
+  "Unsupported recommendations must never expose partial control values",
+);
+
+assert.deepEqual(
+  module.aioTorchCompileRecommendationDiff(
+    {
+      enabled: false,
+      backend: "manual-backend",
+      dynamic: "false",
+      future_manual_field: "preserve",
+    },
+    {
+      ...expectedNormalized.values,
+      future_recommendation_field: "ignored",
+    },
+  ),
+  [
+    { name: "enabled", current: false, recommended: true },
+    { name: "backend", current: "manual-backend", recommended: "inductor" },
+    { name: "fullgraph", current: undefined, recommended: false },
+    { name: "mode", current: undefined, recommended: "default" },
+    { name: "dynamic", current: "false", recommended: "auto" },
+    { name: "compile_transformer_blocks_only", current: undefined, recommended: true },
+    { name: "dynamo_cache_size_limit", current: undefined, recommended: 64 },
+    { name: "debug_compile_keys", current: undefined, recommended: false },
+    { name: "disable_dynamic_vram", current: undefined, recommended: false },
+  ],
+  "Diffs must be restricted to the nine Torch Compile controls",
+);
+
+const calls = [];
+const client = module.createAioTorchCompileRecommendationClient({
+  fetchJson(url, options) {
+    calls.push({ url, options: clone(options) });
+    return Promise.resolve(clone(backendResponse));
+  },
+});
+assert.equal(calls.length, 0, "Client composition must be side-effect free");
+assert.deepEqual(
+  await client.recommend(settings, {
+    resolution: { width: 1024, height: 1536 },
+    batchSize: 4,
+  }),
+  expectedNormalized,
+);
+assert.deepEqual(calls, [{
+  url: "/easyuse_anima/aio/torch-compile/recommend",
+  options: {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      generation_settings: {
+        highres: { enabled: true },
+        detailer: { enabled: false },
+        upscale: { enabled: true, backend: "ultimate_sd_upscale" },
+      },
+      resolution: { width: 1024, height: 1536 },
+      batch_size: 4,
+    }),
+  },
+}]);
+
+const validValues = backendResponse.values;
+for (const [name, malformed] of [
+  ["missing supported", { ...backendResponse, supported: undefined }],
+  ["bad profile", { ...backendResponse, profile: "" }],
+  ["bad policy", { ...backendResponse, policy_version: 7 }],
+  ["bad reasons", { ...backendResponse, reason_codes: "reason" }],
+  ["too many warnings", { ...backendResponse, warnings: Array(33).fill("warning") }],
+  ["long reason", { ...backendResponse, reason_codes: ["x".repeat(161)] }],
+  ["missing values", { ...backendResponse, values: null }],
+  ["bad enabled", { ...backendResponse, values: { ...validValues, enabled: 1 } }],
+  ["bad backend", { ...backendResponse, values: { ...validValues, backend: "future" } }],
+  ["bad fullgraph", { ...backendResponse, values: { ...validValues, fullgraph: "false" } }],
+  ["bad mode", { ...backendResponse, values: { ...validValues, mode: "future" } }],
+  ["bad dynamic", { ...backendResponse, values: { ...validValues, dynamic: "default" } }],
+  ["bad blocks", {
+    ...backendResponse,
+    values: { ...validValues, compile_transformer_blocks_only: null },
+  }],
+  ["bad cache", {
+    ...backendResponse,
+    values: { ...validValues, dynamo_cache_size_limit: 4097 },
+  }],
+  ["bad debug", { ...backendResponse, values: { ...validValues, debug_compile_keys: 0 } }],
+  ["bad vram flag", {
+    ...backendResponse,
+    values: { ...validValues, disable_dynamic_vram: "false" },
+  }],
+]) {
+  assert.throws(
+    () => module.aioNormalizeTorchCompileRecommendation(malformed),
+    TypeError,
+    `${name} must fail closed`,
+  );
+}
+
+const fetchFailure = new Error("network unavailable");
+const failingClient = module.createAioTorchCompileRecommendationClient({
+  fetchJson() {
+    return Promise.reject(fetchFailure);
+  },
+});
+await assert.rejects(failingClient.recommend({}, {}), (error) => error === fetchFailure);
+
+console.log("AiO Torch Compile recommendation smoke passed.");

--- a/tests/test_frontend_modules.py
+++ b/tests/test_frontend_modules.py
@@ -93,6 +93,12 @@ AIO_ADVANCED_SETTINGS_DIALOG_JS = AIO_MODULES / "advanced_settings_dialog.js"
 AIO_ADVANCED_SETTINGS_DIALOG_SMOKE = (
     ROOT / "tests" / "frontend_aio_advanced_settings_dialog_smoke.mjs"
 )
+AIO_TORCH_COMPILE_RECOMMENDATION_JS = (
+    AIO_MODULES / "torch_compile_recommendation.js"
+)
+AIO_TORCH_COMPILE_RECOMMENDATION_SMOKE = (
+    ROOT / "tests" / "frontend_aio_torch_compile_recommendation_smoke.mjs"
+)
 AIO_PREVIEW_JS = AIO_MODULES / "preview.js"
 AIO_PREVIEW_CORE_SMOKE = ROOT / "tests" / "frontend_aio_preview_core_smoke.mjs"
 AIO_PRESETS_JS = AIO_MODULES / "presets.js"
@@ -1492,6 +1498,48 @@ class FrontendModuleStructureTests(unittest.TestCase):
             frontend_check_source,
         )
 
+    def test_aio_torch_compile_recommendation_has_bounded_data_contract(self):
+        source = AIO_TORCH_COMPILE_RECOMMENDATION_JS.read_text(encoding="utf-8")
+        entry_source = AIO_JS.read_text(encoding="utf-8")
+        frontend_check_source = FRONTEND_CHECK_SCRIPT.read_text(encoding="utf-8")
+
+        self.assertTrue(source.startswith("// @ts-check\n"))
+        self.assertEqual(STATIC_IMPORT_RE.findall(source), [])
+        self.assertNotRegex(source, r"(?m)^\s*import\s")
+        self.assertNotIn("fetch(", source)
+        self.assertNotIn("app.registerExtension", source)
+        self.assertNotRegex(
+            source,
+            re.compile(r"^(?:window|globalThis)\.[A-Za-z_$]", re.MULTILINE),
+        )
+        self.assertEqual(
+            re.findall(r"^export function ([A-Za-z0-9_]+)\(", source, re.MULTILINE),
+            [
+                "aioTorchCompileRecommendationRequest",
+                "aioNormalizeTorchCompileRecommendation",
+                "aioTorchCompileRecommendationDiff",
+                "createAioTorchCompileRecommendationClient",
+            ],
+        )
+        self.assertIn(
+            'from "./aio/torch_compile_recommendation.js";',
+            entry_source,
+        )
+        self.assertIn(
+            "const torchCompileRecommendationClient = "
+            "createAioTorchCompileRecommendationClient({",
+            entry_source,
+        )
+        self.assertIn(
+            "fetchJson: (url, options) => easyuseAnimaFetchComfyJson(api, url, options),",
+            entry_source,
+        )
+        self.assertTrue(AIO_TORCH_COMPILE_RECOMMENDATION_SMOKE.is_file())
+        self.assertIn(
+            r'node "tests\frontend_aio_torch_compile_recommendation_smoke.mjs"',
+            frontend_check_source,
+        )
+
     def test_aio_advanced_settings_dialog_has_closed_lifecycle_boundary(self):
         source = AIO_ADVANCED_SETTINGS_DIALOG_JS.read_text(encoding="utf-8")
         entry_source = AIO_JS.read_text(encoding="utf-8")
@@ -1545,6 +1593,9 @@ class FrontendModuleStructureTests(unittest.TestCase):
             "available: optionalDependencyAvailable,",
             "pack: optionalDependencyPack,",
             "load: loadGeneratorOptionalDependencies,",
+            "recommend: (settings, context) =>",
+            "torchCompileRecommendationClient.recommend(settings, context)",
+            "diff: aioTorchCompileRecommendationDiff,",
         ):
             with self.subTest(composition_dependency=expected):
                 self.assertIn(expected, composition)

--- a/tools/check_frontend.ps1
+++ b/tools/check_frontend.ps1
@@ -94,6 +94,11 @@ try {
         throw "Frontend AiO Save settings dialog smoke failed with exit code $LASTEXITCODE."
     }
 
+    & node "tests\frontend_aio_torch_compile_recommendation_smoke.mjs"
+    if ($LASTEXITCODE -ne 0) {
+        throw "Frontend AiO Torch Compile recommendation smoke failed with exit code $LASTEXITCODE."
+    }
+
     & node "tests\frontend_aio_advanced_settings_dialog_smoke.mjs"
     if ($LASTEXITCODE -ne 0) {
         throw "Frontend AiO Advanced settings dialog smoke failed with exit code $LASTEXITCODE."

--- a/web/js/aio/advanced_settings_dialog.js
+++ b/web/js/aio/advanced_settings_dialog.js
@@ -43,6 +43,12 @@
  */
 
 /**
+ * @typedef {object} AioAdvancedDialogRecommendationAdapter
+ * @property {(settings: any, context?: Record<string, any>) => Promise<any>} recommend
+ * @property {(current: any, values: any) => Array<{name: string, current: any, recommended: any}>} diff
+ */
+
+/**
  * @typedef {object} AioAdvancedSettingsDialogDependencies
  * @property {any} document
  * @property {AioAdvancedDialogControls} controls
@@ -50,6 +56,7 @@
  * @property {AioAdvancedDialogSettingsCore} settingsCore
  * @property {AioAdvancedDialogNodeAdapter} nodeAdapter
  * @property {AioAdvancedDialogDependencyAdapter} dependencyAdapter
+ * @property {AioAdvancedDialogRecommendationAdapter} recommendationAdapter
  */
 
 const DAVE_STAGE_IDS = Object.freeze([
@@ -100,6 +107,7 @@ export function aioCreateAdvancedSettingsDialog(dependencies) {
     settingsCore,
     nodeAdapter,
     dependencyAdapter,
+    recommendationAdapter,
   } = dependencies;
   const {
     createDialog,
@@ -133,6 +141,10 @@ export function aioCreateAdvancedSettingsDialog(dependencies) {
     notifyMissing: notifyMissingDependency,
     load: loadGeneratorOptionalDependencies,
   } = dependencyAdapter;
+  const {
+    recommend: recommendTorchCompile,
+    diff: torchCompileRecommendationDiff,
+  } = recommendationAdapter;
 
   function openAdvancedSettings(node) {
     const widget = findWidget(node, GENERATOR_SETTINGS_WIDGET);
@@ -305,7 +317,7 @@ export function aioCreateAdvancedSettingsDialog(dependencies) {
     const torchCompileDynamic = field(
       torchDetails,
       "Dynamic",
-      selectInput(["false", "true", "default"], settings.model_patches.kj.torch_compile.dynamic),
+      selectInput(["auto", "false", "true", "default"], settings.model_patches.kj.torch_compile.dynamic),
       "tip.torchCompileDynamic",
     );
     const torchCompileBlocksOnly = field(
@@ -332,7 +344,18 @@ export function aioCreateAdvancedSettingsDialog(dependencies) {
       checkbox(settings.model_patches.kj.torch_compile.disable_dynamic_vram),
       "tip.torchCompileVram",
     );
-    torch.append(torchDetails);
+    const torchRecommendationActions = document.createElement("div");
+    torchRecommendationActions.className = "easyuse-anima-aio-dialog-actions";
+    const torchRecommendButton = document.createElement("button");
+    torchRecommendButton.type = "button";
+    torchRecommendButton.textContent = aioText("button.torchCompileRecommend");
+    torchRecommendationActions.append(torchRecommendButton);
+    const torchRecommendationStatus = document.createElement("div");
+    torchRecommendationStatus.className = "easyuse-anima-aio-warning";
+    torchRecommendationStatus.hidden = true;
+    torchRecommendationStatus.style.whiteSpace = "pre-line";
+    torchRecommendationStatus.setAttribute("aria-live", "polite");
+    torch.append(torchRecommendationActions, torchRecommendationStatus, torchDetails);
     kj.append(torch);
 
     const modelWarning = document.createElement("div");
@@ -373,6 +396,106 @@ export function aioCreateAdvancedSettingsDialog(dependencies) {
     const refreshTorchDetails = () => {
       torchDetails.style.display = torchCompileEnabled.checked ? "" : "none";
     };
+    const torchControlValues = () => ({
+      enabled: torchCompileEnabled.checked,
+      backend: torchCompileBackend.value,
+      fullgraph: torchCompileFullgraph.checked,
+      mode: torchCompileMode.value,
+      dynamic: torchCompileDynamic.value,
+      compile_transformer_blocks_only: torchCompileBlocksOnly.checked,
+      dynamo_cache_size_limit: Number(torchCompileCache.value),
+      debug_compile_keys: torchCompileDebug.checked,
+      disable_dynamic_vram: torchCompileDisableVram.checked,
+    });
+    const applyTorchRecommendationDraft = (values) => {
+      torchCompileEnabled.checked = values.enabled;
+      torchCompileBackend.value = values.backend;
+      torchCompileFullgraph.checked = values.fullgraph;
+      torchCompileMode.value = values.mode;
+      torchCompileDynamic.value = values.dynamic;
+      torchCompileBlocksOnly.checked = values.compile_transformer_blocks_only;
+      torchCompileCache.value = String(values.dynamo_cache_size_limit);
+      torchCompileDebug.checked = values.debug_compile_keys;
+      torchCompileDisableVram.checked = values.disable_dynamic_vram;
+      refreshTorchDetails();
+    };
+    const displayRecommendationValue = (value) => (
+      value === undefined || value === null || value === "" ? "—" : String(value)
+    );
+    const recommendationLines = (result, changes = null) => {
+      const vram = result.environment.totalVramMb == null
+        ? "unknown"
+        : `${result.environment.totalVramMb} MiB`;
+      return [
+        aioFormat("status.torchCompileProfile", { profile: result.profile }),
+        aioFormat("status.torchCompileEnvironment", {
+          accelerator: result.environment.accelerator,
+          vram,
+        }),
+        ...(Array.isArray(changes) && changes.length
+          ? changes.map((change) => aioFormat("status.torchCompileChange", {
+              field: change.name,
+              current: displayRecommendationValue(change.current),
+              recommended: displayRecommendationValue(change.recommended),
+            }))
+          : (changes === null ? [] : [aioText("status.torchCompileNoChanges")])),
+        ...result.reasonCodes.map((code) => aioFormat("status.torchCompileReason", { code })),
+        ...result.warnings.map((code) => aioFormat("status.torchCompileWarning", { code })),
+      ];
+    };
+    const showTorchRecommendationStatus = (state, lines) => {
+      torchRecommendationStatus.hidden = false;
+      torchRecommendationStatus.setAttribute("data-state", state);
+      torchRecommendationStatus.textContent = lines.join("\n");
+    };
+    let recommendationClosed = false;
+    let recommendationPending = false;
+    torchRecommendButton.addEventListener("click", () => {
+      if (recommendationClosed || recommendationPending) {
+        return;
+      }
+      recommendationPending = true;
+      torchRecommendButton.disabled = true;
+      showTorchRecommendationStatus("loading", [aioText("status.torchCompileLoading")]);
+      Promise.resolve()
+        .then(() => recommendTorchCompile(settings, {}))
+        .then((result) => {
+          if (recommendationClosed) {
+            return;
+          }
+          if (!result.supported || !result.values) {
+            showTorchRecommendationStatus("unsupported", [
+              aioText("status.torchCompileUnsupported"),
+              ...recommendationLines(result),
+            ]);
+            return;
+          }
+          const changes = torchCompileRecommendationDiff(
+            torchControlValues(),
+            result.values,
+          );
+          applyTorchRecommendationDraft(result.values);
+          showTorchRecommendationStatus("supported", [
+            aioText("status.torchCompileDraftApplied"),
+            ...recommendationLines(result, changes),
+          ]);
+        })
+        .catch((error) => {
+          if (!recommendationClosed) {
+            showTorchRecommendationStatus("error", [
+              aioFormat("status.torchCompileRequestFailed", {
+                message: error?.message || "unknown error",
+              }),
+            ]);
+          }
+        })
+        .finally(() => {
+          recommendationPending = false;
+          if (!recommendationClosed) {
+            torchRecommendButton.disabled = false;
+          }
+        });
+    });
     const refreshDaveStageScope = () => {
       const preset = DAVE_STAGE_SCOPE_PRESETS[daveStagePreset.value];
       if (preset) {
@@ -547,8 +670,12 @@ export function aioCreateAdvancedSettingsDialog(dependencies) {
     apply.className = "primary";
     apply.textContent = aioText("button.apply");
     actions.append(cancel, apply);
-    cancel.addEventListener("click", () => backdrop.remove());
+    cancel.addEventListener("click", () => {
+      recommendationClosed = true;
+      backdrop.remove();
+    });
     apply.addEventListener("click", () => {
+      recommendationClosed = true;
       const next = mergeDefaults(DEFAULT_GENERATION_SETTINGS, settings);
       delete next.sampler.dave;
       delete next.model_patches.aura_flow.enabled;

--- a/web/js/aio/torch_compile_recommendation.js
+++ b/web/js/aio/torch_compile_recommendation.js
@@ -1,0 +1,206 @@
+// @ts-check
+
+const RECOMMENDATION_ENDPOINT = "/easyuse_anima/aio/torch-compile/recommend";
+const RECOMMENDATION_FIELDS = Object.freeze([
+  "enabled",
+  "backend",
+  "fullgraph",
+  "mode",
+  "dynamic",
+  "compile_transformer_blocks_only",
+  "dynamo_cache_size_limit",
+  "debug_compile_keys",
+  "disable_dynamic_vram",
+]);
+const MODES = new Set([
+  "default",
+  "reduce-overhead",
+  "max-autotune",
+  "max-autotune-no-cudagraphs",
+]);
+const DYNAMIC_VALUES = new Set(["auto", "true", "false"]);
+
+function objectValue(value) {
+  return value && typeof value === "object" && !Array.isArray(value) ? value : null;
+}
+
+function explicitBoolean(value) {
+  return typeof value === "boolean" ? value : null;
+}
+
+function boundedString(value, name, { maximum = 160, allowed = null } = {}) {
+  if (typeof value !== "string" || !value || value.length > maximum) {
+    throw new TypeError(`Malformed Torch Compile recommendation ${name}`);
+  }
+  if (allowed && !allowed.has(value)) {
+    throw new TypeError(`Unsupported Torch Compile recommendation ${name}`);
+  }
+  return value;
+}
+
+function boundedStringList(value, name) {
+  if (!Array.isArray(value) || value.length > 32) {
+    throw new TypeError(`Malformed Torch Compile recommendation ${name}`);
+  }
+  return value.map((item) => boundedString(item, name));
+}
+
+function requiredBoolean(value, name) {
+  if (typeof value !== "boolean") {
+    throw new TypeError(`Malformed Torch Compile recommendation ${name}`);
+  }
+  return value;
+}
+
+function requiredInteger(value, name) {
+  if (!Number.isInteger(value) || value < 1 || value > 4096) {
+    throw new TypeError(`Malformed Torch Compile recommendation ${name}`);
+  }
+  return value;
+}
+
+function stageRequest(settings, name) {
+  const section = objectValue(settings?.[name]);
+  /** @type {{ enabled: boolean | null, backend?: string | null }} */
+  const request = { enabled: explicitBoolean(section?.enabled) };
+  if (name === "upscale") {
+    request.backend = typeof section?.backend === "string" && section.backend
+      ? section.backend.slice(0, 80)
+      : null;
+  }
+  return request;
+}
+
+/**
+ * Build the minimum workload request. Prompt fields, profiles, workflow data,
+ * and model/user values are intentionally excluded.
+ */
+export function aioTorchCompileRecommendationRequest(settings, context = {}) {
+  const resolution = objectValue(context?.resolution);
+  const width = resolution?.width;
+  const height = resolution?.height;
+  const exactResolution = Number.isInteger(width)
+    && width > 0
+    && width <= 16384
+    && Number.isInteger(height)
+    && height > 0
+    && height <= 16384
+      ? { width, height }
+      : {};
+  const requestedBatch = context?.batchSize;
+  const batchSize = Number.isInteger(requestedBatch)
+    && requestedBatch > 0
+    && requestedBatch <= 4096
+      ? requestedBatch
+      : 1;
+
+  return {
+    generation_settings: {
+      highres: stageRequest(settings, "highres"),
+      detailer: stageRequest(settings, "detailer"),
+      upscale: stageRequest(settings, "upscale"),
+    },
+    resolution: exactResolution,
+    batch_size: batchSize,
+  };
+}
+
+/**
+ * Validate and narrow the backend response before any dialog control changes.
+ */
+export function aioNormalizeTorchCompileRecommendation(payload) {
+  const source = objectValue(payload);
+  if (!source || typeof source.supported !== "boolean") {
+    throw new TypeError("Malformed Torch Compile recommendation response");
+  }
+  const profile = boundedString(source.profile, "profile", { maximum: 80 });
+  const policyVersion = boundedString(source.policy_version, "policy version", { maximum: 80 });
+  const reasonCodes = boundedStringList(source.reason_codes, "reason codes");
+  const warnings = boundedStringList(source.warnings, "warnings");
+  const environment = objectValue(source.environment) || {};
+  const accelerator = typeof environment.accelerator === "string"
+    ? environment.accelerator.slice(0, 40)
+    : "unknown";
+  const totalVramMb = Number.isInteger(environment.total_vram_mb)
+    && environment.total_vram_mb > 0
+      ? environment.total_vram_mb
+      : null;
+
+  if (!source.supported) {
+    return {
+      supported: false,
+      profile,
+      policyVersion,
+      values: null,
+      reasonCodes,
+      warnings,
+      environment: { accelerator, totalVramMb },
+    };
+  }
+
+  const values = objectValue(source.values);
+  if (!values) {
+    throw new TypeError("Malformed Torch Compile recommendation values");
+  }
+  const normalizedValues = {
+    enabled: requiredBoolean(values.enabled, "enabled"),
+    backend: boundedString(values.backend, "backend", {
+      maximum: 80,
+      allowed: new Set(["inductor"]),
+    }),
+    fullgraph: requiredBoolean(values.fullgraph, "fullgraph"),
+    mode: boundedString(values.mode, "mode", { maximum: 80, allowed: MODES }),
+    dynamic: boundedString(values.dynamic, "dynamic", {
+      maximum: 16,
+      allowed: DYNAMIC_VALUES,
+    }),
+    compile_transformer_blocks_only: requiredBoolean(
+      values.compile_transformer_blocks_only,
+      "compile_transformer_blocks_only",
+    ),
+    dynamo_cache_size_limit: requiredInteger(
+      values.dynamo_cache_size_limit,
+      "dynamo_cache_size_limit",
+    ),
+    debug_compile_keys: requiredBoolean(values.debug_compile_keys, "debug_compile_keys"),
+    disable_dynamic_vram: requiredBoolean(
+      values.disable_dynamic_vram,
+      "disable_dynamic_vram",
+    ),
+  };
+
+  return {
+    supported: true,
+    profile,
+    policyVersion,
+    values: normalizedValues,
+    reasonCodes,
+    warnings,
+    environment: { accelerator, totalVramMb },
+  };
+}
+
+export function aioTorchCompileRecommendationDiff(current, recommendationValues) {
+  const currentValues = objectValue(current) || {};
+  const nextValues = objectValue(recommendationValues) || {};
+  return RECOMMENDATION_FIELDS
+    .filter((name) => Object.hasOwn(nextValues, name) && currentValues[name] !== nextValues[name])
+    .map((name) => ({
+      name,
+      current: currentValues[name],
+      recommended: nextValues[name],
+    }));
+}
+
+export function createAioTorchCompileRecommendationClient(dependencies) {
+  const { fetchJson } = dependencies;
+  return {
+    recommend(settings, context = {}) {
+      return fetchJson(RECOMMENDATION_ENDPOINT, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(aioTorchCompileRecommendationRequest(settings, context)),
+      }).then(aioNormalizeTorchCompileRecommendation);
+    },
+  };
+}

--- a/web/js/easyuse_anima_aio.js
+++ b/web/js/easyuse_anima_aio.js
@@ -27,6 +27,10 @@ import { aioCreateDetailerSettingsDialog } from "./aio/detailer_settings_dialog.
 import { aioCreateSamplerSettingsDialog } from "./aio/sampler_settings_dialog.js";
 import { aioCreateSaveSettingsDialog } from "./aio/save_settings_dialog.js";
 import { aioCreateAdvancedSettingsDialog } from "./aio/advanced_settings_dialog.js";
+import {
+  aioTorchCompileRecommendationDiff,
+  createAioTorchCompileRecommendationClient,
+} from "./aio/torch_compile_recommendation.js";
 import { aioMarkMissingDependencyControl } from "./aio/dependency_controls.js";
 import { aioCreateNativePreviewRuntime } from "./aio/native_preview_runtime.js";
 import {
@@ -1052,6 +1056,17 @@ const AIO_TOOLTIP_TEXT = {
     "button.close": "Close",
     "button.cancel": "Cancel",
     "button.apply": "Apply",
+    "button.torchCompileRecommend": "Auto-configure for current environment",
+    "status.torchCompileLoading": "Checking the current environment…",
+    "status.torchCompileUnsupported": "Automatic Torch Compile settings are unavailable.",
+    "status.torchCompileDraftApplied": "Recommendation applied to this dialog draft. Use Apply to save it.",
+    "status.torchCompileProfile": "Profile: {profile}",
+    "status.torchCompileEnvironment": "Environment: {accelerator}, VRAM {vram}",
+    "status.torchCompileChange": "{field}: {current} → {recommended}",
+    "status.torchCompileNoChanges": "Recommended values already match this dialog.",
+    "status.torchCompileReason": "Reason: {code}",
+    "status.torchCompileWarning": "Warning: {code}",
+    "status.torchCompileRequestFailed": "Recommendation request failed: {message}",
     "tip.inputUnetDtype": "Weight dtype used when Easy Use Anima Input loads the diffusion model. Keep default unless VRAM or speed tuning requires another dtype.",
     "tip.inputClipDevice": "Device preference for loading CLIP. CPU can reduce VRAM use at the cost of slower prompt encoding.",
     "tip.seedMode": "After-execution behavior for the seed value. This mirrors rgthree Seed controls.",
@@ -1165,6 +1180,17 @@ const AIO_TOOLTIP_TEXT = {
     "button.close": "닫기",
     "button.cancel": "취소",
     "button.apply": "적용",
+    "button.torchCompileRecommend": "현재 환경에 맞게 자동 설정",
+    "status.torchCompileLoading": "현재 환경을 확인하는 중…",
+    "status.torchCompileUnsupported": "Torch Compile 자동 설정을 사용할 수 없습니다.",
+    "status.torchCompileDraftApplied": "추천값을 이 대화상자 초안에 적용했습니다. 저장하려면 적용을 누르세요.",
+    "status.torchCompileProfile": "프로필: {profile}",
+    "status.torchCompileEnvironment": "환경: {accelerator}, VRAM {vram}",
+    "status.torchCompileChange": "{field}: {current} → {recommended}",
+    "status.torchCompileNoChanges": "추천값이 현재 대화상자와 같습니다.",
+    "status.torchCompileReason": "이유: {code}",
+    "status.torchCompileWarning": "주의: {code}",
+    "status.torchCompileRequestFailed": "추천 요청 실패: {message}",
     "tip.inputUnetDtype": "Easy Use Anima Input이 디퓨전 모델을 로드할 때 사용할 weight dtype입니다. VRAM/속도 튜닝이 필요 없으면 default를 유지합니다.",
     "tip.inputClipDevice": "CLIP 로드 장치 설정입니다. CPU는 VRAM을 줄일 수 있지만 프롬프트 인코딩이 느려질 수 있습니다.",
     "tip.seedMode": "백엔드 실행 완료 후 시드 처리 방식입니다. rgthree Seed 컨트롤과 같은 의미로 동작합니다.",
@@ -1278,6 +1304,17 @@ const AIO_TOOLTIP_TEXT = {
     "button.close": "閉じる",
     "button.cancel": "キャンセル",
     "button.apply": "適用",
+    "button.torchCompileRecommend": "現在の環境に合わせて自動設定",
+    "status.torchCompileLoading": "現在の環境を確認しています…",
+    "status.torchCompileUnsupported": "Torch Compile の自動設定は利用できません。",
+    "status.torchCompileDraftApplied": "推奨値をこのダイアログの下書きに適用しました。保存するには適用を押してください。",
+    "status.torchCompileProfile": "プロファイル: {profile}",
+    "status.torchCompileEnvironment": "環境: {accelerator}, VRAM {vram}",
+    "status.torchCompileChange": "{field}: {current} → {recommended}",
+    "status.torchCompileNoChanges": "推奨値は現在のダイアログと一致しています。",
+    "status.torchCompileReason": "理由: {code}",
+    "status.torchCompileWarning": "注意: {code}",
+    "status.torchCompileRequestFailed": "推奨設定の取得に失敗しました: {message}",
     "tip.inputUnetDtype": "Easy Use Anima Input が diffusion model を読み込むときの weight dtype です。VRAM や速度調整が不要なら default を使います。",
     "tip.inputClipDevice": "CLIP の読み込みデバイスです。CPU は VRAM を抑えますが、プロンプトエンコードが遅くなります。",
     "tip.seedMode": "バックエンド実行完了後のシード制御です。rgthree Seed と同じ考え方で動作します。",
@@ -1381,6 +1418,17 @@ const AIO_TOOLTIP_TEXT = {
     "button.close": "关闭",
     "button.cancel": "取消",
     "button.apply": "应用",
+    "button.torchCompileRecommend": "根据当前环境自动设置",
+    "status.torchCompileLoading": "正在检查当前环境…",
+    "status.torchCompileUnsupported": "无法使用 Torch Compile 自动设置。",
+    "status.torchCompileDraftApplied": "推荐值已应用到此对话框草稿。请点击应用以保存。",
+    "status.torchCompileProfile": "配置: {profile}",
+    "status.torchCompileEnvironment": "环境: {accelerator}, VRAM {vram}",
+    "status.torchCompileChange": "{field}: {current} → {recommended}",
+    "status.torchCompileNoChanges": "推荐值已与当前对话框一致。",
+    "status.torchCompileReason": "原因: {code}",
+    "status.torchCompileWarning": "注意: {code}",
+    "status.torchCompileRequestFailed": "推荐请求失败: {message}",
     "tip.inputUnetDtype": "Easy Use Anima Input 加载 diffusion model 时使用的 weight dtype。除非需要显存或速度调优，否则保持 default。",
     "tip.inputClipDevice": "CLIP 加载设备。CPU 可减少显存占用，但会降低提示词编码速度。",
     "tip.seedMode": "后端执行完成后的种子控制方式，行为与 rgthree Seed 控件一致。",
@@ -3712,6 +3760,10 @@ const generatorProfileApi = createAioProfileApiClient({
   encodeURIComponent,
 });
 
+const torchCompileRecommendationClient = createAioTorchCompileRecommendationClient({
+  fetchJson: (url, options) => easyuseAnimaFetchComfyJson(api, url, options),
+});
+
 const generatorProfileDialogs = aioCreateProfileDialogs({
   document,
   createDialog,
@@ -4035,6 +4087,12 @@ const openAdvancedSettings = aioCreateAdvancedSettingsDialog({
     markMissingControl: aioMarkMissingDependencyControl,
     notifyMissing: notifyGeneratorMissingDependencies,
     load: loadGeneratorOptionalDependencies,
+  },
+  recommendationAdapter: {
+    recommend: (settings, context) => (
+      torchCompileRecommendationClient.recommend(settings, context)
+    ),
+    diff: aioTorchCompileRecommendationDiff,
   },
 });
 


### PR DESCRIPTION
## 목적과 변경 경계

Task: AIO-COMPILE-03 / #410
Class: FEATURE
Base -> Head: f5c6ff28347b0dc84e64ee9434a9ec22850c155c -> 4a36be3d6e25c14a7c21a897f6fa40912d78cfb6

현재 AiO workload와 backend diagnostics를 이용해 안전한 Torch Compile 추천을 dialog draft에만 적용합니다.

Changed boundary:
- bounded frontend recommendation request/response adapter
- Advanced Options recommendation button, loading/error/unsupported/supported states, diff/reason/warning text
- frontend focused fixtures and runner only

Preserved contracts:
- request는 highres/detailer/upscale enabled, upscale backend, bounded explicit resolution/batch만 전송
- response는 9개 canonical Torch Compile field만 허용하며 malformed/unsupported는 fail-closed
- 추천 click은 compile, benchmark, queue, workflow save를 실행하지 않음
- Cancel/dispose는 late result를 무시하고 settings/widget을 보존
- final Apply만 기존 settings writer를 통해 저장하며 unknown field를 보존
- legacy dynamic value default는 읽기 호환, 새 canonical recommendation은 auto/true/false만 허용

## 검증

Focused:
- node --check: changed JS/MJS PASS
- node tests/frontend_aio_torch_compile_recommendation_smoke.mjs: PASS
- node tests/frontend_aio_advanced_settings_dialog_smoke.mjs: PASS
- focused unittest: recommendation bounded data contract PASS
- focused unittest: Advanced dialog closed lifecycle boundary PASS
- git diff --check: PASS

Official full:
- command: workspace tools/check_custom_node.ps1 -Profile full
- exact SHA: 4a36be3d6e25c14a7c21a897f6fa40912d78cfb6
- result: PASS; Python unittest 1192, frontend 119 JS files / TypeScript 6.0.3, Pyright baseline 117 files / 14 reviewed errors, import boundary 0 violations

Package:
- comfy node validate: PASS
- comfy node pack: PASS; 272 entries
- new recommendation module and Advanced dialog included; tests/docs/.git excluded
- SHA256: F2ACFA29B14F2F748850CD7A99F92D51227F143A0AB29A6992F7A14F8AC13AAE
- generated archive removed

Live:
- isolated ComfyUI only; source/installed/served SHA256 matched for all three production files
- Legacy Canvas: button enabled; loading -> supported; conservative_unknown draft shown
- Node 2.0: button enabled; supported draft shown
- Cancel used; Node 2.0 setting restored to off
- queue_running=0, queue_pending=0; no model generation/compile
- extension-scoped browser errors: 0
- server/browser/processes cleaned

Rollback: revert this single feature commit.
Next: AIO-COMPILE-04 live matrix after review and dev merge.