### PR TITLE
refactor: move wildcard dynamic parsing (D-12g2)

### DIFF
--- a/docs/architecture/python-backend-execution-roadmap.md
+++ b/docs/architecture/python-backend-execution-roadmap.md
@@ -1363,7 +1363,10 @@ syntax patterns, UTF-8 text accounting, segment/replacement values,
 budget/cycle state, bounded-prefix helper, and state signature to
 `easyuse_anima.wildcard.expansion`. Root retains direct aliases plus snapshot
 lifecycle, library ownership, replacement resolution, and expansion
-orchestration for later slices.
+orchestration for later slices. D-12g2 moves escaped dynamic-option splitting,
+weighted option parsing, and count/range parsing into the same canonical
+expansion owner. Root retains direct aliases plus selector construction,
+library lookup, replacement stages, and expansion orchestration.
 
 ## 12. Phase E — Runtime ownership and lifecycle
 

--- a/easyuse_anima/wildcard/expansion.py
+++ b/easyuse_anima/wildcard/expansion.py
@@ -10,7 +10,8 @@ from collections.abc import Callable, Iterable
 from dataclasses import dataclass
 
 from . import sources as _wildcard_sources
-from .models import WildcardExpansionBudget
+from .models import WildcardExpansionBudget, WildcardOption
+from .selector import _Selector
 
 __all__ = (
     "COMMENT_RE",
@@ -34,6 +35,56 @@ WILDCARD_QUANTIFIER_RE = re.compile(
 COUNT_SPEC_RE = re.compile(
     r"(?:(?P<fixed>\d+)|(?P<minimum>\d*)\s*-\s*(?P<maximum>\d*))"
 )
+
+
+def _split_unescaped(value: str, separator: str) -> list[str]:
+    parts: list[str] = []
+    current: list[str] = []
+    escaped = False
+    for char in value:
+        if escaped:
+            current.append(char)
+            escaped = False
+            continue
+        if char == "\\":
+            current.append(char)
+            escaped = True
+            continue
+        if char == separator:
+            parts.append("".join(current))
+            current = []
+            continue
+        current.append(char)
+    parts.append("".join(current))
+    return parts
+
+
+def _parse_dynamic_options(value: str) -> list[WildcardOption]:
+    options: list[WildcardOption] = []
+    for option in _split_unescaped(value, "|"):
+        parsed = _wildcard_sources._parse_option(option)
+        if parsed is not None:
+            options.append(parsed)
+    return options
+
+
+def _parse_count_spec(spec: str, selector: _Selector) -> int | None:
+    text = str(spec or "").strip()
+    if not text:
+        return 1
+    match = COUNT_SPEC_RE.fullmatch(text)
+    if match is None:
+        return None
+    fixed = match.group("fixed")
+    if fixed is not None:
+        return int(fixed)
+    left = match.group("minimum")
+    right = match.group("maximum")
+    if not left and not right:
+        return None
+    minimum = int(left) if left else 0
+    maximum = int(right) if right else minimum
+    return selector.count_from_range(minimum, maximum)
 
 
 def _utf8_width(char: str) -> int:

--- a/tests/fixtures/python_backend_baseline.json
+++ b/tests/fixtures/python_backend_baseline.json
@@ -28421,6 +28421,42 @@
       },
       {
         "alias": null,
+        "bound_name": "WildcardOption",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".models:WildcardOption",
+        "kind": "static_from",
+        "line": 13,
+        "name": "WildcardOption",
+        "optional": false,
+        "requested": ".models",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/wildcard/expansion.py",
+        "target": "easyuse_anima/wildcard/models.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_Selector",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".selector:_Selector",
+        "kind": "static_from",
+        "line": 14,
+        "name": "_Selector",
+        "optional": false,
+        "requested": ".selector",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/wildcard/expansion.py",
+        "target": "easyuse_anima/wildcard/selector.py"
+      },
+      {
+        "alias": null,
         "bound_name": "annotations",
         "branch_context": [],
         "classification": "external",
@@ -57979,7 +58015,7 @@
         "target": "easyuse_anima/wildcard/expansion.py"
       },
       {
-        "alias": null,
+        "alias": "COUNT_SPEC_RE",
         "bound_name": "COUNT_SPEC_RE",
         "branch_context": [
           {
@@ -58321,6 +58357,99 @@
       },
       {
         "alias": null,
+        "bound_name": "_parse_count_spec",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 139
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "_parse_count_spec",
+          "target": "easyuse_anima/wildcard/expansion.py",
+          "try_line": 139
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.wildcard.expansion:_parse_count_spec",
+        "kind": "static_from",
+        "line": 140,
+        "name": "_parse_count_spec",
+        "optional": false,
+        "requested": ".easyuse_anima.wildcard.expansion",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "wildcard_engine.py",
+        "target": "easyuse_anima/wildcard/expansion.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_parse_dynamic_options",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 139
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "_parse_dynamic_options",
+          "target": "easyuse_anima/wildcard/expansion.py",
+          "try_line": 139
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.wildcard.expansion:_parse_dynamic_options",
+        "kind": "static_from",
+        "line": 140,
+        "name": "_parse_dynamic_options",
+        "optional": false,
+        "requested": ".easyuse_anima.wildcard.expansion",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "wildcard_engine.py",
+        "target": "easyuse_anima/wildcard/expansion.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_split_unescaped",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 139
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "_split_unescaped",
+          "target": "easyuse_anima/wildcard/expansion.py",
+          "try_line": 139
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.wildcard.expansion:_split_unescaped",
+        "kind": "static_from",
+        "line": 140,
+        "name": "_split_unescaped",
+        "optional": false,
+        "requested": ".easyuse_anima.wildcard.expansion",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "wildcard_engine.py",
+        "target": "easyuse_anima/wildcard/expansion.py"
+      },
+      {
+        "alias": null,
         "bound_name": "_utf8_length",
         "branch_context": [
           {
@@ -58422,7 +58551,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 157,
+            "handler_line": 160,
             "kind": "try",
             "line": 139
           }
@@ -58437,7 +58566,7 @@
         "conditional": true,
         "imported": "easyuse_anima.wildcard.expansion:COMMENT_RE",
         "kind": "static_from",
-        "line": 158,
+        "line": 161,
         "name": "COMMENT_RE",
         "optional": false,
         "requested": "easyuse_anima.wildcard.expansion",
@@ -58447,7 +58576,7 @@
         "target": "easyuse_anima/wildcard/expansion.py"
       },
       {
-        "alias": null,
+        "alias": "COUNT_SPEC_RE",
         "bound_name": "COUNT_SPEC_RE",
         "branch_context": [
           {
@@ -58456,7 +58585,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 157,
+            "handler_line": 160,
             "kind": "try",
             "line": 139
           }
@@ -58471,7 +58600,7 @@
         "conditional": true,
         "imported": "easyuse_anima.wildcard.expansion:COUNT_SPEC_RE",
         "kind": "static_from",
-        "line": 158,
+        "line": 161,
         "name": "COUNT_SPEC_RE",
         "optional": false,
         "requested": "easyuse_anima.wildcard.expansion",
@@ -58490,7 +58619,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 157,
+            "handler_line": 160,
             "kind": "try",
             "line": 139
           }
@@ -58505,7 +58634,7 @@
         "conditional": true,
         "imported": "easyuse_anima.wildcard.expansion:DYNAMIC_RE",
         "kind": "static_from",
-        "line": 158,
+        "line": 161,
         "name": "DYNAMIC_RE",
         "optional": false,
         "requested": "easyuse_anima.wildcard.expansion",
@@ -58524,7 +58653,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 157,
+            "handler_line": 160,
             "kind": "try",
             "line": 139
           }
@@ -58539,7 +58668,7 @@
         "conditional": true,
         "imported": "easyuse_anima.wildcard.expansion:WILDCARD_FULL_RE",
         "kind": "static_from",
-        "line": 158,
+        "line": 161,
         "name": "WILDCARD_FULL_RE",
         "optional": false,
         "requested": "easyuse_anima.wildcard.expansion",
@@ -58558,7 +58687,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 157,
+            "handler_line": 160,
             "kind": "try",
             "line": 139
           }
@@ -58573,7 +58702,7 @@
         "conditional": true,
         "imported": "easyuse_anima.wildcard.expansion:WILDCARD_QUANTIFIER_RE",
         "kind": "static_from",
-        "line": 158,
+        "line": 161,
         "name": "WILDCARD_QUANTIFIER_RE",
         "optional": false,
         "requested": "easyuse_anima.wildcard.expansion",
@@ -58592,7 +58721,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 157,
+            "handler_line": 160,
             "kind": "try",
             "line": 139
           }
@@ -58607,7 +58736,7 @@
         "conditional": true,
         "imported": "easyuse_anima.wildcard.expansion:WILDCARD_RE",
         "kind": "static_from",
-        "line": 158,
+        "line": 161,
         "name": "WILDCARD_RE",
         "optional": false,
         "requested": "easyuse_anima.wildcard.expansion",
@@ -58626,7 +58755,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 157,
+            "handler_line": 160,
             "kind": "try",
             "line": 139
           }
@@ -58641,7 +58770,7 @@
         "conditional": true,
         "imported": "easyuse_anima.wildcard.expansion:_ExpansionSegment",
         "kind": "static_from",
-        "line": 158,
+        "line": 161,
         "name": "_ExpansionSegment",
         "optional": false,
         "requested": "easyuse_anima.wildcard.expansion",
@@ -58660,7 +58789,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 157,
+            "handler_line": 160,
             "kind": "try",
             "line": 139
           }
@@ -58675,7 +58804,7 @@
         "conditional": true,
         "imported": "easyuse_anima.wildcard.expansion:_ExpansionState",
         "kind": "static_from",
-        "line": 158,
+        "line": 161,
         "name": "_ExpansionState",
         "optional": false,
         "requested": "easyuse_anima.wildcard.expansion",
@@ -58694,7 +58823,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 157,
+            "handler_line": 160,
             "kind": "try",
             "line": 139
           }
@@ -58709,7 +58838,7 @@
         "conditional": true,
         "imported": "easyuse_anima.wildcard.expansion:_ExpansionText",
         "kind": "static_from",
-        "line": 158,
+        "line": 161,
         "name": "_ExpansionText",
         "optional": false,
         "requested": "easyuse_anima.wildcard.expansion",
@@ -58728,7 +58857,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 157,
+            "handler_line": 160,
             "kind": "try",
             "line": 139
           }
@@ -58743,7 +58872,7 @@
         "conditional": true,
         "imported": "easyuse_anima.wildcard.expansion:_Replacement",
         "kind": "static_from",
-        "line": 158,
+        "line": 161,
         "name": "_Replacement",
         "optional": false,
         "requested": "easyuse_anima.wildcard.expansion",
@@ -58762,7 +58891,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 157,
+            "handler_line": 160,
             "kind": "try",
             "line": 139
           }
@@ -58777,7 +58906,7 @@
         "conditional": true,
         "imported": "easyuse_anima.wildcard.expansion:_bounded_output_prefix",
         "kind": "static_from",
-        "line": 158,
+        "line": 161,
         "name": "_bounded_output_prefix",
         "optional": false,
         "requested": "easyuse_anima.wildcard.expansion",
@@ -58796,7 +58925,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 157,
+            "handler_line": 160,
             "kind": "try",
             "line": 139
           }
@@ -58811,8 +58940,110 @@
         "conditional": true,
         "imported": "easyuse_anima.wildcard.expansion:_expansion_state_signature",
         "kind": "static_from",
-        "line": 158,
+        "line": 161,
         "name": "_expansion_state_signature",
+        "optional": false,
+        "requested": "easyuse_anima.wildcard.expansion",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "wildcard_engine.py",
+        "target": "easyuse_anima/wildcard/expansion.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_parse_count_spec",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 160,
+            "kind": "try",
+            "line": 139
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "_parse_count_spec",
+          "target": "easyuse_anima/wildcard/expansion.py",
+          "try_line": 139
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.wildcard.expansion:_parse_count_spec",
+        "kind": "static_from",
+        "line": 161,
+        "name": "_parse_count_spec",
+        "optional": false,
+        "requested": "easyuse_anima.wildcard.expansion",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "wildcard_engine.py",
+        "target": "easyuse_anima/wildcard/expansion.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_parse_dynamic_options",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 160,
+            "kind": "try",
+            "line": 139
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "_parse_dynamic_options",
+          "target": "easyuse_anima/wildcard/expansion.py",
+          "try_line": 139
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.wildcard.expansion:_parse_dynamic_options",
+        "kind": "static_from",
+        "line": 161,
+        "name": "_parse_dynamic_options",
+        "optional": false,
+        "requested": "easyuse_anima.wildcard.expansion",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "wildcard_engine.py",
+        "target": "easyuse_anima/wildcard/expansion.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_split_unescaped",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 160,
+            "kind": "try",
+            "line": 139
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "_split_unescaped",
+          "target": "easyuse_anima/wildcard/expansion.py",
+          "try_line": 139
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.wildcard.expansion:_split_unescaped",
+        "kind": "static_from",
+        "line": 161,
+        "name": "_split_unescaped",
         "optional": false,
         "requested": "easyuse_anima.wildcard.expansion",
         "role": "compatibility_fallback",
@@ -58830,7 +59061,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 157,
+            "handler_line": 160,
             "kind": "try",
             "line": 139
           }
@@ -58845,7 +59076,7 @@
         "conditional": true,
         "imported": "easyuse_anima.wildcard.expansion:_utf8_length",
         "kind": "static_from",
-        "line": 158,
+        "line": 161,
         "name": "_utf8_length",
         "optional": false,
         "requested": "easyuse_anima.wildcard.expansion",
@@ -58864,7 +59095,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 157,
+            "handler_line": 160,
             "kind": "try",
             "line": 139
           }
@@ -58879,7 +59110,7 @@
         "conditional": true,
         "imported": "easyuse_anima.wildcard.expansion:_utf8_width",
         "kind": "static_from",
-        "line": 158,
+        "line": 161,
         "name": "_utf8_width",
         "optional": false,
         "requested": "easyuse_anima.wildcard.expansion",
@@ -58898,7 +59129,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 157,
+            "handler_line": 160,
             "kind": "try",
             "line": 139
           }
@@ -58913,7 +59144,7 @@
         "conditional": true,
         "imported": "easyuse_anima.wildcard.expansion:has_wildcard_syntax",
         "kind": "static_from",
-        "line": 158,
+        "line": 161,
         "name": "has_wildcard_syntax",
         "optional": false,
         "requested": "easyuse_anima.wildcard.expansion",
@@ -60319,6 +60550,10 @@
       {
         "from": "easyuse_anima/wildcard/expansion.py",
         "to": "easyuse_anima/wildcard/models.py"
+      },
+      {
+        "from": "easyuse_anima/wildcard/expansion.py",
+        "to": "easyuse_anima/wildcard/selector.py"
       },
       {
         "from": "easyuse_anima/wildcard/expansion.py",
@@ -62948,13 +63183,13 @@
       },
       {
         "is_package": false,
-        "loc": 308,
+        "loc": 359,
         "module": "easyuse_anima.wildcard.expansion",
-        "normalized_git_blob_sha1": "640b9c7ed720693f233e63d509ad7da4de3daa00",
+        "normalized_git_blob_sha1": "cb30a5dbd56959328bc04aec97f1a4f0d9244583",
         "path": "easyuse_anima/wildcard/expansion.py",
         "top_level": {
           "class_count": 4,
-          "function_count": 5,
+          "function_count": 8,
           "global_count": 7
         }
       },
@@ -63092,13 +63327,13 @@
       },
       {
         "is_package": false,
-        "loc": 606,
+        "loc": 562,
         "module": "wildcard_engine",
-        "normalized_git_blob_sha1": "0b7fd838f0ecf266e19c9aad1bb2fe5c85652c61",
+        "normalized_git_blob_sha1": "66b53dea9e37c9fe8309f48ab3481d314d1963d1",
         "path": "wildcard_engine.py",
         "top_level": {
           "class_count": 2,
-          "function_count": 13,
+          "function_count": 10,
           "global_count": 4
         }
       }
@@ -74530,7 +74765,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 157,
+            "handler_line": 160,
             "kind": "try",
             "line": 139
           }
@@ -74539,7 +74774,7 @@
         "conditional": true,
         "imported": "easyuse_anima.wildcard.expansion:COMMENT_RE",
         "kind": "static_from",
-        "line": 158,
+        "line": 161,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "wildcard_engine.py",
@@ -74553,7 +74788,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 157,
+            "handler_line": 160,
             "kind": "try",
             "line": 139
           }
@@ -74562,7 +74797,7 @@
         "conditional": true,
         "imported": "easyuse_anima.wildcard.expansion:COUNT_SPEC_RE",
         "kind": "static_from",
-        "line": 158,
+        "line": 161,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "wildcard_engine.py",
@@ -74576,7 +74811,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 157,
+            "handler_line": 160,
             "kind": "try",
             "line": 139
           }
@@ -74585,7 +74820,7 @@
         "conditional": true,
         "imported": "easyuse_anima.wildcard.expansion:DYNAMIC_RE",
         "kind": "static_from",
-        "line": 158,
+        "line": 161,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "wildcard_engine.py",
@@ -74599,7 +74834,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 157,
+            "handler_line": 160,
             "kind": "try",
             "line": 139
           }
@@ -74608,7 +74843,7 @@
         "conditional": true,
         "imported": "easyuse_anima.wildcard.expansion:WILDCARD_FULL_RE",
         "kind": "static_from",
-        "line": 158,
+        "line": 161,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "wildcard_engine.py",
@@ -74622,7 +74857,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 157,
+            "handler_line": 160,
             "kind": "try",
             "line": 139
           }
@@ -74631,7 +74866,7 @@
         "conditional": true,
         "imported": "easyuse_anima.wildcard.expansion:WILDCARD_QUANTIFIER_RE",
         "kind": "static_from",
-        "line": 158,
+        "line": 161,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "wildcard_engine.py",
@@ -74645,7 +74880,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 157,
+            "handler_line": 160,
             "kind": "try",
             "line": 139
           }
@@ -74654,7 +74889,7 @@
         "conditional": true,
         "imported": "easyuse_anima.wildcard.expansion:WILDCARD_RE",
         "kind": "static_from",
-        "line": 158,
+        "line": 161,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "wildcard_engine.py",
@@ -74668,7 +74903,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 157,
+            "handler_line": 160,
             "kind": "try",
             "line": 139
           }
@@ -74677,7 +74912,7 @@
         "conditional": true,
         "imported": "easyuse_anima.wildcard.expansion:_ExpansionSegment",
         "kind": "static_from",
-        "line": 158,
+        "line": 161,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "wildcard_engine.py",
@@ -74691,7 +74926,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 157,
+            "handler_line": 160,
             "kind": "try",
             "line": 139
           }
@@ -74700,7 +74935,7 @@
         "conditional": true,
         "imported": "easyuse_anima.wildcard.expansion:_ExpansionState",
         "kind": "static_from",
-        "line": 158,
+        "line": 161,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "wildcard_engine.py",
@@ -74714,7 +74949,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 157,
+            "handler_line": 160,
             "kind": "try",
             "line": 139
           }
@@ -74723,7 +74958,7 @@
         "conditional": true,
         "imported": "easyuse_anima.wildcard.expansion:_ExpansionText",
         "kind": "static_from",
-        "line": 158,
+        "line": 161,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "wildcard_engine.py",
@@ -74737,7 +74972,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 157,
+            "handler_line": 160,
             "kind": "try",
             "line": 139
           }
@@ -74746,7 +74981,7 @@
         "conditional": true,
         "imported": "easyuse_anima.wildcard.expansion:_Replacement",
         "kind": "static_from",
-        "line": 158,
+        "line": 161,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "wildcard_engine.py",
@@ -74760,7 +74995,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 157,
+            "handler_line": 160,
             "kind": "try",
             "line": 139
           }
@@ -74769,7 +75004,7 @@
         "conditional": true,
         "imported": "easyuse_anima.wildcard.expansion:_bounded_output_prefix",
         "kind": "static_from",
-        "line": 158,
+        "line": 161,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "wildcard_engine.py",
@@ -74783,7 +75018,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 157,
+            "handler_line": 160,
             "kind": "try",
             "line": 139
           }
@@ -74792,7 +75027,7 @@
         "conditional": true,
         "imported": "easyuse_anima.wildcard.expansion:_expansion_state_signature",
         "kind": "static_from",
-        "line": 158,
+        "line": 161,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "wildcard_engine.py",
@@ -74806,7 +75041,76 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 157,
+            "handler_line": 160,
+            "kind": "try",
+            "line": 139
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.wildcard.expansion:_parse_count_spec",
+        "kind": "static_from",
+        "line": 161,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "wildcard_engine.py",
+        "target": "easyuse_anima/wildcard/expansion.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 160,
+            "kind": "try",
+            "line": 139
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.wildcard.expansion:_parse_dynamic_options",
+        "kind": "static_from",
+        "line": 161,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "wildcard_engine.py",
+        "target": "easyuse_anima/wildcard/expansion.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 160,
+            "kind": "try",
+            "line": 139
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.wildcard.expansion:_split_unescaped",
+        "kind": "static_from",
+        "line": 161,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "wildcard_engine.py",
+        "target": "easyuse_anima/wildcard/expansion.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 160,
             "kind": "try",
             "line": 139
           }
@@ -74815,7 +75119,7 @@
         "conditional": true,
         "imported": "easyuse_anima.wildcard.expansion:_utf8_length",
         "kind": "static_from",
-        "line": 158,
+        "line": 161,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "wildcard_engine.py",
@@ -74829,7 +75133,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 157,
+            "handler_line": 160,
             "kind": "try",
             "line": 139
           }
@@ -74838,7 +75142,7 @@
         "conditional": true,
         "imported": "easyuse_anima.wildcard.expansion:_utf8_width",
         "kind": "static_from",
-        "line": 158,
+        "line": 161,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "wildcard_engine.py",
@@ -74852,7 +75156,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 157,
+            "handler_line": 160,
             "kind": "try",
             "line": 139
           }
@@ -74861,7 +75165,7 @@
         "conditional": true,
         "imported": "easyuse_anima.wildcard.expansion:has_wildcard_syntax",
         "kind": "static_from",
-        "line": 158,
+        "line": 161,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "wildcard_engine.py",
@@ -83951,7 +84255,7 @@
         "column": 13,
         "context": "assign:COMMENT_RE",
         "kind": "import_time_call",
-        "line": 26,
+        "line": 27,
         "module": "easyuse_anima/wildcard/expansion.py",
         "scope": "<module>"
       },
@@ -83960,7 +84264,7 @@
         "column": 13,
         "context": "assign:DYNAMIC_RE",
         "kind": "import_time_call",
-        "line": 27,
+        "line": 28,
         "module": "easyuse_anima/wildcard/expansion.py",
         "scope": "<module>"
       },
@@ -83969,7 +84273,7 @@
         "column": 14,
         "context": "assign:WILDCARD_RE",
         "kind": "import_time_call",
-        "line": 28,
+        "line": 29,
         "module": "easyuse_anima/wildcard/expansion.py",
         "scope": "<module>"
       },
@@ -83978,7 +84282,7 @@
         "column": 19,
         "context": "assign:WILDCARD_FULL_RE",
         "kind": "import_time_call",
-        "line": 29,
+        "line": 30,
         "module": "easyuse_anima/wildcard/expansion.py",
         "scope": "<module>"
       },
@@ -83987,7 +84291,7 @@
         "column": 25,
         "context": "assign:WILDCARD_QUANTIFIER_RE",
         "kind": "import_time_call",
-        "line": 30,
+        "line": 31,
         "module": "easyuse_anima/wildcard/expansion.py",
         "scope": "<module>"
       },
@@ -83996,7 +84300,7 @@
         "column": 16,
         "context": "assign:COUNT_SPEC_RE",
         "kind": "import_time_call",
-        "line": 34,
+        "line": 35,
         "module": "easyuse_anima/wildcard/expansion.py",
         "scope": "<module>"
       },
@@ -84005,7 +84309,7 @@
         "column": 1,
         "context": "decorator:_ExpansionSegment",
         "kind": "import_time_call",
-        "line": 54,
+        "line": 105,
         "module": "easyuse_anima/wildcard/expansion.py",
         "scope": "<module>"
       },
@@ -84014,7 +84318,7 @@
         "column": 1,
         "context": "decorator:_Replacement",
         "kind": "import_time_call",
-        "line": 136,
+        "line": 187,
         "module": "easyuse_anima/wildcard/expansion.py",
         "scope": "<module>"
       },
@@ -84086,7 +84390,7 @@
         "column": 22,
         "context": "assign:_SNAPSHOT_CONDITION",
         "kind": "import_time_call",
-        "line": 177,
+        "line": 183,
         "module": "wildcard_engine.py",
         "scope": "<module>"
       },
@@ -84095,7 +84399,7 @@
         "column": 57,
         "context": "assign:_SNAPSHOT_CACHE",
         "kind": "import_time_call",
-        "line": 178,
+        "line": 184,
         "module": "wildcard_engine.py",
         "scope": "<module>"
       },
@@ -84104,7 +84408,7 @@
         "column": 33,
         "context": "assign:_SNAPSHOT_BUILDING",
         "kind": "import_time_call",
-        "line": 179,
+        "line": 185,
         "module": "wildcard_engine.py",
         "scope": "<module>"
       }
@@ -84528,13 +84832,13 @@
       },
       {
         "kind": "set",
-        "line": 179,
+        "line": 185,
         "module": "wildcard_engine.py",
         "name": "_SNAPSHOT_BUILDING"
       },
       {
         "kind": "dict",
-        "line": 178,
+        "line": 184,
         "module": "wildcard_engine.py",
         "name": "_SNAPSHOT_CACHE"
       }
@@ -84699,7 +85003,7 @@
           "single_flight"
         ],
         "initializer": "set",
-        "line": 179,
+        "line": 185,
         "module": "wildcard_engine.py",
         "name": "_SNAPSHOT_BUILDING"
       },
@@ -84709,7 +85013,7 @@
           "mutable_container"
         ],
         "initializer": "OrderedDict",
-        "line": 178,
+        "line": 184,
         "module": "wildcard_engine.py",
         "name": "_SNAPSHOT_CACHE"
       }

--- a/tests/test_wildcards.py
+++ b/tests/test_wildcards.py
@@ -57,6 +57,9 @@ class WildcardEngineTests(unittest.TestCase):
             "_ExpansionText",
             "_Replacement",
             "_ExpansionState",
+            "_split_unescaped",
+            "_parse_dynamic_options",
+            "_parse_count_spec",
             "_bounded_output_prefix",
             "_expansion_state_signature",
         )

--- a/wildcard_engine.py
+++ b/wildcard_engine.py
@@ -139,7 +139,7 @@ except ImportError:
 try:
     from .easyuse_anima.wildcard.expansion import (
         COMMENT_RE,
-        COUNT_SPEC_RE,
+        COUNT_SPEC_RE as COUNT_SPEC_RE,
         DYNAMIC_RE,
         WILDCARD_FULL_RE,
         WILDCARD_QUANTIFIER_RE,
@@ -149,7 +149,10 @@ try:
         _ExpansionSegment as _ExpansionSegment,
         _ExpansionState,
         _ExpansionText,
+        _parse_count_spec,
+        _parse_dynamic_options,
         _Replacement,
+        _split_unescaped,
         _utf8_length,
         _utf8_width as _utf8_width,
         has_wildcard_syntax,
@@ -157,7 +160,7 @@ try:
 except ImportError:
     from easyuse_anima.wildcard.expansion import (
         COMMENT_RE,
-        COUNT_SPEC_RE,
+        COUNT_SPEC_RE as COUNT_SPEC_RE,
         DYNAMIC_RE,
         WILDCARD_FULL_RE,
         WILDCARD_QUANTIFIER_RE,
@@ -167,7 +170,10 @@ except ImportError:
         _ExpansionSegment as _ExpansionSegment,
         _ExpansionState,
         _ExpansionText,
+        _parse_count_spec,
+        _parse_dynamic_options,
         _Replacement,
+        _split_unescaped,
         _utf8_length,
         _utf8_width as _utf8_width,
         has_wildcard_syntax,
@@ -289,56 +295,6 @@ class _WildcardLibrary:
             ):
                 options.extend(self.mapping[key])
         return options
-
-
-def _split_unescaped(value: str, separator: str) -> list[str]:
-    parts = []
-    current = []
-    escaped = False
-    for char in value:
-        if escaped:
-            current.append(char)
-            escaped = False
-            continue
-        if char == "\\":
-            current.append(char)
-            escaped = True
-            continue
-        if char == separator:
-            parts.append("".join(current))
-            current = []
-            continue
-        current.append(char)
-    parts.append("".join(current))
-    return parts
-
-
-def _parse_dynamic_options(value: str) -> list[WildcardOption]:
-    options = []
-    for option in _split_unescaped(value, "|"):
-        parsed = _wildcard_sources._parse_option(option)
-        if parsed is not None:
-            options.append(parsed)
-    return options
-
-
-def _parse_count_spec(spec: str, selector: _Selector) -> int | None:
-    text = str(spec or "").strip()
-    if not text:
-        return 1
-    match = COUNT_SPEC_RE.fullmatch(text)
-    if match is None:
-        return None
-    fixed = match.group("fixed")
-    if fixed is not None:
-        return int(fixed)
-    left = match.group("minimum")
-    right = match.group("maximum")
-    if not left and not right:
-        return None
-    minimum = int(left) if left else 0
-    maximum = int(right) if right else minimum
-    return selector.count_from_range(minimum, maximum)
 
 
 def _expand_multiselect_options(


### PR DESCRIPTION
## 목적과 변경 경계

- Task: D-12g2 / #186 / Move
- Base -> Head: `4fd998e4cb6e9edc6bd07d733dfa630cdd2539d2` -> `b97c0b2c3618cddad55b7c690228665c38fb19dc`
- escaped dynamic-option splitting, weighted option parsing, count/range parsing만 기존 `easyuse_anima.wildcard.expansion` owner로 이동했습니다.
- root `wildcard_engine.py`는 direct aliases를 유지하며 selector construction, snapshot lifecycle, `_WildcardLibrary`, replacement stages, expansion orchestration을 계속 소유합니다.
- production behavior, public node/workflow schema, E-06 lifecycle ownership은 변경하지 않습니다.

## 보존 계약

- escaped separator와 weighted option parsing
- malformed count/range 원문 보존
- random/sequential multiselect와 PCG64 selector call order
- canonical selector import는 NumPy를 eager-load하지 않음
- root/canonical symbol identity
- compatibility fixture와 package/public surface는 변경 없음

## 검증

- Changed-file compile: PASS
- Canonical expansion Ruff: PASS
- Focused:
  - root/canonical identity
  - package import/no side effects
  - dynamic weight prefix
  - wildcard-backed multiselect
  - random weighted/multiselect golden
  - random zero-weight exclusion
  - sequential zero-weight retention
  - malformed count ranges
  - analyzer current surface + byte determinism
  - G-03 import boundary
  - compatibility surface determinism
  - 모두 PASS
- Official full at exact SHA `b97c0b2c3618cddad55b7c690228665c38fb19dc`: PASS — Python 1235, frontend 119, TypeScript 6.0.3, Pyright baseline, G-03, diff check
- Ruff: existing 121 report-only findings maintained
- Package: not triggered; no package path/public surface change
- Live: not triggered

## 위험, rollback, 다음

- Risk: internal pure-helper Move only; supported root identity is fixture-locked.
- Rollback: squash commit revert.
- Next: D-12g3 smallest remaining replacement/library leaf after review and merge.