### PR TITLE
D-07d: AiO profile mutation routes를 API package로 이동

### DIFF
--- a/api.py
+++ b/api.py
@@ -62,6 +62,9 @@ from .easyuse_anima.api.responses import (
     create_request_id,
     error_payload,
 )
+from .easyuse_anima.api.routes.aio_profile_mutations import (
+    build_aio_profile_mutation_handlers as _build_aio_profile_mutation_handlers,
+)
 from .easyuse_anima.api.routes.autocomplete import (
     build_autocomplete_handlers as _build_autocomplete_handlers,
     build_classify_prompt_handler as _build_classify_prompt_handler,
@@ -699,80 +702,41 @@ if web is not None:
         )
     )
 
-    @_request_correlated
-    async def delete_aio_profile_handler(request):
-        try:
-            data = await parse_json_object(request)
-            name = json_string(data, "name", allow_empty=False)
-            profile_id = json_uuid_string(
-                data,
-                "profile_id",
-                required=False,
-            )
-            revision = json_integer(
-                data,
-                "revision",
-                default=None,
-                minimum=0,
-            )
-        except ApiContractError as exc:
-            return _contract_error_response(exc)
-        try:
-            payload = await _run_file_io(
-                _delete_aio_profile,
+    (
+        delete_aio_profile_handler,
+        rename_aio_profile_handler,
+    ) = (
+        _request_correlated(handler)
+        for handler in _build_aio_profile_mutation_handlers(
+            parse_json_object=parse_json_object,
+            json_string=json_string,
+            json_boolean=json_boolean,
+            json_uuid_string=json_uuid_string,
+            json_integer=json_integer,
+            contract_error_type=ApiContractError,
+            contract_error_response=lambda exc: _contract_error_response(exc),
+            run_file_io=lambda function, *args, **kwargs: _run_file_io(
+                function,
+                *args,
+                **kwargs,
+            ),
+            delete_aio_profile=lambda name, **kwargs: _delete_aio_profile(
                 name,
-                profile_id=profile_id,
-                revision=revision,
-            )
-        except (FileNotFoundError, ValueError) as exc:
-            return _profile_error_response(exc)
-        return web.json_response({"status": "ok", "profile": payload})
-
-    @_request_correlated
-    async def rename_aio_profile_handler(request):
-        try:
-            data = await parse_json_object(request)
-            old_name = json_string(data, "old_name", allow_empty=False)
-            new_name = json_string(data, "new_name", allow_empty=False)
-            overwrite = json_boolean(data, "overwrite")
-            profile_id = json_uuid_string(
-                data,
-                "profile_id",
-                required=False,
-            )
-            revision = json_integer(
-                data,
-                "revision",
-                default=None,
-                minimum=0,
-            )
-            target_profile_id = json_uuid_string(
-                data,
-                "target_profile_id",
-                required=False,
-            )
-            target_revision = json_integer(
-                data,
-                "target_revision",
-                default=None,
-                minimum=0,
-            )
-        except ApiContractError as exc:
-            return _contract_error_response(exc)
-        try:
-            payload = await _run_file_io(
-                _rename_aio_profile,
-                old_name,
-                new_name,
-                overwrite=overwrite,
-                profile_id=profile_id,
-                revision=revision,
-                target_profile_id=target_profile_id,
-                target_revision=target_revision,
-            )
-        except (FileExistsError, FileNotFoundError, ValueError) as exc:
-            return _profile_error_response(exc)
-        return web.json_response({"status": "ok", "profile": payload})
+                **kwargs,
+            ),
+            rename_aio_profile=lambda old_name, new_name, **kwargs: (
+                _rename_aio_profile(
+                    old_name,
+                    new_name,
+                    **kwargs,
+                )
+            ),
+            delete_error_types=(FileNotFoundError, ValueError),
+            rename_error_types=(FileExistsError, FileNotFoundError, ValueError),
+            profile_error_response=lambda exc: _profile_error_response(exc),
+            json_response=lambda payload: web.json_response(payload),
+        )
+    )
 
     @_request_correlated
     async def fix_lora_profile_handler(request):

--- a/easyuse_anima/api/routes/aio_profile_mutations.py
+++ b/easyuse_anima/api/routes/aio_profile_mutations.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+
+def build_aio_profile_mutation_handlers(
+    *,
+    parse_json_object,
+    json_string,
+    json_boolean,
+    json_uuid_string,
+    json_integer,
+    contract_error_type,
+    contract_error_response,
+    run_file_io,
+    delete_aio_profile,
+    rename_aio_profile,
+    delete_error_types,
+    rename_error_types,
+    profile_error_response,
+    json_response,
+):
+    """Build AiO delete/rename routes without loading profile domain owners."""
+
+    async def delete_aio_profile_handler(request):
+        try:
+            data = await parse_json_object(request)
+            name = json_string(data, "name", allow_empty=False)
+            profile_id = json_uuid_string(
+                data,
+                "profile_id",
+                required=False,
+            )
+            revision = json_integer(
+                data,
+                "revision",
+                default=None,
+                minimum=0,
+            )
+        except contract_error_type as exc:
+            return contract_error_response(exc)
+        try:
+            payload = await run_file_io(
+                delete_aio_profile,
+                name,
+                profile_id=profile_id,
+                revision=revision,
+            )
+        except delete_error_types as exc:
+            return profile_error_response(exc)
+        return json_response({"status": "ok", "profile": payload})
+
+    async def rename_aio_profile_handler(request):
+        try:
+            data = await parse_json_object(request)
+            old_name = json_string(data, "old_name", allow_empty=False)
+            new_name = json_string(data, "new_name", allow_empty=False)
+            overwrite = json_boolean(data, "overwrite")
+            profile_id = json_uuid_string(
+                data,
+                "profile_id",
+                required=False,
+            )
+            revision = json_integer(
+                data,
+                "revision",
+                default=None,
+                minimum=0,
+            )
+            target_profile_id = json_uuid_string(
+                data,
+                "target_profile_id",
+                required=False,
+            )
+            target_revision = json_integer(
+                data,
+                "target_revision",
+                default=None,
+                minimum=0,
+            )
+        except contract_error_type as exc:
+            return contract_error_response(exc)
+        try:
+            payload = await run_file_io(
+                rename_aio_profile,
+                old_name,
+                new_name,
+                overwrite=overwrite,
+                profile_id=profile_id,
+                revision=revision,
+                target_profile_id=target_profile_id,
+                target_revision=target_revision,
+            )
+        except rename_error_types as exc:
+            return profile_error_response(exc)
+        return json_response({"status": "ok", "profile": payload})
+
+    return delete_aio_profile_handler, rename_aio_profile_handler
+
+
+__all__ = ("build_aio_profile_mutation_handlers",)

--- a/tests/fixtures/python_backend_baseline.json
+++ b/tests/fixtures/python_backend_baseline.json
@@ -3599,6 +3599,24 @@
         "target": "easyuse_anima/api/responses.py"
       },
       {
+        "alias": "_build_aio_profile_mutation_handlers",
+        "bound_name": "_build_aio_profile_mutation_handlers",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".easyuse_anima.api.routes.aio_profile_mutations:build_aio_profile_mutation_handlers",
+        "kind": "static_from",
+        "line": 65,
+        "name": "build_aio_profile_mutation_handlers",
+        "optional": false,
+        "requested": ".easyuse_anima.api.routes.aio_profile_mutations",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "api.py",
+        "target": "easyuse_anima/api/routes/aio_profile_mutations.py"
+      },
+      {
         "alias": "_build_autocomplete_handlers",
         "bound_name": "_build_autocomplete_handlers",
         "branch_context": [],
@@ -3607,7 +3625,7 @@
         "conditional": false,
         "imported": ".easyuse_anima.api.routes.autocomplete:build_autocomplete_handlers",
         "kind": "static_from",
-        "line": 65,
+        "line": 68,
         "name": "build_autocomplete_handlers",
         "optional": false,
         "requested": ".easyuse_anima.api.routes.autocomplete",
@@ -3625,7 +3643,7 @@
         "conditional": false,
         "imported": ".easyuse_anima.api.routes.autocomplete:build_classify_prompt_handler",
         "kind": "static_from",
-        "line": 65,
+        "line": 68,
         "name": "build_classify_prompt_handler",
         "optional": false,
         "requested": ".easyuse_anima.api.routes.autocomplete",
@@ -3643,7 +3661,7 @@
         "conditional": false,
         "imported": ".easyuse_anima.api.routes.long_text_settings:build_long_text_settings_handlers",
         "kind": "static_from",
-        "line": 69,
+        "line": 72,
         "name": "build_long_text_settings_handlers",
         "optional": false,
         "requested": ".easyuse_anima.api.routes.long_text_settings",
@@ -3661,7 +3679,7 @@
         "conditional": false,
         "imported": ".easyuse_anima.api.routes.lora_catalog:build_loras_handler",
         "kind": "static_from",
-        "line": 72,
+        "line": 75,
         "name": "build_loras_handler",
         "optional": false,
         "requested": ".easyuse_anima.api.routes.lora_catalog",
@@ -3679,7 +3697,7 @@
         "conditional": false,
         "imported": ".easyuse_anima.api.routes.lora_preview:build_lora_preview_handler",
         "kind": "static_from",
-        "line": 75,
+        "line": 78,
         "name": "build_lora_preview_handler",
         "optional": false,
         "requested": ".easyuse_anima.api.routes.lora_preview",
@@ -3697,7 +3715,7 @@
         "conditional": false,
         "imported": ".easyuse_anima.api.routes.profile_lists:build_profile_list_handlers",
         "kind": "static_from",
-        "line": 78,
+        "line": 81,
         "name": "build_profile_list_handlers",
         "optional": false,
         "requested": ".easyuse_anima.api.routes.profile_lists",
@@ -3715,7 +3733,7 @@
         "conditional": false,
         "imported": ".easyuse_anima.api.routes.profile_loads:build_profile_load_handlers",
         "kind": "static_from",
-        "line": 81,
+        "line": 84,
         "name": "build_profile_load_handlers",
         "optional": false,
         "requested": ".easyuse_anima.api.routes.profile_loads",
@@ -3733,7 +3751,7 @@
         "conditional": false,
         "imported": ".easyuse_anima.api.routes.profile_saves:build_profile_save_handlers",
         "kind": "static_from",
-        "line": 84,
+        "line": 87,
         "name": "build_profile_save_handlers",
         "optional": false,
         "requested": ".easyuse_anima.api.routes.profile_saves",
@@ -3751,7 +3769,7 @@
         "conditional": false,
         "imported": ".easyuse_anima.api.routes.wildcards:build_wildcards_handler",
         "kind": "static_from",
-        "line": 87,
+        "line": 90,
         "name": "build_wildcards_handler",
         "optional": false,
         "requested": ".easyuse_anima.api.routes.wildcards",
@@ -3769,7 +3787,7 @@
         "conditional": false,
         "imported": ".easyuse_anima.api.routes.translation:build_translate_prompt_handler",
         "kind": "static_from",
-        "line": 90,
+        "line": 93,
         "name": "build_translate_prompt_handler",
         "optional": false,
         "requested": ".easyuse_anima.api.routes.translation",
@@ -3787,7 +3805,7 @@
         "conditional": false,
         "imported": ".easyuse_anima.api.routes.translation_execution:PromptTranslationRouteExecutor",
         "kind": "static_from",
-        "line": 93,
+        "line": 96,
         "name": "PromptTranslationRouteExecutor",
         "optional": false,
         "requested": ".easyuse_anima.api.routes.translation_execution",
@@ -3805,7 +3823,7 @@
         "conditional": false,
         "imported": ".easyuse_anima.api.routes.aio_torch_compile:build_aio_torch_compile_recommend_handler",
         "kind": "static_from",
-        "line": 96,
+        "line": 99,
         "name": "build_aio_torch_compile_recommend_handler",
         "optional": false,
         "requested": ".easyuse_anima.api.routes.aio_torch_compile",
@@ -3823,7 +3841,7 @@
         "conditional": false,
         "imported": ".easyuse_anima.aio.torch_compile_diagnostics:collect_torch_compile_diagnostics",
         "kind": "static_from",
-        "line": 99,
+        "line": 102,
         "name": "collect_torch_compile_diagnostics",
         "optional": false,
         "requested": ".easyuse_anima.aio.torch_compile_diagnostics",
@@ -3841,7 +3859,7 @@
         "conditional": false,
         "imported": ".easyuse_anima.aio.torch_compile_recommendation:recommend_torch_compile",
         "kind": "static_from",
-        "line": 102,
+        "line": 105,
         "name": "recommend_torch_compile",
         "optional": false,
         "requested": ".easyuse_anima.aio.torch_compile_recommendation",
@@ -3859,7 +3877,7 @@
         "conditional": false,
         "imported": ".easyuse_anima.profiles:aio",
         "kind": "static_from",
-        "line": 105,
+        "line": 108,
         "name": "aio",
         "optional": false,
         "requested": ".easyuse_anima.profiles",
@@ -3877,7 +3895,7 @@
         "conditional": false,
         "imported": ".easyuse_anima.profiles:contract",
         "kind": "static_from",
-        "line": 106,
+        "line": 109,
         "name": "contract",
         "optional": false,
         "requested": ".easyuse_anima.profiles",
@@ -3895,7 +3913,7 @@
         "conditional": false,
         "imported": ".easyuse_anima.profiles:lora",
         "kind": "static_from",
-        "line": 107,
+        "line": 110,
         "name": "lora",
         "optional": false,
         "requested": ".easyuse_anima.profiles",
@@ -3913,7 +3931,7 @@
         "conditional": false,
         "imported": ".easyuse_anima.profiles:mutation",
         "kind": "static_from",
-        "line": 108,
+        "line": 111,
         "name": "mutation",
         "optional": false,
         "requested": ".easyuse_anima.profiles",
@@ -3931,7 +3949,7 @@
         "conditional": false,
         "imported": ".easyuse_anima.profiles:repository",
         "kind": "static_from",
-        "line": 109,
+        "line": 112,
         "name": "repository",
         "optional": false,
         "requested": ".easyuse_anima.profiles",
@@ -3949,7 +3967,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 312
+            "line": 315
           }
         ],
         "classification": "external",
@@ -3957,7 +3975,7 @@
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 313,
+        "line": 316,
         "name": null,
         "optional": true,
         "requested": "folder_paths",
@@ -15246,6 +15264,23 @@
         "role": "ordinary",
         "scope": "<module>",
         "source": "easyuse_anima/api/responses.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "annotations",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "__future__:annotations",
+        "kind": "static_from",
+        "line": 1,
+        "name": "annotations",
+        "optional": false,
+        "requested": "__future__",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/api/routes/aio_profile_mutations.py"
       },
       {
         "alias": null,
@@ -63154,6 +63189,10 @@
       },
       {
         "from": "api.py",
+        "to": "easyuse_anima/api/routes/aio_profile_mutations.py"
+      },
+      {
+        "from": "api.py",
         "to": "easyuse_anima/api/routes/aio_torch_compile.py"
       },
       {
@@ -65265,6 +65304,12 @@
       {
         "cyclic": false,
         "modules": [
+          "easyuse_anima/api/routes/aio_profile_mutations.py"
+        ]
+      },
+      {
+        "cyclic": false,
+        "modules": [
           "easyuse_anima/api/routes/aio_torch_compile.py"
         ]
       },
@@ -65914,7 +65959,7 @@
     ]
   },
   "inventory": {
-    "module_count": 161,
+    "module_count": 162,
     "modules": [
       {
         "is_package": true,
@@ -66014,14 +66059,14 @@
       },
       {
         "is_package": false,
-        "loc": 848,
+        "loc": 812,
         "module": "api",
-        "normalized_git_blob_sha1": "b1499ed8e8a6ee66d6e73a06056b9e8fb5beea72",
+        "normalized_git_blob_sha1": "a86400822b9c91ce71598bbd478ab4fcb75737a4",
         "path": "api.py",
         "top_level": {
           "class_count": 0,
           "function_count": 23,
-          "global_count": 91
+          "global_count": 93
         }
       },
       {
@@ -66537,6 +66582,18 @@
         "top_level": {
           "class_count": 0,
           "function_count": 0,
+          "global_count": 1
+        }
+      },
+      {
+        "is_package": false,
+        "loc": 99,
+        "module": "easyuse_anima.api.routes.aio_profile_mutations",
+        "normalized_git_blob_sha1": "6be3d466dd0d3cba8157a7d924cd5ea31ac7e696",
+        "path": "easyuse_anima/api/routes/aio_profile_mutations.py",
+        "top_level": {
+          "class_count": 0,
+          "function_count": 1,
           "global_count": 1
         }
       },
@@ -80876,14 +80933,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 312
+            "line": 315
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 313,
+        "line": 316,
         "optional": true,
         "role": "optional_dependency",
         "source": "api.py"
@@ -82915,6 +82972,17 @@
         "optional": false,
         "role": "ordinary",
         "source": "easyuse_anima/api/responses.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "__future__:annotations",
+        "kind": "static_from",
+        "line": 1,
+        "optional": false,
+        "role": "ordinary",
+        "source": "easyuse_anima/api/routes/aio_profile_mutations.py"
       },
       {
         "branch_context": [],
@@ -87190,14 +87258,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 312
+            "line": 315
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 313,
+        "line": 316,
         "optional": true,
         "role": "optional_dependency",
         "source": "api.py"
@@ -88137,6 +88205,7 @@
       "easyuse_anima/api/requests.py",
       "easyuse_anima/api/responses.py",
       "easyuse_anima/api/routes/__init__.py",
+      "easyuse_anima/api/routes/aio_profile_mutations.py",
       "easyuse_anima/api/routes/aio_torch_compile.py",
       "easyuse_anima/api/routes/autocomplete.py",
       "easyuse_anima/api/routes/long_text_settings.py",
@@ -88300,6 +88369,7 @@
       "easyuse_anima/api/requests.py",
       "easyuse_anima/api/responses.py",
       "easyuse_anima/api/routes/__init__.py",
+      "easyuse_anima/api/routes/aio_profile_mutations.py",
       "easyuse_anima/api/routes/aio_torch_compile.py",
       "easyuse_anima/api/routes/autocomplete.py",
       "easyuse_anima/api/routes/long_text_settings.py",
@@ -88429,7 +88499,7 @@
         "column": 10,
         "context": "assign:_LOGGER",
         "kind": "import_time_call",
-        "line": 189,
+        "line": 192,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -88438,7 +88508,7 @@
         "column": 25,
         "context": "assign:_FILE_IO_LIMITERS_LOCK",
         "kind": "import_time_call",
-        "line": 192,
+        "line": 195,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -88447,7 +88517,7 @@
         "column": 47,
         "context": "assign:_FILE_IO_LIMITERS",
         "kind": "import_time_call",
-        "line": 193,
+        "line": 196,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -88456,7 +88526,7 @@
         "column": 29,
         "context": "assign:_PROMPT_TRANSLATION_WORKER",
         "kind": "route_registry_creation",
-        "line": 196,
+        "line": 199,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -88465,7 +88535,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 201,
+        "line": 204,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -88474,7 +88544,7 @@
         "column": 36,
         "context": "assign:_SAFE_PROFILE_VALIDATION_MESSAGES",
         "kind": "import_time_call",
-        "line": 339,
+        "line": 342,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -88483,7 +88553,7 @@
         "column": 9,
         "context": "assign:routes",
         "kind": "route_registry_creation",
-        "line": 496,
+        "line": 499,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -88492,7 +88562,7 @@
         "column": 8,
         "context": "assign:get_long_text_settings_handler,save_long_text_settings_handler",
         "kind": "import_time_call",
-        "line": 526,
+        "line": 529,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -88501,7 +88571,7 @@
         "column": 23,
         "context": "assign:get_long_text_settings_handler,save_long_text_settings_handler",
         "kind": "import_time_call",
-        "line": 527,
+        "line": 530,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -88510,7 +88580,7 @@
         "column": 28,
         "context": "assign:get_wildcards_handler",
         "kind": "import_time_call",
-        "line": 541,
+        "line": 544,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -88519,7 +88589,7 @@
         "column": 8,
         "context": "assign:get_wildcards_handler",
         "kind": "import_time_call",
-        "line": 542,
+        "line": 545,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -88528,7 +88598,7 @@
         "column": 8,
         "context": "assign:autocomplete_handler,autocomplete_status_handler",
         "kind": "import_time_call",
-        "line": 553,
+        "line": 556,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -88537,7 +88607,7 @@
         "column": 23,
         "context": "assign:autocomplete_handler,autocomplete_status_handler",
         "kind": "import_time_call",
-        "line": 554,
+        "line": 557,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -88546,7 +88616,7 @@
         "column": 30,
         "context": "assign:classify_prompt_handler",
         "kind": "import_time_call",
-        "line": 564,
+        "line": 567,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -88555,7 +88625,7 @@
         "column": 8,
         "context": "assign:classify_prompt_handler",
         "kind": "import_time_call",
-        "line": 565,
+        "line": 568,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -88564,7 +88634,7 @@
         "column": 31,
         "context": "assign:translate_prompt_handler",
         "kind": "import_time_call",
-        "line": 583,
+        "line": 586,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -88573,7 +88643,7 @@
         "column": 8,
         "context": "assign:translate_prompt_handler",
         "kind": "import_time_call",
-        "line": 584,
+        "line": 587,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -88582,7 +88652,7 @@
         "column": 42,
         "context": "assign:aio_torch_compile_recommend_handler",
         "kind": "import_time_call",
-        "line": 596,
+        "line": 599,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -88591,7 +88661,7 @@
         "column": 8,
         "context": "assign:aio_torch_compile_recommend_handler",
         "kind": "import_time_call",
-        "line": 597,
+        "line": 600,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -88600,7 +88670,7 @@
         "column": 27,
         "context": "assign:lora_preview_handler",
         "kind": "import_time_call",
-        "line": 613,
+        "line": 616,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -88609,7 +88679,7 @@
         "column": 8,
         "context": "assign:lora_preview_handler",
         "kind": "import_time_call",
-        "line": 614,
+        "line": 617,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -88618,7 +88688,7 @@
         "column": 20,
         "context": "assign:loras_handler",
         "kind": "import_time_call",
-        "line": 623,
+        "line": 626,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -88627,7 +88697,7 @@
         "column": 8,
         "context": "assign:loras_handler",
         "kind": "import_time_call",
-        "line": 624,
+        "line": 627,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -88636,7 +88706,7 @@
         "column": 8,
         "context": "assign:aio_profiles_handler,lora_profiles_handler",
         "kind": "import_time_call",
-        "line": 635,
+        "line": 638,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -88645,7 +88715,7 @@
         "column": 23,
         "context": "assign:aio_profiles_handler,lora_profiles_handler",
         "kind": "import_time_call",
-        "line": 636,
+        "line": 639,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -88654,7 +88724,7 @@
         "column": 8,
         "context": "assign:load_aio_profile_handler,load_lora_profile_handler",
         "kind": "import_time_call",
-        "line": 650,
+        "line": 653,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -88663,7 +88733,7 @@
         "column": 23,
         "context": "assign:load_aio_profile_handler,load_lora_profile_handler",
         "kind": "import_time_call",
-        "line": 651,
+        "line": 654,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -88672,7 +88742,7 @@
         "column": 8,
         "context": "assign:save_aio_profile_handler,save_lora_profile_handler",
         "kind": "import_time_call",
-        "line": 671,
+        "line": 674,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -88681,7 +88751,25 @@
         "column": 23,
         "context": "assign:save_aio_profile_handler,save_lora_profile_handler",
         "kind": "import_time_call",
-        "line": 672,
+        "line": 675,
+        "module": "api.py",
+        "scope": "<module>"
+      },
+      {
+        "callee": "_request_correlated",
+        "column": 8,
+        "context": "assign:delete_aio_profile_handler,rename_aio_profile_handler",
+        "kind": "import_time_call",
+        "line": 709,
+        "module": "api.py",
+        "scope": "<module>"
+      },
+      {
+        "callee": "_build_aio_profile_mutation_handlers",
+        "column": 23,
+        "context": "assign:delete_aio_profile_handler,rename_aio_profile_handler",
+        "kind": "import_time_call",
+        "line": 710,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -88690,7 +88778,7 @@
         "column": 19,
         "context": "assign:_ROUTE_SIGNATURE",
         "kind": "route_registry_creation",
-        "line": 824,
+        "line": 788,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -88699,7 +88787,7 @@
         "column": 5,
         "context": "assign:_ROUTE_SIGNATURE",
         "kind": "route_registry_creation",
-        "line": 825,
+        "line": 789,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -90970,7 +91058,7 @@
           "lock"
         ],
         "initializer": "threading.Lock",
-        "line": 192,
+        "line": 195,
         "module": "api.py",
         "name": "_FILE_IO_LIMITERS_LOCK"
       },
@@ -90979,7 +91067,7 @@
           "executor"
         ],
         "initializer": "_PromptTranslationRouteExecutor",
-        "line": 196,
+        "line": 199,
         "module": "api.py",
         "name": "_PROMPT_TRANSLATION_WORKER"
       },

--- a/tests/test_api_contract.py
+++ b/tests/test_api_contract.py
@@ -796,6 +796,168 @@ class ApiProfileSaveRouteTests(unittest.TestCase):
                 self.assertNotIn(forbidden, serialized)
 
 
+class ApiAioProfileMutationRouteTests(unittest.TestCase):
+    def test_route_handlers_are_owned_by_the_canonical_factory(self):
+        api, routes = load_api_routes()
+        cases = (
+            (
+                "delete_aio_profile_handler",
+                "/easyuse_anima/aio_profiles/delete",
+            ),
+            (
+                "rename_aio_profile_handler",
+                "/easyuse_anima/aio_profiles/rename",
+            ),
+        )
+
+        for name, path in cases:
+            with self.subTest(path=path):
+                handler = routes.handlers[path]
+                self.assertIs(getattr(api, name), handler)
+                self.assertEqual(handler.__name__, name)
+                self.assertTrue(
+                    handler.__module__.endswith(
+                        ".easyuse_anima.api.routes.aio_profile_mutations"
+                    )
+                )
+                self.assertTrue(handler._easyuse_anima_request_correlation)
+
+    def test_routes_keep_dynamic_operation_seams_kwargs_and_success_shape(self):
+        api, routes = load_api_routes()
+        source_id = "52345678-1234-4567-89ab-1234567890ab"
+        target_id = "62345678-1234-4567-89ab-1234567890ab"
+        cases = (
+            (
+                "/easyuse_anima/aio_profiles/delete",
+                "_delete_aio_profile",
+                {
+                    "name": "Portrait",
+                    "profile_id": source_id,
+                    "revision": 7,
+                },
+                ("Portrait",),
+                {"profile_id": source_id, "revision": 7},
+            ),
+            (
+                "/easyuse_anima/aio_profiles/rename",
+                "_rename_aio_profile",
+                {
+                    "old_name": "Portrait",
+                    "new_name": "Portrait 2",
+                    "overwrite": True,
+                    "profile_id": source_id,
+                    "revision": 7,
+                    "target_profile_id": target_id,
+                    "target_revision": 3,
+                },
+                ("Portrait", "Portrait 2"),
+                {
+                    "overwrite": True,
+                    "profile_id": source_id,
+                    "revision": 7,
+                    "target_profile_id": target_id,
+                    "target_revision": 3,
+                },
+            ),
+        )
+
+        for path, operation_name, data, expected_args, expected_kwargs in cases:
+            changed = {
+                "name": data.get("new_name", data.get("name")),
+                "profile_id": source_id,
+                "revision": 8,
+            }
+            with self.subTest(path=path), patch.object(
+                api,
+                operation_name,
+                return_value=changed,
+            ) as operation:
+                response = asyncio.run(routes.handlers[path](JsonRequest(data)))
+
+            self.assertEqual(response["status"], 200)
+            self.assertEqual(
+                response["payload"],
+                {"status": "ok", "profile": changed},
+            )
+            operation.assert_called_once_with(*expected_args, **expected_kwargs)
+
+    def test_rename_rejects_invalid_target_revision_before_file_io(self):
+        api, routes = load_api_routes()
+        with patch.object(api, "_rename_aio_profile") as rename_profile:
+            response = asyncio.run(
+                routes.handlers["/easyuse_anima/aio_profiles/rename"](
+                    JsonRequest(
+                        {
+                            "old_name": "Portrait",
+                            "new_name": "Portrait 2",
+                            "target_revision": -1,
+                        }
+                    )
+                )
+            )
+
+        self.assertEqual(response["status"], 422)
+        self.assertEqual(response["payload"]["code"], "invalid_request")
+        self.assertEqual(
+            response["payload"]["details"],
+            {"field": "target_revision"},
+        )
+        rename_profile.assert_not_called()
+
+    def test_routes_preserve_error_mapping_target_details_and_redaction(self):
+        api, routes = load_api_routes()
+        cases = (
+            (
+                "/easyuse_anima/aio_profiles/delete",
+                "_delete_aio_profile",
+                {"name": "Portrait"},
+                FileNotFoundError("C:\\private\\missing.json"),
+                404,
+                "profile_not_found",
+                None,
+            ),
+            (
+                "/easyuse_anima/aio_profiles/rename",
+                "_rename_aio_profile",
+                {"old_name": "Portrait", "new_name": "Portrait 2"},
+                FileExistsError("/home/alice/existing.json"),
+                409,
+                "profile_exists",
+                None,
+            ),
+            (
+                "/easyuse_anima/aio_profiles/rename",
+                "_rename_aio_profile",
+                {"old_name": "Portrait", "new_name": "Portrait 2"},
+                api.ProfileMutationError(
+                    status=409,
+                    code="profile_revision_conflict",
+                    message="Profile revision does not match",
+                    details={"profile": "target"},
+                ),
+                409,
+                "profile_revision_conflict",
+                {"profile": "target"},
+            ),
+        )
+
+        for path, operation_name, data, error, status, code, details in cases:
+            with self.subTest(path=path, code=code), patch.object(
+                api,
+                operation_name,
+                side_effect=error,
+            ):
+                response = asyncio.run(routes.handlers[path](JsonRequest(data)))
+
+            self.assertEqual(response["status"], status)
+            self.assertEqual(response["payload"]["code"], code)
+            if details is not None:
+                self.assertEqual(response["payload"]["details"], details)
+            serialized = json.dumps(response["payload"])
+            for forbidden in ("private", "/home/", "alice"):
+                self.assertNotIn(forbidden, serialized)
+
+
 class ApiWildcardRouteTests(unittest.TestCase):
     def test_route_handler_is_owned_by_the_canonical_factory(self):
         api, routes = load_api_routes()

--- a/tests/test_python_backend_analyzer.py
+++ b/tests/test_python_backend_analyzer.py
@@ -690,9 +690,9 @@ ignored/
 
         self.assertEqual(analyzer.render_json(report), expected_text)
         self.assertEqual(report["schema_version"], 2)
-        self.assertEqual(report["inventory"]["module_count"], 161)
-        self.assertEqual(len(report["registry"]["shipped_python_modules"]), 161)
-        self.assertEqual(len(report["registry"]["runtime_import_closure"]), 161)
+        self.assertEqual(report["inventory"]["module_count"], 162)
+        self.assertEqual(len(report["registry"]["shipped_python_modules"]), 162)
+        self.assertEqual(len(report["registry"]["runtime_import_closure"]), 162)
         self.assertEqual(
             report["registry"]["entry_modules"],
             [

--- a/tests/test_python_package_skeleton.py
+++ b/tests/test_python_package_skeleton.py
@@ -47,6 +47,7 @@ PACKAGE_MODULES = (
     "easyuse_anima.api.requests",
     "easyuse_anima.api.responses",
     "easyuse_anima.api.routes",
+    "easyuse_anima.api.routes.aio_profile_mutations",
     "easyuse_anima.api.routes.aio_torch_compile",
     "easyuse_anima.api.routes.autocomplete",
     "easyuse_anima.api.routes.lora_catalog",
@@ -220,6 +221,11 @@ print(json.dumps({{
             "attach_request_id_header",
             "correlate_response",
         ]
+        expected_all[
+            PACKAGE_MODULES.index(
+                "easyuse_anima.api.routes.aio_profile_mutations"
+            )
+        ] = ["build_aio_profile_mutation_handlers"]
         expected_all[
             PACKAGE_MODULES.index(
                 "easyuse_anima.api.routes.aio_torch_compile"


### PR DESCRIPTION
## 목적과 변경 경계

Issue #186의 D-07d로 AiO 프로필 delete/rename HTTP adapter를 root `api.py`에서 `easyuse_anima.api.routes.aio_profile_mutations`로 이동합니다. 도메인·repository·migration·save/load·LoRA fix·frontend production·#199는 변경하지 않습니다.

## Base -> Head

- Base: `74f93622694db04e8da4cac331f067382b75091d`
- Head: `033dd5c40412dde63be38490df9c47385cb181d9`

## 주요 파일과 보존 계약

- `api.py`: canonical factory를 composition하고 기존 dynamic root seams를 유지
- `easyuse_anima/api/routes/aio_profile_mutations.py`: delete/rename request parsing, file-I/O dispatch, response adapter 소유
- `tests/test_api_contract.py`: canonical ownership, kwargs 전달, contract fail-closed, 오류 taxonomy/redaction fixture
- package skeleton/analyzer baseline: 새 shipped module 등록

보존:
- delete의 nonempty name 및 optional profile_id/revision
- rename의 old/new/overwrite/source·target CAS tokens
- `_run_file_io` kwargs 및 dynamic root operation seams
- 기존 exception tuple, target conflict details, response shape, request correlation, route order
- corruption/CAS 안전성

## 검증

- changed-file AST/static: 통과
- 직접 route fixture: 4 tests 통과
- API contract: 64 tests 통과
- package skeleton 1, analyzer 18, scanner 8, import boundary 16, compatibility 26 통과
- AiO profile API client smoke: 통과
- `git diff --check`: 통과
- package validate: 통과
- package archive: 304 entries, 새 route/api/AiO domain 포함
- official full (최종 SHA에서 정확히 1회): Python 1,280 / frontend 120 / Pyright 145 files·기존 14 / G-03a 11 groups·0 violations / Ruff report-only 112
- isolated live: source+target 생성, stale target overwrite rename 409 fail-closed 및 양쪽 보존, 정확한 source/target tokens로 multi-token overwrite rename 200, token delete 200, source/target load 404, EasyUse 응답 correlation, queue 0/0
- live cleanup: D-07d profile file 0, port 8194 listener 0, 검증 PID 0

## 위험과 rollback

HTTP 공개 계약과 저장 형식은 변경하지 않는 adapter extraction입니다. rollback은 이 단일 squash commit을 되돌리면 됩니다. 남은 위험은 root composition과 실제 저장소 operation 사이의 미관측 host 차이이며, focused/full/package/isolated live에서 직접 경계를 확인했습니다.

## Next

D-07e LoRA fix route extraction.