### PR TITLE
[AIO-SAFEPAG-04] Record Safe PAG live matrix

### DIFF
--- a/docs/development/README.md
+++ b/docs/development/README.md
@@ -34,6 +34,8 @@ conversation.
      `docs/development/frontend-maintenance-roadmap.md`
    - repeatable legacy-canvas and Node 2.0 browser validation:
      `docs/development/browser-smoke-matrix.md`
+   - Safe PAG stage-scope risk-based live evidence:
+     `docs/development/aio-safe-pag-live-matrix.md`
    - historical Issue #14 PR #18 execution plan:
      `docs/development/issue-14-frontend-js-maintenance.md`
    - deferred Node 2.0 DOM widget resize investigation:
@@ -72,6 +74,8 @@ not be loaded during ordinary successful tasks.
   `docs/development/frontend-maintenance-roadmap.md`
 - Dual-canvas browser smoke matrix:
   `docs/development/browser-smoke-matrix.md`
+- Safe PAG stage-scope live matrix:
+  `docs/development/aio-safe-pag-live-matrix.md`
 - Historical Issue #14 PR #18 execution plan:
   `docs/development/issue-14-frontend-js-maintenance.md`
 - Deferred Node 2.0 DOM widget resize investigation:

--- a/docs/development/aio-safe-pag-live-matrix.md
+++ b/docs/development/aio-safe-pag-live-matrix.md
@@ -1,0 +1,57 @@
+# AIO-SAFEPAG-04 Risk-based Live Matrix
+
+## 결론
+
+- production 기준: `dev@fa016174f81a68ee551b08dd30ddb672697f91e8`
+- 범위: Issue #440의 Safe PAG `first_pass/highres/detailer/upscale`
+  stage-scope와 Legacy Canvas / Node 2.0 저장·재로드·queue parity
+- 결과: **PASS**
+- production, public node socket, workflow schema와 외부 custom-node는 변경하지
+  않았다. 전체 optional-integration Cartesian matrix도 실행하지 않았다.
+
+## 고정한 live 경계
+
+- `AnimaSafePAG` object-info는 현재 production adapter가 요구하는 MODEL과 8개
+  Safe PAG parameter를 그대로 제공했다.
+- source와 Codex test instance 설치본의 Safe PAG schema, migration,
+  normalization, model-preparation, Advanced UI owner hash가 일치했다.
+- 다음 frontend module은 source, installed, HTTP served SHA-256이 각각
+  일치했고 served response는 모두 HTTP 200이었다.
+
+| Module | SHA-256 |
+| --- | --- |
+| `web/js/aio/settings.js` | `CCD288D2814DD499405D16F8477331267DF7EFCFAE75438CD8EAB7DB9AA7FFBC` |
+| `web/js/aio/advanced_settings_dialog.js` | `3D7F76A2E0ACA994432DA0EFC2FC2F6E0B3047549EBD37339F76098485E908E2` |
+| `web/js/easyuse_anima_aio.js` | `C1DCA1104DBECFFCE9F175C0424D09DD2CF54CB05B756CE59796D1C6DCD125A0` |
+
+## 선택 live matrix
+
+| Surface / risk | 설정과 저장·재로드 관측 | Terminal / output |
+| --- | --- | --- |
+| Legacy Canvas fresh scope | Modern Node Design off. 기존 v1 workflow를 실제 Advanced UI에서 v3로 적용했다. Safe PAG on, `first_pass_only`; Highres, Detailer, Upscale off. 저장 후 hard reload와 재로드에서 preset과 네 stage boolean이 동일했다. | success/completed, 약 13.43 s, 512×512 image 1개, running 0, pending 0 |
+| Node 2.0 custom scope | Modern Node Design on, Vue node signal 8. Safe PAG `custom`에서 Highres만 true; first pass, Detailer, Upscale false. Highres 1.25×, 1 step. 저장 후 hard reload와 재로드에서 custom checkbox와 hidden v3 settings가 동일했다. | success/completed, 약 11.86 s, Highres 결과 640×640 image 1개, running 0, pending 0 |
+
+Legacy case는 선택되지 않은 후속 sampling stage를 비활성화해 first-pass lineage만
+실행했다. Node 2.0 case는 first pass를 Safe PAG scope에서 제외하고 Highres만
+선택했으며, 512×512 first pass 뒤 640×640 output이 생성되어 Highres stage가
+실제로 실행됐음을 확인했다. Detailer와 USDU의 deterministic selected/unselected
+lineage는 repository fixture가 소유하고 live matrix에서는 중복 조합을 추가하지
+않았다.
+
+## UI, error, cleanup
+
+- 두 표면 모두 실제 Safe PAG-owned preset/custom controls를 사용했다.
+- Apply 뒤 hidden settings는 `version: 3`과 exact stage booleans를 보존했다.
+- reload 뒤 Advanced UI의 preset/custom 표시와 serialized settings가 일치했다.
+- 두 queue의 EasyUse Anima page error와 Safe PAG 관련 browser error는 0건이었다.
+- user CSS, autocomplete와 subgraph endpoint 404, 타 custom-node의 optional Python
+  dependency 누락, frontend deprecation warning은 startup baseline으로 분리했다.
+- 시작 canvas mode인 Legacy를 복구했다. disposable workflow와 output, headless
+  browser profile을 제거하고 browser/server process tree를 종료했다. 종료 후 test
+  ports에 listener가 남지 않았다.
+
+## Fallback
+
+Safe PAG는 기존 `enabled` switch로 전체 비활성화할 수 있고, 각 stage는 feature-owned
+scope boolean으로 독립적으로 제외할 수 있다. Legacy settings에 scope가 없으면 기존
+all-stage 결과를 보존하며, malformed explicit scope는 all-disabled로 fail-closed한다.


### PR DESCRIPTION
## 목적과 경계

- Task: AIO-SAFEPAG-04 / #440
- Class: LIVE EVIDENCE
- Base -> Head: fa016174f81a68ee551b08dd30ddb672697f91e8 -> 3d90289f84e6b70da6bce9c2ca3e44eb85d9cdbc
- Changed boundary: risk-based live matrix 문서와 development index만
- Production JavaScript/Python, public socket, workflow schema, external dependency: unchanged

## Live 결과

- Source / installed / HTTP served closure: Safe PAG settings/Advanced UI owners 일치; served frontend 3개 HTTP 200
- Optional dependency: AnimaSafePAG object-info가 production adapter input contract와 일치
- Legacy Canvas: modern-node off, Safe PAG first-pass-only, Highres/Detailer/Upscale off
  - v3 hidden settings 및 UI preset save/reload PASS
  - queue success/completed, 512x512 image 1개, running/pending 0
- Node 2.0: modern-node on, Vue node signal 8, Safe PAG custom Highres-only
  - Highres 1.25x/1 step; v3 hidden settings 및 custom checkbox save/reload PASS
  - queue success/completed, 640x640 image 1개, running/pending 0
- EasyUse Anima / Safe PAG browser errors: 0
- Unrelated startup baseline: optional Python dependency 누락, user CSS/autocomplete/subgraph 404, frontend deprecation warnings
- Cleanup: starting Legacy mode 복구; disposable workflow/output/profile 제거; browser/server process tree 종료; test listeners 0

## 검증

- Focused: tests.test_aio_safe_pag_stage_scope_contract — 5 PASS
- Package: comfy node validate — PASS
- Full: official full at 3d90289f84e6b70da6bce9c2ca3e44eb85d9cdbc — PASS
  - Python unittest 1,224
  - frontend 119 / TypeScript 6.0.3
  - Pyright baseline, import boundary, git diff — PASS
  - Ruff 120 existing report-only findings

## 위험과 rollback

- No production risk added; evidence document records bounded cases rather than a Cartesian claim.
- Rollback: 3d90289 docs commit.
- Next: close #440 after merge; continue #441 SageAttention stage-scope from latest dev.