### PR TITLE
FRONT-05B: LoRA root entry checkJs 부채 해소

### DIFF
--- a/docs/development/frontend-maintenance-roadmap.md
+++ b/docs/development/frontend-maintenance-roadmap.md
@@ -130,17 +130,19 @@ line suppression, 현재 effective 값이 동일한 duplicate key 정리, caller
 dead entry helper 제거, 좁은 window/payload 타입 경계로 해소하고 명시적 include로
 승격했다. Runtime, DOM, hook, queue와 serialization 의미는 변경하지 않았다.
 
-현재 debt ledger:
+Phase 4e에서는 `easyuse_anima_lora_preset.js`의 10개 오류(TS2304 4개,
+TS2307 2개, TS2345 1개, TS6133 3개)를 host import 두 줄의 line-specific
+suppression, 기존 `globalThis.LiteGraph`의 좁은 local alias, optional menu item
+shape와 unused entry destructuring 정리로 해소하고 명시적 include로 승격했다.
+LoRA canvas, menu, preview, node lifecycle, hook, queue와 serialization 의미는
+변경하지 않았다.
 
-| TODO 파일 | 총 오류 | TypeScript 오류 코드별 개수 |
-| --- | ---: | --- |
-| `easyuse_anima_lora_preset.js` | 10 | TS2304 4, TS2307 2, TS2345 1, TS6133 3 |
+현재 root-entry debt는 없으며 11개 root entry가 모두 typecheck 대상이다.
 
 코드는 TS1117 duplicate property, TS2304 undeclared host global, TS2307 외부
 Comfy import resolution, TS2339 DOM/window property shape, TS2345 argument/shape
-mismatch, TS6133 unused declaration/parameter를 뜻한다. TODO는 각 파일의 오류를
-동작 변경이나 광범위한 suppression 없이 해소한 뒤, 같은 PR에서 해당 entry를
-`jsconfig.json` include로 옮기고 테스트와 이 ledger의 debt에서 제거하는 것이다.
+mismatch, TS6133 unused declaration/parameter를 뜻한다. 새 root entry는 오류 없이
+`jsconfig.json` include에 추가해야 하며 root wildcard로 이 계약을 우회하지 않는다.
 
 재현 명령은 `jsconfig.json`과 같은 compiler option을 파일별로 적용한다.
 

--- a/jsconfig.json
+++ b/jsconfig.json
@@ -22,6 +22,7 @@
     "web/js/easyuse_anima_aio.js",
     "web/js/easyuse_anima_autocomplete.js",
     "web/js/easyuse_anima_i18n.js",
+    "web/js/easyuse_anima_lora_preset.js",
     "web/js/easyuse_anima_naia.js",
     "web/js/easyuse_anima_prompt_rules.js",
     "web/js/easyuse_anima_settings.js",

--- a/tests/test_frontend_lora_preset.py
+++ b/tests/test_frontend_lora_preset.py
@@ -66,6 +66,21 @@ FRONTEND_CHECK_SCRIPT = ROOT / "tools" / "check_frontend.ps1"
 
 
 class LoraPresetFrontendTests(unittest.TestCase):
+    def test_entry_checkjs_contract(self):
+        source = LORA_PRESET_ENTRY.read_text(encoding="utf-8")
+
+        self.assertEqual(source.splitlines()[0], "// @ts-check")
+        for host_name, host_module in (("app", "app.js"), ("api", "api.js")):
+            with self.subTest(host_module=host_module):
+                self.assertIn(
+                    "// @ts-expect-error ComfyUI provides this host module at runtime.\n"
+                    f'import {{ {host_name} }} from '
+                    f'"../../../scripts/{host_module}";',
+                    source,
+                )
+        self.assertIn("function loraLiteGraphRuntime()", source)
+        self.assertIn("}} */ (globalThis).LiteGraph;", source)
+
     def test_node_runtime_module_boundary(self):
         module_source = LORA_PRESET_NODE_RUNTIME.read_text(encoding="utf-8")
         entry_source = LORA_PRESET_ENTRY.read_text(encoding="utf-8")
@@ -332,7 +347,7 @@ class LoraPresetFrontendTests(unittest.TestCase):
             dependency_entries,
             {
                 "getCanvas: () => app.canvas",
-                "getLiteGraph: () => LiteGraph",
+                "getLiteGraph: loraLiteGraphRuntime",
                 "getSettings: () => LORA_PRESET_SETTINGS",
                 "text: lpText",
                 "formatText: lpFormat",

--- a/tests/test_frontend_modules.py
+++ b/tests/test_frontend_modules.py
@@ -3584,9 +3584,7 @@ class FrontendModuleStructureTests(unittest.TestCase):
             and "/" not in entry.removeprefix("web/js/")
             and "*" not in entry
         }
-        debt_root_entries = {
-            "web/js/easyuse_anima_lora_preset.js",
-        }
+        debt_root_entries = set()
         actual_root_entries = {
             path.relative_to(ROOT).as_posix()
             for path in WEB_JS.glob("*.js")

--- a/web/js/easyuse_anima_lora_preset.js
+++ b/web/js/easyuse_anima_lora_preset.js
@@ -1,4 +1,8 @@
+// @ts-check
+
+// @ts-expect-error ComfyUI provides this host module at runtime.
 import { app } from "../../../scripts/app.js";
+// @ts-expect-error ComfyUI provides this host module at runtime.
 import { api } from "../../../scripts/api.js";
 import { easyuseAnimaEncodeRFC3986URIComponent as encodeRFC3986URIComponent, easyuseAnimaFetchJson, easyuseAnimaGetSettings } from "./easyuse_anima_api.js";
 import { easyuseAnimaText, easyuseAnimaWatchLocale } from "./easyuse_anima_i18n.js";
@@ -31,6 +35,12 @@ import {
   normalizeLoraNameList,
   validComboEntryText,
 } from "./lora_preset/lora_state.js";
+
+function loraLiteGraphRuntime() {
+  return /** @type {typeof globalThis & {
+   *   LiteGraph: { ContextMenu: new (...args: any[]) => unknown }
+   * }} */ (globalThis).LiteGraph;
+}
 
 const NODE_TYPE = "EasyUseAnimaLoraPreset";
 const DEFAULT_STRENGTH_BUTTON_STEP = 0.05;
@@ -335,18 +345,15 @@ const {
   setProfileIndex,
   setProfileCount,
   scrollProfileBarTo,
-  currentProfileContent,
   saveProfile,
   saveCurrentProfile,
   loadProfile,
   switchProfile,
   addProfile,
   deleteProfile,
-  selectedProfilePayload,
   profileSaveStatus,
   verifyProfileProvenance,
   rememberProfileTokens,
-  appendProfilePayload,
   saveProfileSet,
   loadProfileSet,
   fullProfilePayload,
@@ -358,7 +365,7 @@ const {
 } = loraProfileMutations;
 loraCanvasWidgets = createLoraPresetCanvasWidgets({
   getCanvas: () => app.canvas,
-  getLiteGraph: () => LiteGraph,
+  getLiteGraph: loraLiteGraphRuntime,
   getSettings: () => LORA_PRESET_SETTINGS,
   text: lpText,
   formatText: lpFormat,
@@ -546,7 +553,7 @@ async function openProfileLoadMenu(node, event, pos) {
   }
   const values = profiles.map((profile) => String(profile.name || "")).filter(Boolean);
   const clientPoint = menuClientPoint(node, pos, event);
-  new LiteGraph.ContextMenu(values, {
+  new loraLiteGraphRuntime().ContextMenu(values, {
     event: makeMenuEvent(clientPoint),
     title: lpText("profile.loadTitle"),
     scale: Math.max(1, Number(app.canvas?.ds?.scale) || 1),
@@ -762,6 +769,11 @@ function openLoraEntryMenu(node, event, index) {
   }
   const loras = lorasWidgetValue(node);
   const state = loraResolveState(node, lora);
+  /** @type {Array<null | {
+   *   content: string,
+   *   disabled?: boolean,
+   *   callback: () => void,
+   * }>} */
   const items = [
     {
       content: lpText("lora.moveUp"),
@@ -788,7 +800,7 @@ function openLoraEntryMenu(node, event, index) {
       callback: () => removeLoraEntry(node, index),
     },
   );
-  new LiteGraph.ContextMenu(items, {
+  new loraLiteGraphRuntime().ContextMenu(items, {
     event,
     title: loraDisplayName(lora.name),
     scale: Math.max(1, Number(app.canvas?.ds?.scale) || 1),
@@ -914,7 +926,7 @@ async function openLoraMenu(node, event, pos, onChoose) {
     return;
   }
   loraMenuLifecycle.activateMenu(node, clientPoint, menuItems);
-  new LiteGraph.ContextMenu(menuItems, {
+  new loraLiteGraphRuntime().ContextMenu(menuItems, {
     event: makeMenuEvent(clientPoint),
     title: lpText("lora.chooseTitle"),
     scale: Math.max(1, Number(app.canvas?.ds?.scale) || 1),


### PR DESCRIPTION
## 목적과 변경 경계

Issue #166의 마지막 root-entry TypeScript 부채인 LoRA entry 10건만 해소합니다. Composition-root 구조나 production lifecycle은 재설계하지 않습니다.

Base -> Head: `fab2f73160ab2c78e66b6e46ed28205a5c254f66` -> `1826775403845054c680a82b61b50052bd6b83c7`

변경 파일:
- `web/js/easyuse_anima_lora_preset.js`
- `jsconfig.json`
- `tests/test_frontend_lora_preset.py`
- `tests/test_frontend_modules.py`
- `docs/development/frontend-maintenance-roadmap.md`

## 주요 결정

- TypeScript 6.0.3 오류 10건을 0건으로 줄이고 마지막 LoRA root entry를 typecheck 대상에 포함했습니다.
- ComfyUI host import suppression은 해당 import 두 줄에만 제한했습니다.
- `LiteGraph`는 사용 시점마다 기존 `globalThis.LiteGraph`의 동일 객체를 반환하는 좁은 accessor로 표현해 초기화 순서를 보존합니다.
- module 내부에서만 사용되는 helper를 entry가 중복 destructuring하던 세 항목만 제거했습니다.
- menu item의 optional `disabled` shape만 JSDoc으로 명시했으며 runtime object는 변경하지 않았습니다.
- LoRA canvas/menu/preview/node/hook/queue/serialization/save-sync 의미는 유지됩니다.
- root entry 11개 모두가 explicit TypeScript include 대상이며 debt ledger는 0입니다.

## 검증

Focused PASS:
- `node --check web/js/easyuse_anima_lora_preset.js`
- file-local TypeScript 6.0.3: 10 -> 0
- shared `tsc -p jsconfig.json`
- LoRA canvas widgets / menu lifecycle / node runtime / profile mutation+save-sync / entry lifecycle smoke
- entry checkJs, canvas dependency ownership, root coverage exact unittests
- row-controls/API wiring runtime exact unittest
- `git diff --check`

Official full at `1826775403845054c680a82b61b50052bd6b83c7`: PASS
- Python unittest 1234
- Frontend 119 JavaScript / TypeScript 6.0.3
- Pyright baseline, import boundary, diff check
- Ruff 120건은 기존 G-01 report-only baseline

Package: not triggered
Live: not triggered

## 위험·롤백·다음 작업

위험은 source-only host typing과 fixture ratchet에 제한됩니다. 롤백 단위는 이 squash commit입니다.

Next: merge 후 Issue #166의 checkJs 완료를 기록하고 남은 lifecycle/composition-root 종료 조건을 최신 dev에서 재판정합니다.