### PR TITLE
feat(aio): add NegPip On-mode adapter (AIO-NEGPIP-02)

### DIFF
--- a/docs/development/aio-negpip-external-contract.md
+++ b/docs/development/aio-negpip-external-contract.md
@@ -25,10 +25,11 @@ Comfy node mapping and invoke its public classmethod. It must not:
 - silently accept a changed required input, output order, execute signature, or
   malformed result.
 
-The test-local contract fixture only models inspection and adaptation of the
-public boundary. AIO-NEGPIP-01 adds no shipped helper and does not connect to AiO
-generation, settings, cache, metadata, conditioning, CFG, workflow
-serialization, UI, or public sockets.
+AIO-NEGPIP-02 promotes the validated fixture to a shipped adapter and connects
+only the explicit backend extension `negpip.mode=on`. An absent extension or
+`mode=off` performs no dependency lookup and preserves the previous model,
+clip, cache payload and stage metadata. The formal settings schema, defaults,
+profile surface and UI remain unchanged in this phase.
 
 ## Ownership and fail-closed decisions
 
@@ -45,10 +46,15 @@ serialization, UI, or public sockets.
   upstream once and passes the previously returned objects through unchanged;
   upstream remains responsible for avoiding duplicate wrapper installation.
 
-## Phase boundary
+## On-mode runtime boundary
 
-AIO-NEGPIP-02 will implement the validated adapter together with its actual
-LoRA-derived MODEL/CLIP lineage ownership, add On-mode settings/cache/metadata
-behavior, and run one real Anima + ComfyUI-ppm live smoke. Turbo prompt
-transformation, neutral conditioning, effective CFG 1 and UI remain later
-phases.
+- The public adapter is invoked exactly once after LoRA application.
+- Its MODEL becomes the clean base for the existing stage model resolver; its
+  CLIP encodes both positive and negative conditioning.
+- First-pass cache entries include the mode and contract revision only while On.
+- On stage metadata records the mode and contract revision. CFG and sampler
+  settings are not rewritten.
+- The returned MODEL is registered with the existing ephemeral model lifecycle.
+
+Turbo prompt transformation, neutral conditioning, effective CFG 1, formal
+settings/UI ownership and public workflow editing remain later phases.

--- a/easyuse_anima/aio/first_pass_cache.py
+++ b/easyuse_anima/aio/first_pass_cache.py
@@ -15,6 +15,7 @@ from .generation_migrations import (
     AIO_MODEL_PATCH_PRECEDENCE,
 )
 from .model_preparation import _aio_lora_stack_signature
+from .negpip import _aio_negpip_cache_signature
 
 AIO_FIRST_PASS_CACHE_MAX_ENTRIES = 2
 AIO_FIRST_PASS_CACHE_MAX_BYTES = 512 * 1024 * 1024
@@ -362,7 +363,7 @@ def _aio_first_pass_cache_key(
 ) -> str:
     resource_info = context.get("resource_info", {})
     lora_signature = _aio_lora_stack_signature(lora_stack)
-    return _stable_change_key({
+    payload = {
         "schema": "easyuse_anima_aio_first_pass_cache",
         "version": 3,
         "scope": str(cache_scope or ""),
@@ -397,7 +398,11 @@ def _aio_first_pass_cache_key(
         "use_negative_anima_mod_guidance": bool(use_negative_anima_mod_guidance),
         "width": int(width),
         "height": int(height),
-    })
+    }
+    negpip_signature = _aio_negpip_cache_signature(settings.get("negpip"))
+    if negpip_signature is not None:
+        payload["negpip"] = negpip_signature
+    return _stable_change_key(payload)
 
 
 def _get_aio_first_pass_cache(cache_key: str):

--- a/easyuse_anima/aio/legacy_generation.py
+++ b/easyuse_anima/aio/legacy_generation.py
@@ -70,9 +70,14 @@ from .input_context import _require_easy_use_anima_input
 from .model_preparation import (
     _aio_stage_model_patch_plan,
     _apply_aio_lora_stack,
-    _apply_aio_stage_model_patch_plan,
     _apply_aio_spectrum_model_patches_for_comfy_sampler,
+    _apply_aio_stage_model_patch_plan,
     _cleanup_aio_ephemeral_model,
+)
+from .negpip import (
+    _aio_negpip_metadata,
+    _aio_negpip_mode,
+    apply_aio_negpip,
 )
 from .output import (
     _aio_save_filename_prefix,
@@ -714,35 +719,48 @@ def _run_aio_generation_pipeline(
         base_clip,
         lora_stack,
     )
-    prompt_data = _normalize_prompt_data(context["prompt_data"])
-    (
-        positive_prompt,
-        negative_prompt,
-        quality_tags,
-        quality_neg,
-        use_anima_mod_guidance,
-        use_negative_anima_mod_guidance,
-        metadata_prompt,
-        metadata_negative_prompt,
-        width,
-        height,
-    ) = _advanced_outputs_from_prompt_data(prompt_data)
-    artist_mix = settings["artist_mix"]
-    positive = _encode_prompt_data_positive_conditioning(
-        clip,
-        prompt_data,
-        positive_prompt,
-        artist_mix_mode=artist_mix["mode"],
-        artist_mix_start_percent=artist_mix["start_percent"],
-        artist_mix_strength_scale=artist_mix["strength_scale"],
-        artist_mix_style_gain=artist_mix["style_gain"],
-        artist_mix_rms_scale_cap=artist_mix["rms_scale_cap"],
-        artist_mix_exact_top_k=artist_mix["exact_top_k"],
-        artist_mix_cluster_count=artist_mix["cluster_count"],
-        artist_mix_dominant_isolation=artist_mix["dominant_isolation"],
-        artist_mix_dominant_threshold=artist_mix["dominant_threshold"],
-    )
-    negative = _encode_with_comfy_clip(clip, negative_prompt)
+    negpip_mode = _aio_negpip_mode(settings.get("negpip"))
+    model_lineage_base = model_with_lora
+    try:
+        model_lineage_base, clip = apply_aio_negpip(
+            model_with_lora,
+            clip,
+            negpip_mode,
+        )
+        prompt_data = _normalize_prompt_data(context["prompt_data"])
+        (
+            positive_prompt,
+            negative_prompt,
+            quality_tags,
+            quality_neg,
+            use_anima_mod_guidance,
+            use_negative_anima_mod_guidance,
+            metadata_prompt,
+            metadata_negative_prompt,
+            width,
+            height,
+        ) = _advanced_outputs_from_prompt_data(prompt_data)
+        artist_mix = settings["artist_mix"]
+        positive = _encode_prompt_data_positive_conditioning(
+            clip,
+            prompt_data,
+            positive_prompt,
+            artist_mix_mode=artist_mix["mode"],
+            artist_mix_start_percent=artist_mix["start_percent"],
+            artist_mix_strength_scale=artist_mix["strength_scale"],
+            artist_mix_style_gain=artist_mix["style_gain"],
+            artist_mix_rms_scale_cap=artist_mix["rms_scale_cap"],
+            artist_mix_exact_top_k=artist_mix["exact_top_k"],
+            artist_mix_cluster_count=artist_mix["cluster_count"],
+            artist_mix_dominant_isolation=artist_mix["dominant_isolation"],
+            artist_mix_dominant_threshold=artist_mix["dominant_threshold"],
+        )
+        negative = _encode_with_comfy_clip(clip, negative_prompt)
+    except BaseException:
+        if model_lineage_base is not model_with_lora:
+            _cleanup_aio_ephemeral_model(model_lineage_base, base_model)
+        _cleanup_aio_ephemeral_model(model_with_lora, base_model)
+        raise
 
     sampler = settings["sampler"]
     mod_guidance = settings["mod_guidance"]
@@ -774,13 +792,15 @@ def _run_aio_generation_pipeline(
         cleanup_model=_cleanup_aio_ephemeral_model,
         model_with_lora=model_with_lora,
     )
+    if model_lineage_base is not model_with_lora:
+        model_registry.register_model(model_lineage_base)
     stage_models = StageModelVariantResolver(
         runtime=StageModelVariantRuntime(
             build_plan=_aio_stage_model_patch_plan,
             apply_plan=_apply_aio_stage_model_patch_plan,
         ),
         registry=model_registry,
-        model_with_lora=model_with_lora,
+        model_with_lora=model_lineage_base,
         settings=settings,
     )
     model_variant_runtime = ModelVariantRuntime(
@@ -839,6 +859,9 @@ def _run_aio_generation_pipeline(
         "upscale": [],
     }
     generation_state.metadata["model_patches_by_stage"] = model_patches_by_stage
+    negpip_metadata = _aio_negpip_metadata(negpip_mode)
+    if negpip_metadata is not None:
+        generation_state.metadata["negpip"] = negpip_metadata
     preview_settings = settings["preview"]
     preview_node_id = _single_value(unique_id)
     preview_run_id = (
@@ -890,7 +913,7 @@ def _run_aio_generation_pipeline(
         resources=ResourceBundle(
             base_model=base_model,
             base_clip=base_clip,
-            model_with_lora=model_with_lora,
+            model_with_lora=model_lineage_base,
             model=base_sample_model,
             clip=clip,
             vae=vae,

--- a/easyuse_anima/aio/negpip.py
+++ b/easyuse_anima/aio/negpip.py
@@ -1,21 +1,21 @@
-"""Test-local public ComfyUI-ppm CLIPNegPip contract fixture.
-
-This module intentionally does not import ComfyUI-ppm. Production invocation
-and AiO runtime wiring are owned by the later On-mode phase.
-"""
+"""Public ComfyUI-ppm NegPip adapter for AiO generation."""
 
 from __future__ import annotations
 
 import inspect
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
 from typing import Any
 
-from easyuse_anima.infrastructure.comfy.invocation import _node_output_tuple
+from ..infrastructure.comfy.invocation import _node_output_tuple
+from ..infrastructure.comfy.wiring import resolve_comfy_host_helper
 
 NEGPIP_NODE_ID = "CLIPNegPip"
 NEGPIP_NODE_PACK = "ComfyUI-ppm"
 NEGPIP_REPOSITORY = "https://github.com/pamparamm/ComfyUI-ppm"
 NEGPIP_CONTRACT_REVISION = 1
+
+NEGPIP_MODE_OFF = "off"
+NEGPIP_MODE_ON = "on"
 
 _EXPECTED_INPUTS = {
     "model": "MODEL",
@@ -24,10 +24,30 @@ _EXPECTED_INPUTS = {
 _EXPECTED_OUTPUTS = ("MODEL", "CLIP")
 
 
+def _missing_host_helper(name: str):
+    raise RuntimeError(
+        f"[EasyUseAnima] AiO NegPip Comfy host helper is unavailable: {name}"
+    )
+
+
+def _require_custom_node_class(
+    node_id: str,
+    node_pack: str,
+    install_hint: str,
+):
+    helper = resolve_comfy_host_helper(
+        "_require_custom_node_class",
+        _missing_host_helper,
+    )
+    return helper(node_id, node_pack, install_hint)
+
+
 def _payload(*, available: bool, reason_codes: list[str]) -> dict[str, Any]:
     return {
         "available": available,
-        "compatible": available and reason_codes == ["ppm_negpip_contract_ready"],
+        "compatible": (
+            available and reason_codes == ["ppm_negpip_contract_ready"]
+        ),
         "node_id": NEGPIP_NODE_ID,
         "node_pack": NEGPIP_NODE_PACK,
         "repository": NEGPIP_REPOSITORY,
@@ -92,7 +112,9 @@ def _inspect_negpip_node_class(node_class: Any) -> list[str]:
         if return_types != _EXPECTED_OUTPUTS:
             reasons.append("ppm_negpip_output_contract_drift")
 
-        if not _execute_contract_is_compatible(getattr(node_class, "execute", None)):
+        if not _execute_contract_is_compatible(
+            getattr(node_class, "execute", None)
+        ):
             reasons.append("ppm_negpip_execute_contract_drift")
     except Exception:
         return ["ppm_negpip_contract_unreadable"]
@@ -102,7 +124,7 @@ def _inspect_negpip_node_class(node_class: Any) -> list[str]:
 def collect_negpip_contract(
     find_node_class: Callable[[str], Any],
 ) -> dict[str, Any]:
-    """Inspect a fake loaded public node class without importing its package."""
+    """Inspect the loaded public node class without importing its package."""
 
     try:
         node_class = find_node_class(NEGPIP_NODE_ID)
@@ -123,13 +145,13 @@ def collect_negpip_contract(
 
 
 def invoke_negpip_node(node_class: Any, model: Any, clip: Any) -> tuple[Any, Any]:
-    """Model one compatible V3 node call and adapt its MODEL/CLIP output."""
+    """Invoke one compatible public CLIPNegPip node call."""
 
     if node_class is None:
         raise RuntimeError(
             "[EasyUseAnima] Missing required custom node 'CLIPNegPip'. "
             "Install/enable ComfyUI-ppm, then restart ComfyUI. "
-            "Repository: https://github.com/pamparamm/ComfyUI-ppm"
+            f"Repository: {NEGPIP_REPOSITORY}"
         )
 
     reason_codes = _inspect_negpip_node_class(node_class)
@@ -150,3 +172,63 @@ def invoke_negpip_node(node_class: Any, model: Any, clip: Any) -> tuple[Any, Any
             "[EasyUseAnima] CLIPNegPip did not return cloned MODEL/CLIP outputs."
         )
     return values[0], values[1]
+
+
+def _aio_negpip_mode(value: object) -> str:
+    if value is None:
+        return NEGPIP_MODE_OFF
+    if not isinstance(value, Mapping):
+        raise RuntimeError(
+            "[EasyUseAnima] AiO NegPip settings are malformed; "
+            "disable NegPip or select a supported mode."
+        )
+    mode = value.get("mode")
+    if mode not in (NEGPIP_MODE_OFF, NEGPIP_MODE_ON):
+        raise RuntimeError(
+            f"[EasyUseAnima] Unsupported AiO NegPip mode: {mode!r}. "
+            "AIO-NEGPIP-02 supports only 'off' and 'on'."
+        )
+    return str(mode)
+
+
+def _aio_negpip_cache_signature(value: object) -> dict[str, object] | None:
+    mode = _aio_negpip_mode(value)
+    if mode == NEGPIP_MODE_OFF:
+        return None
+    return {
+        "mode": mode,
+        "contract_revision": NEGPIP_CONTRACT_REVISION,
+    }
+
+
+def _aio_negpip_metadata(mode: str) -> dict[str, object] | None:
+    if mode == NEGPIP_MODE_OFF:
+        return None
+    if mode != NEGPIP_MODE_ON:
+        raise RuntimeError(
+            f"[EasyUseAnima] Unsupported normalized AiO NegPip mode: {mode!r}."
+        )
+    return {
+        "mode": mode,
+        "contract_revision": NEGPIP_CONTRACT_REVISION,
+    }
+
+
+def apply_aio_negpip(model: Any, clip: Any, mode: str) -> tuple[Any, Any]:
+    """Apply the public NegPip adapter once when the normalized mode is On."""
+
+    if mode == NEGPIP_MODE_OFF:
+        return model, clip
+    if mode != NEGPIP_MODE_ON:
+        raise RuntimeError(
+            f"[EasyUseAnima] Unsupported normalized AiO NegPip mode: {mode!r}."
+        )
+    node_class = _require_custom_node_class(
+        NEGPIP_NODE_ID,
+        NEGPIP_NODE_PACK,
+        f"Required for AiO NegPip On mode. Repository: {NEGPIP_REPOSITORY}",
+    )
+    return invoke_negpip_node(node_class, model, clip)
+
+
+__all__ = ()

--- a/tests/fixtures/comfy_host_compatibility.v1.json
+++ b/tests/fixtures/comfy_host_compatibility.v1.json
@@ -14,8 +14,8 @@
     ]
   },
   "expected_counts": {
-    "production_consumer_slots": 22,
-    "unique_production_modules": 15,
+    "production_consumer_slots": 23,
+    "unique_production_modules": 16,
     "root_monkeypatch_test_files": 0,
     "canonical_monkeypatch_test_files": 3
   },
@@ -373,6 +373,11 @@
         },
         {
           "module": "easyuse_anima.aio.model_preparation",
+          "binder": null,
+          "root_observation": "call_time"
+        },
+        {
+          "module": "easyuse_anima.aio.negpip",
           "binder": null,
           "root_observation": "call_time"
         },

--- a/tests/fixtures/python_backend_baseline.json
+++ b/tests/fixtures/python_backend_baseline.json
@@ -4600,6 +4600,24 @@
       },
       {
         "alias": null,
+        "bound_name": "_aio_negpip_cache_signature",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".negpip:_aio_negpip_cache_signature",
+        "kind": "static_from",
+        "line": 18,
+        "name": "_aio_negpip_cache_signature",
+        "optional": false,
+        "requested": ".negpip",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/aio/first_pass_cache.py",
+        "target": "easyuse_anima/aio/negpip.py"
+      },
+      {
+        "alias": null,
         "bound_name": "annotations",
         "branch_context": [],
         "classification": "external",
@@ -9975,6 +9993,60 @@
       },
       {
         "alias": null,
+        "bound_name": "_aio_negpip_metadata",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".negpip:_aio_negpip_metadata",
+        "kind": "static_from",
+        "line": 77,
+        "name": "_aio_negpip_metadata",
+        "optional": false,
+        "requested": ".negpip",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/aio/legacy_generation.py",
+        "target": "easyuse_anima/aio/negpip.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_aio_negpip_mode",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".negpip:_aio_negpip_mode",
+        "kind": "static_from",
+        "line": 77,
+        "name": "_aio_negpip_mode",
+        "optional": false,
+        "requested": ".negpip",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/aio/legacy_generation.py",
+        "target": "easyuse_anima/aio/negpip.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "apply_aio_negpip",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".negpip:apply_aio_negpip",
+        "kind": "static_from",
+        "line": 77,
+        "name": "apply_aio_negpip",
+        "optional": false,
+        "requested": ".negpip",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/aio/legacy_generation.py",
+        "target": "easyuse_anima/aio/negpip.py"
+      },
+      {
+        "alias": null,
         "bound_name": "_aio_save_filename_prefix",
         "branch_context": [],
         "classification": "internal",
@@ -9982,7 +10054,7 @@
         "conditional": false,
         "imported": ".output:_aio_save_filename_prefix",
         "kind": "static_from",
-        "line": 77,
+        "line": 82,
         "name": "_aio_save_filename_prefix",
         "optional": false,
         "requested": ".output",
@@ -10000,7 +10072,7 @@
         "conditional": false,
         "imported": ".output:_save_image_with_comfy",
         "kind": "static_from",
-        "line": 77,
+        "line": 82,
         "name": "_save_image_with_comfy",
         "optional": false,
         "requested": ".output",
@@ -10018,7 +10090,7 @@
         "conditional": false,
         "imported": ".output:_save_image_with_image_saver",
         "kind": "static_from",
-        "line": 77,
+        "line": 82,
         "name": "_save_image_with_image_saver",
         "optional": false,
         "requested": ".output",
@@ -10036,7 +10108,7 @@
         "conditional": false,
         "imported": ".postprocess:_resize_image_to_size_if_needed",
         "kind": "static_from",
-        "line": 82,
+        "line": 87,
         "name": "_resize_image_to_size_if_needed",
         "optional": false,
         "requested": ".postprocess",
@@ -10054,7 +10126,7 @@
         "conditional": false,
         "imported": ".postprocess:_run_aio_postprocess_stage",
         "kind": "static_from",
-        "line": 82,
+        "line": 87,
         "name": "_run_aio_postprocess_stage",
         "optional": false,
         "requested": ".postprocess",
@@ -10072,7 +10144,7 @@
         "conditional": false,
         "imported": ".preview:_save_aio_temp_preview_image",
         "kind": "static_from",
-        "line": 86,
+        "line": 91,
         "name": "_save_aio_temp_preview_image",
         "optional": false,
         "requested": ".preview",
@@ -10090,7 +10162,7 @@
         "conditional": false,
         "imported": ".preview:_send_aio_preview_event",
         "kind": "static_from",
-        "line": 86,
+        "line": 91,
         "name": "_send_aio_preview_event",
         "optional": false,
         "requested": ".preview",
@@ -10108,7 +10180,7 @@
         "conditional": false,
         "imported": ".preview:_tag_aio_preview_images",
         "kind": "static_from",
-        "line": 86,
+        "line": 91,
         "name": "_tag_aio_preview_images",
         "optional": false,
         "requested": ".preview",
@@ -10126,7 +10198,7 @@
         "conditional": false,
         "imported": ".resources:_load_aio_resources_from_input_context",
         "kind": "static_from",
-        "line": 91,
+        "line": 96,
         "name": "_load_aio_resources_from_input_context",
         "optional": false,
         "requested": ".resources",
@@ -10144,7 +10216,7 @@
         "conditional": false,
         "imported": ".resources:_load_aio_sam3_context",
         "kind": "static_from",
-        "line": 91,
+        "line": 96,
         "name": "_load_aio_sam3_context",
         "optional": false,
         "requested": ".resources",
@@ -10162,7 +10234,7 @@
         "conditional": false,
         "imported": ".resources:_load_upscale_model_with_comfy",
         "kind": "static_from",
-        "line": 91,
+        "line": 96,
         "name": "_load_upscale_model_with_comfy",
         "optional": false,
         "requested": ".resources",
@@ -10180,7 +10252,7 @@
         "conditional": false,
         "imported": ".sampling:_aio_highres_effective_backend",
         "kind": "static_from",
-        "line": 96,
+        "line": 101,
         "name": "_aio_highres_effective_backend",
         "optional": false,
         "requested": ".sampling",
@@ -10198,7 +10270,7 @@
         "conditional": false,
         "imported": ".sampling:_aio_stage_sampler_settings",
         "kind": "static_from",
-        "line": 96,
+        "line": 101,
         "name": "_aio_stage_sampler_settings",
         "optional": false,
         "requested": ".sampling",
@@ -10216,7 +10288,7 @@
         "conditional": false,
         "imported": ".sampling:_decode_latent_with_comfy",
         "kind": "static_from",
-        "line": 96,
+        "line": 101,
         "name": "_decode_latent_with_comfy",
         "optional": false,
         "requested": ".sampling",
@@ -10234,7 +10306,7 @@
         "conditional": false,
         "imported": ".sampling:_encode_image_with_comfy_vae",
         "kind": "static_from",
-        "line": 96,
+        "line": 101,
         "name": "_encode_image_with_comfy_vae",
         "optional": false,
         "requested": ".sampling",
@@ -10252,7 +10324,7 @@
         "conditional": false,
         "imported": ".sampling:_generate_empty_latent_with_comfy",
         "kind": "static_from",
-        "line": 96,
+        "line": 101,
         "name": "_generate_empty_latent_with_comfy",
         "optional": false,
         "requested": ".sampling",
@@ -10270,7 +10342,7 @@
         "conditional": false,
         "imported": ".sampling:_resolve_aio_runtime_seed",
         "kind": "static_from",
-        "line": 96,
+        "line": 101,
         "name": "_resolve_aio_runtime_seed",
         "optional": false,
         "requested": ".sampling",
@@ -10288,7 +10360,7 @@
         "conditional": false,
         "imported": ".sampling:_sample_latent_with_aio_backend",
         "kind": "static_from",
-        "line": 96,
+        "line": 101,
         "name": "_sample_latent_with_aio_backend",
         "optional": false,
         "requested": ".sampling",
@@ -10306,7 +10378,7 @@
         "conditional": false,
         "imported": ".usdu:_aio_usdu_tile_plan",
         "kind": "static_from",
-        "line": 105,
+        "line": 110,
         "name": "_aio_usdu_tile_plan",
         "optional": false,
         "requested": ".usdu",
@@ -10605,6 +10677,127 @@
         "role": "optional_dependency",
         "scope": "_cleanup_aio_ephemeral_model",
         "source": "easyuse_anima/aio/model_preparation.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "annotations",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "__future__:annotations",
+        "kind": "static_from",
+        "line": 3,
+        "name": "annotations",
+        "optional": false,
+        "requested": "__future__",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/aio/negpip.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "inspect",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "inspect",
+        "kind": "static_import",
+        "line": 5,
+        "name": null,
+        "optional": false,
+        "requested": "inspect",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/aio/negpip.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "Callable",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "collections.abc:Callable",
+        "kind": "static_from",
+        "line": 6,
+        "name": "Callable",
+        "optional": false,
+        "requested": "collections.abc",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/aio/negpip.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "Mapping",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "collections.abc:Mapping",
+        "kind": "static_from",
+        "line": 6,
+        "name": "Mapping",
+        "optional": false,
+        "requested": "collections.abc",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/aio/negpip.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "Any",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "typing:Any",
+        "kind": "static_from",
+        "line": 7,
+        "name": "Any",
+        "optional": false,
+        "requested": "typing",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/aio/negpip.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_node_output_tuple",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": "..infrastructure.comfy.invocation:_node_output_tuple",
+        "kind": "static_from",
+        "line": 9,
+        "name": "_node_output_tuple",
+        "optional": false,
+        "requested": "..infrastructure.comfy.invocation",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/aio/negpip.py",
+        "target": "easyuse_anima/infrastructure/comfy/invocation.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "resolve_comfy_host_helper",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": "..infrastructure.comfy.wiring:resolve_comfy_host_helper",
+        "kind": "static_from",
+        "line": 10,
+        "name": "resolve_comfy_host_helper",
+        "optional": false,
+        "requested": "..infrastructure.comfy.wiring",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/aio/negpip.py",
+        "target": "easyuse_anima/infrastructure/comfy/wiring.py"
       },
       {
         "alias": null,
@@ -57589,6 +57782,10 @@
       },
       {
         "from": "easyuse_anima/aio/first_pass_cache.py",
+        "to": "easyuse_anima/aio/negpip.py"
+      },
+      {
+        "from": "easyuse_anima/aio/first_pass_cache.py",
         "to": "easyuse_anima/common/serialization.py"
       },
       {
@@ -57813,6 +58010,10 @@
       },
       {
         "from": "easyuse_anima/aio/legacy_generation.py",
+        "to": "easyuse_anima/aio/negpip.py"
+      },
+      {
+        "from": "easyuse_anima/aio/legacy_generation.py",
         "to": "easyuse_anima/aio/output.py"
       },
       {
@@ -57902,6 +58103,14 @@
       {
         "from": "easyuse_anima/aio/model_preparation.py",
         "to": "easyuse_anima/lora/metadata.py"
+      },
+      {
+        "from": "easyuse_anima/aio/negpip.py",
+        "to": "easyuse_anima/infrastructure/comfy/invocation.py"
+      },
+      {
+        "from": "easyuse_anima/aio/negpip.py",
+        "to": "easyuse_anima/infrastructure/comfy/wiring.py"
       },
       {
         "from": "easyuse_anima/aio/output.py",
@@ -59302,6 +59511,12 @@
       {
         "cyclic": false,
         "modules": [
+          "easyuse_anima/aio/negpip.py"
+        ]
+      },
+      {
+        "cyclic": false,
+        "modules": [
           "easyuse_anima/aio/output.py"
         ]
       },
@@ -59879,7 +60094,7 @@
     ]
   },
   "inventory": {
-    "module_count": 134,
+    "module_count": 135,
     "modules": [
       {
         "is_package": true,
@@ -60063,9 +60278,9 @@
       },
       {
         "is_package": false,
-        "loc": 477,
+        "loc": 482,
         "module": "easyuse_anima.aio.first_pass_cache",
-        "normalized_git_blob_sha1": "f59f28b337382e217639fe9144b40c51fcbb909c",
+        "normalized_git_blob_sha1": "0e48e070c228f298f298beaf03f1c854510e06c3",
         "path": "easyuse_anima/aio/first_pass_cache.py",
         "top_level": {
           "class_count": 2,
@@ -60303,9 +60518,9 @@
       },
       {
         "is_package": false,
-        "loc": 1054,
+        "loc": 1077,
         "module": "easyuse_anima.aio.legacy_generation",
-        "normalized_git_blob_sha1": "3ee84d4eed4333932f84a0f52dfa5a891e9f2003",
+        "normalized_git_blob_sha1": "685c0c81c7ff0bf170f7b8f7a94b5332d92d61d5",
         "path": "easyuse_anima/aio/legacy_generation.py",
         "top_level": {
           "class_count": 0,
@@ -60323,6 +60538,18 @@
           "class_count": 0,
           "function_count": 20,
           "global_count": 2
+        }
+      },
+      {
+        "is_package": false,
+        "loc": 234,
+        "module": "easyuse_anima.aio.negpip",
+        "normalized_git_blob_sha1": "a71bd949f56c541529daeab302bef1e5c62acedc",
+        "path": "easyuse_anima/aio/negpip.py",
+        "top_level": {
+          "class_count": 0,
+          "function_count": 12,
+          "global_count": 9
         }
       },
       {
@@ -74618,6 +74845,61 @@
         "line": 3,
         "optional": false,
         "role": "ordinary",
+        "source": "easyuse_anima/aio/negpip.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "inspect",
+        "kind": "static_import",
+        "line": 5,
+        "optional": false,
+        "role": "ordinary",
+        "source": "easyuse_anima/aio/negpip.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "collections.abc:Callable",
+        "kind": "static_from",
+        "line": 6,
+        "optional": false,
+        "role": "ordinary",
+        "source": "easyuse_anima/aio/negpip.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "collections.abc:Mapping",
+        "kind": "static_from",
+        "line": 6,
+        "optional": false,
+        "role": "ordinary",
+        "source": "easyuse_anima/aio/negpip.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "typing:Any",
+        "kind": "static_from",
+        "line": 7,
+        "optional": false,
+        "role": "ordinary",
+        "source": "easyuse_anima/aio/negpip.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "__future__:annotations",
+        "kind": "static_from",
+        "line": 3,
+        "optional": false,
+        "role": "ordinary",
         "source": "easyuse_anima/aio/output.py"
       },
       {
@@ -79899,6 +80181,7 @@
       "easyuse_anima/aio/input_defaults.py",
       "easyuse_anima/aio/legacy_generation.py",
       "easyuse_anima/aio/model_preparation.py",
+      "easyuse_anima/aio/negpip.py",
       "easyuse_anima/aio/output.py",
       "easyuse_anima/aio/output_settings.py",
       "easyuse_anima/aio/postprocess.py",
@@ -80035,6 +80318,7 @@
       "easyuse_anima/aio/input_defaults.py",
       "easyuse_anima/aio/legacy_generation.py",
       "easyuse_anima/aio/model_preparation.py",
+      "easyuse_anima/aio/negpip.py",
       "easyuse_anima/aio/output.py",
       "easyuse_anima/aio/output_settings.py",
       "easyuse_anima/aio/postprocess.py",
@@ -80467,7 +80751,7 @@
         "column": 1,
         "context": "decorator:_AIOFirstPassCacheEntry",
         "kind": "import_time_call",
-        "line": 26,
+        "line": 27,
         "module": "easyuse_anima/aio/first_pass_cache.py",
         "scope": "<module>"
       },
@@ -80476,7 +80760,7 @@
         "column": 1,
         "context": "decorator:_AIOFirstPassCacheMetrics",
         "kind": "import_time_call",
-        "line": 62,
+        "line": 63,
         "module": "easyuse_anima/aio/first_pass_cache.py",
         "scope": "<module>"
       },
@@ -80485,7 +80769,7 @@
         "column": 29,
         "context": "assign:_AIO_FIRST_PASS_CACHE_LOCK",
         "kind": "import_time_call",
-        "line": 75,
+        "line": 76,
         "module": "easyuse_anima/aio/first_pass_cache.py",
         "scope": "<module>"
       },
@@ -81151,7 +81435,7 @@
         "column": 9,
         "context": "assign:logger",
         "kind": "import_time_call",
-        "line": 107,
+        "line": 112,
         "module": "easyuse_anima/aio/legacy_generation.py",
         "scope": "<module>"
       },
@@ -81959,19 +82243,19 @@
       },
       {
         "kind": "dict",
-        "line": 70,
+        "line": 71,
         "module": "easyuse_anima/aio/first_pass_cache.py",
         "name": "_AIO_FIRST_PASS_CACHE"
       },
       {
         "kind": "dict",
-        "line": 77,
+        "line": 78,
         "module": "easyuse_anima/aio/first_pass_cache.py",
         "name": "_AIO_FIRST_PASS_CACHE_METRICS"
       },
       {
         "kind": "list",
-        "line": 74,
+        "line": 75,
         "module": "easyuse_anima/aio/first_pass_cache.py",
         "name": "_AIO_FIRST_PASS_CACHE_ORDER"
       },
@@ -81998,6 +82282,12 @@
         "line": 49,
         "module": "easyuse_anima/aio/input_defaults.py",
         "name": "AIO_INPUT_DEFAULT_SETTINGS"
+      },
+      {
+        "kind": "dict",
+        "line": 20,
+        "module": "easyuse_anima/aio/negpip.py",
+        "name": "_EXPECTED_INPUTS"
       },
       {
         "kind": "dict",
@@ -82373,7 +82663,7 @@
           "mutable_container"
         ],
         "initializer": "Dict",
-        "line": 70,
+        "line": 71,
         "module": "easyuse_anima/aio/first_pass_cache.py",
         "name": "_AIO_FIRST_PASS_CACHE"
       },
@@ -82382,7 +82672,7 @@
           "lock"
         ],
         "initializer": "RLock",
-        "line": 75,
+        "line": 76,
         "module": "easyuse_anima/aio/first_pass_cache.py",
         "name": "_AIO_FIRST_PASS_CACHE_LOCK"
       },
@@ -82392,7 +82682,7 @@
           "mutable_container"
         ],
         "initializer": "Dict",
-        "line": 77,
+        "line": 78,
         "module": "easyuse_anima/aio/first_pass_cache.py",
         "name": "_AIO_FIRST_PASS_CACHE_METRICS"
       },
@@ -82402,7 +82692,7 @@
           "mutable_container"
         ],
         "initializer": "List",
-        "line": 74,
+        "line": 75,
         "module": "easyuse_anima/aio/first_pass_cache.py",
         "name": "_AIO_FIRST_PASS_CACHE_ORDER"
       },

--- a/tests/test_aio_first_pass_cache.py
+++ b/tests/test_aio_first_pass_cache.py
@@ -974,6 +974,56 @@ class AIOFirstPassCacheMoveTests(unittest.TestCase):
                 baseline,
             )
 
+    def test_negpip_off_preserves_cache_key_and_on_separates_contract_revision(self):
+        settings = {
+            "mode": "txt2img",
+            "sampler": {"seed": 42},
+            "model_patches": {},
+            "mod_guidance": {},
+            "artist_mix": {},
+        }
+        key_args = {
+            "cache_scope": "node",
+            "context": {"resource_info": {}, "input_settings": {}},
+            "prompt_data": {},
+            "lora_stack": [],
+            "settings": settings,
+            "positive_prompt": "prompt",
+            "negative_prompt": "",
+            "quality_tags": "",
+            "quality_neg": "",
+            "use_anima_mod_guidance": False,
+            "use_negative_anima_mod_guidance": False,
+            "width": 1024,
+            "height": 1024,
+        }
+
+        baseline = first_pass_cache._aio_first_pass_cache_key(**key_args)
+        explicit_off = copy.deepcopy(settings)
+        explicit_off["negpip"] = {"mode": "off"}
+        on = copy.deepcopy(settings)
+        on["negpip"] = {"mode": "on"}
+
+        self.assertEqual(
+            first_pass_cache._aio_first_pass_cache_key(
+                **{**key_args, "settings": explicit_off}
+            ),
+            baseline,
+        )
+        self.assertNotEqual(
+            first_pass_cache._aio_first_pass_cache_key(
+                **{**key_args, "settings": on}
+            ),
+            baseline,
+        )
+        with self.assertRaisesRegex(RuntimeError, "NegPip"):
+            first_pass_cache._aio_first_pass_cache_key(
+                **{
+                    **key_args,
+                    "settings": {**settings, "negpip": {"mode": "turbo"}},
+                }
+            )
+
     def test_resource_revision_maps_base_resources_and_loras_in_signature_order(self):
         revisions = Mock(
             side_effect=lambda folder_name, filename: (

--- a/tests/test_aio_legacy_generation.py
+++ b/tests/test_aio_legacy_generation.py
@@ -2137,6 +2137,37 @@ class AIOGeneratorLegacyMoveTests(unittest.TestCase):
             },
         )
 
+    def test_negpip_on_routes_one_model_clip_pair_and_preserves_cfg_metadata_cleanup(self):
+        execution = self._execute_case(
+            upscale_enabled=False,
+            intermediate_preview=False,
+            unique_id="node-negpip-on",
+            negpip_mode="on",
+        )
+
+        trace = execution["trace"]
+        self.assertEqual(trace.count("apply_negpip"), 1)
+        self.assertLess(
+            trace.index("apply_negpip"),
+            trace.index("encode_positive"),
+        )
+        self.assertLess(
+            trace.index("apply_negpip"),
+            trace.index("encode_negative"),
+        )
+        self.assertEqual(trace.count("cleanup:negpip"), 1)
+        self.assertEqual(trace.count("cleanup:lora"), 1)
+        metadata = execution["result"]["metadata"]
+        self.assertEqual(
+            metadata["stages"]["negpip"],
+            {"mode": "on", "contract_revision": 1},
+        )
+        self.assertEqual(metadata["generation_settings"]["sampler"]["cfg"], 6.5)
+        self.assertEqual(
+            metadata["generation_settings"]["negpip"],
+            {"mode": "on"},
+        )
+
     def test_resshift_does_not_resolve_upscale_sampling_model(self):
         execution = self._execute_case(
             upscale_enabled=True,
@@ -2171,6 +2202,7 @@ class AIOGeneratorLegacyMoveTests(unittest.TestCase):
         detailer_enabled: bool = False,
         upscale_backend: str = "usdu",
         stage_signatures: dict[str, str] | None = None,
+        negpip_mode: str | None = None,
     ) -> dict:
         trace = trace_sink if trace_sink is not None else []
         custom_stage_models = stage_signatures is not None
@@ -2215,9 +2247,13 @@ class AIOGeneratorLegacyMoveTests(unittest.TestCase):
                 "filename_prefix": "Anima",
             },
         }
+        if negpip_mode is not None:
+            settings["negpip"] = {"mode": negpip_mode}
+            settings["sampler"]["cfg"] = 6.5
 
         base_model = _Token("base")
         lora_model = _Token("lora")
+        negpip_model = _Token("negpip")
         variant_models = {
             signature: _Token(
                 f"model:{signature}" if custom_stage_models else "model"
@@ -2228,9 +2264,13 @@ class AIOGeneratorLegacyMoveTests(unittest.TestCase):
         sample_model = _Token("sample")
         base_clip = _Token("base_clip")
         clip = _Token("clip")
+        negpip_clip = _Token("negpip_clip")
+        lineage_model = negpip_model if negpip_mode == "on" else lora_model
+        lineage_clip = negpip_clip if negpip_mode == "on" else clip
         vae = _Token("vae")
         model_names = {
             id(lora_model): "lora",
+            id(negpip_model): "negpip",
             id(sample_model): "sample",
             **{
                 id(model): model.name
@@ -2318,6 +2358,15 @@ class AIOGeneratorLegacyMoveTests(unittest.TestCase):
             self.assertEqual(stack, "lora-stack")
             return lora_model, clip, [{"name": "style.safetensors"}]
 
+        def apply_negpip(model, source_clip, mode):
+            self.assertIs(model, lora_model)
+            self.assertIs(source_clip, clip)
+            self.assertEqual(mode, negpip_mode or "off")
+            if mode == "off":
+                return model, source_clip
+            trace.append("apply_negpip")
+            return negpip_model, negpip_clip
+
         def build_stage_plan(normalized_settings, stage_id):
             self.assertIn(
                 stage_id,
@@ -2337,7 +2386,7 @@ class AIOGeneratorLegacyMoveTests(unittest.TestCase):
 
         def apply_model_patches(model, plan):
             trace.append("apply_model_patches")
-            self.assertIs(model, lora_model)
+            self.assertIs(model, lineage_model)
             return variant_models[plan.signature]
 
         def advanced_outputs(prompt_data):
@@ -2354,6 +2403,17 @@ class AIOGeneratorLegacyMoveTests(unittest.TestCase):
                 64,
                 96,
             )
+
+        def encode_positive(source_clip, *_args, **_kwargs):
+            trace.append("encode_positive")
+            self.assertIs(source_clip, lineage_clip)
+            return "positive-conditioning"
+
+        def encode_negative(source_clip, text):
+            trace.append("encode_negative")
+            self.assertIs(source_clip, lineage_clip)
+            self.assertEqual(text, "negative")
+            return "negative-conditioning"
 
         def apply_spectrum_model(model, source_clip, positive, sampler):
             trace.append("apply_spectrum_model_patches")
@@ -2478,6 +2538,7 @@ class AIOGeneratorLegacyMoveTests(unittest.TestCase):
                 _aio_generation_config_from_dict=typed_config,
                 _load_aio_resources_from_input_context=load_resources,
                 _apply_aio_lora_stack=apply_lora,
+                apply_aio_negpip=apply_negpip,
                 _aio_stage_model_patch_plan=build_stage_plan,
                 _apply_aio_stage_model_patch_plan=apply_model_patches,
                 _normalize_prompt_data=phase(
@@ -2485,10 +2546,7 @@ class AIOGeneratorLegacyMoveTests(unittest.TestCase):
                     context["prompt_data"],
                 ),
                 _advanced_outputs_from_prompt_data=advanced_outputs,
-                _encode_prompt_data_positive_conditioning=phase(
-                    "encode_positive",
-                    "positive-conditioning",
-                ),
+                _encode_prompt_data_positive_conditioning=encode_positive,
                 _as_bool=lambda value, default: bool(value),
                 _aio_detailer_has_enabled_targets=phase(
                     "detailer_enabled",
@@ -2536,7 +2594,7 @@ class AIOGeneratorLegacyMoveTests(unittest.TestCase):
             patch_comfy_helper(
                 nodes,
                 "_encode_with_comfy_clip",
-                phase("encode_negative", "negative-conditioning"),
+                encode_negative,
             ),
         ):
             output = generator.generate(

--- a/tests/test_aio_negpip_contract.py
+++ b/tests/test_aio_negpip_contract.py
@@ -5,7 +5,10 @@ import unittest
 from pathlib import Path
 from types import SimpleNamespace
 
-from tests import aio_negpip_contract_fixture as negpip_contract
+from easyuse_anima.aio import negpip as negpip_contract
+from tests.comfy_host_fakes import FakeComfyHostProvider, use_fake_comfy_host
+
+_ROOT_MODULE = SimpleNamespace(__package__="")
 
 
 class FakeValue:
@@ -206,6 +209,77 @@ class NegPipExternalContractTests(unittest.TestCase):
             "cosmos_diffusion_negpip_wrapper",
         ):
             self.assertNotIn(upstream_symbol, source)
+
+
+class NegPipOnModeTests(unittest.TestCase):
+    def setUp(self):
+        CompatibleCLIPNegPip.calls = []
+
+    def test_absent_and_explicit_off_preserve_identity_without_dependency_lookup(self):
+        class TrackingProvider(FakeComfyHostProvider):
+            def __init__(self):
+                super().__init__()
+                self.requests = []
+
+            def find_node_class(self, node_id: str):
+                self.requests.append(node_id)
+                return super().find_node_class(node_id)
+
+        provider = TrackingProvider()
+        model = FakeValue()
+        clip = FakeValue()
+        with use_fake_comfy_host(_ROOT_MODULE, provider):
+            for value in (None, {"mode": "off"}):
+                with self.subTest(value=value):
+                    mode = negpip_contract._aio_negpip_mode(value)
+                    result = negpip_contract.apply_aio_negpip(model, clip, mode)
+                    self.assertEqual(result, (model, clip))
+                    self.assertIs(result[0], model)
+                    self.assertIs(result[1], clip)
+                    self.assertIsNone(
+                        negpip_contract._aio_negpip_cache_signature(value)
+                    )
+                    self.assertIsNone(negpip_contract._aio_negpip_metadata(mode))
+        self.assertEqual(provider.requests, [])
+
+    def test_on_requires_public_node_and_invokes_exactly_once(self):
+        model = FakeValue()
+        clip = FakeValue()
+        provider = FakeComfyHostProvider(
+            node_classes={"CLIPNegPip": CompatibleCLIPNegPip}
+        )
+        with use_fake_comfy_host(_ROOT_MODULE, provider):
+            patched_model, patched_clip = negpip_contract.apply_aio_negpip(
+                model,
+                clip,
+                negpip_contract._aio_negpip_mode({"mode": "on"}),
+            )
+
+        self.assertEqual(CompatibleCLIPNegPip.calls, [{"model": model, "clip": clip}])
+        self.assertIsNot(patched_model, model)
+        self.assertIsNot(patched_clip, clip)
+        self.assertEqual(
+            negpip_contract._aio_negpip_cache_signature({"mode": "on"}),
+            {"mode": "on", "contract_revision": 1},
+        )
+        self.assertEqual(
+            negpip_contract._aio_negpip_metadata("on"),
+            {"mode": "on", "contract_revision": 1},
+        )
+
+    def test_missing_dependency_and_unsupported_modes_fail_closed(self):
+        with use_fake_comfy_host(_ROOT_MODULE, FakeComfyHostProvider()):
+            with self.assertRaisesRegex(RuntimeError, "ComfyUI-ppm"):
+                negpip_contract.apply_aio_negpip(
+                    FakeValue(),
+                    FakeValue(),
+                    "on",
+                )
+
+        for value in ({}, {"mode": "turbo"}, "on", {"mode": None}):
+            with self.subTest(value=value):
+                with self.assertRaisesRegex(RuntimeError, "NegPip"):
+                    negpip_contract._aio_negpip_mode(value)
 
 
 if __name__ == "__main__":

--- a/tests/test_python_backend_analyzer.py
+++ b/tests/test_python_backend_analyzer.py
@@ -7,7 +7,6 @@ import subprocess
 import unittest
 from pathlib import Path
 
-
 ROOT = Path(__file__).resolve().parents[1]
 ANALYZER_PATH = ROOT / "tools" / "analyze_python_backend.py"
 BASELINE_PATH = ROOT / "tests" / "fixtures" / "python_backend_baseline.json"
@@ -691,9 +690,9 @@ ignored/
 
         self.assertEqual(analyzer.render_json(report), expected_text)
         self.assertEqual(report["schema_version"], 2)
-        self.assertEqual(report["inventory"]["module_count"], 134)
-        self.assertEqual(len(report["registry"]["shipped_python_modules"]), 134)
-        self.assertEqual(len(report["registry"]["runtime_import_closure"]), 134)
+        self.assertEqual(report["inventory"]["module_count"], 135)
+        self.assertEqual(len(report["registry"]["shipped_python_modules"]), 135)
+        self.assertEqual(len(report["registry"]["runtime_import_closure"]), 135)
         self.assertEqual(
             report["registry"]["entry_modules"],
             [
@@ -733,6 +732,7 @@ ignored/
                 "easyuse_anima/aio/generation_migrations.py",
                 "easyuse_anima/aio/generation_settings.py",
                 "easyuse_anima/aio/model_preparation.py",
+                "easyuse_anima/aio/negpip.py",
                 "easyuse_anima/aio/output.py",
                 "easyuse_anima/aio/output_settings.py",
                 "easyuse_anima/aio/postprocess.py",
@@ -820,6 +820,7 @@ ignored/
                 "easyuse_anima/aio/first_pass_cache.py",
                 "easyuse_anima/aio/legacy_generation.py",
                 "easyuse_anima/aio/model_preparation.py",
+                "easyuse_anima/aio/negpip.py",
                 "easyuse_anima/aio/output.py",
                 "easyuse_anima/aio/preview.py",
                 "easyuse_anima/aio/resources.py",


### PR DESCRIPTION
## 목적과 변경 경계

AIO-NEGPIP-02 / #411

ComfyUI-ppm의 public `CLIPNegPip` contract를 통해 AiO On 모드에서 LoRA 적용 뒤 MODEL/CLIP lineage를 한 번 변환합니다. formal settings schema/UI, Turbo prompt/CFG semantics, public socket/workflow schema는 이번 PR에 포함하지 않습니다.

Base -> Head: `71b8e22aa2391af65c0d77b3663373e427484733` -> `cc63929db1821c73fd9d0bb8ee4829fb80035ab1`

## 주요 변경과 보존 계약

- test-local contract fixture를 shipped `easyuse_anima/aio/negpip.py` adapter로 승격
- public node id `CLIPNegPip`, required MODEL/CLIP, returned MODEL/CLIP, execute signature와 malformed output을 fail-closed 검증
- `negpip.mode=on` backend extension만 소비; absent/explicit Off는 dependency lookup, identity, cache payload, stage metadata를 그대로 보존
- On adapter invocation은 execution당 정확히 한 번
- returned MODEL은 기존 stage resolver의 clean base, returned CLIP은 positive/negative conditioning의 공통 source
- CFG/sampler settings는 변경하지 않음
- On cache만 mode + contract revision으로 분리
- On metadata만 mode + contract revision 기록
- returned MODEL은 기존 ephemeral model registry에서 bounded cleanup
- ComfyUI-ppm source/private wrapper를 import·vendor·해석하지 않음

## 검증

Focused:
- `tests.test_aio_negpip_contract.NegPipExternalContractTests`: 6 PASS — public contract/drift/malformed/repeat
- `tests.test_aio_negpip_contract.NegPipOnModeTests`: 3 PASS — Off no-lookup, On one-call, missing/unsupported fail-closed
- `tests.test_aio_first_pass_cache.AIOFirstPassCacheMoveTests`: 31 PASS — Off key parity와 On separation
- `tests.test_aio_legacy_generation.AIOGeneratorLegacyMoveTests`: 30 PASS — MODEL/CLIP lineage, conditioning, CFG, metadata, cleanup, 기존 execution trace
- backend analyzer fixture: 1 PASS — shipped module 135개, runtime reachable
- Comfy host compatibility ledger: 7 PASS — call-time provider consumer exactness
- changed Python compile/Ruff, `git diff --check`: PASS

Full:
- `tools/check_project.ps1 -Profile full`
- exact SHA: `cc63929db1821c73fd9d0bb8ee4829fb80035ab1`
- Python 1203 PASS
- frontend 119 JS PASS, TypeScript 6.0.3
- Pyright baseline/import boundary/diff PASS

Package:
- `comfy node validate`: PASS

Live:
- isolated ComfyUI + official ComfyUI-ppm inspected commit
- `CLIPNegPip` 및 `EasyUseAnimaAIOGenerator` registration PASS
- real Anima NegPip On queue PASS
- observed metadata: mode=on, contract revision=1, requested CFG 5.0 preserved, bounded 256x256 result
- listener/wrapper와 임시 dependency/helper cleanup 완료

## 보정 기록

초기 full에서 compatibility ledger/snapshot fixture drift만 발견했습니다. production 동작은 유지하고 기존 fake host provider 경로와 exact ledger를 갱신했으며, 최종 SHA에서 full을 통과했습니다.

## 위험·rollback·Next

- 위험: formal settings/UI가 아직 없으므로 On은 explicit backend extension consumer로만 접근합니다.
- Rollback: 이 squash commit 전체
- Next: review/merge 후 AIO-NEGPIP-03 Turbo contract. On-mode PR에 Turbo/UI를 선행하지 않습니다.