### PR TITLE
refactor: move long-text settings routes to API package (D-06b)

### DIFF
--- a/api.py
+++ b/api.py
@@ -66,6 +66,9 @@ from .easyuse_anima.api.routes.autocomplete import (
     build_autocomplete_handlers as _build_autocomplete_handlers,
     build_classify_prompt_handler as _build_classify_prompt_handler,
 )
+from .easyuse_anima.api.routes.long_text_settings import (
+    build_long_text_settings_handlers as _build_long_text_settings_handlers,
+)
 from .easyuse_anima.api.routes.wildcards import (
     build_wildcards_handler as _build_wildcards_handler,
 )
@@ -501,11 +504,24 @@ if web is not None:
             return _error_response(422, "unknown_setting", "Unknown setting")
         return web.json_response(payload)
 
-    @_request_correlated
-    async def get_long_text_settings_handler(request):
-        return web.json_response(
-            await _run_file_io(_get_long_text_settings_payload_sync)
+    (
+        get_long_text_settings_handler,
+        save_long_text_settings_handler,
+    ) = (
+        _request_correlated(handler)
+        for handler in _build_long_text_settings_handlers(
+            parse_json_object=lambda request: parse_json_object(request),
+            json_object=lambda data, field: json_object(data, field),
+            contract_error_type=ApiContractError,
+            contract_error_response=lambda exc: _contract_error_response(exc),
+            run_file_io=lambda function, *args: _run_file_io(function, *args),
+            get_long_text_settings_payload=lambda: _get_long_text_settings_payload_sync(),
+            save_long_text_settings_payload=lambda values: _save_long_text_settings_payload_sync(
+                values
+            ),
+            json_response=lambda payload: web.json_response(payload),
         )
+    )
 
     get_wildcards_handler = _request_correlated(
         _build_wildcards_handler(
@@ -514,17 +530,6 @@ if web is not None:
             json_response=lambda payload: web.json_response(payload),
         )
     )
-
-    @_request_correlated
-    async def save_long_text_settings_handler(request):
-        try:
-            data = await parse_json_object(request)
-            values = json_object(data, "values") if "values" in data else data
-        except ApiContractError as exc:
-            return _contract_error_response(exc)
-        return web.json_response(
-            await _run_file_io(_save_long_text_settings_payload_sync, values)
-        )
 
     (
         autocomplete_status_handler,

--- a/easyuse_anima/api/routes/long_text_settings.py
+++ b/easyuse_anima/api/routes/long_text_settings.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+
+def build_long_text_settings_handlers(
+    *,
+    parse_json_object,
+    json_object,
+    contract_error_type,
+    contract_error_response,
+    run_file_io,
+    get_long_text_settings_payload,
+    save_long_text_settings_payload,
+    json_response,
+):
+    """Build long-text settings routes without loading persistence adapters."""
+
+    async def get_long_text_settings_handler(request):
+        return json_response(
+            await run_file_io(get_long_text_settings_payload)
+        )
+
+    async def save_long_text_settings_handler(request):
+        try:
+            data = await parse_json_object(request)
+            values = json_object(data, "values") if "values" in data else data
+        except contract_error_type as exc:
+            return contract_error_response(exc)
+        return json_response(
+            await run_file_io(save_long_text_settings_payload, values)
+        )
+
+    return get_long_text_settings_handler, save_long_text_settings_handler
+
+
+__all__ = ("build_long_text_settings_handlers",)

--- a/tests/fixtures/python_backend_baseline.json
+++ b/tests/fixtures/python_backend_baseline.json
@@ -3635,6 +3635,24 @@
         "target": "easyuse_anima/api/routes/autocomplete.py"
       },
       {
+        "alias": "_build_long_text_settings_handlers",
+        "bound_name": "_build_long_text_settings_handlers",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".easyuse_anima.api.routes.long_text_settings:build_long_text_settings_handlers",
+        "kind": "static_from",
+        "line": 69,
+        "name": "build_long_text_settings_handlers",
+        "optional": false,
+        "requested": ".easyuse_anima.api.routes.long_text_settings",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "api.py",
+        "target": "easyuse_anima/api/routes/long_text_settings.py"
+      },
+      {
         "alias": "_build_wildcards_handler",
         "bound_name": "_build_wildcards_handler",
         "branch_context": [],
@@ -3643,7 +3661,7 @@
         "conditional": false,
         "imported": ".easyuse_anima.api.routes.wildcards:build_wildcards_handler",
         "kind": "static_from",
-        "line": 69,
+        "line": 72,
         "name": "build_wildcards_handler",
         "optional": false,
         "requested": ".easyuse_anima.api.routes.wildcards",
@@ -3661,7 +3679,7 @@
         "conditional": false,
         "imported": ".easyuse_anima.api.routes.translation:build_translate_prompt_handler",
         "kind": "static_from",
-        "line": 72,
+        "line": 75,
         "name": "build_translate_prompt_handler",
         "optional": false,
         "requested": ".easyuse_anima.api.routes.translation",
@@ -3679,7 +3697,7 @@
         "conditional": false,
         "imported": ".easyuse_anima.api.routes.translation_execution:PromptTranslationRouteExecutor",
         "kind": "static_from",
-        "line": 75,
+        "line": 78,
         "name": "PromptTranslationRouteExecutor",
         "optional": false,
         "requested": ".easyuse_anima.api.routes.translation_execution",
@@ -3697,7 +3715,7 @@
         "conditional": false,
         "imported": ".easyuse_anima.api.routes.aio_torch_compile:build_aio_torch_compile_recommend_handler",
         "kind": "static_from",
-        "line": 78,
+        "line": 81,
         "name": "build_aio_torch_compile_recommend_handler",
         "optional": false,
         "requested": ".easyuse_anima.api.routes.aio_torch_compile",
@@ -3715,7 +3733,7 @@
         "conditional": false,
         "imported": ".easyuse_anima.aio.torch_compile_diagnostics:collect_torch_compile_diagnostics",
         "kind": "static_from",
-        "line": 81,
+        "line": 84,
         "name": "collect_torch_compile_diagnostics",
         "optional": false,
         "requested": ".easyuse_anima.aio.torch_compile_diagnostics",
@@ -3733,7 +3751,7 @@
         "conditional": false,
         "imported": ".easyuse_anima.aio.torch_compile_recommendation:recommend_torch_compile",
         "kind": "static_from",
-        "line": 84,
+        "line": 87,
         "name": "recommend_torch_compile",
         "optional": false,
         "requested": ".easyuse_anima.aio.torch_compile_recommendation",
@@ -3751,7 +3769,7 @@
         "conditional": false,
         "imported": ".easyuse_anima.profiles:aio",
         "kind": "static_from",
-        "line": 87,
+        "line": 90,
         "name": "aio",
         "optional": false,
         "requested": ".easyuse_anima.profiles",
@@ -3769,7 +3787,7 @@
         "conditional": false,
         "imported": ".easyuse_anima.profiles:contract",
         "kind": "static_from",
-        "line": 88,
+        "line": 91,
         "name": "contract",
         "optional": false,
         "requested": ".easyuse_anima.profiles",
@@ -3787,7 +3805,7 @@
         "conditional": false,
         "imported": ".easyuse_anima.profiles:lora",
         "kind": "static_from",
-        "line": 89,
+        "line": 92,
         "name": "lora",
         "optional": false,
         "requested": ".easyuse_anima.profiles",
@@ -3805,7 +3823,7 @@
         "conditional": false,
         "imported": ".easyuse_anima.profiles:mutation",
         "kind": "static_from",
-        "line": 90,
+        "line": 93,
         "name": "mutation",
         "optional": false,
         "requested": ".easyuse_anima.profiles",
@@ -3823,7 +3841,7 @@
         "conditional": false,
         "imported": ".easyuse_anima.profiles:repository",
         "kind": "static_from",
-        "line": 91,
+        "line": 94,
         "name": "repository",
         "optional": false,
         "requested": ".easyuse_anima.profiles",
@@ -3841,7 +3859,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 294
+            "line": 297
           }
         ],
         "classification": "external",
@@ -3849,7 +3867,7 @@
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 295,
+        "line": 298,
         "name": null,
         "optional": true,
         "requested": "folder_paths",
@@ -15172,6 +15190,23 @@
         "role": "ordinary",
         "scope": "<module>",
         "source": "easyuse_anima/api/routes/autocomplete.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "annotations",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "__future__:annotations",
+        "kind": "static_from",
+        "line": 1,
+        "name": "annotations",
+        "optional": false,
+        "requested": "__future__",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/api/routes/long_text_settings.py"
       },
       {
         "alias": null,
@@ -62952,6 +62987,10 @@
       },
       {
         "from": "api.py",
+        "to": "easyuse_anima/api/routes/long_text_settings.py"
+      },
+      {
+        "from": "api.py",
         "to": "easyuse_anima/api/routes/translation.py"
       },
       {
@@ -65043,6 +65082,12 @@
       {
         "cyclic": false,
         "modules": [
+          "easyuse_anima/api/routes/long_text_settings.py"
+        ]
+      },
+      {
+        "cyclic": false,
+        "modules": [
           "easyuse_anima/api/routes/translation.py"
         ]
       },
@@ -65644,7 +65689,7 @@
     ]
   },
   "inventory": {
-    "module_count": 155,
+    "module_count": 156,
     "modules": [
       {
         "is_package": true,
@@ -65744,14 +65789,14 @@
       },
       {
         "is_package": false,
-        "loc": 866,
+        "loc": 871,
         "module": "api",
-        "normalized_git_blob_sha1": "45868b24386541875e81314941afda82787479a6",
+        "normalized_git_blob_sha1": "30a1544adc0bfa88e55b3a5f8d9ce2ab1e26dc40",
         "path": "api.py",
         "top_level": {
           "class_count": 0,
           "function_count": 23,
-          "global_count": 81
+          "global_count": 83
         }
       },
       {
@@ -66291,6 +66336,18 @@
         "top_level": {
           "class_count": 0,
           "function_count": 2,
+          "global_count": 1
+        }
+      },
+      {
+        "is_package": false,
+        "loc": 35,
+        "module": "easyuse_anima.api.routes.long_text_settings",
+        "normalized_git_blob_sha1": "059a8239197df8f81df12b1e1d83834fb476a906",
+        "path": "easyuse_anima/api/routes/long_text_settings.py",
+        "top_level": {
+          "class_count": 0,
+          "function_count": 1,
           "global_count": 1
         }
       },
@@ -80534,14 +80591,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 294
+            "line": 297
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 295,
+        "line": 298,
         "optional": true,
         "role": "optional_dependency",
         "source": "api.py"
@@ -82595,6 +82652,17 @@
         "optional": false,
         "role": "ordinary",
         "source": "easyuse_anima/api/routes/autocomplete.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "__future__:annotations",
+        "kind": "static_from",
+        "line": 1,
+        "optional": false,
+        "role": "ordinary",
+        "source": "easyuse_anima/api/routes/long_text_settings.py"
       },
       {
         "branch_context": [],
@@ -86782,14 +86850,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 294
+            "line": 297
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 295,
+        "line": 298,
         "optional": true,
         "role": "optional_dependency",
         "source": "api.py"
@@ -87731,6 +87799,7 @@
       "easyuse_anima/api/routes/__init__.py",
       "easyuse_anima/api/routes/aio_torch_compile.py",
       "easyuse_anima/api/routes/autocomplete.py",
+      "easyuse_anima/api/routes/long_text_settings.py",
       "easyuse_anima/api/routes/translation.py",
       "easyuse_anima/api/routes/translation_execution.py",
       "easyuse_anima/api/routes/wildcards.py",
@@ -87888,6 +87957,7 @@
       "easyuse_anima/api/routes/__init__.py",
       "easyuse_anima/api/routes/aio_torch_compile.py",
       "easyuse_anima/api/routes/autocomplete.py",
+      "easyuse_anima/api/routes/long_text_settings.py",
       "easyuse_anima/api/routes/translation.py",
       "easyuse_anima/api/routes/translation_execution.py",
       "easyuse_anima/api/routes/wildcards.py",
@@ -88009,7 +88079,7 @@
         "column": 10,
         "context": "assign:_LOGGER",
         "kind": "import_time_call",
-        "line": 171,
+        "line": 174,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -88018,7 +88088,7 @@
         "column": 25,
         "context": "assign:_FILE_IO_LIMITERS_LOCK",
         "kind": "import_time_call",
-        "line": 174,
+        "line": 177,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -88027,7 +88097,7 @@
         "column": 47,
         "context": "assign:_FILE_IO_LIMITERS",
         "kind": "import_time_call",
-        "line": 175,
+        "line": 178,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -88036,7 +88106,7 @@
         "column": 29,
         "context": "assign:_PROMPT_TRANSLATION_WORKER",
         "kind": "route_registry_creation",
-        "line": 178,
+        "line": 181,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -88045,7 +88115,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 183,
+        "line": 186,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -88054,7 +88124,7 @@
         "column": 36,
         "context": "assign:_SAFE_PROFILE_VALIDATION_MESSAGES",
         "kind": "import_time_call",
-        "line": 321,
+        "line": 324,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -88063,7 +88133,25 @@
         "column": 9,
         "context": "assign:routes",
         "kind": "route_registry_creation",
-        "line": 478,
+        "line": 481,
+        "module": "api.py",
+        "scope": "<module>"
+      },
+      {
+        "callee": "_request_correlated",
+        "column": 8,
+        "context": "assign:get_long_text_settings_handler,save_long_text_settings_handler",
+        "kind": "import_time_call",
+        "line": 511,
+        "module": "api.py",
+        "scope": "<module>"
+      },
+      {
+        "callee": "_build_long_text_settings_handlers",
+        "column": 23,
+        "context": "assign:get_long_text_settings_handler,save_long_text_settings_handler",
+        "kind": "import_time_call",
+        "line": 512,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -88072,7 +88160,7 @@
         "column": 28,
         "context": "assign:get_wildcards_handler",
         "kind": "import_time_call",
-        "line": 510,
+        "line": 526,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -88081,7 +88169,7 @@
         "column": 8,
         "context": "assign:get_wildcards_handler",
         "kind": "import_time_call",
-        "line": 511,
+        "line": 527,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -88090,7 +88178,7 @@
         "column": 8,
         "context": "assign:autocomplete_handler,autocomplete_status_handler",
         "kind": "import_time_call",
-        "line": 533,
+        "line": 538,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -88099,7 +88187,7 @@
         "column": 23,
         "context": "assign:autocomplete_handler,autocomplete_status_handler",
         "kind": "import_time_call",
-        "line": 534,
+        "line": 539,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -88108,7 +88196,7 @@
         "column": 30,
         "context": "assign:classify_prompt_handler",
         "kind": "import_time_call",
-        "line": 544,
+        "line": 549,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -88117,7 +88205,7 @@
         "column": 8,
         "context": "assign:classify_prompt_handler",
         "kind": "import_time_call",
-        "line": 545,
+        "line": 550,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -88126,7 +88214,7 @@
         "column": 31,
         "context": "assign:translate_prompt_handler",
         "kind": "import_time_call",
-        "line": 563,
+        "line": 568,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -88135,7 +88223,7 @@
         "column": 8,
         "context": "assign:translate_prompt_handler",
         "kind": "import_time_call",
-        "line": 564,
+        "line": 569,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -88144,7 +88232,7 @@
         "column": 42,
         "context": "assign:aio_torch_compile_recommend_handler",
         "kind": "import_time_call",
-        "line": 576,
+        "line": 581,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -88153,7 +88241,7 @@
         "column": 8,
         "context": "assign:aio_torch_compile_recommend_handler",
         "kind": "import_time_call",
-        "line": 577,
+        "line": 582,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -88162,7 +88250,7 @@
         "column": 19,
         "context": "assign:_ROUTE_SIGNATURE",
         "kind": "route_registry_creation",
-        "line": 842,
+        "line": 847,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -88171,7 +88259,7 @@
         "column": 5,
         "context": "assign:_ROUTE_SIGNATURE",
         "kind": "route_registry_creation",
-        "line": 843,
+        "line": 848,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -90442,7 +90530,7 @@
           "lock"
         ],
         "initializer": "threading.Lock",
-        "line": 174,
+        "line": 177,
         "module": "api.py",
         "name": "_FILE_IO_LIMITERS_LOCK"
       },
@@ -90451,7 +90539,7 @@
           "executor"
         ],
         "initializer": "_PromptTranslationRouteExecutor",
-        "line": 178,
+        "line": 181,
         "module": "api.py",
         "name": "_PROMPT_TRANSLATION_WORKER"
       },

--- a/tests/test_api_contract.py
+++ b/tests/test_api_contract.py
@@ -461,6 +461,85 @@ class ApiWildcardRouteTests(unittest.TestCase):
         wildcards_payload.assert_called_once_with()
 
 
+class ApiLongTextSettingsRouteTests(unittest.TestCase):
+    def test_route_handlers_are_owned_by_the_canonical_factory(self):
+        api, routes = load_api_routes()
+        cases = (
+            (
+                "get_long_text_settings_handler",
+                "/easyuse_anima/long_text_settings",
+            ),
+            (
+                "save_long_text_settings_handler",
+                "/easyuse_anima/long_text_settings/save",
+            ),
+        )
+
+        for name, path in cases:
+            with self.subTest(path=path):
+                handler = routes.handlers[path]
+                self.assertIs(getattr(api, name), handler)
+                self.assertEqual(handler.__name__, name)
+                self.assertTrue(
+                    handler.__module__.endswith(
+                        ".easyuse_anima.api.routes.long_text_settings"
+                    )
+                )
+                self.assertTrue(handler._easyuse_anima_request_correlation)
+
+    def test_get_route_keeps_dynamic_payload_seam(self):
+        api, routes = load_api_routes()
+        payload = {
+            "status": "ok",
+            "values": {"naia.pre_prompt": "quality"},
+            "settings": {"naia.pre_prompt": "quality"},
+        }
+
+        with patch.object(
+            api,
+            "_get_long_text_settings_payload_sync",
+            return_value=payload,
+        ) as get_payload:
+            response = asyncio.run(
+                routes.handlers["/easyuse_anima/long_text_settings"](
+                    JsonRequest()
+                )
+            )
+
+        self.assertEqual(response["status"], 200)
+        self.assertEqual(response["payload"], payload)
+        get_payload.assert_called_once_with()
+
+    def test_save_route_preserves_wrapped_and_legacy_payloads(self):
+        api, routes = load_api_routes()
+        handler = routes.handlers["/easyuse_anima/long_text_settings/save"]
+        values = {"naia.pre_prompt": "quality"}
+        cases = (
+            ({"values": values}, values),
+            (values, values),
+        )
+
+        for request_payload, expected_values in cases:
+            with self.subTest(request_payload=request_payload):
+                payload = {
+                    "status": "ok",
+                    "values": expected_values,
+                    "settings": expected_values,
+                }
+                with patch.object(
+                    api,
+                    "_save_long_text_settings_payload_sync",
+                    return_value=payload,
+                ) as save_payload:
+                    response = asyncio.run(
+                        handler(JsonRequest(request_payload))
+                    )
+
+                self.assertEqual(response["status"], 200)
+                self.assertEqual(response["payload"], payload)
+                save_payload.assert_called_once_with(expected_values)
+
+
 class ApiAutocompleteRouteTests(unittest.TestCase):
     def test_read_only_route_handlers_are_owned_by_the_canonical_factory(self):
         api, routes = load_api_routes()

--- a/tests/test_python_backend_analyzer.py
+++ b/tests/test_python_backend_analyzer.py
@@ -690,9 +690,9 @@ ignored/
 
         self.assertEqual(analyzer.render_json(report), expected_text)
         self.assertEqual(report["schema_version"], 2)
-        self.assertEqual(report["inventory"]["module_count"], 155)
-        self.assertEqual(len(report["registry"]["shipped_python_modules"]), 155)
-        self.assertEqual(len(report["registry"]["runtime_import_closure"]), 155)
+        self.assertEqual(report["inventory"]["module_count"], 156)
+        self.assertEqual(len(report["registry"]["shipped_python_modules"]), 156)
+        self.assertEqual(len(report["registry"]["runtime_import_closure"]), 156)
         self.assertEqual(
             report["registry"]["entry_modules"],
             [

--- a/tests/test_python_package_skeleton.py
+++ b/tests/test_python_package_skeleton.py
@@ -49,6 +49,7 @@ PACKAGE_MODULES = (
     "easyuse_anima.api.routes",
     "easyuse_anima.api.routes.aio_torch_compile",
     "easyuse_anima.api.routes.autocomplete",
+    "easyuse_anima.api.routes.long_text_settings",
     "easyuse_anima.api.routes.translation",
     "easyuse_anima.api.routes.translation_execution",
     "easyuse_anima.api.routes.wildcards",
@@ -225,6 +226,9 @@ print(json.dumps({{
             "build_autocomplete_handlers",
             "build_classify_prompt_handler",
         ]
+        expected_all[
+            PACKAGE_MODULES.index("easyuse_anima.api.routes.long_text_settings")
+        ] = ["build_long_text_settings_handlers"]
         expected_all[
             PACKAGE_MODULES.index("easyuse_anima.api.routes.translation")
         ] = ["build_translate_prompt_handler"]


### PR DESCRIPTION
## 목적과 변경 경계

Issue #186의 D-06b로, long-text settings GET/POST HTTP adapter를 canonical `easyuse_anima.api.routes` owner로 이동합니다. persistence/schema/프런트 동작과 `/settings`·`/set_setting`은 변경하지 않습니다.

## Base → Head

- Base: `b550f1c963e8bc966cf25267f15b7648ca6be16f`
- Head: `617993d34d2995c62ed35538c28f44926b733980`

## 주요 파일과 보존 계약

- `easyuse_anima/api/routes/long_text_settings.py`: pure GET/POST handler factory
- `api.py`: dynamic dependency wiring과 request-correlation wrapper
- `tests/test_api_contract.py`: canonical ownership, dynamic payload seam, wrapped/legacy payload 고정
- package/analyzer manifest와 reviewed fixture: shipping module 155 → 156

보존 계약:

- 기존 `status`/`values`/`settings` response shape
- `{values: ...}` wrapper와 legacy top-level save payload
- malformed/type error contract와 file-I/O offload
- root monkeypatch seam, request correlation, route order
- 허용된 네 long-text key normalize/merge/AtomicJsonStore persistence
- #199의 settings access/path diagnostics 정책은 이 PR에서 제외

## 검증

- changed-file Python syntax: 통과
- D-06b canonical route: 3 tests
- API contract: 48 tests
- settings runtime Node smoke: 통과
- package skeleton: 1, backend analyzer: 18, scanner: 8, import boundary: 16, compatibility surface: 26
- `git diff --check`: 통과
- `comfy node validate`: 통과
- `comfy node pack`: 298 entries, 새 route module 포함 확인 후 archive 삭제
- official full (Head에서 정확히 1회): Python 1,264 / frontend 120 / Pyright 139 files, 기존 14 diagnostics / G-03 11 groups, 0 violations / Ruff 기존 112 report-only
- isolated live: GET/POST 200, UUID correlation, 허용 key 4개, round-trip 동일, 로컬 경로 미노출, queue `0/0 → 0/0`
- isolated listener/process tree: 종료 및 잔존 0 확인

## 남은 위험과 rollback

동작 변경이 아닌 adapter owner 이동이지만 root wiring과 canonical factory가 함께 rollback 경계입니다. 문제 시 이 단일 commit을 revert하면 기존 inline handler owner로 복귀합니다.

## Next

D-06c 후보를 직접 owner/Issue 결정으로 다시 inventory합니다. `/settings`와 `/set_setting`은 #199 결정 전까지 이동하지 않습니다.