### PR TITLE
refactor: D-02 API contract canonical Move

### DIFF
--- a/api.py
+++ b/api.py
@@ -48,18 +48,20 @@ from .easyuse_anima.translation.contracts import (
 from .easyuse_anima.translation.service import (
     translate_prompt_markers,
 )
-from .api_contract import (
-    ApiContractError,
-    attach_request_id_header,
-    correlate_response,
-    create_request_id,
-    error_payload,
+from .easyuse_anima.api.errors import ApiContractError
+from .easyuse_anima.api.requests import (
     json_boolean,
     json_integer,
     json_object,
     json_string,
     json_uuid_string,
     parse_json_object,
+)
+from .easyuse_anima.api.responses import (
+    attach_request_id_header,
+    correlate_response,
+    create_request_id,
+    error_payload,
 )
 from .easyuse_anima.aio.torch_compile_diagnostics import (
     collect_torch_compile_diagnostics as _collect_torch_compile_diagnostics,

--- a/api_contract.py
+++ b/api_contract.py
@@ -1,199 +1,54 @@
+"""Compatibility exports for the canonical API contract package."""
+
 from __future__ import annotations
 
-import json
-import uuid
-from typing import Any, Mapping
-
-
-REQUEST_ID_HEADER = "X-Request-ID"
-
-
-class ApiContractError(ValueError):
-    """A public request-contract error with a stable HTTP mapping."""
-
-    def __init__(
-        self,
-        status: int,
-        code: str,
-        message: str,
-        *,
-        details: Mapping[str, Any] | None = None,
-    ) -> None:
-        super().__init__(message)
-        self.status = status
-        self.code = code
-        self.message = message
-        self.details = dict(details) if details is not None else None
-
-
-def error_payload(
-    code: str,
-    message: str,
-    *,
-    details: Mapping[str, Any] | None = None,
-) -> dict[str, Any]:
-    """Keep the legacy status/message shape while adding a stable code."""
-
-    payload: dict[str, Any] = {
-        "status": "error",
-        "code": code,
-        "message": message,
-    }
-    if details is not None:
-        payload["details"] = dict(details)
-    return payload
-
-
-def create_request_id() -> str:
-    """Create one server-owned correlation ID for an API request."""
-
-    return str(uuid.uuid4())
-
-
-def attach_request_id_header(response, request_id: str):
-    """Attach correlation metadata without requiring a global middleware."""
-
-    headers = getattr(response, "headers", None)
-    if headers is not None:
-        headers[REQUEST_ID_HEADER] = request_id
-    return response
-
-
-def correlate_response(response, request_id: str):
-    """Correlate JSON errors while preserving non-JSON response bodies."""
-
-    attach_request_id_header(response, request_id)
-    if (
-        getattr(response, "status", 0) < 400
-        or getattr(response, "content_type", "") != "application/json"
-    ):
-        return response
-
-    try:
-        payload = json.loads(response.text)
-    except (AttributeError, json.JSONDecodeError, TypeError, UnicodeDecodeError):
-        return response
-    if not isinstance(payload, dict):
-        return response
-
-    payload["request_id"] = request_id
-    response.text = json.dumps(payload, ensure_ascii=False)
-    return response
-
-
-async def parse_json_object(request) -> dict[str, Any]:
-    try:
-        data = await request.json()
-    except (json.JSONDecodeError, UnicodeDecodeError, ValueError) as exc:
-        raise ApiContractError(
-            400,
-            "malformed_json",
-            "Request body must contain valid JSON.",
-        ) from exc
-    if not isinstance(data, dict):
-        raise ApiContractError(
-            400,
-            "json_object_required",
-            "Request body must be a JSON object.",
-        )
-    return data
-
-
-def _field_error(field: str, expectation: str) -> ApiContractError:
-    return ApiContractError(
-        422,
-        "invalid_request",
-        f"{field} must be {expectation}.",
-        details={"field": field},
+try:
+    from .easyuse_anima.api.errors import ApiContractError
+    from .easyuse_anima.api.requests import (
+        json_boolean,
+        json_integer,
+        json_object,
+        json_string,
+        json_uuid_string,
+        parse_json_object,
+    )
+    from .easyuse_anima.api.responses import (
+        REQUEST_ID_HEADER,
+        attach_request_id_header,
+        correlate_response,
+        create_request_id,
+        error_payload,
+    )
+except ImportError:
+    from easyuse_anima.api.errors import ApiContractError
+    from easyuse_anima.api.requests import (
+        json_boolean,
+        json_integer,
+        json_object,
+        json_string,
+        json_uuid_string,
+        parse_json_object,
+    )
+    from easyuse_anima.api.responses import (
+        REQUEST_ID_HEADER,
+        attach_request_id_header,
+        correlate_response,
+        create_request_id,
+        error_payload,
     )
 
 
-def json_object(
-    data: Mapping[str, Any],
-    field: str,
-    *,
-    required: bool = True,
-    default: Mapping[str, Any] | None = None,
-) -> dict[str, Any]:
-    if field not in data:
-        if required:
-            raise _field_error(field, "a JSON object")
-        return dict(default or {})
-    value = data[field]
-    if not isinstance(value, dict):
-        raise _field_error(field, "a JSON object")
-    return value
-
-
-def json_string(
-    data: Mapping[str, Any],
-    field: str,
-    *,
-    required: bool = True,
-    default: str = "",
-    allow_empty: bool = True,
-) -> str:
-    if field not in data:
-        if required:
-            raise _field_error(field, "a JSON string")
-        return default
-    value = data[field]
-    if not isinstance(value, str):
-        raise _field_error(field, "a JSON string")
-    if not allow_empty and not value.strip():
-        raise _field_error(field, "a non-empty JSON string")
-    return value
-
-
-def json_boolean(
-    data: Mapping[str, Any],
-    field: str,
-    *,
-    default: bool = False,
-) -> bool:
-    if field not in data:
-        return default
-    value = data[field]
-    if type(value) is not bool:
-        raise _field_error(field, "a JSON boolean")
-    return value
-
-
-def json_integer(
-    data: Mapping[str, Any],
-    field: str,
-    *,
-    default: int | None,
-    minimum: int | None = None,
-    maximum: int | None = None,
-) -> int | None:
-    if field not in data:
-        return default
-    value = data[field]
-    if type(value) is not int:
-        raise _field_error(field, "a JSON integer")
-    if minimum is not None and value < minimum:
-        raise _field_error(field, f"an integer greater than or equal to {minimum}")
-    if maximum is not None and value > maximum:
-        raise _field_error(field, f"an integer less than or equal to {maximum}")
-    return value
-
-
-def json_uuid_string(
-    data: Mapping[str, Any],
-    field: str,
-    *,
-    required: bool = True,
-    default: str | None = None,
-) -> str | None:
-    if field not in data:
-        if required:
-            raise _field_error(field, "a UUID string")
-        return default
-    value = data[field]
-    if not isinstance(value, str):
-        raise _field_error(field, "a UUID string")
-    try:
-        return str(uuid.UUID(value))
-    except (AttributeError, ValueError) as exc:
-        raise _field_error(field, "a UUID string") from exc
+__all__ = [
+    "REQUEST_ID_HEADER",
+    "ApiContractError",
+    "error_payload",
+    "create_request_id",
+    "attach_request_id_header",
+    "correlate_response",
+    "parse_json_object",
+    "json_object",
+    "json_string",
+    "json_boolean",
+    "json_integer",
+    "json_uuid_string",
+]

--- a/docs/architecture/python-backend-execution-roadmap.md
+++ b/docs/architecture/python-backend-execution-roadmap.md
@@ -33,7 +33,7 @@ merged PR, the owning issue's evidence record, and every stated exit gate.
 | A - baseline | Complete; #191 is closed | Keep fixtures and analyzers current during later moves |
 | B - `nodes.py` extraction | Complete in B-11d / PR #356 | Preserve the audited compatibility shim until ADR-002 retirement gates are met |
 | C - feature contracts/behavior | Partially complete through S167-01a / PR #344 | Continue #167 and #169 in separate Contract/Move/Behavior PRs |
-| D - root consolidation | D-01, D-08, D-09, D-10, D-11, D-12, and D-13 complete or in promotion | Re-evaluate the D-02 through D-07 API route sequence and D-14 gates |
+| D - root consolidation | D-01, D-02, and D-08 through D-13 complete or in promotion | Inventory the smallest D-03 feature-route leaf; keep D-14 gated |
 | E - runtime ownership | Partial: E-02a and E-07a/E-07b integrated | Continue #187 only where canonical feature owners and explicit contracts exist |
 | F - typed boundaries | Partial patterns exist | Extend typed request/result/config and pure migration patterns feature by feature |
 | G - quality ratchet | G-01, G-02a/G-02b, and G-03a complete | Extend G-03 enrollment, then continue with G-04 through G-06 |
@@ -408,7 +408,7 @@ mechanical retirement series.
 | 15 | S167 backend seed reservation series | S167-01 through S167-03d COMPLETE on `dev`; S167-03e AiO cutover VALIDATED with isolated API/module/browser-load parity | Contract then Move then Behavior | #167 | Canonical AiO/node seams |
 | 16 | A169 stage pipeline series | A169-01 through A169-08 MERGED; A169-09 final adapter/integration VALIDATED in PR #372 | Contract then Behavior | #169 | Typed config and mechanical AiO move |
 | 17 | A169 first-pass cache policy | COMPLETE through CACHE-06; 4K/batch evidence VALIDATED in PR #380 | Contract then Behavior | #169 | Mechanical cache move and stable stage seam |
-| 18 | D-series canonical root consolidation | D-01 translation, D-08 filesystem, D-09 settings, D-10 profiles, D-11 autocomplete, D-12 wildcard, and D-13 ANIMA prompt COMPLETE or in promotion | Re-evaluate D-02 through D-07 and D-14 | #186 | Phase B exit; per-feature behavior stable |
+| 18 | D-series canonical root consolidation | D-01 translation, D-02 API contracts, D-08 filesystem, D-09 settings, D-10 profiles, D-11 autocomplete, D-12 wildcard, and D-13 ANIMA prompt COMPLETE or in promotion | Inventory the smallest D-03 feature-route leaf; keep D-14 gated | #186 | Phase B exit; per-feature behavior stable |
 | 19 | E-series RuntimeServices/lifecycle | BLOCKED by canonical owners | Move/Contract, split PRs | #187 | Relevant D moves |
 | 20 | G-04 through G-06 and H | INCREMENTAL/LATER | Gate/Contract | #188 | Appropriate package and release evidence |
 
@@ -1324,6 +1324,14 @@ Every D PR moves one root implementation surface, updates internal consumers to
 the canonical path, leaves an explicit root shim, and proves root/canonical
 identity plus packed-archive closure. Behavior, error semantics, migration,
 ranking, async, and cache changes remain in their owner issues.
+
+D-02 moves the stable #165 request validators, public contract error, error
+payload, and request-correlation helpers from root `api_contract.py` to
+`easyuse_anima.api.requests`, `.errors`, and `.responses`. Root
+`api_contract.py` remains an explicit 12-symbol identity shim and `api.py`
+imports the canonical owners directly. Route handlers, registration, bounded
+file-I/O, redaction, and error semantics remain root-owned until D-03 through
+D-07. The canonical contract package becomes the eleventh G-03 completed group.
 
 D-11 is split by dependency ownership. D-11a moves the SQLite index leaf to
 `easyuse_anima.autocomplete.index`, retains `autocomplete_index.py` as an

--- a/docs/architecture/python-compatibility-shims.md
+++ b/docs/architecture/python-compatibility-shims.md
@@ -59,7 +59,7 @@ import them.
 | Root `__init__.py` exports | Permanent ComfyUI entrypoint, not a shim | root entrypoint plus `easyuse_anima.registration`/`bootstrap` | #184/#185 | Existing 0.5.2 surface; B-11 rewires internals | ComfyUI loader; node contract fixture | Not removable as a package entrypoint |
 | `nodes.py` mapped public classes | 18 direct compatibility re-exports plus audited private/residual debt | `easyuse_anima.nodes.*_nodes` | #184 B-04 through B-11, #188 | Existing 0.5.2 surface; B-04 through B-09b2 canonicalized all mapped adapters; B-11 completes the shim | Root mappings and workflows; repository tests are not public-support evidence; no confirmed external direct importer | No scheduled removal; public breaking-change gate after N+1 at earliest |
 | `api.py` route-registration surface | Current route implementation plus explicit D-10 profile aliases; planned API shim | `easyuse_anima.profiles.*`, then `easyuse_anima.api.router` and `easyuse_anima.api.routes.*` | #163, #165, #186 D-10/D-02-D-07 | Existing 0.5.2 route surface; profile implementation canonicalized in D-10; route conversion remains D-02-D-07/D-14 | Root entrypoint side-effect import, frontend endpoints, profile/API tests | Unscheduled; N+1 gate and route parity |
-| `api_contract.py` request/error helpers | Phase C temporary implementation; D-02 move and D-14 shim decision pending | `easyuse_anima.api.requests`, `responses`, and `errors` | #165, #186 D-02/D-14 | Introduced by #165; convert in D-02 and freeze any required root shim in D-14 | `api.py`, API contract tests, Registry package-closure test | Unscheduled; internal consumers canonical and contract/package parity pass |
+| `api_contract.py` request/error helpers | Explicit 12-symbol request/error/response identity shim (D-02); D-14 freeze decision pending | `easyuse_anima.api.requests`, `.responses`, and `.errors` | #165, #186 D-02/D-14 | #165 contract canonicalized in D-02; exact root surface and flat/package identity fixture | External/legacy imports and compatibility tests; production `api.py` uses canonical owners | Unscheduled; first canonical+shim release N not yet recorded, then D-14/N+1 gate and request/error/frontend parity |
 | `settings.py` | Explicit direct re-export shim (D-09) | `easyuse_anima.settings.schema`, `.repository`, and `.service` | #163, #186 D-09 | Existing 0.5.2 module-owned public surface; exact `__all__` and identity fixture | External/legacy imports and settings compatibility tests; production callers use canonical modules | Unscheduled; first canonical+shim release N not yet recorded, then N+1 gate and settings migration/round-trip |
 | `storage.py` | Explicit direct re-export shim (D-08) | `easyuse_anima.infrastructure.filesystem.atomic_json` and `.paths` | #163, #186 D-08 | Existing 0.5.2 supported module-owned public surface; exact `__all__` and identity fixture | External/legacy imports and storage compatibility tests; production callers use canonical modules | Unscheduled; first canonical+shim release N not yet recorded, then N+1 gate and last-known-good/atomic-write parity |
 | `autocomplete_index.py` | Explicit direct re-export shim (D-11a) | `easyuse_anima.autocomplete.index` | #162, #186 D-11a | Existing indexed-search surface; exact seven-name `__all__` and identity fixture | External/legacy imports; `autocomplete_dataset.py` now uses the canonical owner | Unscheduled; first canonical+shim release N not yet recorded, then N+1 gate and index/ranking/rebuild parity |
@@ -1377,10 +1377,11 @@ EasyUseAnimaWildcard
 
 - Candidate scope: the internal JSON-object parser, typed field validators,
   stable error type, and additive error-payload helper introduced by #165.
-- State: temporary Phase C root implementation, not a declared public Python
-  API. D-02 moves the implementation and `api.py` consumer to
-  `easyuse_anima.api.requests`, `responses`, and `errors`; D-14 decides whether
-  consumer evidence requires a supported root re-export shim.
+- State: D-02 moves the implementation and `api.py` consumer to
+  `easyuse_anima.api.requests`, `.responses`, and `.errors`. Root
+  `api_contract.py` retains an explicit 12-symbol identity shim; D-14 decides
+  whether consumer evidence requires retaining that supported surface after the
+  first canonical+shim release.
 - Removal gate: the #165 request/error and frontend compatibility matrices pass,
   internal imports are canonical, and the actual Registry package retains
   import closure. If a root shim is retained, ADR-002 identity and N+1 gates

--- a/easyuse_anima/api/__init__.py
+++ b/easyuse_anima/api/__init__.py
@@ -1,0 +1,3 @@
+"""Pure request and response contracts for EasyUse Anima API adapters."""
+
+__all__ = []

--- a/easyuse_anima/api/errors.py
+++ b/easyuse_anima/api/errors.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from typing import Any, Mapping
+
+
+class ApiContractError(ValueError):
+    """A public request-contract error with a stable HTTP mapping."""
+
+    def __init__(
+        self,
+        status: int,
+        code: str,
+        message: str,
+        *,
+        details: Mapping[str, Any] | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.status = status
+        self.code = code
+        self.message = message
+        self.details = dict(details) if details is not None else None
+
+
+def _field_error(field: str, expectation: str) -> ApiContractError:
+    return ApiContractError(
+        422,
+        "invalid_request",
+        f"{field} must be {expectation}.",
+        details={"field": field},
+    )
+
+
+__all__ = ("ApiContractError",)

--- a/easyuse_anima/api/requests.py
+++ b/easyuse_anima/api/requests.py
@@ -1,0 +1,126 @@
+from __future__ import annotations
+
+import json
+import uuid
+from typing import Any, Mapping
+
+from .errors import ApiContractError, _field_error
+
+
+async def parse_json_object(request) -> dict[str, Any]:
+    try:
+        data = await request.json()
+    except (json.JSONDecodeError, UnicodeDecodeError, ValueError) as exc:
+        raise ApiContractError(
+            400,
+            "malformed_json",
+            "Request body must contain valid JSON.",
+        ) from exc
+    if not isinstance(data, dict):
+        raise ApiContractError(
+            400,
+            "json_object_required",
+            "Request body must be a JSON object.",
+        )
+    return data
+
+
+def json_object(
+    data: Mapping[str, Any],
+    field: str,
+    *,
+    required: bool = True,
+    default: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    if field not in data:
+        if required:
+            raise _field_error(field, "a JSON object")
+        return dict(default or {})
+    value = data[field]
+    if not isinstance(value, dict):
+        raise _field_error(field, "a JSON object")
+    return value
+
+
+def json_string(
+    data: Mapping[str, Any],
+    field: str,
+    *,
+    required: bool = True,
+    default: str = "",
+    allow_empty: bool = True,
+) -> str:
+    if field not in data:
+        if required:
+            raise _field_error(field, "a JSON string")
+        return default
+    value = data[field]
+    if not isinstance(value, str):
+        raise _field_error(field, "a JSON string")
+    if not allow_empty and not value.strip():
+        raise _field_error(field, "a non-empty JSON string")
+    return value
+
+
+def json_boolean(
+    data: Mapping[str, Any],
+    field: str,
+    *,
+    default: bool = False,
+) -> bool:
+    if field not in data:
+        return default
+    value = data[field]
+    if type(value) is not bool:
+        raise _field_error(field, "a JSON boolean")
+    return value
+
+
+def json_integer(
+    data: Mapping[str, Any],
+    field: str,
+    *,
+    default: int | None,
+    minimum: int | None = None,
+    maximum: int | None = None,
+) -> int | None:
+    if field not in data:
+        return default
+    value = data[field]
+    if type(value) is not int:
+        raise _field_error(field, "a JSON integer")
+    if minimum is not None and value < minimum:
+        raise _field_error(field, f"an integer greater than or equal to {minimum}")
+    if maximum is not None and value > maximum:
+        raise _field_error(field, f"an integer less than or equal to {maximum}")
+    return value
+
+
+def json_uuid_string(
+    data: Mapping[str, Any],
+    field: str,
+    *,
+    required: bool = True,
+    default: str | None = None,
+) -> str | None:
+    if field not in data:
+        if required:
+            raise _field_error(field, "a UUID string")
+        return default
+    value = data[field]
+    if not isinstance(value, str):
+        raise _field_error(field, "a UUID string")
+    try:
+        return str(uuid.UUID(value))
+    except (AttributeError, ValueError) as exc:
+        raise _field_error(field, "a UUID string") from exc
+
+
+__all__ = (
+    "parse_json_object",
+    "json_object",
+    "json_string",
+    "json_boolean",
+    "json_integer",
+    "json_uuid_string",
+)

--- a/easyuse_anima/api/responses.py
+++ b/easyuse_anima/api/responses.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+import json
+import uuid
+from typing import Any, Mapping
+
+
+REQUEST_ID_HEADER = "X-Request-ID"
+
+
+def error_payload(
+    code: str,
+    message: str,
+    *,
+    details: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Keep the legacy status/message shape while adding a stable code."""
+
+    payload: dict[str, Any] = {
+        "status": "error",
+        "code": code,
+        "message": message,
+    }
+    if details is not None:
+        payload["details"] = dict(details)
+    return payload
+
+
+def create_request_id() -> str:
+    """Create one server-owned correlation ID for an API request."""
+
+    return str(uuid.uuid4())
+
+
+def attach_request_id_header(response, request_id: str):
+    """Attach correlation metadata without requiring a global middleware."""
+
+    headers = getattr(response, "headers", None)
+    if headers is not None:
+        headers[REQUEST_ID_HEADER] = request_id
+    return response
+
+
+def correlate_response(response, request_id: str):
+    """Correlate JSON errors while preserving non-JSON response bodies."""
+
+    attach_request_id_header(response, request_id)
+    if (
+        getattr(response, "status", 0) < 400
+        or getattr(response, "content_type", "") != "application/json"
+    ):
+        return response
+
+    try:
+        payload = json.loads(response.text)
+    except (AttributeError, json.JSONDecodeError, TypeError, UnicodeDecodeError):
+        return response
+    if not isinstance(payload, dict):
+        return response
+
+    payload["request_id"] = request_id
+    response.text = json.dumps(payload, ensure_ascii=False)
+    return response
+
+
+__all__ = (
+    "REQUEST_ID_HEADER",
+    "error_payload",
+    "create_request_id",
+    "attach_request_id_header",
+    "correlate_response",
+)

--- a/tests/fixtures/python_backend_baseline.json
+++ b/tests/fixtures/python_backend_baseline.json
@@ -3441,88 +3441,16 @@
         "classification": "internal",
         "column": 0,
         "conditional": false,
-        "imported": ".api_contract:ApiContractError",
+        "imported": ".easyuse_anima.api.errors:ApiContractError",
         "kind": "static_from",
         "line": 51,
         "name": "ApiContractError",
         "optional": false,
-        "requested": ".api_contract",
+        "requested": ".easyuse_anima.api.errors",
         "role": "ordinary",
         "scope": "<module>",
         "source": "api.py",
-        "target": "api_contract.py"
-      },
-      {
-        "alias": null,
-        "bound_name": "attach_request_id_header",
-        "branch_context": [],
-        "classification": "internal",
-        "column": 0,
-        "conditional": false,
-        "imported": ".api_contract:attach_request_id_header",
-        "kind": "static_from",
-        "line": 51,
-        "name": "attach_request_id_header",
-        "optional": false,
-        "requested": ".api_contract",
-        "role": "ordinary",
-        "scope": "<module>",
-        "source": "api.py",
-        "target": "api_contract.py"
-      },
-      {
-        "alias": null,
-        "bound_name": "correlate_response",
-        "branch_context": [],
-        "classification": "internal",
-        "column": 0,
-        "conditional": false,
-        "imported": ".api_contract:correlate_response",
-        "kind": "static_from",
-        "line": 51,
-        "name": "correlate_response",
-        "optional": false,
-        "requested": ".api_contract",
-        "role": "ordinary",
-        "scope": "<module>",
-        "source": "api.py",
-        "target": "api_contract.py"
-      },
-      {
-        "alias": null,
-        "bound_name": "create_request_id",
-        "branch_context": [],
-        "classification": "internal",
-        "column": 0,
-        "conditional": false,
-        "imported": ".api_contract:create_request_id",
-        "kind": "static_from",
-        "line": 51,
-        "name": "create_request_id",
-        "optional": false,
-        "requested": ".api_contract",
-        "role": "ordinary",
-        "scope": "<module>",
-        "source": "api.py",
-        "target": "api_contract.py"
-      },
-      {
-        "alias": null,
-        "bound_name": "error_payload",
-        "branch_context": [],
-        "classification": "internal",
-        "column": 0,
-        "conditional": false,
-        "imported": ".api_contract:error_payload",
-        "kind": "static_from",
-        "line": 51,
-        "name": "error_payload",
-        "optional": false,
-        "requested": ".api_contract",
-        "role": "ordinary",
-        "scope": "<module>",
-        "source": "api.py",
-        "target": "api_contract.py"
+        "target": "easyuse_anima/api/errors.py"
       },
       {
         "alias": null,
@@ -3531,16 +3459,16 @@
         "classification": "internal",
         "column": 0,
         "conditional": false,
-        "imported": ".api_contract:json_boolean",
+        "imported": ".easyuse_anima.api.requests:json_boolean",
         "kind": "static_from",
-        "line": 51,
+        "line": 52,
         "name": "json_boolean",
         "optional": false,
-        "requested": ".api_contract",
+        "requested": ".easyuse_anima.api.requests",
         "role": "ordinary",
         "scope": "<module>",
         "source": "api.py",
-        "target": "api_contract.py"
+        "target": "easyuse_anima/api/requests.py"
       },
       {
         "alias": null,
@@ -3549,16 +3477,16 @@
         "classification": "internal",
         "column": 0,
         "conditional": false,
-        "imported": ".api_contract:json_integer",
+        "imported": ".easyuse_anima.api.requests:json_integer",
         "kind": "static_from",
-        "line": 51,
+        "line": 52,
         "name": "json_integer",
         "optional": false,
-        "requested": ".api_contract",
+        "requested": ".easyuse_anima.api.requests",
         "role": "ordinary",
         "scope": "<module>",
         "source": "api.py",
-        "target": "api_contract.py"
+        "target": "easyuse_anima/api/requests.py"
       },
       {
         "alias": null,
@@ -3567,16 +3495,16 @@
         "classification": "internal",
         "column": 0,
         "conditional": false,
-        "imported": ".api_contract:json_object",
+        "imported": ".easyuse_anima.api.requests:json_object",
         "kind": "static_from",
-        "line": 51,
+        "line": 52,
         "name": "json_object",
         "optional": false,
-        "requested": ".api_contract",
+        "requested": ".easyuse_anima.api.requests",
         "role": "ordinary",
         "scope": "<module>",
         "source": "api.py",
-        "target": "api_contract.py"
+        "target": "easyuse_anima/api/requests.py"
       },
       {
         "alias": null,
@@ -3585,16 +3513,16 @@
         "classification": "internal",
         "column": 0,
         "conditional": false,
-        "imported": ".api_contract:json_string",
+        "imported": ".easyuse_anima.api.requests:json_string",
         "kind": "static_from",
-        "line": 51,
+        "line": 52,
         "name": "json_string",
         "optional": false,
-        "requested": ".api_contract",
+        "requested": ".easyuse_anima.api.requests",
         "role": "ordinary",
         "scope": "<module>",
         "source": "api.py",
-        "target": "api_contract.py"
+        "target": "easyuse_anima/api/requests.py"
       },
       {
         "alias": null,
@@ -3603,16 +3531,16 @@
         "classification": "internal",
         "column": 0,
         "conditional": false,
-        "imported": ".api_contract:json_uuid_string",
+        "imported": ".easyuse_anima.api.requests:json_uuid_string",
         "kind": "static_from",
-        "line": 51,
+        "line": 52,
         "name": "json_uuid_string",
         "optional": false,
-        "requested": ".api_contract",
+        "requested": ".easyuse_anima.api.requests",
         "role": "ordinary",
         "scope": "<module>",
         "source": "api.py",
-        "target": "api_contract.py"
+        "target": "easyuse_anima/api/requests.py"
       },
       {
         "alias": null,
@@ -3621,16 +3549,88 @@
         "classification": "internal",
         "column": 0,
         "conditional": false,
-        "imported": ".api_contract:parse_json_object",
+        "imported": ".easyuse_anima.api.requests:parse_json_object",
         "kind": "static_from",
-        "line": 51,
+        "line": 52,
         "name": "parse_json_object",
         "optional": false,
-        "requested": ".api_contract",
+        "requested": ".easyuse_anima.api.requests",
         "role": "ordinary",
         "scope": "<module>",
         "source": "api.py",
-        "target": "api_contract.py"
+        "target": "easyuse_anima/api/requests.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "attach_request_id_header",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".easyuse_anima.api.responses:attach_request_id_header",
+        "kind": "static_from",
+        "line": 60,
+        "name": "attach_request_id_header",
+        "optional": false,
+        "requested": ".easyuse_anima.api.responses",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "api.py",
+        "target": "easyuse_anima/api/responses.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "correlate_response",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".easyuse_anima.api.responses:correlate_response",
+        "kind": "static_from",
+        "line": 60,
+        "name": "correlate_response",
+        "optional": false,
+        "requested": ".easyuse_anima.api.responses",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "api.py",
+        "target": "easyuse_anima/api/responses.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "create_request_id",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".easyuse_anima.api.responses:create_request_id",
+        "kind": "static_from",
+        "line": 60,
+        "name": "create_request_id",
+        "optional": false,
+        "requested": ".easyuse_anima.api.responses",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "api.py",
+        "target": "easyuse_anima/api/responses.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "error_payload",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".easyuse_anima.api.responses:error_payload",
+        "kind": "static_from",
+        "line": 60,
+        "name": "error_payload",
+        "optional": false,
+        "requested": ".easyuse_anima.api.responses",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "api.py",
+        "target": "easyuse_anima/api/responses.py"
       },
       {
         "alias": "_collect_torch_compile_diagnostics",
@@ -3641,7 +3641,7 @@
         "conditional": false,
         "imported": ".easyuse_anima.aio.torch_compile_diagnostics:collect_torch_compile_diagnostics",
         "kind": "static_from",
-        "line": 64,
+        "line": 66,
         "name": "collect_torch_compile_diagnostics",
         "optional": false,
         "requested": ".easyuse_anima.aio.torch_compile_diagnostics",
@@ -3659,7 +3659,7 @@
         "conditional": false,
         "imported": ".easyuse_anima.aio.torch_compile_recommendation:recommend_torch_compile",
         "kind": "static_from",
-        "line": 67,
+        "line": 69,
         "name": "recommend_torch_compile",
         "optional": false,
         "requested": ".easyuse_anima.aio.torch_compile_recommendation",
@@ -3677,7 +3677,7 @@
         "conditional": false,
         "imported": ".easyuse_anima.profiles:aio",
         "kind": "static_from",
-        "line": 70,
+        "line": 72,
         "name": "aio",
         "optional": false,
         "requested": ".easyuse_anima.profiles",
@@ -3695,7 +3695,7 @@
         "conditional": false,
         "imported": ".easyuse_anima.profiles:contract",
         "kind": "static_from",
-        "line": 71,
+        "line": 73,
         "name": "contract",
         "optional": false,
         "requested": ".easyuse_anima.profiles",
@@ -3713,7 +3713,7 @@
         "conditional": false,
         "imported": ".easyuse_anima.profiles:lora",
         "kind": "static_from",
-        "line": 72,
+        "line": 74,
         "name": "lora",
         "optional": false,
         "requested": ".easyuse_anima.profiles",
@@ -3731,7 +3731,7 @@
         "conditional": false,
         "imported": ".easyuse_anima.profiles:mutation",
         "kind": "static_from",
-        "line": 73,
+        "line": 75,
         "name": "mutation",
         "optional": false,
         "requested": ".easyuse_anima.profiles",
@@ -3749,7 +3749,7 @@
         "conditional": false,
         "imported": ".easyuse_anima.profiles:repository",
         "kind": "static_from",
-        "line": 74,
+        "line": 76,
         "name": "repository",
         "optional": false,
         "requested": ".easyuse_anima.profiles",
@@ -3767,7 +3767,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 330
+            "line": 332
           }
         ],
         "classification": "external",
@@ -3775,7 +3775,7 @@
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 331,
+        "line": 333,
         "name": null,
         "optional": true,
         "requested": "folder_paths",
@@ -3792,7 +3792,7 @@
         "conditional": false,
         "imported": "__future__:annotations",
         "kind": "static_from",
-        "line": 1,
+        "line": 3,
         "name": "annotations",
         "optional": false,
         "requested": "__future__",
@@ -3802,71 +3802,783 @@
       },
       {
         "alias": null,
-        "bound_name": "json",
-        "branch_context": [],
-        "classification": "external",
-        "column": 0,
-        "conditional": false,
-        "imported": "json",
-        "kind": "static_import",
-        "line": 3,
-        "name": null,
-        "optional": false,
-        "requested": "json",
-        "role": "ordinary",
-        "scope": "<module>",
-        "source": "api_contract.py"
-      },
-      {
-        "alias": null,
-        "bound_name": "uuid",
-        "branch_context": [],
-        "classification": "external",
-        "column": 0,
-        "conditional": false,
-        "imported": "uuid",
-        "kind": "static_import",
-        "line": 4,
-        "name": null,
-        "optional": false,
-        "requested": "uuid",
-        "role": "ordinary",
-        "scope": "<module>",
-        "source": "api_contract.py"
-      },
-      {
-        "alias": null,
-        "bound_name": "Any",
-        "branch_context": [],
-        "classification": "external",
-        "column": 0,
-        "conditional": false,
-        "imported": "typing:Any",
+        "bound_name": "ApiContractError",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 5
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "ApiContractError",
+          "target": "easyuse_anima/api/errors.py",
+          "try_line": 5
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.api.errors:ApiContractError",
         "kind": "static_from",
-        "line": 5,
-        "name": "Any",
+        "line": 6,
+        "name": "ApiContractError",
         "optional": false,
-        "requested": "typing",
-        "role": "ordinary",
+        "requested": ".easyuse_anima.api.errors",
+        "role": "compatibility_primary",
         "scope": "<module>",
-        "source": "api_contract.py"
+        "source": "api_contract.py",
+        "target": "easyuse_anima/api/errors.py"
       },
       {
         "alias": null,
-        "bound_name": "Mapping",
-        "branch_context": [],
-        "classification": "external",
-        "column": 0,
-        "conditional": false,
-        "imported": "typing:Mapping",
+        "bound_name": "json_boolean",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 5
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "json_boolean",
+          "target": "easyuse_anima/api/requests.py",
+          "try_line": 5
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.api.requests:json_boolean",
         "kind": "static_from",
-        "line": 5,
-        "name": "Mapping",
+        "line": 7,
+        "name": "json_boolean",
         "optional": false,
-        "requested": "typing",
-        "role": "ordinary",
+        "requested": ".easyuse_anima.api.requests",
+        "role": "compatibility_primary",
         "scope": "<module>",
-        "source": "api_contract.py"
+        "source": "api_contract.py",
+        "target": "easyuse_anima/api/requests.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "json_integer",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 5
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "json_integer",
+          "target": "easyuse_anima/api/requests.py",
+          "try_line": 5
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.api.requests:json_integer",
+        "kind": "static_from",
+        "line": 7,
+        "name": "json_integer",
+        "optional": false,
+        "requested": ".easyuse_anima.api.requests",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "api_contract.py",
+        "target": "easyuse_anima/api/requests.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "json_object",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 5
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "json_object",
+          "target": "easyuse_anima/api/requests.py",
+          "try_line": 5
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.api.requests:json_object",
+        "kind": "static_from",
+        "line": 7,
+        "name": "json_object",
+        "optional": false,
+        "requested": ".easyuse_anima.api.requests",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "api_contract.py",
+        "target": "easyuse_anima/api/requests.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "json_string",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 5
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "json_string",
+          "target": "easyuse_anima/api/requests.py",
+          "try_line": 5
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.api.requests:json_string",
+        "kind": "static_from",
+        "line": 7,
+        "name": "json_string",
+        "optional": false,
+        "requested": ".easyuse_anima.api.requests",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "api_contract.py",
+        "target": "easyuse_anima/api/requests.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "json_uuid_string",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 5
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "json_uuid_string",
+          "target": "easyuse_anima/api/requests.py",
+          "try_line": 5
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.api.requests:json_uuid_string",
+        "kind": "static_from",
+        "line": 7,
+        "name": "json_uuid_string",
+        "optional": false,
+        "requested": ".easyuse_anima.api.requests",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "api_contract.py",
+        "target": "easyuse_anima/api/requests.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "parse_json_object",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 5
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "parse_json_object",
+          "target": "easyuse_anima/api/requests.py",
+          "try_line": 5
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.api.requests:parse_json_object",
+        "kind": "static_from",
+        "line": 7,
+        "name": "parse_json_object",
+        "optional": false,
+        "requested": ".easyuse_anima.api.requests",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "api_contract.py",
+        "target": "easyuse_anima/api/requests.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "REQUEST_ID_HEADER",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 5
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "REQUEST_ID_HEADER",
+          "target": "easyuse_anima/api/responses.py",
+          "try_line": 5
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.api.responses:REQUEST_ID_HEADER",
+        "kind": "static_from",
+        "line": 15,
+        "name": "REQUEST_ID_HEADER",
+        "optional": false,
+        "requested": ".easyuse_anima.api.responses",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "api_contract.py",
+        "target": "easyuse_anima/api/responses.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "attach_request_id_header",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 5
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "attach_request_id_header",
+          "target": "easyuse_anima/api/responses.py",
+          "try_line": 5
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.api.responses:attach_request_id_header",
+        "kind": "static_from",
+        "line": 15,
+        "name": "attach_request_id_header",
+        "optional": false,
+        "requested": ".easyuse_anima.api.responses",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "api_contract.py",
+        "target": "easyuse_anima/api/responses.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "correlate_response",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 5
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "correlate_response",
+          "target": "easyuse_anima/api/responses.py",
+          "try_line": 5
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.api.responses:correlate_response",
+        "kind": "static_from",
+        "line": 15,
+        "name": "correlate_response",
+        "optional": false,
+        "requested": ".easyuse_anima.api.responses",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "api_contract.py",
+        "target": "easyuse_anima/api/responses.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "create_request_id",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 5
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "create_request_id",
+          "target": "easyuse_anima/api/responses.py",
+          "try_line": 5
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.api.responses:create_request_id",
+        "kind": "static_from",
+        "line": 15,
+        "name": "create_request_id",
+        "optional": false,
+        "requested": ".easyuse_anima.api.responses",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "api_contract.py",
+        "target": "easyuse_anima/api/responses.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "error_payload",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 5
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "error_payload",
+          "target": "easyuse_anima/api/responses.py",
+          "try_line": 5
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.api.responses:error_payload",
+        "kind": "static_from",
+        "line": 15,
+        "name": "error_payload",
+        "optional": false,
+        "requested": ".easyuse_anima.api.responses",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "api_contract.py",
+        "target": "easyuse_anima/api/responses.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "ApiContractError",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 22,
+            "kind": "try",
+            "line": 5
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "ApiContractError",
+          "target": "easyuse_anima/api/errors.py",
+          "try_line": 5
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.api.errors:ApiContractError",
+        "kind": "static_from",
+        "line": 23,
+        "name": "ApiContractError",
+        "optional": false,
+        "requested": "easyuse_anima.api.errors",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "api_contract.py",
+        "target": "easyuse_anima/api/errors.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "json_boolean",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 22,
+            "kind": "try",
+            "line": 5
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "json_boolean",
+          "target": "easyuse_anima/api/requests.py",
+          "try_line": 5
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.api.requests:json_boolean",
+        "kind": "static_from",
+        "line": 24,
+        "name": "json_boolean",
+        "optional": false,
+        "requested": "easyuse_anima.api.requests",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "api_contract.py",
+        "target": "easyuse_anima/api/requests.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "json_integer",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 22,
+            "kind": "try",
+            "line": 5
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "json_integer",
+          "target": "easyuse_anima/api/requests.py",
+          "try_line": 5
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.api.requests:json_integer",
+        "kind": "static_from",
+        "line": 24,
+        "name": "json_integer",
+        "optional": false,
+        "requested": "easyuse_anima.api.requests",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "api_contract.py",
+        "target": "easyuse_anima/api/requests.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "json_object",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 22,
+            "kind": "try",
+            "line": 5
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "json_object",
+          "target": "easyuse_anima/api/requests.py",
+          "try_line": 5
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.api.requests:json_object",
+        "kind": "static_from",
+        "line": 24,
+        "name": "json_object",
+        "optional": false,
+        "requested": "easyuse_anima.api.requests",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "api_contract.py",
+        "target": "easyuse_anima/api/requests.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "json_string",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 22,
+            "kind": "try",
+            "line": 5
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "json_string",
+          "target": "easyuse_anima/api/requests.py",
+          "try_line": 5
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.api.requests:json_string",
+        "kind": "static_from",
+        "line": 24,
+        "name": "json_string",
+        "optional": false,
+        "requested": "easyuse_anima.api.requests",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "api_contract.py",
+        "target": "easyuse_anima/api/requests.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "json_uuid_string",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 22,
+            "kind": "try",
+            "line": 5
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "json_uuid_string",
+          "target": "easyuse_anima/api/requests.py",
+          "try_line": 5
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.api.requests:json_uuid_string",
+        "kind": "static_from",
+        "line": 24,
+        "name": "json_uuid_string",
+        "optional": false,
+        "requested": "easyuse_anima.api.requests",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "api_contract.py",
+        "target": "easyuse_anima/api/requests.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "parse_json_object",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 22,
+            "kind": "try",
+            "line": 5
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "parse_json_object",
+          "target": "easyuse_anima/api/requests.py",
+          "try_line": 5
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.api.requests:parse_json_object",
+        "kind": "static_from",
+        "line": 24,
+        "name": "parse_json_object",
+        "optional": false,
+        "requested": "easyuse_anima.api.requests",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "api_contract.py",
+        "target": "easyuse_anima/api/requests.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "REQUEST_ID_HEADER",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 22,
+            "kind": "try",
+            "line": 5
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "REQUEST_ID_HEADER",
+          "target": "easyuse_anima/api/responses.py",
+          "try_line": 5
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.api.responses:REQUEST_ID_HEADER",
+        "kind": "static_from",
+        "line": 32,
+        "name": "REQUEST_ID_HEADER",
+        "optional": false,
+        "requested": "easyuse_anima.api.responses",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "api_contract.py",
+        "target": "easyuse_anima/api/responses.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "attach_request_id_header",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 22,
+            "kind": "try",
+            "line": 5
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "attach_request_id_header",
+          "target": "easyuse_anima/api/responses.py",
+          "try_line": 5
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.api.responses:attach_request_id_header",
+        "kind": "static_from",
+        "line": 32,
+        "name": "attach_request_id_header",
+        "optional": false,
+        "requested": "easyuse_anima.api.responses",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "api_contract.py",
+        "target": "easyuse_anima/api/responses.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "correlate_response",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 22,
+            "kind": "try",
+            "line": 5
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "correlate_response",
+          "target": "easyuse_anima/api/responses.py",
+          "try_line": 5
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.api.responses:correlate_response",
+        "kind": "static_from",
+        "line": 32,
+        "name": "correlate_response",
+        "optional": false,
+        "requested": "easyuse_anima.api.responses",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "api_contract.py",
+        "target": "easyuse_anima/api/responses.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "create_request_id",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 22,
+            "kind": "try",
+            "line": 5
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "create_request_id",
+          "target": "easyuse_anima/api/responses.py",
+          "try_line": 5
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.api.responses:create_request_id",
+        "kind": "static_from",
+        "line": 32,
+        "name": "create_request_id",
+        "optional": false,
+        "requested": "easyuse_anima.api.responses",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "api_contract.py",
+        "target": "easyuse_anima/api/responses.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "error_payload",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 22,
+            "kind": "try",
+            "line": 5
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "error_payload",
+          "target": "easyuse_anima/api/responses.py",
+          "try_line": 5
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.api.responses:error_payload",
+        "kind": "static_from",
+        "line": 32,
+        "name": "error_payload",
+        "optional": false,
+        "requested": "easyuse_anima.api.responses",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "api_contract.py",
+        "target": "easyuse_anima/api/responses.py"
       },
       {
         "alias": null,
@@ -14095,6 +14807,263 @@
         "scope": "<module>",
         "source": "easyuse_anima/aio/usdu.py",
         "target": "easyuse_anima/image/geometry.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "annotations",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "__future__:annotations",
+        "kind": "static_from",
+        "line": 1,
+        "name": "annotations",
+        "optional": false,
+        "requested": "__future__",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/api/errors.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "Any",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "typing:Any",
+        "kind": "static_from",
+        "line": 3,
+        "name": "Any",
+        "optional": false,
+        "requested": "typing",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/api/errors.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "Mapping",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "typing:Mapping",
+        "kind": "static_from",
+        "line": 3,
+        "name": "Mapping",
+        "optional": false,
+        "requested": "typing",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/api/errors.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "annotations",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "__future__:annotations",
+        "kind": "static_from",
+        "line": 1,
+        "name": "annotations",
+        "optional": false,
+        "requested": "__future__",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/api/requests.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "json",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "json",
+        "kind": "static_import",
+        "line": 3,
+        "name": null,
+        "optional": false,
+        "requested": "json",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/api/requests.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "uuid",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "uuid",
+        "kind": "static_import",
+        "line": 4,
+        "name": null,
+        "optional": false,
+        "requested": "uuid",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/api/requests.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "Any",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "typing:Any",
+        "kind": "static_from",
+        "line": 5,
+        "name": "Any",
+        "optional": false,
+        "requested": "typing",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/api/requests.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "Mapping",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "typing:Mapping",
+        "kind": "static_from",
+        "line": 5,
+        "name": "Mapping",
+        "optional": false,
+        "requested": "typing",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/api/requests.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "ApiContractError",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".errors:ApiContractError",
+        "kind": "static_from",
+        "line": 7,
+        "name": "ApiContractError",
+        "optional": false,
+        "requested": ".errors",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/api/requests.py",
+        "target": "easyuse_anima/api/errors.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_field_error",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".errors:_field_error",
+        "kind": "static_from",
+        "line": 7,
+        "name": "_field_error",
+        "optional": false,
+        "requested": ".errors",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/api/requests.py",
+        "target": "easyuse_anima/api/errors.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "annotations",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "__future__:annotations",
+        "kind": "static_from",
+        "line": 1,
+        "name": "annotations",
+        "optional": false,
+        "requested": "__future__",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/api/responses.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "json",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "json",
+        "kind": "static_import",
+        "line": 3,
+        "name": null,
+        "optional": false,
+        "requested": "json",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/api/responses.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "uuid",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "uuid",
+        "kind": "static_import",
+        "line": 4,
+        "name": null,
+        "optional": false,
+        "requested": "uuid",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/api/responses.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "Any",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "typing:Any",
+        "kind": "static_from",
+        "line": 5,
+        "name": "Any",
+        "optional": false,
+        "requested": "typing",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/api/responses.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "Mapping",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "typing:Mapping",
+        "kind": "static_from",
+        "line": 5,
+        "name": "Mapping",
+        "optional": false,
+        "requested": "typing",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/api/responses.py"
       },
       {
         "alias": null,
@@ -61728,15 +62697,23 @@
       },
       {
         "from": "api.py",
-        "to": "api_contract.py"
-      },
-      {
-        "from": "api.py",
         "to": "easyuse_anima/aio/torch_compile_diagnostics.py"
       },
       {
         "from": "api.py",
         "to": "easyuse_anima/aio/torch_compile_recommendation.py"
+      },
+      {
+        "from": "api.py",
+        "to": "easyuse_anima/api/errors.py"
+      },
+      {
+        "from": "api.py",
+        "to": "easyuse_anima/api/requests.py"
+      },
+      {
+        "from": "api.py",
+        "to": "easyuse_anima/api/responses.py"
       },
       {
         "from": "api.py",
@@ -61793,6 +62770,18 @@
       {
         "from": "api.py",
         "to": "wildcard_engine.py"
+      },
+      {
+        "from": "api_contract.py",
+        "to": "easyuse_anima/api/errors.py"
+      },
+      {
+        "from": "api_contract.py",
+        "to": "easyuse_anima/api/requests.py"
+      },
+      {
+        "from": "api_contract.py",
+        "to": "easyuse_anima/api/responses.py"
       },
       {
         "from": "autocomplete_dataset.py",
@@ -62317,6 +63306,10 @@
       {
         "from": "easyuse_anima/aio/usdu.py",
         "to": "easyuse_anima/image/geometry.py"
+      },
+      {
+        "from": "easyuse_anima/api/requests.py",
+        "to": "easyuse_anima/api/errors.py"
       },
       {
         "from": "easyuse_anima/autocomplete/classification.py",
@@ -63761,6 +64754,30 @@
       {
         "cyclic": false,
         "modules": [
+          "easyuse_anima/api/__init__.py"
+        ]
+      },
+      {
+        "cyclic": false,
+        "modules": [
+          "easyuse_anima/api/errors.py"
+        ]
+      },
+      {
+        "cyclic": false,
+        "modules": [
+          "easyuse_anima/api/requests.py"
+        ]
+      },
+      {
+        "cyclic": false,
+        "modules": [
+          "easyuse_anima/api/responses.py"
+        ]
+      },
+      {
+        "cyclic": false,
+        "modules": [
           "easyuse_anima/autocomplete/__init__.py"
         ]
       },
@@ -64344,7 +65361,7 @@
     ]
   },
   "inventory": {
-    "module_count": 145,
+    "module_count": 149,
     "modules": [
       {
         "is_package": true,
@@ -64444,9 +65461,9 @@
       },
       {
         "is_package": false,
-        "loc": 930,
+        "loc": 932,
         "module": "api",
-        "normalized_git_blob_sha1": "90a144841255a4ac816627a0760b5ffed82c438a",
+        "normalized_git_blob_sha1": "52d8adb828255158051856bbeb774669e9a5233a",
         "path": "api.py",
         "top_level": {
           "class_count": 1,
@@ -64456,13 +65473,13 @@
       },
       {
         "is_package": false,
-        "loc": 199,
+        "loc": 54,
         "module": "api_contract",
-        "normalized_git_blob_sha1": "99fdcf3a54bb475e112df0ee663261aa13bb5e91",
+        "normalized_git_blob_sha1": "14bbd742ca5ebf49389c7a39a8518ca4a6f4ad60",
         "path": "api_contract.py",
         "top_level": {
-          "class_count": 1,
-          "function_count": 11,
+          "class_count": 0,
+          "function_count": 0,
           "global_count": 1
         }
       },
@@ -64908,6 +65925,54 @@
           "class_count": 0,
           "function_count": 2,
           "global_count": 1
+        }
+      },
+      {
+        "is_package": true,
+        "loc": 3,
+        "module": "easyuse_anima.api",
+        "normalized_git_blob_sha1": "0f8799555e2370f2fdb94be29d39b462b80324cd",
+        "path": "easyuse_anima/api/__init__.py",
+        "top_level": {
+          "class_count": 0,
+          "function_count": 0,
+          "global_count": 1
+        }
+      },
+      {
+        "is_package": false,
+        "loc": 33,
+        "module": "easyuse_anima.api.errors",
+        "normalized_git_blob_sha1": "cb31805669ac7db452a4ab40ed4681a14cf6bdae",
+        "path": "easyuse_anima/api/errors.py",
+        "top_level": {
+          "class_count": 1,
+          "function_count": 1,
+          "global_count": 1
+        }
+      },
+      {
+        "is_package": false,
+        "loc": 126,
+        "module": "easyuse_anima.api.requests",
+        "normalized_git_blob_sha1": "771ec7c194950e5d07d594059a55cee514f163d4",
+        "path": "easyuse_anima/api/requests.py",
+        "top_level": {
+          "class_count": 0,
+          "function_count": 6,
+          "global_count": 1
+        }
+      },
+      {
+        "is_package": false,
+        "loc": 72,
+        "module": "easyuse_anima.api.responses",
+        "normalized_git_blob_sha1": "2ef95bf5a6b9c0c5a1eea455e6d16f7449e1c8c0",
+        "path": "easyuse_anima/api/responses.py",
+        "top_level": {
+          "class_count": 0,
+          "function_count": 4,
+          "global_count": 2
         }
       },
       {
@@ -67132,6 +68197,282 @@
         "role": "compatibility_fallback",
         "source": "anima_prompt/parser.py",
         "target": "easyuse_anima/prompt/anima/parser.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 22,
+            "kind": "try",
+            "line": 5
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.api.errors:ApiContractError",
+        "kind": "static_from",
+        "line": 23,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "api_contract.py",
+        "target": "easyuse_anima/api/errors.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 22,
+            "kind": "try",
+            "line": 5
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.api.requests:json_boolean",
+        "kind": "static_from",
+        "line": 24,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "api_contract.py",
+        "target": "easyuse_anima/api/requests.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 22,
+            "kind": "try",
+            "line": 5
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.api.requests:json_integer",
+        "kind": "static_from",
+        "line": 24,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "api_contract.py",
+        "target": "easyuse_anima/api/requests.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 22,
+            "kind": "try",
+            "line": 5
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.api.requests:json_object",
+        "kind": "static_from",
+        "line": 24,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "api_contract.py",
+        "target": "easyuse_anima/api/requests.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 22,
+            "kind": "try",
+            "line": 5
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.api.requests:json_string",
+        "kind": "static_from",
+        "line": 24,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "api_contract.py",
+        "target": "easyuse_anima/api/requests.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 22,
+            "kind": "try",
+            "line": 5
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.api.requests:json_uuid_string",
+        "kind": "static_from",
+        "line": 24,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "api_contract.py",
+        "target": "easyuse_anima/api/requests.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 22,
+            "kind": "try",
+            "line": 5
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.api.requests:parse_json_object",
+        "kind": "static_from",
+        "line": 24,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "api_contract.py",
+        "target": "easyuse_anima/api/requests.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 22,
+            "kind": "try",
+            "line": 5
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.api.responses:REQUEST_ID_HEADER",
+        "kind": "static_from",
+        "line": 32,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "api_contract.py",
+        "target": "easyuse_anima/api/responses.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 22,
+            "kind": "try",
+            "line": 5
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.api.responses:attach_request_id_header",
+        "kind": "static_from",
+        "line": 32,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "api_contract.py",
+        "target": "easyuse_anima/api/responses.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 22,
+            "kind": "try",
+            "line": 5
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.api.responses:correlate_response",
+        "kind": "static_from",
+        "line": 32,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "api_contract.py",
+        "target": "easyuse_anima/api/responses.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 22,
+            "kind": "try",
+            "line": 5
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.api.responses:create_request_id",
+        "kind": "static_from",
+        "line": 32,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "api_contract.py",
+        "target": "easyuse_anima/api/responses.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 22,
+            "kind": "try",
+            "line": 5
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.api.responses:error_payload",
+        "kind": "static_from",
+        "line": 32,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "api_contract.py",
+        "target": "easyuse_anima/api/responses.py"
       },
       {
         "branch_context": [
@@ -78666,6 +80007,7 @@
       "anima_prompt/normalize.py",
       "anima_prompt/ordering.py",
       "anima_prompt/parser.py",
+      "api_contract.py",
       "autocomplete_dataset.py",
       "autocomplete_index.py",
       "nodes.py",
@@ -78859,14 +80201,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 330
+            "line": 332
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 331,
+        "line": 333,
         "optional": true,
         "role": "optional_dependency",
         "source": "api.py"
@@ -78877,51 +80219,7 @@
         "conditional": false,
         "imported": "__future__:annotations",
         "kind": "static_from",
-        "line": 1,
-        "optional": false,
-        "role": "ordinary",
-        "source": "api_contract.py"
-      },
-      {
-        "branch_context": [],
-        "classification": "external",
-        "conditional": false,
-        "imported": "json",
-        "kind": "static_import",
         "line": 3,
-        "optional": false,
-        "role": "ordinary",
-        "source": "api_contract.py"
-      },
-      {
-        "branch_context": [],
-        "classification": "external",
-        "conditional": false,
-        "imported": "uuid",
-        "kind": "static_import",
-        "line": 4,
-        "optional": false,
-        "role": "ordinary",
-        "source": "api_contract.py"
-      },
-      {
-        "branch_context": [],
-        "classification": "external",
-        "conditional": false,
-        "imported": "typing:Any",
-        "kind": "static_from",
-        "line": 5,
-        "optional": false,
-        "role": "ordinary",
-        "source": "api_contract.py"
-      },
-      {
-        "branch_context": [],
-        "classification": "external",
-        "conditional": false,
-        "imported": "typing:Mapping",
-        "kind": "static_from",
-        "line": 5,
         "optional": false,
         "role": "ordinary",
         "source": "api_contract.py"
@@ -80799,6 +82097,149 @@
         "optional": false,
         "role": "ordinary",
         "source": "easyuse_anima/aio/usdu.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "__future__:annotations",
+        "kind": "static_from",
+        "line": 1,
+        "optional": false,
+        "role": "ordinary",
+        "source": "easyuse_anima/api/errors.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "typing:Any",
+        "kind": "static_from",
+        "line": 3,
+        "optional": false,
+        "role": "ordinary",
+        "source": "easyuse_anima/api/errors.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "typing:Mapping",
+        "kind": "static_from",
+        "line": 3,
+        "optional": false,
+        "role": "ordinary",
+        "source": "easyuse_anima/api/errors.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "__future__:annotations",
+        "kind": "static_from",
+        "line": 1,
+        "optional": false,
+        "role": "ordinary",
+        "source": "easyuse_anima/api/requests.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "json",
+        "kind": "static_import",
+        "line": 3,
+        "optional": false,
+        "role": "ordinary",
+        "source": "easyuse_anima/api/requests.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "uuid",
+        "kind": "static_import",
+        "line": 4,
+        "optional": false,
+        "role": "ordinary",
+        "source": "easyuse_anima/api/requests.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "typing:Any",
+        "kind": "static_from",
+        "line": 5,
+        "optional": false,
+        "role": "ordinary",
+        "source": "easyuse_anima/api/requests.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "typing:Mapping",
+        "kind": "static_from",
+        "line": 5,
+        "optional": false,
+        "role": "ordinary",
+        "source": "easyuse_anima/api/requests.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "__future__:annotations",
+        "kind": "static_from",
+        "line": 1,
+        "optional": false,
+        "role": "ordinary",
+        "source": "easyuse_anima/api/responses.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "json",
+        "kind": "static_import",
+        "line": 3,
+        "optional": false,
+        "role": "ordinary",
+        "source": "easyuse_anima/api/responses.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "uuid",
+        "kind": "static_import",
+        "line": 4,
+        "optional": false,
+        "role": "ordinary",
+        "source": "easyuse_anima/api/responses.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "typing:Any",
+        "kind": "static_from",
+        "line": 5,
+        "optional": false,
+        "role": "ordinary",
+        "source": "easyuse_anima/api/responses.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "typing:Mapping",
+        "kind": "static_from",
+        "line": 5,
+        "optional": false,
+        "role": "ordinary",
+        "source": "easyuse_anima/api/responses.py"
       },
       {
         "branch_context": [],
@@ -84909,14 +86350,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 330
+            "line": 332
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 331,
+        "line": 333,
         "optional": true,
         "role": "optional_dependency",
         "source": "api.py"
@@ -85851,6 +87292,10 @@
       "easyuse_anima/aio/torch_compile_diagnostics.py",
       "easyuse_anima/aio/torch_compile_recommendation.py",
       "easyuse_anima/aio/usdu.py",
+      "easyuse_anima/api/__init__.py",
+      "easyuse_anima/api/errors.py",
+      "easyuse_anima/api/requests.py",
+      "easyuse_anima/api/responses.py",
       "easyuse_anima/autocomplete/__init__.py",
       "easyuse_anima/autocomplete/classification.py",
       "easyuse_anima/autocomplete/dataset.py",
@@ -85998,6 +87443,10 @@
       "easyuse_anima/aio/torch_compile_diagnostics.py",
       "easyuse_anima/aio/torch_compile_recommendation.py",
       "easyuse_anima/aio/usdu.py",
+      "easyuse_anima/api/__init__.py",
+      "easyuse_anima/api/errors.py",
+      "easyuse_anima/api/requests.py",
+      "easyuse_anima/api/responses.py",
       "easyuse_anima/autocomplete/__init__.py",
       "easyuse_anima/autocomplete/classification.py",
       "easyuse_anima/autocomplete/dataset.py",
@@ -86116,7 +87565,7 @@
         "column": 10,
         "context": "assign:_LOGGER",
         "kind": "import_time_call",
-        "line": 154,
+        "line": 156,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -86125,7 +87574,7 @@
         "column": 25,
         "context": "assign:_FILE_IO_LIMITERS_LOCK",
         "kind": "import_time_call",
-        "line": 157,
+        "line": 159,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -86134,7 +87583,7 @@
         "column": 47,
         "context": "assign:_FILE_IO_LIMITERS",
         "kind": "import_time_call",
-        "line": 158,
+        "line": 160,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -86143,7 +87592,7 @@
         "column": 29,
         "context": "assign:_PROMPT_TRANSLATION_WORKER",
         "kind": "import_time_call",
-        "line": 207,
+        "line": 209,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -86152,7 +87601,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 208,
+        "line": 210,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -86161,7 +87610,7 @@
         "column": 36,
         "context": "assign:_SAFE_PROFILE_VALIDATION_MESSAGES",
         "kind": "import_time_call",
-        "line": 357,
+        "line": 359,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -86170,7 +87619,7 @@
         "column": 9,
         "context": "assign:routes",
         "kind": "route_registry_creation",
-        "line": 514,
+        "line": 516,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -86179,7 +87628,7 @@
         "column": 19,
         "context": "assign:_ROUTE_SIGNATURE",
         "kind": "route_registry_creation",
-        "line": 906,
+        "line": 908,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -86188,7 +87637,7 @@
         "column": 5,
         "context": "assign:_ROUTE_SIGNATURE",
         "kind": "route_registry_creation",
-        "line": 907,
+        "line": 909,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -88010,6 +89459,12 @@
       },
       {
         "kind": "list",
+        "line": 41,
+        "module": "api_contract.py",
+        "name": "__all__"
+      },
+      {
+        "kind": "list",
         "line": 42,
         "module": "autocomplete_dataset.py",
         "name": "__all__"
@@ -88090,6 +89545,12 @@
         "kind": "list",
         "line": 278,
         "module": "easyuse_anima/aio/torch_compile_recommendation.py",
+        "name": "__all__"
+      },
+      {
+        "kind": "list",
+        "line": 3,
+        "module": "easyuse_anima/api/__init__.py",
         "name": "__all__"
       },
       {
@@ -88441,7 +89902,7 @@
           "lock"
         ],
         "initializer": "threading.Lock",
-        "line": 157,
+        "line": 159,
         "module": "api.py",
         "name": "_FILE_IO_LIMITERS_LOCK"
       },
@@ -88450,7 +89911,7 @@
           "executor"
         ],
         "initializer": "_PromptTranslationWorker",
-        "line": 207,
+        "line": 209,
         "module": "api.py",
         "name": "_PROMPT_TRANSLATION_WORKER"
       },

--- a/tests/fixtures/python_import_boundary_contract.v1.json
+++ b/tests/fixtures/python_import_boundary_contract.v1.json
@@ -2,6 +2,12 @@
   "schema_version": 1,
   "groups": [
     {
+      "group": "api",
+      "owner_issue": 165,
+      "prefix": "easyuse_anima/api/",
+      "role": "feature"
+    },
+    {
       "group": "autocomplete",
       "owner_issue": 162,
       "prefix": "easyuse_anima/autocomplete/",

--- a/tests/test_api_contract_compatibility.py
+++ b/tests/test_api_contract_compatibility.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+import ast
+import importlib
+import sys
+import types
+import unittest
+from pathlib import Path
+
+import api_contract
+from easyuse_anima.api import errors, requests, responses
+
+
+ROOT = Path(__file__).resolve().parents[1]
+API_PATH = ROOT / "api.py"
+EXPECTED_EXPORTS = [
+    "REQUEST_ID_HEADER",
+    "ApiContractError",
+    "error_payload",
+    "create_request_id",
+    "attach_request_id_header",
+    "correlate_response",
+    "parse_json_object",
+    "json_object",
+    "json_string",
+    "json_boolean",
+    "json_integer",
+    "json_uuid_string",
+]
+
+
+def canonical_exports(errors_module, requests_module, responses_module):
+    return {
+        "REQUEST_ID_HEADER": responses_module.REQUEST_ID_HEADER,
+        "ApiContractError": errors_module.ApiContractError,
+        "error_payload": responses_module.error_payload,
+        "create_request_id": responses_module.create_request_id,
+        "attach_request_id_header": responses_module.attach_request_id_header,
+        "correlate_response": responses_module.correlate_response,
+        "parse_json_object": requests_module.parse_json_object,
+        "json_object": requests_module.json_object,
+        "json_string": requests_module.json_string,
+        "json_boolean": requests_module.json_boolean,
+        "json_integer": requests_module.json_integer,
+        "json_uuid_string": requests_module.json_uuid_string,
+    }
+
+
+class ApiContractCompatibilityTests(unittest.TestCase):
+    def test_root_public_surface_is_an_exact_identity_shim(self):
+        expected = canonical_exports(errors, requests, responses)
+        self.assertEqual(api_contract.__all__, EXPECTED_EXPORTS)
+        for name, value in expected.items():
+            with self.subTest(name=name):
+                self.assertIs(getattr(api_contract, name), value)
+        self.assertFalse(hasattr(api_contract, "_field_error"))
+
+    def test_package_relative_import_mode_preserves_identity(self):
+        parent_name = "_api_contract_compat_parent"
+        parent = types.ModuleType(parent_name)
+        parent.__path__ = [str(ROOT)]
+        sys.modules[parent_name] = parent
+        try:
+            root_module = importlib.import_module(f"{parent_name}.api_contract")
+            errors_module = importlib.import_module(
+                f"{parent_name}.easyuse_anima.api.errors"
+            )
+            requests_module = importlib.import_module(
+                f"{parent_name}.easyuse_anima.api.requests"
+            )
+            responses_module = importlib.import_module(
+                f"{parent_name}.easyuse_anima.api.responses"
+            )
+            expected = canonical_exports(
+                errors_module,
+                requests_module,
+                responses_module,
+            )
+            self.assertEqual(root_module.__all__, EXPECTED_EXPORTS)
+            for name, value in expected.items():
+                with self.subTest(name=name):
+                    self.assertIs(getattr(root_module, name), value)
+        finally:
+            for name in tuple(sys.modules):
+                if name == parent_name or name.startswith(f"{parent_name}."):
+                    sys.modules.pop(name, None)
+
+    def test_api_imports_only_canonical_contract_owners(self):
+        tree = ast.parse(API_PATH.read_text(encoding="utf-8"), filename=str(API_PATH))
+        imports = [node for node in tree.body if isinstance(node, ast.ImportFrom)]
+        modules = {
+            node.module
+            for node in imports
+            if node.level == 1 and node.module is not None
+        }
+        self.assertTrue(
+            {
+                "easyuse_anima.api.errors",
+                "easyuse_anima.api.requests",
+                "easyuse_anima.api.responses",
+            }.issubset(modules)
+        )
+        self.assertNotIn("api_contract", modules)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_python_backend_analyzer.py
+++ b/tests/test_python_backend_analyzer.py
@@ -690,9 +690,9 @@ ignored/
 
         self.assertEqual(analyzer.render_json(report), expected_text)
         self.assertEqual(report["schema_version"], 2)
-        self.assertEqual(report["inventory"]["module_count"], 145)
-        self.assertEqual(len(report["registry"]["shipped_python_modules"]), 145)
-        self.assertEqual(len(report["registry"]["runtime_import_closure"]), 145)
+        self.assertEqual(report["inventory"]["module_count"], 149)
+        self.assertEqual(len(report["registry"]["shipped_python_modules"]), 149)
+        self.assertEqual(len(report["registry"]["runtime_import_closure"]), 149)
         self.assertEqual(
             report["registry"]["entry_modules"],
             [
@@ -704,6 +704,7 @@ ignored/
                 "anima_prompt/normalize.py",
                 "anima_prompt/ordering.py",
                 "anima_prompt/parser.py",
+                "api_contract.py",
                 "autocomplete_dataset.py",
                 "autocomplete_index.py",
                 "nodes.py",
@@ -717,6 +718,10 @@ ignored/
         self.assertTrue(
             {
                 "easyuse_anima/__init__.py",
+                "easyuse_anima/api/__init__.py",
+                "easyuse_anima/api/errors.py",
+                "easyuse_anima/api/requests.py",
+                "easyuse_anima/api/responses.py",
                 "easyuse_anima/aio/__init__.py",
                 "easyuse_anima/aio/conditioning.py",
                 "easyuse_anima/aio/first_pass_cache.py",
@@ -1085,10 +1090,19 @@ ignored/
                     module,
                     report["registry"]["runtime_import_closure"],
                 )
-        self.assertIn(
-            {"from": "api.py", "to": "api_contract.py"},
-            report["imports"]["module_graph"],
-        )
+        for source, target in (
+            ("api.py", "easyuse_anima/api/errors.py"),
+            ("api.py", "easyuse_anima/api/requests.py"),
+            ("api.py", "easyuse_anima/api/responses.py"),
+            ("api_contract.py", "easyuse_anima/api/errors.py"),
+            ("api_contract.py", "easyuse_anima/api/requests.py"),
+            ("api_contract.py", "easyuse_anima/api/responses.py"),
+        ):
+            with self.subTest(source=source, target=target):
+                self.assertIn(
+                    {"from": source, "to": target},
+                    report["imports"]["module_graph"],
+                )
         profile_edges = {
             (item["from"], item["to"])
             for item in report["imports"]["module_graph"]

--- a/tests/test_python_package_skeleton.py
+++ b/tests/test_python_package_skeleton.py
@@ -42,6 +42,10 @@ PACKAGE_MODULES = (
     "easyuse_anima.aio.generation_settings",
     "easyuse_anima.aio.resources",
     "easyuse_anima.aio.usdu",
+    "easyuse_anima.api",
+    "easyuse_anima.api.errors",
+    "easyuse_anima.api.requests",
+    "easyuse_anima.api.responses",
     "easyuse_anima.autocomplete",
     "easyuse_anima.autocomplete.classification",
     "easyuse_anima.autocomplete.dataset",
@@ -186,6 +190,24 @@ print(json.dumps({{
         self.assertEqual(payload["modules"], list(PACKAGE_MODULES))
         expected_all = [[] for _ in PACKAGE_MODULES]
         expected_all[PACKAGE_MODULES.index("easyuse_anima.bootstrap")] = ["initialize"]
+        expected_all[PACKAGE_MODULES.index("easyuse_anima.api.errors")] = [
+            "ApiContractError"
+        ]
+        expected_all[PACKAGE_MODULES.index("easyuse_anima.api.requests")] = [
+            "parse_json_object",
+            "json_object",
+            "json_string",
+            "json_boolean",
+            "json_integer",
+            "json_uuid_string",
+        ]
+        expected_all[PACKAGE_MODULES.index("easyuse_anima.api.responses")] = [
+            "REQUEST_ID_HEADER",
+            "error_payload",
+            "create_request_id",
+            "attach_request_id_header",
+            "correlate_response",
+        ]
         expected_all[
             PACKAGE_MODULES.index("easyuse_anima.autocomplete.classification")
         ] = ["classify_prompt_text"]

--- a/tests/test_registry_scanner_safety.py
+++ b/tests/test_registry_scanner_safety.py
@@ -32,6 +32,10 @@ EXPECTED_PYTHON_PACKAGE_FILES = {
     "easyuse_anima/aio/preview.py",
     "easyuse_anima/aio/resources.py",
     "easyuse_anima/aio/sampling.py",
+    "easyuse_anima/api/__init__.py",
+    "easyuse_anima/api/errors.py",
+    "easyuse_anima/api/requests.py",
+    "easyuse_anima/api/responses.py",
     "easyuse_anima/autocomplete/__init__.py",
     "easyuse_anima/autocomplete/dataset.py",
     "easyuse_anima/autocomplete/index.py",
@@ -366,13 +370,24 @@ class RegistryScannerSafetyTests(unittest.TestCase):
             f"{sorted(closure & ignored)}",
         )
 
-    def test_api_contract_runtime_module_is_in_registry_package_surface(self):
-        runtime_path = "api_contract.py"
-        self.assertTrue((ROOT / runtime_path).is_file())
-        self.assertIn("from .api_contract import (", (ROOT / "api.py").read_text(encoding="utf-8"))
+    def test_api_contract_runtime_modules_are_in_registry_package_surface(self):
+        runtime_paths = {
+            "api_contract.py",
+            "easyuse_anima/api/__init__.py",
+            "easyuse_anima/api/errors.py",
+            "easyuse_anima/api/requests.py",
+            "easyuse_anima/api/responses.py",
+        }
+        for runtime_path in runtime_paths:
+            with self.subTest(runtime_path=runtime_path):
+                self.assertTrue((ROOT / runtime_path).is_file())
+
+        api_source = (ROOT / "api.py").read_text(encoding="utf-8")
+        for module in ("errors", "requests", "responses"):
+            self.assertIn(f"from .easyuse_anima.api.{module} import", api_source)
 
         tracked = _git_paths("ls-files", "--cached")
-        self.assertIn(runtime_path, tracked)
+        self.assertFalse(runtime_paths - tracked)
 
         ignored = _git_paths(
             "ls-files",
@@ -380,7 +395,7 @@ class RegistryScannerSafetyTests(unittest.TestCase):
             "--ignored",
             "--exclude-from=.comfyignore",
         )
-        self.assertNotIn(runtime_path, ignored)
+        self.assertFalse(runtime_paths & ignored)
 
     def test_python_package_skeleton_is_in_registry_package_surface(self):
         for runtime_path in EXPECTED_PYTHON_PACKAGE_FILES:

--- a/tools/analyze_python_backend.py
+++ b/tools/analyze_python_backend.py
@@ -39,6 +39,7 @@ REGISTRY_ENTRY_MODULE_CANDIDATES = (
     "anima_prompt/normalize.py",
     "anima_prompt/ordering.py",
     "anima_prompt/parser.py",
+    "api_contract.py",
     "autocomplete_dataset.py",
     "autocomplete_index.py",
     "nodes.py",

--- a/tools/check_python_import_boundaries.py
+++ b/tools/check_python_import_boundaries.py
@@ -25,6 +25,7 @@ DEFAULT_CONTRACT_PATH = (
 )
 CONTRACT_SCHEMA_VERSION = 1
 EXPECTED_GROUPS = (
+    ("api", 165, "easyuse_anima/api/", "feature"),
     ("autocomplete", 162, "easyuse_anima/autocomplete/", "feature"),
     ("common", 184, "easyuse_anima/common/", "common"),
     ("image", 184, "easyuse_anima/image/", "feature"),


### PR DESCRIPTION
## 목적과 변경 경계

- #186 D-02 Move이며 안정화된 #165 API request/error/correlation contract를 canonical package로 이동합니다.
- root `api_contract.py` 구현을 `easyuse_anima.api.errors`, `.requests`, `.responses`로 분리 이동했습니다.
- `api.py`는 세 canonical owner를 직접 import합니다.
- root `api_contract.py`는 `REQUEST_ID_HEADER`를 포함한 exact 12-symbol identity shim으로 유지합니다.
- route handler/등록, endpoint URL/order, bounded file-I/O, redaction, frontend 동작은 이동하지 않습니다.

## Base -> Head

- Base: `701d5ebf4e6fb9f366136d7939bb6d3b88ec29bb` (`dev`)
- Head: `a569352b405c3ea0d08ede7f46ed1fafcdd89c3b`
- Candidate tree: `bb4a0a225e7bf025220df9111773bcd97340d64e`

## 주요 파일과 보존 계약

- `easyuse_anima/api/errors.py`: `ApiContractError`와 private field-error owner
- `easyuse_anima/api/requests.py`: JSON object/typed field validators
- `easyuse_anima/api/responses.py`: error payload와 request-ID response correlation
- `api_contract.py`: flat/package exact identity shim
- analyzer/package/Registry/G-03 fixtures와 architecture roadmap/shim ledger 갱신
- 보존: 400/422 taxonomy와 message/details, UUID/string/integer/object/boolean validation, legacy error envelope, JSON header/body request-ID correlation, success/non-JSON response, 21 route registration/order/idempotence, patch seam

## 검증

- changed Python syntax: 12 files PASS
- origin/dev 대비 이동 class/function AST: 12/12 unchanged
- `tests.test_api_contract_compatibility`: 3 PASS
- `tests.test_api_contract`: 38 PASS
- `tests.test_prompt_translation_api`: 6 PASS
- `tests.test_python_package_skeleton`: 1 PASS
- `tests.test_python_backend_analyzer`: 18 PASS
- `tests.test_registry_scanner_safety`: 8 PASS
- `tests.test_python_import_boundaries`: 16 PASS
- `tests.test_python_compatibility_surface`: 26 PASS
- `git diff --check`: PASS
- `comfy node validate`: PASS
- `comfy node pack`: PASS, 291 entries; root `api.py`/`api_contract.py`와 canonical API 4 modules closure 확인
- official full (Head SHA에서 1회): Python 1,252 PASS; frontend 120 JavaScript files PASS; TypeScript 6.0.3; Pyright 132 files / 기존 14 errors 유지; G-03 11 groups / 0 violations
- package archive와 full runner process 정리 확인

## 남은 위험과 rollback

- G-01 Ruff 112건은 report-only입니다. 새 canonical 정의는 Move parity를 위해 origin/dev AST를 그대로 유지했으며 별도 formatting/typing modernization을 섞지 않았습니다.
- live ComfyUI는 동작 변경 없는 identity-preserving Move이므로 재실행하지 않고 #165의 기존 live request/error evidence를 재사용합니다.
- 문제가 있으면 이 단일 Move squash commit을 되돌려 root implementation/API import 상태로 복원할 수 있습니다.

## Next

- D-02 완료 후 canonical feature-service ownership을 기준으로 가장 작은 D-03 feature-route leaf를 inventory합니다.
- D-14 root shim freeze/retirement는 첫 canonical+shim release와 consumer evidence 전까지 계속 보류합니다.

Refs #165
Refs #186