### PR TITLE
test(aio): define Safe PAG stage-scope contract

### DIFF
--- a/docs/architecture/aio-advanced-integrations-roadmap.md
+++ b/docs/architecture/aio-advanced-integrations-roadmap.md
@@ -2,16 +2,21 @@
 
 ## 문서 상태
 
-- 상태: **IN PROGRESS — #411 AIO-NEGPIP**
+- 상태: **IN PROGRESS — #440 AIO-SAFEPAG**
 - 기준일: 2026-07-27
 - 기준 브랜치: `dev`
-- 기준 커밋: `3cd9edc3048b4a98d7186288319311f4e703eea8`
+- 기준 커밋: `866f3e7d6e9f29c7ddf5cfaf15784261c00c4ba0`
 - 완료된 선행: [#395](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/395),
-  [#409](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/409)
+  [#409](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/409),
+  [#410](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/410),
+  [#411](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/411),
+  0.6.0 release
 - 기능 이슈:
   - [#409](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/409): stage별 고급 MODEL patch 범위
   - [#410](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/410): KJNodes Torch Compile 자동 추천
   - [#411](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/411): ComfyUI-ppm NegPip Off/On/Turbo
+  - [#440](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/440): Safe PAG stage-scope opt-in
+  - [#441](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/441): SageAttention stage-scope isolation
 - 관련 기반:
   - [#169](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/169): AiO stage pipeline/cache
   - [#187](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/187): runtime/provider lifecycle
@@ -21,10 +26,10 @@ rollback 단위와 검증 순서를 고정한다. 기능 이슈의 behavior 요�
 구체적이면 해당 이슈가 우선하며, 아키텍처 ADR과 `MAINTAINING.md`는 계속
 최상위 정책이다.
 
-`#395`의 Registry checkpoint와 `#409`의 stage-scope/precedence 구현은 완료됐다.
-`AIO-COMPILE-01`부터 `04`까지 완료됐다. 현재 production queue는 `#411`로
-이동한다.
-`#440/#441`의 patch-specific 후속은 이 queue를 선행하지 않는다.
+`#409`부터 `#411`까지의 advanced integration queue는 0.6.0으로 공개됐다.
+현재 queue는 `#440` Safe PAG follow-up이며, production cutover 전에
+`AIO-SAFEPAG-01` Contract와 migration 결정을 먼저 고정한다. `#441`의
+SageAttention scope는 #440이 완료된 뒤 별도 experimental contract로 진행한다.
 
 ## 1. 현재 확인된 실행 구조
 
@@ -568,29 +573,66 @@ Queue: repeated / concurrent / cancelled / exception
 
 ## 13. Codex 시작 지시
 
-현재 `#410` 실행:
+현재 `#440` 실행:
 
 ```text
-1. 최신 origin/dev와 open PR/branch를 확인한다.
-2. installed KJ input/signature와 직접 owner를 현재 단계에서만 재확인한다.
-3. AIO-COMPILE-01 diagnostics부터 04 live matrix까지 PR/rollback 단위를 분리한다.
-4. COMPILE-01은 fake environment만 사용하고 compile/benchmark/live를 실행하지 않는다.
-5. COMPILE-02 전에는 추천값을 추측하지 않는다.
-6. 각 최종 후보에서 focused/full/package/live trigger를 단계 계약대로 기록한다.
-7. #410 완료 후에만 #411을 시작한다.
+1. 최신 origin/dev와 #440의 pinned upstream contract를 확인한다.
+2. AIO-SAFEPAG-01은 test-local Contract와 migration 결정만 추가한다.
+3. legacy missing scope는 all-stage, fresh default는 first-pass-only로 분리한다.
+4. malformed scope, unselected stage lookup, callback success/exception cleanup을 fail-closed fixture로 고정한다.
+5. production planner/schema/UI는 Contract review와 dev merge 뒤 각각 분리한다.
+6. Legacy/Node 2.0 live는 최종 UI cutover에서만 실행한다.
+7. #440 완료 후에만 #441 SageAttention experimental contract를 시작한다.
 ```
 
 ## 14. 릴리스 정책
 
-이 문서는 다음 버전 번호를 미리 예약하지 않는다. 세 기능은 독립적으로 릴리스될
-수 있지만, #409의 stage/precedence contract가 안정되지 않은 상태에서 #410 또는
-#411만 부분 공개하지 않는다.
+`#409`부터 `#411`까지는 0.6.0으로 공개됐다. 이 문서는 #440/#441의 다음 버전
+번호를 미리 예약하지 않으며, 두 follow-up은 각각 독립 rollback과 release 결정을
+유지한다.
 
 release candidate를 만들 때 다음을 별도로 결정한다.
 
-- 세 기능을 한 minor release에 묶을지
-- #409/DAVE만 먼저 공개할지
+- #440과 #441을 같은 minor release에 묶을지
+- Safe PAG stage scope만 먼저 공개할지
 - optional dependency minimum version
 - workflow/profile migration note
 - Registry scanner/package evidence
 - 사용자에게 필요한 restart/hard-refresh 안내
+
+## 15. #440 실행 manifest
+
+### AIO-SAFEPAG-01 — Contract와 migration 결정
+
+- 유형: Contract
+- production JavaScript/Python 변경 없음
+- pinned `AnimaSafePAG` clone/callback/finally 계약
+- fresh first-pass-only와 legacy missing-scope all-stage 분리
+- malformed scope all-disabled fail-closed
+- selected stage만 dependency lookup과 clean-base clone 허용
+- Compile -> DAVE -> Safe PAG precedence; Sage scope는 #441 소유
+- package/live 미실행
+
+### AIO-SAFEPAG-02 — Backend stage plan과 lifecycle
+
+- 유형: Feature/Lifecycle
+- Safe PAG 전용 stage scope만 planner와 cache signature에 연결
+- unselected stage는 lookup/call 없음
+- selected variant는 clean `model_with_lora`에서 생성
+- sampling callback success/exception exact restore와 repeated queue cleanup
+- schema/UI/profile 변경 없음
+
+### AIO-SAFEPAG-03 — Settings/schema/UI cutover
+
+- 유형: Schema/UI
+- Safe PAG owner에만 four-stage scope UI 추가
+- migration과 fresh default, profile round-trip, Cancel/Apply 보존
+- generic patch catalog/scope UI 금지
+
+### AIO-SAFEPAG-04 — Selected live matrix와 close
+
+- Legacy Canvas와 Node 2.0 save/reload/queue
+- first-pass-only, legacy all-stage, one custom scope
+- Highres, Detailer, USDU와 ResShift no-op
+- DAVE/Torch Compile pairwise, temporary mutation cleanup
+- 전체 optional integration Cartesian matrix 미실행

--- a/tests/fixtures/aio_safe_pag_stage_scope_contract.v1.json
+++ b/tests/fixtures/aio_safe_pag_stage_scope_contract.v1.json
@@ -1,0 +1,109 @@
+{
+  "schema": "easyuse_anima_aio_safe_pag_stage_scope_contract",
+  "version": 1,
+  "upstream": {
+    "repository": "iljung1106/comfyui-anima-safe-pag",
+    "commit": "905b0107d1f924fc6acbcac3b6a879b566ff671c",
+    "node_id": "AnimaSafePAG"
+  },
+  "stage_ids": ["first_pass", "highres", "detailer", "upscale"],
+  "fresh_stage_scope": {
+    "first_pass": true,
+    "highres": false,
+    "detailer": false,
+    "upscale": false
+  },
+  "legacy_missing_scope": {
+    "first_pass": true,
+    "highres": true,
+    "detailer": true,
+    "upscale": true
+  },
+  "malformed_scope": {
+    "policy": "fail-closed-all-disabled",
+    "expected": {
+      "first_pass": false,
+      "highres": false,
+      "detailer": false,
+      "upscale": false
+    }
+  },
+  "scope_cases": [
+    {
+      "id": "disabled",
+      "enabled": false,
+      "scope": {
+        "first_pass": true,
+        "highres": true,
+        "detailer": true,
+        "upscale": true
+      },
+      "selected_stages": []
+    },
+    {
+      "id": "fresh-first-pass-only",
+      "enabled": true,
+      "scope": {
+        "first_pass": true,
+        "highres": false,
+        "detailer": false,
+        "upscale": false
+      },
+      "selected_stages": ["first_pass"]
+    },
+    {
+      "id": "legacy-missing-scope",
+      "enabled": true,
+      "scope_missing": true,
+      "selected_stages": ["first_pass", "highres", "detailer", "upscale"]
+    },
+    {
+      "id": "custom-highres-upscale",
+      "enabled": true,
+      "scope": {
+        "first_pass": false,
+        "highres": true,
+        "detailer": false,
+        "upscale": true,
+        "future_stage": true
+      },
+      "selected_stages": ["highres", "upscale"]
+    },
+    {
+      "id": "malformed-explicit-scope",
+      "enabled": true,
+      "scope": "all",
+      "selected_stages": []
+    }
+  ],
+  "non_sampling_ids": ["res_shift", "postprocess", "save"],
+  "precedence": {
+    "current_chain": [
+      "aura_flow",
+      "kj.torch_compile",
+      "dave",
+      "safe_pag",
+      "kj.fp16_accumulation",
+      "kj.sage_attention"
+    ],
+    "fixed_edges": [
+      ["kj.torch_compile", "dave"],
+      ["dave", "safe_pag"]
+    ],
+    "sage_stage_scope_owner": "#441"
+  },
+  "lifecycle": {
+    "selected_stage_requires_clone": true,
+    "external_lookup": "selected-stage-only",
+    "mutation_window": "sampling-callback-only",
+    "restore_on": ["success", "exception"],
+    "restore_identity": "exact-original-reference",
+    "persistent_shared_mutation": false
+  },
+  "ownership": {
+    "generic_patch_registry": false,
+    "generic_scope_ui": false,
+    "feature_payload_owner": "safe-pag-adapter",
+    "public_socket_or_workflow_schema_change": false
+  }
+}

--- a/tests/test_aio_safe_pag_stage_scope_contract.py
+++ b/tests/test_aio_safe_pag_stage_scope_contract.py
@@ -1,0 +1,184 @@
+from __future__ import annotations
+
+import json
+import unittest
+from pathlib import Path
+from typing import Any, Callable
+
+
+ROOT = Path(__file__).resolve().parents[1]
+FIXTURE_PATH = ROOT / "tests" / "fixtures" / "aio_safe_pag_stage_scope_contract.v1.json"
+
+
+def _scope(enabled: bool, raw: object, fixture: dict[str, Any]) -> dict[str, bool]:
+    stage_ids = tuple(fixture["stage_ids"])
+    if not enabled:
+        return {stage_id: False for stage_id in stage_ids}
+    if raw is None:
+        return dict(fixture["legacy_missing_scope"])
+    if not isinstance(raw, dict):
+        return dict(fixture["malformed_scope"]["expected"])
+    return {stage_id: raw.get(stage_id) is True for stage_id in stage_ids}
+
+
+def _selected_stages(enabled: bool, raw: object, fixture: dict[str, Any]) -> list[str]:
+    normalized = _scope(enabled, raw, fixture)
+    return [stage_id for stage_id in fixture["stage_ids"] if normalized[stage_id]]
+
+
+def _apply_selected_stage(
+    base_model: dict[str, Any],
+    *,
+    stage_id: str,
+    selected: bool,
+    lookups: list[str],
+) -> dict[str, Any]:
+    if not selected:
+        return base_model
+    lookups.append(stage_id)
+    cloned = {**base_model, "lineage": list(base_model["lineage"])}
+    cloned["lineage"].append(f"safe_pag:{stage_id}")
+    return cloned
+
+
+def _with_temporary_attention(
+    module: dict[str, object],
+    replacement: object,
+    sampler: Callable[[], object],
+) -> object:
+    original = module["optimized_attention"]
+    module["optimized_attention"] = replacement
+    try:
+        return sampler()
+    finally:
+        module["optimized_attention"] = original
+
+
+class AioSafePagStageScopeContractTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.fixture = json.loads(FIXTURE_PATH.read_text(encoding="utf-8"))
+
+    def test_identity_scope_and_ownership_decisions_are_frozen(self) -> None:
+        fixture = self.fixture
+
+        self.assertEqual(
+            fixture["upstream"],
+            {
+                "repository": "iljung1106/comfyui-anima-safe-pag",
+                "commit": "905b0107d1f924fc6acbcac3b6a879b566ff671c",
+                "node_id": "AnimaSafePAG",
+            },
+        )
+        self.assertEqual(
+            fixture["stage_ids"],
+            ["first_pass", "highres", "detailer", "upscale"],
+        )
+        self.assertEqual(
+            fixture["fresh_stage_scope"],
+            {
+                "first_pass": True,
+                "highres": False,
+                "detailer": False,
+                "upscale": False,
+            },
+        )
+        self.assertTrue(all(fixture["legacy_missing_scope"].values()))
+        self.assertEqual(
+            fixture["malformed_scope"]["policy"],
+            "fail-closed-all-disabled",
+        )
+        self.assertFalse(fixture["ownership"]["generic_patch_registry"])
+        self.assertFalse(fixture["ownership"]["generic_scope_ui"])
+        self.assertFalse(
+            fixture["ownership"]["public_socket_or_workflow_schema_change"]
+        )
+
+    def test_scope_cases_select_only_known_sampling_stages(self) -> None:
+        fixture = self.fixture
+
+        for case in fixture["scope_cases"]:
+            with self.subTest(case=case["id"]):
+                raw_scope = None if case.get("scope_missing") else case.get("scope")
+                self.assertEqual(
+                    _selected_stages(case["enabled"], raw_scope, fixture),
+                    case["selected_stages"],
+                )
+
+        self.assertTrue(
+            set(fixture["non_sampling_ids"]).isdisjoint(fixture["stage_ids"])
+        )
+
+    def test_lookup_and_clone_happen_only_for_selected_stage(self) -> None:
+        fixture = self.fixture
+        custom = next(
+            case for case in fixture["scope_cases"] if case["id"] == "custom-highres-upscale"
+        )
+        selected = set(
+            _selected_stages(custom["enabled"], custom["scope"], fixture)
+        )
+        base_model = {"lineage": ["model_with_lora"]}
+        lookups: list[str] = []
+
+        variants = {
+            stage_id: _apply_selected_stage(
+                base_model,
+                stage_id=stage_id,
+                selected=stage_id in selected,
+                lookups=lookups,
+            )
+            for stage_id in fixture["stage_ids"]
+        }
+
+        self.assertEqual(lookups, ["highres", "upscale"])
+        self.assertIs(variants["first_pass"], base_model)
+        self.assertIs(variants["detailer"], base_model)
+        self.assertIsNot(variants["highres"], base_model)
+        self.assertIsNot(variants["upscale"], base_model)
+        self.assertIsNot(variants["highres"], variants["upscale"])
+        self.assertEqual(base_model, {"lineage": ["model_with_lora"]})
+
+    def test_temporary_attention_mutation_restores_exact_reference(self) -> None:
+        original = object()
+        replacement = object()
+        module: dict[str, object] = {"optimized_attention": original}
+
+        seen = _with_temporary_attention(
+            module,
+            replacement,
+            lambda: module["optimized_attention"],
+        )
+
+        self.assertIs(seen, replacement)
+        self.assertIs(module["optimized_attention"], original)
+
+        def fail() -> object:
+            self.assertIs(module["optimized_attention"], replacement)
+            raise RuntimeError("sampling failed")
+
+        with self.assertRaisesRegex(RuntimeError, "sampling failed"):
+            _with_temporary_attention(module, replacement, fail)
+        self.assertIs(module["optimized_attention"], original)
+
+    def test_precedence_keeps_safe_pag_feature_owned_and_defers_sage_scope(self) -> None:
+        precedence = self.fixture["precedence"]
+        chain = precedence["current_chain"]
+
+        for before, after in precedence["fixed_edges"]:
+            with self.subTest(edge=(before, after)):
+                self.assertLess(chain.index(before), chain.index(after))
+
+        self.assertEqual(precedence["sage_stage_scope_owner"], "#441")
+        self.assertEqual(
+            self.fixture["ownership"]["feature_payload_owner"],
+            "safe-pag-adapter",
+        )
+        self.assertFalse(self.fixture["lifecycle"]["persistent_shared_mutation"])
+        self.assertEqual(
+            self.fixture["lifecycle"]["restore_on"],
+            ["success", "exception"],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 목적과 변경 경계

Task: AIO-SAFEPAG-01 / #440
Class: CONTRACT
Base -> Head: 866f3e7d6e9f29c7ddf5cfaf15784261c00c4ba0 -> ed6f3c37ece7bd0381b042da62fe2b939b8c45af

- Safe PAG four-stage scope와 migration/lifecycle 결정을 test-local fixture로 고정
- advanced integration roadmap을 0.6.0 이후 #440 queue로 갱신
- production JavaScript/Python, schema/UI/runtime, public socket/workflow 변경 없음

## Contract decisions

- stages: first_pass / highres / detailer / upscale
- fresh: first-pass-only
- legacy missing scope: all sampling stages
- malformed explicit scope: all-disabled fail-closed
- selected stage만 external lookup과 clean model_with_lora clone 허용
- temporary attention mutation은 sampling callback 안에서만 존재하고 success/exception 모두 exact original reference 복원
- precedence: KJ Torch Compile -> DAVE -> Safe PAG
- SageAttention stage scope는 #441 소유; generic patch registry/scope UI 금지
- ResShift/postprocess/save는 scope 대상 아님

## 검증

- changed Python py_compile, fixture JSON parse, git diff --check — PASS
- Focused: tests.test_aio_safe_pag_stage_scope_contract — 5 PASS; scope/lookup/clone/cleanup/precedence 증명
- Full: official full at ed6f3c37ece7bd0381b042da62fe2b939b8c45af — Python 1,222; frontend 119 JS; TypeScript 6.0.3; Pyright/import/diff PASS
- Package: not triggered; production/package tree unchanged
- Live: not triggered; Contract-only phase

## 위험과 rollback

- Runtime planner는 아직 Safe PAG stage_scope를 해석하지 않으며 기존 all-stage 동작을 유지함
- Rollback: ed6f3c3 Contract commit

## Next

review/dev merge 후 AIO-SAFEPAG-02 backend stage plan과 lifecycle. Schema/UI/live cutover는 후속 독립 PR.