### PR TITLE
refactor(api): extract settings route handlers (D-08a)

### DIFF
--- a/api.py
+++ b/api.py
@@ -90,6 +90,9 @@ from .easyuse_anima.api.routes.profile_loads import (
 from .easyuse_anima.api.routes.profile_saves import (
     build_profile_save_handlers as _build_profile_save_handlers,
 )
+from .easyuse_anima.api.routes.settings import (
+    build_settings_handlers as _build_settings_handlers,
+)
 from .easyuse_anima.api.routes.wildcards import (
     build_wildcards_handler as _build_wildcards_handler,
 )
@@ -503,27 +506,35 @@ routes = _get_prompt_routes()
 
 
 if web is not None:
-
-    @_request_correlated
-    async def get_settings_handler(request):
-        return web.json_response(await _run_file_io(_get_settings_payload_sync))
-
-    @_request_correlated
-    async def set_setting_handler(request):
-        try:
-            data = await parse_json_object(request)
-            key = json_string(data, "key", allow_empty=False)
-        except ApiContractError as exc:
-            return _contract_error_response(exc)
-        try:
-            payload = await _run_file_io(
-                _save_setting_payload_sync,
+    (
+        get_settings_handler,
+        set_setting_handler,
+    ) = (
+        _request_correlated(handler)
+        for handler in _build_settings_handlers(
+            parse_json_object=parse_json_object,
+            json_string=json_string,
+            contract_error_type=ApiContractError,
+            contract_error_response=lambda exc: _contract_error_response(exc),
+            run_file_io=lambda function, *args, **kwargs: _run_file_io(
+                function,
+                *args,
+                **kwargs,
+            ),
+            get_settings_payload=lambda: _get_settings_payload_sync(),
+            save_setting_payload=lambda key, value: _save_setting_payload_sync(
                 key,
-                data.get("value", ""),
-            )
-        except KeyError:
-            return _error_response(422, "unknown_setting", "Unknown setting")
-        return web.json_response(payload)
+                value,
+            ),
+            unknown_setting_error_type=KeyError,
+            unknown_setting_response=lambda: _error_response(
+                422,
+                "unknown_setting",
+                "Unknown setting",
+            ),
+            json_response=lambda payload: web.json_response(payload),
+        )
+    )
 
     (
         get_long_text_settings_handler,

--- a/easyuse_anima/api/routes/settings.py
+++ b/easyuse_anima/api/routes/settings.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+
+def build_settings_handlers(
+    *,
+    parse_json_object,
+    json_string,
+    contract_error_type,
+    contract_error_response,
+    run_file_io,
+    get_settings_payload,
+    save_setting_payload,
+    unknown_setting_error_type,
+    unknown_setting_response,
+    json_response,
+):
+    """Build settings routes without loading settings persistence owners."""
+
+    async def get_settings_handler(request):
+        payload = await run_file_io(get_settings_payload)
+        return json_response(payload)
+
+    async def set_setting_handler(request):
+        try:
+            data = await parse_json_object(request)
+            key = json_string(data, "key", allow_empty=False)
+        except contract_error_type as exc:
+            return contract_error_response(exc)
+        try:
+            payload = await run_file_io(
+                save_setting_payload,
+                key,
+                data.get("value", ""),
+            )
+        except unknown_setting_error_type:
+            return unknown_setting_response()
+        return json_response(payload)
+
+    return get_settings_handler, set_setting_handler
+
+
+__all__ = ("build_settings_handlers",)

--- a/tests/fixtures/python_backend_baseline.json
+++ b/tests/fixtures/python_backend_baseline.json
@@ -3779,6 +3779,24 @@
         "target": "easyuse_anima/api/routes/profile_saves.py"
       },
       {
+        "alias": "_build_settings_handlers",
+        "bound_name": "_build_settings_handlers",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".easyuse_anima.api.routes.settings:build_settings_handlers",
+        "kind": "static_from",
+        "line": 93,
+        "name": "build_settings_handlers",
+        "optional": false,
+        "requested": ".easyuse_anima.api.routes.settings",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "api.py",
+        "target": "easyuse_anima/api/routes/settings.py"
+      },
+      {
         "alias": "_build_wildcards_handler",
         "bound_name": "_build_wildcards_handler",
         "branch_context": [],
@@ -3787,7 +3805,7 @@
         "conditional": false,
         "imported": ".easyuse_anima.api.routes.wildcards:build_wildcards_handler",
         "kind": "static_from",
-        "line": 93,
+        "line": 96,
         "name": "build_wildcards_handler",
         "optional": false,
         "requested": ".easyuse_anima.api.routes.wildcards",
@@ -3805,7 +3823,7 @@
         "conditional": false,
         "imported": ".easyuse_anima.api.routes.translation:build_translate_prompt_handler",
         "kind": "static_from",
-        "line": 96,
+        "line": 99,
         "name": "build_translate_prompt_handler",
         "optional": false,
         "requested": ".easyuse_anima.api.routes.translation",
@@ -3823,7 +3841,7 @@
         "conditional": false,
         "imported": ".easyuse_anima.api.routes.translation_execution:PromptTranslationRouteExecutor",
         "kind": "static_from",
-        "line": 99,
+        "line": 102,
         "name": "PromptTranslationRouteExecutor",
         "optional": false,
         "requested": ".easyuse_anima.api.routes.translation_execution",
@@ -3841,7 +3859,7 @@
         "conditional": false,
         "imported": ".easyuse_anima.api.routes.aio_torch_compile:build_aio_torch_compile_recommend_handler",
         "kind": "static_from",
-        "line": 102,
+        "line": 105,
         "name": "build_aio_torch_compile_recommend_handler",
         "optional": false,
         "requested": ".easyuse_anima.api.routes.aio_torch_compile",
@@ -3859,7 +3877,7 @@
         "conditional": false,
         "imported": ".easyuse_anima.aio.torch_compile_diagnostics:collect_torch_compile_diagnostics",
         "kind": "static_from",
-        "line": 105,
+        "line": 108,
         "name": "collect_torch_compile_diagnostics",
         "optional": false,
         "requested": ".easyuse_anima.aio.torch_compile_diagnostics",
@@ -3877,7 +3895,7 @@
         "conditional": false,
         "imported": ".easyuse_anima.aio.torch_compile_recommendation:recommend_torch_compile",
         "kind": "static_from",
-        "line": 108,
+        "line": 111,
         "name": "recommend_torch_compile",
         "optional": false,
         "requested": ".easyuse_anima.aio.torch_compile_recommendation",
@@ -3895,7 +3913,7 @@
         "conditional": false,
         "imported": ".easyuse_anima.profiles:aio",
         "kind": "static_from",
-        "line": 111,
+        "line": 114,
         "name": "aio",
         "optional": false,
         "requested": ".easyuse_anima.profiles",
@@ -3913,7 +3931,7 @@
         "conditional": false,
         "imported": ".easyuse_anima.profiles:contract",
         "kind": "static_from",
-        "line": 112,
+        "line": 115,
         "name": "contract",
         "optional": false,
         "requested": ".easyuse_anima.profiles",
@@ -3931,7 +3949,7 @@
         "conditional": false,
         "imported": ".easyuse_anima.profiles:lora",
         "kind": "static_from",
-        "line": 113,
+        "line": 116,
         "name": "lora",
         "optional": false,
         "requested": ".easyuse_anima.profiles",
@@ -3949,7 +3967,7 @@
         "conditional": false,
         "imported": ".easyuse_anima.profiles:mutation",
         "kind": "static_from",
-        "line": 114,
+        "line": 117,
         "name": "mutation",
         "optional": false,
         "requested": ".easyuse_anima.profiles",
@@ -3967,7 +3985,7 @@
         "conditional": false,
         "imported": ".easyuse_anima.profiles:repository",
         "kind": "static_from",
-        "line": 115,
+        "line": 118,
         "name": "repository",
         "optional": false,
         "requested": ".easyuse_anima.profiles",
@@ -3985,7 +4003,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 318
+            "line": 321
           }
         ],
         "classification": "external",
@@ -3993,7 +4011,7 @@
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 319,
+        "line": 322,
         "name": null,
         "optional": true,
         "requested": "folder_paths",
@@ -15452,6 +15470,23 @@
         "role": "ordinary",
         "scope": "<module>",
         "source": "easyuse_anima/api/routes/profile_saves.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "annotations",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "__future__:annotations",
+        "kind": "static_from",
+        "line": 1,
+        "name": "annotations",
+        "optional": false,
+        "requested": "__future__",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/api/routes/settings.py"
       },
       {
         "alias": null,
@@ -63264,6 +63299,10 @@
       },
       {
         "from": "api.py",
+        "to": "easyuse_anima/api/routes/settings.py"
+      },
+      {
+        "from": "api.py",
         "to": "easyuse_anima/api/routes/translation.py"
       },
       {
@@ -65403,6 +65442,12 @@
       {
         "cyclic": false,
         "modules": [
+          "easyuse_anima/api/routes/settings.py"
+        ]
+      },
+      {
+        "cyclic": false,
+        "modules": [
           "easyuse_anima/api/routes/translation.py"
         ]
       },
@@ -66004,7 +66049,7 @@
     ]
   },
   "inventory": {
-    "module_count": 163,
+    "module_count": 164,
     "modules": [
       {
         "is_package": true,
@@ -66104,14 +66149,14 @@
       },
       {
         "is_package": false,
-        "loc": 820,
+        "loc": 831,
         "module": "api",
-        "normalized_git_blob_sha1": "196e31dfc72710f45c8a809c8a64831a7e346835",
+        "normalized_git_blob_sha1": "64972a0213ae74a392e0194020eb92ce5444d459",
         "path": "api.py",
         "top_level": {
           "class_count": 0,
           "function_count": 23,
-          "global_count": 94
+          "global_count": 96
         }
       },
       {
@@ -66744,6 +66789,18 @@
         "module": "easyuse_anima.api.routes.profile_saves",
         "normalized_git_blob_sha1": "c33c9239a508909caa2da92585d9d2bb83bbc519",
         "path": "easyuse_anima/api/routes/profile_saves.py",
+        "top_level": {
+          "class_count": 0,
+          "function_count": 1,
+          "global_count": 1
+        }
+      },
+      {
+        "is_package": false,
+        "loc": 42,
+        "module": "easyuse_anima.api.routes.settings",
+        "normalized_git_blob_sha1": "114a38b60c8cc8cceb3aad6fbad24071d499ec89",
+        "path": "easyuse_anima/api/routes/settings.py",
         "top_level": {
           "class_count": 0,
           "function_count": 1,
@@ -80990,14 +81047,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 318
+            "line": 321
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 319,
+        "line": 322,
         "optional": true,
         "role": "optional_dependency",
         "source": "api.py"
@@ -83139,6 +83196,17 @@
         "optional": false,
         "role": "ordinary",
         "source": "easyuse_anima/api/routes/profile_saves.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "__future__:annotations",
+        "kind": "static_from",
+        "line": 1,
+        "optional": false,
+        "role": "ordinary",
+        "source": "easyuse_anima/api/routes/settings.py"
       },
       {
         "branch_context": [],
@@ -87326,14 +87394,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 318
+            "line": 321
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 319,
+        "line": 322,
         "optional": true,
         "role": "optional_dependency",
         "source": "api.py"
@@ -88283,6 +88351,7 @@
       "easyuse_anima/api/routes/profile_lists.py",
       "easyuse_anima/api/routes/profile_loads.py",
       "easyuse_anima/api/routes/profile_saves.py",
+      "easyuse_anima/api/routes/settings.py",
       "easyuse_anima/api/routes/translation.py",
       "easyuse_anima/api/routes/translation_execution.py",
       "easyuse_anima/api/routes/wildcards.py",
@@ -88448,6 +88517,7 @@
       "easyuse_anima/api/routes/profile_lists.py",
       "easyuse_anima/api/routes/profile_loads.py",
       "easyuse_anima/api/routes/profile_saves.py",
+      "easyuse_anima/api/routes/settings.py",
       "easyuse_anima/api/routes/translation.py",
       "easyuse_anima/api/routes/translation_execution.py",
       "easyuse_anima/api/routes/wildcards.py",
@@ -88569,7 +88639,7 @@
         "column": 10,
         "context": "assign:_LOGGER",
         "kind": "import_time_call",
-        "line": 195,
+        "line": 198,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -88578,7 +88648,7 @@
         "column": 25,
         "context": "assign:_FILE_IO_LIMITERS_LOCK",
         "kind": "import_time_call",
-        "line": 198,
+        "line": 201,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -88587,7 +88657,7 @@
         "column": 47,
         "context": "assign:_FILE_IO_LIMITERS",
         "kind": "import_time_call",
-        "line": 199,
+        "line": 202,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -88596,7 +88666,7 @@
         "column": 29,
         "context": "assign:_PROMPT_TRANSLATION_WORKER",
         "kind": "route_registry_creation",
-        "line": 202,
+        "line": 205,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -88605,7 +88675,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 207,
+        "line": 210,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -88614,7 +88684,7 @@
         "column": 36,
         "context": "assign:_SAFE_PROFILE_VALIDATION_MESSAGES",
         "kind": "import_time_call",
-        "line": 345,
+        "line": 348,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -88623,7 +88693,25 @@
         "column": 9,
         "context": "assign:routes",
         "kind": "route_registry_creation",
-        "line": 502,
+        "line": 505,
+        "module": "api.py",
+        "scope": "<module>"
+      },
+      {
+        "callee": "_request_correlated",
+        "column": 8,
+        "context": "assign:get_settings_handler,set_setting_handler",
+        "kind": "import_time_call",
+        "line": 513,
+        "module": "api.py",
+        "scope": "<module>"
+      },
+      {
+        "callee": "_build_settings_handlers",
+        "column": 23,
+        "context": "assign:get_settings_handler,set_setting_handler",
+        "kind": "import_time_call",
+        "line": 514,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -88632,7 +88720,7 @@
         "column": 8,
         "context": "assign:get_long_text_settings_handler,save_long_text_settings_handler",
         "kind": "import_time_call",
-        "line": 532,
+        "line": 543,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -88641,7 +88729,7 @@
         "column": 23,
         "context": "assign:get_long_text_settings_handler,save_long_text_settings_handler",
         "kind": "import_time_call",
-        "line": 533,
+        "line": 544,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -88650,7 +88738,7 @@
         "column": 28,
         "context": "assign:get_wildcards_handler",
         "kind": "import_time_call",
-        "line": 547,
+        "line": 558,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -88659,7 +88747,7 @@
         "column": 8,
         "context": "assign:get_wildcards_handler",
         "kind": "import_time_call",
-        "line": 548,
+        "line": 559,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -88668,7 +88756,7 @@
         "column": 8,
         "context": "assign:autocomplete_handler,autocomplete_status_handler",
         "kind": "import_time_call",
-        "line": 559,
+        "line": 570,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -88677,7 +88765,7 @@
         "column": 23,
         "context": "assign:autocomplete_handler,autocomplete_status_handler",
         "kind": "import_time_call",
-        "line": 560,
+        "line": 571,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -88686,7 +88774,7 @@
         "column": 30,
         "context": "assign:classify_prompt_handler",
         "kind": "import_time_call",
-        "line": 570,
+        "line": 581,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -88695,7 +88783,7 @@
         "column": 8,
         "context": "assign:classify_prompt_handler",
         "kind": "import_time_call",
-        "line": 571,
+        "line": 582,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -88704,7 +88792,7 @@
         "column": 31,
         "context": "assign:translate_prompt_handler",
         "kind": "import_time_call",
-        "line": 589,
+        "line": 600,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -88713,7 +88801,7 @@
         "column": 8,
         "context": "assign:translate_prompt_handler",
         "kind": "import_time_call",
-        "line": 590,
+        "line": 601,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -88722,7 +88810,7 @@
         "column": 42,
         "context": "assign:aio_torch_compile_recommend_handler",
         "kind": "import_time_call",
-        "line": 602,
+        "line": 613,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -88731,7 +88819,7 @@
         "column": 8,
         "context": "assign:aio_torch_compile_recommend_handler",
         "kind": "import_time_call",
-        "line": 603,
+        "line": 614,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -88740,7 +88828,7 @@
         "column": 27,
         "context": "assign:lora_preview_handler",
         "kind": "import_time_call",
-        "line": 619,
+        "line": 630,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -88749,7 +88837,7 @@
         "column": 8,
         "context": "assign:lora_preview_handler",
         "kind": "import_time_call",
-        "line": 620,
+        "line": 631,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -88758,7 +88846,7 @@
         "column": 20,
         "context": "assign:loras_handler",
         "kind": "import_time_call",
-        "line": 629,
+        "line": 640,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -88767,7 +88855,7 @@
         "column": 8,
         "context": "assign:loras_handler",
         "kind": "import_time_call",
-        "line": 630,
+        "line": 641,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -88776,7 +88864,7 @@
         "column": 8,
         "context": "assign:aio_profiles_handler,lora_profiles_handler",
         "kind": "import_time_call",
-        "line": 641,
+        "line": 652,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -88785,7 +88873,7 @@
         "column": 23,
         "context": "assign:aio_profiles_handler,lora_profiles_handler",
         "kind": "import_time_call",
-        "line": 642,
+        "line": 653,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -88794,7 +88882,7 @@
         "column": 8,
         "context": "assign:load_aio_profile_handler,load_lora_profile_handler",
         "kind": "import_time_call",
-        "line": 656,
+        "line": 667,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -88803,7 +88891,7 @@
         "column": 23,
         "context": "assign:load_aio_profile_handler,load_lora_profile_handler",
         "kind": "import_time_call",
-        "line": 657,
+        "line": 668,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -88812,7 +88900,7 @@
         "column": 8,
         "context": "assign:save_aio_profile_handler,save_lora_profile_handler",
         "kind": "import_time_call",
-        "line": 677,
+        "line": 688,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -88821,7 +88909,7 @@
         "column": 23,
         "context": "assign:save_aio_profile_handler,save_lora_profile_handler",
         "kind": "import_time_call",
-        "line": 678,
+        "line": 689,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -88830,7 +88918,7 @@
         "column": 8,
         "context": "assign:delete_aio_profile_handler,rename_aio_profile_handler",
         "kind": "import_time_call",
-        "line": 712,
+        "line": 723,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -88839,7 +88927,7 @@
         "column": 23,
         "context": "assign:delete_aio_profile_handler,rename_aio_profile_handler",
         "kind": "import_time_call",
-        "line": 713,
+        "line": 724,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -88848,7 +88936,7 @@
         "column": 31,
         "context": "assign:fix_lora_profile_handler",
         "kind": "import_time_call",
-        "line": 744,
+        "line": 755,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -88857,7 +88945,7 @@
         "column": 8,
         "context": "assign:fix_lora_profile_handler",
         "kind": "import_time_call",
-        "line": 745,
+        "line": 756,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -88866,7 +88954,7 @@
         "column": 19,
         "context": "assign:_ROUTE_SIGNATURE",
         "kind": "route_registry_creation",
-        "line": 796,
+        "line": 807,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -88875,7 +88963,7 @@
         "column": 5,
         "context": "assign:_ROUTE_SIGNATURE",
         "kind": "route_registry_creation",
-        "line": 797,
+        "line": 808,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -91146,7 +91234,7 @@
           "lock"
         ],
         "initializer": "threading.Lock",
-        "line": 198,
+        "line": 201,
         "module": "api.py",
         "name": "_FILE_IO_LIMITERS_LOCK"
       },
@@ -91155,7 +91243,7 @@
           "executor"
         ],
         "initializer": "_PromptTranslationRouteExecutor",
-        "line": 202,
+        "line": 205,
         "module": "api.py",
         "name": "_PROMPT_TRANSLATION_WORKER"
       },

--- a/tests/test_api_contract.py
+++ b/tests/test_api_contract.py
@@ -1092,6 +1092,155 @@ class ApiWildcardRouteTests(unittest.TestCase):
         wildcards_payload.assert_called_once_with()
 
 
+class ApiSettingsRouteTests(unittest.TestCase):
+    def test_route_handlers_are_owned_by_the_canonical_factory(self):
+        api, routes = load_api_routes()
+        cases = (
+            ("get_settings_handler", "/easyuse_anima/settings"),
+            ("set_setting_handler", "/easyuse_anima/set_setting"),
+        )
+
+        for name, path in cases:
+            with self.subTest(path=path):
+                handler = routes.handlers[path]
+                self.assertIs(getattr(api, name), handler)
+                self.assertEqual(handler.__name__, name)
+                self.assertTrue(
+                    handler.__module__.endswith(
+                        ".easyuse_anima.api.routes.settings"
+                    )
+                )
+                self.assertTrue(handler._easyuse_anima_request_correlation)
+
+    def test_get_keeps_dynamic_payload_seam_and_legacy_success_shape(self):
+        api, routes = load_api_routes()
+        payload = {
+            "autocomplete.limit": 20,
+            "wildcard.extra_paths": ["D:\\private\\wildcards"],
+        }
+        with patch.object(
+            api,
+            "_get_settings_payload_sync",
+            return_value=payload,
+        ) as get_payload:
+            response = asyncio.run(
+                routes.handlers["/easyuse_anima/settings"](JsonRequest())
+            )
+
+        self.assertEqual(response["status"], 200)
+        self.assertIs(response["payload"], payload)
+        get_payload.assert_called_once_with()
+
+    def test_set_keeps_dynamic_seam_raw_value_default_and_success_shape(self):
+        api, routes = load_api_routes()
+        cases = (
+            ({"key": "autocomplete.limit"}, ""),
+            ({"key": "autocomplete.limit", "value": None}, None),
+            (
+                {
+                    "key": "wildcard.extra_paths",
+                    "value": {"future": {"kept": True}},
+                },
+                {"future": {"kept": True}},
+            ),
+        )
+
+        for data, expected_value in cases:
+            payload = {"status": "ok", "saved": expected_value}
+            with self.subTest(data=data), patch.object(
+                api,
+                "_save_setting_payload_sync",
+                return_value=payload,
+            ) as save_payload:
+                response = asyncio.run(
+                    routes.handlers["/easyuse_anima/set_setting"](
+                        JsonRequest(data)
+                    )
+                )
+
+            self.assertEqual(response["status"], 200)
+            self.assertIs(response["payload"], payload)
+            save_payload.assert_called_once_with(
+                data["key"],
+                expected_value,
+            )
+
+    def test_invalid_key_is_rejected_before_file_io(self):
+        api, routes = load_api_routes()
+        with (
+            patch.object(api, "_save_setting_payload_sync") as save_payload,
+            patch.object(api, "_run_file_io") as file_io,
+        ):
+            response = asyncio.run(
+                routes.handlers["/easyuse_anima/set_setting"](
+                    JsonRequest({"key": []})
+                )
+            )
+
+        self.assertEqual(response["status"], 422)
+        self.assertEqual(response["payload"]["code"], "invalid_request")
+        self.assertEqual(response["payload"]["details"], {"field": "key"})
+        save_payload.assert_not_called()
+        file_io.assert_not_called()
+
+    def test_unknown_setting_keeps_fixed_422_taxonomy_and_redaction(self):
+        api, routes = load_api_routes()
+        secret = "C:\\Users\\alice\\settings.json API_TOKEN=top-secret"
+        with patch.object(
+            api,
+            "_save_setting_payload_sync",
+            side_effect=KeyError(secret),
+        ):
+            response = asyncio.run(
+                routes.handlers["/easyuse_anima/set_setting"](
+                    JsonRequest({"key": "future.setting", "value": secret})
+                )
+            )
+
+        self.assertEqual(response["status"], 422)
+        self.assertEqual(
+            response["payload"],
+            {
+                "status": "error",
+                "code": "unknown_setting",
+                "message": "Unknown setting",
+                "request_id": response.headers["X-Request-ID"],
+            },
+        )
+        serialized = json.dumps(response["payload"])
+        for forbidden in ("alice", "settings.json", "API_TOKEN", "top-secret"):
+            self.assertNotIn(forbidden, serialized)
+
+    def test_unexpected_save_failure_stays_on_correlated_safe_500_boundary(self):
+        api, routes = load_api_routes()
+        secret = "C:\\Users\\alice\\settings.json API_TOKEN=top-secret"
+        with (
+            patch.object(
+                api,
+                "_save_setting_payload_sync",
+                side_effect=ValueError(secret),
+            ),
+            patch.object(api._LOGGER, "exception") as log_exception,
+        ):
+            response = asyncio.run(
+                routes.handlers["/easyuse_anima/set_setting"](
+                    JsonRequest({"key": "future.setting", "value": secret})
+                )
+            )
+
+        self.assertEqual(response["status"], 500)
+        self.assertEqual(response["payload"]["code"], "internal_error")
+        self.assertEqual(
+            response["payload"]["request_id"],
+            response.headers["X-Request-ID"],
+        )
+        uuid.UUID(response["payload"]["request_id"])
+        serialized = json.dumps(response["payload"])
+        for forbidden in ("alice", "settings.json", "API_TOKEN", "top-secret"):
+            self.assertNotIn(forbidden, serialized)
+        log_exception.assert_called_once()
+
+
 class ApiLongTextSettingsRouteTests(unittest.TestCase):
     def test_route_handlers_are_owned_by_the_canonical_factory(self):
         api, routes = load_api_routes()

--- a/tests/test_python_backend_analyzer.py
+++ b/tests/test_python_backend_analyzer.py
@@ -690,9 +690,9 @@ ignored/
 
         self.assertEqual(analyzer.render_json(report), expected_text)
         self.assertEqual(report["schema_version"], 2)
-        self.assertEqual(report["inventory"]["module_count"], 163)
-        self.assertEqual(len(report["registry"]["shipped_python_modules"]), 163)
-        self.assertEqual(len(report["registry"]["runtime_import_closure"]), 163)
+        self.assertEqual(report["inventory"]["module_count"], 164)
+        self.assertEqual(len(report["registry"]["shipped_python_modules"]), 164)
+        self.assertEqual(len(report["registry"]["runtime_import_closure"]), 164)
         self.assertEqual(
             report["registry"]["entry_modules"],
             [

--- a/tests/test_python_package_skeleton.py
+++ b/tests/test_python_package_skeleton.py
@@ -57,6 +57,7 @@ PACKAGE_MODULES = (
     "easyuse_anima.api.routes.profile_lists",
     "easyuse_anima.api.routes.profile_loads",
     "easyuse_anima.api.routes.profile_saves",
+    "easyuse_anima.api.routes.settings",
     "easyuse_anima.api.routes.translation",
     "easyuse_anima.api.routes.translation_execution",
     "easyuse_anima.api.routes.wildcards",
@@ -259,6 +260,9 @@ print(json.dumps({{
         expected_all[
             PACKAGE_MODULES.index("easyuse_anima.api.routes.profile_saves")
         ] = ["build_profile_save_handlers"]
+        expected_all[
+            PACKAGE_MODULES.index("easyuse_anima.api.routes.settings")
+        ] = ["build_settings_handlers"]
         expected_all[
             PACKAGE_MODULES.index("easyuse_anima.api.routes.translation")
         ] = ["build_translate_prompt_handler"]


### PR DESCRIPTION
## 목적과 변경 경계

- 로드맵 D-08a로 GET `/easyuse_anima/settings`와 POST `/easyuse_anima/set_setting` handler 소유권을 `easyuse_anima.api.routes.settings`로 이동합니다.
- settings schema/repository, 프런트엔드, access policy, route registration 방식은 변경하지 않습니다.

## Base -> Head

- Base: `9c613627423505eebe146b2c107a25f1d13b033f`
- Head: `a778c8bd158a74d53f342796407e7123af37f20d`

## 주요 파일과 보존 계약

- `easyuse_anima/api/routes/settings.py`: GET/POST handler factory 추가
- `api.py`: 기존 동적 payload/file-I/O/error/response seam을 주입해 두 handler를 조립
- 직접 계약 테스트와 package/analyzer 기준선 갱신
- GET 공개 payload shape, POST의 missing value 기본값과 raw value 보존, `KeyError`만 `unknown_setting` 422로 매핑, correlated safe 500, 기존 비인증/wildcard path 의미를 보존합니다.

## 검증

- changed-file AST: 5개 통과
- 직접 settings route 계약: 6개 통과
- 전체 API contract: 74개 통과
- package skeleton 1, analyzer 18, scanner 8, import boundary 16, compatibility 26 통과
- settings runtime 및 wildcard path Node smoke 통과
- `git diff --check` 통과
- package validate 통과, pack 306 entries 확인 후 archive 제거
- 후보 SHA에서 official full 정확히 1회 통과: Python 1,290 / frontend 120 / Pyright 147 files(기존 진단 14) / G03 11·위반 0 / Ruff report-only 112
- 격리 live: GET 200, invalid/unknown 422와 redaction, `autocomplete.limit` write/read/restore, 원복 전후 전체 payload 동일, queue 0/0. 생성 설정 파일과 서버/probe 정리 완료

## 남은 위험과 rollback

- 실질 동작 변경 없이 handler 소유권만 이동했지만 import-time composition 경계가 바뀝니다. package/import/analyzer/full/live 증거로 해당 위험을 검증했습니다.
- rollback은 이 단일 squash commit을 되돌리면 됩니다.

## Next task

- D-08b에서 남은 router/registration 소유권 경계를 별도 task card와 PR로 진행합니다.