### PR TITLE
D-08g: wildcard payload owner를 canonical route로 이동

### DIFF
--- a/api.py
+++ b/api.py
@@ -106,6 +106,7 @@ from .easyuse_anima.api.routes import settings as _api_settings_routes
 from .easyuse_anima.api.routes.settings import (
     build_settings_handlers as _build_settings_handlers,
 )
+from .easyuse_anima.api.routes import wildcards as _api_wildcard_routes
 from .easyuse_anima.api.routes.wildcards import (
     build_wildcards_handler as _build_wildcards_handler,
 )
@@ -347,25 +348,11 @@ def _profile_error_response(exc: Exception):
 )
 
 
-def _wildcards_payload_sync() -> dict:
-    settings = public_settings()
-    extra_paths = settings.get("wildcard.extra_paths", "")
-    roots = resolve_wildcard_roots(extra_paths)
-    sources = [
-        {
-            "id": f"wildcard:{index}",
-            "label": f"Wildcard source {index}",
-            "exists": root.is_dir(),
-        }
-        for index, root in enumerate(roots, start=1)
-    ]
-    return {
-        "status": "ok",
-        "items": list_wildcards(roots=roots),
-        # Preserve the legacy list-of-strings type without publishing paths.
-        "roots": [source["id"] for source in sources],
-        "sources": sources,
-    }
+_wildcards_payload_sync = _api_wildcard_routes.build_wildcards_payload(
+    public_settings=lambda: public_settings(),
+    resolve_wildcard_roots=lambda extra_paths: resolve_wildcard_roots(extra_paths),
+    list_wildcards=lambda **kwargs: list_wildcards(**kwargs),
+)
 
 
 def _autocomplete_status_payload_sync() -> dict:

--- a/easyuse_anima/api/routes/wildcards.py
+++ b/easyuse_anima/api/routes/wildcards.py
@@ -1,6 +1,37 @@
 from __future__ import annotations
 
 
+def build_wildcards_payload(
+    *,
+    public_settings,
+    resolve_wildcard_roots,
+    list_wildcards,
+):
+    """Build the redacted wildcard payload with runtime-resolved owners."""
+
+    def _wildcards_payload_sync() -> dict:
+        settings = public_settings()
+        extra_paths = settings.get("wildcard.extra_paths", "")
+        roots = resolve_wildcard_roots(extra_paths)
+        sources = [
+            {
+                "id": f"wildcard:{index}",
+                "label": f"Wildcard source {index}",
+                "exists": root.is_dir(),
+            }
+            for index, root in enumerate(roots, start=1)
+        ]
+        return {
+            "status": "ok",
+            "items": list_wildcards(roots=roots),
+            # Preserve the legacy list-of-strings type without publishing paths.
+            "roots": [source["id"] for source in sources],
+            "sources": sources,
+        }
+
+    return _wildcards_payload_sync
+
+
 def build_wildcards_handler(
     *,
     run_file_io,

--- a/tests/fixtures/python_backend_baseline.json
+++ b/tests/fixtures/python_backend_baseline.json
@@ -3962,6 +3962,24 @@
         "target": "easyuse_anima/api/routes/settings.py"
       },
       {
+        "alias": "_api_wildcard_routes",
+        "bound_name": "_api_wildcard_routes",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".easyuse_anima.api.routes:wildcards",
+        "kind": "static_from",
+        "line": 109,
+        "name": "wildcards",
+        "optional": false,
+        "requested": ".easyuse_anima.api.routes",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "api.py",
+        "target": "easyuse_anima/api/routes/wildcards.py"
+      },
+      {
         "alias": "_build_wildcards_handler",
         "bound_name": "_build_wildcards_handler",
         "branch_context": [],
@@ -3970,7 +3988,7 @@
         "conditional": false,
         "imported": ".easyuse_anima.api.routes.wildcards:build_wildcards_handler",
         "kind": "static_from",
-        "line": 109,
+        "line": 110,
         "name": "build_wildcards_handler",
         "optional": false,
         "requested": ".easyuse_anima.api.routes.wildcards",
@@ -3988,7 +4006,7 @@
         "conditional": false,
         "imported": ".easyuse_anima.api.routes.translation:build_translate_prompt_handler",
         "kind": "static_from",
-        "line": 112,
+        "line": 113,
         "name": "build_translate_prompt_handler",
         "optional": false,
         "requested": ".easyuse_anima.api.routes.translation",
@@ -4006,7 +4024,7 @@
         "conditional": false,
         "imported": ".easyuse_anima.api.routes.translation_execution:PromptTranslationRouteExecutor",
         "kind": "static_from",
-        "line": 115,
+        "line": 116,
         "name": "PromptTranslationRouteExecutor",
         "optional": false,
         "requested": ".easyuse_anima.api.routes.translation_execution",
@@ -4024,7 +4042,7 @@
         "conditional": false,
         "imported": ".easyuse_anima.api.routes.aio_torch_compile:build_aio_torch_compile_recommend_handler",
         "kind": "static_from",
-        "line": 118,
+        "line": 119,
         "name": "build_aio_torch_compile_recommend_handler",
         "optional": false,
         "requested": ".easyuse_anima.api.routes.aio_torch_compile",
@@ -4042,7 +4060,7 @@
         "conditional": false,
         "imported": ".easyuse_anima.aio.torch_compile_diagnostics:collect_torch_compile_diagnostics",
         "kind": "static_from",
-        "line": 121,
+        "line": 122,
         "name": "collect_torch_compile_diagnostics",
         "optional": false,
         "requested": ".easyuse_anima.aio.torch_compile_diagnostics",
@@ -4060,7 +4078,7 @@
         "conditional": false,
         "imported": ".easyuse_anima.aio.torch_compile_recommendation:recommend_torch_compile",
         "kind": "static_from",
-        "line": 124,
+        "line": 125,
         "name": "recommend_torch_compile",
         "optional": false,
         "requested": ".easyuse_anima.aio.torch_compile_recommendation",
@@ -4078,7 +4096,7 @@
         "conditional": false,
         "imported": ".easyuse_anima.profiles:aio",
         "kind": "static_from",
-        "line": 127,
+        "line": 128,
         "name": "aio",
         "optional": false,
         "requested": ".easyuse_anima.profiles",
@@ -4096,7 +4114,7 @@
         "conditional": false,
         "imported": ".easyuse_anima.profiles:contract",
         "kind": "static_from",
-        "line": 128,
+        "line": 129,
         "name": "contract",
         "optional": false,
         "requested": ".easyuse_anima.profiles",
@@ -4114,7 +4132,7 @@
         "conditional": false,
         "imported": ".easyuse_anima.profiles:lora",
         "kind": "static_from",
-        "line": 129,
+        "line": 130,
         "name": "lora",
         "optional": false,
         "requested": ".easyuse_anima.profiles",
@@ -4132,7 +4150,7 @@
         "conditional": false,
         "imported": ".easyuse_anima.profiles:mutation",
         "kind": "static_from",
-        "line": 130,
+        "line": 131,
         "name": "mutation",
         "optional": false,
         "requested": ".easyuse_anima.profiles",
@@ -4150,7 +4168,7 @@
         "conditional": false,
         "imported": ".easyuse_anima.profiles:repository",
         "kind": "static_from",
-        "line": 131,
+        "line": 132,
         "name": "repository",
         "optional": false,
         "requested": ".easyuse_anima.profiles",
@@ -4168,7 +4186,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 266
+            "line": 267
           }
         ],
         "classification": "external",
@@ -4176,7 +4194,7 @@
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 267,
+        "line": 268,
         "name": null,
         "optional": true,
         "requested": "folder_paths",
@@ -66453,14 +66471,14 @@
       },
       {
         "is_package": false,
-        "loc": 761,
+        "loc": 748,
         "module": "api",
-        "normalized_git_blob_sha1": "31f134c6efea729517c093b022053855a80f81ab",
+        "normalized_git_blob_sha1": "cb9af5df02ce9a34d72c4b1e6479cf99c3a87bd1",
         "path": "api.py",
         "top_level": {
           "class_count": 0,
-          "function_count": 13,
-          "global_count": 99
+          "function_count": 12,
+          "global_count": 100
         }
       },
       {
@@ -67161,13 +67179,13 @@
       },
       {
         "is_package": false,
-        "loc": 18,
+        "loc": 49,
         "module": "easyuse_anima.api.routes.wildcards",
-        "normalized_git_blob_sha1": "f062caa60b476bf37b2c10ba081d3bc62a191829",
+        "normalized_git_blob_sha1": "8291bdcd199df2d77b9369246094b410f80e2ea0",
         "path": "easyuse_anima/api/routes/wildcards.py",
         "top_level": {
           "class_count": 0,
-          "function_count": 1,
+          "function_count": 2,
           "global_count": 1
         }
       },
@@ -81342,14 +81360,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 266
+            "line": 267
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 267,
+        "line": 268,
         "optional": true,
         "role": "optional_dependency",
         "source": "api.py"
@@ -87766,14 +87784,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 266
+            "line": 267
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 267,
+        "line": 268,
         "optional": true,
         "role": "optional_dependency",
         "source": "api.py"
@@ -89015,7 +89033,7 @@
         "column": 10,
         "context": "assign:_LOGGER",
         "kind": "import_time_call",
-        "line": 210,
+        "line": 211,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -89024,7 +89042,7 @@
         "column": 29,
         "context": "assign:_PROMPT_TRANSLATION_WORKER",
         "kind": "route_registry_creation",
-        "line": 213,
+        "line": 214,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -89033,7 +89051,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 218,
+        "line": 219,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -89042,7 +89060,7 @@
         "column": 18,
         "context": "assign:_error_response",
         "kind": "import_time_call",
-        "line": 241,
+        "line": 242,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -89051,7 +89069,7 @@
         "column": 27,
         "context": "assign:_contract_error_response",
         "kind": "import_time_call",
-        "line": 249,
+        "line": 250,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -89060,7 +89078,7 @@
         "column": 22,
         "context": "assign:_request_correlated",
         "kind": "import_time_call",
-        "line": 252,
+        "line": 253,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -89069,7 +89087,7 @@
         "column": 36,
         "context": "assign:_SAFE_PROFILE_VALIDATION_MESSAGES",
         "kind": "import_time_call",
-        "line": 293,
+        "line": 294,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -89078,7 +89096,7 @@
         "column": 4,
         "context": "assign:_get_settings_payload_sync,_save_setting_payload_sync",
         "kind": "route_registry_creation",
-        "line": 334,
+        "line": 335,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -89087,7 +89105,16 @@
         "column": 4,
         "context": "assign:_get_long_text_settings_payload_sync,_save_long_text_settings_payload_sync",
         "kind": "route_registry_creation",
-        "line": 343,
+        "line": 344,
+        "module": "api.py",
+        "scope": "<module>"
+      },
+      {
+        "callee": "_api_wildcard_routes.build_wildcards_payload",
+        "column": 26,
+        "context": "assign:_wildcards_payload_sync",
+        "kind": "route_registry_creation",
+        "line": 351,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -89096,7 +89123,7 @@
         "column": 9,
         "context": "assign:routes",
         "kind": "route_registry_creation",
-        "line": 444,
+        "line": 431,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -89105,7 +89132,7 @@
         "column": 8,
         "context": "assign:get_settings_handler,set_setting_handler",
         "kind": "import_time_call",
-        "line": 452,
+        "line": 439,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -89114,7 +89141,7 @@
         "column": 23,
         "context": "assign:get_settings_handler,set_setting_handler",
         "kind": "import_time_call",
-        "line": 453,
+        "line": 440,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -89123,7 +89150,7 @@
         "column": 8,
         "context": "assign:get_long_text_settings_handler,save_long_text_settings_handler",
         "kind": "import_time_call",
-        "line": 482,
+        "line": 469,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -89132,7 +89159,7 @@
         "column": 23,
         "context": "assign:get_long_text_settings_handler,save_long_text_settings_handler",
         "kind": "import_time_call",
-        "line": 483,
+        "line": 470,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -89141,7 +89168,7 @@
         "column": 28,
         "context": "assign:get_wildcards_handler",
         "kind": "import_time_call",
-        "line": 497,
+        "line": 484,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -89150,7 +89177,7 @@
         "column": 8,
         "context": "assign:get_wildcards_handler",
         "kind": "import_time_call",
-        "line": 498,
+        "line": 485,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -89159,7 +89186,7 @@
         "column": 8,
         "context": "assign:autocomplete_handler,autocomplete_status_handler",
         "kind": "import_time_call",
-        "line": 509,
+        "line": 496,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -89168,7 +89195,7 @@
         "column": 23,
         "context": "assign:autocomplete_handler,autocomplete_status_handler",
         "kind": "import_time_call",
-        "line": 510,
+        "line": 497,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -89177,7 +89204,7 @@
         "column": 30,
         "context": "assign:classify_prompt_handler",
         "kind": "import_time_call",
-        "line": 520,
+        "line": 507,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -89186,7 +89213,7 @@
         "column": 8,
         "context": "assign:classify_prompt_handler",
         "kind": "import_time_call",
-        "line": 521,
+        "line": 508,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -89195,7 +89222,7 @@
         "column": 31,
         "context": "assign:translate_prompt_handler",
         "kind": "import_time_call",
-        "line": 539,
+        "line": 526,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -89204,7 +89231,7 @@
         "column": 8,
         "context": "assign:translate_prompt_handler",
         "kind": "import_time_call",
-        "line": 540,
+        "line": 527,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -89213,7 +89240,7 @@
         "column": 42,
         "context": "assign:aio_torch_compile_recommend_handler",
         "kind": "import_time_call",
-        "line": 552,
+        "line": 539,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -89222,7 +89249,7 @@
         "column": 8,
         "context": "assign:aio_torch_compile_recommend_handler",
         "kind": "import_time_call",
-        "line": 553,
+        "line": 540,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -89231,7 +89258,7 @@
         "column": 27,
         "context": "assign:lora_preview_handler",
         "kind": "import_time_call",
-        "line": 569,
+        "line": 556,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -89240,7 +89267,7 @@
         "column": 8,
         "context": "assign:lora_preview_handler",
         "kind": "import_time_call",
-        "line": 570,
+        "line": 557,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -89249,7 +89276,7 @@
         "column": 20,
         "context": "assign:loras_handler",
         "kind": "import_time_call",
-        "line": 579,
+        "line": 566,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -89258,7 +89285,7 @@
         "column": 8,
         "context": "assign:loras_handler",
         "kind": "import_time_call",
-        "line": 580,
+        "line": 567,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -89267,7 +89294,7 @@
         "column": 8,
         "context": "assign:aio_profiles_handler,lora_profiles_handler",
         "kind": "import_time_call",
-        "line": 591,
+        "line": 578,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -89276,7 +89303,7 @@
         "column": 23,
         "context": "assign:aio_profiles_handler,lora_profiles_handler",
         "kind": "import_time_call",
-        "line": 592,
+        "line": 579,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -89285,7 +89312,7 @@
         "column": 8,
         "context": "assign:load_aio_profile_handler,load_lora_profile_handler",
         "kind": "import_time_call",
-        "line": 606,
+        "line": 593,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -89294,7 +89321,7 @@
         "column": 23,
         "context": "assign:load_aio_profile_handler,load_lora_profile_handler",
         "kind": "import_time_call",
-        "line": 607,
+        "line": 594,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -89303,7 +89330,7 @@
         "column": 8,
         "context": "assign:save_aio_profile_handler,save_lora_profile_handler",
         "kind": "import_time_call",
-        "line": 627,
+        "line": 614,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -89312,7 +89339,7 @@
         "column": 23,
         "context": "assign:save_aio_profile_handler,save_lora_profile_handler",
         "kind": "import_time_call",
-        "line": 628,
+        "line": 615,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -89321,7 +89348,7 @@
         "column": 8,
         "context": "assign:delete_aio_profile_handler,rename_aio_profile_handler",
         "kind": "import_time_call",
-        "line": 662,
+        "line": 649,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -89330,7 +89357,7 @@
         "column": 23,
         "context": "assign:delete_aio_profile_handler,rename_aio_profile_handler",
         "kind": "import_time_call",
-        "line": 663,
+        "line": 650,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -89339,7 +89366,7 @@
         "column": 31,
         "context": "assign:fix_lora_profile_handler",
         "kind": "import_time_call",
-        "line": 694,
+        "line": 681,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -89348,7 +89375,7 @@
         "column": 8,
         "context": "assign:fix_lora_profile_handler",
         "kind": "import_time_call",
-        "line": 695,
+        "line": 682,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -89357,7 +89384,7 @@
         "column": 19,
         "context": "assign:_ROUTE_SIGNATURE",
         "kind": "route_registry_creation",
-        "line": 745,
+        "line": 732,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -91646,7 +91673,7 @@
           "executor"
         ],
         "initializer": "_PromptTranslationRouteExecutor",
-        "line": 213,
+        "line": 214,
         "module": "api.py",
         "name": "_PROMPT_TRANSLATION_WORKER"
       },

--- a/tests/test_api_contract.py
+++ b/tests/test_api_contract.py
@@ -1168,6 +1168,95 @@ class ApiLoraProfileFixRouteTests(unittest.TestCase):
 
 
 class ApiWildcardRouteTests(unittest.TestCase):
+    def test_payload_helper_is_owned_by_the_canonical_factory(self):
+        api, _routes = load_api_routes()
+        helper = api._wildcards_payload_sync
+
+        self.assertEqual(helper.__name__, "_wildcards_payload_sync")
+        self.assertTrue(
+            helper.__module__.endswith(
+                ".easyuse_anima.api.routes.wildcards"
+            )
+        )
+        self.assertEqual(helper.__code__.co_argcount, 0)
+        owner = sys.modules[helper.__module__]
+        self.assertEqual(owner.__all__, ("build_wildcards_handler",))
+
+    def test_payload_helper_keeps_dynamic_dependencies_order_and_redaction(self):
+        api, _routes = load_api_routes()
+        calls = []
+
+        class RootProbe:
+            def __init__(self, label, exists):
+                self.label = label
+                self.exists = exists
+
+            def is_dir(self):
+                calls.append(("is_dir", self.label))
+                return self.exists
+
+        resolved_roots = [
+            RootProbe("private-a", True),
+            RootProbe("private-b", False),
+        ]
+        items = ["artist/name"]
+        extra_paths = "C:\\Users\\alice\\wildcards\n/home/alice/wildcards"
+
+        def public_settings():
+            calls.append(("settings",))
+            return {"wildcard.extra_paths": extra_paths}
+
+        def resolve_wildcard_roots(received):
+            calls.append(("resolve", received))
+            return resolved_roots
+
+        def list_wildcards(*, roots):
+            calls.append(("list", roots))
+            return items
+
+        with (
+            patch.object(api, "public_settings", side_effect=public_settings),
+            patch.object(
+                api,
+                "resolve_wildcard_roots",
+                side_effect=resolve_wildcard_roots,
+            ),
+            patch.object(api, "list_wildcards", side_effect=list_wildcards),
+        ):
+            payload = api._wildcards_payload_sync()
+
+        self.assertEqual(
+            calls,
+            [
+                ("settings",),
+                ("resolve", extra_paths),
+                ("is_dir", "private-a"),
+                ("is_dir", "private-b"),
+                ("list", resolved_roots),
+            ],
+        )
+        self.assertIs(calls[-1][1], resolved_roots)
+        self.assertIs(payload["items"], items)
+        self.assertEqual(payload["roots"], ["wildcard:1", "wildcard:2"])
+        self.assertEqual(
+            payload["sources"],
+            [
+                {
+                    "id": "wildcard:1",
+                    "label": "Wildcard source 1",
+                    "exists": True,
+                },
+                {
+                    "id": "wildcard:2",
+                    "label": "Wildcard source 2",
+                    "exists": False,
+                },
+            ],
+        )
+        serialized = json.dumps(payload)
+        for forbidden in ("alice", "private-a", "private-b", "/home"):
+            self.assertNotIn(forbidden, serialized)
+
     def test_route_handler_is_owned_by_the_canonical_factory(self):
         api, routes = load_api_routes()
         handler = routes.handlers["/easyuse_anima/wildcards"]


### PR DESCRIPTION
## 목적과 변경 경계

D-08g roadmap slice로 root `_wildcards_payload_sync` 구현 소유권을 canonical `easyuse_anima.api.routes.wildcards` 내부 builder로 이동합니다. wildcard 동작, settings persistence, 다른 payload/composition, frontend 및 #199 인증 경계는 변경하지 않습니다.

## Base -> Head

- Base: `32e8daee803ac11a77b723eb6b7f6ca4acc52e88`
- Head: `d550cf50e513d2057180f8d99ef746f464d472d7`
- Tree: `b0fd7c3ffd3098af3e8231597e863ab0d09bfa8a`

## 주요 파일과 보존 계약

- `api.py`: root compatibility helper는 유지하고 canonical builder를 동적 dependency seam으로 연결
- `easyuse_anima/api/routes/wildcards.py`: payload builder의 canonical owner 추가, public `__all__`은 기존 handler만 유지
- `tests/test_api_contract.py`: owner/module/argcount, 동적 호출 순서, root identity, source shape, ID/label/exists, redaction 계약 고정
- `tests/fixtures/python_backend_baseline.json`: 실제 구조 변화 반영

보존 계약:
- extra path를 포함한 root resolution과 list 호출 순서
- 동일 root 객체 전달
- `wildcard:<index>` ID, label/exists shape
- items identity와 절대경로 비노출
- 기존 public export 및 root compatibility seam

## 검증

Focused/edit loop:
- changed-file AST / `git diff --check`
- `ApiWildcardRouteTests`: 4
- `tests.test_api_contract`: 85
- wildcard extra-path/root/list focused methods: 3
- analyzer 18, scanner 8, import boundary 16, compatibility surface 26, package skeleton 1
- frontend settings wildcard path editor smoke
- Pyright baseline: 149 files, 기존 14 errors
- G-03: 11 groups, 0 violations
- Ruff: 120 report-only

Final candidate SHA official full 정확히 1회:
- Python unittest: 1301 passed
- Frontend: 120 JavaScript files passed
- Pyright/G-03/Ruff 결과 동일

Package:
- `comfy node validate` 통과
- `comfy node pack`: 308 entries, 핵심 runtime 경로 포함
- 생성 archive 제거

Isolated live:
- `GET /easyuse_anima/wildcards`: 200
- UUID `X-Request-ID`, body `request_id` 비포함
- items/root/source shape 및 root-source ID 일치
- 절대경로 누출 없음
- source/runtime hash 일치, queue 0/0
- listener/설정 잔여물 정리 완료

## 남은 위험과 rollback

payload 구현의 물리적 owner만 이동한 slice입니다. rollback은 이 단일 commit revert로 가능하며 저장 형식이나 wildcard expansion 동작 migration은 없습니다.

## Next task

D-08 후속 payload owner slice를 roadmap 순서와 별도 rollback 경계로 진행합니다.