### PR TITLE
test: freeze AiO NegPip external contract

### DIFF
--- a/docs/development/aio-negpip-external-contract.md
+++ b/docs/development/aio-negpip-external-contract.md
@@ -1,0 +1,54 @@
+# AiO NegPip External Contract and License Boundary
+
+## Upstream evidence
+
+- repository: `pamparamm/ComfyUI-ppm`
+- inspected commit: `cb4a46ba9b0ebdb1f9a228a901bb958bfc8ed3ba`
+- public node id: `CLIPNegPip`
+- license: AGPL-3.0
+
+At the inspected commit, `CLIPNegPip` is a public ComfyUI V3 node. Its schema
+requires `model: MODEL` and `clip: CLIP`, returns `MODEL` and `CLIP`, and exposes
+a classmethod `execute(**kwargs)` returning `io.NodeOutput`. ComfyUI's public V3
+compatibility bridge exposes the same schema through `INPUT_TYPES` and
+`RETURN_TYPES`; `NodeOutput.result` contains the ordered output tuple.
+
+## EasyUse Anima boundary
+
+EasyUse Anima may discover the loaded public node class through the existing
+Comfy node mapping and invoke its public classmethod. It must not:
+
+- import `nodes_ppm`, `clip_negpip`, or another ComfyUI-ppm source module;
+- copy or vendor the upstream patch, encoder, wrapper, or model-family logic;
+- interpret or mutate the upstream private wrapper marker;
+- require ComfyUI-ppm while the future mode remains Off;
+- silently accept a changed required input, output order, execute signature, or
+  malformed result.
+
+The test-local contract fixture only models inspection and adaptation of the
+public boundary. AIO-NEGPIP-01 adds no shipped helper and does not connect to AiO
+generation, settings, cache, metadata, conditioning, CFG, workflow
+serialization, UI, or public sockets.
+
+## Ownership and fail-closed decisions
+
+- ComfyUI-ppm owns cloning, model-family support, wrapper installation and its
+  idempotency marker.
+- EasyUse Anima owns one-call invocation, exact two-output adaptation, and
+  actionable absence/contract errors.
+- Returned MODEL and CLIP must both be non-null clones. Returning an input
+  object directly fails closed because ownership would be ambiguous.
+- Additional optional schema inputs can remain compatible. Missing/changed
+  `model` or `clip`, any additional required input, changed output order/count,
+  or an incompatible execute signature fails closed.
+- Repeated calls are not retried by the adapter. Each requested invocation calls
+  upstream once and passes the previously returned objects through unchanged;
+  upstream remains responsible for avoiding duplicate wrapper installation.
+
+## Phase boundary
+
+AIO-NEGPIP-02 will implement the validated adapter together with its actual
+LoRA-derived MODEL/CLIP lineage ownership, add On-mode settings/cache/metadata
+behavior, and run one real Anima + ComfyUI-ppm live smoke. Turbo prompt
+transformation, neutral conditioning, effective CFG 1 and UI remain later
+phases.

--- a/tests/aio_negpip_contract_fixture.py
+++ b/tests/aio_negpip_contract_fixture.py
@@ -1,0 +1,152 @@
+"""Test-local public ComfyUI-ppm CLIPNegPip contract fixture.
+
+This module intentionally does not import ComfyUI-ppm. Production invocation
+and AiO runtime wiring are owned by the later On-mode phase.
+"""
+
+from __future__ import annotations
+
+import inspect
+from collections.abc import Callable
+from typing import Any
+
+from easyuse_anima.infrastructure.comfy.invocation import _node_output_tuple
+
+NEGPIP_NODE_ID = "CLIPNegPip"
+NEGPIP_NODE_PACK = "ComfyUI-ppm"
+NEGPIP_REPOSITORY = "https://github.com/pamparamm/ComfyUI-ppm"
+NEGPIP_CONTRACT_REVISION = 1
+
+_EXPECTED_INPUTS = {
+    "model": "MODEL",
+    "clip": "CLIP",
+}
+_EXPECTED_OUTPUTS = ("MODEL", "CLIP")
+
+
+def _payload(*, available: bool, reason_codes: list[str]) -> dict[str, Any]:
+    return {
+        "available": available,
+        "compatible": available and reason_codes == ["ppm_negpip_contract_ready"],
+        "node_id": NEGPIP_NODE_ID,
+        "node_pack": NEGPIP_NODE_PACK,
+        "repository": NEGPIP_REPOSITORY,
+        "contract_revision": NEGPIP_CONTRACT_REVISION,
+        "reason_codes": reason_codes,
+    }
+
+
+def _input_type_name(value: Any) -> str | None:
+    if not isinstance(value, (list, tuple)) or not value:
+        return None
+    input_type = value[0]
+    return input_type if isinstance(input_type, str) else None
+
+
+def _execute_contract_is_compatible(method: Any) -> bool:
+    if not callable(method):
+        return False
+    try:
+        parameters = inspect.signature(method).parameters
+    except (TypeError, ValueError):
+        return False
+
+    accepts_kwargs = any(
+        parameter.kind == inspect.Parameter.VAR_KEYWORD
+        for parameter in parameters.values()
+    )
+    for name in _EXPECTED_INPUTS:
+        parameter = parameters.get(name)
+        if parameter is None:
+            if not accepts_kwargs:
+                return False
+            continue
+        if parameter.kind == inspect.Parameter.POSITIONAL_ONLY:
+            return False
+
+    for name, parameter in parameters.items():
+        if name in _EXPECTED_INPUTS or parameter.kind in (
+            inspect.Parameter.VAR_POSITIONAL,
+            inspect.Parameter.VAR_KEYWORD,
+        ):
+            continue
+        if parameter.default is inspect.Parameter.empty:
+            return False
+    return True
+
+
+def _inspect_negpip_node_class(node_class: Any) -> list[str]:
+    reasons: list[str] = []
+    try:
+        input_types = node_class.INPUT_TYPES()
+        required = input_types.get("required", {})
+        if not isinstance(required, dict):
+            raise TypeError("required inputs must be a mapping")
+        if set(required) != set(_EXPECTED_INPUTS) or any(
+            _input_type_name(required.get(name)) != input_type
+            for name, input_type in _EXPECTED_INPUTS.items()
+        ):
+            reasons.append("ppm_negpip_input_contract_drift")
+
+        return_types = tuple(node_class.RETURN_TYPES)
+        if return_types != _EXPECTED_OUTPUTS:
+            reasons.append("ppm_negpip_output_contract_drift")
+
+        if not _execute_contract_is_compatible(getattr(node_class, "execute", None)):
+            reasons.append("ppm_negpip_execute_contract_drift")
+    except Exception:
+        return ["ppm_negpip_contract_unreadable"]
+    return reasons or ["ppm_negpip_contract_ready"]
+
+
+def collect_negpip_contract(
+    find_node_class: Callable[[str], Any],
+) -> dict[str, Any]:
+    """Inspect a fake loaded public node class without importing its package."""
+
+    try:
+        node_class = find_node_class(NEGPIP_NODE_ID)
+    except Exception:
+        return _payload(
+            available=False,
+            reason_codes=["ppm_negpip_contract_unreadable"],
+        )
+    if node_class is None:
+        return _payload(
+            available=False,
+            reason_codes=["ppm_negpip_missing"],
+        )
+    return _payload(
+        available=True,
+        reason_codes=_inspect_negpip_node_class(node_class),
+    )
+
+
+def invoke_negpip_node(node_class: Any, model: Any, clip: Any) -> tuple[Any, Any]:
+    """Model one compatible V3 node call and adapt its MODEL/CLIP output."""
+
+    if node_class is None:
+        raise RuntimeError(
+            "[EasyUseAnima] Missing required custom node 'CLIPNegPip'. "
+            "Install/enable ComfyUI-ppm, then restart ComfyUI. "
+            "Repository: https://github.com/pamparamm/ComfyUI-ppm"
+        )
+
+    reason_codes = _inspect_negpip_node_class(node_class)
+    if reason_codes != ["ppm_negpip_contract_ready"]:
+        raise RuntimeError(
+            "[EasyUseAnima] CLIPNegPip public node contract is incompatible: "
+            f"{', '.join(reason_codes)}. Update ComfyUI-ppm or disable NegPip."
+        )
+
+    result = node_class.execute(model=model, clip=clip)
+    values = _node_output_tuple(result)
+    if len(values) != 2 or values[0] is None or values[1] is None:
+        raise RuntimeError(
+            "[EasyUseAnima] CLIPNegPip returned an invalid MODEL/CLIP result."
+        )
+    if values[0] is model or values[1] is clip:
+        raise RuntimeError(
+            "[EasyUseAnima] CLIPNegPip did not return cloned MODEL/CLIP outputs."
+        )
+    return values[0], values[1]

--- a/tests/test_aio_negpip_contract.py
+++ b/tests/test_aio_negpip_contract.py
@@ -1,0 +1,212 @@
+from __future__ import annotations
+
+import ast
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+
+from tests import aio_negpip_contract_fixture as negpip_contract
+
+
+class FakeValue:
+    def __init__(self, *, patch_depth: int = 0):
+        self.patch_depth = patch_depth
+
+
+class CompatibleCLIPNegPip:
+    calls: list[dict[str, FakeValue]] = []
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "model": ("MODEL",),
+                "clip": ("CLIP",),
+            }
+        }
+
+    RETURN_TYPES = ("MODEL", "CLIP")
+
+    @classmethod
+    def execute(cls, **kwargs):
+        cls.calls.append(dict(kwargs))
+        incoming_depth = max(
+            kwargs["model"].patch_depth,
+            kwargs["clip"].patch_depth,
+        )
+        applied_depth = max(1, incoming_depth)
+        return SimpleNamespace(
+            result=(
+                FakeValue(patch_depth=applied_depth),
+                FakeValue(patch_depth=applied_depth),
+            )
+        )
+
+
+class NegPipExternalContractTests(unittest.TestCase):
+    def setUp(self):
+        CompatibleCLIPNegPip.calls = []
+
+    def test_dependency_absence_is_serializable_and_does_not_invoke(self):
+        requested = []
+
+        payload = negpip_contract.collect_negpip_contract(
+            lambda node_id: requested.append(node_id) or None
+        )
+
+        self.assertEqual(requested, ["CLIPNegPip"])
+        self.assertEqual(
+            payload,
+            {
+                "available": False,
+                "compatible": False,
+                "node_id": "CLIPNegPip",
+                "node_pack": "ComfyUI-ppm",
+                "repository": "https://github.com/pamparamm/ComfyUI-ppm",
+                "contract_revision": 1,
+                "reason_codes": ["ppm_negpip_missing"],
+            },
+        )
+        self.assertEqual(CompatibleCLIPNegPip.calls, [])
+
+    def test_compatible_v3_schema_and_node_output_are_adapted_once(self):
+        payload = negpip_contract.collect_negpip_contract(
+            lambda _node_id: CompatibleCLIPNegPip
+        )
+        model = FakeValue()
+        clip = FakeValue()
+
+        patched_model, patched_clip = negpip_contract.invoke_negpip_node(
+            CompatibleCLIPNegPip,
+            model,
+            clip,
+        )
+
+        self.assertTrue(payload["available"])
+        self.assertTrue(payload["compatible"])
+        self.assertEqual(payload["reason_codes"], ["ppm_negpip_contract_ready"])
+        self.assertEqual(CompatibleCLIPNegPip.calls, [{"model": model, "clip": clip}])
+        self.assertIsNot(patched_model, model)
+        self.assertIsNot(patched_clip, clip)
+        self.assertEqual((patched_model.patch_depth, patched_clip.patch_depth), (1, 1))
+
+    def test_input_output_and_execute_drift_fail_closed_without_invocation(self):
+        class InputDrift(CompatibleCLIPNegPip):
+            @classmethod
+            def INPUT_TYPES(cls):
+                inputs = super().INPUT_TYPES()
+                inputs["required"]["mode"] = ("STRING",)
+                return inputs
+
+        class OutputDrift(CompatibleCLIPNegPip):
+            RETURN_TYPES = ("MODEL",)
+
+        class ExecuteDrift(CompatibleCLIPNegPip):
+            @classmethod
+            def execute(cls, model, clip, new_required):
+                raise AssertionError("drifted contract must not be invoked")
+
+        for node_class, reason_code in (
+            (InputDrift, "ppm_negpip_input_contract_drift"),
+            (OutputDrift, "ppm_negpip_output_contract_drift"),
+            (ExecuteDrift, "ppm_negpip_execute_contract_drift"),
+        ):
+            with self.subTest(node_class=node_class.__name__):
+                payload = negpip_contract.collect_negpip_contract(
+                    lambda _node_id, node_class=node_class: node_class
+                )
+                self.assertFalse(payload["compatible"])
+                self.assertIn(reason_code, payload["reason_codes"])
+                with self.assertRaisesRegex(RuntimeError, reason_code):
+                    negpip_contract.invoke_negpip_node(
+                        node_class,
+                        FakeValue(),
+                        FakeValue(),
+                    )
+        self.assertEqual(CompatibleCLIPNegPip.calls, [])
+
+    def test_unreadable_and_malformed_outputs_fail_closed(self):
+        class Unreadable(CompatibleCLIPNegPip):
+            @classmethod
+            def INPUT_TYPES(cls):
+                raise RuntimeError(r"C:\Users\alice\private-token")
+
+        payload = negpip_contract.collect_negpip_contract(
+            lambda _node_id: Unreadable
+        )
+        self.assertEqual(
+            payload["reason_codes"],
+            ["ppm_negpip_contract_unreadable"],
+        )
+        self.assertNotIn("alice", str(payload))
+        self.assertNotIn("private-token", str(payload))
+
+        model = FakeValue()
+        clip = FakeValue()
+        malformed_results = (
+            SimpleNamespace(result=(FakeValue(),)),
+            SimpleNamespace(result=(FakeValue(), FakeValue(), FakeValue())),
+            SimpleNamespace(result=(None, FakeValue())),
+            SimpleNamespace(result=(model, FakeValue())),
+            SimpleNamespace(result=(FakeValue(), clip)),
+        )
+        for malformed in malformed_results:
+            with self.subTest(result=malformed.result):
+                class Malformed(CompatibleCLIPNegPip):
+                    @classmethod
+                    def execute(cls, **_kwargs):
+                        return malformed
+
+                with self.assertRaisesRegex(RuntimeError, "CLIPNegPip"):
+                    negpip_contract.invoke_negpip_node(Malformed, model, clip)
+
+    def test_repeated_invocation_calls_upstream_once_and_preserves_idempotency(self):
+        first_model, first_clip = negpip_contract.invoke_negpip_node(
+            CompatibleCLIPNegPip,
+            FakeValue(),
+            FakeValue(),
+        )
+        second_model, second_clip = negpip_contract.invoke_negpip_node(
+            CompatibleCLIPNegPip,
+            first_model,
+            first_clip,
+        )
+
+        self.assertEqual(len(CompatibleCLIPNegPip.calls), 2)
+        self.assertEqual((first_model.patch_depth, first_clip.patch_depth), (1, 1))
+        self.assertEqual((second_model.patch_depth, second_clip.patch_depth), (1, 1))
+        self.assertIs(CompatibleCLIPNegPip.calls[1]["model"], first_model)
+        self.assertIs(CompatibleCLIPNegPip.calls[1]["clip"], first_clip)
+
+    def test_module_has_no_eager_private_import_or_vendored_upstream_symbols(self):
+        module_path = Path(negpip_contract.__file__)
+        source = module_path.read_text(encoding="utf-8")
+        tree = ast.parse(source)
+        imported_modules = set()
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Import):
+                imported_modules.update(alias.name for alias in node.names)
+            elif isinstance(node, ast.ImportFrom) and node.module:
+                imported_modules.add(node.module)
+
+        self.assertFalse(
+            any(
+                name == "comfy"
+                or name.startswith("comfy.")
+                or name.startswith("comfy_api")
+                or name.startswith("nodes_ppm")
+                for name in imported_modules
+            )
+        )
+        self.assertNotIn("importlib", imported_modules)
+        for upstream_symbol in (
+            "patch_adv_encode",
+            "patch_negpip",
+            "anima_extra_conds_negpip",
+            "cosmos_diffusion_negpip_wrapper",
+        ):
+            self.assertNotIn(upstream_symbol, source)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 목적과 변경 경계

AIO-NEGPIP-01 / #411의 external `CLIPNegPip` V3 contract와 AGPL license boundary를 test-local fixture로 고정합니다.

- Class: CONTRACT
- Base -> Head: `0d12a3a424a2dd6fb50867620001b1dc632e4ff9` -> `254852e531375d4c0c319e0ff2814c59a7986b65`
- Changed boundary: contract fixture/test + development document only
- Production JavaScript/Python, settings, cache, metadata, conditioning, CFG, workflow/public socket: 변경 없음

## Contract decisions

- Public node id: `CLIPNegPip`
- Inputs/outputs: `model: MODEL`, `clip: CLIP` -> `MODEL`, `CLIP`
- Invocation/result: V3 classmethod `execute(**kwargs)` and `NodeOutput.result`
- Missing, required-input drift, output drift, execute drift, malformed/non-cloned result: fail-closed
- Each requested invocation is modeled as one external call; retries/polling 없음
- ComfyUI-ppm owns cloning, wrapper install/idempotency marker and model-family behavior
- No ComfyUI-ppm eager/private import, dynamic import, source copy or vendoring

Upstream evidence: `pamparamm/ComfyUI-ppm@cb4a46ba9b0ebdb1f9a228a901bb958bfc8ed3ba`, AGPL-3.0.

## 검증

- Changed Python compile: PASS
- Ruff 0.15.22 on changed fixture/test: PASS
- Focused `tests.test_aio_negpip_contract.NegPipExternalContractTests`: 6 PASS
- Focused backend analyzer repository fixture: PASS
- `git diff --check`: PASS
- Official full: exact head `254852e531375d4c0c319e0ff2814c59a7986b65`, PASS
  - Python 1,198
  - frontend 119 JS files / TypeScript 6.0.3
  - Pyright baseline, import boundary, diff gate PASS
- Package: not triggered; shipped/package tree unchanged
- Live: not triggered by NEGPIP-01 policy; isolated instance has no ComfyUI-ppm

The first candidate added an unconnected shipped helper; the analyzer correctly rejected it as unreachable. The final candidate removed that module rather than adding artificial eager ownership. AIO-NEGPIP-02 will add adapter + actual MODEL/CLIP wiring as one rollback unit.

## 위험, rollback, next

- Remaining risk: real ComfyUI-ppm model/clip lineage is intentionally deferred
- Rollback: this Contract commit
- Next: review/dev squash merge, then AIO-NEGPIP-02 On-mode integration and one real Anima+PPM live smoke