### PR TITLE
refactor: move profile save routes to API package (D-07c)

### DIFF
--- a/api.py
+++ b/api.py
@@ -81,6 +81,9 @@ from .easyuse_anima.api.routes.profile_lists import (
 from .easyuse_anima.api.routes.profile_loads import (
     build_profile_load_handlers as _build_profile_load_handlers,
 )
+from .easyuse_anima.api.routes.profile_saves import (
+    build_profile_save_handlers as _build_profile_save_handlers,
+)
 from .easyuse_anima.api.routes.wildcards import (
     build_wildcards_handler as _build_wildcards_handler,
 )
@@ -661,72 +664,40 @@ if web is not None:
         )
     )
 
-    @_request_correlated
-    async def save_lora_profile_handler(request):
-        try:
-            data = await parse_json_object(request)
-            name = json_string(data, "name", allow_empty=False)
-            overwrite = json_boolean(data, "overwrite")
-            if "profile_data" in data:
-                json_object(data, "profile_data")
-            profile_id = json_uuid_string(
-                data,
-                "profile_id",
-                required=False,
-            )
-            revision = json_integer(
-                data,
-                "revision",
-                default=None,
-                minimum=0,
-            )
-        except ApiContractError as exc:
-            return _contract_error_response(exc)
-        try:
-            payload = await _run_file_io(
-                _save_lora_profile,
+    (
+        save_lora_profile_handler,
+        save_aio_profile_handler,
+    ) = (
+        _request_correlated(handler)
+        for handler in _build_profile_save_handlers(
+            parse_json_object=parse_json_object,
+            json_string=json_string,
+            json_boolean=json_boolean,
+            json_object=json_object,
+            json_uuid_string=json_uuid_string,
+            json_integer=json_integer,
+            contract_error_type=ApiContractError,
+            contract_error_response=lambda exc: _contract_error_response(exc),
+            run_file_io=lambda function, *args, **kwargs: _run_file_io(
+                function,
+                *args,
+                **kwargs,
+            ),
+            save_lora_profile=lambda name, data, **kwargs: _save_lora_profile(
                 name,
                 data,
-                overwrite=overwrite,
-                profile_id=profile_id,
-                revision=revision,
-            )
-        except (FileExistsError, FileNotFoundError, ValueError) as exc:
-            return _profile_error_response(exc)
-        return web.json_response({"status": "ok", "profile": payload})
-
-    @_request_correlated
-    async def save_aio_profile_handler(request):
-        try:
-            data = await parse_json_object(request)
-            name = json_string(data, "name", allow_empty=False)
-            json_object(data, "settings")
-            overwrite = json_boolean(data, "overwrite")
-            profile_id = json_uuid_string(
-                data,
-                "profile_id",
-                required=False,
-            )
-            revision = json_integer(
-                data,
-                "revision",
-                default=None,
-                minimum=0,
-            )
-        except ApiContractError as exc:
-            return _contract_error_response(exc)
-        try:
-            payload = await _run_file_io(
-                _save_aio_profile,
+                **kwargs,
+            ),
+            save_aio_profile=lambda name, data, **kwargs: _save_aio_profile(
                 name,
                 data,
-                overwrite=overwrite,
-                profile_id=profile_id,
-                revision=revision,
-            )
-        except (FileExistsError, FileNotFoundError, ValueError) as exc:
-            return _profile_error_response(exc)
-        return web.json_response({"status": "ok", "profile": payload})
+                **kwargs,
+            ),
+            save_error_types=(FileExistsError, FileNotFoundError, ValueError),
+            profile_error_response=lambda exc: _profile_error_response(exc),
+            json_response=lambda payload: web.json_response(payload),
+        )
+    )
 
     @_request_correlated
     async def delete_aio_profile_handler(request):

--- a/easyuse_anima/api/routes/profile_saves.py
+++ b/easyuse_anima/api/routes/profile_saves.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+
+def build_profile_save_handlers(
+    *,
+    parse_json_object,
+    json_string,
+    json_boolean,
+    json_object,
+    json_uuid_string,
+    json_integer,
+    contract_error_type,
+    contract_error_response,
+    run_file_io,
+    save_lora_profile,
+    save_aio_profile,
+    save_error_types,
+    profile_error_response,
+    json_response,
+):
+    """Build profile save routes without loading profile persistence owners."""
+
+    async def save_lora_profile_handler(request):
+        try:
+            data = await parse_json_object(request)
+            name = json_string(data, "name", allow_empty=False)
+            overwrite = json_boolean(data, "overwrite")
+            if "profile_data" in data:
+                json_object(data, "profile_data")
+            profile_id = json_uuid_string(
+                data,
+                "profile_id",
+                required=False,
+            )
+            revision = json_integer(
+                data,
+                "revision",
+                default=None,
+                minimum=0,
+            )
+        except contract_error_type as exc:
+            return contract_error_response(exc)
+        try:
+            payload = await run_file_io(
+                save_lora_profile,
+                name,
+                data,
+                overwrite=overwrite,
+                profile_id=profile_id,
+                revision=revision,
+            )
+        except save_error_types as exc:
+            return profile_error_response(exc)
+        return json_response({"status": "ok", "profile": payload})
+
+    async def save_aio_profile_handler(request):
+        try:
+            data = await parse_json_object(request)
+            name = json_string(data, "name", allow_empty=False)
+            json_object(data, "settings")
+            overwrite = json_boolean(data, "overwrite")
+            profile_id = json_uuid_string(
+                data,
+                "profile_id",
+                required=False,
+            )
+            revision = json_integer(
+                data,
+                "revision",
+                default=None,
+                minimum=0,
+            )
+        except contract_error_type as exc:
+            return contract_error_response(exc)
+        try:
+            payload = await run_file_io(
+                save_aio_profile,
+                name,
+                data,
+                overwrite=overwrite,
+                profile_id=profile_id,
+                revision=revision,
+            )
+        except save_error_types as exc:
+            return profile_error_response(exc)
+        return json_response({"status": "ok", "profile": payload})
+
+    return save_lora_profile_handler, save_aio_profile_handler
+
+
+__all__ = ("build_profile_save_handlers",)

--- a/tests/fixtures/python_backend_baseline.json
+++ b/tests/fixtures/python_backend_baseline.json
@@ -3725,6 +3725,24 @@
         "target": "easyuse_anima/api/routes/profile_loads.py"
       },
       {
+        "alias": "_build_profile_save_handlers",
+        "bound_name": "_build_profile_save_handlers",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".easyuse_anima.api.routes.profile_saves:build_profile_save_handlers",
+        "kind": "static_from",
+        "line": 84,
+        "name": "build_profile_save_handlers",
+        "optional": false,
+        "requested": ".easyuse_anima.api.routes.profile_saves",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "api.py",
+        "target": "easyuse_anima/api/routes/profile_saves.py"
+      },
+      {
         "alias": "_build_wildcards_handler",
         "bound_name": "_build_wildcards_handler",
         "branch_context": [],
@@ -3733,7 +3751,7 @@
         "conditional": false,
         "imported": ".easyuse_anima.api.routes.wildcards:build_wildcards_handler",
         "kind": "static_from",
-        "line": 84,
+        "line": 87,
         "name": "build_wildcards_handler",
         "optional": false,
         "requested": ".easyuse_anima.api.routes.wildcards",
@@ -3751,7 +3769,7 @@
         "conditional": false,
         "imported": ".easyuse_anima.api.routes.translation:build_translate_prompt_handler",
         "kind": "static_from",
-        "line": 87,
+        "line": 90,
         "name": "build_translate_prompt_handler",
         "optional": false,
         "requested": ".easyuse_anima.api.routes.translation",
@@ -3769,7 +3787,7 @@
         "conditional": false,
         "imported": ".easyuse_anima.api.routes.translation_execution:PromptTranslationRouteExecutor",
         "kind": "static_from",
-        "line": 90,
+        "line": 93,
         "name": "PromptTranslationRouteExecutor",
         "optional": false,
         "requested": ".easyuse_anima.api.routes.translation_execution",
@@ -3787,7 +3805,7 @@
         "conditional": false,
         "imported": ".easyuse_anima.api.routes.aio_torch_compile:build_aio_torch_compile_recommend_handler",
         "kind": "static_from",
-        "line": 93,
+        "line": 96,
         "name": "build_aio_torch_compile_recommend_handler",
         "optional": false,
         "requested": ".easyuse_anima.api.routes.aio_torch_compile",
@@ -3805,7 +3823,7 @@
         "conditional": false,
         "imported": ".easyuse_anima.aio.torch_compile_diagnostics:collect_torch_compile_diagnostics",
         "kind": "static_from",
-        "line": 96,
+        "line": 99,
         "name": "collect_torch_compile_diagnostics",
         "optional": false,
         "requested": ".easyuse_anima.aio.torch_compile_diagnostics",
@@ -3823,7 +3841,7 @@
         "conditional": false,
         "imported": ".easyuse_anima.aio.torch_compile_recommendation:recommend_torch_compile",
         "kind": "static_from",
-        "line": 99,
+        "line": 102,
         "name": "recommend_torch_compile",
         "optional": false,
         "requested": ".easyuse_anima.aio.torch_compile_recommendation",
@@ -3841,7 +3859,7 @@
         "conditional": false,
         "imported": ".easyuse_anima.profiles:aio",
         "kind": "static_from",
-        "line": 102,
+        "line": 105,
         "name": "aio",
         "optional": false,
         "requested": ".easyuse_anima.profiles",
@@ -3859,7 +3877,7 @@
         "conditional": false,
         "imported": ".easyuse_anima.profiles:contract",
         "kind": "static_from",
-        "line": 103,
+        "line": 106,
         "name": "contract",
         "optional": false,
         "requested": ".easyuse_anima.profiles",
@@ -3877,7 +3895,7 @@
         "conditional": false,
         "imported": ".easyuse_anima.profiles:lora",
         "kind": "static_from",
-        "line": 104,
+        "line": 107,
         "name": "lora",
         "optional": false,
         "requested": ".easyuse_anima.profiles",
@@ -3895,7 +3913,7 @@
         "conditional": false,
         "imported": ".easyuse_anima.profiles:mutation",
         "kind": "static_from",
-        "line": 105,
+        "line": 108,
         "name": "mutation",
         "optional": false,
         "requested": ".easyuse_anima.profiles",
@@ -3913,7 +3931,7 @@
         "conditional": false,
         "imported": ".easyuse_anima.profiles:repository",
         "kind": "static_from",
-        "line": 106,
+        "line": 109,
         "name": "repository",
         "optional": false,
         "requested": ".easyuse_anima.profiles",
@@ -3931,7 +3949,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 309
+            "line": 312
           }
         ],
         "classification": "external",
@@ -3939,7 +3957,7 @@
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 310,
+        "line": 313,
         "name": null,
         "optional": true,
         "requested": "folder_paths",
@@ -15347,6 +15365,23 @@
         "role": "ordinary",
         "scope": "<module>",
         "source": "easyuse_anima/api/routes/profile_loads.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "annotations",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "__future__:annotations",
+        "kind": "static_from",
+        "line": 1,
+        "name": "annotations",
+        "optional": false,
+        "requested": "__future__",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/api/routes/profile_saves.py"
       },
       {
         "alias": null,
@@ -63147,6 +63182,10 @@
       },
       {
         "from": "api.py",
+        "to": "easyuse_anima/api/routes/profile_saves.py"
+      },
+      {
+        "from": "api.py",
         "to": "easyuse_anima/api/routes/translation.py"
       },
       {
@@ -65268,6 +65307,12 @@
       {
         "cyclic": false,
         "modules": [
+          "easyuse_anima/api/routes/profile_saves.py"
+        ]
+      },
+      {
+        "cyclic": false,
+        "modules": [
           "easyuse_anima/api/routes/translation.py"
         ]
       },
@@ -65869,7 +65914,7 @@
     ]
   },
   "inventory": {
-    "module_count": 160,
+    "module_count": 161,
     "modules": [
       {
         "is_package": true,
@@ -65969,14 +66014,14 @@
       },
       {
         "is_package": false,
-        "loc": 877,
+        "loc": 848,
         "module": "api",
-        "normalized_git_blob_sha1": "792ce6070d3792366d563d72f03d8319ba5042c7",
+        "normalized_git_blob_sha1": "b1499ed8e8a6ee66d6e73a06056b9e8fb5beea72",
         "path": "api.py",
         "top_level": {
           "class_count": 0,
           "function_count": 23,
-          "global_count": 89
+          "global_count": 91
         }
       },
       {
@@ -66573,6 +66618,18 @@
         "module": "easyuse_anima.api.routes.profile_loads",
         "normalized_git_blob_sha1": "b3f950cd4c1d9c726010446741f717f927d3edc5",
         "path": "easyuse_anima/api/routes/profile_loads.py",
+        "top_level": {
+          "class_count": 0,
+          "function_count": 1,
+          "global_count": 1
+        }
+      },
+      {
+        "is_package": false,
+        "loc": 91,
+        "module": "easyuse_anima.api.routes.profile_saves",
+        "normalized_git_blob_sha1": "c33c9239a508909caa2da92585d9d2bb83bbc519",
+        "path": "easyuse_anima/api/routes/profile_saves.py",
         "top_level": {
           "class_count": 0,
           "function_count": 1,
@@ -80819,14 +80876,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 309
+            "line": 312
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 310,
+        "line": 313,
         "optional": true,
         "role": "optional_dependency",
         "source": "api.py"
@@ -82935,6 +82992,17 @@
         "optional": false,
         "role": "ordinary",
         "source": "easyuse_anima/api/routes/profile_loads.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "__future__:annotations",
+        "kind": "static_from",
+        "line": 1,
+        "optional": false,
+        "role": "ordinary",
+        "source": "easyuse_anima/api/routes/profile_saves.py"
       },
       {
         "branch_context": [],
@@ -87122,14 +87190,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 309
+            "line": 312
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 310,
+        "line": 313,
         "optional": true,
         "role": "optional_dependency",
         "source": "api.py"
@@ -88076,6 +88144,7 @@
       "easyuse_anima/api/routes/lora_preview.py",
       "easyuse_anima/api/routes/profile_lists.py",
       "easyuse_anima/api/routes/profile_loads.py",
+      "easyuse_anima/api/routes/profile_saves.py",
       "easyuse_anima/api/routes/translation.py",
       "easyuse_anima/api/routes/translation_execution.py",
       "easyuse_anima/api/routes/wildcards.py",
@@ -88238,6 +88307,7 @@
       "easyuse_anima/api/routes/lora_preview.py",
       "easyuse_anima/api/routes/profile_lists.py",
       "easyuse_anima/api/routes/profile_loads.py",
+      "easyuse_anima/api/routes/profile_saves.py",
       "easyuse_anima/api/routes/translation.py",
       "easyuse_anima/api/routes/translation_execution.py",
       "easyuse_anima/api/routes/wildcards.py",
@@ -88359,7 +88429,7 @@
         "column": 10,
         "context": "assign:_LOGGER",
         "kind": "import_time_call",
-        "line": 186,
+        "line": 189,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -88368,7 +88438,7 @@
         "column": 25,
         "context": "assign:_FILE_IO_LIMITERS_LOCK",
         "kind": "import_time_call",
-        "line": 189,
+        "line": 192,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -88377,7 +88447,7 @@
         "column": 47,
         "context": "assign:_FILE_IO_LIMITERS",
         "kind": "import_time_call",
-        "line": 190,
+        "line": 193,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -88386,7 +88456,7 @@
         "column": 29,
         "context": "assign:_PROMPT_TRANSLATION_WORKER",
         "kind": "route_registry_creation",
-        "line": 193,
+        "line": 196,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -88395,7 +88465,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 198,
+        "line": 201,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -88404,7 +88474,7 @@
         "column": 36,
         "context": "assign:_SAFE_PROFILE_VALIDATION_MESSAGES",
         "kind": "import_time_call",
-        "line": 336,
+        "line": 339,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -88413,7 +88483,7 @@
         "column": 9,
         "context": "assign:routes",
         "kind": "route_registry_creation",
-        "line": 493,
+        "line": 496,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -88422,7 +88492,7 @@
         "column": 8,
         "context": "assign:get_long_text_settings_handler,save_long_text_settings_handler",
         "kind": "import_time_call",
-        "line": 523,
+        "line": 526,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -88431,7 +88501,7 @@
         "column": 23,
         "context": "assign:get_long_text_settings_handler,save_long_text_settings_handler",
         "kind": "import_time_call",
-        "line": 524,
+        "line": 527,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -88440,7 +88510,7 @@
         "column": 28,
         "context": "assign:get_wildcards_handler",
         "kind": "import_time_call",
-        "line": 538,
+        "line": 541,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -88449,7 +88519,7 @@
         "column": 8,
         "context": "assign:get_wildcards_handler",
         "kind": "import_time_call",
-        "line": 539,
+        "line": 542,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -88458,7 +88528,7 @@
         "column": 8,
         "context": "assign:autocomplete_handler,autocomplete_status_handler",
         "kind": "import_time_call",
-        "line": 550,
+        "line": 553,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -88467,7 +88537,7 @@
         "column": 23,
         "context": "assign:autocomplete_handler,autocomplete_status_handler",
         "kind": "import_time_call",
-        "line": 551,
+        "line": 554,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -88476,7 +88546,7 @@
         "column": 30,
         "context": "assign:classify_prompt_handler",
         "kind": "import_time_call",
-        "line": 561,
+        "line": 564,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -88485,7 +88555,7 @@
         "column": 8,
         "context": "assign:classify_prompt_handler",
         "kind": "import_time_call",
-        "line": 562,
+        "line": 565,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -88494,7 +88564,7 @@
         "column": 31,
         "context": "assign:translate_prompt_handler",
         "kind": "import_time_call",
-        "line": 580,
+        "line": 583,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -88503,7 +88573,7 @@
         "column": 8,
         "context": "assign:translate_prompt_handler",
         "kind": "import_time_call",
-        "line": 581,
+        "line": 584,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -88512,7 +88582,7 @@
         "column": 42,
         "context": "assign:aio_torch_compile_recommend_handler",
         "kind": "import_time_call",
-        "line": 593,
+        "line": 596,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -88521,7 +88591,7 @@
         "column": 8,
         "context": "assign:aio_torch_compile_recommend_handler",
         "kind": "import_time_call",
-        "line": 594,
+        "line": 597,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -88530,7 +88600,7 @@
         "column": 27,
         "context": "assign:lora_preview_handler",
         "kind": "import_time_call",
-        "line": 610,
+        "line": 613,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -88539,7 +88609,7 @@
         "column": 8,
         "context": "assign:lora_preview_handler",
         "kind": "import_time_call",
-        "line": 611,
+        "line": 614,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -88548,7 +88618,7 @@
         "column": 20,
         "context": "assign:loras_handler",
         "kind": "import_time_call",
-        "line": 620,
+        "line": 623,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -88557,7 +88627,7 @@
         "column": 8,
         "context": "assign:loras_handler",
         "kind": "import_time_call",
-        "line": 621,
+        "line": 624,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -88566,7 +88636,7 @@
         "column": 8,
         "context": "assign:aio_profiles_handler,lora_profiles_handler",
         "kind": "import_time_call",
-        "line": 632,
+        "line": 635,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -88575,7 +88645,7 @@
         "column": 23,
         "context": "assign:aio_profiles_handler,lora_profiles_handler",
         "kind": "import_time_call",
-        "line": 633,
+        "line": 636,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -88584,7 +88654,7 @@
         "column": 8,
         "context": "assign:load_aio_profile_handler,load_lora_profile_handler",
         "kind": "import_time_call",
-        "line": 647,
+        "line": 650,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -88593,7 +88663,25 @@
         "column": 23,
         "context": "assign:load_aio_profile_handler,load_lora_profile_handler",
         "kind": "import_time_call",
-        "line": 648,
+        "line": 651,
+        "module": "api.py",
+        "scope": "<module>"
+      },
+      {
+        "callee": "_request_correlated",
+        "column": 8,
+        "context": "assign:save_aio_profile_handler,save_lora_profile_handler",
+        "kind": "import_time_call",
+        "line": 671,
+        "module": "api.py",
+        "scope": "<module>"
+      },
+      {
+        "callee": "_build_profile_save_handlers",
+        "column": 23,
+        "context": "assign:save_aio_profile_handler,save_lora_profile_handler",
+        "kind": "import_time_call",
+        "line": 672,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -88602,7 +88690,7 @@
         "column": 19,
         "context": "assign:_ROUTE_SIGNATURE",
         "kind": "route_registry_creation",
-        "line": 853,
+        "line": 824,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -88611,7 +88699,7 @@
         "column": 5,
         "context": "assign:_ROUTE_SIGNATURE",
         "kind": "route_registry_creation",
-        "line": 854,
+        "line": 825,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -90882,7 +90970,7 @@
           "lock"
         ],
         "initializer": "threading.Lock",
-        "line": 189,
+        "line": 192,
         "module": "api.py",
         "name": "_FILE_IO_LIMITERS_LOCK"
       },
@@ -90891,7 +90979,7 @@
           "executor"
         ],
         "initializer": "_PromptTranslationRouteExecutor",
-        "line": 193,
+        "line": 196,
         "module": "api.py",
         "name": "_PROMPT_TRANSLATION_WORKER"
       },

--- a/tests/test_api_contract.py
+++ b/tests/test_api_contract.py
@@ -648,6 +648,154 @@ class ApiProfileLoadRouteTests(unittest.TestCase):
                 self.assertNotIn(forbidden, serialized)
 
 
+class ApiProfileSaveRouteTests(unittest.TestCase):
+    def test_route_handlers_are_owned_by_the_canonical_factory(self):
+        api, routes = load_api_routes()
+        cases = (
+            (
+                "save_lora_profile_handler",
+                "/easyuse_anima/lora_profiles/save",
+            ),
+            (
+                "save_aio_profile_handler",
+                "/easyuse_anima/aio_profiles/save",
+            ),
+        )
+
+        for name, path in cases:
+            with self.subTest(path=path):
+                handler = routes.handlers[path]
+                self.assertIs(getattr(api, name), handler)
+                self.assertEqual(handler.__name__, name)
+                self.assertTrue(
+                    handler.__module__.endswith(
+                        ".easyuse_anima.api.routes.profile_saves"
+                    )
+                )
+                self.assertTrue(handler._easyuse_anima_request_correlation)
+
+    def test_routes_keep_dynamic_save_seams_payloads_kwargs_and_success_shape(self):
+        api, routes = load_api_routes()
+        profile_id = "42345678-1234-4567-89ab-1234567890ab"
+        cases = (
+            (
+                "/easyuse_anima/lora_profiles/save",
+                "_save_lora_profile",
+                {
+                    "name": "Portrait",
+                    "overwrite": True,
+                    "profile_data": {"1": {"style_prompt": "soft"}},
+                    "profile_id": profile_id,
+                    "revision": 5,
+                },
+            ),
+            (
+                "/easyuse_anima/aio_profiles/save",
+                "_save_aio_profile",
+                {
+                    "name": "Portrait",
+                    "overwrite": True,
+                    "settings": {"future": {"kept": True}},
+                    "profile_id": profile_id,
+                    "revision": 5,
+                },
+            ),
+        )
+
+        for path, operation_name, data in cases:
+            saved = {
+                "name": data["name"],
+                "profile_id": profile_id,
+                "revision": 6,
+            }
+            with self.subTest(path=path), patch.object(
+                api,
+                operation_name,
+                return_value=saved,
+            ) as save_profile:
+                response = asyncio.run(routes.handlers[path](JsonRequest(data)))
+
+            self.assertEqual(response["status"], 200)
+            self.assertEqual(
+                response["payload"],
+                {"status": "ok", "profile": saved},
+            )
+            save_profile.assert_called_once_with(
+                "Portrait",
+                data,
+                overwrite=True,
+                profile_id=profile_id,
+                revision=5,
+            )
+
+    def test_aio_route_requires_settings_before_file_io(self):
+        api, routes = load_api_routes()
+        with patch.object(api, "_save_aio_profile") as save_profile:
+            response = asyncio.run(
+                routes.handlers["/easyuse_anima/aio_profiles/save"](
+                    JsonRequest({"name": "Portrait"})
+                )
+            )
+
+        self.assertEqual(response["status"], 422)
+        self.assertEqual(response["payload"]["code"], "invalid_request")
+        self.assertEqual(response["payload"]["details"], {"field": "settings"})
+        save_profile.assert_not_called()
+
+    def test_routes_preserve_profile_error_mapping_and_redaction(self):
+        api, routes = load_api_routes()
+        cases = (
+            (
+                "/easyuse_anima/lora_profiles/save",
+                "_save_lora_profile",
+                {"name": "Portrait", "profile_data": {}},
+                FileNotFoundError("C:\\private\\missing.json"),
+                404,
+                "profile_not_found",
+                None,
+            ),
+            (
+                "/easyuse_anima/aio_profiles/save",
+                "_save_aio_profile",
+                {"name": "Portrait", "settings": {}},
+                FileExistsError("/home/alice/existing.json"),
+                409,
+                "profile_exists",
+                None,
+            ),
+            (
+                "/easyuse_anima/aio_profiles/save",
+                "_save_aio_profile",
+                {"name": "Portrait", "settings": {}},
+                api.ProfileMutationError(
+                    status=409,
+                    code="profile_revision_conflict",
+                    message="Profile revision does not match",
+                    details={"profile": "source"},
+                ),
+                409,
+                "profile_revision_conflict",
+                {"profile": "source"},
+            ),
+        )
+
+        for path, operation_name, data, error, status, code, details in cases:
+            with self.subTest(path=path, code=code), patch.object(
+                api,
+                operation_name,
+                side_effect=error,
+            ):
+                response = asyncio.run(routes.handlers[path](JsonRequest(data)))
+
+            self.assertEqual(response["status"], status)
+            self.assertEqual(response["payload"]["code"], code)
+            if details is not None:
+                self.assertEqual(response["payload"]["details"], details)
+            serialized = json.dumps(response["payload"])
+            for forbidden in ("private", "/home/", "alice"):
+                self.assertNotIn(forbidden, serialized)
+
+
 class ApiWildcardRouteTests(unittest.TestCase):
     def test_route_handler_is_owned_by_the_canonical_factory(self):
         api, routes = load_api_routes()

--- a/tests/test_python_backend_analyzer.py
+++ b/tests/test_python_backend_analyzer.py
@@ -690,9 +690,9 @@ ignored/
 
         self.assertEqual(analyzer.render_json(report), expected_text)
         self.assertEqual(report["schema_version"], 2)
-        self.assertEqual(report["inventory"]["module_count"], 160)
-        self.assertEqual(len(report["registry"]["shipped_python_modules"]), 160)
-        self.assertEqual(len(report["registry"]["runtime_import_closure"]), 160)
+        self.assertEqual(report["inventory"]["module_count"], 161)
+        self.assertEqual(len(report["registry"]["shipped_python_modules"]), 161)
+        self.assertEqual(len(report["registry"]["runtime_import_closure"]), 161)
         self.assertEqual(
             report["registry"]["entry_modules"],
             [

--- a/tests/test_python_package_skeleton.py
+++ b/tests/test_python_package_skeleton.py
@@ -54,6 +54,7 @@ PACKAGE_MODULES = (
     "easyuse_anima.api.routes.long_text_settings",
     "easyuse_anima.api.routes.profile_lists",
     "easyuse_anima.api.routes.profile_loads",
+    "easyuse_anima.api.routes.profile_saves",
     "easyuse_anima.api.routes.translation",
     "easyuse_anima.api.routes.translation_execution",
     "easyuse_anima.api.routes.wildcards",
@@ -245,6 +246,9 @@ print(json.dumps({{
         expected_all[
             PACKAGE_MODULES.index("easyuse_anima.api.routes.profile_loads")
         ] = ["build_profile_load_handlers"]
+        expected_all[
+            PACKAGE_MODULES.index("easyuse_anima.api.routes.profile_saves")
+        ] = ["build_profile_save_handlers"]
         expected_all[
             PACKAGE_MODULES.index("easyuse_anima.api.routes.translation")
         ] = ["build_translate_prompt_handler"]


### PR DESCRIPTION
## 목적과 변경 경계

Issue #186의 D-07c로, LoRA/AiO profile save HTTP adapter 두 개만 canonical API route package로 이동합니다.

- Base: `4a632ef84a03262a0d4921f65547cc6c83e13ebc`
- Head: `b6dd6a10331b3a6571d12f250820cccfab9ca61d`
- 추가: `easyuse_anima/api/routes/profile_saves.py`
- 조합 변경: `api.py`
- 직접 contract/shipping fixture만 갱신
- profile storage/domain, AiO delete/rename, LoRA fix, frontend production, #199 access policy는 변경하지 않음

## 보존 계약

- JSON object parse와 route별 required/optional field validation
- non-empty name, overwrite boolean, optional UUID profile_id, non-negative optional revision
- LoRA optional object profile_data / AiO required object settings
- 원본 request data와 kwargs를 domain save operation에 전달
- root `_save_lora_profile` / `_save_aio_profile` dynamic seams
- kwargs 포함 bounded `_run_file_io`
- FileExists/FileNotFound/ValueError 및 ProfileMutationError taxonomy/redaction
- `{status: "ok", profile}` success shape와 request correlation/route order
- #163 identity/revision/strict CAS, legacy/v2 persistence 계약

## 검증

- changed-file AST 및 `git diff --check` 통과
- 새 direct save-route contract 4 / 전체 API contract 60
- LoRA/AiO profile API client payload smoke
- package skeleton 1, backend analyzer 18, Registry scanner 8, import boundary 16, compatibility 26
- `comfy node validate` 통과
- actual pack 303 entries; root adapter, canonical save route, LoRA/AiO domain owners 포함 확인
- final Head SHA에서 official full 정확히 1회: Python 1,276 / frontend 120 / Pyright 144 files·기존 14 diagnostics / G-03 11 groups·0 violations / Ruff 기존 112 report-only
- isolated live: 두 invalid payload 422; 두 create/load 200와 UUID/revision 1 round-trip; stale revision overwrite 409 `profile_revision_conflict`; AiO delete 200→load 404; queue `0/0 → 0/0`
- test listener/process tree 및 생성 `CodexD07c*.json` 잔존 0

## 위험과 rollback

동작 변경 없는 adapter owner 이동입니다. 회귀 시 이 PR을 revert하면 기존 root save handlers로 원복됩니다. GitHub checks는 구성되어 있지 않아 local official full/package/isolated live를 promotion 근거로 사용합니다.

## Next

D-07d에서 AiO delete/rename multi-token CAS adapter를 별도 rollback 경계로 이동합니다. LoRA fix는 D-07e로 유지합니다.