### PR TITLE
FRONT-05A: AiO root entry checkJs 부채 해소

### DIFF
--- a/docs/development/frontend-maintenance-roadmap.md
+++ b/docs/development/frontend-maintenance-roadmap.md
@@ -120,12 +120,20 @@ TS6133 1개)를 ComfyUI host import 두 줄의 line-specific suppression,
 unused callback formal 제거로 해소하고 명시적 include로 승격했다. 현재 root
 entry 11개 중 8개가 typecheck 대상이고, debt는 3개 entry·31개 오류다.
 
+Phase 4c에서는 `easyuse_anima_autocomplete.js`의 5개 오류를 host import 한 줄의
+line-specific suppression, 좁은 DOM 경계와 unused callback/dead local 정리로
+해소하고 명시적 include로 승격했다.
+
+Phase 4d에서는 최신 `dev`에서 `easyuse_anima_aio.js`를 재계측한 15개 오류
+(TS2307 4개, TS1117 4개, TS6133 3개, TS2339 2개, TS2345 2개)를 host import
+line suppression, 현재 effective 값이 동일한 duplicate key 정리, caller가 없는
+dead entry helper 제거, 좁은 window/payload 타입 경계로 해소하고 명시적 include로
+승격했다. Runtime, DOM, hook, queue와 serialization 의미는 변경하지 않았다.
+
 현재 debt ledger:
 
 | TODO 파일 | 총 오류 | TypeScript 오류 코드별 개수 |
 | --- | ---: | --- |
-| `easyuse_anima_aio.js` | 16 | TS1117 4, TS2307 4, TS2339 2, TS2345 2, TS6133 4 |
-| `easyuse_anima_autocomplete.js` | 5 | TS2307 1, TS2339 2, TS6133 2 |
 | `easyuse_anima_lora_preset.js` | 10 | TS2304 4, TS2307 2, TS2345 1, TS6133 3 |
 
 코드는 TS1117 duplicate property, TS2304 undeclared host global, TS2307 외부

--- a/jsconfig.json
+++ b/jsconfig.json
@@ -19,6 +19,7 @@
     "web/js/lifecycle/**/*.js",
     "web/js/settings/**/*.js",
     "web/js/easyuse_anima_api.js",
+    "web/js/easyuse_anima_aio.js",
     "web/js/easyuse_anima_autocomplete.js",
     "web/js/easyuse_anima_i18n.js",
     "web/js/easyuse_anima_naia.js",

--- a/tests/test_aio_frontend.py
+++ b/tests/test_aio_frontend.py
@@ -742,15 +742,10 @@ class AIOFrontendSourceTests(unittest.TestCase):
         self.assertIn("...fit", body)
         self.assertIn("delete next.upscale?.fit", body)
 
-    def test_upscale_optional_dependency_sanitizer_disables_missing_backend(self):
+    def test_entry_has_no_dead_optional_dependency_sanitizer_duplicate(self):
         source = AIO_JS.read_text(encoding="utf-8")
-        start = source.index("function sanitizeGeneratorSettingsForOptionalDependencies")
-        end = source.index("\nfunction applyVisibleGeneratorSettings", start)
-        body = source[start:end]
-
-        self.assertIn("disableGeneratorSpectrumOptions(next.upscale)", body)
-        self.assertIn("upscaleBackendMissingPacks(next.upscale.backend).length", body)
-        self.assertIn("next.upscale.enabled = false", body)
+        self.assertNotIn("sanitizeGeneratorSettingsForOptionalDependencies", source)
+        self.assertNotIn("disableGeneratorSpectrumOptions", source)
 
     def test_optional_dependency_query_is_silent_until_explicit_missing_selection(self):
         source = AIO_JS.read_text(encoding="utf-8")

--- a/tests/test_frontend_modules.py
+++ b/tests/test_frontend_modules.py
@@ -1043,8 +1043,10 @@ class FrontendModuleStructureTests(unittest.TestCase):
             "entry-relative direct store imports": (
                 r"loadDirectStoreModules\s*:\s*\(\s*\)\s*=>\s*"
                 r"Promise\.all\(\s*\[\s*"
+                r"// @ts-expect-error ComfyUI provides this host module at runtime\.\s*"
                 r'import\(\s*"\.\./\.\./\.\./stores/nodeOutputStore\.js"\s*\)\s*'
                 r"\.catch\(\s*\(\s*\)\s*=>\s*null\s*\)\s*,\s*"
+                r"// @ts-expect-error ComfyUI provides this host module at runtime\.\s*"
                 r'import\(\s*"\.\./\.\./\.\./platform/workflow/management/'
                 r'stores/workflowStore\.js"\s*\)\s*'
                 r"\.catch\(\s*\(\s*\)\s*=>\s*null\s*\)\s*,?\s*"
@@ -1931,7 +1933,10 @@ class FrontendModuleStructureTests(unittest.TestCase):
             for name in import_match.group("names").split(",")
             if name.strip()
         }
-        self.assertEqual(imported_exports, expected_functions)
+        self.assertEqual(
+            imported_exports,
+            expected_functions - {"aioNodeInputDefault"},
+        )
 
         self.assertNotRegex(source, re.compile(r"^\s*import\s", re.MULTILINE))
         self.assertNotRegex(source, r"\b(?:app|api)\b")
@@ -3580,7 +3585,6 @@ class FrontendModuleStructureTests(unittest.TestCase):
             and "*" not in entry
         }
         debt_root_entries = {
-            "web/js/easyuse_anima_aio.js",
             "web/js/easyuse_anima_lora_preset.js",
         }
         actual_root_entries = {

--- a/web/js/easyuse_anima_aio.js
+++ b/web/js/easyuse_anima_aio.js
@@ -1,4 +1,8 @@
+// @ts-check
+
+// @ts-expect-error ComfyUI provides this host module at runtime.
 import { app } from "../../../scripts/app.js";
+// @ts-expect-error ComfyUI provides this host module at runtime.
 import { api } from "../../../scripts/api.js";
 import { easyuseAnimaFetchComfyJson, easyuseAnimaFetchText } from "./easyuse_anima_api.js";
 import { easyuseAnimaText, easyuseAnimaWatchLocale } from "./easyuse_anima_i18n.js";
@@ -10,7 +14,6 @@ import {
   aioCreateTextareaInput as textareaInput,
   aioCreateTextInput as textInput,
   aioNodeInputControlForSpec as nodeInputControlForSpec,
-  aioNodeInputDefault as nodeInputDefault,
   aioValueFromNodeInputControl as valueFromNodeInputControl,
 } from "./aio/dom_controls.js";
 import { aioCreateDialogPrimitives } from "./aio/dialog_primitives.js";
@@ -331,7 +334,6 @@ const AIO_TEXT = {
     "field.guideSizeBasis": "Guide size basis",
     "field.inpaintModel": "Inpaint model",
     "field.tiledEncode": "Tiled encode",
-    "field.tiledDecode": "Tiled decode",
     "field.refine": "Refine",
     "field.individual": "Individual",
     "field.combined": "Combined",
@@ -687,7 +689,6 @@ const AIO_TEXT = {
     "field.guideSizeBasis": "가이드 크기 기준",
     "field.inpaintModel": "인페인트 모델",
     "field.tiledEncode": "타일 인코드",
-    "field.tiledDecode": "타일 디코드",
     "field.refine": "정제",
     "field.individual": "개별 마스크",
     "field.combined": "통합 마스크",
@@ -1721,7 +1722,6 @@ const AIO_FIELD_TOOLTIP_KEYS = {
   "USDU prompt": "tip.usduPrompt",
   "Fit final size": "tip.finalFit",
   "Fit by": "tip.finalFit",
-  "Max long edge": "tip.finalFit",
   "Max megapixels": "tip.finalFit",
   "Fit method": "tip.finalFit",
   "Tile width": "tip.usduTile",
@@ -1929,7 +1929,6 @@ const AIO_FIELD_LABEL_KEYS = {
   "Guide size basis": "field.guideSizeBasis",
   "Inpaint model": "field.inpaintModel",
   "Tiled encode": "field.tiledEncode",
-  "Tiled decode": "field.tiledDecode",
   "Refine": "field.refine",
   "Individual": "field.individual",
   "Combined": "field.combined",
@@ -2201,69 +2200,6 @@ function nodeInputSupported(dependencyKey, inputName) {
   return aioNodeInputSupported(generatorOptionalDependencyState, dependencyKey, inputName);
 }
 
-
-function disableGeneratorSpectrumOptions(target) {
-  if (!target || typeof target !== "object") {
-    return;
-  }
-  if (target.spectrum && typeof target.spectrum === "object") {
-    target.spectrum.enabled = false;
-  }
-  if (target.dit_corrections && typeof target.dit_corrections === "object") {
-    target.dit_corrections.enabled = false;
-  }
-}
-
-function sanitizeGeneratorSettingsForOptionalDependencies(settings) {
-  const next = migrateGeneratorPostprocessSettings(mergeDefaults(DEFAULT_GENERATION_SETTINGS, settings));
-  delete next.sampler.dave;
-  const backendDependency = AIO_BACKEND_DEPENDENCIES[next.sampler.backend];
-  if (backendDependency && !optionalDependencyAvailable(backendDependency)) {
-    next.sampler.backend = "comfy_ksampler";
-  }
-  delete next.highres?.backend;
-  if (!optionalDependencyAvailable("spectrumPatch")) {
-    disableGeneratorSpectrumOptions(next.sampler);
-    disableGeneratorSpectrumOptions(next.highres);
-    disableGeneratorSpectrumOptions(next.upscale);
-    for (const targetName of normalizeDetailerOrder(next.detailer?.order, next.detailer)) {
-      disableGeneratorSpectrumOptions(next.detailer?.[targetName]);
-    }
-  }
-  if (!optionalDependencyAvailable("kjFp16")) {
-    next.model_patches.kj.fp16_accumulation = false;
-  }
-  if (!optionalDependencyAvailable("kjSage")) {
-    next.model_patches.kj.sage_attention = "disabled";
-    next.model_patches.kj.sage_allow_compile = false;
-  }
-  if (!optionalDependencyAvailable("kjTorchCompile")) {
-    next.model_patches.kj.torch_compile.enabled = false;
-  }
-  if (!optionalDependencyAvailable("dave")) {
-    next.model_patches.dave.enabled = false;
-  }
-  if (!optionalDependencyAvailable("safePag")) {
-    next.model_patches.safe_pag.enabled = false;
-  }
-  if (!optionalDependencyAvailable("imageSaver") && next.save.backend === "image_saver") {
-    next.save.backend = "comfy_save_image";
-  }
-  const impactMissing = !optionalDependencyAvailable("impactDetailer")
-    || !optionalDependencyAvailable("impactMaskToSegs");
-  if (impactMissing) {
-    next.detailer.enabled = false;
-    for (const targetName of normalizeDetailerOrder(next.detailer?.order, next.detailer)) {
-      if (next.detailer[targetName]) {
-        next.detailer[targetName].enabled = false;
-      }
-    }
-  }
-  if (next.upscale?.enabled && upscaleBackendMissingPacks(next.upscale.backend).length) {
-    next.upscale.enabled = false;
-  }
-  return next;
-}
 
 function samplerNameOptions(current) {
   return aioChoiceOptionsWithCurrent(generatorSamplerOptionState.samplerNames, current);
@@ -3390,6 +3326,11 @@ function setWidgetValue(node, name, value) {
   node.__easyuseAnimaGeneratorUiValues[name] = value;
 }
 
+/**
+ * @param {unknown} value
+ * @param {unknown} [fallback]
+ * @returns {unknown}
+ */
 function firstValue(value, fallback = "") {
   if (Array.isArray(value)) {
     return value.length > 0 ? value[0] : fallback;
@@ -3760,10 +3701,13 @@ function forwardGeneratorPanelWheel(event) {
 }
 
 function installGeneratorWheelForwarder() {
-  if (window.__easyuseAnimaAioWheelForwarderInstalled) {
+  const runtimeWindow = /** @type {Window & typeof globalThis & {
+   *   __easyuseAnimaAioWheelForwarderInstalled?: boolean
+   * }} */ (window);
+  if (runtimeWindow.__easyuseAnimaAioWheelForwarderInstalled) {
     return;
   }
-  window.__easyuseAnimaAioWheelForwarderInstalled = true;
+  runtimeWindow.__easyuseAnimaAioWheelForwarderInstalled = true;
   // Node 2.0 handles wheel on an ancestor of the DOM widget, so ownership must
   // be decided during window capture before that ancestor can zoom the canvas.
   window.addEventListener("wheel", forwardGeneratorPanelWheel, {
@@ -3833,10 +3777,6 @@ function randomSeed() {
 }
 
 
-
-function openGeneratorSettings(node) {
-  openAdvancedSettings(node);
-}
 
 function isGeneratorGraphNode(node) {
   return node?.type === GENERATOR_NODE_TYPE || node?.comfyClass === GENERATOR_NODE_TYPE;
@@ -4230,7 +4170,9 @@ const {
   storeAdapter: {
     getLegacyPreviewImages: () => app.nodePreviewImages,
     loadDirectStoreModules: () => Promise.all([
+      // @ts-expect-error ComfyUI provides this host module at runtime.
       import("../../../stores/nodeOutputStore.js").catch(() => null),
+      // @ts-expect-error ComfyUI provides this host module at runtime.
       import("../../../platform/workflow/management/stores/workflowStore.js").catch(() => null),
     ]),
     fetchFrontendHtml: () => easyuseAnimaFetchText("/"),


### PR DESCRIPTION
## 목적과 변경 경계

Issue #166의 남은 root-entry TypeScript 부채 중 AiO entry만 해소합니다. LoRA entry와 composition-root 구조는 건드리지 않습니다.

Base -> Head: `4e596a52b98d45e1924cbd667aacb9f4affc0cff` -> `d87dad8193a045b4193c444bfdf4bfc2d7fd982e`

변경 파일:
- `web/js/easyuse_anima_aio.js`
- `jsconfig.json`
- `tests/test_aio_frontend.py`
- `tests/test_frontend_modules.py`
- `docs/development/frontend-maintenance-roadmap.md`

## 주요 결정

- TypeScript 6.0.3에서 재계측한 AiO entry 오류 15건을 0건으로 줄이고 root typecheck 대상에 포함했습니다.
- ComfyUI host import suppression은 해당 import 네 줄에만 제한했습니다.
- 동일한 effective 값을 가진 duplicate key, unused import/local, export·caller가 없는 optional-dependency sanitizer 중복 경로만 제거했습니다.
- DOM, hook, queue, serialization 및 optional-dependency runtime 의미는 보존합니다.
- 기존 source-contract는 checkJs 표기를 정확히 인식하도록 좁게 갱신했습니다.

## 검증

Focused PASS:
- `node --check web/js/easyuse_anima_aio.js`
- `npx --yes --package "typescript@6.0.3" -- tsc -p jsconfig.json --pretty false`
- AiO extension / generator panel / settings core / dependency core smoke
- root-entry coverage, dead-sanitizer absence, wheel routing, DOM controls ownership, native preview adapter exact unittests
- `git diff --check`

Official full:
- 최초 candidate `865cafe`: 기존 source fixture 3건 mismatch를 발견하여 실패
- 최종 candidate `d87dad8193a045b4193c444bfdf4bfc2d7fd982e`: PASS
- Python unittest 1233 PASS
- Frontend 119 JavaScript / TypeScript 6.0.3 PASS
- Pyright baseline, import boundary, diff check PASS
- Ruff 120건은 기존 G-01 report-only baseline

Package: not triggered
Live: not triggered

## 위험·롤백·다음 작업

위험은 source-only checkJs 정리와 fixture 표현 변경에 제한됩니다. 롤백 단위는 이 squash commit입니다.

Next: review/merge 후 별도 PR에서 LoRA root entry checkJs 부채를 처리합니다.