### PR TITLE
feat: persist Prompt Studio NAIA execution deltas

### DIFF
--- a/tests/frontend_prompt_studio_advanced_values_smoke.mjs
+++ b/tests/frontend_prompt_studio_advanced_values_smoke.mjs
@@ -76,12 +76,19 @@ let renderCount = 0;
 let consumedMappedItemCount = null;
 let wildcardViewCommitCount = 0;
 let linkedViewCommitCount = 0;
+let naiaFieldCommitCount = 0;
+let naiaResolutionCommitCount = 0;
 publishAdvancedExecution(
   node,
   {
     prompt_studio_advanced: [{
       advanced_fields: "[]",
       field_inputs: { field_positive_general: "resolved linked text" },
+      naia_field_updates: {
+        positive_naia: "resolved positive NAIA",
+        negative_naia: "resolved negative NAIA",
+      },
+      naia_resolution_update: { width: 832, height: 1216 },
       wildcard_mode: "순차",
       wildcard_execution_seed: 41,
       wildcard_seed: 42,
@@ -109,6 +116,20 @@ publishAdvancedExecution(
         target.__easyuseAnimaAdvancedFieldInputValues[inputName] = value;
       },
     }),
+    createNaiaExecutionCommitter: (_target, fieldId, value) => ({
+      surface: `prompt.execution.naia:${fieldId}`,
+      commit: () => {
+        naiaFieldCommitCount += 1;
+        assert(value.includes("NAIA"), "Advanced lost an explicit NAIA field delta");
+      },
+    }),
+    createNaiaResolutionExecutionCommitter: (_target, value) => ({
+      surface: "prompt.execution.naia_resolution",
+      commit: () => {
+        naiaResolutionCommitCount += 1;
+        assert(value.width === 832 && value.height === 1216, "Advanced lost the NAIA resolution delta");
+      },
+    }),
     markNodeDirty: () => { dirtyCount += 1; },
     parseAdvancedFields: () => [],
     renderAdvancedEditor: () => { renderCount += 1; },
@@ -122,6 +143,8 @@ assert(
 assert(consumedMappedItemCount === 1, "Advanced did not report one mapped payload");
 assert(wildcardViewCommitCount === 1, "Advanced did not delegate the next seed to the narrow view owner");
 assert(linkedViewCommitCount === 1, "Advanced did not delegate linked input to a feature committer");
+assert(naiaFieldCommitCount === 2, "Advanced did not fan out exact NAIA field committers");
+assert(naiaResolutionCommitCount === 1, "Advanced did not fan out the NAIA resolution committer");
 assert(
   node.__easyuseAnimaAdvancedFieldInputValues.field_positive_general
     === "resolved linked text",

--- a/tests/frontend_prompt_studio_naia_projection_smoke.mjs
+++ b/tests/frontend_prompt_studio_naia_projection_smoke.mjs
@@ -1,0 +1,375 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+function inlineModule(source) {
+  return `data:text/javascript;base64,${Buffer.from(source).toString("base64")}`;
+}
+
+function dataModule(relativePath, replacements = {}) {
+  let source = readFileSync(new URL(relativePath, import.meta.url), "utf8");
+  for (const [specifier, replacement] of Object.entries(replacements)) {
+    source = source.replaceAll(`"${specifier}"`, `"${replacement}"`);
+  }
+  return inlineModule(source);
+}
+
+const constantsUrl = inlineModule(`
+  export const NAIA_ADVANCED_RESOLUTION_BUCKET = "NAIA";
+`);
+const stateUrl = inlineModule(`
+  export function getAdvancedEditorElement(node) { return node.__editor || null; }
+  export function getAdvancedFields(node) { return node.__fields || []; }
+`);
+const widgetsUrl = inlineModule(`
+  export function findWidget(node, name) {
+    return node?.widgets?.find((widget) => widget.name === name) || null;
+  }
+`);
+const projection = await import(dataModule(
+  "../web/js/prompt_studio/naia_projection.js",
+  {
+    "./constants.js": constantsUrl,
+    "./state.js": stateUrl,
+    "./widgets.js": widgetsUrl,
+  },
+));
+const ownerModule = await import(dataModule(
+  "../web/js/lifecycle/queue_ui_transaction.js",
+));
+const contextModule = await import(dataModule(
+  "../web/js/lifecycle/executed_event_context.js",
+));
+const transactionModule = await import(dataModule(
+  "../web/js/prompt_studio/execution_transaction.js",
+));
+
+class FakeApi {
+  constructor() { this.listeners = new Map(); }
+  addEventListener(type, listener) {
+    const listeners = this.listeners.get(type) || [];
+    listeners.push(listener);
+    this.listeners.set(type, listeners);
+  }
+  removeEventListener(type, listener) {
+    this.listeners.set(
+      type,
+      (this.listeners.get(type) || []).filter((candidate) => candidate !== listener),
+    );
+  }
+  emit(type, detail) {
+    for (const listener of this.listeners.get(type) || []) listener({ detail });
+  }
+}
+
+function naiaField(id, pane, text) {
+  return {
+    id,
+    pane,
+    type: "naia",
+    enabled: true,
+    label: `${pane} NAIA`,
+    text,
+    height: 72,
+  };
+}
+
+function generalField(id, pane, text) {
+  return {
+    id,
+    pane,
+    type: "general",
+    enabled: true,
+    label: `${pane} General`,
+    text,
+    height: 96,
+  };
+}
+
+function createNode(id, fields, {
+  bucket = "NAIA",
+  width = 1024,
+  height = 1024,
+  artistMix = "exact",
+} = {}) {
+  const textareas = fields.map((field) => ({
+    dataset: { easyuseAnimaAdvancedFieldId: field.id },
+    value: field.text,
+  }));
+  const node = {
+    id,
+    __fields: fields,
+    __editor: {
+      querySelectorAll: () => textareas,
+    },
+    properties: {},
+    textareas,
+    persistCount: 0,
+    renderCount: 0,
+    resolutionCommitCount: 0,
+    widgets: [
+      { name: "advanced_fields", value: JSON.stringify(fields) },
+      { name: "resolution_bucket", value: bucket },
+      { name: "resolution_size", value: `${width} * ${height}` },
+      { name: "resolution_custom_width", value: width },
+      { name: "resolution_custom_height", value: height },
+      { name: "artist_mix_mode", value: artistMix },
+    ],
+  };
+  node.properties.easyuse_anima_advanced_fields = node.widgets[0].value;
+  return node;
+}
+
+function widget(node, name) {
+  return node.widgets.find((candidate) => candidate.name === name);
+}
+
+function createHarness() {
+  const api = new FakeApi();
+  const owner = ownerModule.createQueueUiTransactionOwner();
+  let runtime;
+  const executedContext = contextModule.createExecutedEventContext(api, {
+    finishPrompt: (promptId) => runtime.finishPrompt(promptId),
+  });
+  runtime = transactionModule.createPromptStudioExecutionTransaction({
+    owner,
+    executedContext,
+  });
+  executedContext.install();
+  return { api, runtime };
+}
+
+function capture(runtime, node, promptId) {
+  const naia = projection.captureAdvancedNaiaFieldSnapshots(node.__fields);
+  const resolution = projection.captureAdvancedNaiaResolutionSnapshot(node);
+  const captured = runtime.captureQueue([{
+    node,
+    surfaces: [
+      ...naia.map((snapshot) => snapshot.surface),
+      ...(resolution ? [resolution.surface] : []),
+    ],
+  }]);
+  assert.equal(captured.length, 1);
+  assert.equal(
+    runtime.acceptQueue(captured, { ok: true, result: { prompt_id: promptId } }),
+    1,
+  );
+  return {
+    naia,
+    resolution,
+    transaction: captured[0].transaction,
+  };
+}
+
+function emit(api, promptId, node, output) {
+  api.emit("executed", {
+    prompt_id: promptId,
+    node: String(node.id),
+    output,
+  });
+}
+
+function persistFields(node, fields) {
+  const value = JSON.stringify(fields);
+  widget(node, "advanced_fields").value = value;
+  node.properties.easyuse_anima_advanced_fields = value;
+  node.persistCount += 1;
+}
+
+function commitFieldView(node, _field, textarea, text) {
+  assert.ok(textarea, "NAIA commit must target the exact field textarea");
+  textarea.value = text;
+  assert.equal(node.renderCount, 0, "NAIA commit must not broadly rerender the editor");
+}
+
+function fieldCommitter(node, snapshot, value) {
+  return {
+    surface: snapshot.surface,
+    commit: () => projection.commitAdvancedNaiaFieldCanonical(
+      node,
+      snapshot,
+      value,
+      { persistFields, commitView: commitFieldView },
+    ),
+  };
+}
+
+function commitResolutionView(node, width, height) {
+  widget(node, "resolution_custom_width").value = width;
+  widget(node, "resolution_custom_height").value = height;
+  widget(node, "resolution_size").value = `${width} * ${height}`;
+  node.resolutionCommitCount += 1;
+  return true;
+}
+
+function resolutionCommitter(node, snapshot, value) {
+  return {
+    surface: snapshot.surface,
+    commit: () => projection.commitAdvancedNaiaResolution(
+      node,
+      snapshot,
+      value,
+      { commitView: commitResolutionView },
+    ),
+  };
+}
+
+// Exact positive/negative fields become canonical and survive workflow save/reload.
+// Unrelated fields, resolution, and Artist Mix remain untouched.
+{
+  const { api, runtime } = createHarness();
+  const node = createNode("single", [
+    naiaField("positive_naia", "positive", "old positive"),
+    generalField("positive_general", "positive", "keep general"),
+    naiaField("negative_naia", "negative", "old negative"),
+  ], { bucket: "Custom", width: 1344, height: 768, artistMix: "average" });
+  const queued = capture(runtime, node, "single");
+  assert.equal(queued.resolution, null, "Custom resolution must not capture a NAIA surface");
+  const output = { prompt_studio_advanced: [{
+    naia_field_updates: {
+      positive_naia: "new positive",
+      negative_naia: "new negative",
+    },
+  }] };
+  emit(api, "single", node, output);
+  assert.equal(await runtime.consumeExecution(node, output, 1, [
+    fieldCommitter(node, queued.naia[0], "new positive"),
+    fieldCommitter(node, queued.naia[1], "new negative"),
+  ]), true);
+  const saved = JSON.parse(widget(node, "advanced_fields").value);
+  assert.deepEqual(saved.map((field) => [field.id, field.text]), [
+    ["positive_naia", "new positive"],
+    ["positive_general", "keep general"],
+    ["negative_naia", "new negative"],
+  ]);
+  assert.deepEqual(
+    JSON.parse(node.properties.easyuse_anima_advanced_fields),
+    saved,
+    "workflow property reload must preserve canonical NAIA text",
+  );
+  assert.equal(widget(node, "resolution_custom_width").value, 1344);
+  assert.equal(widget(node, "resolution_custom_height").value, 768);
+  assert.equal(widget(node, "artist_mix_mode").value, "average");
+  assert.equal(node.textareas[0].value, "new positive");
+  assert.equal(node.textareas[2].value, "new negative");
+}
+
+// Q3 owns both NAIA field and resolution surfaces regardless of completion order.
+{
+  const { api, runtime } = createHarness();
+  const node = createNode("latest", [
+    naiaField("positive_naia", "positive", "initial"),
+    generalField("positive_general", "positive", "preserve"),
+  ]);
+  const queued = [1, 2, 3].map((number) => capture(runtime, node, `q${number}`));
+  for (const number of [2, 1, 3]) {
+    const promptId = `q${number}`;
+    const output = { prompt_studio_advanced: [{
+      naia_field_updates: { positive_naia: promptId },
+      naia_resolution_update: { width: 800 + (number * 32), height: 1184 + (number * 32) },
+    }] };
+    emit(api, promptId, node, output);
+    assert.equal(await runtime.consumeExecution(node, output, 1, [
+      fieldCommitter(node, queued[number - 1].naia[0], promptId),
+      resolutionCommitter(
+        node,
+        queued[number - 1].resolution,
+        output.prompt_studio_advanced[0].naia_resolution_update,
+      ),
+    ]), number === 3);
+  }
+  assert.equal(node.__fields[0].text, "q3");
+  assert.equal(node.__fields[1].text, "preserve");
+  assert.equal(widget(node, "resolution_bucket").value, "NAIA");
+  assert.equal(widget(node, "resolution_custom_width").value, 896);
+  assert.equal(widget(node, "resolution_custom_height").value, 1280);
+  assert.equal(node.persistCount, 1, "only Q3 may persist canonical field text");
+  assert.equal(node.resolutionCommitCount, 1, "only Q3 may update runtime resolution");
+}
+
+// A terminal Q3 never re-opens an older accepted fallback.
+{
+  const { api, runtime } = createHarness();
+  const node = createNode("terminal", [
+    naiaField("positive_naia", "positive", "initial"),
+  ]);
+  const older = capture(runtime, node, "older");
+  capture(runtime, node, "newer");
+  api.emit("execution_error", { prompt_id: "newer" });
+  const output = { prompt_studio_advanced: [{
+    naia_field_updates: { positive_naia: "must-not-fallback" },
+  }] };
+  emit(api, "older", node, output);
+  assert.equal(await runtime.consumeExecution(node, output, 1, [
+    fieldCommitter(node, older.naia[0], "must-not-fallback"),
+  ]), false);
+  assert.equal(node.__fields[0].text, "initial");
+  assert.equal(node.persistCount, 0);
+}
+
+// Post-queue field and resolution edits invalidate only their exact surfaces.
+{
+  const { api, runtime } = createHarness();
+  const node = createNode("edited", [
+    naiaField("positive_naia", "positive", "initial"),
+  ]);
+  const queued = capture(runtime, node, "edited");
+  assert.equal(runtime.markEdited(node, [queued.naia[0].surface]), true);
+  node.__fields[0].text = "manual field edit";
+  assert.equal(runtime.markEdited(node, [queued.resolution.surface]), true);
+  widget(node, "resolution_custom_width").value = 1152;
+  const output = { prompt_studio_advanced: [{
+    naia_field_updates: { positive_naia: "stale field" },
+    naia_resolution_update: { width: 832, height: 1216 },
+  }] };
+  emit(api, "edited", node, output);
+  assert.equal(await runtime.consumeExecution(node, output, 1, [
+    fieldCommitter(node, queued.naia[0], "stale field"),
+    resolutionCommitter(node, queued.resolution, { width: 832, height: 1216 }),
+  ]), false);
+  assert.equal(node.__fields[0].text, "manual field edit");
+  assert.equal(widget(node, "resolution_custom_width").value, 1152);
+}
+
+// Missed revision signals still fail closed on exact field and resolution identity.
+for (const mutation of [
+  (node) => { node.__fields = []; },
+  (node) => { node.__fields[0].type = "general"; },
+  (node) => { node.__fields[0].pane = "negative"; },
+  (node) => { node.__fields[0].enabled = false; },
+]) {
+  const node = createNode("structure", [
+    naiaField("positive_naia", "positive", "initial"),
+  ]);
+  const [snapshot] = projection.captureAdvancedNaiaFieldSnapshots(node.__fields);
+  mutation(node);
+  assert.equal(
+    projection.commitAdvancedNaiaFieldCanonical(
+      node,
+      snapshot,
+      "must-not-commit",
+      { persistFields },
+    ),
+    false,
+  );
+  assert.equal(node.persistCount, 0);
+}
+
+{
+  const node = createNode("resolution-structure", [
+    naiaField("positive_naia", "positive", "initial"),
+  ]);
+  const snapshot = projection.captureAdvancedNaiaResolutionSnapshot(node);
+  widget(node, "resolution_bucket").value = "Custom";
+  assert.equal(
+    projection.commitAdvancedNaiaResolution(
+      node,
+      snapshot,
+      { width: 832, height: 1216 },
+      { commitView: commitResolutionView },
+    ),
+    false,
+  );
+  assert.equal(node.resolutionCommitCount, 0);
+}
+
+console.log("Prompt Studio NAIA canonical projection smoke passed.");

--- a/tests/frontend_prompt_studio_resolution_orientation_smoke.mjs
+++ b/tests/frontend_prompt_studio_resolution_orientation_smoke.mjs
@@ -124,6 +124,7 @@ globalThis.HTMLInputElement = Object;
 globalThis.HTMLTextAreaElement = Object;
 
 const {
+  commitAdvancedNaiaResolutionView,
   createAdvancedResolutionSettingsBody,
 } = await import(advancedControlsUrl);
 const {
@@ -414,5 +415,28 @@ const afterNaia = widgetSnapshot(naia.node);
 assertEqual(afterNaia.resolution_bucket, "NAIA", "NAIA was silently changed to Custom");
 assertEqual(afterNaia.resolution_custom_width, beforeNaia.resolution_custom_width, "NAIA width changed");
 assertEqual(afterNaia.resolution_custom_height, beforeNaia.resolution_custom_height, "NAIA height changed");
+
+naia.node.callbackSnapshots.length = 0;
+assertEqual(
+  commitAdvancedNaiaResolutionView(naia.node, 832, 1216),
+  true,
+  "Accepted NAIA resolution did not commit",
+);
+const committedNaia = widgetSnapshot(naia.node);
+assertEqual(committedNaia.resolution_bucket, "NAIA", "NAIA commit changed the bucket owner");
+assertEqual(committedNaia.resolution_custom_width, 832, "NAIA commit width");
+assertEqual(committedNaia.resolution_custom_height, 1216, "NAIA commit height");
+assertEqual(committedNaia.resolution_size, "832 * 1216 (13:19)", "NAIA commit size label");
+assertEqual(
+  naia.node.__summaries.resolution,
+  "NAIA · 832 * 1216 (13:19)",
+  "NAIA commit summary",
+);
+assertEqual(naia.node.callbackSnapshots.length, 3, "NAIA commit callback count");
+for (const callback of naia.node.callbackSnapshots) {
+  assertEqual(callback.snapshot.resolution_custom_width, 832, `${callback.name} saw stale NAIA width`);
+  assertEqual(callback.snapshot.resolution_custom_height, 1216, `${callback.name} saw stale NAIA height`);
+  assertEqual(callback.snapshot.resolution_size, "832 * 1216 (13:19)", `${callback.name} saw stale NAIA size`);
+}
 
 console.log("Prompt Studio resolution orientation smoke passed.");

--- a/tests/test_frontend_modules.py
+++ b/tests/test_frontend_modules.py
@@ -19,6 +19,9 @@ PROMPT_STUDIO_EXECUTION_PROJECTION_SMOKE = (
 PROMPT_STUDIO_LINKED_PROJECTION_SMOKE = (
     ROOT / "tests" / "frontend_prompt_studio_linked_projection_smoke.mjs"
 )
+PROMPT_STUDIO_NAIA_PROJECTION_SMOKE = (
+    ROOT / "tests" / "frontend_prompt_studio_naia_projection_smoke.mjs"
+)
 PROMPT_STUDIO_WILDCARD_TRANSACTION_SMOKE = (
     ROOT / "tests" / "frontend_prompt_studio_wildcard_transaction_smoke.mjs"
 )
@@ -2386,12 +2389,19 @@ class FrontendModuleStructureTests(unittest.TestCase):
             "owner.settle(transaction, pending.envelope)",
             execution_transaction_source,
         )
-        self.assertIn("editBindings: WILDCARD_SEED_EDIT_BINDINGS", extension_runtime_source)
+        self.assertIn("editBindings: PROMPT_STUDIO_EDIT_BINDINGS", extension_runtime_source)
         self.assertIn("WILDCARD_SEED_CONTROL_SURFACE,", extension_runtime_source)
         self.assertIn(
-            "...snapshots.map((snapshot) => snapshot.surface)",
+            "...linked.map((snapshot) => snapshot.surface)",
             extension_runtime_source,
         )
+        self.assertIn(
+            "...naia.map((snapshot) => snapshot.surface)",
+            extension_runtime_source,
+        )
+        self.assertIn("captureAdvancedNaiaResolutionSnapshot", extension_runtime_source)
+        self.assertIn("createNaiaExecutionCommitter", extension_runtime_source)
+        self.assertIn("createNaiaResolutionExecutionCommitter", extension_runtime_source)
         self.assertIn("../lifecycle/queue_ui_transaction.js", extension_runtime_source)
         self.assertIn("../lifecycle/executed_event_context.js", extension_runtime_source)
         self.assertIn('"advanced-wildcard-seed-transaction"', extension_runtime_source)
@@ -2418,6 +2428,8 @@ class FrontendModuleStructureTests(unittest.TestCase):
         self.assertNotIn("applyExecutedInputs", studio_values_source)
         self.assertNotIn("hooks.applyExecutedInputs", node_hooks_source)
         self.assertIn("publishAdvancedExecution", advanced_values_source)
+        self.assertIn("naia_field_updates", advanced_values_source)
+        self.assertIn("naia_resolution_update", advanced_values_source)
         self.assertIn("wildcard_execution_seed", advanced_values_source)
         self.assertIn("writePreviousWildcardExecution", advanced_values_source)
         self.assertTrue(PROMPT_STUDIO_ADVANCED_VALUES_SMOKE.is_file())
@@ -2435,6 +2447,17 @@ class FrontendModuleStructureTests(unittest.TestCase):
             r'node "tests\frontend_prompt_studio_linked_projection_smoke.mjs"',
             FRONTEND_CHECK_SCRIPT.read_text(encoding="utf-8"),
         )
+        self.assertTrue(PROMPT_STUDIO_NAIA_PROJECTION_SMOKE.is_file())
+        self.assertIn(
+            r'node "tests\frontend_prompt_studio_naia_projection_smoke.mjs"',
+            FRONTEND_CHECK_SCRIPT.read_text(encoding="utf-8"),
+        )
+        naia_projection_source = (
+            PROMPT_STUDIO_MODULES / "naia_projection.js"
+        ).read_text(encoding="utf-8")
+        self.assertIn("commitAdvancedNaiaFieldCanonical", naia_projection_source)
+        self.assertIn("commitAdvancedNaiaResolution", naia_projection_source)
+        self.assertNotIn("renderAdvancedEditor", naia_projection_source)
         self.assertTrue(PROMPT_STUDIO_WILDCARD_TRANSACTION_SMOKE.is_file())
         self.assertIn(
             r'node "tests\frontend_prompt_studio_wildcard_transaction_smoke.mjs"',
@@ -3739,6 +3762,7 @@ class FrontendModuleStructureTests(unittest.TestCase):
             "highlight_overlay_core.js",
             "highlight_ui.js",
             "legend.js",
+            "naia_projection.js",
             "node_hooks.js",
             "text.js",
             "widgets.js",

--- a/tools/check_frontend.ps1
+++ b/tools/check_frontend.ps1
@@ -189,6 +189,11 @@ try {
         throw "Frontend Prompt Studio linked execution projection smoke failed with exit code $LASTEXITCODE."
     }
 
+    & node "tests\frontend_prompt_studio_naia_projection_smoke.mjs"
+    if ($LASTEXITCODE -ne 0) {
+        throw "Frontend Prompt Studio NAIA canonical projection smoke failed with exit code $LASTEXITCODE."
+    }
+
     & node "tests\frontend_prompt_studio_wildcard_transaction_smoke.mjs"
     if ($LASTEXITCODE -ne 0) {
         throw "Frontend Prompt Studio wildcard transaction smoke failed with exit code $LASTEXITCODE."

--- a/web/js/prompt_studio/advanced_controls.js
+++ b/web/js/prompt_studio/advanced_controls.js
@@ -802,6 +802,26 @@ function advancedResolutionSummary(node) {
   return `${bucketValue} · ${sizeValue}`;
 }
 
+function commitAdvancedNaiaResolutionView(node, width, height) {
+  const bucket = normalizeAdvancedResolutionBucket(
+    findWidget(node, "resolution_bucket")?.value,
+  );
+  if (bucket !== NAIA_ADVANCED_RESOLUTION_BUCKET) {
+    return false;
+  }
+  const nextWidth = snapResolution32(width, 1024);
+  const nextHeight = snapResolution32(height, 1024);
+  if (!setAdvancedWidgetValues(node, [
+    ["resolution_custom_width", nextWidth],
+    ["resolution_custom_height", nextHeight],
+    ["resolution_size", advancedResolutionLabel(nextWidth, nextHeight)],
+  ])) {
+    return false;
+  }
+  updateAdvancedSummary(node, "resolution", advancedResolutionSummary(node));
+  return true;
+}
+
 function createAdvancedResolutionSettingsBody(node, hooks = {}) {
   const bucketWidget = findWidget(node, "resolution_bucket");
   const sizeWidget = findWidget(node, "resolution_size");
@@ -1073,6 +1093,7 @@ export {
   advancedModGuidanceSummary,
   advancedResolutionSummary,
   advancedWildcardSummary,
+  commitAdvancedNaiaResolutionView,
   commitAdvancedWildcardSeedView,
   createAdvancedControlBar,
   createAdvancedResolutionBar,

--- a/web/js/prompt_studio/advanced_fields_ui.js
+++ b/web/js/prompt_studio/advanced_fields_ui.js
@@ -74,14 +74,21 @@ function setAdvancedTextareaHeight(node, textarea, height, options = {}, hooks =
   return nextHeight;
 }
 
-function syncAdvancedLinkedFieldTextarea(node, field, textarea, value, hooks = {}) {
+function syncAdvancedExecutionFieldTextarea(
+  node,
+  field,
+  textarea,
+  value,
+  { linked = false, layoutReason = "execution" } = {},
+  hooks = {},
+) {
   if (!textarea) {
     return false;
   }
   const previousHeight = advancedTextareaCurrentHeight(textarea);
   textarea.value = String(value ?? "");
-  textarea.classList.toggle("is-linked", true);
-  textarea.title = advancedFieldTextareaTitle(field, true, psText);
+  textarea.classList.toggle("is-linked", linked);
+  textarea.title = advancedFieldTextareaTitle(field, linked, psText);
   textarea.style.height = "auto";
   const nextHeight = setAdvancedTextareaHeight(
     node,
@@ -94,9 +101,31 @@ function syncAdvancedLinkedFieldTextarea(node, field, textarea, value, hooks = {
   hooks.scheduleAdvancedFieldHighlight?.(node, field, textarea);
   requestOverlaySync(textarea, true);
   if (Math.abs(nextHeight - previousHeight) > 1) {
-    hooks.scheduleAdvancedLayout?.(node, "linked-execution");
+    hooks.scheduleAdvancedLayout?.(node, layoutReason);
   }
   return true;
+}
+
+function syncAdvancedLinkedFieldTextarea(node, field, textarea, value, hooks = {}) {
+  return syncAdvancedExecutionFieldTextarea(
+    node,
+    field,
+    textarea,
+    value,
+    { linked: true, layoutReason: "linked-execution" },
+    hooks,
+  );
+}
+
+function syncAdvancedNaiaFieldTextarea(node, field, textarea, value, hooks = {}) {
+  return syncAdvancedExecutionFieldTextarea(
+    node,
+    field,
+    textarea,
+    value,
+    { linked: false, layoutReason: "naia-execution" },
+    hooks,
+  );
 }
 
 /**
@@ -423,4 +452,5 @@ export {
   remeasureAdvancedTextareaHeightsForWidth,
   setAdvancedTextareaHeight,
   syncAdvancedLinkedFieldTextarea,
+  syncAdvancedNaiaFieldTextarea,
 };

--- a/web/js/prompt_studio/advanced_values.js
+++ b/web/js/prompt_studio/advanced_values.js
@@ -95,6 +95,25 @@ function publishAdvancedExecution(node, message, hooks = {}) {
       committers.push(committer);
     }
   }
+  for (const [fieldId, value] of Object.entries(payload.naia_field_updates || {})) {
+    const committer = hooks.createNaiaExecutionCommitter?.(
+      node,
+      fieldId,
+      value,
+    );
+    if (committer) {
+      committers.push(committer);
+    }
+  }
+  if (payload.naia_resolution_update && typeof payload.naia_resolution_update === "object") {
+    const committer = hooks.createNaiaResolutionExecutionCommitter?.(
+      node,
+      payload.naia_resolution_update,
+    );
+    if (committer) {
+      committers.push(committer);
+    }
+  }
   hooks.consumePromptStudioExecution?.(
     node,
     message,

--- a/web/js/prompt_studio/extension_runtime.js
+++ b/web/js/prompt_studio/extension_runtime.js
@@ -98,6 +98,7 @@ import {
 import {
   remeasureAdvancedTextareaHeightsForWidth as remeasureAdvancedTextareaHeightsForWidthWithHooks,
   syncAdvancedLinkedFieldTextarea as syncAdvancedLinkedFieldTextareaWithHooks,
+  syncAdvancedNaiaFieldTextarea as syncAdvancedNaiaFieldTextareaWithHooks,
 } from "./advanced_fields_ui.js";
 import {
   disposeAdvancedAutocompleteInputs,
@@ -123,6 +124,14 @@ import {
   pruneDisconnectedAdvancedFieldInputValues,
 } from "./serialization.js";
 import {
+  ADVANCED_NAIA_RESOLUTION_SURFACE,
+  advancedNaiaFieldSurface,
+  captureAdvancedNaiaFieldSnapshots,
+  captureAdvancedNaiaResolutionSnapshot,
+  commitAdvancedNaiaFieldCanonical,
+  commitAdvancedNaiaResolution,
+} from "./naia_projection.js";
+import {
   getAdvancedFields,
 } from "./state.js";
 import {
@@ -145,6 +154,7 @@ import {
   createPromptStudioExecutionTransaction,
 } from "./execution_transaction.js";
 import {
+  commitAdvancedNaiaResolutionView,
   commitAdvancedWildcardSeedView,
 } from "./advanced_controls.js";
 
@@ -154,13 +164,22 @@ const PROMPT_STUDIO_GLOBAL_HOOK_RUNTIME_OWNER = Symbol.for(
 const PROMPT_STUDIO_WILDCARD_SEED_TRANSACTION_OWNER = Symbol.for(
   "easyuse-anima.prompt-studio.wildcard-seed-transaction",
 );
-const WILDCARD_SEED_EDIT_BINDINGS = [
+const PROMPT_STUDIO_EDIT_BINDINGS = [
   {
     widgetNames: [
       "wildcard_seed",
       "wildcard_seed_after_generate",
     ],
     surfaces: [WILDCARD_SEED_CONTROL_SURFACE],
+  },
+  {
+    widgetNames: [
+      "resolution_bucket",
+      "resolution_size",
+      "resolution_custom_width",
+      "resolution_custom_height",
+    ],
+    surfaces: [ADVANCED_NAIA_RESOLUTION_SURFACE],
   },
 ];
 
@@ -178,9 +197,9 @@ function createPromptStudioExtensionRuntime(app, api) {
     owner: queueUiTransactionOwner,
     executedContext: executedEventContext,
     findWidget,
-    editBindings: WILDCARD_SEED_EDIT_BINDINGS,
+    editBindings: PROMPT_STUDIO_EDIT_BINDINGS,
   });
-  const linkedSnapshotsByTransaction = new WeakMap();
+  const snapshotsByTransaction = new WeakMap();
   let advancedSaveSyncSerializeHost;
   let executionTransactionGraphHost;
 
@@ -223,6 +242,20 @@ function createPromptStudioExtensionRuntime(app, api) {
     );
   }
 
+  function syncAdvancedNaiaFieldTextarea(node, field, textarea, value) {
+    return syncAdvancedNaiaFieldTextareaWithHooks(
+      node,
+      field,
+      textarea,
+      value,
+      {
+        scheduleAdvancedFieldHighlight,
+        scheduleAdvancedLayout,
+        updateAdvancedFieldHighlight,
+      },
+    );
+  }
+
   function createLinkedExecutionCommitter(node, inputName, value) {
     const currentSnapshot = captureAdvancedLinkedFieldSnapshots(
       node,
@@ -235,7 +268,7 @@ function createPromptStudioExtensionRuntime(app, api) {
     return {
       surface: currentSnapshot.surface,
       commit: ({ transaction }) => {
-        const queuedSnapshot = (linkedSnapshotsByTransaction.get(transaction) || [])
+        const queuedSnapshot = (snapshotsByTransaction.get(transaction)?.linked || [])
           .find((snapshot) => snapshot.inputName === inputName);
         if (!queuedSnapshot) {
           return false;
@@ -248,12 +281,60 @@ function createPromptStudioExtensionRuntime(app, api) {
     };
   }
 
+  function createNaiaExecutionCommitter(node, fieldId, value) {
+    const currentSnapshot = captureAdvancedNaiaFieldSnapshots(
+      getAdvancedFields(node) || parseAdvancedFields(node),
+    ).find((snapshot) => snapshot.fieldId === fieldId);
+    if (!currentSnapshot) {
+      return null;
+    }
+    return {
+      surface: currentSnapshot.surface,
+      commit: ({ transaction }) => {
+        const queuedSnapshot = (snapshotsByTransaction.get(transaction)?.naia || [])
+          .find((snapshot) => snapshot.fieldId === fieldId);
+        if (!queuedSnapshot) {
+          return false;
+        }
+        return commitAdvancedNaiaFieldCanonical(node, queuedSnapshot, value, {
+          persistFields: (target, fields) => writeAdvancedFields(
+            target,
+            fields,
+            { syncInputs: false },
+          ),
+          commitView: syncAdvancedNaiaFieldTextarea,
+        });
+      },
+    };
+  }
+
+  function createNaiaResolutionExecutionCommitter(node, value) {
+    const currentSnapshot = captureAdvancedNaiaResolutionSnapshot(node);
+    if (!currentSnapshot) {
+      return null;
+    }
+    return {
+      surface: currentSnapshot.surface,
+      commit: ({ transaction }) => {
+        const queuedSnapshot = snapshotsByTransaction.get(transaction)?.resolution;
+        if (!queuedSnapshot) {
+          return false;
+        }
+        return commitAdvancedNaiaResolution(node, queuedSnapshot, value, {
+          commitView: commitAdvancedNaiaResolutionView,
+        });
+      },
+    };
+  }
+
   function advancedValuesHooks() {
     return {
       advancedWidget,
       commitAdvancedWildcardSeedView,
       consumePromptStudioExecution: executionTransaction.consumeExecution,
       createLinkedExecutionCommitter,
+      createNaiaExecutionCommitter,
+      createNaiaResolutionExecutionCommitter,
       markNodeDirty,
       parseAdvancedFields,
       repairAdvancedInternalWidgetValues,
@@ -461,25 +542,30 @@ function createPromptStudioExtensionRuntime(app, api) {
   function capturePromptStudioExecutionQueue() {
     const snapshotsByNode = new Map();
     const entries = (app.graph?._nodes || []).filter(isAdvancedNode).map((node) => {
-      const snapshots = captureAdvancedLinkedFieldSnapshots(
+      const fields = getAdvancedFields(node) || parseAdvancedFields(node);
+      const linked = captureAdvancedLinkedFieldSnapshots(
         node,
-        getAdvancedFields(node) || parseAdvancedFields(node),
+        fields,
         app.graph,
       );
-      snapshotsByNode.set(node, snapshots);
+      const naia = captureAdvancedNaiaFieldSnapshots(fields);
+      const resolution = captureAdvancedNaiaResolutionSnapshot(node);
+      snapshotsByNode.set(node, { linked, naia, resolution });
       return {
         node,
         surfaces: [
           WILDCARD_SEED_CONTROL_SURFACE,
-          ...snapshots.map((snapshot) => snapshot.surface),
+          ...linked.map((snapshot) => snapshot.surface),
+          ...naia.map((snapshot) => snapshot.surface),
+          ...(resolution ? [resolution.surface] : []),
         ],
       };
     });
     const captured = executionTransaction.captureQueue(entries);
     for (const entry of captured) {
-      linkedSnapshotsByTransaction.set(
+      snapshotsByTransaction.set(
         entry.transaction,
-        snapshotsByNode.get(entry.node) || [],
+        snapshotsByNode.get(entry.node) || { linked: [], naia: [], resolution: null },
       );
     }
     return captured;
@@ -533,10 +619,9 @@ function createPromptStudioExtensionRuntime(app, api) {
   }
 
   function markAdvancedFieldEdited(node, field) {
-    if (field?.type === "naia") {
-      return false;
-    }
-    const surface = advancedLinkedFieldSurface(field?.id);
+    const surface = field?.type === "naia"
+      ? advancedNaiaFieldSurface(field?.id)
+      : advancedLinkedFieldSurface(field?.id);
     return surface != null && executionTransaction.markEdited(node, [surface]);
   }
 

--- a/web/js/prompt_studio/naia_projection.js
+++ b/web/js/prompt_studio/naia_projection.js
@@ -1,0 +1,148 @@
+// @ts-check
+
+import {
+  NAIA_ADVANCED_RESOLUTION_BUCKET,
+} from "./constants.js";
+import {
+  getAdvancedEditorElement,
+  getAdvancedFields,
+} from "./state.js";
+import {
+  findWidget,
+} from "./widgets.js";
+
+const ADVANCED_NAIA_RESOLUTION_SURFACE = "prompt.execution.naia_resolution";
+
+function advancedNaiaFieldSurface(fieldId) {
+  const normalized = String(fieldId || "").trim();
+  return normalized ? `prompt.execution.naia:${normalized}` : null;
+}
+
+function captureAdvancedNaiaFieldSnapshots(fields) {
+  const snapshots = [];
+  for (const field of fields || []) {
+    if (field?.type !== "naia" || field?.enabled === false) {
+      continue;
+    }
+    const surface = advancedNaiaFieldSurface(field?.id);
+    if (surface == null) {
+      continue;
+    }
+    snapshots.push(Object.freeze({
+      fieldId: String(field.id),
+      pane: String(field.pane || "positive"),
+      type: "naia",
+      enabled: true,
+      text: String(field.text || ""),
+      surface,
+    }));
+  }
+  return snapshots;
+}
+
+function currentAdvancedNaiaField(node, snapshot) {
+  if (!snapshot || typeof snapshot !== "object") {
+    return null;
+  }
+  const field = (getAdvancedFields(node) || []).find(
+    (candidate) => candidate?.id === snapshot.fieldId,
+  );
+  if (
+    !field
+    || String(field.pane || "positive") !== snapshot.pane
+    || String(field.type || "general") !== snapshot.type
+    || (field.enabled !== false) !== snapshot.enabled
+    || String(field.text || "") !== snapshot.text
+  ) {
+    return null;
+  }
+  return field;
+}
+
+function commitAdvancedNaiaFieldCanonical(
+  node,
+  snapshot,
+  value,
+  { persistFields = null, commitView = null } = {},
+) {
+  const field = currentAdvancedNaiaField(node, snapshot);
+  if (!field) {
+    return false;
+  }
+  const text = String(value ?? "");
+  field.text = text;
+  const fields = getAdvancedFields(node) || [];
+  persistFields?.(node, fields);
+  const editor = getAdvancedEditorElement(node);
+  const textarea = [...(editor?.querySelectorAll?.(
+    "textarea[data-easyuse-anima-advanced-field-id]",
+  ) || [])].find((candidate) => (
+    String(candidate?.dataset?.easyuseAnimaAdvancedFieldId || "") === snapshot.fieldId
+  ));
+  commitView?.(node, field, textarea || null, text);
+  return true;
+}
+
+function advancedNaiaResolutionSnapshot(node) {
+  return {
+    bucket: String(findWidget(node, "resolution_bucket")?.value ?? ""),
+    size: String(findWidget(node, "resolution_size")?.value ?? ""),
+    customWidth: String(findWidget(node, "resolution_custom_width")?.value ?? ""),
+    customHeight: String(findWidget(node, "resolution_custom_height")?.value ?? ""),
+  };
+}
+
+function captureAdvancedNaiaResolutionSnapshot(node) {
+  const snapshot = advancedNaiaResolutionSnapshot(node);
+  if (snapshot.bucket !== NAIA_ADVANCED_RESOLUTION_BUCKET) {
+    return null;
+  }
+  return Object.freeze({
+    ...snapshot,
+    surface: ADVANCED_NAIA_RESOLUTION_SURFACE,
+  });
+}
+
+function currentAdvancedNaiaResolution(node, snapshot) {
+  if (!snapshot || typeof snapshot !== "object") {
+    return false;
+  }
+  const current = advancedNaiaResolutionSnapshot(node);
+  return current.bucket === NAIA_ADVANCED_RESOLUTION_BUCKET
+    && current.bucket === snapshot.bucket
+    && current.size === snapshot.size
+    && current.customWidth === snapshot.customWidth
+    && current.customHeight === snapshot.customHeight;
+}
+
+function commitAdvancedNaiaResolution(
+  node,
+  snapshot,
+  value,
+  { commitView = null } = {},
+) {
+  const width = Number(value?.width);
+  const height = Number(value?.height);
+  if (
+    !currentAdvancedNaiaResolution(node, snapshot)
+    || !Number.isFinite(width)
+    || !Number.isFinite(height)
+    || width <= 0
+    || height <= 0
+    || typeof commitView !== "function"
+  ) {
+    return false;
+  }
+  return commitView(node, width, height) !== false;
+}
+
+export {
+  ADVANCED_NAIA_RESOLUTION_SURFACE,
+  advancedNaiaFieldSurface,
+  captureAdvancedNaiaFieldSnapshots,
+  captureAdvancedNaiaResolutionSnapshot,
+  commitAdvancedNaiaFieldCanonical,
+  commitAdvancedNaiaResolution,
+  currentAdvancedNaiaField,
+  currentAdvancedNaiaResolution,
+};


### PR DESCRIPTION
## 목적과 변경 경계

- Issue #470 QSTATE-04C4에 따라 latest accepted NAIA execution delta만 Prompt Studio canonical state로 반영합니다.
- positive/negative NAIA field와 NAIA resolution을 exact 값으로 저장하고, 관련 없는 field/Artist Mix 상태를 보존합니다.
- field edit/structure revision과 resolution revision을 독립적으로 gate하며 broad editor rerender를 피합니다.

## Base -> Head

- `2e8b356afe107ebc3208c6708795629e1860d07b` -> `4ac9aef7525042fa517ef5e716b25d5138d27200`

## 주요 파일과 보존 계약

- `web/js/prompt_studio/naia_projection.js`: NAIA field/resolution capture, current, canonical commit 계약
- `web/js/prompt_studio/extension_runtime.js`: transaction별 linked/NAIA/resolution snapshot과 revision ownership
- `web/js/prompt_studio/advanced_fields_ui.js`: exact NAIA textarea만 동기화하며 editability 보존
- `web/js/prompt_studio/advanced_controls.js`: NAIA resolution을 custom width/height/size에 원자적으로 반영
- `tests/frontend_prompt_studio_naia_projection_smoke.mjs`: Q1/Q2/Q3, newer failure no fallback, edit/structure/type/pane/resolution fail-closed fixture

보존 계약:

- unrelated field와 Artist Mix 설정 보존
- NAIA field는 canonical persistence 후에도 editable/non-linked 유지
- 최신 accepted queue만 field/resolution을 소유하며 older fallback 금지
- linked projection과 Wildcard transaction parity 유지

## 검증

- changed-file `node --check`, Python compile, PowerShell parser 통과
- NAIA canonical projection / execution projection / linked projection / execution transaction and Wildcard parity smoke 통과
- resolution orientation, narrow Wildcard view-sync, Classic/Extend, paste autosize smoke 통과
- Prompt Studio module boundary unittest 2개 통과
- TypeScript 6.0.3 통과
- Node 2.0 live: positive/negative canonical, 832x1216 resolution, unrelated field/Artist Mix 보존, workflow 저장/재로드 통과
- Node 2.0 rapid Q1/Q2/Q3: 서버 요청 3개, canvas/save에는 Q3와 896x1152만 반영
- Legacy live: cache-miss NAIA canonical, unrelated field/Artist Mix 보존, workflow 저장/재로드 통과
- 테스트 인스턴스 Node 2.0 설정 원래 값 `false` 복구 확인
- final SHA official full 정확히 1회 통과: Python 1241, frontend 120, TypeScript 6.0.3, `git diff --check`

## 남은 위험과 rollback

- 테스트 인스턴스의 다른 custom node에서 기존 `WIDGET_*` Node 2.0 오류 알림이 발생했으나 Prompt Studio projection과 저장 계약은 통과했습니다.
- rollback은 이 PR의 단일 기능 commit을 revert합니다.

## Next task

- QSTATE-04C5 integrated dev SHA에서 full/package/Legacy+Node 2.0 live matrix를 수행합니다.
