### PR TITLE
feat: add Safe PAG stage-scope backend runtime

### DIFF
--- a/easyuse_anima/aio/first_pass_cache.py
+++ b/easyuse_anima/aio/first_pass_cache.py
@@ -14,7 +14,7 @@ from .generation_migrations import (
     AIO_MODEL_PATCH_ORDER_REVISION,
     AIO_MODEL_PATCH_PRECEDENCE,
 )
-from .model_preparation import _aio_lora_stack_signature
+from .model_preparation import _aio_lora_stack_signature, _aio_safe_pag_in_stage
 from .negpip import _aio_negpip_cache_signature
 
 AIO_FIRST_PASS_CACHE_MAX_ENTRIES = 2
@@ -323,7 +323,10 @@ def _aio_first_pass_model_patch_plan(model_patches) -> dict[str, Any]:
             }
 
     safe_pag = source.get("safe_pag")
-    if isinstance(safe_pag, dict) and bool(safe_pag.get("enabled")):
+    if isinstance(safe_pag, dict) and _aio_safe_pag_in_stage(
+        safe_pag,
+        "first_pass",
+    ):
         patches["safe_pag"] = {
             key: safe_pag.get(key)
             for key in (
@@ -337,6 +340,7 @@ def _aio_first_pass_model_patch_plan(model_patches) -> dict[str, Any]:
                 "rescale_mode",
             )
         }
+        patches["safe_pag"]["stage_scope"] = {"first_pass": True}
 
     return {
         "order_revision": AIO_MODEL_PATCH_ORDER_REVISION,

--- a/easyuse_anima/aio/model_preparation.py
+++ b/easyuse_anima/aio/model_preparation.py
@@ -23,6 +23,22 @@ from .generation_migrations import (
 logger = logging.getLogger("ComfyUI-EasyUseAnima")
 
 
+def _aio_safe_pag_in_stage(
+    safe_pag_settings: object,
+    stage_id: str,
+) -> bool:
+    if stage_id not in AIO_GENERATION_STAGE_IDS:
+        raise ValueError(f"Unknown AiO sampling stage: {stage_id}")
+    if not isinstance(safe_pag_settings, dict) or not _as_bool(
+        safe_pag_settings.get("enabled"), False
+    ):
+        return False
+    if "stage_scope" not in safe_pag_settings:
+        return True
+    stage_scope = safe_pag_settings.get("stage_scope")
+    return isinstance(stage_scope, dict) and stage_scope.get(stage_id) is True
+
+
 def _missing_host_helper(name: str):
     raise RuntimeError(
         f"[EasyUseAnima] AiO model preparation Comfy host helper is unavailable: {name}"
@@ -184,7 +200,7 @@ def _aio_stage_model_patch_plan(
         isinstance(compile_settings, dict)
         and _as_bool(compile_settings.get("enabled"), False)
     )
-    safe_pag_enabled = _as_bool(safe_pag_settings.get("enabled"), False)
+    safe_pag_in_stage = _aio_safe_pag_in_stage(safe_pag_settings, stage_id)
     fp16_enabled = _as_bool(kj_settings.get("fp16_accumulation"), False)
     sage_enabled = str(kj_settings.get("sage_attention") or "disabled") != "disabled"
     compile_before_dave = dave_in_stage and compile_enabled
@@ -194,7 +210,7 @@ def _aio_stage_model_patch_plan(
         patch_ids.append("kj.torch_compile")
     if dave_in_stage:
         patch_ids.append("dave")
-    if safe_pag_enabled:
+    if safe_pag_in_stage:
         patch_ids.append("safe_pag")
     if fp16_enabled:
         patch_ids.append("kj.fp16_accumulation")
@@ -207,7 +223,7 @@ def _aio_stage_model_patch_plan(
         "order_revision": AIO_MODEL_PATCH_ORDER_REVISION,
         "aura_flow": dict(aura_settings),
         "dave": dict(dave_settings) if dave_in_stage else None,
-        "safe_pag": dict(safe_pag_settings),
+        "safe_pag": dict(safe_pag_settings) if safe_pag_in_stage else None,
         "kj": dict(kj_settings),
         "compile_before_dave": compile_before_dave,
     }

--- a/tests/fixtures/python_backend_baseline.json
+++ b/tests/fixtures/python_backend_baseline.json
@@ -4618,6 +4618,24 @@
       },
       {
         "alias": null,
+        "bound_name": "_aio_safe_pag_in_stage",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".model_preparation:_aio_safe_pag_in_stage",
+        "kind": "static_from",
+        "line": 17,
+        "name": "_aio_safe_pag_in_stage",
+        "optional": false,
+        "requested": ".model_preparation",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/aio/first_pass_cache.py",
+        "target": "easyuse_anima/aio/model_preparation.py"
+      },
+      {
+        "alias": null,
         "bound_name": "_aio_negpip_cache_signature",
         "branch_context": [],
         "classification": "internal",
@@ -10716,7 +10734,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 412
+            "line": 428
           }
         ],
         "classification": "external",
@@ -10724,7 +10742,7 @@
         "conditional": true,
         "imported": "comfy.model_management",
         "kind": "static_import",
-        "line": 413,
+        "line": 429,
         "name": null,
         "optional": true,
         "requested": "comfy.model_management",
@@ -60467,9 +60485,9 @@
       },
       {
         "is_package": false,
-        "loc": 485,
+        "loc": 489,
         "module": "easyuse_anima.aio.first_pass_cache",
-        "normalized_git_blob_sha1": "9feb50eab574b1c7ff2f833b35a00271da8b3b32",
+        "normalized_git_blob_sha1": "f0ac3ed37b7ea03ecfbc853629211605ad569494",
         "path": "easyuse_anima/aio/first_pass_cache.py",
         "top_level": {
           "class_count": 2,
@@ -60719,13 +60737,13 @@
       },
       {
         "is_package": false,
-        "loc": 551,
+        "loc": 567,
         "module": "easyuse_anima.aio.model_preparation",
-        "normalized_git_blob_sha1": "87898b28862487c31131757a9ae19b4ce4f5b1fe",
+        "normalized_git_blob_sha1": "91bc80df06162725a0d9f76afb97492b6a50f910",
         "path": "easyuse_anima/aio/model_preparation.py",
         "top_level": {
           "class_count": 0,
-          "function_count": 20,
+          "function_count": 21,
           "global_count": 2
         }
       },
@@ -75013,14 +75031,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 412
+            "line": 428
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "comfy.model_management",
         "kind": "static_import",
-        "line": 413,
+        "line": 429,
         "optional": true,
         "role": "optional_dependency",
         "source": "easyuse_anima/aio/model_preparation.py"
@@ -79490,14 +79508,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 412
+            "line": 428
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "comfy.model_management",
         "kind": "static_import",
-        "line": 413,
+        "line": 429,
         "optional": true,
         "role": "optional_dependency",
         "source": "easyuse_anima/aio/model_preparation.py"

--- a/tests/test_aio_first_pass_cache.py
+++ b/tests/test_aio_first_pass_cache.py
@@ -899,7 +899,23 @@ class AIOFirstPassCacheMoveTests(unittest.TestCase):
                         "upscale": False,
                     },
                 },
-                "safe_pag": {"enabled": False},
+                "safe_pag": {
+                    "enabled": True,
+                    "scale": 4.0,
+                    "block_indices": "18",
+                    "perturbation_strength": 0.75,
+                    "head_indices": "",
+                    "start_percent": 0.0,
+                    "end_percent": 0.7,
+                    "rescale": 0.2,
+                    "rescale_mode": "full",
+                    "stage_scope": {
+                        "first_pass": True,
+                        "highres": False,
+                        "detailer": False,
+                        "upscale": False,
+                    },
+                },
                 "kj": {
                     "fp16_accumulation": False,
                     "sage_attention": "disabled",
@@ -945,13 +961,18 @@ class AIOFirstPassCacheMoveTests(unittest.TestCase):
         )
         self.assertEqual(
             list(plan["patches"]),
-            ["aura_flow", "kj.torch_compile", "dave"],
+            ["aura_flow", "kj.torch_compile", "dave", "safe_pag"],
+        )
+        self.assertEqual(
+            plan["patches"]["safe_pag"]["stage_scope"],
+            {"first_pass": True},
         )
 
         for stage_id in ("highres", "detailer", "upscale"):
             with self.subTest(later_stage=stage_id):
                 changed = copy.deepcopy(settings)
                 changed["model_patches"]["dave"]["stage_scope"][stage_id] = True
+                changed["model_patches"]["safe_pag"]["stage_scope"][stage_id] = True
                 self.assertEqual(
                     first_pass_cache._aio_first_pass_cache_key(
                         **{**key_args, "settings": changed}
@@ -966,6 +987,41 @@ class AIOFirstPassCacheMoveTests(unittest.TestCase):
                 **{**key_args, "settings": first_disabled}
             ),
             baseline,
+        )
+
+        safe_pag_first_disabled = copy.deepcopy(settings)
+        safe_pag_first_disabled["model_patches"]["safe_pag"]["stage_scope"][
+            "first_pass"
+        ] = False
+        self.assertNotEqual(
+            first_pass_cache._aio_first_pass_cache_key(
+                **{**key_args, "settings": safe_pag_first_disabled}
+            ),
+            baseline,
+        )
+
+        legacy_safe_pag = copy.deepcopy(settings)
+        del legacy_safe_pag["model_patches"]["safe_pag"]["stage_scope"]
+        self.assertEqual(
+            first_pass_cache._aio_first_pass_cache_key(
+                **{**key_args, "settings": legacy_safe_pag}
+            ),
+            baseline,
+        )
+
+        malformed_safe_pag = copy.deepcopy(settings)
+        malformed_safe_pag["model_patches"]["safe_pag"]["stage_scope"] = "all"
+        self.assertNotEqual(
+            first_pass_cache._aio_first_pass_cache_key(
+                **{**key_args, "settings": malformed_safe_pag}
+            ),
+            baseline,
+        )
+        self.assertNotIn(
+            "safe_pag",
+            first_pass_cache._aio_first_pass_model_patch_plan(
+                malformed_safe_pag["model_patches"]
+            )["patches"],
         )
 
         with patch.object(first_pass_cache, "AIO_MODEL_PATCH_ORDER_REVISION", 2):

--- a/tests/test_aio_model_preparation.py
+++ b/tests/test_aio_model_preparation.py
@@ -194,7 +194,7 @@ class AIOModelPreparationMoveTests(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "Unknown AiO sampling stage"):
             model_preparation._aio_stage_model_patch_plan(first_only, "save")
 
-    def test_unapproved_scope_fields_do_not_partially_select_safe_pag_or_kj(self):
+    def test_safe_pag_scope_is_stage_local_while_kj_scopes_remain_run_wide(self):
         settings = {
             "model_patches": {
                 "dave": {"enabled": False},
@@ -228,9 +228,15 @@ class AIOModelPreparationMoveTests(unittest.TestCase):
                 },
             }
         }
-        expected_patch_ids = (
+        first_pass_patch_ids = (
             "aura_flow",
             "safe_pag",
+            "kj.fp16_accumulation",
+            "kj.sage_attention",
+            "kj.torch_compile",
+        )
+        later_stage_patch_ids = (
+            "aura_flow",
             "kj.fp16_accumulation",
             "kj.sage_attention",
             "kj.torch_compile",
@@ -243,12 +249,60 @@ class AIOModelPreparationMoveTests(unittest.TestCase):
 
         self.assertEqual(
             {stage_id: plan.patch_ids for stage_id, plan in plans.items()},
-            {stage_id: expected_patch_ids for stage_id in plans},
+            {
+                "first_pass": first_pass_patch_ids,
+                "highres": later_stage_patch_ids,
+                "detailer": later_stage_patch_ids,
+                "upscale": later_stage_patch_ids,
+            },
         )
         self.assertEqual(
             len({plan.signature for plan in plans.values()}),
+            2,
+            "Safe PAG scope must split selected and unselected stage variants",
+        )
+        self.assertEqual(
+            len(
+                {
+                    plans[stage_id].signature
+                    for stage_id in ("highres", "detailer", "upscale")
+                }
+            ),
             1,
-            "Unsupported scope fields must not create partial stage variants",
+            "Unsupported KJ scope fields must remain run-wide",
+        )
+
+    def test_safe_pag_missing_scope_is_legacy_all_stage_and_malformed_fails_closed(self):
+        legacy = {
+            "model_patches": {
+                "safe_pag": {"enabled": True},
+            }
+        }
+        self.assertTrue(
+            all(
+                "safe_pag"
+                in model_preparation._aio_stage_model_patch_plan(
+                    legacy,
+                    stage_id,
+                ).patch_ids
+                for stage_id in ("first_pass", "highres", "detailer", "upscale")
+            )
+        )
+
+        malformed = {
+            "model_patches": {
+                "safe_pag": {"enabled": True, "stage_scope": "all"},
+            }
+        }
+        self.assertTrue(
+            all(
+                "safe_pag"
+                not in model_preparation._aio_stage_model_patch_plan(
+                    malformed,
+                    stage_id,
+                ).patch_ids
+                for stage_id in ("first_pass", "highres", "detailer", "upscale")
+            )
         )
 
     def test_stage_plan_moves_only_compile_before_dave_in_the_patch_chain(self):
@@ -379,6 +433,38 @@ class AIOModelPreparationMoveTests(unittest.TestCase):
                 "aura",
             )
         apply_dave.assert_not_called()
+
+    def test_safe_pag_disabled_stage_does_not_call_safe_pag_adapter(self):
+        settings = {
+            "model_patches": {
+                "safe_pag": {
+                    "enabled": True,
+                    "stage_scope": {"highres": False},
+                },
+            }
+        }
+        plan = model_preparation._aio_stage_model_patch_plan(settings, "highres")
+        with (
+            patch.object(
+                model_preparation,
+                "_patch_model_sampling_aura_flow",
+                return_value="aura",
+            ),
+            patch.object(
+                model_preparation,
+                "_apply_aio_safe_pag_patch",
+            ) as apply_safe_pag,
+            patch.object(
+                model_preparation,
+                "_apply_aio_kj_model_patches",
+                side_effect=lambda model, _settings: model,
+            ),
+        ):
+            self.assertEqual(
+                model_preparation._apply_aio_stage_model_patch_plan("base", plan),
+                "aura",
+            )
+        apply_safe_pag.assert_not_called()
 
     def test_kj_patch_chain_preserves_fp16_sage_compile_order_and_arguments(self):
         calls: list[tuple[object, ...]] = []


### PR DESCRIPTION
## 목적과 변경 경계
AIO-SAFEPAG-02 / #440 backend runtime만 구현합니다. Safe PAG의 optional stage_scope를 model preparation과 first-pass cache의 직접 owner에서 처리하며 schema/UI/profile/public workflow는 변경하지 않습니다.

## Base -> Head
d14d0fea9e06f00bfc3d404f252bf7162538c9c6 -> ffd120ccb83e4513d1b02d3678877027472fde58

## 주요 파일과 보존 계약
- easyuse_anima/aio/model_preparation.py
- easyuse_anima/aio/first_pass_cache.py
- tests/test_aio_model_preparation.py
- tests/test_aio_first_pass_cache.py
- tests/fixtures/python_backend_baseline.json
- missing stage_scope: legacy all-stage
- malformed explicit scope: all-disabled fail-closed
- selected stage만 Safe PAG lookup/patch plan에 참여
- clean model_with_lora stage variant, 기존 metadata/bounded cleanup owner 유지
- first-pass cache signature는 first_pass 선택만 canonicalize
- Compile -> DAVE -> Safe PAG 순서 유지

## 검증
- Focused: model preparation 14 PASS; first-pass cache 31 PASS; generation lifecycle 10 PASS; Safe PAG Contract 5 PASS
- Analyzer correction: repository fixture exact match 1 PASS
- Changed Python compile/static: PASS
- git diff --check: PASS
- Full: check_custom_node.ps1 -Profile full, exact ffd120ccb83e4513d1b02d3678877027472fde58, Python 1,224 / frontend 119 / TypeScript 6.0.3 / Pyright / import / diff PASS
- Package: comfy node validate PASS
- Live: not triggered; schema/UI가 아직 없으므로 AIO-SAFEPAG-04에서 수행

## 위험, rollback, next
- Rollback: ffd120c까지의 AIO-SAFEPAG-02 commits
- Next: AIO-SAFEPAG-03 schema/settings/UI
