### PR TITLE
refactor: move LoRA preview route to API package (D-06d)

### DIFF
--- a/api.py
+++ b/api.py
@@ -72,6 +72,9 @@ from .easyuse_anima.api.routes.long_text_settings import (
 from .easyuse_anima.api.routes.lora_catalog import (
     build_loras_handler as _build_loras_handler,
 )
+from .easyuse_anima.api.routes.lora_preview import (
+    build_lora_preview_handler as _build_lora_preview_handler,
+)
 from .easyuse_anima.api.routes.wildcards import (
     build_wildcards_handler as _build_wildcards_handler,
 )
@@ -598,18 +601,15 @@ if web is not None:
         )
     )
 
-    @_request_correlated
-    async def lora_preview_handler(request):
-        preview_path = await _run_file_io(
-            _resolve_lora_preview_path,
-            request.query.get("name", ""),
+    lora_preview_handler = _request_correlated(
+        _build_lora_preview_handler(
+            run_file_io=lambda function, *args: _run_file_io(function, *args),
+            resolve_lora_preview_path=lambda name: _resolve_lora_preview_path(name),
+            empty_response=lambda **kwargs: web.Response(**kwargs),
+            file_response=lambda path, **kwargs: web.FileResponse(path, **kwargs),
+            basename=lambda path: os.path.basename(path),
         )
-        if not preview_path:
-            return web.Response(status=404)
-        return web.FileResponse(
-            preview_path,
-            headers={"Content-Disposition": f'filename="{os.path.basename(preview_path)}"'},
-        )
+    )
 
     loras_handler = _request_correlated(
         _build_loras_handler(

--- a/easyuse_anima/api/routes/lora_preview.py
+++ b/easyuse_anima/api/routes/lora_preview.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+
+def build_lora_preview_handler(
+    *,
+    run_file_io,
+    resolve_lora_preview_path,
+    empty_response,
+    file_response,
+    basename,
+):
+    """Build the LoRA preview route without loading path adapters."""
+
+    async def lora_preview_handler(request):
+        preview_path = await run_file_io(
+            resolve_lora_preview_path,
+            request.query.get("name", ""),
+        )
+        if not preview_path:
+            return empty_response(status=404)
+        return file_response(
+            preview_path,
+            headers={"Content-Disposition": f'filename="{basename(preview_path)}"'},
+        )
+
+    return lora_preview_handler
+
+
+__all__ = ("build_lora_preview_handler",)

--- a/tests/fixtures/python_backend_baseline.json
+++ b/tests/fixtures/python_backend_baseline.json
@@ -3671,6 +3671,24 @@
         "target": "easyuse_anima/api/routes/lora_catalog.py"
       },
       {
+        "alias": "_build_lora_preview_handler",
+        "bound_name": "_build_lora_preview_handler",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".easyuse_anima.api.routes.lora_preview:build_lora_preview_handler",
+        "kind": "static_from",
+        "line": 75,
+        "name": "build_lora_preview_handler",
+        "optional": false,
+        "requested": ".easyuse_anima.api.routes.lora_preview",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "api.py",
+        "target": "easyuse_anima/api/routes/lora_preview.py"
+      },
+      {
         "alias": "_build_wildcards_handler",
         "bound_name": "_build_wildcards_handler",
         "branch_context": [],
@@ -3679,7 +3697,7 @@
         "conditional": false,
         "imported": ".easyuse_anima.api.routes.wildcards:build_wildcards_handler",
         "kind": "static_from",
-        "line": 75,
+        "line": 78,
         "name": "build_wildcards_handler",
         "optional": false,
         "requested": ".easyuse_anima.api.routes.wildcards",
@@ -3697,7 +3715,7 @@
         "conditional": false,
         "imported": ".easyuse_anima.api.routes.translation:build_translate_prompt_handler",
         "kind": "static_from",
-        "line": 78,
+        "line": 81,
         "name": "build_translate_prompt_handler",
         "optional": false,
         "requested": ".easyuse_anima.api.routes.translation",
@@ -3715,7 +3733,7 @@
         "conditional": false,
         "imported": ".easyuse_anima.api.routes.translation_execution:PromptTranslationRouteExecutor",
         "kind": "static_from",
-        "line": 81,
+        "line": 84,
         "name": "PromptTranslationRouteExecutor",
         "optional": false,
         "requested": ".easyuse_anima.api.routes.translation_execution",
@@ -3733,7 +3751,7 @@
         "conditional": false,
         "imported": ".easyuse_anima.api.routes.aio_torch_compile:build_aio_torch_compile_recommend_handler",
         "kind": "static_from",
-        "line": 84,
+        "line": 87,
         "name": "build_aio_torch_compile_recommend_handler",
         "optional": false,
         "requested": ".easyuse_anima.api.routes.aio_torch_compile",
@@ -3751,7 +3769,7 @@
         "conditional": false,
         "imported": ".easyuse_anima.aio.torch_compile_diagnostics:collect_torch_compile_diagnostics",
         "kind": "static_from",
-        "line": 87,
+        "line": 90,
         "name": "collect_torch_compile_diagnostics",
         "optional": false,
         "requested": ".easyuse_anima.aio.torch_compile_diagnostics",
@@ -3769,7 +3787,7 @@
         "conditional": false,
         "imported": ".easyuse_anima.aio.torch_compile_recommendation:recommend_torch_compile",
         "kind": "static_from",
-        "line": 90,
+        "line": 93,
         "name": "recommend_torch_compile",
         "optional": false,
         "requested": ".easyuse_anima.aio.torch_compile_recommendation",
@@ -3787,7 +3805,7 @@
         "conditional": false,
         "imported": ".easyuse_anima.profiles:aio",
         "kind": "static_from",
-        "line": 93,
+        "line": 96,
         "name": "aio",
         "optional": false,
         "requested": ".easyuse_anima.profiles",
@@ -3805,7 +3823,7 @@
         "conditional": false,
         "imported": ".easyuse_anima.profiles:contract",
         "kind": "static_from",
-        "line": 94,
+        "line": 97,
         "name": "contract",
         "optional": false,
         "requested": ".easyuse_anima.profiles",
@@ -3823,7 +3841,7 @@
         "conditional": false,
         "imported": ".easyuse_anima.profiles:lora",
         "kind": "static_from",
-        "line": 95,
+        "line": 98,
         "name": "lora",
         "optional": false,
         "requested": ".easyuse_anima.profiles",
@@ -3841,7 +3859,7 @@
         "conditional": false,
         "imported": ".easyuse_anima.profiles:mutation",
         "kind": "static_from",
-        "line": 96,
+        "line": 99,
         "name": "mutation",
         "optional": false,
         "requested": ".easyuse_anima.profiles",
@@ -3859,7 +3877,7 @@
         "conditional": false,
         "imported": ".easyuse_anima.profiles:repository",
         "kind": "static_from",
-        "line": 97,
+        "line": 100,
         "name": "repository",
         "optional": false,
         "requested": ".easyuse_anima.profiles",
@@ -3877,7 +3895,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 300
+            "line": 303
           }
         ],
         "classification": "external",
@@ -3885,7 +3903,7 @@
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 301,
+        "line": 304,
         "name": null,
         "optional": true,
         "requested": "folder_paths",
@@ -15242,6 +15260,23 @@
         "role": "ordinary",
         "scope": "<module>",
         "source": "easyuse_anima/api/routes/lora_catalog.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "annotations",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "__future__:annotations",
+        "kind": "static_from",
+        "line": 1,
+        "name": "annotations",
+        "optional": false,
+        "requested": "__future__",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/api/routes/lora_preview.py"
       },
       {
         "alias": null,
@@ -63030,6 +63065,10 @@
       },
       {
         "from": "api.py",
+        "to": "easyuse_anima/api/routes/lora_preview.py"
+      },
+      {
+        "from": "api.py",
         "to": "easyuse_anima/api/routes/translation.py"
       },
       {
@@ -65133,6 +65172,12 @@
       {
         "cyclic": false,
         "modules": [
+          "easyuse_anima/api/routes/lora_preview.py"
+        ]
+      },
+      {
+        "cyclic": false,
+        "modules": [
           "easyuse_anima/api/routes/translation.py"
         ]
       },
@@ -65734,7 +65779,7 @@
     ]
   },
   "inventory": {
-    "module_count": 157,
+    "module_count": 158,
     "modules": [
       {
         "is_package": true,
@@ -65836,12 +65881,12 @@
         "is_package": false,
         "loc": 878,
         "module": "api",
-        "normalized_git_blob_sha1": "03427df266f2800a63f576c55959c7232f293e7c",
+        "normalized_git_blob_sha1": "f0059e6c202b30f4f1f5aec5c5c3023122d6fd17",
         "path": "api.py",
         "top_level": {
           "class_count": 0,
           "function_count": 23,
-          "global_count": 84
+          "global_count": 85
         }
       },
       {
@@ -66402,6 +66447,18 @@
         "module": "easyuse_anima.api.routes.lora_catalog",
         "normalized_git_blob_sha1": "bd425cc3e9f2d5df2e8492ce38da28221c08e41f",
         "path": "easyuse_anima/api/routes/lora_catalog.py",
+        "top_level": {
+          "class_count": 0,
+          "function_count": 1,
+          "global_count": 1
+        }
+      },
+      {
+        "is_package": false,
+        "loc": 29,
+        "module": "easyuse_anima.api.routes.lora_preview",
+        "normalized_git_blob_sha1": "03bdcfbe68d71124ea2c424e271543a61c2093c4",
+        "path": "easyuse_anima/api/routes/lora_preview.py",
         "top_level": {
           "class_count": 0,
           "function_count": 1,
@@ -80648,14 +80705,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 300
+            "line": 303
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 301,
+        "line": 304,
         "optional": true,
         "role": "optional_dependency",
         "source": "api.py"
@@ -82731,6 +82788,17 @@
         "optional": false,
         "role": "ordinary",
         "source": "easyuse_anima/api/routes/lora_catalog.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "__future__:annotations",
+        "kind": "static_from",
+        "line": 1,
+        "optional": false,
+        "role": "ordinary",
+        "source": "easyuse_anima/api/routes/lora_preview.py"
       },
       {
         "branch_context": [],
@@ -86918,14 +86986,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 300
+            "line": 303
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 301,
+        "line": 304,
         "optional": true,
         "role": "optional_dependency",
         "source": "api.py"
@@ -87869,6 +87937,7 @@
       "easyuse_anima/api/routes/autocomplete.py",
       "easyuse_anima/api/routes/long_text_settings.py",
       "easyuse_anima/api/routes/lora_catalog.py",
+      "easyuse_anima/api/routes/lora_preview.py",
       "easyuse_anima/api/routes/translation.py",
       "easyuse_anima/api/routes/translation_execution.py",
       "easyuse_anima/api/routes/wildcards.py",
@@ -88028,6 +88097,7 @@
       "easyuse_anima/api/routes/autocomplete.py",
       "easyuse_anima/api/routes/long_text_settings.py",
       "easyuse_anima/api/routes/lora_catalog.py",
+      "easyuse_anima/api/routes/lora_preview.py",
       "easyuse_anima/api/routes/translation.py",
       "easyuse_anima/api/routes/translation_execution.py",
       "easyuse_anima/api/routes/wildcards.py",
@@ -88149,7 +88219,7 @@
         "column": 10,
         "context": "assign:_LOGGER",
         "kind": "import_time_call",
-        "line": 177,
+        "line": 180,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -88158,7 +88228,7 @@
         "column": 25,
         "context": "assign:_FILE_IO_LIMITERS_LOCK",
         "kind": "import_time_call",
-        "line": 180,
+        "line": 183,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -88167,7 +88237,7 @@
         "column": 47,
         "context": "assign:_FILE_IO_LIMITERS",
         "kind": "import_time_call",
-        "line": 181,
+        "line": 184,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -88176,7 +88246,7 @@
         "column": 29,
         "context": "assign:_PROMPT_TRANSLATION_WORKER",
         "kind": "route_registry_creation",
-        "line": 184,
+        "line": 187,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -88185,7 +88255,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 189,
+        "line": 192,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -88194,7 +88264,7 @@
         "column": 36,
         "context": "assign:_SAFE_PROFILE_VALIDATION_MESSAGES",
         "kind": "import_time_call",
-        "line": 327,
+        "line": 330,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -88203,7 +88273,7 @@
         "column": 9,
         "context": "assign:routes",
         "kind": "route_registry_creation",
-        "line": 484,
+        "line": 487,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -88212,7 +88282,7 @@
         "column": 8,
         "context": "assign:get_long_text_settings_handler,save_long_text_settings_handler",
         "kind": "import_time_call",
-        "line": 514,
+        "line": 517,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -88221,7 +88291,7 @@
         "column": 23,
         "context": "assign:get_long_text_settings_handler,save_long_text_settings_handler",
         "kind": "import_time_call",
-        "line": 515,
+        "line": 518,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -88230,7 +88300,7 @@
         "column": 28,
         "context": "assign:get_wildcards_handler",
         "kind": "import_time_call",
-        "line": 529,
+        "line": 532,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -88239,7 +88309,7 @@
         "column": 8,
         "context": "assign:get_wildcards_handler",
         "kind": "import_time_call",
-        "line": 530,
+        "line": 533,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -88248,7 +88318,7 @@
         "column": 8,
         "context": "assign:autocomplete_handler,autocomplete_status_handler",
         "kind": "import_time_call",
-        "line": 541,
+        "line": 544,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -88257,7 +88327,7 @@
         "column": 23,
         "context": "assign:autocomplete_handler,autocomplete_status_handler",
         "kind": "import_time_call",
-        "line": 542,
+        "line": 545,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -88266,7 +88336,7 @@
         "column": 30,
         "context": "assign:classify_prompt_handler",
         "kind": "import_time_call",
-        "line": 552,
+        "line": 555,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -88275,7 +88345,7 @@
         "column": 8,
         "context": "assign:classify_prompt_handler",
         "kind": "import_time_call",
-        "line": 553,
+        "line": 556,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -88284,7 +88354,7 @@
         "column": 31,
         "context": "assign:translate_prompt_handler",
         "kind": "import_time_call",
-        "line": 571,
+        "line": 574,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -88293,7 +88363,7 @@
         "column": 8,
         "context": "assign:translate_prompt_handler",
         "kind": "import_time_call",
-        "line": 572,
+        "line": 575,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -88302,7 +88372,7 @@
         "column": 42,
         "context": "assign:aio_torch_compile_recommend_handler",
         "kind": "import_time_call",
-        "line": 584,
+        "line": 587,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -88311,7 +88381,25 @@
         "column": 8,
         "context": "assign:aio_torch_compile_recommend_handler",
         "kind": "import_time_call",
-        "line": 585,
+        "line": 588,
+        "module": "api.py",
+        "scope": "<module>"
+      },
+      {
+        "callee": "_request_correlated",
+        "column": 27,
+        "context": "assign:lora_preview_handler",
+        "kind": "import_time_call",
+        "line": 604,
+        "module": "api.py",
+        "scope": "<module>"
+      },
+      {
+        "callee": "_build_lora_preview_handler",
+        "column": 8,
+        "context": "assign:lora_preview_handler",
+        "kind": "import_time_call",
+        "line": 605,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -90618,7 +90706,7 @@
           "lock"
         ],
         "initializer": "threading.Lock",
-        "line": 180,
+        "line": 183,
         "module": "api.py",
         "name": "_FILE_IO_LIMITERS_LOCK"
       },
@@ -90627,7 +90715,7 @@
           "executor"
         ],
         "initializer": "_PromptTranslationRouteExecutor",
-        "line": 184,
+        "line": 187,
         "module": "api.py",
         "name": "_PROMPT_TRANSLATION_WORKER"
       },

--- a/tests/test_api_contract.py
+++ b/tests/test_api_contract.py
@@ -401,6 +401,15 @@ class ApiRequestCorrelationTests(unittest.TestCase):
         api, routes = load_api_routes()
         handler = routes.handlers["/easyuse_anima/lora_preview"]
 
+        self.assertIs(api.lora_preview_handler, handler)
+        self.assertEqual(handler.__name__, "lora_preview_handler")
+        self.assertTrue(
+            handler.__module__.endswith(
+                ".easyuse_anima.api.routes.lora_preview"
+            )
+        )
+        self.assertTrue(handler._easyuse_anima_request_correlation)
+
         with patch.object(api, "_resolve_lora_preview_path", return_value=None):
             missing = asyncio.run(handler(JsonRequest(query={"name": "missing"})))
         self.assertIsInstance(missing, FakeResponse)

--- a/tests/test_python_backend_analyzer.py
+++ b/tests/test_python_backend_analyzer.py
@@ -690,9 +690,9 @@ ignored/
 
         self.assertEqual(analyzer.render_json(report), expected_text)
         self.assertEqual(report["schema_version"], 2)
-        self.assertEqual(report["inventory"]["module_count"], 157)
-        self.assertEqual(len(report["registry"]["shipped_python_modules"]), 157)
-        self.assertEqual(len(report["registry"]["runtime_import_closure"]), 157)
+        self.assertEqual(report["inventory"]["module_count"], 158)
+        self.assertEqual(len(report["registry"]["shipped_python_modules"]), 158)
+        self.assertEqual(len(report["registry"]["runtime_import_closure"]), 158)
         self.assertEqual(
             report["registry"]["entry_modules"],
             [

--- a/tests/test_python_package_skeleton.py
+++ b/tests/test_python_package_skeleton.py
@@ -50,6 +50,7 @@ PACKAGE_MODULES = (
     "easyuse_anima.api.routes.aio_torch_compile",
     "easyuse_anima.api.routes.autocomplete",
     "easyuse_anima.api.routes.lora_catalog",
+    "easyuse_anima.api.routes.lora_preview",
     "easyuse_anima.api.routes.long_text_settings",
     "easyuse_anima.api.routes.translation",
     "easyuse_anima.api.routes.translation_execution",
@@ -230,6 +231,9 @@ print(json.dumps({{
         expected_all[
             PACKAGE_MODULES.index("easyuse_anima.api.routes.lora_catalog")
         ] = ["build_loras_handler"]
+        expected_all[
+            PACKAGE_MODULES.index("easyuse_anima.api.routes.lora_preview")
+        ] = ["build_lora_preview_handler"]
         expected_all[
             PACKAGE_MODULES.index("easyuse_anima.api.routes.long_text_settings")
         ] = ["build_long_text_settings_handlers"]


### PR DESCRIPTION
## 목적과 변경 경계

Issue #186의 D-06d로, `GET /easyuse_anima/lora_preview` HTTP adapter를 canonical `easyuse_anima.api.routes` owner로 이동합니다. preview resolver/security와 프런트 production은 변경하지 않습니다.

## Base → Head

- Base: `681ec9bb16b54fba25c1575e8e0b4db3ddf42bb4`
- Head: `be821d7344ec8fba16e7fe642fa9e6727abf111d`

## 주요 파일과 보존 계약

- `easyuse_anima/api/routes/lora_preview.py`: pure binary/file-response handler factory
- `api.py`: dynamic resolver/offload/response/basename/correlation wiring
- `tests/test_api_contract.py`: canonical ownership과 기존 missing/found/header contract
- package/analyzer manifest와 reviewed fixture: shipping module 157 → 158

보존 계약:

- query `name` 기본값과 `_run_file_io` offload
- root `_resolve_lora_preview_path` monkeypatch seam
- missing preview의 raw empty 404
- found preview의 `FileResponse`와 basename-only `Content-Disposition`
- request correlation과 route order

제외 범위:

- resolver, `LORA_PREVIEW_EXTENSIONS`, catalog/profile routes, 프런트 production은 변경하지 않음

## 검증

- changed-file syntax와 `git diff --check`: 통과
- direct raw/binary/header contract: 1 test
- API contract: 50 tests
- LoRA preview lifecycle smoke: 통과
- package skeleton 1 / backend analyzer 18 / scanner 8 / import boundary 16 / compatibility surface 26
- `comfy node validate`: 통과
- `comfy node pack`: 300 entries, 새 route module 포함 확인 후 archive 삭제
- official full (Head에서 정확히 1회): Python 1,266 / frontend 120 / Pyright 141 files, 기존 14 diagnostics / G-03 11 groups, 0 violations / Ruff 기존 112 report-only
- isolated live missing: 404, empty body, UUID
- isolated live found: actual JPEG 200, UUID, `filename="Cosmos-Predict2.5-2B-base-distilled-LoRA.jpeg"`, basename-only, queue `0/0 → 0/0`
- isolated listener/process tree: 종료 및 잔존 0 확인

## 남은 위험과 rollback

동작 변경이 아닌 adapter owner 이동입니다. 문제 시 이 단일 commit을 revert하면 기존 inline handler로 복귀합니다.

## Next

latest `dev`에서 remaining profile routes의 mutation/identity 계약을 D-07 rollback 경계로 inventory합니다.