### PR TITLE
refactor: move profile load routes to API package (D-07b)

### DIFF
--- a/api.py
+++ b/api.py
@@ -78,6 +78,9 @@ from .easyuse_anima.api.routes.lora_preview import (
 from .easyuse_anima.api.routes.profile_lists import (
     build_profile_list_handlers as _build_profile_list_handlers,
 )
+from .easyuse_anima.api.routes.profile_loads import (
+    build_profile_load_handlers as _build_profile_load_handlers,
+)
 from .easyuse_anima.api.routes.wildcards import (
     build_wildcards_handler as _build_wildcards_handler,
 )
@@ -637,6 +640,27 @@ if web is not None:
         )
     )
 
+    (
+        load_lora_profile_handler,
+        load_aio_profile_handler,
+    ) = (
+        _request_correlated(handler)
+        for handler in _build_profile_load_handlers(
+            run_file_io=lambda function, *args: _run_file_io(function, *args),
+            load_lora_profile=lambda name: _load_lora_profile(name),
+            load_aio_profile=lambda name: _load_aio_profile(name),
+            lora_load_error_types=(
+                json.JSONDecodeError,
+                UnicodeDecodeError,
+                FileNotFoundError,
+                ValueError,
+            ),
+            aio_load_error_types=(FileNotFoundError, ValueError),
+            profile_error_response=lambda exc: _profile_error_response(exc),
+            json_response=lambda payload: web.json_response(payload),
+        )
+    )
+
     @_request_correlated
     async def save_lora_profile_handler(request):
         try:
@@ -672,22 +696,6 @@ if web is not None:
         return web.json_response({"status": "ok", "profile": payload})
 
     @_request_correlated
-    async def load_lora_profile_handler(request):
-        try:
-            payload = await _run_file_io(
-                _load_lora_profile,
-                request.query.get("name", ""),
-            )
-        except (
-            json.JSONDecodeError,
-            UnicodeDecodeError,
-            FileNotFoundError,
-            ValueError,
-        ) as exc:
-            return _profile_error_response(exc)
-        return web.json_response({"status": "ok", "profile": payload})
-
-    @_request_correlated
     async def save_aio_profile_handler(request):
         try:
             data = await parse_json_object(request)
@@ -717,17 +725,6 @@ if web is not None:
                 revision=revision,
             )
         except (FileExistsError, FileNotFoundError, ValueError) as exc:
-            return _profile_error_response(exc)
-        return web.json_response({"status": "ok", "profile": payload})
-
-    @_request_correlated
-    async def load_aio_profile_handler(request):
-        try:
-            payload = await _run_file_io(
-                _load_aio_profile,
-                request.query.get("name", ""),
-            )
-        except (FileNotFoundError, ValueError) as exc:
             return _profile_error_response(exc)
         return web.json_response({"status": "ok", "profile": payload})
 

--- a/easyuse_anima/api/routes/profile_loads.py
+++ b/easyuse_anima/api/routes/profile_loads.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+
+def build_profile_load_handlers(
+    *,
+    run_file_io,
+    load_lora_profile,
+    load_aio_profile,
+    lora_load_error_types,
+    aio_load_error_types,
+    profile_error_response,
+    json_response,
+):
+    """Build read-only profile load routes without loading mutation adapters."""
+
+    async def load_lora_profile_handler(request):
+        try:
+            payload = await run_file_io(
+                load_lora_profile,
+                request.query.get("name", ""),
+            )
+        except lora_load_error_types as exc:
+            return profile_error_response(exc)
+        return json_response({"status": "ok", "profile": payload})
+
+    async def load_aio_profile_handler(request):
+        try:
+            payload = await run_file_io(
+                load_aio_profile,
+                request.query.get("name", ""),
+            )
+        except aio_load_error_types as exc:
+            return profile_error_response(exc)
+        return json_response({"status": "ok", "profile": payload})
+
+    return load_lora_profile_handler, load_aio_profile_handler
+
+
+__all__ = ("build_profile_load_handlers",)

--- a/tests/fixtures/python_backend_baseline.json
+++ b/tests/fixtures/python_backend_baseline.json
@@ -3707,6 +3707,24 @@
         "target": "easyuse_anima/api/routes/profile_lists.py"
       },
       {
+        "alias": "_build_profile_load_handlers",
+        "bound_name": "_build_profile_load_handlers",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".easyuse_anima.api.routes.profile_loads:build_profile_load_handlers",
+        "kind": "static_from",
+        "line": 81,
+        "name": "build_profile_load_handlers",
+        "optional": false,
+        "requested": ".easyuse_anima.api.routes.profile_loads",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "api.py",
+        "target": "easyuse_anima/api/routes/profile_loads.py"
+      },
+      {
         "alias": "_build_wildcards_handler",
         "bound_name": "_build_wildcards_handler",
         "branch_context": [],
@@ -3715,7 +3733,7 @@
         "conditional": false,
         "imported": ".easyuse_anima.api.routes.wildcards:build_wildcards_handler",
         "kind": "static_from",
-        "line": 81,
+        "line": 84,
         "name": "build_wildcards_handler",
         "optional": false,
         "requested": ".easyuse_anima.api.routes.wildcards",
@@ -3733,7 +3751,7 @@
         "conditional": false,
         "imported": ".easyuse_anima.api.routes.translation:build_translate_prompt_handler",
         "kind": "static_from",
-        "line": 84,
+        "line": 87,
         "name": "build_translate_prompt_handler",
         "optional": false,
         "requested": ".easyuse_anima.api.routes.translation",
@@ -3751,7 +3769,7 @@
         "conditional": false,
         "imported": ".easyuse_anima.api.routes.translation_execution:PromptTranslationRouteExecutor",
         "kind": "static_from",
-        "line": 87,
+        "line": 90,
         "name": "PromptTranslationRouteExecutor",
         "optional": false,
         "requested": ".easyuse_anima.api.routes.translation_execution",
@@ -3769,7 +3787,7 @@
         "conditional": false,
         "imported": ".easyuse_anima.api.routes.aio_torch_compile:build_aio_torch_compile_recommend_handler",
         "kind": "static_from",
-        "line": 90,
+        "line": 93,
         "name": "build_aio_torch_compile_recommend_handler",
         "optional": false,
         "requested": ".easyuse_anima.api.routes.aio_torch_compile",
@@ -3787,7 +3805,7 @@
         "conditional": false,
         "imported": ".easyuse_anima.aio.torch_compile_diagnostics:collect_torch_compile_diagnostics",
         "kind": "static_from",
-        "line": 93,
+        "line": 96,
         "name": "collect_torch_compile_diagnostics",
         "optional": false,
         "requested": ".easyuse_anima.aio.torch_compile_diagnostics",
@@ -3805,7 +3823,7 @@
         "conditional": false,
         "imported": ".easyuse_anima.aio.torch_compile_recommendation:recommend_torch_compile",
         "kind": "static_from",
-        "line": 96,
+        "line": 99,
         "name": "recommend_torch_compile",
         "optional": false,
         "requested": ".easyuse_anima.aio.torch_compile_recommendation",
@@ -3823,7 +3841,7 @@
         "conditional": false,
         "imported": ".easyuse_anima.profiles:aio",
         "kind": "static_from",
-        "line": 99,
+        "line": 102,
         "name": "aio",
         "optional": false,
         "requested": ".easyuse_anima.profiles",
@@ -3841,7 +3859,7 @@
         "conditional": false,
         "imported": ".easyuse_anima.profiles:contract",
         "kind": "static_from",
-        "line": 100,
+        "line": 103,
         "name": "contract",
         "optional": false,
         "requested": ".easyuse_anima.profiles",
@@ -3859,7 +3877,7 @@
         "conditional": false,
         "imported": ".easyuse_anima.profiles:lora",
         "kind": "static_from",
-        "line": 101,
+        "line": 104,
         "name": "lora",
         "optional": false,
         "requested": ".easyuse_anima.profiles",
@@ -3877,7 +3895,7 @@
         "conditional": false,
         "imported": ".easyuse_anima.profiles:mutation",
         "kind": "static_from",
-        "line": 102,
+        "line": 105,
         "name": "mutation",
         "optional": false,
         "requested": ".easyuse_anima.profiles",
@@ -3895,7 +3913,7 @@
         "conditional": false,
         "imported": ".easyuse_anima.profiles:repository",
         "kind": "static_from",
-        "line": 103,
+        "line": 106,
         "name": "repository",
         "optional": false,
         "requested": ".easyuse_anima.profiles",
@@ -3913,7 +3931,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 306
+            "line": 309
           }
         ],
         "classification": "external",
@@ -3921,7 +3939,7 @@
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 307,
+        "line": 310,
         "name": null,
         "optional": true,
         "requested": "folder_paths",
@@ -15312,6 +15330,23 @@
         "role": "ordinary",
         "scope": "<module>",
         "source": "easyuse_anima/api/routes/profile_lists.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "annotations",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "__future__:annotations",
+        "kind": "static_from",
+        "line": 1,
+        "name": "annotations",
+        "optional": false,
+        "requested": "__future__",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/api/routes/profile_loads.py"
       },
       {
         "alias": null,
@@ -63108,6 +63143,10 @@
       },
       {
         "from": "api.py",
+        "to": "easyuse_anima/api/routes/profile_loads.py"
+      },
+      {
+        "from": "api.py",
         "to": "easyuse_anima/api/routes/translation.py"
       },
       {
@@ -65223,6 +65262,12 @@
       {
         "cyclic": false,
         "modules": [
+          "easyuse_anima/api/routes/profile_loads.py"
+        ]
+      },
+      {
+        "cyclic": false,
+        "modules": [
           "easyuse_anima/api/routes/translation.py"
         ]
       },
@@ -65824,7 +65869,7 @@
     ]
   },
   "inventory": {
-    "module_count": 159,
+    "module_count": 160,
     "modules": [
       {
         "is_package": true,
@@ -65924,14 +65969,14 @@
       },
       {
         "is_package": false,
-        "loc": 880,
+        "loc": 877,
         "module": "api",
-        "normalized_git_blob_sha1": "99923f365c173e29eea65519b3311d7f140a71ab",
+        "normalized_git_blob_sha1": "792ce6070d3792366d563d72f03d8319ba5042c7",
         "path": "api.py",
         "top_level": {
           "class_count": 0,
           "function_count": 23,
-          "global_count": 87
+          "global_count": 89
         }
       },
       {
@@ -66516,6 +66561,18 @@
         "module": "easyuse_anima.api.routes.profile_lists",
         "normalized_git_blob_sha1": "309a56e41a1e6e276d2dd4b0f5905a4bbf76345b",
         "path": "easyuse_anima/api/routes/profile_lists.py",
+        "top_level": {
+          "class_count": 0,
+          "function_count": 1,
+          "global_count": 1
+        }
+      },
+      {
+        "is_package": false,
+        "loc": 39,
+        "module": "easyuse_anima.api.routes.profile_loads",
+        "normalized_git_blob_sha1": "b3f950cd4c1d9c726010446741f717f927d3edc5",
+        "path": "easyuse_anima/api/routes/profile_loads.py",
         "top_level": {
           "class_count": 0,
           "function_count": 1,
@@ -80762,14 +80819,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 306
+            "line": 309
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 307,
+        "line": 310,
         "optional": true,
         "role": "optional_dependency",
         "source": "api.py"
@@ -82867,6 +82924,17 @@
         "optional": false,
         "role": "ordinary",
         "source": "easyuse_anima/api/routes/profile_lists.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "__future__:annotations",
+        "kind": "static_from",
+        "line": 1,
+        "optional": false,
+        "role": "ordinary",
+        "source": "easyuse_anima/api/routes/profile_loads.py"
       },
       {
         "branch_context": [],
@@ -87054,14 +87122,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 306
+            "line": 309
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 307,
+        "line": 310,
         "optional": true,
         "role": "optional_dependency",
         "source": "api.py"
@@ -88007,6 +88075,7 @@
       "easyuse_anima/api/routes/lora_catalog.py",
       "easyuse_anima/api/routes/lora_preview.py",
       "easyuse_anima/api/routes/profile_lists.py",
+      "easyuse_anima/api/routes/profile_loads.py",
       "easyuse_anima/api/routes/translation.py",
       "easyuse_anima/api/routes/translation_execution.py",
       "easyuse_anima/api/routes/wildcards.py",
@@ -88168,6 +88237,7 @@
       "easyuse_anima/api/routes/lora_catalog.py",
       "easyuse_anima/api/routes/lora_preview.py",
       "easyuse_anima/api/routes/profile_lists.py",
+      "easyuse_anima/api/routes/profile_loads.py",
       "easyuse_anima/api/routes/translation.py",
       "easyuse_anima/api/routes/translation_execution.py",
       "easyuse_anima/api/routes/wildcards.py",
@@ -88289,7 +88359,7 @@
         "column": 10,
         "context": "assign:_LOGGER",
         "kind": "import_time_call",
-        "line": 183,
+        "line": 186,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -88298,7 +88368,7 @@
         "column": 25,
         "context": "assign:_FILE_IO_LIMITERS_LOCK",
         "kind": "import_time_call",
-        "line": 186,
+        "line": 189,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -88307,7 +88377,7 @@
         "column": 47,
         "context": "assign:_FILE_IO_LIMITERS",
         "kind": "import_time_call",
-        "line": 187,
+        "line": 190,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -88316,7 +88386,7 @@
         "column": 29,
         "context": "assign:_PROMPT_TRANSLATION_WORKER",
         "kind": "route_registry_creation",
-        "line": 190,
+        "line": 193,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -88325,7 +88395,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 195,
+        "line": 198,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -88334,7 +88404,7 @@
         "column": 36,
         "context": "assign:_SAFE_PROFILE_VALIDATION_MESSAGES",
         "kind": "import_time_call",
-        "line": 333,
+        "line": 336,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -88343,7 +88413,7 @@
         "column": 9,
         "context": "assign:routes",
         "kind": "route_registry_creation",
-        "line": 490,
+        "line": 493,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -88352,7 +88422,7 @@
         "column": 8,
         "context": "assign:get_long_text_settings_handler,save_long_text_settings_handler",
         "kind": "import_time_call",
-        "line": 520,
+        "line": 523,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -88361,7 +88431,7 @@
         "column": 23,
         "context": "assign:get_long_text_settings_handler,save_long_text_settings_handler",
         "kind": "import_time_call",
-        "line": 521,
+        "line": 524,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -88370,7 +88440,7 @@
         "column": 28,
         "context": "assign:get_wildcards_handler",
         "kind": "import_time_call",
-        "line": 535,
+        "line": 538,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -88379,7 +88449,7 @@
         "column": 8,
         "context": "assign:get_wildcards_handler",
         "kind": "import_time_call",
-        "line": 536,
+        "line": 539,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -88388,7 +88458,7 @@
         "column": 8,
         "context": "assign:autocomplete_handler,autocomplete_status_handler",
         "kind": "import_time_call",
-        "line": 547,
+        "line": 550,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -88397,7 +88467,7 @@
         "column": 23,
         "context": "assign:autocomplete_handler,autocomplete_status_handler",
         "kind": "import_time_call",
-        "line": 548,
+        "line": 551,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -88406,7 +88476,7 @@
         "column": 30,
         "context": "assign:classify_prompt_handler",
         "kind": "import_time_call",
-        "line": 558,
+        "line": 561,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -88415,7 +88485,7 @@
         "column": 8,
         "context": "assign:classify_prompt_handler",
         "kind": "import_time_call",
-        "line": 559,
+        "line": 562,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -88424,7 +88494,7 @@
         "column": 31,
         "context": "assign:translate_prompt_handler",
         "kind": "import_time_call",
-        "line": 577,
+        "line": 580,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -88433,7 +88503,7 @@
         "column": 8,
         "context": "assign:translate_prompt_handler",
         "kind": "import_time_call",
-        "line": 578,
+        "line": 581,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -88442,7 +88512,7 @@
         "column": 42,
         "context": "assign:aio_torch_compile_recommend_handler",
         "kind": "import_time_call",
-        "line": 590,
+        "line": 593,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -88451,7 +88521,7 @@
         "column": 8,
         "context": "assign:aio_torch_compile_recommend_handler",
         "kind": "import_time_call",
-        "line": 591,
+        "line": 594,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -88460,7 +88530,7 @@
         "column": 27,
         "context": "assign:lora_preview_handler",
         "kind": "import_time_call",
-        "line": 607,
+        "line": 610,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -88469,7 +88539,7 @@
         "column": 8,
         "context": "assign:lora_preview_handler",
         "kind": "import_time_call",
-        "line": 608,
+        "line": 611,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -88478,7 +88548,7 @@
         "column": 20,
         "context": "assign:loras_handler",
         "kind": "import_time_call",
-        "line": 617,
+        "line": 620,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -88487,7 +88557,7 @@
         "column": 8,
         "context": "assign:loras_handler",
         "kind": "import_time_call",
-        "line": 618,
+        "line": 621,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -88496,7 +88566,7 @@
         "column": 8,
         "context": "assign:aio_profiles_handler,lora_profiles_handler",
         "kind": "import_time_call",
-        "line": 629,
+        "line": 632,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -88505,7 +88575,25 @@
         "column": 23,
         "context": "assign:aio_profiles_handler,lora_profiles_handler",
         "kind": "import_time_call",
-        "line": 630,
+        "line": 633,
+        "module": "api.py",
+        "scope": "<module>"
+      },
+      {
+        "callee": "_request_correlated",
+        "column": 8,
+        "context": "assign:load_aio_profile_handler,load_lora_profile_handler",
+        "kind": "import_time_call",
+        "line": 647,
+        "module": "api.py",
+        "scope": "<module>"
+      },
+      {
+        "callee": "_build_profile_load_handlers",
+        "column": 23,
+        "context": "assign:load_aio_profile_handler,load_lora_profile_handler",
+        "kind": "import_time_call",
+        "line": 648,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -88514,7 +88602,7 @@
         "column": 19,
         "context": "assign:_ROUTE_SIGNATURE",
         "kind": "route_registry_creation",
-        "line": 856,
+        "line": 853,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -88523,7 +88611,7 @@
         "column": 5,
         "context": "assign:_ROUTE_SIGNATURE",
         "kind": "route_registry_creation",
-        "line": 857,
+        "line": 854,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -90794,7 +90882,7 @@
           "lock"
         ],
         "initializer": "threading.Lock",
-        "line": 186,
+        "line": 189,
         "module": "api.py",
         "name": "_FILE_IO_LIMITERS_LOCK"
       },
@@ -90803,7 +90891,7 @@
           "executor"
         ],
         "initializer": "_PromptTranslationRouteExecutor",
-        "line": 190,
+        "line": 193,
         "module": "api.py",
         "name": "_PROMPT_TRANSLATION_WORKER"
       },

--- a/tests/test_api_contract.py
+++ b/tests/test_api_contract.py
@@ -535,6 +535,119 @@ class ApiProfileListRouteTests(unittest.TestCase):
             self.assertNotIn("private path", json.dumps(response["payload"]))
 
 
+class ApiProfileLoadRouteTests(unittest.TestCase):
+    def test_route_handlers_are_owned_by_the_canonical_factory(self):
+        api, routes = load_api_routes()
+        cases = (
+            (
+                "load_lora_profile_handler",
+                "/easyuse_anima/lora_profiles/load",
+            ),
+            (
+                "load_aio_profile_handler",
+                "/easyuse_anima/aio_profiles/load",
+            ),
+        )
+
+        for name, path in cases:
+            with self.subTest(path=path):
+                handler = routes.handlers[path]
+                self.assertIs(getattr(api, name), handler)
+                self.assertEqual(handler.__name__, name)
+                self.assertTrue(
+                    handler.__module__.endswith(
+                        ".easyuse_anima.api.routes.profile_loads"
+                    )
+                )
+                self.assertTrue(handler._easyuse_anima_request_correlation)
+
+    def test_routes_keep_dynamic_load_seams_query_contract_and_success_shape(self):
+        api, routes = load_api_routes()
+        profile = {
+            "name": "Portrait",
+            "profile_id": "32345678-1234-4567-89ab-1234567890ab",
+            "revision": 4,
+        }
+        cases = (
+            (
+                "/easyuse_anima/lora_profiles/load",
+                "_load_lora_profile",
+                JsonRequest(query={"name": "Portrait"}),
+                "Portrait",
+            ),
+            (
+                "/easyuse_anima/aio_profiles/load",
+                "_load_aio_profile",
+                JsonRequest(),
+                "",
+            ),
+        )
+
+        for path, operation_name, request, expected_name in cases:
+            with self.subTest(path=path), patch.object(
+                api,
+                operation_name,
+                return_value=profile,
+            ) as load_profile:
+                response = asyncio.run(routes.handlers[path](request))
+
+            self.assertEqual(response["status"], 200)
+            self.assertEqual(
+                response["payload"],
+                {"status": "ok", "profile": profile},
+            )
+            load_profile.assert_called_once_with(expected_name)
+
+    def test_routes_preserve_mapped_load_error_boundaries(self):
+        api, routes = load_api_routes()
+        cases = (
+            (
+                "/easyuse_anima/lora_profiles/load",
+                "_load_lora_profile",
+                FileNotFoundError("C:\\private\\missing.json"),
+                404,
+                "profile_not_found",
+            ),
+            (
+                "/easyuse_anima/aio_profiles/load",
+                "_load_aio_profile",
+                FileNotFoundError("/home/alice/missing.json"),
+                404,
+                "profile_not_found",
+            ),
+            (
+                "/easyuse_anima/lora_profiles/load",
+                "_load_lora_profile",
+                json.JSONDecodeError("private json", "{", 0),
+                422,
+                "invalid_profile_data",
+            ),
+            (
+                "/easyuse_anima/aio_profiles/load",
+                "_load_aio_profile",
+                api.InvalidProfileDataError("private profile"),
+                422,
+                "invalid_profile_data",
+            ),
+        )
+
+        for path, operation_name, error, status, code in cases:
+            with self.subTest(path=path, code=code), patch.object(
+                api,
+                operation_name,
+                side_effect=error,
+            ):
+                response = asyncio.run(
+                    routes.handlers[path](JsonRequest(query={"name": "Broken"}))
+                )
+
+            self.assertEqual(response["status"], status)
+            self.assertEqual(response["payload"]["code"], code)
+            serialized = json.dumps(response["payload"])
+            for forbidden in ("private", "/home/", "alice"):
+                self.assertNotIn(forbidden, serialized)
+
+
 class ApiWildcardRouteTests(unittest.TestCase):
     def test_route_handler_is_owned_by_the_canonical_factory(self):
         api, routes = load_api_routes()

--- a/tests/test_python_backend_analyzer.py
+++ b/tests/test_python_backend_analyzer.py
@@ -690,9 +690,9 @@ ignored/
 
         self.assertEqual(analyzer.render_json(report), expected_text)
         self.assertEqual(report["schema_version"], 2)
-        self.assertEqual(report["inventory"]["module_count"], 159)
-        self.assertEqual(len(report["registry"]["shipped_python_modules"]), 159)
-        self.assertEqual(len(report["registry"]["runtime_import_closure"]), 159)
+        self.assertEqual(report["inventory"]["module_count"], 160)
+        self.assertEqual(len(report["registry"]["shipped_python_modules"]), 160)
+        self.assertEqual(len(report["registry"]["runtime_import_closure"]), 160)
         self.assertEqual(
             report["registry"]["entry_modules"],
             [

--- a/tests/test_python_package_skeleton.py
+++ b/tests/test_python_package_skeleton.py
@@ -53,6 +53,7 @@ PACKAGE_MODULES = (
     "easyuse_anima.api.routes.lora_preview",
     "easyuse_anima.api.routes.long_text_settings",
     "easyuse_anima.api.routes.profile_lists",
+    "easyuse_anima.api.routes.profile_loads",
     "easyuse_anima.api.routes.translation",
     "easyuse_anima.api.routes.translation_execution",
     "easyuse_anima.api.routes.wildcards",
@@ -241,6 +242,9 @@ print(json.dumps({{
         expected_all[
             PACKAGE_MODULES.index("easyuse_anima.api.routes.profile_lists")
         ] = ["build_profile_list_handlers"]
+        expected_all[
+            PACKAGE_MODULES.index("easyuse_anima.api.routes.profile_loads")
+        ] = ["build_profile_load_handlers"]
         expected_all[
             PACKAGE_MODULES.index("easyuse_anima.api.routes.translation")
         ] = ["build_translate_prompt_handler"]


### PR DESCRIPTION
## 목적과 변경 경계

Issue #186의 D-07b로, 두 read-only profile load HTTP adapter만 canonical API route package로 이동합니다.

- Base: `5ca6e2f2bb8999dc43d83e4dc824981f23e1558b`
- Head: `4529bdf800036f5cc84f0e86fd4e4d2bd9419067`
- 추가: `easyuse_anima/api/routes/profile_loads.py`
- 조합 변경: `api.py`
- 직접 contract/shipping fixture만 갱신
- profile storage/domain, save/delete/rename/fix mutation, frontend production, #199 access policy는 변경하지 않음

## 보존 계약

- query `name` 기본값 `""`
- root `_load_lora_profile` / `_load_aio_profile` dynamic seam
- bounded `_run_file_io` offload
- route별 기존 catch tuple과 `_profile_error_response` taxonomy/redaction
- `{status: "ok", profile}` success shape
- #163 profile identity/revision/CAS 및 legacy/empty stored profile 호환
- #165 request correlation, safe error, route signature/order

## 검증

- changed-file AST 및 `git diff --check` 통과
- 새 direct route contract 3, 전체 API contract 56
- LoRA/AiO profile API client smoke
- package skeleton 1, backend analyzer 18, Registry scanner 8, import boundary 16, compatibility 26
- `comfy node validate` 통과
- actual pack 302 entries; root adapter, canonical route, LoRA/AiO profile owners 포함 확인
- final Head SHA에서 official full 정확히 1회: Python 1,272 / frontend 120 / Pyright 143 files·기존 14 diagnostics / G-03 11 groups·0 violations / Ruff 기존 112 report-only
- isolated live: 두 list 200, 두 missing load 404 `profile_not_found`, error body/header UUID 일치, 경로 redaction, queue `0/0 → 0/0`
- test instance profile 0개라 live success token은 실행 불가; focused/storage contract가 success shape와 token을 검증
- 8194 listener와 test process tree 정리 완료

## 위험과 rollback

동작 변경 없는 adapter owner 이동입니다. 회귀 시 이 PR을 revert하면 기존 root handler 정의로 원복됩니다. GitHub checks는 구성되어 있지 않아 local official full과 isolated live를 promotion 근거로 사용합니다.

## Next

D-07c에서 remaining profile mutation adapters의 identity/precondition/error 경계를 별도 inventory합니다.