### PR TITLE
refactor: QSTATE-04C2 Prompt Studio execution transaction 일반화

### DIFF
--- a/tests/frontend_prompt_studio_wildcard_transaction_smoke.mjs
+++ b/tests/frontend_prompt_studio_wildcard_transaction_smoke.mjs
@@ -13,25 +13,15 @@ const contextModule = await import(dataModule(
   "../web/js/lifecycle/executed_event_context.js",
 ));
 const transactionModule = await import(dataModule(
-  "../web/js/prompt_studio/wildcard_seed_transaction.js",
+  "../web/js/prompt_studio/execution_transaction.js",
 ));
 
 assert.deepEqual(
   Object.keys(transactionModule).sort(),
-  [
-    "WILDCARD_HISTORY_SURFACE",
-    "WILDCARD_SEED_CONTROL_SURFACE",
-    "createPromptStudioWildcardSeedTransaction",
-  ],
+  ["createPromptStudioExecutionTransaction"],
 );
-assert.equal(
-  transactionModule.WILDCARD_SEED_CONTROL_SURFACE,
-  "prompt.wildcard_seed_control",
-);
-assert.equal(
-  transactionModule.WILDCARD_HISTORY_SURFACE,
-  "prompt.wildcard_history",
-);
+
+const WILDCARD_SEED_CONTROL_SURFACE = "prompt.wildcard_seed_control";
 
 class FakeApi {
   constructor() {
@@ -77,22 +67,44 @@ function createNode(id) {
 
 function createHarness() {
   const api = new FakeApi();
-  const owner = ownerModule.createQueueUiTransactionOwner();
+  const transactionOwner = ownerModule.createQueueUiTransactionOwner();
+  let settleCount = 0;
+  const owner = Object.freeze({
+    ...transactionOwner,
+    settle(...args) {
+      settleCount += 1;
+      return transactionOwner.settle(...args);
+    },
+  });
   let runtime;
   const executedContext = contextModule.createExecutedEventContext(api, {
     finishPrompt: (promptId) => runtime.finishPrompt(promptId),
   });
-  runtime = transactionModule.createPromptStudioWildcardSeedTransaction({
+  runtime = transactionModule.createPromptStudioExecutionTransaction({
     owner,
     executedContext,
     findWidget: (node, name) => node.widgets.find((widget) => widget.name === name),
+    editBindings: [{
+      widgetNames: ["wildcard_seed", "wildcard_seed_after_generate"],
+      surfaces: [WILDCARD_SEED_CONTROL_SURFACE],
+    }],
   });
   executedContext.install();
-  return { api, executedContext, runtime };
+  return {
+    api,
+    executedContext,
+    runtime,
+    settleCount: () => settleCount,
+  };
 }
 
-function accepted(runtime, node, promptId) {
-  const captured = runtime.captureQueue([node]);
+function accepted(
+  runtime,
+  node,
+  promptId,
+  surfaces = [WILDCARD_SEED_CONTROL_SURFACE],
+) {
+  const captured = runtime.captureQueue([{ node, surfaces }]);
   assert.equal(captured.length, 1);
   assert.equal(
     runtime.acceptQueue(captured, { ok: true, result: { prompt_id: promptId } }),
@@ -117,7 +129,10 @@ function captureEnvelope(api, promptId, node, output) {
   let commitCount = 0;
   captureEnvelope(api, "prompt-current", node, output);
   assert.equal(
-    await runtime.consumeExecution(node, output, 1, () => { commitCount += 1; }),
+    await runtime.consumeExecution(node, output, 1, [{
+      surface: WILDCARD_SEED_CONTROL_SURFACE,
+      commit: () => { commitCount += 1; },
+    }]),
     true,
   );
   assert.equal(commitCount, 1);
@@ -140,7 +155,10 @@ function captureEnvelope(api, promptId, node, output) {
     node,
     output,
     1,
-    () => { commitCount += 1; },
+    [{
+      surface: WILDCARD_SEED_CONTROL_SURFACE,
+      commit: () => { commitCount += 1; },
+    }],
   );
   captureEnvelope(api, "prompt-node-first", node, output);
   assert.equal(await delivery, true, "node-first delivery must wait within the event turn");
@@ -159,7 +177,10 @@ for (const widgetName of ["wildcard_seed", "wildcard_seed_after_generate"]) {
   let commitCount = 0;
   captureEnvelope(api, transaction.promptId, node, output);
   assert.equal(
-    await runtime.consumeExecution(node, output, 1, () => { commitCount += 1; }),
+    await runtime.consumeExecution(node, output, 1, [{
+      surface: WILDCARD_SEED_CONTROL_SURFACE,
+      commit: () => { commitCount += 1; },
+    }]),
     false,
     `${widgetName} edit must invalidate the atomic seed/control surface`,
   );
@@ -178,7 +199,10 @@ for (const widgetName of ["wildcard_seed", "wildcard_seed_after_generate"]) {
     false,
     "cloned output must fail closed",
   );
-  assert.equal(await runtime.consumeExecution(node, output, 1, () => {}), true);
+  assert.equal(await runtime.consumeExecution(node, output, 1, [{
+    surface: WILDCARD_SEED_CONTROL_SURFACE,
+    commit: () => {},
+  }]), true);
 }
 
 {
@@ -193,7 +217,10 @@ for (const widgetName of ["wildcard_seed", "wildcard_seed_after_generate"]) {
   };
   captureEnvelope(api, "prompt-mapped", node, output);
   assert.equal(
-    await runtime.consumeExecution(node, output, 2, () => {}),
+    await runtime.consumeExecution(node, output, 2, [{
+      surface: WILDCARD_SEED_CONTROL_SURFACE,
+      commit: () => {},
+    }]),
     false,
     "multiple mapped payloads must not publish editable state",
   );
@@ -203,13 +230,19 @@ for (const widgetName of ["wildcard_seed", "wildcard_seed_after_generate"]) {
 {
   const { api, runtime } = createHarness();
   const node = createNode(10);
-  const captured = runtime.captureQueue([node]);
+  const captured = runtime.captureQueue([{
+    node,
+    surfaces: [WILDCARD_SEED_CONTROL_SURFACE],
+  }]);
   const transaction = captured[0].transaction;
   const output = { prompt_studio_advanced: [{ wildcard_seed: 14 }] };
   let commitCount = 0;
   captureEnvelope(api, "prompt-out-of-order", node, output);
   assert.equal(
-    await runtime.consumeExecution(node, output, 1, () => { commitCount += 1; }),
+    await runtime.consumeExecution(node, output, 1, [{
+      surface: WILDCARD_SEED_CONTROL_SURFACE,
+      commit: () => { commitCount += 1; },
+    }]),
     false,
     "executed-before-accept must defer editable publication",
   );
@@ -229,7 +262,10 @@ for (const widgetName of ["wildcard_seed", "wildcard_seed_after_generate"]) {
 {
   const { runtime } = createHarness();
   const node = createNode(11);
-  const captured = runtime.captureQueue([node]);
+  const captured = runtime.captureQueue([{
+    node,
+    surfaces: [WILDCARD_SEED_CONTROL_SURFACE],
+  }]);
   assert.equal(runtime.acceptQueue(captured, { ok: true, result: {} }), 0);
   assert.equal(captured[0].transaction.state, "cancelled");
   assert.equal(captured[0].transaction.reason, "reject");
@@ -256,4 +292,45 @@ for (const widgetName of ["wildcard_seed", "wildcard_seed_after_generate"]) {
   assert.equal(transaction.reason, "prompt-terminal");
 }
 
-console.log("Prompt Studio wildcard transaction smoke passed.");
+{
+  const { api, runtime, settleCount } = createHarness();
+  const node = createNode("fan-out");
+  const surfaces = [
+    WILDCARD_SEED_CONTROL_SURFACE,
+    "prompt.execution.linked:positive_general",
+    "prompt.execution.naia:positive_naia",
+  ];
+  const transaction = accepted(runtime, node, "prompt-fan-out", surfaces);
+  const output = { prompt_studio_advanced: [{ wildcard_seed: 15 }] };
+  const commits = [];
+  captureEnvelope(api, "prompt-fan-out", node, output);
+  assert.equal(await runtime.consumeExecution(node, output, 1, [
+    {
+      surface: WILDCARD_SEED_CONTROL_SURFACE,
+      commit: () => { commits.push("wildcard"); },
+    },
+    {
+      surface: "prompt.execution.linked:positive_general",
+      commit: () => { commits.push("linked"); },
+    },
+    {
+      surface: "prompt.execution.naia:positive_naia",
+      commit: () => { commits.push("naia"); },
+    },
+  ]), true);
+  assert.deepEqual(commits, ["wildcard", "linked", "naia"]);
+  assert.equal(transaction.state, "settled", "one fan-out must settle once");
+  assert.equal(settleCount(), 1);
+  assert.equal(
+    await runtime.consumeExecution(node, output, 1, [{
+      surface: WILDCARD_SEED_CONTROL_SURFACE,
+      commit: () => { commits.push("duplicate"); },
+    }]),
+    false,
+    "the consumed envelope must not fan out twice",
+  );
+  assert.deepEqual(commits, ["wildcard", "linked", "naia"]);
+  assert.equal(settleCount(), 1, "duplicate delivery must not settle twice");
+}
+
+console.log("Prompt Studio execution transaction and Wildcard parity smoke passed.");

--- a/tests/test_frontend_modules.py
+++ b/tests/test_frontend_modules.py
@@ -2366,7 +2366,28 @@ class FrontendModuleStructureTests(unittest.TestCase):
         self.assertIn('./advanced_fields_ui.js"', advanced_node_ui_source)
         self.assertIn("./advanced_fields_state.js", extension_runtime_source)
         self.assertIn("./advanced_values.js", extension_runtime_source)
-        self.assertIn("./wildcard_seed_transaction.js", extension_runtime_source)
+        self.assertIn("./execution_transaction.js", extension_runtime_source)
+        self.assertNotIn("./wildcard_seed_transaction.js", extension_runtime_source)
+        execution_transaction_source = (
+            PROMPT_STUDIO_MODULES / "execution_transaction.js"
+        ).read_text(encoding="utf-8")
+        self.assertFalse(
+            (PROMPT_STUDIO_MODULES / "wildcard_seed_transaction.js").exists()
+        )
+        self.assertIn(
+            "createPromptStudioExecutionTransaction",
+            execution_transaction_source,
+        )
+        self.assertIn("for (const committer", execution_transaction_source)
+        self.assertIn(
+            "owner.settle(transaction, pending.envelope)",
+            execution_transaction_source,
+        )
+        self.assertIn("editBindings: WILDCARD_SEED_EDIT_BINDINGS", extension_runtime_source)
+        self.assertIn(
+            "surface: WILDCARD_SEED_CONTROL_SURFACE",
+            extension_runtime_source,
+        )
         self.assertIn("../lifecycle/queue_ui_transaction.js", extension_runtime_source)
         self.assertIn("../lifecycle/executed_event_context.js", extension_runtime_source)
         self.assertIn('"advanced-wildcard-seed-transaction"', extension_runtime_source)

--- a/web/js/prompt_studio/execution_transaction.js
+++ b/web/js/prompt_studio/execution_transaction.js
@@ -1,11 +1,5 @@
 // @ts-check
 
-const WILDCARD_SEED_CONTROL_SURFACE = "prompt.wildcard_seed_control";
-const WILDCARD_HISTORY_SURFACE = "prompt.wildcard_history";
-const EDITABLE_WIDGET_NAMES = Object.freeze([
-  "wildcard_seed",
-  "wildcard_seed_after_generate",
-]);
 const WIDGET_CALLBACK_OWNER = Symbol.for(
   "easyuse-anima.prompt-studio.wildcard-seed-callback-owner",
 );
@@ -19,25 +13,67 @@ function isReference(value) {
   );
 }
 
+/** @param {unknown} value */
+function normalizeSurface(value) {
+  return typeof value === "string" && value.trim() !== ""
+    ? value.trim()
+    : null;
+}
+
 /**
- * Bind Prompt Studio's concrete next-seed publication to the shared queue UI
- * transaction contract. Seed values and controls remain feature-owned; the
- * shared owner sees only an opaque surface token and its revision.
+ * @param {unknown} value
+ * @returns {Array<{ surface: string, commit: () => unknown }> | null}
+ */
+function normalizeCommitters(value) {
+  if (value == null) {
+    return [];
+  }
+  if (!Array.isArray(value)) {
+    return null;
+  }
+  const surfaces = new Set();
+  const committers = [];
+  for (const candidate of value) {
+    const surface = normalizeSurface(candidate?.surface);
+    if (
+      surface == null
+      || surfaces.has(surface)
+      || typeof candidate?.commit !== "function"
+    ) {
+      return null;
+    }
+    surfaces.add(surface);
+    committers.push({ surface, commit: candidate.commit });
+  }
+  return committers;
+}
+
+/**
+ * Bind Prompt Studio feature-owned surfaces to the shared queue UI transaction
+ * and executed-envelope contracts. Surface strings, edit bindings, and commit
+ * callbacks remain opaque; this lifecycle does not parse feature payloads.
  *
  * @param {{
  *   owner: ReturnType<import("../lifecycle/queue_ui_transaction.js").createQueueUiTransactionOwner>,
  *   executedContext: ReturnType<import("../lifecycle/executed_event_context.js").createExecutedEventContext>,
- *   findWidget: (node: any, name: string) => any,
+ *   findWidget?: ((node: any, name: string) => any) | null,
+ *   editBindings?: Array<{ widgetNames: string[], surfaces: string[] }>,
  * }} options
  */
-function createPromptStudioWildcardSeedTransaction(options) {
-  const { owner, executedContext, findWidget } = options || {};
+function createPromptStudioExecutionTransaction(options) {
+  const {
+    owner,
+    executedContext,
+    findWidget = null,
+    editBindings = [],
+  } = options || {};
   if (
     !owner
     || !executedContext
-    || typeof findWidget !== "function"
+    || !Array.isArray(editBindings)
+    || (editBindings.length > 0 && typeof findWidget !== "function")
   ) {
-    throw new TypeError("Prompt Studio wildcard transaction dependencies are required.");
+    throw new TypeError("Prompt Studio execution transaction dependencies are required.");
   }
 
   let disposed = false;
@@ -85,57 +121,69 @@ function createPromptStudioWildcardSeedTransaction(options) {
     }
   }
 
+  /** @param {any} node @param {unknown} surfaces */
+  function markEdited(node, surfaces) {
+    return !disposed && owner.markEdited(node, surfaces);
+  }
+
   /** @param {any} node */
   function hookNode(node) {
     if (disposed || !isReference(node)) {
       return false;
     }
     let changed = false;
-    for (const name of EDITABLE_WIDGET_NAMES) {
-      const widget = findWidget(node, name);
-      if (!widget || typeof widget !== "object") {
+    for (const binding of editBindings) {
+      if (
+        !Array.isArray(binding?.widgetNames)
+        || !Array.isArray(binding?.surfaces)
+      ) {
         continue;
       }
-      const current = widget.callback;
-      const callbackState = current?.[WIDGET_CALLBACK_OWNER];
-      if (callbackState?.runtime === runtime) {
-        continue;
-      }
-      const original = callbackState?.original ?? current;
-      const wrapped = function (...args) {
-        try {
-          return typeof original === "function"
-            ? original.apply(this, args)
-            : undefined;
-        } finally {
-          if (!disposed) {
-            owner.markEdited(node, [WILDCARD_SEED_CONTROL_SURFACE]);
-          }
+      for (const name of binding.widgetNames) {
+        const widget = findWidget?.(node, name);
+        if (!widget || typeof widget !== "object") {
+          continue;
         }
-      };
-      Object.defineProperty(wrapped, WIDGET_CALLBACK_OWNER, {
-        value: { runtime, original },
-      });
-      widget.callback = wrapped;
-      changed = true;
+        const current = widget.callback;
+        const callbackState = current?.[WIDGET_CALLBACK_OWNER];
+        if (callbackState?.runtime === runtime) {
+          continue;
+        }
+        const original = callbackState?.original ?? current;
+        const wrapped = function (...args) {
+          try {
+            return typeof original === "function"
+              ? original.apply(this, args)
+              : undefined;
+          } finally {
+            markEdited(node, binding.surfaces);
+          }
+        };
+        Object.defineProperty(wrapped, WIDGET_CALLBACK_OWNER, {
+          value: { runtime, original },
+        });
+        widget.callback = wrapped;
+        changed = true;
+      }
     }
     return changed;
   }
 
-  /** @param {any[]} nodes */
-  function captureQueue(nodes) {
-    if (disposed || !Array.isArray(nodes)) {
+  /** @param {Array<{ node: any, surfaces: string[] }>} entries */
+  function captureQueue(entries) {
+    if (disposed || !Array.isArray(entries)) {
       return [];
     }
     const captured = [];
-    for (const node of nodes) {
+    for (const entry of entries) {
+      const node = entry?.node;
       if (!isReference(node)) {
         continue;
       }
       hookNode(node);
       const transaction = owner.captureProvisional({
         node,
-        surfaces: [WILDCARD_SEED_CONTROL_SURFACE],
+        surfaces: entry.surfaces,
       });
       if (transaction) {
         remember(node, transaction);
@@ -178,7 +226,11 @@ function createPromptStudioWildcardSeedTransaction(options) {
   /**
    * @param {any} node
    * @param {any} transaction
-   * @param {{ envelope: any, mappedItemCount: number, commit?: (() => unknown) | null }} pending
+   * @param {{
+   *   envelope: any,
+   *   mappedItemCount: number,
+   *   committers: Array<{ surface: string, commit: () => unknown }> | null,
+   * }} pending
    */
   function finishExecution(node, transaction, pending) {
     if (transaction.promptId !== pending.envelope.promptId) {
@@ -186,18 +238,22 @@ function createPromptStudioWildcardSeedTransaction(options) {
       forget(node, transaction);
       return false;
     }
-    const canCommit = owner.canCommit(transaction, {
-      envelope: pending.envelope,
-      node,
-      surface: WILDCARD_SEED_CONTROL_SURFACE,
-      mappedItemCount: pending.mappedItemCount,
-    });
-    let committed = canCommit;
-    if (canCommit && typeof pending.commit === "function") {
+    let committed = false;
+    for (const committer of pending.committers || []) {
+      const canCommit = owner.canCommit(transaction, {
+        envelope: pending.envelope,
+        node,
+        surface: committer.surface,
+        mappedItemCount: pending.mappedItemCount,
+      });
+      if (!canCommit) {
+        continue;
+      }
       try {
-        pending.commit();
+        committer.commit();
+        committed = true;
       } catch {
-        committed = false;
+        // One feature commit failure must not block independent surfaces.
       }
     }
     owner.settle(transaction, pending.envelope);
@@ -207,15 +263,19 @@ function createPromptStudioWildcardSeedTransaction(options) {
 
   /**
    * Consume only the exact output object captured from ComfyUI's outer
-   * `executed` event. Multiple mapped payloads settle the transaction but are
-   * never allowed to publish an editable next seed.
+   * `executed` event, fan out feature-owned callbacks, then settle once.
    *
    * @param {any} node
    * @param {unknown} output
    * @param {number} mappedItemCount
-   * @param {(() => unknown) | null} [commit]
+   * @param {Array<{ surface: string, commit: () => unknown }> | null} [committers]
    */
-  async function consumeExecution(node, output, mappedItemCount, commit = null) {
+  async function consumeExecution(
+    node,
+    output,
+    mappedItemCount,
+    committers = [],
+  ) {
     if (disposed || !isReference(node)) {
       return false;
     }
@@ -223,6 +283,7 @@ function createPromptStudioWildcardSeedTransaction(options) {
     if (!envelope || disposed || !isReference(node)) {
       return false;
     }
+    const normalizedCommitters = normalizeCommitters(committers);
     const active = activeTransactions(node);
     const matches = active.filter(
       (transaction) => transaction.state === "accepted"
@@ -232,7 +293,7 @@ function createPromptStudioWildcardSeedTransaction(options) {
       return finishExecution(node, matches[0], {
         envelope,
         mappedItemCount,
-        commit,
+        committers: normalizedCommitters,
       });
     }
     const provisional = active.filter(
@@ -244,7 +305,7 @@ function createPromptStudioWildcardSeedTransaction(options) {
     pendingExecutions.set(provisional[0], {
       envelope,
       mappedItemCount,
-      commit,
+      committers: normalizedCommitters,
     });
     return false;
   }
@@ -302,12 +363,11 @@ function createPromptStudioWildcardSeedTransaction(options) {
     disposeNode,
     finishPrompt,
     hookNode,
+    markEdited,
   });
   return runtime;
 }
 
 export {
-  WILDCARD_HISTORY_SURFACE,
-  WILDCARD_SEED_CONTROL_SURFACE,
-  createPromptStudioWildcardSeedTransaction,
+  createPromptStudioExecutionTransaction,
 };

--- a/web/js/prompt_studio/extension_runtime.js
+++ b/web/js/prompt_studio/extension_runtime.js
@@ -131,8 +131,8 @@ import {
   createExecutedEventContext,
 } from "../lifecycle/executed_event_context.js";
 import {
-  createPromptStudioWildcardSeedTransaction,
-} from "./wildcard_seed_transaction.js";
+  createPromptStudioExecutionTransaction,
+} from "./execution_transaction.js";
 import {
   commitAdvancedWildcardSeedView,
 } from "./advanced_controls.js";
@@ -143,6 +143,16 @@ const PROMPT_STUDIO_GLOBAL_HOOK_RUNTIME_OWNER = Symbol.for(
 const PROMPT_STUDIO_WILDCARD_SEED_TRANSACTION_OWNER = Symbol.for(
   "easyuse-anima.prompt-studio.wildcard-seed-transaction",
 );
+const WILDCARD_SEED_CONTROL_SURFACE = "prompt.wildcard_seed_control";
+const WILDCARD_SEED_EDIT_BINDINGS = [
+  {
+    widgetNames: [
+      "wildcard_seed",
+      "wildcard_seed_after_generate",
+    ],
+    surfaces: [WILDCARD_SEED_CONTROL_SURFACE],
+  },
+];
 
 function createPromptStudioExtensionRuntime(app, api) {
   const globalHookLifecycle = createHostHookRuntimeLifecycle(
@@ -150,17 +160,18 @@ function createPromptStudioExtensionRuntime(app, api) {
     PROMPT_STUDIO_GLOBAL_HOOK_RUNTIME_OWNER,
   );
   const queueUiTransactionOwner = createQueueUiTransactionOwner();
-  let wildcardSeedTransaction;
+  let executionTransaction;
   const executedEventContext = createExecutedEventContext(api, {
-    finishPrompt: (promptId) => wildcardSeedTransaction.finishPrompt(promptId),
+    finishPrompt: (promptId) => executionTransaction.finishPrompt(promptId),
   });
-  wildcardSeedTransaction = createPromptStudioWildcardSeedTransaction({
+  executionTransaction = createPromptStudioExecutionTransaction({
     owner: queueUiTransactionOwner,
     executedContext: executedEventContext,
     findWidget,
+    editBindings: WILDCARD_SEED_EDIT_BINDINGS,
   });
   let advancedSaveSyncSerializeHost;
-  let wildcardSeedTransactionGraphHost;
+  let executionTransactionGraphHost;
 
   function markNodeDirty(node) {
     markNodeDirtyWithApp(app, node);
@@ -191,7 +202,16 @@ function createPromptStudioExtensionRuntime(app, api) {
     return {
       advancedWidget,
       commitAdvancedWildcardSeedView,
-      consumeWildcardSeedExecution: wildcardSeedTransaction.consumeExecution,
+      consumeWildcardSeedExecution: (node, output, mappedItemCount, commit) => (
+        executionTransaction.consumeExecution(
+          node,
+          output,
+          mappedItemCount,
+          typeof commit === "function"
+            ? [{ surface: WILDCARD_SEED_CONTROL_SURFACE, commit }]
+            : [],
+        )
+      ),
       markNodeDirty,
       parseAdvancedFields,
       repairAdvancedInternalWidgetValues,
@@ -398,9 +418,9 @@ function createPromptStudioExtensionRuntime(app, api) {
 
   function installAdvancedWildcardSeedTransactionForApp() {
     const graphHost = app?.graph || null;
-    const replace = wildcardSeedTransactionGraphHost !== undefined
+    const replace = executionTransactionGraphHost !== undefined
       && graphHost != null
-      && graphHost !== wildcardSeedTransactionGraphHost;
+      && graphHost !== executionTransactionGraphHost;
     const installed = globalHookLifecycle.install(
       "advanced-wildcard-seed-transaction",
       () => registerHostHookCallbacks({
@@ -410,19 +430,22 @@ function createPromptStudioExtensionRuntime(app, api) {
         // successful result owns the accepted prompt_id.
         queueHost: api,
         graphHost,
-        beforeQueue: () => wildcardSeedTransaction.captureQueue(
-          (app.graph?._nodes || []).filter(isAdvancedNode),
+        beforeQueue: () => executionTransaction.captureQueue(
+          (app.graph?._nodes || []).filter(isAdvancedNode).map((node) => ({
+            node,
+            surfaces: [WILDCARD_SEED_CONTROL_SURFACE],
+          })),
         ),
-        afterQueue: (context) => wildcardSeedTransaction.acceptQueue(
+        afterQueue: (context) => executionTransaction.acceptQueue(
           context.callbackState,
           context,
         ),
-        onGraphClear: () => wildcardSeedTransaction.clear(),
+        onGraphClear: () => executionTransaction.clear(),
       }),
       { replace },
     );
     if (installed) {
-      wildcardSeedTransactionGraphHost = graphHost;
+      executionTransactionGraphHost = graphHost;
     }
     return installed;
   }
@@ -434,14 +457,14 @@ function createPromptStudioExtensionRuntime(app, api) {
 
   function disposeGlobalHooks() {
     advancedSaveSyncSerializeHost = undefined;
-    wildcardSeedTransactionGraphHost = undefined;
+    executionTransactionGraphHost = undefined;
     return globalHookLifecycle.dispose();
   }
 
   function disposeRuntime() {
     let changed = disposeGlobalHooks();
     changed = executedEventContext.dispose() || changed;
-    changed = wildcardSeedTransaction.dispose() || changed;
+    changed = executionTransaction.dispose() || changed;
     return changed;
   }
 
@@ -521,9 +544,9 @@ function createPromptStudioExtensionRuntime(app, api) {
         ),
         disconnectAdvancedEditorWidthObserver,
         disposeAdvancedAutocompleteInputs,
-        disposeAdvancedWildcardSeedNode: wildcardSeedTransaction.disposeNode,
+        disposeAdvancedWildcardSeedNode: executionTransaction.disposeNode,
         hookWildcardSeedWidget,
-        hookAdvancedWildcardSeedNode: wildcardSeedTransaction.hookNode,
+        hookAdvancedWildcardSeedNode: executionTransaction.hookNode,
         hookStudioNode,
         isExtendNode,
         layoutExtendPromptWidgets,


### PR DESCRIPTION
## 목적과 변경 경계

Issue #470 로드맵의 **QSTATE-04C2 — Unified execution transaction**을 구현합니다.

- Base: `c22041314cf290d76fd7a90dab45195ab6d5a836` (`dev`)
- Head: `99ce6219ad2d7b7596f077a66ab8338a2bb87882`
- Wildcard 전용 transaction 내부 owner를 feature-agnostic Prompt Studio execution transaction으로 일반화합니다.
- backend delta, linked projection, NAIA adoption은 포함하지 않습니다.

## 주요 변경

- `wildcard_seed_transaction.js`를 `execution_transaction.js`로 이동·일반화했습니다.
- transaction은 feature payload를 해석하지 않고 opaque surface와 feature-owned commit callback만 처리합니다.
- 하나의 executed envelope을 한 번 consume하고 surface별 callback으로 fan-out한 뒤 한 번만 settle합니다.
- Wildcard adapter는 기존 seed/control widget revision과 commit semantics를 그대로 연결합니다.
- direct smoke에 Wildcard parity와 wildcard/linked/NAIA 3-surface fan-out·duplicate no-op을 고정했습니다.

## 보존 계약

- latest accepted queue와 per-surface revision gate를 유지합니다.
- mapped item count가 1이 아니면 editable commit을 하지 않고 settle합니다.
- exact output identity, duplicate callback, executed-before-accept, reject/remove/terminal semantics를 유지합니다.
- 기존 hot-reload callback owner와 host-hook owner 문자열을 유지합니다.
- public socket, workflow schema, return order와 사용자-visible Wildcard 동작은 변경하지 않습니다.

## 검증

- changed-file JS/Python syntax: 통과
- Prompt Studio execution transaction + Wildcard parity smoke: 통과
- QSTATE-04C1 projection contract smoke: 통과
- 기존 Prompt Studio Advanced executed-values smoke: 통과
- shared Queue UI transaction smoke: 10 scenarios 통과
- exact module-boundary focused unittest: 1 test 통과
- TypeScript 6.0.3: 통과
- `git diff --check`: 통과
- final SHA official full 1회: 통과
  - Python unittest 1,239개
  - frontend JavaScript 119개 및 TypeScript
  - compile, Pyright baseline ratchet, import boundary, diff gate
  - G-01 Ruff 121건은 기존 report-only baseline이며 비차단

## Package / live

이 단계는 사용자-visible behavior를 바꾸지 않는 narrow lifecycle 일반화이므로 로드맵에 따라 package/live를 실행하지 않았습니다.

## 위험과 rollback

- 위험은 internal transaction adapter 경계와 callback fan-out 순서에 한정됩니다.
- rollback 단위는 이 단일 commit이며 기존 Wildcard 전용 module로 되돌릴 수 있습니다.

## Next

Review/merge 후 QSTATE-04C3에서 backend delta와 linked input projection을 별도 behavior PR로 진행합니다.