### PR TITLE
[AIO-SAGE-01] Define Sage stage-scope contract

### DIFF
--- a/docs/architecture/aio-advanced-integrations-roadmap.md
+++ b/docs/architecture/aio-advanced-integrations-roadmap.md
@@ -2,10 +2,10 @@
 
 ## 문서 상태
 
-- 상태: **IN PROGRESS — #440 AIO-SAFEPAG**
+- 상태: **IN PROGRESS — #441 AIO-SAGE**
 - 기준일: 2026-07-27
 - 기준 브랜치: `dev`
-- 기준 커밋: `866f3e7d6e9f29c7ddf5cfaf15784261c00c4ba0`
+- 기준 커밋: `9a2ae70841b52d42bc47eb90d4698ddbe411e0d1`
 - 완료된 선행: [#395](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/395),
   [#409](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/409),
   [#410](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/410),
@@ -27,9 +27,9 @@ rollback 단위와 검증 순서를 고정한다. 기능 이슈의 behavior 요�
 최상위 정책이다.
 
 `#409`부터 `#411`까지의 advanced integration queue는 0.6.0으로 공개됐다.
-현재 queue는 `#440` Safe PAG follow-up이며, production cutover 전에
-`AIO-SAFEPAG-01` Contract와 migration 결정을 먼저 고정한다. `#441`의
-SageAttention scope는 #440이 완료된 뒤 별도 experimental contract로 진행한다.
+`#440` Safe PAG follow-up은 완료됐다. 현재 queue는 `#441` SageAttention
+follow-up이며, production cutover 전에 `AIO-SAGE-01` experimental Contract와
+migration 결정을 먼저 고정한다.
 
 ## 1. 현재 확인된 실행 구조
 
@@ -573,16 +573,17 @@ Queue: repeated / concurrent / cancelled / exception
 
 ## 13. Codex 시작 지시
 
-현재 `#440` 실행:
+현재 `#441` 실행:
 
 ```text
-1. 최신 origin/dev와 #440의 pinned upstream contract를 확인한다.
-2. AIO-SAFEPAG-01은 test-local Contract와 migration 결정만 추가한다.
-3. legacy missing scope는 all-stage, fresh default는 first-pass-only로 분리한다.
-4. malformed scope, unselected stage lookup, callback success/exception cleanup을 fail-closed fixture로 고정한다.
-5. production planner/schema/UI는 Contract review와 dev merge 뒤 각각 분리한다.
-6. Legacy/Node 2.0 live는 최종 UI cutover에서만 실행한다.
-7. #440 완료 후에만 #441 SageAttention experimental contract를 시작한다.
+1. 최신 origin/dev와 #441의 pinned/current upstream contract를 확인한다.
+2. AIO-SAGE-01은 test-local Contract와 migration 결정만 추가한다.
+3. clean-base clone의 model_options와 attention override isolation을 증명한다.
+4. allow_compile=false/true를 분리하되 patch 시점의 eager compile을 허용하지 않는다.
+5. legacy missing scope는 all-stage, fresh default는 first-pass-only로 분리한다.
+6. malformed scope, unselected lookup, dependency/input/signature drift를 fail-closed fixture로 고정한다.
+7. production planner/schema/UI는 Contract review와 dev merge 뒤 각각 분리한다.
+8. Legacy/Node 2.0 live는 최종 UI cutover에서만 실행한다.
 ```
 
 ## 14. 릴리스 정책
@@ -635,4 +636,41 @@ release candidate를 만들 때 다음을 별도로 결정한다.
 - first-pass-only, legacy all-stage, one custom scope
 - Highres, Detailer, USDU와 ResShift no-op
 - DAVE/Torch Compile pairwise, temporary mutation cleanup
+- 전체 optional integration Cartesian matrix 미실행
+
+## 16. #441 실행 manifest
+
+### AIO-SAGE-01 — Experimental Contract와 migration 결정
+
+- 유형: Contract
+- production JavaScript/Python 변경 없음
+- pinned/current `PathchSageAttentionKJ` clone-local override 계약
+- fresh first-pass-only와 legacy missing-scope all-stage 분리
+- malformed scope와 dependency/input/signature drift fail-closed
+- allow_compile=false는 compiler-disable wrapper, true는 downstream trace만 허용
+- patch 시점 eager compile과 shared compile registry 소유 금지
+- package/live 미실행
+
+### AIO-SAGE-02 — Backend stage plan과 cache
+
+- 유형: Feature/Lifecycle
+- SageAttention 전용 scope만 planner와 first-pass cache signature에 연결
+- unselected stage는 KJ node lookup/call 없음
+- selected variant는 clean `model_with_lora`에서 clone
+- FP16 accumulation과 Torch Compile은 기존 run-global/run-wide 계약 유지
+- schema/UI/profile 변경 없음
+
+### AIO-SAGE-03 — Settings/schema/UI cutover
+
+- 유형: Schema/UI
+- SageAttention owner에만 four-stage scope UI 추가
+- migration과 fresh default, profile round-trip, Cancel/Apply 보존
+- allow_compile은 Sage feature field로 유지하고 generic compile owner를 만들지 않음
+
+### AIO-SAGE-04 — Selected live matrix와 close
+
+- Legacy Canvas와 Node 2.0 save/reload/queue
+- first-pass-only, legacy all-stage, one custom scope
+- allow_compile=false/true를 대표 queue로 분리
+- DAVE/Safe PAG/Torch Compile pairwise만 실행
 - 전체 optional integration Cartesian matrix 미실행

--- a/tests/fixtures/aio_sage_stage_scope_contract.v1.json
+++ b/tests/fixtures/aio_sage_stage_scope_contract.v1.json
@@ -1,0 +1,170 @@
+{
+  "schema": "easyuse_anima_aio_sage_stage_scope_contract",
+  "version": 1,
+  "decision": "FEASIBLE",
+  "upstream": {
+    "repository": "kijai/ComfyUI-KJNodes",
+    "pinned_commit": "e27a505b3ba6ce42687fe00500deda103d9d6071",
+    "verified_current_commit": "bb131be9e83d2f773c90f1d6f1e4b248a498c8c5",
+    "node_id": "PathchSageAttentionKJ",
+    "function": "patch",
+    "experimental": true,
+    "model_options_path": ["transformer_options", "optimized_attention_override"]
+  },
+  "node_contract": {
+    "required_inputs": ["model", "sage_attention"],
+    "optional_inputs": ["allow_compile"],
+    "patch_parameters": ["model", "sage_attention", "allow_compile"],
+    "allow_compile_default": false,
+    "sage_modes": [
+      "disabled",
+      "auto",
+      "sageattn_qk_int8_pv_fp16_cuda",
+      "sageattn_qk_int8_pv_fp16_triton",
+      "sageattn_qk_int8_pv_fp8_cuda",
+      "sageattn_qk_int8_pv_fp8_cuda++",
+      "sageattn3",
+      "sageattn3_per_block_mean"
+    ],
+    "drift_policy": "fail-closed-before-patch"
+  },
+  "stage_ids": ["first_pass", "highres", "detailer", "upscale"],
+  "fresh_stage_scope": {
+    "first_pass": true,
+    "highres": false,
+    "detailer": false,
+    "upscale": false
+  },
+  "legacy_missing_scope": {
+    "first_pass": true,
+    "highres": true,
+    "detailer": true,
+    "upscale": true
+  },
+  "malformed_scope": {
+    "policy": "fail-closed-all-disabled",
+    "expected": {
+      "first_pass": false,
+      "highres": false,
+      "detailer": false,
+      "upscale": false
+    }
+  },
+  "scope_cases": [
+    {
+      "id": "disabled",
+      "mode": "disabled",
+      "scope": {
+        "first_pass": true,
+        "highres": true,
+        "detailer": true,
+        "upscale": true
+      },
+      "selected_stages": []
+    },
+    {
+      "id": "fresh-first-pass-only",
+      "mode": "auto",
+      "scope": {
+        "first_pass": true,
+        "highres": false,
+        "detailer": false,
+        "upscale": false
+      },
+      "selected_stages": ["first_pass"]
+    },
+    {
+      "id": "legacy-missing-scope",
+      "mode": "auto",
+      "scope_missing": true,
+      "selected_stages": ["first_pass", "highres", "detailer", "upscale"]
+    },
+    {
+      "id": "custom-highres-detailer",
+      "mode": "sageattn3",
+      "scope": {
+        "first_pass": false,
+        "highres": true,
+        "detailer": true,
+        "upscale": false,
+        "future_stage": true
+      },
+      "selected_stages": ["highres", "detailer"]
+    },
+    {
+      "id": "malformed-explicit-scope",
+      "mode": "auto",
+      "scope": "all",
+      "selected_stages": []
+    }
+  ],
+  "non_sampling_ids": ["res_shift", "postprocess", "save"],
+  "clone_contract": {
+    "selected_stage_requires_clone": true,
+    "model_options_copy": "deep-list-dict-with-leaf-identity",
+    "external_lookup": "selected-stage-only",
+    "base_model_mutation": false,
+    "sibling_variant_leak": false,
+    "override_identity": "clone-local",
+    "exception_cleanup": "discard-stage-clone",
+    "repeated_queue_cleanup_owner": "existing-run-lifecycle"
+  },
+  "allow_compile": {
+    "false": {
+      "compiler_disable_wrapper": true,
+      "eager_torch_compile_calls": 0
+    },
+    "true": {
+      "compiler_disable_wrapper": false,
+      "eager_torch_compile_calls": 0,
+      "downstream_trace_permitted": true
+    },
+    "shared_compile_registry_owner": false
+  },
+  "precedence": {
+    "dave_selected_chain": [
+      "aura_flow",
+      "kj.torch_compile",
+      "dave",
+      "safe_pag",
+      "kj.fp16_accumulation",
+      "kj.sage_attention"
+    ],
+    "dave_unselected_chain": [
+      "aura_flow",
+      "safe_pag",
+      "kj.fp16_accumulation",
+      "kj.sage_attention",
+      "kj.torch_compile"
+    ],
+    "fixed_edges": [
+      ["dave", "safe_pag"],
+      ["safe_pag", "kj.sage_attention"],
+      ["kj.fp16_accumulation", "kj.sage_attention"]
+    ],
+    "torch_compile_pairwise": "preserve-current-dave-dependent-order"
+  },
+  "ownership": {
+    "generic_patch_registry": false,
+    "generic_scope_ui": false,
+    "feature_payload_owner": "sage-attention-adapter",
+    "fp16_accumulation_scope": "run-global",
+    "torch_compile_scope": "run-wide",
+    "public_socket_or_workflow_schema_change": false
+  },
+  "handoff": {
+    "next": "AIO-SAGE-02",
+    "goal": "backend-stage-plan-and-first-pass-cache",
+    "allowed_production_files": [
+      "easyuse_anima/aio/model_preparation.py",
+      "easyuse_anima/aio/first_pass_cache.py"
+    ],
+    "forbidden": [
+      "schema-settings-ui-cutover",
+      "fp16-stage-scope",
+      "torch-compile-stage-scope",
+      "generic-patch-registry",
+      "public-socket-or-workflow-change"
+    ]
+  }
+}

--- a/tests/test_aio_sage_stage_scope_contract.py
+++ b/tests/test_aio_sage_stage_scope_contract.py
@@ -1,0 +1,402 @@
+from __future__ import annotations
+
+import json
+import unittest
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable
+
+
+ROOT = Path(__file__).resolve().parents[1]
+FIXTURE_PATH = ROOT / "tests" / "fixtures" / "aio_sage_stage_scope_contract.v1.json"
+
+
+class SageContractError(ValueError):
+    pass
+
+
+@dataclass
+class FakeModel:
+    name: str
+    model_options: dict[str, Any]
+
+    def clone(self) -> FakeModel:
+        return FakeModel(
+            name=f"{self.name}:clone",
+            model_options=_deepcopy_list_dict(self.model_options),
+        )
+
+
+def _deepcopy_list_dict(value: Any) -> Any:
+    if isinstance(value, dict):
+        return {key: _deepcopy_list_dict(item) for key, item in value.items()}
+    if isinstance(value, list):
+        return [_deepcopy_list_dict(item) for item in value]
+    return value
+
+
+def _scope(mode: str, raw: object, fixture: dict[str, Any]) -> dict[str, bool]:
+    stage_ids = tuple(fixture["stage_ids"])
+    if mode == "disabled":
+        return {stage_id: False for stage_id in stage_ids}
+    if raw is None:
+        return dict(fixture["legacy_missing_scope"])
+    if not isinstance(raw, dict):
+        return dict(fixture["malformed_scope"]["expected"])
+    return {stage_id: raw.get(stage_id) is True for stage_id in stage_ids}
+
+
+def _selected_stages(
+    mode: str,
+    raw: object,
+    fixture: dict[str, Any],
+) -> list[str]:
+    normalized = _scope(mode, raw, fixture)
+    return [stage_id for stage_id in fixture["stage_ids"] if normalized[stage_id]]
+
+
+def _validate_node_contract(
+    object_info: object,
+    patch_parameters: object,
+    fixture: dict[str, Any],
+) -> bool:
+    if not isinstance(object_info, dict):
+        return False
+    node_id = fixture["upstream"]["node_id"]
+    node = object_info.get(node_id)
+    if not isinstance(node, dict):
+        return False
+    inputs = node.get("input")
+    if not isinstance(inputs, dict):
+        return False
+    required = inputs.get("required")
+    optional = inputs.get("optional")
+    if not isinstance(required, dict) or not isinstance(optional, dict):
+        return False
+    contract = fixture["node_contract"]
+    if list(required) != contract["required_inputs"]:
+        return False
+    if list(optional) != contract["optional_inputs"]:
+        return False
+    allow_compile = optional.get("allow_compile")
+    if not (
+        isinstance(allow_compile, list)
+        and allow_compile
+        and allow_compile[0] == "BOOLEAN"
+    ):
+        return False
+    return patch_parameters == contract["patch_parameters"]
+
+
+def _apply_selected_stage(
+    base_model: FakeModel,
+    *,
+    stage_id: str,
+    selected: bool,
+    mode: str,
+    allow_compile: bool,
+    fixture: dict[str, Any],
+    lookups: list[str],
+    disable_wrapper: Callable[[object], object],
+    compile_calls: list[str],
+    override_factory: Callable[[], object] = object,
+) -> FakeModel:
+    if not selected:
+        return base_model
+    if mode not in fixture["node_contract"]["sage_modes"] or mode == "disabled":
+        raise SageContractError("unsupported SageAttention mode")
+
+    lookups.append(stage_id)
+    cloned = base_model.clone()
+    override = override_factory()
+    if not allow_compile:
+        override = disable_wrapper(override)
+    # PathchSageAttentionKJ does not call torch.compile. The boolean only
+    # permits a downstream compile owner to trace the attention function.
+    if compile_calls:
+        raise AssertionError("test harness must not pre-populate compile calls")
+    cloned.model_options.setdefault("transformer_options", {})[
+        "optimized_attention_override"
+    ] = override
+    return cloned
+
+
+class AioSageStageScopeContractTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.fixture = json.loads(FIXTURE_PATH.read_text(encoding="utf-8"))
+
+    def test_upstream_scope_and_ownership_decisions_are_frozen(self) -> None:
+        fixture = self.fixture
+
+        self.assertEqual(fixture["decision"], "FEASIBLE")
+        self.assertEqual(
+            fixture["upstream"],
+            {
+                "repository": "kijai/ComfyUI-KJNodes",
+                "pinned_commit": "e27a505b3ba6ce42687fe00500deda103d9d6071",
+                "verified_current_commit": "bb131be9e83d2f773c90f1d6f1e4b248a498c8c5",
+                "node_id": "PathchSageAttentionKJ",
+                "function": "patch",
+                "experimental": True,
+                "model_options_path": [
+                    "transformer_options",
+                    "optimized_attention_override",
+                ],
+            },
+        )
+        self.assertEqual(
+            fixture["stage_ids"],
+            ["first_pass", "highres", "detailer", "upscale"],
+        )
+        self.assertEqual(
+            fixture["fresh_stage_scope"],
+            {
+                "first_pass": True,
+                "highres": False,
+                "detailer": False,
+                "upscale": False,
+            },
+        )
+        self.assertTrue(all(fixture["legacy_missing_scope"].values()))
+        self.assertEqual(
+            fixture["malformed_scope"]["policy"],
+            "fail-closed-all-disabled",
+        )
+        self.assertFalse(fixture["ownership"]["generic_patch_registry"])
+        self.assertFalse(fixture["ownership"]["generic_scope_ui"])
+        self.assertEqual(
+            fixture["ownership"]["fp16_accumulation_scope"],
+            "run-global",
+        )
+        self.assertEqual(
+            fixture["ownership"]["torch_compile_scope"],
+            "run-wide",
+        )
+
+    def test_scope_cases_select_only_known_sampling_stages(self) -> None:
+        fixture = self.fixture
+
+        for case in fixture["scope_cases"]:
+            with self.subTest(case=case["id"]):
+                raw_scope = None if case.get("scope_missing") else case.get("scope")
+                self.assertEqual(
+                    _selected_stages(case["mode"], raw_scope, fixture),
+                    case["selected_stages"],
+                )
+
+        self.assertTrue(
+            set(fixture["non_sampling_ids"]).isdisjoint(fixture["stage_ids"])
+        )
+
+    def test_selected_clones_isolate_override_from_base_and_siblings(self) -> None:
+        fixture = self.fixture
+        custom = next(
+            case
+            for case in fixture["scope_cases"]
+            if case["id"] == "custom-highres-detailer"
+        )
+        selected = set(_selected_stages(custom["mode"], custom["scope"], fixture))
+        existing_leaf = object()
+        base = FakeModel(
+            "model_with_lora",
+            {"transformer_options": {"existing": existing_leaf}},
+        )
+        lookups: list[str] = []
+        disable_calls: list[object] = []
+        compile_calls: list[str] = []
+
+        def disable(value: object) -> object:
+            disable_calls.append(value)
+            return ("compiler-disabled", value)
+
+        variants = {
+            stage_id: _apply_selected_stage(
+                base,
+                stage_id=stage_id,
+                selected=stage_id in selected,
+                mode=custom["mode"],
+                allow_compile=False,
+                fixture=fixture,
+                lookups=lookups,
+                disable_wrapper=disable,
+                compile_calls=compile_calls,
+            )
+            for stage_id in fixture["stage_ids"]
+        }
+
+        self.assertEqual(lookups, ["highres", "detailer"])
+        self.assertEqual(len(disable_calls), 2)
+        self.assertEqual(compile_calls, [])
+        self.assertIs(variants["first_pass"], base)
+        self.assertIs(variants["upscale"], base)
+        self.assertIsNot(variants["highres"], base)
+        self.assertIsNot(variants["detailer"], base)
+        self.assertIsNot(variants["highres"], variants["detailer"])
+        self.assertIsNot(
+            variants["highres"].model_options["transformer_options"],
+            variants["detailer"].model_options["transformer_options"],
+        )
+        self.assertIs(
+            variants["highres"].model_options["transformer_options"]["existing"],
+            existing_leaf,
+        )
+        self.assertNotIn(
+            "optimized_attention_override",
+            base.model_options["transformer_options"],
+        )
+        highres_override = variants["highres"].model_options["transformer_options"][
+            "optimized_attention_override"
+        ]
+        detailer_override = variants["detailer"].model_options[
+            "transformer_options"
+        ]["optimized_attention_override"]
+        self.assertIsNot(highres_override, detailer_override)
+
+    def test_allow_compile_and_failure_paths_do_not_mutate_shared_base(self) -> None:
+        fixture = self.fixture
+        base = FakeModel("base", {"transformer_options": {}})
+        compile_calls: list[str] = []
+        disable_calls: list[object] = []
+        lookups: list[str] = []
+
+        def disable(value: object) -> object:
+            disable_calls.append(value)
+            return value
+
+        disabled = _apply_selected_stage(
+            base,
+            stage_id="first_pass",
+            selected=True,
+            mode="auto",
+            allow_compile=False,
+            fixture=fixture,
+            lookups=lookups,
+            disable_wrapper=disable,
+            compile_calls=compile_calls,
+        )
+        traceable = _apply_selected_stage(
+            base,
+            stage_id="highres",
+            selected=True,
+            mode="auto",
+            allow_compile=True,
+            fixture=fixture,
+            lookups=lookups,
+            disable_wrapper=disable,
+            compile_calls=compile_calls,
+        )
+
+        self.assertEqual(len(disable_calls), 1)
+        self.assertEqual(compile_calls, [])
+        self.assertIsNot(disabled, traceable)
+        self.assertNotIn(
+            "optimized_attention_override",
+            base.model_options["transformer_options"],
+        )
+
+        with self.assertRaisesRegex(RuntimeError, "override construction failed"):
+            _apply_selected_stage(
+                base,
+                stage_id="detailer",
+                selected=True,
+                mode="auto",
+                allow_compile=True,
+                fixture=fixture,
+                lookups=lookups,
+                disable_wrapper=disable,
+                compile_calls=compile_calls,
+                override_factory=lambda: (_ for _ in ()).throw(
+                    RuntimeError("override construction failed")
+                ),
+            )
+        self.assertNotIn(
+            "optimized_attention_override",
+            base.model_options["transformer_options"],
+        )
+
+        before_unknown = list(lookups)
+        with self.assertRaisesRegex(SageContractError, "unsupported"):
+            _apply_selected_stage(
+                base,
+                stage_id="upscale",
+                selected=True,
+                mode="future-mode",
+                allow_compile=False,
+                fixture=fixture,
+                lookups=lookups,
+                disable_wrapper=disable,
+                compile_calls=compile_calls,
+            )
+        self.assertEqual(lookups, before_unknown)
+
+    def test_node_drift_precedence_and_backend_handoff_are_bounded(self) -> None:
+        fixture = self.fixture
+        valid_info = {
+            "PathchSageAttentionKJ": {
+                "input": {
+                    "required": {
+                        "model": ["MODEL"],
+                        "sage_attention": [fixture["node_contract"]["sage_modes"]],
+                    },
+                    "optional": {"allow_compile": ["BOOLEAN"]},
+                }
+            }
+        }
+        valid_parameters = ["model", "sage_attention", "allow_compile"]
+
+        self.assertTrue(
+            _validate_node_contract(valid_info, valid_parameters, fixture)
+        )
+        drift_cases = [
+            ({}, valid_parameters),
+            (
+                {
+                    "PathchSageAttentionKJ": {
+                        "input": {
+                            "required": valid_info["PathchSageAttentionKJ"]["input"][
+                                "required"
+                            ],
+                            "optional": {},
+                        }
+                    }
+                },
+                valid_parameters,
+            ),
+            (valid_info, ["model", "sage_attention"]),
+        ]
+        for info, parameters in drift_cases:
+            with self.subTest(info=info, parameters=parameters):
+                self.assertFalse(
+                    _validate_node_contract(info, parameters, fixture)
+                )
+
+        precedence = fixture["precedence"]
+        for chain_name in ("dave_selected_chain", "dave_unselected_chain"):
+            chain = precedence[chain_name]
+            for before, after in precedence["fixed_edges"]:
+                if before in chain and after in chain:
+                    with self.subTest(chain=chain_name, edge=(before, after)):
+                        self.assertLess(chain.index(before), chain.index(after))
+        self.assertEqual(
+            precedence["torch_compile_pairwise"],
+            "preserve-current-dave-dependent-order",
+        )
+
+        handoff = fixture["handoff"]
+        self.assertEqual(handoff["next"], "AIO-SAGE-02")
+        self.assertEqual(
+            handoff["allowed_production_files"],
+            [
+                "easyuse_anima/aio/model_preparation.py",
+                "easyuse_anima/aio/first_pass_cache.py",
+            ],
+        )
+        self.assertIn("schema-settings-ui-cutover", handoff["forbidden"])
+        self.assertFalse(
+            fixture["ownership"]["public_socket_or_workflow_schema_change"]
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 목적과 변경 경계
- Task: AIO-SAGE-01 / #441
- Class: CONTRACT
- Base -> Head: `9a2ae70841b52d42bc47eb90d4698ddbe411e0d1` -> `8f7dd6a74140d956b508f8418d03e5d1ea7a7063`
- 변경 경계: test-local Contract fixture/test와 architecture roadmap만 변경. Production/schema/UI는 변경하지 않음.

## Contract 결정
- Decision: **FEASIBLE**
- 직접 owner 근거: KJNodes `PathchSageAttentionKJ`는 model clone의 `model_options.transformer_options.optimized_attention_override`만 기록하고, ComfyUI ModelPatcher clone은 dict/list 구조를 분리하면서 leaf identity를 유지함.
- fresh workflow: first-pass-only
- legacy missing scope: all-stage
- malformed explicit scope: fail-closed / all-disabled
- 선택된 stage만 KJ node lookup·clone·patch를 허용하며 base/sibling stage에는 override가 누출되지 않음.
- `allow_compile=false`는 compiler-disable wrapper, `true`는 해당 wrapper를 생략하되 eager `torch.compile`은 소유하지 않음.
- 현재 DAVE/Safe PAG/FP16/Sage/Compile 상대 순서를 고정하며, shared generic registry/UI는 추가하지 않음.
- unknown mode, node contract drift, clone failure는 fail-closed.

## 검증
- Focused: fixture JSON parse + changed Python compile + `tests.test_aio_sage_stage_scope_contract` — 5 PASS
- Diff: `git diff --check` — PASS
- Full: `powershell -ExecutionPolicy Bypass -File D:\ComfyUI\custom_nodes_workplace\tools\check_custom_node.ps1 -Project <worktree> -Profile full` at exact SHA `8f7dd6a74140d956b508f8418d03e5d1ea7a7063` — Python 1,229 PASS, frontend 119 PASS, TypeScript 6.0.3, Pyright/import/diff PASS. Ruff 120 report-only.
- Package: not triggered
- Live: not triggered

## 위험과 rollback
- Contract-only 변경이라 runtime 위험 없음.
- Rollback: commit `8f7dd6a74140d956b508f8418d03e5d1ea7a7063`

## Next
- Review/merge 후 AIO-SAGE-02 backend stage selector 및 first-pass cache signature 구현.