### PR TITLE
docs: plan Prompt Studio execution-derived projection fix

### DIFF
--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -17,12 +17,18 @@ section, owning Issue, direct owner files, and direct tests.
   focused edit loop, final-full-once rule, package/live/benchmark triggers,
   evidence reuse, and current task-specific test maps. It reduces repeated work;
   it does not weaken an Issue or release gate.
+- Issue [#470](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/470) is the
+  active P1 post-0.6.0 regression lane. Read
+  [`prompt-studio-execution-derived-projection.md`](prompt-studio-execution-derived-projection.md)
+  before modifying Prompt Studio queue/result behavior. QSTATE-04C1 is the first
+  READY task and targets a 0.6.1 patch.
 - Issues [#413](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/413),
   [#414](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/414), and
   [#415](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/415) completed the
-  queue/live-UI hotfix and release lane. Their two-phase correlation and seed
-  ownership contracts remain authoritative for later feature adapters, but no
-  longer block the AiO advanced-integration queue.
+  original queue/live-UI hotfix and release lane. Their two-phase correlation and
+  seed ownership contracts remain authoritative. Issue #470 supersedes only the
+  old classification that treated linked `field_inputs` and NAIA responses as
+  non-projectable submitted snapshots.
 - Before Prompt Studio wildcard next-seed publication or AiO seed cutover, read
   [`seed-ui-semantics-gate.md`](seed-ui-semantics-gate.md). Prompt Studio uses a
   concrete seed plus an after-generate transition; AiO special `-1/-2/-3` values
@@ -36,11 +42,10 @@ section, owning Issue, direct owner files, and direct tests.
 - The DAVE stage-scope, Torch Compile recommendation, and NegPip plans are
   recorded in
   [`aio-advanced-integrations-roadmap.md`](aio-advanced-integrations-roadmap.md).
-  Issue #409 is complete. The active queue is #410 AIO-COMPILE-01 through 04,
-  followed by #411; patch-specific #440/#441 follow-ups do not jump this queue.
-- New D/E/G/H, AiO Hook, opportunistic cleanup, and unrelated feature work remain
-  outside the active #410/#411 queue unless a separately recorded priority
-  decision changes it.
+  Issues #409, #410, and #411 and the 0.6.0 release lane #452 are complete.
+- Deferred patch-specific follow-ups #440/#441, ordinary backend work,
+  opportunistic cleanup, and unrelated features do not jump the active #470
+  patch lane.
 - The former B-11 Comfy host-provider bridge is complete. Its document remains a
   historical sequencing record and no longer overrides the active queue.
 
@@ -48,38 +53,41 @@ section, owning Issue, direct owner files, and direct tests.
 
 - [`../development/codex-execution-efficiency.md`](../development/codex-execution-efficiency.md):
   cross-roadmap Codex context budget, work-packet format, test ladder, invalidation
-  rules, compact evidence format, and scoped test maps for #413/#414, #409/#410/#411,
+  rules, compact evidence format, and scoped test maps for queue/UI, AiO integration,
   and ordinary backend work.
+- [`prompt-studio-execution-derived-projection.md`](prompt-studio-execution-derived-projection.md):
+  active Issue #470 plan separating submitted Prompt Studio snapshots from
+  execution-derived linked-input and NAIA deltas; defines latest-accepted queue
+  ownership, per-field revisions, persistence rules, one-envelope fan-out,
+  implementation units, focused tests, dual-canvas evidence, and the 0.6.1 gate.
 - [`queue-ui-two-phase-correlation-addendum.md`](queue-ui-two-phase-correlation-addendum.md):
-  active correction after QSTATE-02A. It separates provisional submission,
-  accepted `promptId`, and the executed-event envelope; removes mandatory
-  `listIndex` from the node-level stale-result critical path; defines cache,
-  subgraph, mapped-result, transaction-core, and envelope-bridge boundaries; and
-  provides the current Codex start instruction.
+  identity/revision correction after QSTATE-02A. It separates provisional
+  submission, accepted `promptId`, and the executed-event envelope; removes
+  mandatory `listIndex` from node-level stale-result correlation; and defines
+  cache, subgraph, mapped-result, transaction-core, and envelope-bridge boundaries.
 - [`seed-ui-semantics-gate.md`](seed-ui-semantics-gate.md): feature boundary and
   hard test gate separating Prompt Studio Wildcard concrete after-generate seed
   publication from AiO rgthree-style persistent special-token selection, including
-  the special-token × stored-control no-double-advance matrix.
+  the special-token x stored-control no-double-advance matrix.
 - [`queue-ui-execution-state-hotfix.md`](queue-ui-execution-state-hotfix.md):
-  base runbook for stale LoRA/Prompt Studio execution results (#413),
+  historical base runbook for stale LoRA/Prompt Studio execution results (#413),
   rgthree-compatible AiO special-seed display semantics (#414), integrated
-  validation, and the patch release gate owned by #415. Its exact-identity-at-
+  validation, and the completed release gate owned by #415. Its exact-identity-at-
   submission assumptions are superseded by the two-phase addendum.
 - [`python-backend.md`](python-backend.md): living architecture, ownership,
   execution phases, validation gates, and overall Definition of Done.
 - [`python-backend-execution-roadmap.md`](python-backend-execution-roadmap.md):
   verified backend progress, ordered work units, stop conditions, and task-level
-  validation gates. Its next-work ordering is paused while #415 is open. When it
+  validation gates. Its next-work ordering is paused while #470 is open. When it
   resumes, apply the efficiency protocol instead of rerunning every historical
   inventory and broad test after each edit.
 - [`aio-advanced-integrations-roadmap.md`](aio-advanced-integrations-roadmap.md):
-  blocked follow-on plan for stage-scoped DAVE and other MODEL patches (#409),
-  KJNodes Torch Compile environment recommendations (#410), and ComfyUI-ppm
-  NegPip Off/On/Turbo conditioning (#411).
+  completed sequencing plan for stage-scoped DAVE (#409), KJNodes Torch Compile
+  recommendations (#410), and ComfyUI-ppm NegPip (#411). Patch-specific follow-ups
+  remain independently tracked.
 - [`aio-hook-extensibility-plan.md`](aio-hook-extensibility-plan.md): follow-on AiO
   extension contract and stage/cache/lifecycle sequencing. It does not authorize
-  implementation while a higher-priority bug, release, or integration gate is
-  active.
+  implementation while a higher-priority bug or release gate is active.
 - [`comfy-host-provider-bridge.md`](comfy-host-provider-bridge.md): completed
   historical sequencing addendum for the seven former root Comfy capability and
   invocation wrappers and the minimum runtime-bound provider Contract required
@@ -106,16 +114,14 @@ section, owning Issue, direct owner files, and direct tests.
   workflow/profile compatibility, optional custom-node contracts, packaging,
   and live ComfyUI evidence when those surfaces are inseparable from the backend
   execution contract.
-- The active hotfix is tracked by
-  [#413](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/413),
-  [#414](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/414), and
-  [#415](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/415).
+- The active post-0.6.0 patch is tracked by
+  [#470](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/470). Completed
+  #413/#414/#415 remain historical contract sources and are not reopened.
 - Long-term implementation is tracked by
   [#184](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/184),
   [#185](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/185), and their
-  child issues. The blocked advanced integrations are tracked independently by
-  [#409](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/409),
-  [#410](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/410), and
-  [#411](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/411).
+  child issues. Deferred patch-specific integrations are tracked independently by
+  [#440](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/440) and
+  [#441](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/441).
 - An ADR, roadmap, or sequencing note does not authorize a behavior change,
   package move, merge, version bump, tag, or Registry publication by itself.

--- a/docs/architecture/prompt-studio-execution-derived-projection.md
+++ b/docs/architecture/prompt-studio-execution-derived-projection.md
@@ -1,0 +1,618 @@
+# Prompt Studio Execution-Derived Projection Roadmap
+
+## Status and authority
+
+- Status: active P1 regression plan.
+- Owner: Issue #470.
+- Released baseline: 0.6.0.
+- Default patch candidate: 0.6.1.
+- Priority: before #440, #441, ordinary backend refactoring, and opportunistic feature work.
+- This document does not reopen completed Issues #413 or #415.
+- This document preserves the two-phase queue identity and stale-edit protection from
+  `queue-ui-two-phase-correlation-addendum.md`.
+- This document supersedes only the QSTATE-04 assumption that every
+  `advanced_fields`/`field_inputs` execution result is a submitted snapshot that must
+  never project to the current canvas.
+
+The required correction is narrower:
+
+```text
+submitted editor snapshot
+  != execution-derived display/result delta
+```
+
+Submitted snapshots must not regain authority over the current editor. Values that do
+not exist until execution, such as a linked input value or an NAIA response, may project
+only through the latest accepted queue transaction and a field-specific revision gate.
+
+## 1. Verified current behavior
+
+The 0.6.0 queue-ownership work removed broad execution replay from Prompt Studio.
+That fixed destructive stale updates, but it also removed normal execution-result
+presentation:
+
+- linked Advanced field sockets still reach the Python node and are returned in
+  `field_inputs`, but the frontend no longer projects them into the linked textarea;
+- NAIA still generates prompt text and may resolve a runtime resolution, but the
+  frontend no longer adopts the generated field text;
+- Advanced Wildcard next-seed/history remains a separately gated execution result;
+- broad `advanced_fields`, resolution, Artist Mix, and editor-state replay correctly
+  remains retired.
+
+The old `applyAdvancedExecutedInputs()` path is not a valid rollback target. It replaced
+all mutable groups and rerendered the complete Advanced editor. Restoring it would
+reintroduce #413, including prompt/caret loss and completion-order-driven UI changes.
+
+## 2. State classification
+
+Every Prompt Studio result field must be assigned to exactly one class before it can be
+published.
+
+### 2.1 User-authored editable state
+
+Examples:
+
+```text
+ordinary field text
+field order/type/pane/enabled/pin
+resolution selection
+Artist Mix settings
+use_naia request controls
+local fallback text for a linked field
+```
+
+Rules:
+
+- current live state is authoritative;
+- a submitted snapshot never restores it;
+- queue completion does not rerender the whole editor;
+- workflow serialization stores the current live state.
+
+### 2.2 Execution-derived projection state
+
+Examples:
+
+```text
+resolved linked input string
+NAIA-generated field prompt
+NAIA runtime resolution
+Wildcard next-seed publication
+```
+
+Rules:
+
+- it may project only from the latest accepted queue transaction for that surface;
+- it must pass field/surface revision and current-structure checks at commit time;
+- projection is narrow and does not grant authority to unrelated payload fields;
+- missing or ambiguous identity fails closed.
+
+### 2.3 Non-editable execution history
+
+Examples:
+
+```text
+previous Wildcard execution seed/mode
+execution diagnostics
+safe result status
+```
+
+Rules:
+
+- history does not own current editor revisions;
+- it may be monotonic or append-only according to its feature contract;
+- it does not trigger a broad editor replay.
+
+## 3. User-visible queue contract
+
+The implementation does not branch on a special "single queue" or "multi queue" mode.
+Local queue sequence and latest-surface ownership make both cases deterministic.
+
+### 3.1 Single queue
+
+```text
+Q1 captured and accepted
+Q1 execution-derived value arrives
+no relevant user edit or structure change since capture
+-> project Q1 value
+```
+
+### 3.2 Rapid multiple queues
+
+```text
+Q1 captures A
+Q2 captures B
+Q3 captures C
+
+Q1 result -> no editable projection
+Q2 result -> no editable projection
+Q3 result -> C may project
+```
+
+Completion order is not ownership. Once a newer accepted transaction supersedes an
+older transaction for a surface, the older transaction does not regain ownership.
+
+### 3.3 Rejection, failure, and cancellation
+
+- A submission rejected before prompt acceptance does not become the latest owner.
+- Once Q3 is accepted, Q1/Q2 remain superseded even if Q3 later fails or is cancelled.
+- Failure or cancellation does not cause an older result to appear as a fallback.
+- The canvas keeps its current value until a newer valid projection or user edit.
+
+### 3.4 User edit after queue
+
+```text
+Q3 accepted
+user edits the relevant field/surface
+Q3 result arrives
+-> preserve user edit
+```
+
+An edit to field A must not block a current result for unrelated field B. Revision
+ownership therefore uses stable field IDs rather than one node-wide prompt revision.
+
+## 4. Linked input contract
+
+A linked input value is an execution presentation owned by the upstream connection. It
+is not automatically the permanent local field text.
+
+### 4.1 Storage
+
+Store the latest projected value in the existing linked-input overlay/cache owned by the
+node, keyed by the field input name or stable field ID.
+
+Do not rewrite `advanced_fields` merely because a linked value executed.
+
+### 4.2 Narrow view update
+
+On a valid commit:
+
+```text
+update linked execution overlay
+update the exact field textarea if mounted
+refresh only that field's highlight
+recalculate/grow only that textarea when required
+```
+
+Do not:
+
+```text
+renderAdvancedEditor()
+replace other fields
+move caret/selection
+change resolution or Artist Mix
+invoke a user-edit widget callback
+mark the projection as a user edit
+```
+
+### 4.3 Editing while connected
+
+The textarea remains editable.
+
+- User typing updates the local fallback text and the current visible draft.
+- The edit increments the linked field surface revision.
+- A result from a queue captured before that edit cannot overwrite it.
+- If the socket is disconnected later, the user-authored fallback remains.
+- A later queue after the edit may project its newly resolved upstream value again.
+
+Execution projection itself must not silently serialize the upstream result as the local
+fallback.
+
+### 4.4 Structure validation
+
+Before projection, verify:
+
+- the field ID still exists;
+- its input name still maps to the same field;
+- it is still linked;
+- the connection generation/fingerprint captured for the transaction is still current;
+- field type/pane has not changed;
+- node lifecycle epoch and mapped-item policy pass.
+
+Disconnect/reconnect counts as a new structure revision even when the displayed text is
+unchanged.
+
+## 5. NAIA contract
+
+NAIA differs from a linked overlay. The user explicitly requests generated prompt text
+for later editing and reuse, so an accepted NAIA result becomes canonical field text.
+
+### 5.1 Field update
+
+On a valid commit:
+
+```text
+locate the exact NAIA field ID
+replace only that field's canonical text
+persist advanced_fields for that field update
+update only its mounted textarea/highlight/height
+leave it editable
+```
+
+Do not replay the queue's other fields, `use_naia` snapshot, resolution selection,
+Wildcard controls, Artist Mix, or editor structure.
+
+### 5.2 Multiple NAIA queues
+
+All accepted jobs execute independently. The frontend does not serialize ComfyUI queue
+submission around NAIA responses.
+
+```text
+Q1/Q2/Q3 each generate their own image and NAIA response
+Q1 result -> no canvas adoption
+Q2 result -> no canvas adoption
+Q3 result -> adopt Q3 NAIA field delta when current
+```
+
+Until Q3 returns, the existing canvas text remains. If Q3 fails, do not adopt Q1/Q2 as a
+fallback.
+
+### 5.3 NAIA resolution
+
+When the queue used NAIA resolution mode, publish a separate runtime resolution delta.
+It uses one atomic surface:
+
+```text
+prompt.execution.naia_resolution
+```
+
+Apply width/height and the corresponding resolution presentation only when that surface
+is still current. A user resolution edit after queue blocks the result without blocking
+an unrelated NAIA field update.
+
+## 6. Backend UI-delta contract
+
+The frontend must not infer execution-derived changes by diffing a full submitted
+`advanced_fields` snapshot.
+
+Retain the existing linked input map:
+
+```json
+{
+  "field_inputs": {
+    "field_positive_general": "resolved connected text"
+  }
+}
+```
+
+Add explicit NAIA deltas:
+
+```json
+{
+  "naia_field_updates": {
+    "positive_naia": "generated prompt"
+  },
+  "naia_resolution_update": {
+    "width": 1024,
+    "height": 1536
+  }
+}
+```
+
+Contract rules:
+
+- `naia_field_updates` is keyed by stable field ID, not pane position.
+- Include only fields actually generated by this execution.
+- Omit `naia_resolution_update` unless NAIA resolution mode produced it.
+- Keep full `advanced_fields` in the UI payload only when compatibility/history still
+  needs it; it is never current editable authority.
+- Do not add prompt IDs, frontend transaction tokens, or list indexes to cacheable UI
+  payloads.
+- Do not change public node sockets, return order, or workflow schema.
+- Multiple mapped payload items remain fail-closed for editable projection unless a
+  later feature contract defines aggregation.
+
+## 7. Unified Prompt Studio execution transaction
+
+The exact `executed` output envelope can be consumed once. Wildcard, linked inputs, and
+NAIA must therefore share one Prompt Studio execution transaction instead of creating
+independent envelope consumers.
+
+```text
+capture Prompt Studio node + surfaces
+-> accept promptId
+-> consume exact executed envelope once
+-> validate payload item count
+-> fan out feature-owned commit attempts
+   - Wildcard gate
+   - linked field gates
+   - NAIA field gates
+   - NAIA resolution gate
+-> settle once
+```
+
+### 7.1 Shared owner boundaries
+
+`queue_ui_transaction.js` and `executed_event_context.js` remain feature-agnostic. They
+own identity, ordering, revisions, lifecycle, settlement, and bounded cleanup only.
+
+The Prompt Studio adapter owns:
+
+- field IDs and input names;
+- payload parsing;
+- linked connection fingerprints;
+- NAIA field/type validation;
+- narrow DOM and canonical field mutation;
+- Wildcard feature semantics already frozen by the seed gate.
+
+### 7.2 Existing Wildcard transaction module
+
+Before changing the module name, perform one targeted import/export inventory.
+
+- If `wildcard_seed_transaction.js` is repository-internal and has no unsupported
+  consumer, use a move-only unit to generalize it to `execution_transaction.js`.
+- If a consumer relies on the current import, retain a thin re-export facade and place
+  behavior in the generic owner.
+- Do not combine an avoidable mechanical rename with linked/NAIA behavior changes.
+- Do not create a second transaction framework merely to avoid the rename.
+
+### 7.3 Surface IDs
+
+```text
+prompt.execution.linked:<fieldId>
+prompt.execution.naia:<fieldId>
+prompt.execution.naia_resolution
+prompt.wildcard_seed_control
+```
+
+Capture only surfaces relevant to the submitted node state. Surface revisions increase
+on:
+
+- user text input for that field;
+- socket connect/disconnect or source replacement;
+- field delete, type/pane change, or enable/disable;
+- NAIA field structure change;
+- NAIA resolution control edit;
+- node reconfigure/remove lifecycle.
+
+Commit-time validation repeats structure checks. A captured surface token alone is not
+proof that the current field still matches.
+
+## 8. Implementation units
+
+Each unit is one rollback boundary. Do not merge contract, mechanical move, feature
+behavior, and release metadata into one PR.
+
+### QSTATE-04C1 — Projection contract
+
+Type: `CONTRACT`.
+
+Goals:
+
+- freeze the three state classes;
+- freeze latest-accepted-queue ownership;
+- freeze no-fallback after a newer accepted failure;
+- freeze linked overlay versus NAIA canonical persistence;
+- freeze field-specific revisions and connection fingerprints;
+- prove one envelope fan-out and one settlement;
+- add failing/current characterization where useful.
+
+Production files: none.
+
+Candidate tests:
+
+```text
+tests/frontend_prompt_studio_execution_projection_smoke.mjs
+tests/frontend_prompt_studio_advanced_values_smoke.mjs
+tests/test_prompt_advanced_nodes.py
+```
+
+Validation:
+
+```text
+changed MJS syntax
+projection contract smoke
+existing queue transaction/envelope smoke only when imported contract changes
+git diff --check
+official full once on final Contract SHA
+```
+
+Package/live are not triggered.
+
+### QSTATE-04C2 — Unified execution transaction
+
+Type: `MOVE` or narrow `LIFECYCLE`.
+
+Goals:
+
+- generalize the Wildcard-only adapter without changing visible behavior;
+- preserve existing Wildcard queue, revision, duplicate, mapped-item, and live evidence;
+- make one executed-envelope consumption capable of feature fan-out;
+- expose feature-owned commit callbacks without parsing their payloads in the shared
+  lifecycle owner.
+
+Candidate files:
+
+```text
+web/js/prompt_studio/wildcard_seed_transaction.js
+web/js/prompt_studio/execution_transaction.js
+web/js/prompt_studio/extension_runtime.js
+related direct tests and module-boundary assertions
+```
+
+Choose rename/facade only after the targeted inventory. Run the official full once on
+the final PR SHA. Live is required only if behavior changes rather than a pure move.
+
+### QSTATE-04C3 — Backend deltas and linked projection
+
+Type: `BEHAVIOR`.
+
+Goals:
+
+- emit explicit `naia_field_updates` and optional resolution delta;
+- retain `field_inputs` as the linked execution delta;
+- capture linked field surfaces and connection fingerprints;
+- project only the latest accepted transaction;
+- update linked overlay and the exact mounted textarea only;
+- preserve local fallback serialization.
+
+Candidate owners:
+
+```text
+easyuse_anima/nodes/prompt_advanced_nodes.py
+easyuse_anima/prompt/advanced.py
+web/js/prompt_studio/advanced_values.js
+web/js/prompt_studio/advanced_fields_ui.js
+web/js/prompt_studio/serialization.js
+web/js/prompt_studio/extension_runtime.js
+```
+
+Use the current canonical owners found by targeted symbol search; do not fall back to a
+root compatibility shim merely because an old document names it.
+
+Focused proof:
+
+```text
+backend delta shape and absence when inactive
+single linked projection
+Q1/Q2/Q3 latest ownership
+post-queue field edit
+field A/B independent revisions
+disconnect/reconnect and field removal
+no local-fallback serialization
+multiple mapped/duplicate/missing-envelope fail-closed
+existing Wildcard parity
+```
+
+Run Node 2.0 and Legacy linked-field changed flows once on the final behavior diff, then
+the official full runner once.
+
+### QSTATE-04C4 — NAIA canonical adoption and live matrix
+
+Type: `BEHAVIOR/UI`.
+
+Goals:
+
+- adopt only explicit `naia_field_updates` from the latest accepted queue;
+- persist the exact NAIA field update while preserving unrelated fields;
+- keep the textarea editable without a broad rerender;
+- gate NAIA resolution independently;
+- prove rapid queue behavior with deterministic NAIA responses.
+
+Focused proof:
+
+```text
+single positive/negative NAIA update
+Q1/Q2/Q3 -> Q3 canvas/save only
+Q3 accepted failure -> no Q1/Q2 fallback
+post-queue NAIA field edit
+field structure/type/pane change
+NAIA resolution current/stale cases
+other field/resolution/Artist Mix preservation
+workflow save/reload
+```
+
+Live proof uses a deterministic local NAIA fixture/server rather than relying on random
+external responses. Run Node 2.0 first, then Legacy Canvas. Run official full once on the
+final PR SHA.
+
+### QSTATE-04C5 — 0.6.1 patch gate
+
+Type: `RELEASE` after production freeze.
+
+On one exact integrated `dev` SHA:
+
+```powershell
+powershell -ExecutionPolicy Bypass -File tools\check_project.ps1 -Profile full
+comfy node validate
+comfy node pack
+```
+
+Inspect archive closure and run the combined live matrix:
+
+```text
+Legacy Canvas / Node 2.0
+single and rapid linked queues
+single and rapid deterministic NAIA queues
+edit during execution
+disconnect/reconnect/remove/reconfigure
+queue rejection/cancel where reproducible
+workflow save/reload
+clean user data
+0.6.0 update user data
+Wildcard next-seed regression check
+AiO special-seed regression check
+```
+
+Release preparation changes version/changelog/Registry/workflow release metadata only.
+Any production failure returns to a separate fix PR.
+
+## 9. Test-economy map
+
+Use task-specific focused tests during edits. Do not rerun the repository-wide quick or
+full profile after every correction.
+
+| Unit | Edit-loop proof | Final promotion |
+| --- | --- | --- |
+| C1 Contract | contract/source-boundary fixtures | full once; no live/package |
+| C2 lifecycle/move | transaction, envelope, Wildcard parity | full once; live only if behavior changed |
+| C3 linked behavior | backend delta + linked projection fixtures | Node 2.0 + Legacy changed flow; full once |
+| C4 NAIA behavior | NAIA delta/adoption fixtures | deterministic Node 2.0 + Legacy flow; full once |
+| C5 release | integrated regressions | full + package + archive + live matrix |
+
+A code/test/runner/shared-fixture change invalidates relevant evidence. Documentation,
+Issue comments, labels, and PR prose do not.
+
+## 10. Stop and focused technical-review conditions
+
+Codex resolves ordinary owner-local failures without asking the user to choose an
+implementation. Request focused technical-depth review only when evidence shows one of
+the following:
+
+- the output envelope cannot fan out without changing ComfyUI core or the public socket;
+- stable field identity cannot survive queue capture and current editor structure;
+- NAIA deltas cannot be represented without replaying the complete submitted snapshot;
+- Legacy Canvas and Node 2.0 require incompatible persistent semantics;
+- narrow linked/NAIA view updates are impossible without a destructive full editor
+  rerender;
+- the fix requires a workflow/profile/settings migration with multiple credible policy
+  choices;
+- reason-coded diagnostics cannot identify the first divergent owner.
+
+Do not stop merely because a fixture, DOM lookup, listener order, or one bounded
+implementation attempt is wrong.
+
+## 11. Current execution order
+
+```text
+READY  QSTATE-04C1  projection Contract
+  -> QSTATE-04C2  unified Prompt Studio execution transaction
+  -> QSTATE-04C3  backend delta + linked input projection
+  -> QSTATE-04C4  NAIA canonical adoption + dual-canvas live
+  -> QSTATE-04C5  integrated 0.6.1 patch gate
+  -> resume #440/#441 and ordinary backend queue after re-audit
+```
+
+The first Codex task is QSTATE-04C1 only.
+
+## 12. Codex start instruction
+
+```text
+Read:
+- docs/development/current-policies.md
+- the universal/task-card sections of codex-execution-efficiency.md
+- this document's QSTATE-04C1 section
+- Issue #470 latest decision
+- direct Prompt Studio payload/transaction tests
+
+Create one bounded QSTATE-04C1 task card from latest origin/dev.
+Do not implement production behavior.
+
+Freeze fixtures for:
+- submitted snapshot versus execution-derived delta classification;
+- single queue linked and NAIA projection eligibility;
+- Q1/Q2/Q3 latest accepted ownership independent of completion order;
+- newer accepted failure with no older fallback;
+- field-specific edit/structure revisions;
+- linked overlay not serialized as local fallback;
+- NAIA canonical field persistence;
+- one executed-envelope fan-out and one settlement;
+- mapped/duplicate/missing identity fail-closed.
+
+Use changed-file syntax, the new projection contract smoke, directly affected existing
+Prompt Studio fixtures, and git diff --check during edits. Run official full once on the
+final Contract SHA. Do not run package/live and do not start QSTATE-04C2 in the same PR.
+
+Push a dev-target Draft PR with compact evidence. Proceed to QSTATE-04C2 only after the
+Contract is reviewed and merged. PRO review is not pre-scheduled; use it only if this
+document's technical stop conditions are evidenced.
+```

--- a/docs/architecture/prompt-studio-execution-derived-projection.md
+++ b/docs/architecture/prompt-studio-execution-derived-projection.md
@@ -6,265 +6,187 @@
 - Owner: Issue #470.
 - Released baseline: 0.6.0.
 - Default patch candidate: 0.6.1.
-- Priority: before #440, #441, ordinary backend refactoring, and opportunistic feature work.
-- This document does not reopen completed Issues #413 or #415.
-- This document preserves the two-phase queue identity and stale-edit protection from
-  `queue-ui-two-phase-correlation-addendum.md`.
-- This document supersedes only the QSTATE-04 assumption that every
-  `advanced_fields`/`field_inputs` execution result is a submitted snapshot that must
-  never project to the current canvas.
-
-The required correction is narrower:
+- Priority: before #440/#441, ordinary backend refactoring, and opportunistic work.
+- Completed #413/#415 remain closed.
+- The two-phase queue identity and stale-edit contract remains authoritative.
+- This document supersedes only the old QSTATE-04 assumption that linked
+  `field_inputs` and NAIA responses are non-projectable submitted snapshots.
 
 ```text
-submitted editor snapshot
-  != execution-derived display/result delta
+submitted editor snapshot != execution-derived result delta
 ```
 
-Submitted snapshots must not regain authority over the current editor. Values that do
-not exist until execution, such as a linked input value or an NAIA response, may project
-only through the latest accepted queue transaction and a field-specific revision gate.
+Submitted snapshots never regain authority over the current editor. Linked input and
+NAIA values may project only through the latest accepted queue transaction and the
+relevant field revision.
 
-## 1. Verified current behavior
+## 1. Regression and state classes
 
-The 0.6.0 queue-ownership work removed broad execution replay from Prompt Studio.
-That fixed destructive stale updates, but it also removed normal execution-result
-presentation:
+QSTATE-04A removed broad execution replay. It fixed stale overwrites but also removed:
 
-- linked Advanced field sockets still reach the Python node and are returned in
-  `field_inputs`, but the frontend no longer projects them into the linked textarea;
-- NAIA still generates prompt text and may resolve a runtime resolution, but the
-  frontend no longer adopts the generated field text;
-- Advanced Wildcard next-seed/history remains a separately gated execution result;
-- broad `advanced_fields`, resolution, Artist Mix, and editor-state replay correctly
-  remains retired.
+- linked socket values from Advanced linked textareas;
+- NAIA-generated prompt adoption;
+- NAIA runtime-resolution adoption.
 
-The old `applyAdvancedExecutedInputs()` path is not a valid rollback target. It replaced
-all mutable groups and rerendered the complete Advanced editor. Restoring it would
-reintroduce #413, including prompt/caret loss and completion-order-driven UI changes.
+Do not restore the old `applyAdvancedExecutedInputs()` path. It replaced every mutable
+group and rerendered the full editor.
 
-## 2. State classification
+Classify each result field before publication.
 
-Every Prompt Studio result field must be assigned to exactly one class before it can be
-published.
-
-### 2.1 User-authored editable state
-
-Examples:
+### User-authored editable state
 
 ```text
-ordinary field text
-field order/type/pane/enabled/pin
-resolution selection
-Artist Mix settings
-use_naia request controls
-local fallback text for a linked field
+ordinary field text and structure
+resolution / Artist Mix / editable controls
+use_naia request state
+linked field local fallback text
 ```
 
-Rules:
+A submitted snapshot never restores this state.
 
-- current live state is authoritative;
-- a submitted snapshot never restores it;
-- queue completion does not rerender the whole editor;
-- workflow serialization stores the current live state.
-
-### 2.2 Execution-derived projection state
-
-Examples:
+### Execution-derived projection
 
 ```text
 resolved linked input string
-NAIA-generated field prompt
+NAIA-generated prompt
 NAIA runtime resolution
-Wildcard next-seed publication
+Wildcard next-seed result
 ```
 
-Rules:
+Projection requires latest accepted ownership, current surface revision, current field
+structure, one mapped item, and a live node lifecycle.
 
-- it may project only from the latest accepted queue transaction for that surface;
-- it must pass field/surface revision and current-structure checks at commit time;
-- projection is narrow and does not grant authority to unrelated payload fields;
-- missing or ambiguous identity fails closed.
-
-### 2.3 Non-editable execution history
-
-Examples:
+### Non-editable history
 
 ```text
-previous Wildcard execution seed/mode
-execution diagnostics
-safe result status
+previous Wildcard execution
+execution diagnostics/status
 ```
 
-Rules:
+History does not own editor revisions and does not trigger broad rerender.
 
-- history does not own current editor revisions;
-- it may be monotonic or append-only according to its feature contract;
-- it does not trigger a broad editor replay.
+## 2. Queue ownership contract
 
-## 3. User-visible queue contract
+No separate single-queue/multi-queue mode is required.
 
-The implementation does not branch on a special "single queue" or "multi queue" mode.
-Local queue sequence and latest-surface ownership make both cases deterministic.
-
-### 3.1 Single queue
+### Single queue
 
 ```text
-Q1 captured and accepted
-Q1 execution-derived value arrives
-no relevant user edit or structure change since capture
--> project Q1 value
+Q1 accepted
+Q1 result arrives
+relevant surface unchanged
+-> Q1 may project
 ```
 
-### 3.2 Rapid multiple queues
+### Rapid queues
 
 ```text
-Q1 captures A
-Q2 captures B
-Q3 captures C
-
+Q1=A, Q2=B, Q3=C
 Q1 result -> no editable projection
 Q2 result -> no editable projection
 Q3 result -> C may project
 ```
 
-Completion order is not ownership. Once a newer accepted transaction supersedes an
-older transaction for a surface, the older transaction does not regain ownership.
+Ownership follows latest accepted queue sequence, not completion order.
 
-### 3.3 Rejection, failure, and cancellation
+- A queue rejected before acceptance never becomes owner.
+- Once Q3 is accepted, Q1/Q2 remain superseded even if Q3 fails/cancels.
+- Failure does not make an older result reappear.
+- A user edit after Q3 capture blocks Q3 only for that edited surface.
+- Editing field A does not block a current result for field B.
 
-- A submission rejected before prompt acceptance does not become the latest owner.
-- Once Q3 is accepted, Q1/Q2 remain superseded even if Q3 later fails or is cancelled.
-- Failure or cancellation does not cause an older result to appear as a fallback.
-- The canvas keeps its current value until a newer valid projection or user edit.
+## 3. Linked input contract
 
-### 3.4 User edit after queue
-
-```text
-Q3 accepted
-user edits the relevant field/surface
-Q3 result arrives
--> preserve user edit
-```
-
-An edit to field A must not block a current result for unrelated field B. Revision
-ownership therefore uses stable field IDs rather than one node-wide prompt revision.
-
-## 4. Linked input contract
-
-A linked input value is an execution presentation owned by the upstream connection. It
-is not automatically the permanent local field text.
-
-### 4.1 Storage
-
-Store the latest projected value in the existing linked-input overlay/cache owned by the
-node, keyed by the field input name or stable field ID.
-
-Do not rewrite `advanced_fields` merely because a linked value executed.
-
-### 4.2 Narrow view update
+Linked execution values are presentation overlays, not automatic local field storage.
 
 On a valid commit:
 
 ```text
 update linked execution overlay
-update the exact field textarea if mounted
-refresh only that field's highlight
-recalculate/grow only that textarea when required
+update the exact mounted textarea
+refresh only that field highlight
+resize/grow only that textarea when needed
 ```
 
 Do not:
 
 ```text
+rewrite advanced_fields
 renderAdvancedEditor()
 replace other fields
 move caret/selection
 change resolution or Artist Mix
-invoke a user-edit widget callback
-mark the projection as a user edit
+invoke user-edit callbacks
+increment edit revision for the projection itself
 ```
 
-### 4.3 Editing while connected
+The linked textarea stays editable.
 
-The textarea remains editable.
+- User typing updates the local fallback and increments that field revision.
+- A pre-edit queue result cannot overwrite it.
+- Disconnecting later reveals/preserves the user fallback.
+- A later queue may project a new upstream value.
+- Execution projection itself is not serialized as the fallback.
 
-- User typing updates the local fallback text and the current visible draft.
-- The edit increments the linked field surface revision.
-- A result from a queue captured before that edit cannot overwrite it.
-- If the socket is disconnected later, the user-authored fallback remains.
-- A later queue after the edit may project its newly resolved upstream value again.
+Commit-time checks:
 
-Execution projection itself must not silently serialize the upstream result as the local
-fallback.
+```text
+field ID still exists
+input name still maps to that field
+socket still linked to the captured connection generation/fingerprint
+field type/pane unchanged
+node epoch current
+mapped item count == 1
+surface revision current
+```
 
-### 4.4 Structure validation
+Connect, disconnect, or source replacement increments the structure revision.
 
-Before projection, verify:
+## 4. NAIA contract
 
-- the field ID still exists;
-- its input name still maps to the same field;
-- it is still linked;
-- the connection generation/fingerprint captured for the transaction is still current;
-- field type/pane has not changed;
-- node lifecycle epoch and mapped-item policy pass.
-
-Disconnect/reconnect counts as a new structure revision even when the displayed text is
-unchanged.
-
-## 5. NAIA contract
-
-NAIA differs from a linked overlay. The user explicitly requests generated prompt text
-for later editing and reuse, so an accepted NAIA result becomes canonical field text.
-
-### 5.1 Field update
+NAIA is a requested generated result, so the accepted latest response becomes canonical
+field text.
 
 On a valid commit:
 
 ```text
-locate the exact NAIA field ID
-replace only that field's canonical text
-persist advanced_fields for that field update
-update only its mounted textarea/highlight/height
-leave it editable
+locate exact NAIA field ID
+replace only that field text
+persist that advanced_fields update
+update only its textarea/highlight/height
+keep it editable
 ```
 
-Do not replay the queue's other fields, `use_naia` snapshot, resolution selection,
-Wildcard controls, Artist Mix, or editor structure.
+Do not replay other fields, `use_naia`, resolution selection, Wildcard controls,
+Artist Mix, or editor structure.
 
-### 5.2 Multiple NAIA queues
+### Multiple NAIA queues
 
-All accepted jobs execute independently. The frontend does not serialize ComfyUI queue
-submission around NAIA responses.
+All accepted jobs execute independently; ComfyUI queue submission is not serialized.
 
 ```text
-Q1/Q2/Q3 each generate their own image and NAIA response
-Q1 result -> no canvas adoption
-Q2 result -> no canvas adoption
-Q3 result -> adopt Q3 NAIA field delta when current
+Q1/Q2/Q3 generate independently
+Q1/Q2 results -> images only, no canvas adoption
+Q3 result -> canvas adoption when current
+Q3 failure -> no Q1/Q2 fallback
 ```
 
-Until Q3 returns, the existing canvas text remains. If Q3 fails, do not adopt Q1/Q2 as a
-fallback.
+### NAIA resolution
 
-### 5.3 NAIA resolution
-
-When the queue used NAIA resolution mode, publish a separate runtime resolution delta.
-It uses one atomic surface:
+Use a separate atomic surface:
 
 ```text
 prompt.execution.naia_resolution
 ```
 
-Apply width/height and the corresponding resolution presentation only when that surface
-is still current. A user resolution edit after queue blocks the result without blocking
-an unrelated NAIA field update.
+Apply the runtime width/height only when the resolution revision is current. A stale
+resolution result does not block an unrelated current NAIA field result.
 
-## 6. Backend UI-delta contract
+## 5. Backend UI delta
 
-The frontend must not infer execution-derived changes by diffing a full submitted
-`advanced_fields` snapshot.
+Do not infer execution changes by diffing full `advanced_fields`.
 
-Retain the existing linked input map:
+Retain linked values:
 
 ```json
 {
@@ -288,64 +210,53 @@ Add explicit NAIA deltas:
 }
 ```
 
-Contract rules:
+Rules:
 
-- `naia_field_updates` is keyed by stable field ID, not pane position.
-- Include only fields actually generated by this execution.
-- Omit `naia_resolution_update` unless NAIA resolution mode produced it.
-- Keep full `advanced_fields` in the UI payload only when compatibility/history still
-  needs it; it is never current editable authority.
-- Do not add prompt IDs, frontend transaction tokens, or list indexes to cacheable UI
-  payloads.
-- Do not change public node sockets, return order, or workflow schema.
-- Multiple mapped payload items remain fail-closed for editable projection unless a
-  later feature contract defines aggregation.
+- NAIA updates are keyed by stable field ID.
+- Include only fields actually generated in this execution.
+- Omit resolution delta unless NAIA resolution mode produced it.
+- Full `advanced_fields` may remain for compatibility/history but is never current
+  editable authority.
+- Do not stamp prompt IDs or frontend transaction tokens into cacheable UI payloads.
+- Do not change public sockets, return order, or workflow schema.
+- Multiple mapped payload items remain fail-closed.
 
-## 7. Unified Prompt Studio execution transaction
+## 6. Unified Prompt Studio execution transaction
 
-The exact `executed` output envelope can be consumed once. Wildcard, linked inputs, and
-NAIA must therefore share one Prompt Studio execution transaction instead of creating
-independent envelope consumers.
+The exact executed output envelope is consumed once, then feature gates fan out.
 
 ```text
-capture Prompt Studio node + surfaces
+capture node + surfaces
 -> accept promptId
 -> consume exact executed envelope once
--> validate payload item count
--> fan out feature-owned commit attempts
-   - Wildcard gate
-   - linked field gates
-   - NAIA field gates
-   - NAIA resolution gate
+-> validate mapped count
+-> Wildcard gate
+-> linked field gates
+-> NAIA field gates
+-> NAIA resolution gate
 -> settle once
 ```
 
-### 7.1 Shared owner boundaries
+Do not create independent Wildcard/linked/NAIA envelope consumers.
+
+### Ownership boundary
 
 `queue_ui_transaction.js` and `executed_event_context.js` remain feature-agnostic. They
-own identity, ordering, revisions, lifecycle, settlement, and bounded cleanup only.
+own identity, ordering, revisions, lifecycle, settlement, and bounded cleanup.
 
-The Prompt Studio adapter owns:
+The Prompt Studio adapter owns field IDs, input mapping, payload parsing, connection
+fingerprints, NAIA validation, narrow DOM updates, and existing Wildcard semantics.
 
-- field IDs and input names;
-- payload parsing;
-- linked connection fingerprints;
-- NAIA field/type validation;
-- narrow DOM and canonical field mutation;
-- Wildcard feature semantics already frozen by the seed gate.
+### Existing module
 
-### 7.2 Existing Wildcard transaction module
+Inventory imports before renaming `wildcard_seed_transaction.js`.
 
-Before changing the module name, perform one targeted import/export inventory.
+- Internal-only: generalize with a move-only unit to `execution_transaction.js`.
+- Existing consumer: retain a thin re-export facade.
+- Do not combine an avoidable rename with linked/NAIA behavior.
+- Do not add a second transaction framework.
 
-- If `wildcard_seed_transaction.js` is repository-internal and has no unsupported
-  consumer, use a move-only unit to generalize it to `execution_transaction.js`.
-- If a consumer relies on the current import, retain a thin re-export facade and place
-  behavior in the generic owner.
-- Do not combine an avoidable mechanical rename with linked/NAIA behavior changes.
-- Do not create a second transaction framework merely to avoid the rename.
-
-### 7.3 Surface IDs
+### Surfaces
 
 ```text
 prompt.execution.linked:<fieldId>
@@ -354,39 +265,26 @@ prompt.execution.naia_resolution
 prompt.wildcard_seed_control
 ```
 
-Capture only surfaces relevant to the submitted node state. Surface revisions increase
-on:
+Increment revisions on user text input, connect/disconnect/source replacement, field
+remove/type/pane/enable changes, NAIA structure changes, resolution edits, reconfigure,
+and removal.
 
-- user text input for that field;
-- socket connect/disconnect or source replacement;
-- field delete, type/pane change, or enable/disable;
-- NAIA field structure change;
-- NAIA resolution control edit;
-- node reconfigure/remove lifecycle.
+## 7. Implementation units
 
-Commit-time validation repeats structure checks. A captured surface token alone is not
-proof that the current field still matches.
+Each unit is an independent rollback boundary.
 
-## 8. Implementation units
+### QSTATE-04C1 — Projection Contract
 
-Each unit is one rollback boundary. Do not merge contract, mechanical move, feature
-behavior, and release metadata into one PR.
+Type: `CONTRACT`; production unchanged.
 
-### QSTATE-04C1 — Projection contract
+Freeze:
 
-Type: `CONTRACT`.
-
-Goals:
-
-- freeze the three state classes;
-- freeze latest-accepted-queue ownership;
-- freeze no-fallback after a newer accepted failure;
-- freeze linked overlay versus NAIA canonical persistence;
-- freeze field-specific revisions and connection fingerprints;
-- prove one envelope fan-out and one settlement;
-- add failing/current characterization where useful.
-
-Production files: none.
+- the three state classes;
+- latest-accepted ownership and no old-result fallback;
+- field-specific revisions and connection fingerprints;
+- linked overlay versus NAIA canonical persistence;
+- one-envelope fan-out and one settlement;
+- mapped/duplicate/missing-identity fail-closed behavior.
 
 Candidate tests:
 
@@ -396,29 +294,18 @@ tests/frontend_prompt_studio_advanced_values_smoke.mjs
 tests/test_prompt_advanced_nodes.py
 ```
 
-Validation:
-
-```text
-changed MJS syntax
-projection contract smoke
-existing queue transaction/envelope smoke only when imported contract changes
-git diff --check
-official full once on final Contract SHA
-```
-
+Edit loop: changed-file syntax, projection contract smoke, directly affected existing
+Prompt Studio fixtures, `git diff --check`. Run official full once on the final SHA.
 Package/live are not triggered.
 
 ### QSTATE-04C2 — Unified execution transaction
 
-Type: `MOVE` or narrow `LIFECYCLE`.
+Type: move-only or narrow `LIFECYCLE`.
 
-Goals:
-
-- generalize the Wildcard-only adapter without changing visible behavior;
-- preserve existing Wildcard queue, revision, duplicate, mapped-item, and live evidence;
-- make one executed-envelope consumption capable of feature fan-out;
-- expose feature-owned commit callbacks without parsing their payloads in the shared
-  lifecycle owner.
+- Generalize the Wildcard transaction without visible behavior change.
+- Preserve Wildcard queue/revision/duplicate/mapped-item semantics.
+- Consume one envelope and expose feature-owned commit callbacks.
+- Shared lifecycle does not parse feature payloads.
 
 Candidate files:
 
@@ -426,26 +313,24 @@ Candidate files:
 web/js/prompt_studio/wildcard_seed_transaction.js
 web/js/prompt_studio/execution_transaction.js
 web/js/prompt_studio/extension_runtime.js
-related direct tests and module-boundary assertions
+direct transaction/module-boundary tests
 ```
 
-Choose rename/facade only after the targeted inventory. Run the official full once on
-the final PR SHA. Live is required only if behavior changes rather than a pure move.
+Run official full once. Live is required only if behavior changed rather than a pure
+move.
 
-### QSTATE-04C3 — Backend deltas and linked projection
+### QSTATE-04C3 — Backend delta and linked projection
 
 Type: `BEHAVIOR`.
 
-Goals:
+- Emit explicit NAIA field/resolution deltas.
+- Retain `field_inputs` as the linked execution delta.
+- Capture linked surfaces and connection fingerprints.
+- Project only from the latest accepted transaction.
+- Update overlay and exact textarea without full rerender.
+- Preserve local fallback serialization.
 
-- emit explicit `naia_field_updates` and optional resolution delta;
-- retain `field_inputs` as the linked execution delta;
-- capture linked field surfaces and connection fingerprints;
-- project only the latest accepted transaction;
-- update linked overlay and the exact mounted textarea only;
-- preserve local fallback serialization.
-
-Candidate owners:
+Candidate owners, confirmed by targeted search:
 
 ```text
 easyuse_anima/nodes/prompt_advanced_nodes.py
@@ -456,58 +341,48 @@ web/js/prompt_studio/serialization.js
 web/js/prompt_studio/extension_runtime.js
 ```
 
-Use the current canonical owners found by targeted symbol search; do not fall back to a
-root compatibility shim merely because an old document names it.
-
 Focused proof:
 
 ```text
-backend delta shape and absence when inactive
-single linked projection
+backend delta active/inactive shape
+single linked result
 Q1/Q2/Q3 latest ownership
-post-queue field edit
+post-queue edit
 field A/B independent revisions
-disconnect/reconnect and field removal
-no local-fallback serialization
-multiple mapped/duplicate/missing-envelope fail-closed
-existing Wildcard parity
+disconnect/reconnect/remove/type change
+no fallback serialization
+mapped/duplicate/missing-envelope no-op
+Wildcard parity
 ```
 
-Run Node 2.0 and Legacy linked-field changed flows once on the final behavior diff, then
-the official full runner once.
+Run Node 2.0 and Legacy changed flows once, then official full once.
 
-### QSTATE-04C4 — NAIA canonical adoption and live matrix
+### QSTATE-04C4 — NAIA canonical adoption
 
 Type: `BEHAVIOR/UI`.
 
-Goals:
+- Adopt only explicit NAIA deltas from the latest accepted queue.
+- Persist exact NAIA fields while preserving unrelated state.
+- Gate runtime resolution separately.
+- Keep text editable without broad rerender.
 
-- adopt only explicit `naia_field_updates` from the latest accepted queue;
-- persist the exact NAIA field update while preserving unrelated fields;
-- keep the textarea editable without a broad rerender;
-- gate NAIA resolution independently;
-- prove rapid queue behavior with deterministic NAIA responses.
-
-Focused proof:
+Focused/live proof:
 
 ```text
 single positive/negative NAIA update
 Q1/Q2/Q3 -> Q3 canvas/save only
-Q3 accepted failure -> no Q1/Q2 fallback
-post-queue NAIA field edit
+Q3 failure -> no older fallback
+post-queue field edit
 field structure/type/pane change
-NAIA resolution current/stale cases
+resolution current/stale cases
 other field/resolution/Artist Mix preservation
 workflow save/reload
 ```
 
-Live proof uses a deterministic local NAIA fixture/server rather than relying on random
-external responses. Run Node 2.0 first, then Legacy Canvas. Run official full once on the
-final PR SHA.
+Use a deterministic local NAIA fixture/server. Run Node 2.0 first, then Legacy, then
+official full once.
 
 ### QSTATE-04C5 — 0.6.1 patch gate
-
-Type: `RELEASE` after production freeze.
 
 On one exact integrated `dev` SHA:
 
@@ -517,102 +392,89 @@ comfy node validate
 comfy node pack
 ```
 
-Inspect archive closure and run the combined live matrix:
+Inspect archive closure and run:
 
 ```text
-Legacy Canvas / Node 2.0
+Legacy / Node 2.0
 single and rapid linked queues
 single and rapid deterministic NAIA queues
 edit during execution
 disconnect/reconnect/remove/reconfigure
-queue rejection/cancel where reproducible
+reject/cancel where reproducible
 workflow save/reload
-clean user data
-0.6.0 update user data
-Wildcard next-seed regression check
-AiO special-seed regression check
+clean user data / 0.6.0 update user data
+Wildcard next-seed regression
+AiO special-seed regression
 ```
 
-Release preparation changes version/changelog/Registry/workflow release metadata only.
-Any production failure returns to a separate fix PR.
+Release preparation is metadata-only after production freeze. A production failure
+returns to a separate fix PR.
 
-## 9. Test-economy map
+## 8. Test economy
 
-Use task-specific focused tests during edits. Do not rerun the repository-wide quick or
-full profile after every correction.
-
-| Unit | Edit-loop proof | Final promotion |
+| Unit | Edit loop | Final promotion |
 | --- | --- | --- |
-| C1 Contract | contract/source-boundary fixtures | full once; no live/package |
-| C2 lifecycle/move | transaction, envelope, Wildcard parity | full once; live only if behavior changed |
-| C3 linked behavior | backend delta + linked projection fixtures | Node 2.0 + Legacy changed flow; full once |
-| C4 NAIA behavior | NAIA delta/adoption fixtures | deterministic Node 2.0 + Legacy flow; full once |
-| C5 release | integrated regressions | full + package + archive + live matrix |
+| C1 | contract/source fixtures | full once; no live/package |
+| C2 | transaction/envelope/Wildcard parity | full once; live only if behavior changed |
+| C3 | backend delta + linked fixtures | Node 2.0 + Legacy changed flow; full once |
+| C4 | NAIA delta/adoption fixtures | deterministic dual-canvas flow; full once |
+| C5 | integrated regressions | full + package + archive + live matrix |
 
-A code/test/runner/shared-fixture change invalidates relevant evidence. Documentation,
-Issue comments, labels, and PR prose do not.
+Code/test/runner/shared-fixture changes invalidate relevant evidence. Docs, labels,
+comments, and PR prose do not.
 
-## 10. Stop and focused technical-review conditions
+## 9. Focused technical-review conditions
 
 Codex resolves ordinary owner-local failures without asking the user to choose an
-implementation. Request focused technical-depth review only when evidence shows one of
-the following:
+implementation. Request technical-depth review only if evidence shows:
 
-- the output envelope cannot fan out without changing ComfyUI core or the public socket;
-- stable field identity cannot survive queue capture and current editor structure;
-- NAIA deltas cannot be represented without replaying the complete submitted snapshot;
-- Legacy Canvas and Node 2.0 require incompatible persistent semantics;
-- narrow linked/NAIA view updates are impossible without a destructive full editor
-  rerender;
-- the fix requires a workflow/profile/settings migration with multiple credible policy
-  choices;
+- one-envelope fan-out requires ComfyUI core/public socket changes;
+- stable field identity cannot survive capture and current editor structure;
+- NAIA delta cannot be represented without full snapshot replay;
+- Legacy and Node 2.0 require incompatible persistent semantics;
+- narrow view sync is impossible without destructive full rerender;
+- a workflow/settings migration has multiple credible policies;
 - reason-coded diagnostics cannot identify the first divergent owner.
 
-Do not stop merely because a fixture, DOM lookup, listener order, or one bounded
-implementation attempt is wrong.
+A wrong fixture, DOM lookup, listener order, or one bounded implementation failure is
+not a review trigger.
 
-## 11. Current execution order
+## 10. Execution order
 
 ```text
-READY  QSTATE-04C1  projection Contract
-  -> QSTATE-04C2  unified Prompt Studio execution transaction
-  -> QSTATE-04C3  backend delta + linked input projection
-  -> QSTATE-04C4  NAIA canonical adoption + dual-canvas live
+READY  QSTATE-04C1  Projection Contract
+  -> QSTATE-04C2  unified execution transaction
+  -> QSTATE-04C3  backend delta + linked projection
+  -> QSTATE-04C4  NAIA adoption + dual-canvas live
   -> QSTATE-04C5  integrated 0.6.1 patch gate
-  -> resume #440/#441 and ordinary backend queue after re-audit
+  -> re-audit/resume #440/#441 and ordinary backend queue
 ```
 
-The first Codex task is QSTATE-04C1 only.
-
-## 12. Codex start instruction
+## 11. Codex start instruction
 
 ```text
-Read:
-- docs/development/current-policies.md
-- the universal/task-card sections of codex-execution-efficiency.md
-- this document's QSTATE-04C1 section
-- Issue #470 latest decision
-- direct Prompt Studio payload/transaction tests
+Read current-policies.md, the universal/task-card parts of
+codex-execution-efficiency.md, this document's QSTATE-04C1 section, Issue #470 latest
+decision, and direct Prompt Studio payload/transaction tests.
 
-Create one bounded QSTATE-04C1 task card from latest origin/dev.
-Do not implement production behavior.
+From latest origin/dev, create one QSTATE-04C1 task card. Do not change production.
 
 Freeze fixtures for:
-- submitted snapshot versus execution-derived delta classification;
-- single queue linked and NAIA projection eligibility;
+- submitted snapshot vs execution-derived delta;
+- single linked/NAIA eligibility;
 - Q1/Q2/Q3 latest accepted ownership independent of completion order;
 - newer accepted failure with no older fallback;
-- field-specific edit/structure revisions;
-- linked overlay not serialized as local fallback;
-- NAIA canonical field persistence;
-- one executed-envelope fan-out and one settlement;
+- field-specific edit/structure revision;
+- linked overlay not serialized as fallback;
+- NAIA canonical persistence;
+- one envelope fan-out/settlement;
 - mapped/duplicate/missing identity fail-closed.
 
-Use changed-file syntax, the new projection contract smoke, directly affected existing
-Prompt Studio fixtures, and git diff --check during edits. Run official full once on the
-final Contract SHA. Do not run package/live and do not start QSTATE-04C2 in the same PR.
+During edits run changed-file syntax, the projection contract smoke, directly affected
+Prompt Studio fixtures, and git diff --check. Run official full once on the final
+Contract SHA. Do not run package/live or start QSTATE-04C2 in the same PR.
 
-Push a dev-target Draft PR with compact evidence. Proceed to QSTATE-04C2 only after the
-Contract is reviewed and merged. PRO review is not pre-scheduled; use it only if this
-document's technical stop conditions are evidenced.
+Push a dev-target Draft PR with compact evidence. Continue only after review/merge.
+PRO review is not pre-scheduled; use it only when the technical conditions above are
+evidenced.
 ```

--- a/docs/development/README.md
+++ b/docs/development/README.md
@@ -15,16 +15,21 @@ conversation.
    [`docs/development/codex-blocker-escalation.md`](codex-blocker-escalation.md)
    before requesting PRO review. A stop condition starts bounded local triage; it
    is not an automatic whole-roadmap stop.
-4. While Issue #415 owns the active hotfix, read
-   [`docs/architecture/queue-ui-two-phase-correlation-addendum.md`](../architecture/queue-ui-two-phase-correlation-addendum.md)
-   and only the current task section. It supersedes the original exact-identity-
-   at-submission assumption after the QSTATE-02A blocker.
-5. Python backend architecture or migration work:
+4. While Issue #470 is open, read
+   [`docs/architecture/prompt-studio-execution-derived-projection.md`](../architecture/prompt-studio-execution-derived-projection.md)
+   and only the current QSTATE-04C task section. It owns the 0.6.0 regression
+   correction that distinguishes submitted editor snapshots from linked-input and
+   NAIA execution deltas.
+5. Queue identity or stale-result lifecycle work may also require
+   [`docs/architecture/queue-ui-two-phase-correlation-addendum.md`](../architecture/queue-ui-two-phase-correlation-addendum.md).
+   It remains the identity/revision foundation, but its older QSTATE-04 field-input
+   classification is superseded by the Issue #470 projection roadmap.
+6. Python backend architecture or migration work:
    [`docs/architecture/README.md`](../architecture/README.md)
-6. Active frontend maintenance execution plan:
+7. Active frontend maintenance execution plan:
    `docs/development/frontend-maintenance-execution-plan.md`
-7. Current release candidate: `docs/development/0.6.0.md`
-8. Relevant topic guide:
+8. Current released baseline: `docs/development/0.6.0.md`
+9. Relevant topic guide:
    - Registry publish or flagged-version prevention:
      `docs/development/registry-scanner-safety.md`
    - workflow docs or release templates: `docs/Anima AiO/Workflow_Management.md`
@@ -43,8 +48,8 @@ conversation.
    - deferred Node 2.0 DOM widget resize investigation:
      `docs/development/node2-dom-widget-resize-limitation.md`
    - language or locale work: `docs/development/language-management.md`
-9. `git status --short`
-10. Relevant source and tests for the target area.
+10. `git status --short`
+11. Relevant source and tests for the target area.
 
 Do not read every roadmap or historical document by default. The efficiency
 protocol defines the maximum initial context and the conditions that justify
@@ -58,13 +63,15 @@ not be loaded during ordinary successful tasks.
   [`docs/development/codex-execution-efficiency.md`](codex-execution-efficiency.md)
 - Conditional stop-triage, self-resolution budget, and hard-PRO criteria:
   [`docs/development/codex-blocker-escalation.md`](codex-blocker-escalation.md)
-- Active queue/live-UI correlation correction:
+- Active Prompt Studio linked-input/NAIA projection correction:
+  [`docs/architecture/prompt-studio-execution-derived-projection.md`](../architecture/prompt-studio-execution-derived-projection.md)
+- Queue/live-UI identity and revision foundation:
   [`docs/architecture/queue-ui-two-phase-correlation-addendum.md`](../architecture/queue-ui-two-phase-correlation-addendum.md)
 - Python backend architecture and compatibility-shim registry:
   [`docs/architecture/README.md`](../architecture/README.md)
 - Active frontend maintenance execution ledger:
   `docs/development/frontend-maintenance-execution-plan.md`
-- Current release candidate: `docs/development/0.6.0.md`
+- Current released baseline: `docs/development/0.6.0.md`
 - Registry scanner safety: `docs/development/registry-scanner-safety.md`
 - Older implementation history: `docs/version-plans/`
 - Public workflow JSON templates and preview/source images: `docs/example_workflows/`
@@ -92,9 +99,20 @@ not be loaded during ordinary successful tasks.
   - `web/js/easyuse_anima_lora_preset.js`
   - `tests/test_lora_profiles.py`
   - `tests/test_frontend_lora_preset.py`
-- Prompt Studio or wildcard work:
-  - `nodes.py`
-  - `wildcard_engine.py`
+- Prompt Studio execution-derived projection / Issue #470:
+  - `easyuse_anima/nodes/prompt_advanced_nodes.py`
+  - `easyuse_anima/prompt/advanced.py`
+  - `web/js/prompt_studio/extension_runtime.js`
+  - `web/js/prompt_studio/advanced_values.js`
+  - `web/js/prompt_studio/advanced_fields_ui.js`
+  - `web/js/prompt_studio/serialization.js`
+  - `web/js/prompt_studio/wildcard_seed_transaction.js`
+  - `web/js/lifecycle/queue_ui_transaction.js`
+  - `web/js/lifecycle/executed_event_context.js`
+  - direct Prompt Studio projection, Wildcard, transaction, and backend payload tests
+- Other Prompt Studio or wildcard work:
+  - confirm the current canonical Python owner under `easyuse_anima/prompt/` and
+    `easyuse_anima/nodes/` before using a root compatibility shim;
   - `web/js/easyuse_anima_autocomplete.js`
   - `web/js/easyuse_anima_prompt_studio.js`
   - `web/js/easyuse_anima_prompt_studio_common.js`
@@ -122,6 +140,8 @@ targeted symbol search; do not automatically read every listed file.
 
 ## Current Policy Notes
 
+- Issue #470 is the first READY production lane. Start QSTATE-04C1 Contract work
+  before #440/#441, ordinary backend refactoring, or opportunistic feature work.
 - Do not keep duplicated workflow JSON outside `docs/example_workflows/`.
 - `docs/workflows/` has been removed; use `docs/example_workflows/` as the
   workflow JSON and preview/source image source.
@@ -137,7 +157,8 @@ targeted symbol search; do not automatically read every listed file.
 ### Edit loop
 
 Use only changed-file syntax checks and the task-specific focused tests listed in
-`codex-execution-efficiency.md`, the active two-phase addendum, or the owning Issue.
+`codex-execution-efficiency.md`, the active Issue #470 projection roadmap, the
+two-phase addendum, or the owning Issue.
 
 ```text
 node --check web/js/<changed-file>.js
@@ -152,7 +173,7 @@ it after every edit.
 
 A failed stop condition or live path should follow the bounded self-resolution
 budget in `codex-blocker-escalation.md`. Do not request PRO review until a hard
-criterion is evidenced.
+technical-depth criterion is evidenced.
 
 ### Final PR candidate
 


### PR DESCRIPTION
## 목적

0.6.0에서 확인된 Prompt Studio 회귀를 Issue #470과 0.6.1 patch lane으로 기록합니다.

QSTATE-04A가 과거 queue의 destructive snapshot replay를 제거하면서 함께 사라진 다음 동작을 복구하되, stale overwrite를 다시 도입하지 않습니다.

- 연결 input socket의 실제 실행값 표시
- NAIA prompt의 field 채택·편집·저장
- NAIA runtime resolution의 조건부 반영

## 확정 계약

```text
submitted editor snapshot != execution-derived result delta
```

- queue 완료 순서가 아니라 latest accepted queue가 각 field surface를 소유합니다.
- Q1/Q2/Q3에서는 Q3만 canvas에 투영할 수 있습니다.
- Q3 accepted 후 실패해도 Q1/Q2로 rollback하지 않습니다.
- queue 이후 field 편집·연결 변경·field 구조 변경은 해당 field 결과만 차단합니다.
- linked result는 overlay이며 local fallback에 자동 저장하지 않습니다.
- NAIA result는 exact NAIA field의 canonical text로 저장합니다.
- Wildcard/linked/NAIA는 executed envelope 하나를 공유하고 한 번 settle합니다.
- 전체 `applyAdvancedExecutedInputs()` 또는 full editor rerender는 복원하지 않습니다.

## 로드맵

```text
QSTATE-04C1  Projection Contract
QSTATE-04C2  unified Prompt Studio execution transaction
QSTATE-04C3  backend delta + linked input projection
QSTATE-04C4  NAIA canonical adoption + dual-canvas live
QSTATE-04C5  integrated 0.6.1 patch gate
```

첫 READY 작업은 QSTATE-04C1이며 production 변경이 없는 Contract PR입니다.

## 변경 파일

- `docs/architecture/prompt-studio-execution-derived-projection.md`
- `docs/architecture/README.md`
- `docs/development/README.md`

Architecture/development entry points가 #470을 #440/#441과 ordinary backend work보다 앞선 P1 lane으로 안내합니다. 완료된 #413/#415는 다시 열지 않습니다.

## 검증

Docs-only 변경입니다.

- production JavaScript/Python: 변경 없음
- tests/runner/workflow/version metadata: 변경 없음
- official full/package/live: not triggered

Refs #470
Refs #413
Refs #415