### PR TITLE
test: QSTATE-04C1 Prompt Studio projection contract 고정

### DIFF
--- a/tests/fixtures/prompt_studio_execution_projection_contract.v1.json
+++ b/tests/fixtures/prompt_studio_execution_projection_contract.v1.json
@@ -1,0 +1,879 @@
+{
+  "contract": "QSTATE-04C1",
+  "version": 1,
+  "state_classes": {
+    "submitted_snapshot": [
+      "ordinary_field_text",
+      "resolution",
+      "artist_mix",
+      "editable_controls",
+      "editor_structure"
+    ],
+    "execution_derived_delta": [
+      "linked_field_input",
+      "naia_field_prompt",
+      "naia_resolution",
+      "wildcard_execution_state"
+    ],
+    "non_editable_history": [
+      "prompt_id",
+      "execution_seed",
+      "output_metadata"
+    ]
+  },
+  "surfaces": [
+    "prompt.execution.linked:<fieldId>",
+    "prompt.execution.naia:<fieldId>",
+    "prompt.execution.naia_resolution",
+    "prompt.wildcard_seed_control"
+  ],
+  "persistence": {
+    "linked": "overlay_only",
+    "naia": "canonical"
+  },
+  "scenarios": [
+    {
+      "id": "submitted-snapshot-is-not-editable-authority",
+      "initial": {
+        "editable": {
+          "resolution": "1344x768",
+          "artist_mix": "exact",
+          "editor_structure": "current-layout"
+        },
+        "fields": {
+          "positive_general": {
+            "kind": "linked",
+            "text_revision": 0,
+            "structure_revision": 0,
+            "connection_fingerprint": "source-a:0",
+            "local_fallback": "current local fallback"
+          },
+          "positive_naia": {
+            "kind": "naia",
+            "text_revision": 0,
+            "structure_revision": 0,
+            "canonical": "current NAIA text"
+          }
+        },
+        "wildcard_seed": 900
+      },
+      "events": [
+        {
+          "type": "accept",
+          "prompt_id": "Q1"
+        },
+        {
+          "type": "envelope",
+          "identity": "env-Q1",
+          "prompt_id": "Q1",
+          "mapped_count": 1,
+          "submitted_snapshot": {
+            "editable": {
+              "resolution": "1024x1024",
+              "artist_mix": "average",
+              "editor_structure": "queued-layout"
+            },
+            "field_text": "queued old tags"
+          },
+          "execution_delta": {
+            "linked": [
+              {
+                "field_id": "positive_general",
+                "connection_fingerprint": "source-a:0",
+                "value": "resolved connected text"
+              }
+            ],
+            "naia": [
+              {
+                "field_id": "positive_naia",
+                "value": "generated NAIA prompt"
+              }
+            ]
+          }
+        }
+      ],
+      "expected": {
+        "latest_accepted": "Q1",
+        "editable": {
+          "resolution": "1344x768",
+          "artist_mix": "exact",
+          "editor_structure": "current-layout"
+        },
+        "linked_overlay": {
+          "positive_general": "resolved connected text"
+        },
+        "canonical_text": {
+          "positive_naia": "generated NAIA prompt"
+        },
+        "serialized_text": {
+          "positive_general": "current local fallback",
+          "positive_naia": "generated NAIA prompt"
+        },
+        "wildcard_seed": 900,
+        "commits": [
+          "linked:positive_general",
+          "naia:positive_naia"
+        ],
+        "settled_envelopes": [
+          "env-Q1"
+        ],
+        "ignored": []
+      }
+    },
+    {
+      "id": "single-linked-projection-is-overlay-only",
+      "initial": {
+        "fields": {
+          "positive_general": {
+            "kind": "linked",
+            "text_revision": 0,
+            "structure_revision": 0,
+            "connection_fingerprint": "source-a:0",
+            "local_fallback": "manual fallback"
+          }
+        }
+      },
+      "events": [
+        {
+          "type": "accept",
+          "prompt_id": "Q1"
+        },
+        {
+          "type": "envelope",
+          "identity": "env-Q1",
+          "prompt_id": "Q1",
+          "mapped_count": 1,
+          "execution_delta": {
+            "linked": [
+              {
+                "field_id": "positive_general",
+                "connection_fingerprint": "source-a:0",
+                "value": "linked execution value"
+              }
+            ]
+          }
+        }
+      ],
+      "expected": {
+        "latest_accepted": "Q1",
+        "editable": {},
+        "linked_overlay": {
+          "positive_general": "linked execution value"
+        },
+        "canonical_text": {},
+        "serialized_text": {
+          "positive_general": "manual fallback"
+        },
+        "commits": [
+          "linked:positive_general"
+        ],
+        "settled_envelopes": [
+          "env-Q1"
+        ],
+        "ignored": []
+      }
+    },
+    {
+      "id": "single-naia-projection-is-canonical",
+      "initial": {
+        "fields": {
+          "positive_naia": {
+            "kind": "naia",
+            "text_revision": 0,
+            "structure_revision": 0,
+            "canonical": "old NAIA text"
+          }
+        }
+      },
+      "events": [
+        {
+          "type": "accept",
+          "prompt_id": "Q1"
+        },
+        {
+          "type": "envelope",
+          "identity": "env-Q1",
+          "prompt_id": "Q1",
+          "mapped_count": 1,
+          "execution_delta": {
+            "naia": [
+              {
+                "field_id": "positive_naia",
+                "value": "generated NAIA prompt"
+              }
+            ]
+          }
+        }
+      ],
+      "expected": {
+        "latest_accepted": "Q1",
+        "editable": {},
+        "linked_overlay": {},
+        "canonical_text": {
+          "positive_naia": "generated NAIA prompt"
+        },
+        "serialized_text": {
+          "positive_naia": "generated NAIA prompt"
+        },
+        "commits": [
+          "naia:positive_naia"
+        ],
+        "settled_envelopes": [
+          "env-Q1"
+        ],
+        "ignored": []
+      }
+    },
+    {
+      "id": "q1-q2-q3-latest-accepted-owns-projection",
+      "initial": {
+        "fields": {
+          "positive_general": {
+            "kind": "linked",
+            "text_revision": 0,
+            "structure_revision": 0,
+            "connection_fingerprint": "source-a:0",
+            "local_fallback": "fallback"
+          },
+          "positive_naia": {
+            "kind": "naia",
+            "text_revision": 0,
+            "structure_revision": 0,
+            "canonical": "old NAIA text"
+          }
+        }
+      },
+      "events": [
+        {
+          "type": "accept",
+          "prompt_id": "Q1"
+        },
+        {
+          "type": "accept",
+          "prompt_id": "Q2"
+        },
+        {
+          "type": "accept",
+          "prompt_id": "Q3"
+        },
+        {
+          "type": "envelope",
+          "identity": "env-Q1",
+          "prompt_id": "Q1",
+          "mapped_count": 1,
+          "execution_delta": {
+            "linked": [
+              {
+                "field_id": "positive_general",
+                "connection_fingerprint": "source-a:0",
+                "value": "A"
+              }
+            ],
+            "naia": [
+              {
+                "field_id": "positive_naia",
+                "value": "A-NAIA"
+              }
+            ]
+          }
+        },
+        {
+          "type": "envelope",
+          "identity": "env-Q3",
+          "prompt_id": "Q3",
+          "mapped_count": 1,
+          "execution_delta": {
+            "linked": [
+              {
+                "field_id": "positive_general",
+                "connection_fingerprint": "source-a:0",
+                "value": "C"
+              }
+            ],
+            "naia": [
+              {
+                "field_id": "positive_naia",
+                "value": "C-NAIA"
+              }
+            ]
+          }
+        },
+        {
+          "type": "envelope",
+          "identity": "env-Q2",
+          "prompt_id": "Q2",
+          "mapped_count": 1,
+          "execution_delta": {
+            "linked": [
+              {
+                "field_id": "positive_general",
+                "connection_fingerprint": "source-a:0",
+                "value": "B"
+              }
+            ],
+            "naia": [
+              {
+                "field_id": "positive_naia",
+                "value": "B-NAIA"
+              }
+            ]
+          }
+        }
+      ],
+      "expected": {
+        "latest_accepted": "Q3",
+        "editable": {},
+        "linked_overlay": {
+          "positive_general": "C"
+        },
+        "canonical_text": {
+          "positive_naia": "C-NAIA"
+        },
+        "serialized_text": {
+          "positive_general": "fallback",
+          "positive_naia": "C-NAIA"
+        },
+        "commits": [
+          "linked:positive_general",
+          "naia:positive_naia"
+        ],
+        "settled_envelopes": [
+          "env-Q1",
+          "env-Q3",
+          "env-Q2"
+        ],
+        "ignored": [
+          "not_latest:Q1",
+          "not_latest:Q2"
+        ]
+      }
+    },
+    {
+      "id": "newer-accepted-failure-never-falls-back",
+      "initial": {
+        "fields": {
+          "positive_general": {
+            "kind": "linked",
+            "text_revision": 0,
+            "structure_revision": 0,
+            "connection_fingerprint": "source-a:0",
+            "local_fallback": "fallback"
+          },
+          "positive_naia": {
+            "kind": "naia",
+            "text_revision": 0,
+            "structure_revision": 0,
+            "canonical": "old NAIA text"
+          }
+        }
+      },
+      "events": [
+        {
+          "type": "accept",
+          "prompt_id": "Q1"
+        },
+        {
+          "type": "accept",
+          "prompt_id": "Q2"
+        },
+        {
+          "type": "accept",
+          "prompt_id": "Q3"
+        },
+        {
+          "type": "failure",
+          "prompt_id": "Q3"
+        },
+        {
+          "type": "envelope",
+          "identity": "env-Q2",
+          "prompt_id": "Q2",
+          "mapped_count": 1,
+          "execution_delta": {
+            "linked": [
+              {
+                "field_id": "positive_general",
+                "connection_fingerprint": "source-a:0",
+                "value": "B"
+              }
+            ],
+            "naia": [
+              {
+                "field_id": "positive_naia",
+                "value": "B-NAIA"
+              }
+            ]
+          }
+        },
+        {
+          "type": "envelope",
+          "identity": "env-Q1",
+          "prompt_id": "Q1",
+          "mapped_count": 1,
+          "execution_delta": {
+            "linked": [
+              {
+                "field_id": "positive_general",
+                "connection_fingerprint": "source-a:0",
+                "value": "A"
+              }
+            ],
+            "naia": [
+              {
+                "field_id": "positive_naia",
+                "value": "A-NAIA"
+              }
+            ]
+          }
+        }
+      ],
+      "expected": {
+        "latest_accepted": "Q3",
+        "editable": {},
+        "linked_overlay": {},
+        "canonical_text": {
+          "positive_naia": "old NAIA text"
+        },
+        "serialized_text": {
+          "positive_general": "fallback",
+          "positive_naia": "old NAIA text"
+        },
+        "commits": [],
+        "settled_envelopes": [
+          "env-Q2",
+          "env-Q1"
+        ],
+        "terminal_failures": [
+          "Q3"
+        ],
+        "ignored": [
+          "not_latest:Q2",
+          "not_latest:Q1"
+        ]
+      }
+    },
+    {
+      "id": "field-edit-revision-blocks-only-that-field",
+      "initial": {
+        "fields": {
+          "positive_general": {
+            "kind": "linked",
+            "text_revision": 2,
+            "structure_revision": 1,
+            "connection_fingerprint": "source-a:0",
+            "local_fallback": "before edit"
+          },
+          "positive_naia": {
+            "kind": "naia",
+            "text_revision": 5,
+            "structure_revision": 2,
+            "canonical": "old NAIA text"
+          }
+        }
+      },
+      "events": [
+        {
+          "type": "accept",
+          "prompt_id": "Q1"
+        },
+        {
+          "type": "edit",
+          "field_id": "positive_general",
+          "value": "user edit after queue"
+        },
+        {
+          "type": "envelope",
+          "identity": "env-Q1",
+          "prompt_id": "Q1",
+          "mapped_count": 1,
+          "execution_delta": {
+            "linked": [
+              {
+                "field_id": "positive_general",
+                "connection_fingerprint": "source-a:0",
+                "value": "stale linked result"
+              }
+            ],
+            "naia": [
+              {
+                "field_id": "positive_naia",
+                "value": "fresh NAIA result"
+              }
+            ]
+          }
+        }
+      ],
+      "expected": {
+        "latest_accepted": "Q1",
+        "editable": {},
+        "linked_overlay": {},
+        "canonical_text": {
+          "positive_naia": "fresh NAIA result"
+        },
+        "serialized_text": {
+          "positive_general": "user edit after queue",
+          "positive_naia": "fresh NAIA result"
+        },
+        "commits": [
+          "naia:positive_naia"
+        ],
+        "settled_envelopes": [
+          "env-Q1"
+        ],
+        "ignored": [
+          "text_revision:positive_general"
+        ]
+      }
+    },
+    {
+      "id": "field-structure-revision-and-fingerprint-fail-closed",
+      "initial": {
+        "fields": {
+          "positive_general": {
+            "kind": "linked",
+            "text_revision": 0,
+            "structure_revision": 4,
+            "connection_fingerprint": "source-a:0",
+            "local_fallback": "fallback"
+          }
+        }
+      },
+      "events": [
+        {
+          "type": "accept",
+          "prompt_id": "Q1"
+        },
+        {
+          "type": "structure",
+          "field_id": "positive_general",
+          "connection_fingerprint": "source-b:0"
+        },
+        {
+          "type": "envelope",
+          "identity": "env-Q1",
+          "prompt_id": "Q1",
+          "mapped_count": 1,
+          "execution_delta": {
+            "linked": [
+              {
+                "field_id": "positive_general",
+                "connection_fingerprint": "source-a:0",
+                "value": "stale source result"
+              }
+            ]
+          }
+        }
+      ],
+      "expected": {
+        "latest_accepted": "Q1",
+        "editable": {},
+        "linked_overlay": {},
+        "canonical_text": {},
+        "serialized_text": {
+          "positive_general": "fallback"
+        },
+        "commits": [],
+        "settled_envelopes": [
+          "env-Q1"
+        ],
+        "ignored": [
+          "structure_revision:positive_general"
+        ]
+      }
+    },
+    {
+      "id": "connection-fingerprint-mismatch-fails-closed",
+      "initial": {
+        "fields": {
+          "positive_general": {
+            "kind": "linked",
+            "text_revision": 0,
+            "structure_revision": 4,
+            "connection_fingerprint": "source-a:0",
+            "local_fallback": "fallback"
+          }
+        }
+      },
+      "events": [
+        {
+          "type": "accept",
+          "prompt_id": "Q1"
+        },
+        {
+          "type": "envelope",
+          "identity": "env-Q1",
+          "prompt_id": "Q1",
+          "mapped_count": 1,
+          "execution_delta": {
+            "linked": [
+              {
+                "field_id": "positive_general",
+                "connection_fingerprint": "source-b:0",
+                "value": "wrong source result"
+              }
+            ]
+          }
+        }
+      ],
+      "expected": {
+        "latest_accepted": "Q1",
+        "editable": {},
+        "linked_overlay": {},
+        "canonical_text": {},
+        "serialized_text": {
+          "positive_general": "fallback"
+        },
+        "commits": [],
+        "settled_envelopes": [
+          "env-Q1"
+        ],
+        "ignored": [
+          "connection_fingerprint:positive_general"
+        ]
+      }
+    },
+    {
+      "id": "one-envelope-fans-out-and-settles-once",
+      "initial": {
+        "fields": {
+          "positive_general": {
+            "kind": "linked",
+            "text_revision": 0,
+            "structure_revision": 0,
+            "connection_fingerprint": "source-a:0",
+            "local_fallback": "fallback"
+          },
+          "positive_naia": {
+            "kind": "naia",
+            "text_revision": 0,
+            "structure_revision": 0,
+            "canonical": "old NAIA text"
+          }
+        },
+        "wildcard_seed": 10
+      },
+      "events": [
+        {
+          "type": "accept",
+          "prompt_id": "Q1"
+        },
+        {
+          "type": "envelope",
+          "identity": "env-Q1",
+          "prompt_id": "Q1",
+          "mapped_count": 1,
+          "execution_delta": {
+            "linked": [
+              {
+                "field_id": "positive_general",
+                "connection_fingerprint": "source-a:0",
+                "value": "resolved"
+              }
+            ],
+            "naia": [
+              {
+                "field_id": "positive_naia",
+                "value": "generated"
+              }
+            ],
+            "wildcard_seed": 11
+          }
+        }
+      ],
+      "expected": {
+        "latest_accepted": "Q1",
+        "editable": {},
+        "linked_overlay": {
+          "positive_general": "resolved"
+        },
+        "canonical_text": {
+          "positive_naia": "generated"
+        },
+        "serialized_text": {
+          "positive_general": "fallback",
+          "positive_naia": "generated"
+        },
+        "wildcard_seed": 11,
+        "commits": [
+          "linked:positive_general",
+          "naia:positive_naia",
+          "wildcard_seed_control"
+        ],
+        "settled_envelopes": [
+          "env-Q1"
+        ],
+        "ignored": []
+      }
+    },
+    {
+      "id": "mapped-payload-fails-closed-after-one-settlement",
+      "initial": {
+        "fields": {
+          "positive_general": {
+            "kind": "linked",
+            "text_revision": 0,
+            "structure_revision": 0,
+            "connection_fingerprint": "source-a:0",
+            "local_fallback": "fallback"
+          }
+        }
+      },
+      "events": [
+        {
+          "type": "accept",
+          "prompt_id": "Q1"
+        },
+        {
+          "type": "envelope",
+          "identity": "env-Q1",
+          "prompt_id": "Q1",
+          "mapped_count": 2,
+          "execution_delta": {
+            "linked": [
+              {
+                "field_id": "positive_general",
+                "connection_fingerprint": "source-a:0",
+                "value": "ambiguous"
+              }
+            ]
+          }
+        }
+      ],
+      "expected": {
+        "latest_accepted": "Q1",
+        "editable": {},
+        "linked_overlay": {},
+        "canonical_text": {},
+        "serialized_text": {
+          "positive_general": "fallback"
+        },
+        "commits": [],
+        "settled_envelopes": [
+          "env-Q1"
+        ],
+        "ignored": [
+          "mapped_count:2"
+        ]
+      }
+    },
+    {
+      "id": "duplicate-envelope-fails-closed",
+      "initial": {
+        "fields": {
+          "positive_general": {
+            "kind": "linked",
+            "text_revision": 0,
+            "structure_revision": 0,
+            "connection_fingerprint": "source-a:0",
+            "local_fallback": "fallback"
+          }
+        }
+      },
+      "events": [
+        {
+          "type": "accept",
+          "prompt_id": "Q1"
+        },
+        {
+          "type": "envelope",
+          "identity": "env-Q1",
+          "prompt_id": "Q1",
+          "mapped_count": 1,
+          "execution_delta": {
+            "linked": [
+              {
+                "field_id": "positive_general",
+                "connection_fingerprint": "source-a:0",
+                "value": "first"
+              }
+            ]
+          }
+        },
+        {
+          "type": "envelope",
+          "identity": "env-Q1",
+          "prompt_id": "Q1",
+          "mapped_count": 1,
+          "execution_delta": {
+            "linked": [
+              {
+                "field_id": "positive_general",
+                "connection_fingerprint": "source-a:0",
+                "value": "duplicate"
+              }
+            ]
+          }
+        }
+      ],
+      "expected": {
+        "latest_accepted": "Q1",
+        "editable": {},
+        "linked_overlay": {
+          "positive_general": "first"
+        },
+        "canonical_text": {},
+        "serialized_text": {
+          "positive_general": "fallback"
+        },
+        "commits": [
+          "linked:positive_general"
+        ],
+        "settled_envelopes": [
+          "env-Q1"
+        ],
+        "ignored": [
+          "duplicate:env-Q1"
+        ]
+      }
+    },
+    {
+      "id": "missing-envelope-identity-fails-closed",
+      "initial": {
+        "fields": {
+          "positive_general": {
+            "kind": "linked",
+            "text_revision": 0,
+            "structure_revision": 0,
+            "connection_fingerprint": "source-a:0",
+            "local_fallback": "fallback"
+          }
+        }
+      },
+      "events": [
+        {
+          "type": "accept",
+          "prompt_id": "Q1"
+        },
+        {
+          "type": "envelope",
+          "identity": null,
+          "prompt_id": "Q1",
+          "mapped_count": 1,
+          "execution_delta": {
+            "linked": [
+              {
+                "field_id": "positive_general",
+                "connection_fingerprint": "source-a:0",
+                "value": "unowned"
+              }
+            ]
+          }
+        }
+      ],
+      "expected": {
+        "latest_accepted": "Q1",
+        "editable": {},
+        "linked_overlay": {},
+        "canonical_text": {},
+        "serialized_text": {
+          "positive_general": "fallback"
+        },
+        "commits": [],
+        "settled_envelopes": [],
+        "ignored": [
+          "missing_identity"
+        ]
+      }
+    }
+  ]
+}

--- a/tests/frontend_prompt_studio_execution_projection_smoke.mjs
+++ b/tests/frontend_prompt_studio_execution_projection_smoke.mjs
@@ -1,0 +1,248 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const contract = JSON.parse(readFileSync(new URL(
+  "./fixtures/prompt_studio_execution_projection_contract.v1.json",
+  import.meta.url,
+), "utf8"));
+
+assert.equal(contract.contract, "QSTATE-04C1");
+assert.equal(contract.version, 1);
+assert.deepEqual(
+  Object.keys(contract.state_classes).sort(),
+  ["execution_derived_delta", "non_editable_history", "submitted_snapshot"],
+);
+assert.deepEqual(contract.persistence, {
+  linked: "overlay_only",
+  naia: "canonical",
+});
+assert.deepEqual(contract.surfaces, [
+  "prompt.execution.linked:<fieldId>",
+  "prompt.execution.naia:<fieldId>",
+  "prompt.execution.naia_resolution",
+  "prompt.wildcard_seed_control",
+]);
+
+function clone(value) {
+  return JSON.parse(JSON.stringify(value));
+}
+
+function snapshotFields(fields) {
+  return Object.fromEntries(Object.entries(fields).map(([fieldId, field]) => [
+    fieldId,
+    {
+      kind: field.kind,
+      textRevision: field.text_revision,
+      structureRevision: field.structure_revision,
+      connectionFingerprint: field.connection_fingerprint ?? null,
+    },
+  ]));
+}
+
+function createState(initial = {}) {
+  return {
+    editable: clone(initial.editable ?? {}),
+    fields: clone(initial.fields ?? {}),
+    wildcardSeed: initial.wildcard_seed,
+    wildcardRevision: 0,
+    latestAccepted: null,
+    transactions: new Map(),
+    consumedEnvelopes: new Set(),
+    linkedOverlay: {},
+    commits: [],
+    settledEnvelopes: [],
+    terminalFailures: [],
+    ignored: [],
+  };
+}
+
+function accept(state, event) {
+  state.transactions.set(event.prompt_id, {
+    promptId: event.prompt_id,
+    fields: snapshotFields(state.fields),
+    wildcardRevision: state.wildcardRevision,
+    terminal: false,
+    settled: false,
+  });
+  state.latestAccepted = event.prompt_id;
+}
+
+function editField(state, event) {
+  const field = state.fields[event.field_id];
+  assert(field, `unknown edit field: ${event.field_id}`);
+  field.text_revision += 1;
+  if (field.kind === "linked") {
+    field.local_fallback = event.value;
+    delete state.linkedOverlay[event.field_id];
+  } else if (field.kind === "naia") {
+    field.canonical = event.value;
+  }
+}
+
+function changeStructure(state, event) {
+  const field = state.fields[event.field_id];
+  assert(field, `unknown structure field: ${event.field_id}`);
+  field.structure_revision += 1;
+  if ("connection_fingerprint" in event) {
+    field.connection_fingerprint = event.connection_fingerprint;
+  }
+  if ("kind" in event) {
+    field.kind = event.kind;
+  }
+  delete state.linkedOverlay[event.field_id];
+}
+
+function failTransaction(state, event) {
+  const transaction = state.transactions.get(event.prompt_id);
+  assert(transaction, `unknown failed prompt: ${event.prompt_id}`);
+  transaction.terminal = true;
+  transaction.settled = true;
+  state.terminalFailures.push(event.prompt_id);
+}
+
+function canProjectField(state, transaction, fieldId, expectedKind) {
+  const queued = transaction.fields[fieldId];
+  const current = state.fields[fieldId];
+  if (!queued || !current || queued.kind !== expectedKind || current.kind !== expectedKind) {
+    state.ignored.push(`field_identity:${fieldId}`);
+    return false;
+  }
+  if (queued.textRevision !== current.text_revision) {
+    state.ignored.push(`text_revision:${fieldId}`);
+    return false;
+  }
+  if (queued.structureRevision !== current.structure_revision) {
+    state.ignored.push(`structure_revision:${fieldId}`);
+    return false;
+  }
+  return true;
+}
+
+function projectLinked(state, transaction, delta) {
+  if (!canProjectField(state, transaction, delta.field_id, "linked")) {
+    return;
+  }
+  const queued = transaction.fields[delta.field_id];
+  const current = state.fields[delta.field_id];
+  if (
+    queued.connectionFingerprint !== current.connection_fingerprint
+    || delta.connection_fingerprint !== current.connection_fingerprint
+  ) {
+    state.ignored.push(`connection_fingerprint:${delta.field_id}`);
+    return;
+  }
+  state.linkedOverlay[delta.field_id] = delta.value;
+  state.commits.push(`linked:${delta.field_id}`);
+}
+
+function projectNaia(state, transaction, delta) {
+  if (!canProjectField(state, transaction, delta.field_id, "naia")) {
+    return;
+  }
+  state.fields[delta.field_id].canonical = delta.value;
+  state.commits.push(`naia:${delta.field_id}`);
+}
+
+function consumeEnvelope(state, event) {
+  if (!event.identity) {
+    state.ignored.push("missing_identity");
+    return;
+  }
+  const transaction = state.transactions.get(event.prompt_id);
+  if (!transaction) {
+    state.ignored.push("missing_identity");
+    return;
+  }
+  if (
+    transaction.settled
+    || transaction.terminal
+    || state.consumedEnvelopes.has(event.identity)
+  ) {
+    state.ignored.push(`duplicate:${event.identity}`);
+    return;
+  }
+
+  transaction.settled = true;
+  state.consumedEnvelopes.add(event.identity);
+  state.settledEnvelopes.push(event.identity);
+
+  if (event.mapped_count !== 1) {
+    state.ignored.push(`mapped_count:${event.mapped_count}`);
+    return;
+  }
+  if (event.prompt_id !== state.latestAccepted) {
+    state.ignored.push(`not_latest:${event.prompt_id}`);
+    return;
+  }
+
+  const delta = event.execution_delta ?? {};
+  for (const linked of delta.linked ?? []) {
+    projectLinked(state, transaction, linked);
+  }
+  for (const naia of delta.naia ?? []) {
+    projectNaia(state, transaction, naia);
+  }
+  if (
+    "wildcard_seed" in delta
+    && transaction.wildcardRevision === state.wildcardRevision
+  ) {
+    state.wildcardSeed = delta.wildcard_seed;
+    state.commits.push("wildcard_seed_control");
+  }
+}
+
+function runScenario(scenario) {
+  const state = createState(scenario.initial);
+  for (const event of scenario.events) {
+    if (event.type === "accept") {
+      accept(state, event);
+    } else if (event.type === "edit") {
+      editField(state, event);
+    } else if (event.type === "structure") {
+      changeStructure(state, event);
+    } else if (event.type === "failure") {
+      failTransaction(state, event);
+    } else if (event.type === "envelope") {
+      consumeEnvelope(state, event);
+    } else {
+      assert.fail(`unknown event type: ${event.type}`);
+    }
+  }
+
+  const canonicalText = {};
+  const serializedText = {};
+  for (const [fieldId, field] of Object.entries(state.fields)) {
+    if (field.kind === "linked") {
+      serializedText[fieldId] = field.local_fallback;
+    } else if (field.kind === "naia") {
+      canonicalText[fieldId] = field.canonical;
+      serializedText[fieldId] = field.canonical;
+    }
+  }
+
+  const actual = {
+    latest_accepted: state.latestAccepted,
+    editable: state.editable,
+    linked_overlay: state.linkedOverlay,
+    canonical_text: canonicalText,
+    serialized_text: serializedText,
+    commits: state.commits,
+    settled_envelopes: state.settledEnvelopes,
+    ignored: state.ignored,
+  };
+  if (state.wildcardSeed !== undefined) {
+    actual.wildcard_seed = state.wildcardSeed;
+  }
+  if (state.terminalFailures.length) {
+    actual.terminal_failures = state.terminalFailures;
+  }
+
+  assert.deepEqual(actual, scenario.expected, scenario.id);
+}
+
+assert.equal(contract.scenarios.length, 12);
+for (const scenario of contract.scenarios) {
+  runScenario(scenario);
+}
+
+console.log("Prompt Studio execution projection contract smoke passed.");

--- a/tests/test_frontend_modules.py
+++ b/tests/test_frontend_modules.py
@@ -13,6 +13,9 @@ HOST_HOOK_REGISTRY_SMOKE = ROOT / "tests" / "frontend_host_hook_registry_smoke.m
 PROMPT_STUDIO_ADVANCED_VALUES_SMOKE = (
     ROOT / "tests" / "frontend_prompt_studio_advanced_values_smoke.mjs"
 )
+PROMPT_STUDIO_EXECUTION_PROJECTION_SMOKE = (
+    ROOT / "tests" / "frontend_prompt_studio_execution_projection_smoke.mjs"
+)
 PROMPT_STUDIO_WILDCARD_TRANSACTION_SMOKE = (
     ROOT / "tests" / "frontend_prompt_studio_wildcard_transaction_smoke.mjs"
 )
@@ -2395,6 +2398,11 @@ class FrontendModuleStructureTests(unittest.TestCase):
         self.assertTrue(PROMPT_STUDIO_ADVANCED_VALUES_SMOKE.is_file())
         self.assertIn(
             r'node "tests\frontend_prompt_studio_advanced_values_smoke.mjs"',
+            FRONTEND_CHECK_SCRIPT.read_text(encoding="utf-8"),
+        )
+        self.assertTrue(PROMPT_STUDIO_EXECUTION_PROJECTION_SMOKE.is_file())
+        self.assertIn(
+            r'node "tests\frontend_prompt_studio_execution_projection_smoke.mjs"',
             FRONTEND_CHECK_SCRIPT.read_text(encoding="utf-8"),
         )
         self.assertTrue(PROMPT_STUDIO_WILDCARD_TRANSACTION_SMOKE.is_file())

--- a/tools/check_frontend.ps1
+++ b/tools/check_frontend.ps1
@@ -179,6 +179,11 @@ try {
         throw "Frontend Prompt Studio Advanced executed values smoke failed with exit code $LASTEXITCODE."
     }
 
+    & node "tests\frontend_prompt_studio_execution_projection_smoke.mjs"
+    if ($LASTEXITCODE -ne 0) {
+        throw "Frontend Prompt Studio execution projection contract smoke failed with exit code $LASTEXITCODE."
+    }
+
     & node "tests\frontend_prompt_studio_wildcard_transaction_smoke.mjs"
     if ($LASTEXITCODE -ne 0) {
         throw "Frontend Prompt Studio wildcard transaction smoke failed with exit code $LASTEXITCODE."


### PR DESCRIPTION
## 목적과 변경 경계

Issue #470의 첫 READY 단계인 **QSTATE-04C1 — Projection Contract**를 고정합니다.

- Base: `7035f3669c27004f7d9c630cce7815b6827b2aca` (`origin/dev`)
- Head: `4c22902f6007a7ea3e4a0173d89e3b067046747b`
- production 코드는 변경하지 않습니다.
- contract fixture, executable smoke, official frontend runner 등록만 포함합니다.

## 주요 변경

- `prompt_studio_execution_projection_contract.v1.json`에 12개 시나리오를 고정했습니다.
  - submitted snapshot과 execution-derived delta 분리
  - single linked overlay / single NAIA canonical projection
  - Q1/Q2/Q3 latest accepted ownership
  - newer accepted failure 후 older fallback 금지
  - field별 text/structure revision과 connection fingerprint
  - linked overlay 비직렬화와 NAIA canonical persistence
  - one-envelope fan-out / one settlement
  - mapped / duplicate / missing identity fail-closed
- fixture를 검증하는 Prompt Studio execution projection smoke를 추가했습니다.
- 새 smoke가 official frontend/full runner에서 항상 실행되도록 등록했습니다.

## 보존 계약

- 기존 submitted `advanced_fields`, resolution, Artist Mix, editor structure를 editable authority로 replay하지 않습니다.
- linked 실행값은 overlay로만 표시되고 local fallback 저장값을 덮지 않습니다.
- NAIA 결과는 정확한 NAIA field의 canonical text로 저장됩니다.
- completion order가 아니라 latest accepted queue가 projection을 소유합니다.
- 한 envelope는 여러 surface로 fan-out하되 한 번만 settle합니다.
- public socket, workflow schema, return order는 변경하지 않습니다.

## 검증

- changed-file JS / JSON / Python / PowerShell syntax: 통과
- `frontend_prompt_studio_execution_projection_smoke.mjs`: 12 scenarios 통과
- 기존 Advanced executed-values smoke: 통과
- 기존 Wildcard transaction smoke: 통과
- runner-registration focused unittest: 1 test 통과
- `git diff --check`: 통과
- final SHA official full 1회: 통과
  - Python unittest 1,239개
  - frontend JavaScript 119개 및 TypeScript
  - compile, pyright baseline ratchet, import boundary, diff gate
  - G-01 Ruff 121건은 기존 report-only baseline이며 비차단

## 범위 밖

- QSTATE-04C2 unified execution transaction 구현
- production 코드 변경
- package / live ComfyUI 검증
- release 작업

## 위험과 rollback

- 이 PR은 future implementation이 재사용할 contract oracle과 fixture만 추가합니다.
- QSTATE-04C2는 이 fixture를 production transaction owner에 연결하면서 Wildcard parity를 별도로 증명해야 합니다.
- rollback 단위는 이 단일 test-only commit입니다.

## Next

Review/merge 후에만 QSTATE-04C2를 시작합니다.