### PR TITLE
test(aio): define NegPip Turbo conditioning contract

### DIFF
--- a/docs/development/aio-negpip-external-contract.md
+++ b/docs/development/aio-negpip-external-contract.md
@@ -56,5 +56,7 @@ profile surface and UI remain unchanged in this phase.
   settings are not rewritten.
 - The returned MODEL is registered with the existing ephemeral model lifecycle.
 
-Turbo prompt transformation, neutral conditioning, effective CFG 1, formal
-settings/UI ownership and public workflow editing remain later phases.
+The AIO-NEGPIP-03 Turbo prompt, neutral-conditioning, and runtime CFG decisions
+are frozen in `aio-negpip-turbo-contract.md` and its test-local golden fixture.
+Production cutover, formal settings/UI ownership, and public workflow editing
+remain AIO-NEGPIP-04.

--- a/docs/development/aio-negpip-turbo-contract.md
+++ b/docs/development/aio-negpip-turbo-contract.md
@@ -1,0 +1,75 @@
+# AiO NegPip Turbo Conditioning Contract
+
+Status: AIO-NEGPIP-03 contract fixture. Production and UI cutover remain
+AIO-NEGPIP-04.
+
+## Execution prompt policy
+
+Turbo consumes the execution-ready positive and negative prompts after prompt
+translation and wildcard expansion. It never writes the derived text back to
+prompt data, workflow inputs, profiles, or metadata fields that represent the
+user's original prompt.
+
+The negative contribution uses policy revision 1:
+
+1. discard empty top-level items and lines whose first non-space character is
+   `#`;
+2. preserve escaped delimiters and nested `()`, `{}`, `[]`, and `[[ ]]` text;
+3. canonicalize remaining top-level comma/newline items with `, `;
+4. invert the sign of every explicit parenthetical numeric weight;
+5. wrap the complete derived prompt in one outer `-1` weight group;
+6. append that group to the execution-only positive prompt.
+
+The outer whole-prompt group is selected instead of wrapping each top-level
+item separately. ComfyUI's prompt-weight parser assigns the outer weight to all
+unweighted text in the group. Keeping separators inside the same group avoids
+leaving top-level separator tokens at positive weight. Explicit numeric weights
+are absolute assignments in that parser, so their signs are inverted as well;
+otherwise an inner `(text:0.5)` would escape the requested additional `-1`
+multiplier.
+
+Unbalanced or mismatched delimiters fail closed with
+`negpip_turbo_prompt_malformed`. The caller retains the source text unchanged;
+there is no lossy fallback.
+
+The executable golden scenarios are in
+`tests/fixtures/aio_negpip_turbo_contract.v1.json` and include commas, newlines,
+comments, nesting, escapes, existing positive and negative numeric weights,
+empty prompts, and malformed input.
+
+## Conditioning ownership
+
+Turbo uses the MODEL and CLIP returned by the existing public `CLIPNegPip`
+adapter. The same patched CLIP owns both encodes:
+
+- positive execution conditioning: original positive execution prompt plus the
+  derived negative contribution;
+- negative execution conditioning: an explicit empty prompt encode.
+
+The neutral conditioning is not `None`, a zero tensor, the original negative
+conditioning, or an encode from the unpatched CLIP. Artist Mix and Mod Guidance
+integration remain AIO-NEGPIP-04 compatibility work; this contract does not move
+their feature meaning into the shared lifecycle or prompt owners.
+
+## Runtime CFG ownership
+
+Turbo forces effective CFG `1.0` only at sampling calls:
+
+- first pass;
+- Highres;
+- each enabled Detailer target;
+- USDU upscale.
+
+The stored sampler, Highres, Detailer, and Upscale CFG values remain unchanged.
+ResShift, Postprocess, and Save Output do not acquire a synthetic CFG because
+they are not CFG sampling stages. Turning Turbo off therefore exposes the
+previously stored values without migration or restoration writes.
+
+## AIO-NEGPIP-04 handoff
+
+The implementation reuses the existing NegPip adapter, generation request,
+stage sampler, first-pass cache, and metadata owners. It must consume the golden
+fixture rather than introduce another parser or conditioning policy. The next
+phase adds settings/profile/UI ownership, runtime conditioning and CFG cutover,
+cache/metadata signatures, and the selected compatibility/live matrix. It must
+not import or vendor ComfyUI-ppm private source.

--- a/tests/fixtures/aio_negpip_turbo_contract.v1.json
+++ b/tests/fixtures/aio_negpip_turbo_contract.v1.json
@@ -1,0 +1,173 @@
+{
+  "schema": "easyuse_anima_aio_negpip_turbo_contract",
+  "version": 1,
+  "policy": {
+    "mode": "turbo",
+    "policy_revision": 1,
+    "negative_scale": -1.0,
+    "composition": "whole_prompt_group",
+    "input_phase": "after_translation_and_wildcard_expansion",
+    "neutral_negative_prompt": "",
+    "malformed_policy": "fail_closed",
+    "malformed_reason_code": "negpip_turbo_prompt_malformed",
+    "sampling_stages": [
+      "first_pass",
+      "highres",
+      "detailer",
+      "upscale_usdu"
+    ],
+    "non_sampling_stages": [
+      "upscale_resshift",
+      "postprocess",
+      "save_output"
+    ],
+    "preserved_inputs": [
+      "positive_prompt",
+      "negative_prompt",
+      "sampler.cfg",
+      "highres.cfg",
+      "detailer.*.cfg",
+      "upscale.cfg"
+    ],
+    "rejected_composition": "per_top_level_item",
+    "rejection_reason": "top_level_separators_would_remain_outside_the_negative_weight_group"
+  },
+  "prompt_cases": [
+    {
+      "id": "top_level_comma",
+      "negative_prompt": "bad hands, lowres",
+      "derived_negative_contribution": "(bad hands, lowres:-1)"
+    },
+    {
+      "id": "top_level_newline_empty_and_comment",
+      "negative_prompt": "bad hands,\n\n# execution comment, not prompt text\nlowres",
+      "derived_negative_contribution": "(bad hands, lowres:-1)"
+    },
+    {
+      "id": "nested_delimiters",
+      "negative_prompt": "(bad hands, fused fingers), {red, blue}, [[artist_a, artist_b:0.7]]",
+      "derived_negative_contribution": "((bad hands, fused fingers), {red, blue}, [[artist_a, artist_b:0.7]]:-1)"
+    },
+    {
+      "id": "existing_numeric_weights",
+      "negative_prompt": "(lowres:0.5), (artifact:-1.25), ((blurred):+1.1)",
+      "derived_negative_contribution": "((lowres:-0.5), (artifact:1.25), ((blurred):-1.1):-1)"
+    },
+    {
+      "id": "escaped_delimiters",
+      "negative_prompt": "literal \\(group\\, one\\), bad \\(hands\\), path\\\\name",
+      "derived_negative_contribution": "(literal \\(group\\, one\\), bad \\(hands\\), path\\\\name:-1)"
+    },
+    {
+      "id": "inline_hash_is_prompt_text",
+      "negative_prompt": "bad hands, # inline text",
+      "derived_negative_contribution": "(bad hands, # inline text:-1)"
+    },
+    {
+      "id": "empty",
+      "negative_prompt": "",
+      "derived_negative_contribution": ""
+    },
+    {
+      "id": "comment_only",
+      "negative_prompt": "  # first\n# second, with comma",
+      "derived_negative_contribution": ""
+    }
+  ],
+  "malformed_cases": [
+    {
+      "id": "unclosed_parenthesis",
+      "negative_prompt": "bad (hands"
+    },
+    {
+      "id": "unexpected_parenthesis_close",
+      "negative_prompt": "bad hands)"
+    },
+    {
+      "id": "unclosed_brace",
+      "negative_prompt": "{bad, hands"
+    },
+    {
+      "id": "unclosed_double_bracket",
+      "negative_prompt": "[[bad, hands]"
+    },
+    {
+      "id": "mismatched_delimiter",
+      "negative_prompt": "(bad hands]"
+    }
+  ],
+  "conditioning_cases": [
+    {
+      "id": "positive_and_negative",
+      "positive_prompt": "1girl, portrait",
+      "negative_prompt": "bad hands, (lowres:0.5)",
+      "positive_execution_prompt": "1girl, portrait, (bad hands, (lowres:-0.5):-1)",
+      "negative_execution_prompt": ""
+    },
+    {
+      "id": "empty_positive",
+      "positive_prompt": "",
+      "negative_prompt": "bad hands",
+      "positive_execution_prompt": "(bad hands:-1)",
+      "negative_execution_prompt": ""
+    },
+    {
+      "id": "positive_numeric_weight_preserved",
+      "positive_prompt": "(1girl:1.2)",
+      "negative_prompt": "(bad hands:0.5)",
+      "positive_execution_prompt": "(1girl:1.2), ((bad hands:-0.5):-1)",
+      "negative_execution_prompt": ""
+    },
+    {
+      "id": "empty_negative",
+      "positive_prompt": "1girl",
+      "negative_prompt": "",
+      "positive_execution_prompt": "1girl",
+      "negative_execution_prompt": ""
+    }
+  ],
+  "stage_cfg_cases": [
+    {
+      "stage": "first_pass",
+      "backend": "comfy_ksampler",
+      "stored_cfg": 5.0,
+      "effective_cfg": 1.0
+    },
+    {
+      "stage": "highres",
+      "backend": "comfy_ksampler",
+      "stored_cfg": 6.0,
+      "effective_cfg": 1.0
+    },
+    {
+      "stage": "detailer",
+      "backend": "impact",
+      "stored_cfg": 7.0,
+      "effective_cfg": 1.0
+    },
+    {
+      "stage": "upscale_usdu",
+      "backend": "usdu",
+      "stored_cfg": 8.0,
+      "effective_cfg": 1.0
+    },
+    {
+      "stage": "upscale_resshift",
+      "backend": "resshift",
+      "stored_cfg": null,
+      "effective_cfg": null
+    },
+    {
+      "stage": "postprocess",
+      "backend": "none",
+      "stored_cfg": null,
+      "effective_cfg": null
+    },
+    {
+      "stage": "save_output",
+      "backend": "none",
+      "stored_cfg": null,
+      "effective_cfg": null
+    }
+  ]
+}

--- a/tests/test_aio_negpip_turbo_contract.py
+++ b/tests/test_aio_negpip_turbo_contract.py
@@ -1,0 +1,283 @@
+from __future__ import annotations
+
+import json
+import re
+import unittest
+from copy import deepcopy
+from pathlib import Path
+from typing import Any
+
+_FIXTURE_PATH = (
+    Path(__file__).parent
+    / "fixtures"
+    / "aio_negpip_turbo_contract.v1.json"
+)
+_OPEN_TO_CLOSE = {"(": ")", "{": "}", "[": "]"}
+_CLOSE_TO_OPEN = {value: key for key, value in _OPEN_TO_CLOSE.items()}
+_NUMERIC_WEIGHT_RE = re.compile(
+    r"(?P<prefix>:\s*)"
+    r"(?P<sign>[+-]?)"
+    r"(?P<number>(?:\d+(?:\.\d*)?|\.\d+)(?:[eE][+-]?\d+)?)"
+    r"(?P<suffix>\s*)(?=\))"
+)
+
+
+class TurboContractError(RuntimeError):
+    pass
+
+
+def _is_escaped(text: str, index: int) -> bool:
+    slash_count = 0
+    cursor = index - 1
+    while cursor >= 0 and text[cursor] == "\\":
+        slash_count += 1
+        cursor -= 1
+    return slash_count % 2 == 1
+
+
+def _line_ending(line: str) -> str:
+    if line.endswith("\r\n"):
+        return "\r\n"
+    if line.endswith("\n"):
+        return "\n"
+    if line.endswith("\r"):
+        return "\r"
+    return ""
+
+
+def _strip_comments_and_validate(text: str, reason_code: str) -> str:
+    stack: list[str] = []
+    output: list[str] = []
+    for line in text.splitlines(keepends=True):
+        if not stack and line.lstrip(" \t").startswith("#"):
+            output.append(_line_ending(line))
+            continue
+
+        for index, char in enumerate(line):
+            if _is_escaped(line, index):
+                continue
+            if char in _OPEN_TO_CLOSE:
+                stack.append(char)
+            elif char in _CLOSE_TO_OPEN:
+                if not stack or stack[-1] != _CLOSE_TO_OPEN[char]:
+                    raise TurboContractError(reason_code)
+                stack.pop()
+        output.append(line)
+
+    if stack:
+        raise TurboContractError(reason_code)
+    return "".join(output)
+
+
+def _split_top_level_items(text: str) -> list[str]:
+    stack: list[str] = []
+    items: list[str] = []
+    start = 0
+    for index, char in enumerate(text):
+        if _is_escaped(text, index):
+            continue
+        if char in _OPEN_TO_CLOSE:
+            stack.append(char)
+        elif char in _CLOSE_TO_OPEN:
+            stack.pop()
+        elif not stack and char in ",\r\n":
+            item = text[start:index].strip()
+            if item:
+                items.append(item)
+            start = index + 1
+    final_item = text[start:].strip()
+    if final_item:
+        items.append(final_item)
+    return items
+
+
+def _toggle_numeric_weight(match: re.Match[str]) -> str:
+    sign = "" if match.group("sign") == "-" else "-"
+    return (
+        f"{match.group('prefix')}{sign}{match.group('number')}"
+        f"{match.group('suffix')}"
+    )
+
+
+def _reference_transform(negative_prompt: str, policy: dict[str, Any]) -> str:
+    reason_code = str(policy["malformed_reason_code"])
+    cleaned = _strip_comments_and_validate(negative_prompt, reason_code)
+    items = _split_top_level_items(cleaned)
+    if not items:
+        return ""
+    prompt = ", ".join(items)
+    prompt = _NUMERIC_WEIGHT_RE.sub(_toggle_numeric_weight, prompt)
+    return f"({prompt}:-1)"
+
+
+def _reference_conditioning(
+    *,
+    clip: object,
+    positive_prompt: str,
+    negative_prompt: str,
+    policy: dict[str, Any],
+    encode,
+) -> tuple[object, object, str]:
+    derived = _reference_transform(negative_prompt, policy)
+    positive_execution_prompt = ", ".join(
+        part for part in (positive_prompt, derived) if part
+    )
+    positive = encode(clip, positive_execution_prompt)
+    negative = encode(clip, str(policy["neutral_negative_prompt"]))
+    return positive, negative, positive_execution_prompt
+
+
+def _reference_effective_cfg(
+    case: dict[str, Any], policy: dict[str, Any]
+) -> float | None:
+    if case["stage"] in policy["sampling_stages"]:
+        return 1.0
+    return case["stored_cfg"]
+
+
+class AIONegPipTurboContractTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.fixture = json.loads(_FIXTURE_PATH.read_text(encoding="utf-8"))
+        cls.policy = cls.fixture["policy"]
+
+    def test_contract_identity_and_ownership_are_fixed(self):
+        self.assertEqual(
+            self.fixture["schema"],
+            "easyuse_anima_aio_negpip_turbo_contract",
+        )
+        self.assertEqual(self.fixture["version"], 1)
+        self.assertEqual(self.policy["mode"], "turbo")
+        self.assertEqual(self.policy["policy_revision"], 1)
+        self.assertEqual(self.policy["negative_scale"], -1.0)
+        self.assertEqual(self.policy["composition"], "whole_prompt_group")
+        self.assertEqual(
+            self.policy["input_phase"],
+            "after_translation_and_wildcard_expansion",
+        )
+        self.assertEqual(self.policy["neutral_negative_prompt"], "")
+        self.assertEqual(self.policy["malformed_policy"], "fail_closed")
+        self.assertEqual(
+            self.policy["rejected_composition"],
+            "per_top_level_item",
+        )
+
+    def test_prompt_golden_covers_items_nesting_escapes_weights_and_empty(self):
+        observed_ids = set()
+        for case in self.fixture["prompt_cases"]:
+            with self.subTest(case=case["id"]):
+                observed_ids.add(case["id"])
+                self.assertEqual(
+                    _reference_transform(
+                        case["negative_prompt"],
+                        self.policy,
+                    ),
+                    case["derived_negative_contribution"],
+                )
+
+        self.assertEqual(
+            observed_ids,
+            {
+                "top_level_comma",
+                "top_level_newline_empty_and_comment",
+                "nested_delimiters",
+                "existing_numeric_weights",
+                "escaped_delimiters",
+                "inline_hash_is_prompt_text",
+                "empty",
+                "comment_only",
+            },
+        )
+
+    def test_malformed_prompt_fails_closed_without_mutating_source(self):
+        for case in self.fixture["malformed_cases"]:
+            with self.subTest(case=case["id"]):
+                source = case["negative_prompt"]
+                with self.assertRaisesRegex(
+                    TurboContractError,
+                    self.policy["malformed_reason_code"],
+                ):
+                    _reference_transform(source, self.policy)
+                self.assertEqual(case["negative_prompt"], source)
+
+    def test_conditioning_uses_same_patched_clip_and_neutral_empty_prompt(self):
+        patched_clip = object()
+        for case in self.fixture["conditioning_cases"]:
+            calls: list[tuple[object, str]] = []
+            encoded: list[dict[str, object]] = []
+
+            def encode(clip: object, prompt: str) -> dict[str, object]:
+                calls.append((clip, prompt))
+                result = {
+                    "conditioning": prompt,
+                    "shape": (1, 512, 2048),
+                    "metadata": {"source": "patched_clip"},
+                }
+                encoded.append(result)
+                return result
+
+            with self.subTest(case=case["id"]):
+                positive_source = case["positive_prompt"]
+                negative_source = case["negative_prompt"]
+                positive, negative, execution_prompt = _reference_conditioning(
+                    clip=patched_clip,
+                    positive_prompt=positive_source,
+                    negative_prompt=negative_source,
+                    policy=self.policy,
+                    encode=encode,
+                )
+
+                self.assertEqual(
+                    execution_prompt,
+                    case["positive_execution_prompt"],
+                )
+                self.assertEqual(
+                    calls,
+                    [
+                        (patched_clip, case["positive_execution_prompt"]),
+                        (patched_clip, case["negative_execution_prompt"]),
+                    ],
+                )
+                self.assertIs(positive, encoded[0])
+                self.assertIs(negative, encoded[1])
+                self.assertEqual(negative["shape"], (1, 512, 2048))
+                self.assertEqual(
+                    negative["metadata"],
+                    {"source": "patched_clip"},
+                )
+                self.assertEqual(case["positive_prompt"], positive_source)
+                self.assertEqual(case["negative_prompt"], negative_source)
+
+    def test_sampling_cfg_is_runtime_only_and_saved_values_are_preserved(self):
+        cases = self.fixture["stage_cfg_cases"]
+        saved = deepcopy(cases)
+        observed = {
+            case["stage"]: _reference_effective_cfg(case, self.policy)
+            for case in cases
+        }
+
+        self.assertEqual(
+            observed,
+            {
+                "first_pass": 1.0,
+                "highres": 1.0,
+                "detailer": 1.0,
+                "upscale_usdu": 1.0,
+                "upscale_resshift": None,
+                "postprocess": None,
+                "save_output": None,
+            },
+        )
+        self.assertEqual(cases, saved)
+        self.assertEqual(
+            set(self.policy["sampling_stages"]),
+            {"first_pass", "highres", "detailer", "upscale_usdu"},
+        )
+        self.assertEqual(
+            set(self.policy["non_sampling_stages"]),
+            {"upscale_resshift", "postprocess", "save_output"},
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 목적과 변경 경계

- Task: AIO-NEGPIP-03 / #411
- Class: CONTRACT
- Base -> Head: `d061f40dc69382866b67bbac8236a333a8ed6c42` -> `44bccd9c8f490bc1bab956451bfb9578e8918399`
- production JavaScript/Python, settings/profile/UI/workflow/public socket는 변경하지 않습니다.
- 변경은 Turbo golden JSON, test-local pure parser/conditioning reference fixture, 계약 문서뿐입니다.

## Contract decisions

- execution-ready prompt 순서: translation/wildcard expansion 이후 Turbo transform
- negative contribution: top-level item을 정규화한 전체 prompt를 하나의 `-1` group으로 결합
- explicit parenthetical numeric weight: 부호를 함께 반전해 기존 weight에도 정확히 `× -1` 합성
- per-item wrapping은 separator token이 negative group 밖에 남으므로 채택하지 않음
- malformed delimiter: `negpip_turbo_prompt_malformed`로 fail-closed, 원문 불변
- neutral negative: 같은 patched CLIP으로 empty prompt를 encode한 결과를 shape/metadata 변경 없이 사용
- effective CFG 1: first pass, Highres, Detailer, USDU sampling call만
- stored positive/negative prompt와 sampler/Highres/Detailer/Upscale CFG는 보존
- ResShift/Postprocess/Save Output에는 synthetic CFG를 만들지 않음

## 검증

- Focused: `run_focused_unittest.ps1 -TestTarget tests.test_aio_negpip_turbo_contract` — parser/conditioning/CFG golden 5 PASS
- Changed Python: compile + Ruff PASS
- Fixture JSON parse: PASS
- `git diff --check`: PASS
- Official full: exact SHA `44bccd9c8f490bc1bab956451bfb9578e8918399` — Python 1,208, frontend 119 JS, TypeScript 6.0.3, Pyright/import/diff PASS
- Package: not triggered; package/production tree unchanged
- Live/UI browser: not triggered; AIO-NEGPIP-03 validation map excludes UI/live

## 위험, rollback, Next

- 위험: 실제 Artist Mix/Mod Guidance와 stage integration은 아직 구현되지 않았으며 fixture가 AIO-NEGPIP-04 경계를 고정합니다.
- Rollback: 이 Contract squash commit
- Next: review/merge 후 AIO-NEGPIP-04 production/UI/selected compatibility/live matrix
- Forbidden in this PR: ComfyUI-ppm private import/vendor, production cutover, generic lifecycle framework