### PR TITLE
refactor: move profile list routes to API package (D-07a)

### DIFF
--- a/api.py
+++ b/api.py
@@ -75,6 +75,9 @@ from .easyuse_anima.api.routes.lora_catalog import (
 from .easyuse_anima.api.routes.lora_preview import (
     build_lora_preview_handler as _build_lora_preview_handler,
 )
+from .easyuse_anima.api.routes.profile_lists import (
+    build_profile_list_handlers as _build_profile_list_handlers,
+)
 from .easyuse_anima.api.routes.wildcards import (
     build_wildcards_handler as _build_wildcards_handler,
 )
@@ -619,13 +622,20 @@ if web is not None:
         )
     )
 
-    @_request_correlated
-    async def lora_profiles_handler(request):
-        try:
-            payload = await _run_file_io(_list_lora_profiles)
-        except InvalidProfileDataError as exc:
-            return _profile_error_response(exc)
-        return web.json_response({"profiles": payload})
+    (
+        lora_profiles_handler,
+        aio_profiles_handler,
+    ) = (
+        _request_correlated(handler)
+        for handler in _build_profile_list_handlers(
+            run_file_io=lambda function, *args: _run_file_io(function, *args),
+            list_lora_profiles=lambda: _list_lora_profiles(),
+            list_aio_profiles=lambda: _list_aio_profiles(),
+            profile_data_error_type=InvalidProfileDataError,
+            profile_error_response=lambda exc: _profile_error_response(exc),
+            json_response=lambda payload: web.json_response(payload),
+        )
+    )
 
     @_request_correlated
     async def save_lora_profile_handler(request):
@@ -676,14 +686,6 @@ if web is not None:
         ) as exc:
             return _profile_error_response(exc)
         return web.json_response({"status": "ok", "profile": payload})
-
-    @_request_correlated
-    async def aio_profiles_handler(request):
-        try:
-            payload = await _run_file_io(_list_aio_profiles)
-        except InvalidProfileDataError as exc:
-            return _profile_error_response(exc)
-        return web.json_response({"status": "ok", "profiles": payload})
 
     @_request_correlated
     async def save_aio_profile_handler(request):

--- a/easyuse_anima/api/routes/profile_lists.py
+++ b/easyuse_anima/api/routes/profile_lists.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+
+def build_profile_list_handlers(
+    *,
+    run_file_io,
+    list_lora_profiles,
+    list_aio_profiles,
+    profile_data_error_type,
+    profile_error_response,
+    json_response,
+):
+    """Build read-only profile list routes without loading mutation adapters."""
+
+    async def lora_profiles_handler(request):
+        try:
+            payload = await run_file_io(list_lora_profiles)
+        except profile_data_error_type as exc:
+            return profile_error_response(exc)
+        return json_response({"profiles": payload})
+
+    async def aio_profiles_handler(request):
+        try:
+            payload = await run_file_io(list_aio_profiles)
+        except profile_data_error_type as exc:
+            return profile_error_response(exc)
+        return json_response({"status": "ok", "profiles": payload})
+
+    return lora_profiles_handler, aio_profiles_handler
+
+
+__all__ = ("build_profile_list_handlers",)

--- a/tests/fixtures/python_backend_baseline.json
+++ b/tests/fixtures/python_backend_baseline.json
@@ -3689,6 +3689,24 @@
         "target": "easyuse_anima/api/routes/lora_preview.py"
       },
       {
+        "alias": "_build_profile_list_handlers",
+        "bound_name": "_build_profile_list_handlers",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".easyuse_anima.api.routes.profile_lists:build_profile_list_handlers",
+        "kind": "static_from",
+        "line": 78,
+        "name": "build_profile_list_handlers",
+        "optional": false,
+        "requested": ".easyuse_anima.api.routes.profile_lists",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "api.py",
+        "target": "easyuse_anima/api/routes/profile_lists.py"
+      },
+      {
         "alias": "_build_wildcards_handler",
         "bound_name": "_build_wildcards_handler",
         "branch_context": [],
@@ -3697,7 +3715,7 @@
         "conditional": false,
         "imported": ".easyuse_anima.api.routes.wildcards:build_wildcards_handler",
         "kind": "static_from",
-        "line": 78,
+        "line": 81,
         "name": "build_wildcards_handler",
         "optional": false,
         "requested": ".easyuse_anima.api.routes.wildcards",
@@ -3715,7 +3733,7 @@
         "conditional": false,
         "imported": ".easyuse_anima.api.routes.translation:build_translate_prompt_handler",
         "kind": "static_from",
-        "line": 81,
+        "line": 84,
         "name": "build_translate_prompt_handler",
         "optional": false,
         "requested": ".easyuse_anima.api.routes.translation",
@@ -3733,7 +3751,7 @@
         "conditional": false,
         "imported": ".easyuse_anima.api.routes.translation_execution:PromptTranslationRouteExecutor",
         "kind": "static_from",
-        "line": 84,
+        "line": 87,
         "name": "PromptTranslationRouteExecutor",
         "optional": false,
         "requested": ".easyuse_anima.api.routes.translation_execution",
@@ -3751,7 +3769,7 @@
         "conditional": false,
         "imported": ".easyuse_anima.api.routes.aio_torch_compile:build_aio_torch_compile_recommend_handler",
         "kind": "static_from",
-        "line": 87,
+        "line": 90,
         "name": "build_aio_torch_compile_recommend_handler",
         "optional": false,
         "requested": ".easyuse_anima.api.routes.aio_torch_compile",
@@ -3769,7 +3787,7 @@
         "conditional": false,
         "imported": ".easyuse_anima.aio.torch_compile_diagnostics:collect_torch_compile_diagnostics",
         "kind": "static_from",
-        "line": 90,
+        "line": 93,
         "name": "collect_torch_compile_diagnostics",
         "optional": false,
         "requested": ".easyuse_anima.aio.torch_compile_diagnostics",
@@ -3787,7 +3805,7 @@
         "conditional": false,
         "imported": ".easyuse_anima.aio.torch_compile_recommendation:recommend_torch_compile",
         "kind": "static_from",
-        "line": 93,
+        "line": 96,
         "name": "recommend_torch_compile",
         "optional": false,
         "requested": ".easyuse_anima.aio.torch_compile_recommendation",
@@ -3805,7 +3823,7 @@
         "conditional": false,
         "imported": ".easyuse_anima.profiles:aio",
         "kind": "static_from",
-        "line": 96,
+        "line": 99,
         "name": "aio",
         "optional": false,
         "requested": ".easyuse_anima.profiles",
@@ -3823,7 +3841,7 @@
         "conditional": false,
         "imported": ".easyuse_anima.profiles:contract",
         "kind": "static_from",
-        "line": 97,
+        "line": 100,
         "name": "contract",
         "optional": false,
         "requested": ".easyuse_anima.profiles",
@@ -3841,7 +3859,7 @@
         "conditional": false,
         "imported": ".easyuse_anima.profiles:lora",
         "kind": "static_from",
-        "line": 98,
+        "line": 101,
         "name": "lora",
         "optional": false,
         "requested": ".easyuse_anima.profiles",
@@ -3859,7 +3877,7 @@
         "conditional": false,
         "imported": ".easyuse_anima.profiles:mutation",
         "kind": "static_from",
-        "line": 99,
+        "line": 102,
         "name": "mutation",
         "optional": false,
         "requested": ".easyuse_anima.profiles",
@@ -3877,7 +3895,7 @@
         "conditional": false,
         "imported": ".easyuse_anima.profiles:repository",
         "kind": "static_from",
-        "line": 100,
+        "line": 103,
         "name": "repository",
         "optional": false,
         "requested": ".easyuse_anima.profiles",
@@ -3895,7 +3913,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 303
+            "line": 306
           }
         ],
         "classification": "external",
@@ -3903,7 +3921,7 @@
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 304,
+        "line": 307,
         "name": null,
         "optional": true,
         "requested": "folder_paths",
@@ -15277,6 +15295,23 @@
         "role": "ordinary",
         "scope": "<module>",
         "source": "easyuse_anima/api/routes/lora_preview.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "annotations",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "__future__:annotations",
+        "kind": "static_from",
+        "line": 1,
+        "name": "annotations",
+        "optional": false,
+        "requested": "__future__",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/api/routes/profile_lists.py"
       },
       {
         "alias": null,
@@ -63069,6 +63104,10 @@
       },
       {
         "from": "api.py",
+        "to": "easyuse_anima/api/routes/profile_lists.py"
+      },
+      {
+        "from": "api.py",
         "to": "easyuse_anima/api/routes/translation.py"
       },
       {
@@ -65178,6 +65217,12 @@
       {
         "cyclic": false,
         "modules": [
+          "easyuse_anima/api/routes/profile_lists.py"
+        ]
+      },
+      {
+        "cyclic": false,
+        "modules": [
           "easyuse_anima/api/routes/translation.py"
         ]
       },
@@ -65779,7 +65824,7 @@
     ]
   },
   "inventory": {
-    "module_count": 158,
+    "module_count": 159,
     "modules": [
       {
         "is_package": true,
@@ -65879,14 +65924,14 @@
       },
       {
         "is_package": false,
-        "loc": 878,
+        "loc": 880,
         "module": "api",
-        "normalized_git_blob_sha1": "f0059e6c202b30f4f1f5aec5c5c3023122d6fd17",
+        "normalized_git_blob_sha1": "99923f365c173e29eea65519b3311d7f140a71ab",
         "path": "api.py",
         "top_level": {
           "class_count": 0,
           "function_count": 23,
-          "global_count": 85
+          "global_count": 87
         }
       },
       {
@@ -66459,6 +66504,18 @@
         "module": "easyuse_anima.api.routes.lora_preview",
         "normalized_git_blob_sha1": "03bdcfbe68d71124ea2c424e271543a61c2093c4",
         "path": "easyuse_anima/api/routes/lora_preview.py",
+        "top_level": {
+          "class_count": 0,
+          "function_count": 1,
+          "global_count": 1
+        }
+      },
+      {
+        "is_package": false,
+        "loc": 32,
+        "module": "easyuse_anima.api.routes.profile_lists",
+        "normalized_git_blob_sha1": "309a56e41a1e6e276d2dd4b0f5905a4bbf76345b",
+        "path": "easyuse_anima/api/routes/profile_lists.py",
         "top_level": {
           "class_count": 0,
           "function_count": 1,
@@ -80705,14 +80762,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 303
+            "line": 306
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 304,
+        "line": 307,
         "optional": true,
         "role": "optional_dependency",
         "source": "api.py"
@@ -82799,6 +82856,17 @@
         "optional": false,
         "role": "ordinary",
         "source": "easyuse_anima/api/routes/lora_preview.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "__future__:annotations",
+        "kind": "static_from",
+        "line": 1,
+        "optional": false,
+        "role": "ordinary",
+        "source": "easyuse_anima/api/routes/profile_lists.py"
       },
       {
         "branch_context": [],
@@ -86986,14 +87054,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 303
+            "line": 306
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 304,
+        "line": 307,
         "optional": true,
         "role": "optional_dependency",
         "source": "api.py"
@@ -87938,6 +88006,7 @@
       "easyuse_anima/api/routes/long_text_settings.py",
       "easyuse_anima/api/routes/lora_catalog.py",
       "easyuse_anima/api/routes/lora_preview.py",
+      "easyuse_anima/api/routes/profile_lists.py",
       "easyuse_anima/api/routes/translation.py",
       "easyuse_anima/api/routes/translation_execution.py",
       "easyuse_anima/api/routes/wildcards.py",
@@ -88098,6 +88167,7 @@
       "easyuse_anima/api/routes/long_text_settings.py",
       "easyuse_anima/api/routes/lora_catalog.py",
       "easyuse_anima/api/routes/lora_preview.py",
+      "easyuse_anima/api/routes/profile_lists.py",
       "easyuse_anima/api/routes/translation.py",
       "easyuse_anima/api/routes/translation_execution.py",
       "easyuse_anima/api/routes/wildcards.py",
@@ -88219,7 +88289,7 @@
         "column": 10,
         "context": "assign:_LOGGER",
         "kind": "import_time_call",
-        "line": 180,
+        "line": 183,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -88228,7 +88298,7 @@
         "column": 25,
         "context": "assign:_FILE_IO_LIMITERS_LOCK",
         "kind": "import_time_call",
-        "line": 183,
+        "line": 186,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -88237,7 +88307,7 @@
         "column": 47,
         "context": "assign:_FILE_IO_LIMITERS",
         "kind": "import_time_call",
-        "line": 184,
+        "line": 187,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -88246,7 +88316,7 @@
         "column": 29,
         "context": "assign:_PROMPT_TRANSLATION_WORKER",
         "kind": "route_registry_creation",
-        "line": 187,
+        "line": 190,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -88255,7 +88325,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 192,
+        "line": 195,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -88264,7 +88334,7 @@
         "column": 36,
         "context": "assign:_SAFE_PROFILE_VALIDATION_MESSAGES",
         "kind": "import_time_call",
-        "line": 330,
+        "line": 333,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -88273,7 +88343,7 @@
         "column": 9,
         "context": "assign:routes",
         "kind": "route_registry_creation",
-        "line": 487,
+        "line": 490,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -88282,7 +88352,7 @@
         "column": 8,
         "context": "assign:get_long_text_settings_handler,save_long_text_settings_handler",
         "kind": "import_time_call",
-        "line": 517,
+        "line": 520,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -88291,7 +88361,7 @@
         "column": 23,
         "context": "assign:get_long_text_settings_handler,save_long_text_settings_handler",
         "kind": "import_time_call",
-        "line": 518,
+        "line": 521,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -88300,7 +88370,7 @@
         "column": 28,
         "context": "assign:get_wildcards_handler",
         "kind": "import_time_call",
-        "line": 532,
+        "line": 535,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -88309,7 +88379,7 @@
         "column": 8,
         "context": "assign:get_wildcards_handler",
         "kind": "import_time_call",
-        "line": 533,
+        "line": 536,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -88318,7 +88388,7 @@
         "column": 8,
         "context": "assign:autocomplete_handler,autocomplete_status_handler",
         "kind": "import_time_call",
-        "line": 544,
+        "line": 547,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -88327,7 +88397,7 @@
         "column": 23,
         "context": "assign:autocomplete_handler,autocomplete_status_handler",
         "kind": "import_time_call",
-        "line": 545,
+        "line": 548,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -88336,7 +88406,7 @@
         "column": 30,
         "context": "assign:classify_prompt_handler",
         "kind": "import_time_call",
-        "line": 555,
+        "line": 558,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -88345,7 +88415,7 @@
         "column": 8,
         "context": "assign:classify_prompt_handler",
         "kind": "import_time_call",
-        "line": 556,
+        "line": 559,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -88354,7 +88424,7 @@
         "column": 31,
         "context": "assign:translate_prompt_handler",
         "kind": "import_time_call",
-        "line": 574,
+        "line": 577,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -88363,7 +88433,7 @@
         "column": 8,
         "context": "assign:translate_prompt_handler",
         "kind": "import_time_call",
-        "line": 575,
+        "line": 578,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -88372,7 +88442,7 @@
         "column": 42,
         "context": "assign:aio_torch_compile_recommend_handler",
         "kind": "import_time_call",
-        "line": 587,
+        "line": 590,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -88381,7 +88451,7 @@
         "column": 8,
         "context": "assign:aio_torch_compile_recommend_handler",
         "kind": "import_time_call",
-        "line": 588,
+        "line": 591,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -88390,7 +88460,7 @@
         "column": 27,
         "context": "assign:lora_preview_handler",
         "kind": "import_time_call",
-        "line": 604,
+        "line": 607,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -88399,7 +88469,7 @@
         "column": 8,
         "context": "assign:lora_preview_handler",
         "kind": "import_time_call",
-        "line": 605,
+        "line": 608,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -88408,7 +88478,7 @@
         "column": 20,
         "context": "assign:loras_handler",
         "kind": "import_time_call",
-        "line": 614,
+        "line": 617,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -88417,7 +88487,25 @@
         "column": 8,
         "context": "assign:loras_handler",
         "kind": "import_time_call",
-        "line": 615,
+        "line": 618,
+        "module": "api.py",
+        "scope": "<module>"
+      },
+      {
+        "callee": "_request_correlated",
+        "column": 8,
+        "context": "assign:aio_profiles_handler,lora_profiles_handler",
+        "kind": "import_time_call",
+        "line": 629,
+        "module": "api.py",
+        "scope": "<module>"
+      },
+      {
+        "callee": "_build_profile_list_handlers",
+        "column": 23,
+        "context": "assign:aio_profiles_handler,lora_profiles_handler",
+        "kind": "import_time_call",
+        "line": 630,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -88426,7 +88514,7 @@
         "column": 19,
         "context": "assign:_ROUTE_SIGNATURE",
         "kind": "route_registry_creation",
-        "line": 854,
+        "line": 856,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -88435,7 +88523,7 @@
         "column": 5,
         "context": "assign:_ROUTE_SIGNATURE",
         "kind": "route_registry_creation",
-        "line": 855,
+        "line": 857,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -90706,7 +90794,7 @@
           "lock"
         ],
         "initializer": "threading.Lock",
-        "line": 183,
+        "line": 186,
         "module": "api.py",
         "name": "_FILE_IO_LIMITERS_LOCK"
       },
@@ -90715,7 +90803,7 @@
           "executor"
         ],
         "initializer": "_PromptTranslationRouteExecutor",
-        "line": 187,
+        "line": 190,
         "module": "api.py",
         "name": "_PROMPT_TRANSLATION_WORKER"
       },

--- a/tests/test_api_contract.py
+++ b/tests/test_api_contract.py
@@ -461,6 +461,80 @@ class ApiLoraCatalogRouteTests(unittest.TestCase):
         list_loras.assert_called_once_with()
 
 
+class ApiProfileListRouteTests(unittest.TestCase):
+    def test_route_handlers_are_owned_by_the_canonical_factory(self):
+        api, routes = load_api_routes()
+        cases = (
+            ("lora_profiles_handler", "/easyuse_anima/lora_profiles"),
+            ("aio_profiles_handler", "/easyuse_anima/aio_profiles"),
+        )
+
+        for name, path in cases:
+            with self.subTest(path=path):
+                handler = routes.handlers[path]
+                self.assertIs(getattr(api, name), handler)
+                self.assertEqual(handler.__name__, name)
+                self.assertTrue(
+                    handler.__module__.endswith(
+                        ".easyuse_anima.api.routes.profile_lists"
+                    )
+                )
+                self.assertTrue(handler._easyuse_anima_request_correlation)
+
+    def test_routes_keep_dynamic_list_seams_and_legacy_success_shapes(self):
+        api, routes = load_api_routes()
+        profiles = [
+            {
+                "name": "Portrait",
+                "profile_id": "22345678-1234-4567-89ab-1234567890ab",
+                "revision": 3,
+            }
+        ]
+        cases = (
+            (
+                "/easyuse_anima/lora_profiles",
+                "_list_lora_profiles",
+                {"profiles": profiles},
+            ),
+            (
+                "/easyuse_anima/aio_profiles",
+                "_list_aio_profiles",
+                {"status": "ok", "profiles": profiles},
+            ),
+        )
+
+        for path, operation_name, expected_payload in cases:
+            with self.subTest(path=path), patch.object(
+                api,
+                operation_name,
+                return_value=profiles,
+            ) as list_profiles:
+                response = asyncio.run(routes.handlers[path](JsonRequest()))
+
+            self.assertEqual(response["status"], 200)
+            self.assertEqual(response["payload"], expected_payload)
+            list_profiles.assert_called_once_with()
+
+    def test_routes_map_only_stored_profile_errors(self):
+        api, routes = load_api_routes()
+        cases = (
+            ("/easyuse_anima/lora_profiles", "_list_lora_profiles"),
+            ("/easyuse_anima/aio_profiles", "_list_aio_profiles"),
+        )
+
+        for path, operation_name in cases:
+            with self.subTest(path=path), patch.object(
+                api,
+                operation_name,
+                side_effect=api.InvalidProfileDataError("private path"),
+            ):
+                response = asyncio.run(routes.handlers[path](JsonRequest()))
+
+            self.assertEqual(response["status"], 422)
+            self.assertEqual(response["payload"]["code"], "invalid_profile_data")
+            self.assertNotIn("private path", json.dumps(response["payload"]))
+
+
 class ApiWildcardRouteTests(unittest.TestCase):
     def test_route_handler_is_owned_by_the_canonical_factory(self):
         api, routes = load_api_routes()

--- a/tests/test_python_backend_analyzer.py
+++ b/tests/test_python_backend_analyzer.py
@@ -690,9 +690,9 @@ ignored/
 
         self.assertEqual(analyzer.render_json(report), expected_text)
         self.assertEqual(report["schema_version"], 2)
-        self.assertEqual(report["inventory"]["module_count"], 158)
-        self.assertEqual(len(report["registry"]["shipped_python_modules"]), 158)
-        self.assertEqual(len(report["registry"]["runtime_import_closure"]), 158)
+        self.assertEqual(report["inventory"]["module_count"], 159)
+        self.assertEqual(len(report["registry"]["shipped_python_modules"]), 159)
+        self.assertEqual(len(report["registry"]["runtime_import_closure"]), 159)
         self.assertEqual(
             report["registry"]["entry_modules"],
             [

--- a/tests/test_python_package_skeleton.py
+++ b/tests/test_python_package_skeleton.py
@@ -52,6 +52,7 @@ PACKAGE_MODULES = (
     "easyuse_anima.api.routes.lora_catalog",
     "easyuse_anima.api.routes.lora_preview",
     "easyuse_anima.api.routes.long_text_settings",
+    "easyuse_anima.api.routes.profile_lists",
     "easyuse_anima.api.routes.translation",
     "easyuse_anima.api.routes.translation_execution",
     "easyuse_anima.api.routes.wildcards",
@@ -237,6 +238,9 @@ print(json.dumps({{
         expected_all[
             PACKAGE_MODULES.index("easyuse_anima.api.routes.long_text_settings")
         ] = ["build_long_text_settings_handlers"]
+        expected_all[
+            PACKAGE_MODULES.index("easyuse_anima.api.routes.profile_lists")
+        ] = ["build_profile_list_handlers"]
         expected_all[
             PACKAGE_MODULES.index("easyuse_anima.api.routes.translation")
         ] = ["build_translate_prompt_handler"]


### PR DESCRIPTION
## 목적과 변경 경계

Issue #186의 D-07a로, LoRA/AiO read-only profile list HTTP adapters를 shared canonical `easyuse_anima.api.routes` owner로 이동합니다. profile storage/mutation/load와 프런트 production은 변경하지 않습니다.

## Base → Head

- Base: `aa88ab04fdc17c60770995fb3755ebf7b7016c24`
- Head: `d8056833c7b429b4a4edb6f2a51cbc99f7bbf783`

## 주요 파일과 보존 계약

- `easyuse_anima/api/routes/profile_lists.py`: pure LoRA/AiO list handler factory
- `api.py`: dynamic list/offload/error/JSON/correlation wiring
- `tests/test_api_contract.py`: ownership, dynamic seams, legacy success shapes, stored-data error mapping
- package/analyzer manifest와 reviewed fixture: shipping module 158 → 159

보존 계약:

- root `_list_lora_profiles`/`_list_aio_profiles` monkeypatch seam과 `_run_file_io` offload
- `InvalidProfileDataError`만 stored-data 422
- generic `ValueError`/unexpected error는 correlated safe 500
- LoRA `{profiles}`와 AiO `{status: ok, profiles}` legacy success shape
- request correlation과 route order

제외 범위:

- profile load/save/delete/rename/fix, identity/revision mutation, bytes/mtime migration, 프런트 production은 변경하지 않음

## 검증

- changed-file syntax와 `git diff --check`: 통과
- D-07a direct contract: 3 tests
- API contract: 53 tests
- LoRA/AiO profile API client smokes: 통과
- package skeleton 1 / backend analyzer 18 / scanner 8 / import boundary 16 / compatibility surface 26
- `comfy node validate`: 통과
- `comfy node pack`: 301 entries, 새 route module 포함 확인 후 archive 삭제
- official full (Head에서 정확히 1회): Python 1,269 / frontend 120 / Pyright 142 files, 기존 14 diagnostics / G-03 11 groups, 0 violations / Ruff 기존 112 report-only
- isolated live: LoRA `{profiles}` 200, AiO `{status: ok, profiles}` 200, UUID, 경로 미노출, queue `0/0 → 0/0`
- isolated fixture profile은 0건이며 token semantics는 focused/storage suites에서 검증
- isolated listener/process tree: 종료 및 잔존 0 확인

## 남은 위험과 rollback

동작 변경이 아닌 read-only adapter owner 이동입니다. 문제 시 이 단일 commit을 revert하면 기존 inline handlers로 복귀합니다.

## Next

D-07b에서 LoRA/AiO load routes의 query/not-found/decode error contract를 별도 inventory합니다.