### PR TITLE
D-08h: autocomplete payload owner를 canonical route로 이동

### DIFF
--- a/api.py
+++ b/api.py
@@ -76,6 +76,7 @@ from .easyuse_anima.api.router import (
 from .easyuse_anima.api.routes.aio_profile_mutations import (
     build_aio_profile_mutation_handlers as _build_aio_profile_mutation_handlers,
 )
+from .easyuse_anima.api.routes import autocomplete as _api_autocomplete_routes
 from .easyuse_anima.api.routes.autocomplete import (
     build_autocomplete_handlers as _build_autocomplete_handlers,
     build_classify_prompt_handler as _build_classify_prompt_handler,
@@ -355,70 +356,27 @@ _wildcards_payload_sync = _api_wildcard_routes.build_wildcards_payload(
 )
 
 
-def _autocomplete_status_payload_sync() -> dict:
-    selected_source = resolve_autocomplete_source()
-    source_key, path = resolve_autocomplete_source_path(selected_source)
-    status = _public_autocomplete_status(autocomplete_status(path))
-    sources = []
-    source_label = source_key
-    for source in available_autocomplete_sources(source_key):
-        public_source = {
-            key: value
-            for key, value in source.items()
-            if key != "path"
-        }
-        sources.append(public_source)
-        if public_source.get("selected"):
-            source_label = str(public_source.get("label") or source_key)
-    return {
-        **status,
-        "source": source_key,
-        "source_label": source_label,
-        "sources": sources,
-    }
-
-
-def _public_autocomplete_status(status) -> dict:
-    public_status = dict(status) if isinstance(status, dict) else {}
-    public_status.pop("path", None)
-    return public_status
-
-
-def _public_autocomplete_payload(payload) -> dict:
-    public_payload = dict(payload) if isinstance(payload, dict) else {}
-    if "status" in public_payload:
-        public_payload["status"] = _public_autocomplete_status(
-            public_payload["status"]
-        )
-    return public_payload
-
-
-def _search_autocomplete_payload_sync(
-    query: str,
-    requested_limit: str | None,
-    category_filter: str | None,
-):
-    default_limit = resolve_autocomplete_limit()
-    try:
-        limit = int(requested_limit) if requested_limit is not None else default_limit
-    except ValueError:
-        limit = default_limit
-    _, path = resolve_autocomplete_source_path(resolve_autocomplete_source())
-    return _public_autocomplete_payload(
-        search_autocomplete(
-            query,
-            limit=limit,
-            path=path,
-            category=category_filter,
-        )
-    )
-
-
-def _classify_prompt_payload_sync(text: str, limit: int):
-    _, path = resolve_autocomplete_source_path(resolve_autocomplete_source())
-    return _public_autocomplete_payload(
-        classify_prompt_text(text, limit=limit, path=path)
-    )
+(
+    _autocomplete_status_payload_sync,
+    _public_autocomplete_status,
+    _public_autocomplete_payload,
+    _search_autocomplete_payload_sync,
+    _classify_prompt_payload_sync,
+) = _api_autocomplete_routes.build_autocomplete_payloads(
+    resolve_autocomplete_source=lambda: resolve_autocomplete_source(),
+    resolve_autocomplete_source_path=lambda source: resolve_autocomplete_source_path(
+        source
+    ),
+    autocomplete_status=lambda path: autocomplete_status(path),
+    available_autocomplete_sources=lambda source: available_autocomplete_sources(
+        source
+    ),
+    resolve_autocomplete_limit=lambda: resolve_autocomplete_limit(),
+    search_autocomplete=lambda query, **kwargs: search_autocomplete(query, **kwargs),
+    classify_prompt_text=lambda text, **kwargs: classify_prompt_text(text, **kwargs),
+    public_autocomplete_status=lambda status: _public_autocomplete_status(status),
+    public_autocomplete_payload=lambda payload: _public_autocomplete_payload(payload),
+)
 
 
 def _get_prompt_routes():

--- a/easyuse_anima/api/routes/autocomplete.py
+++ b/easyuse_anima/api/routes/autocomplete.py
@@ -1,6 +1,94 @@
 from __future__ import annotations
 
 
+def build_autocomplete_payloads(
+    *,
+    resolve_autocomplete_source,
+    resolve_autocomplete_source_path,
+    autocomplete_status,
+    available_autocomplete_sources,
+    resolve_autocomplete_limit,
+    search_autocomplete,
+    classify_prompt_text,
+    public_autocomplete_status,
+    public_autocomplete_payload,
+):
+    """Build redacted autocomplete payloads with runtime-resolved owners."""
+
+    def _autocomplete_status_payload_sync() -> dict:
+        selected_source = resolve_autocomplete_source()
+        source_key, path = resolve_autocomplete_source_path(selected_source)
+        status = public_autocomplete_status(autocomplete_status(path))
+        sources = []
+        source_label = source_key
+        for source in available_autocomplete_sources(source_key):
+            public_source = {
+                key: value
+                for key, value in source.items()
+                if key != "path"
+            }
+            sources.append(public_source)
+            if public_source.get("selected"):
+                source_label = str(public_source.get("label") or source_key)
+        return {
+            **status,
+            "source": source_key,
+            "source_label": source_label,
+            "sources": sources,
+        }
+
+    def _public_autocomplete_status(status) -> dict:
+        public_status = dict(status) if isinstance(status, dict) else {}
+        public_status.pop("path", None)
+        return public_status
+
+    def _public_autocomplete_payload(payload) -> dict:
+        public_payload = dict(payload) if isinstance(payload, dict) else {}
+        if "status" in public_payload:
+            public_payload["status"] = public_autocomplete_status(
+                public_payload["status"]
+            )
+        return public_payload
+
+    def _search_autocomplete_payload_sync(
+        query: str,
+        requested_limit: str | None,
+        category_filter: str | None,
+    ):
+        default_limit = resolve_autocomplete_limit()
+        try:
+            limit = (
+                int(requested_limit)
+                if requested_limit is not None
+                else default_limit
+            )
+        except ValueError:
+            limit = default_limit
+        _, path = resolve_autocomplete_source_path(resolve_autocomplete_source())
+        return public_autocomplete_payload(
+            search_autocomplete(
+                query,
+                limit=limit,
+                path=path,
+                category=category_filter,
+            )
+        )
+
+    def _classify_prompt_payload_sync(text: str, limit: int):
+        _, path = resolve_autocomplete_source_path(resolve_autocomplete_source())
+        return public_autocomplete_payload(
+            classify_prompt_text(text, limit=limit, path=path)
+        )
+
+    return (
+        _autocomplete_status_payload_sync,
+        _public_autocomplete_status,
+        _public_autocomplete_payload,
+        _search_autocomplete_payload_sync,
+        _classify_prompt_payload_sync,
+    )
+
+
 def build_autocomplete_handlers(
     *,
     run_file_io,

--- a/tests/fixtures/python_backend_baseline.json
+++ b/tests/fixtures/python_backend_baseline.json
@@ -3746,6 +3746,24 @@
         "target": "easyuse_anima/api/routes/aio_profile_mutations.py"
       },
       {
+        "alias": "_api_autocomplete_routes",
+        "bound_name": "_api_autocomplete_routes",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".easyuse_anima.api.routes:autocomplete",
+        "kind": "static_from",
+        "line": 79,
+        "name": "autocomplete",
+        "optional": false,
+        "requested": ".easyuse_anima.api.routes",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "api.py",
+        "target": "easyuse_anima/api/routes/autocomplete.py"
+      },
+      {
         "alias": "_build_autocomplete_handlers",
         "bound_name": "_build_autocomplete_handlers",
         "branch_context": [],
@@ -3754,7 +3772,7 @@
         "conditional": false,
         "imported": ".easyuse_anima.api.routes.autocomplete:build_autocomplete_handlers",
         "kind": "static_from",
-        "line": 79,
+        "line": 80,
         "name": "build_autocomplete_handlers",
         "optional": false,
         "requested": ".easyuse_anima.api.routes.autocomplete",
@@ -3772,7 +3790,7 @@
         "conditional": false,
         "imported": ".easyuse_anima.api.routes.autocomplete:build_classify_prompt_handler",
         "kind": "static_from",
-        "line": 79,
+        "line": 80,
         "name": "build_classify_prompt_handler",
         "optional": false,
         "requested": ".easyuse_anima.api.routes.autocomplete",
@@ -3790,7 +3808,7 @@
         "conditional": false,
         "imported": ".easyuse_anima.api.routes:long_text_settings",
         "kind": "static_from",
-        "line": 83,
+        "line": 84,
         "name": "long_text_settings",
         "optional": false,
         "requested": ".easyuse_anima.api.routes",
@@ -3808,7 +3826,7 @@
         "conditional": false,
         "imported": ".easyuse_anima.api.routes.long_text_settings:build_long_text_settings_handlers",
         "kind": "static_from",
-        "line": 84,
+        "line": 85,
         "name": "build_long_text_settings_handlers",
         "optional": false,
         "requested": ".easyuse_anima.api.routes.long_text_settings",
@@ -3826,7 +3844,7 @@
         "conditional": false,
         "imported": ".easyuse_anima.api.routes.lora_catalog:build_loras_handler",
         "kind": "static_from",
-        "line": 87,
+        "line": 88,
         "name": "build_loras_handler",
         "optional": false,
         "requested": ".easyuse_anima.api.routes.lora_catalog",
@@ -3844,7 +3862,7 @@
         "conditional": false,
         "imported": ".easyuse_anima.api.routes.lora_profile_fix:build_lora_profile_fix_handler",
         "kind": "static_from",
-        "line": 90,
+        "line": 91,
         "name": "build_lora_profile_fix_handler",
         "optional": false,
         "requested": ".easyuse_anima.api.routes.lora_profile_fix",
@@ -3862,7 +3880,7 @@
         "conditional": false,
         "imported": ".easyuse_anima.api.routes.lora_preview:build_lora_preview_handler",
         "kind": "static_from",
-        "line": 93,
+        "line": 94,
         "name": "build_lora_preview_handler",
         "optional": false,
         "requested": ".easyuse_anima.api.routes.lora_preview",
@@ -3880,7 +3898,7 @@
         "conditional": false,
         "imported": ".easyuse_anima.api.routes.profile_lists:build_profile_list_handlers",
         "kind": "static_from",
-        "line": 96,
+        "line": 97,
         "name": "build_profile_list_handlers",
         "optional": false,
         "requested": ".easyuse_anima.api.routes.profile_lists",
@@ -3898,7 +3916,7 @@
         "conditional": false,
         "imported": ".easyuse_anima.api.routes.profile_loads:build_profile_load_handlers",
         "kind": "static_from",
-        "line": 99,
+        "line": 100,
         "name": "build_profile_load_handlers",
         "optional": false,
         "requested": ".easyuse_anima.api.routes.profile_loads",
@@ -3916,7 +3934,7 @@
         "conditional": false,
         "imported": ".easyuse_anima.api.routes.profile_saves:build_profile_save_handlers",
         "kind": "static_from",
-        "line": 102,
+        "line": 103,
         "name": "build_profile_save_handlers",
         "optional": false,
         "requested": ".easyuse_anima.api.routes.profile_saves",
@@ -3934,7 +3952,7 @@
         "conditional": false,
         "imported": ".easyuse_anima.api.routes:settings",
         "kind": "static_from",
-        "line": 105,
+        "line": 106,
         "name": "settings",
         "optional": false,
         "requested": ".easyuse_anima.api.routes",
@@ -3952,7 +3970,7 @@
         "conditional": false,
         "imported": ".easyuse_anima.api.routes.settings:build_settings_handlers",
         "kind": "static_from",
-        "line": 106,
+        "line": 107,
         "name": "build_settings_handlers",
         "optional": false,
         "requested": ".easyuse_anima.api.routes.settings",
@@ -3970,7 +3988,7 @@
         "conditional": false,
         "imported": ".easyuse_anima.api.routes:wildcards",
         "kind": "static_from",
-        "line": 109,
+        "line": 110,
         "name": "wildcards",
         "optional": false,
         "requested": ".easyuse_anima.api.routes",
@@ -3988,7 +4006,7 @@
         "conditional": false,
         "imported": ".easyuse_anima.api.routes.wildcards:build_wildcards_handler",
         "kind": "static_from",
-        "line": 110,
+        "line": 111,
         "name": "build_wildcards_handler",
         "optional": false,
         "requested": ".easyuse_anima.api.routes.wildcards",
@@ -4006,7 +4024,7 @@
         "conditional": false,
         "imported": ".easyuse_anima.api.routes.translation:build_translate_prompt_handler",
         "kind": "static_from",
-        "line": 113,
+        "line": 114,
         "name": "build_translate_prompt_handler",
         "optional": false,
         "requested": ".easyuse_anima.api.routes.translation",
@@ -4024,7 +4042,7 @@
         "conditional": false,
         "imported": ".easyuse_anima.api.routes.translation_execution:PromptTranslationRouteExecutor",
         "kind": "static_from",
-        "line": 116,
+        "line": 117,
         "name": "PromptTranslationRouteExecutor",
         "optional": false,
         "requested": ".easyuse_anima.api.routes.translation_execution",
@@ -4042,7 +4060,7 @@
         "conditional": false,
         "imported": ".easyuse_anima.api.routes.aio_torch_compile:build_aio_torch_compile_recommend_handler",
         "kind": "static_from",
-        "line": 119,
+        "line": 120,
         "name": "build_aio_torch_compile_recommend_handler",
         "optional": false,
         "requested": ".easyuse_anima.api.routes.aio_torch_compile",
@@ -4060,7 +4078,7 @@
         "conditional": false,
         "imported": ".easyuse_anima.aio.torch_compile_diagnostics:collect_torch_compile_diagnostics",
         "kind": "static_from",
-        "line": 122,
+        "line": 123,
         "name": "collect_torch_compile_diagnostics",
         "optional": false,
         "requested": ".easyuse_anima.aio.torch_compile_diagnostics",
@@ -4078,7 +4096,7 @@
         "conditional": false,
         "imported": ".easyuse_anima.aio.torch_compile_recommendation:recommend_torch_compile",
         "kind": "static_from",
-        "line": 125,
+        "line": 126,
         "name": "recommend_torch_compile",
         "optional": false,
         "requested": ".easyuse_anima.aio.torch_compile_recommendation",
@@ -4096,7 +4114,7 @@
         "conditional": false,
         "imported": ".easyuse_anima.profiles:aio",
         "kind": "static_from",
-        "line": 128,
+        "line": 129,
         "name": "aio",
         "optional": false,
         "requested": ".easyuse_anima.profiles",
@@ -4114,7 +4132,7 @@
         "conditional": false,
         "imported": ".easyuse_anima.profiles:contract",
         "kind": "static_from",
-        "line": 129,
+        "line": 130,
         "name": "contract",
         "optional": false,
         "requested": ".easyuse_anima.profiles",
@@ -4132,7 +4150,7 @@
         "conditional": false,
         "imported": ".easyuse_anima.profiles:lora",
         "kind": "static_from",
-        "line": 130,
+        "line": 131,
         "name": "lora",
         "optional": false,
         "requested": ".easyuse_anima.profiles",
@@ -4150,7 +4168,7 @@
         "conditional": false,
         "imported": ".easyuse_anima.profiles:mutation",
         "kind": "static_from",
-        "line": 131,
+        "line": 132,
         "name": "mutation",
         "optional": false,
         "requested": ".easyuse_anima.profiles",
@@ -4168,7 +4186,7 @@
         "conditional": false,
         "imported": ".easyuse_anima.profiles:repository",
         "kind": "static_from",
-        "line": 132,
+        "line": 133,
         "name": "repository",
         "optional": false,
         "requested": ".easyuse_anima.profiles",
@@ -4186,7 +4204,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 267
+            "line": 268
           }
         ],
         "classification": "external",
@@ -4194,7 +4212,7 @@
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 268,
+        "line": 269,
         "name": null,
         "optional": true,
         "requested": "folder_paths",
@@ -66471,14 +66489,14 @@
       },
       {
         "is_package": false,
-        "loc": 748,
+        "loc": 706,
         "module": "api",
-        "normalized_git_blob_sha1": "cb9af5df02ce9a34d72c4b1e6479cf99c3a87bd1",
+        "normalized_git_blob_sha1": "19c606932ae29f6d40456ef27a430bf56cf2cfd1",
         "path": "api.py",
         "top_level": {
           "class_count": 0,
-          "function_count": 12,
-          "global_count": 100
+          "function_count": 7,
+          "global_count": 105
         }
       },
       {
@@ -67047,13 +67065,13 @@
       },
       {
         "is_package": false,
-        "loc": 73,
+        "loc": 161,
         "module": "easyuse_anima.api.routes.autocomplete",
-        "normalized_git_blob_sha1": "55a8fce0268b10a042343b07822a46ac496d846c",
+        "normalized_git_blob_sha1": "d490aaf684bc64188d87a10711980341dbd7fc8b",
         "path": "easyuse_anima/api/routes/autocomplete.py",
         "top_level": {
           "class_count": 0,
-          "function_count": 2,
+          "function_count": 3,
           "global_count": 1
         }
       },
@@ -81360,14 +81378,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 267
+            "line": 268
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 268,
+        "line": 269,
         "optional": true,
         "role": "optional_dependency",
         "source": "api.py"
@@ -87784,14 +87802,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 267
+            "line": 268
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 268,
+        "line": 269,
         "optional": true,
         "role": "optional_dependency",
         "source": "api.py"
@@ -89033,7 +89051,7 @@
         "column": 10,
         "context": "assign:_LOGGER",
         "kind": "import_time_call",
-        "line": 211,
+        "line": 212,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -89042,7 +89060,7 @@
         "column": 29,
         "context": "assign:_PROMPT_TRANSLATION_WORKER",
         "kind": "route_registry_creation",
-        "line": 214,
+        "line": 215,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -89051,7 +89069,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 219,
+        "line": 220,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -89060,7 +89078,7 @@
         "column": 18,
         "context": "assign:_error_response",
         "kind": "import_time_call",
-        "line": 242,
+        "line": 243,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -89069,7 +89087,7 @@
         "column": 27,
         "context": "assign:_contract_error_response",
         "kind": "import_time_call",
-        "line": 250,
+        "line": 251,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -89078,7 +89096,7 @@
         "column": 22,
         "context": "assign:_request_correlated",
         "kind": "import_time_call",
-        "line": 253,
+        "line": 254,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -89087,7 +89105,7 @@
         "column": 36,
         "context": "assign:_SAFE_PROFILE_VALIDATION_MESSAGES",
         "kind": "import_time_call",
-        "line": 294,
+        "line": 295,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -89096,7 +89114,7 @@
         "column": 4,
         "context": "assign:_get_settings_payload_sync,_save_setting_payload_sync",
         "kind": "route_registry_creation",
-        "line": 335,
+        "line": 336,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -89105,7 +89123,7 @@
         "column": 4,
         "context": "assign:_get_long_text_settings_payload_sync,_save_long_text_settings_payload_sync",
         "kind": "route_registry_creation",
-        "line": 344,
+        "line": 345,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -89114,7 +89132,16 @@
         "column": 26,
         "context": "assign:_wildcards_payload_sync",
         "kind": "route_registry_creation",
-        "line": 351,
+        "line": 352,
+        "module": "api.py",
+        "scope": "<module>"
+      },
+      {
+        "callee": "_api_autocomplete_routes.build_autocomplete_payloads",
+        "column": 4,
+        "context": "assign:_autocomplete_status_payload_sync,_classify_prompt_payload_sync,_public_autocomplete_payload,_public_autocomplete_status,_search_autocomplete_payload_sync",
+        "kind": "route_registry_creation",
+        "line": 365,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -89123,7 +89150,7 @@
         "column": 9,
         "context": "assign:routes",
         "kind": "route_registry_creation",
-        "line": 431,
+        "line": 389,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -89132,7 +89159,7 @@
         "column": 8,
         "context": "assign:get_settings_handler,set_setting_handler",
         "kind": "import_time_call",
-        "line": 439,
+        "line": 397,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -89141,7 +89168,7 @@
         "column": 23,
         "context": "assign:get_settings_handler,set_setting_handler",
         "kind": "import_time_call",
-        "line": 440,
+        "line": 398,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -89150,7 +89177,7 @@
         "column": 8,
         "context": "assign:get_long_text_settings_handler,save_long_text_settings_handler",
         "kind": "import_time_call",
-        "line": 469,
+        "line": 427,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -89159,7 +89186,7 @@
         "column": 23,
         "context": "assign:get_long_text_settings_handler,save_long_text_settings_handler",
         "kind": "import_time_call",
-        "line": 470,
+        "line": 428,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -89168,7 +89195,7 @@
         "column": 28,
         "context": "assign:get_wildcards_handler",
         "kind": "import_time_call",
-        "line": 484,
+        "line": 442,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -89177,7 +89204,7 @@
         "column": 8,
         "context": "assign:get_wildcards_handler",
         "kind": "import_time_call",
-        "line": 485,
+        "line": 443,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -89186,7 +89213,7 @@
         "column": 8,
         "context": "assign:autocomplete_handler,autocomplete_status_handler",
         "kind": "import_time_call",
-        "line": 496,
+        "line": 454,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -89195,7 +89222,7 @@
         "column": 23,
         "context": "assign:autocomplete_handler,autocomplete_status_handler",
         "kind": "import_time_call",
-        "line": 497,
+        "line": 455,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -89204,7 +89231,7 @@
         "column": 30,
         "context": "assign:classify_prompt_handler",
         "kind": "import_time_call",
-        "line": 507,
+        "line": 465,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -89213,7 +89240,7 @@
         "column": 8,
         "context": "assign:classify_prompt_handler",
         "kind": "import_time_call",
-        "line": 508,
+        "line": 466,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -89222,7 +89249,7 @@
         "column": 31,
         "context": "assign:translate_prompt_handler",
         "kind": "import_time_call",
-        "line": 526,
+        "line": 484,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -89231,7 +89258,7 @@
         "column": 8,
         "context": "assign:translate_prompt_handler",
         "kind": "import_time_call",
-        "line": 527,
+        "line": 485,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -89240,7 +89267,7 @@
         "column": 42,
         "context": "assign:aio_torch_compile_recommend_handler",
         "kind": "import_time_call",
-        "line": 539,
+        "line": 497,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -89249,7 +89276,7 @@
         "column": 8,
         "context": "assign:aio_torch_compile_recommend_handler",
         "kind": "import_time_call",
-        "line": 540,
+        "line": 498,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -89258,7 +89285,7 @@
         "column": 27,
         "context": "assign:lora_preview_handler",
         "kind": "import_time_call",
-        "line": 556,
+        "line": 514,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -89267,7 +89294,7 @@
         "column": 8,
         "context": "assign:lora_preview_handler",
         "kind": "import_time_call",
-        "line": 557,
+        "line": 515,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -89276,7 +89303,7 @@
         "column": 20,
         "context": "assign:loras_handler",
         "kind": "import_time_call",
-        "line": 566,
+        "line": 524,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -89285,7 +89312,7 @@
         "column": 8,
         "context": "assign:loras_handler",
         "kind": "import_time_call",
-        "line": 567,
+        "line": 525,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -89294,7 +89321,7 @@
         "column": 8,
         "context": "assign:aio_profiles_handler,lora_profiles_handler",
         "kind": "import_time_call",
-        "line": 578,
+        "line": 536,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -89303,7 +89330,7 @@
         "column": 23,
         "context": "assign:aio_profiles_handler,lora_profiles_handler",
         "kind": "import_time_call",
-        "line": 579,
+        "line": 537,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -89312,7 +89339,7 @@
         "column": 8,
         "context": "assign:load_aio_profile_handler,load_lora_profile_handler",
         "kind": "import_time_call",
-        "line": 593,
+        "line": 551,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -89321,7 +89348,7 @@
         "column": 23,
         "context": "assign:load_aio_profile_handler,load_lora_profile_handler",
         "kind": "import_time_call",
-        "line": 594,
+        "line": 552,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -89330,7 +89357,7 @@
         "column": 8,
         "context": "assign:save_aio_profile_handler,save_lora_profile_handler",
         "kind": "import_time_call",
-        "line": 614,
+        "line": 572,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -89339,7 +89366,7 @@
         "column": 23,
         "context": "assign:save_aio_profile_handler,save_lora_profile_handler",
         "kind": "import_time_call",
-        "line": 615,
+        "line": 573,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -89348,7 +89375,7 @@
         "column": 8,
         "context": "assign:delete_aio_profile_handler,rename_aio_profile_handler",
         "kind": "import_time_call",
-        "line": 649,
+        "line": 607,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -89357,7 +89384,7 @@
         "column": 23,
         "context": "assign:delete_aio_profile_handler,rename_aio_profile_handler",
         "kind": "import_time_call",
-        "line": 650,
+        "line": 608,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -89366,7 +89393,7 @@
         "column": 31,
         "context": "assign:fix_lora_profile_handler",
         "kind": "import_time_call",
-        "line": 681,
+        "line": 639,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -89375,7 +89402,7 @@
         "column": 8,
         "context": "assign:fix_lora_profile_handler",
         "kind": "import_time_call",
-        "line": 682,
+        "line": 640,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -89384,7 +89411,7 @@
         "column": 19,
         "context": "assign:_ROUTE_SIGNATURE",
         "kind": "route_registry_creation",
-        "line": 732,
+        "line": 690,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -91673,7 +91700,7 @@
           "executor"
         ],
         "initializer": "_PromptTranslationRouteExecutor",
-        "line": 214,
+        "line": 215,
         "module": "api.py",
         "name": "_PROMPT_TRANSLATION_WORKER"
       },

--- a/tests/test_api_contract.py
+++ b/tests/test_api_contract.py
@@ -1664,6 +1664,312 @@ class ApiLongTextSettingsRouteTests(unittest.TestCase):
 
 
 class ApiAutocompleteRouteTests(unittest.TestCase):
+    def test_payload_helpers_are_owned_by_the_canonical_factory(self):
+        api, _routes = load_api_routes()
+        cases = (
+            ("_autocomplete_status_payload_sync", 0),
+            ("_public_autocomplete_status", 1),
+            ("_public_autocomplete_payload", 1),
+            ("_search_autocomplete_payload_sync", 3),
+            ("_classify_prompt_payload_sync", 2),
+        )
+
+        for name, argcount in cases:
+            with self.subTest(name=name):
+                helper = getattr(api, name)
+                self.assertEqual(helper.__name__, name)
+                self.assertTrue(
+                    helper.__module__.endswith(
+                        ".easyuse_anima.api.routes.autocomplete"
+                    )
+                )
+                self.assertEqual(helper.__code__.co_argcount, argcount)
+
+        owner = sys.modules[api._autocomplete_status_payload_sync.__module__]
+        self.assertEqual(
+            owner.__all__,
+            (
+                "build_autocomplete_handlers",
+                "build_classify_prompt_handler",
+            ),
+        )
+
+    def test_public_payload_helpers_copy_and_keep_dynamic_redaction_seam(self):
+        api, _routes = load_api_routes()
+        future = {"kept": True}
+        status = {
+            "path": r"C:\Users\alice\secret.csv",
+            "exists": True,
+            "future": future,
+        }
+
+        public_status = api._public_autocomplete_status(status)
+
+        self.assertEqual(
+            public_status,
+            {"exists": True, "future": future},
+        )
+        self.assertIs(public_status["future"], future)
+        self.assertIn("path", status)
+        self.assertEqual(api._public_autocomplete_status(None), {})
+        self.assertEqual(api._public_autocomplete_payload(None), {})
+
+        private_status = object()
+        produced = {"status": private_status, "future": future}
+        redacted = {"redacted": True}
+        with patch.object(
+            api,
+            "_public_autocomplete_status",
+            return_value=redacted,
+        ) as public_status_helper:
+            public_payload = api._public_autocomplete_payload(produced)
+
+        self.assertIsNot(public_payload, produced)
+        self.assertIs(public_payload["status"], redacted)
+        self.assertIs(public_payload["future"], future)
+        self.assertIs(produced["status"], private_status)
+        public_status_helper.assert_called_once_with(private_status)
+
+    def test_status_payload_keeps_dependency_order_identity_and_merge_shape(self):
+        api, _routes = load_api_routes()
+        calls = []
+        selected_source = "configured"
+        source_key = "resolved"
+        path = object()
+        future = {"kept": True}
+        status = {
+            "path": r"C:\Users\alice\secret.csv",
+            "count": 5,
+            "source": "private-source",
+            "source_label": "Private source",
+            "sources": ["private-source"],
+            "future": future,
+        }
+        source = {
+            "key": source_key,
+            "label": "Resolved source",
+            "path": "/home/alice/secret.csv",
+            "exists": True,
+            "selected": True,
+            "future": future,
+        }
+
+        def resolve_source():
+            calls.append(("source",))
+            return selected_source
+
+        def resolve_path(source_name):
+            calls.append(("path", source_name))
+            return source_key, path
+
+        def read_status(status_path):
+            calls.append(("status", status_path))
+            return status
+
+        def list_sources(selected):
+            calls.append(("sources", selected))
+            return [source]
+
+        with (
+            patch.object(
+                api,
+                "resolve_autocomplete_source",
+                side_effect=resolve_source,
+            ),
+            patch.object(
+                api,
+                "resolve_autocomplete_source_path",
+                side_effect=resolve_path,
+            ),
+            patch.object(api, "autocomplete_status", side_effect=read_status),
+            patch.object(
+                api,
+                "available_autocomplete_sources",
+                side_effect=list_sources,
+            ),
+        ):
+            payload = api._autocomplete_status_payload_sync()
+
+        self.assertEqual(
+            calls,
+            [
+                ("source",),
+                ("path", selected_source),
+                ("status", path),
+                ("sources", source_key),
+            ],
+        )
+        self.assertEqual(payload["source"], source_key)
+        self.assertEqual(payload["source_label"], "Resolved source")
+        self.assertEqual(payload["count"], 5)
+        self.assertIs(payload["future"], future)
+        self.assertEqual(len(payload["sources"]), 1)
+        self.assertIsNot(payload["sources"][0], source)
+        self.assertNotIn("path", payload["sources"][0])
+        self.assertIn("path", status)
+        self.assertIn("path", source)
+
+        redacted = {"count": 9}
+        with (
+            patch.object(
+                api,
+                "resolve_autocomplete_source",
+                return_value=selected_source,
+            ),
+            patch.object(
+                api,
+                "resolve_autocomplete_source_path",
+                return_value=(source_key, path),
+            ),
+            patch.object(api, "autocomplete_status", return_value=status),
+            patch.object(api, "available_autocomplete_sources", return_value=[]),
+            patch.object(
+                api,
+                "_public_autocomplete_status",
+                return_value=redacted,
+            ) as public_status_helper,
+        ):
+            dynamically_redacted = api._autocomplete_status_payload_sync()
+
+        self.assertEqual(dynamically_redacted["count"], 9)
+        public_status_helper.assert_called_once_with(status)
+
+    def test_search_payload_keeps_limit_fallback_and_dynamic_public_seam(self):
+        api, _routes = load_api_routes()
+        selected_source = "configured"
+        path = object()
+        produced = {"status": {"path": "private"}}
+        public = {"status": {}}
+
+        for requested_limit, expected_limit in (
+            (None, 37),
+            ("bad", 37),
+            ("19", 19),
+        ):
+            calls = []
+
+            def default_limit():
+                calls.append(("limit",))
+                return 37
+
+            def resolve_source():
+                calls.append(("source",))
+                return selected_source
+
+            def resolve_path(source_name):
+                calls.append(("path", source_name))
+                return "resolved", path
+
+            def search(query, *, limit, path: object, category):
+                calls.append(("search", query, limit, path, category))
+                return produced
+
+            def redact(payload):
+                calls.append(("public", payload))
+                return public
+
+            with self.subTest(requested_limit=requested_limit):
+                with (
+                    patch.object(
+                        api,
+                        "resolve_autocomplete_limit",
+                        side_effect=default_limit,
+                    ),
+                    patch.object(
+                        api,
+                        "resolve_autocomplete_source",
+                        side_effect=resolve_source,
+                    ),
+                    patch.object(
+                        api,
+                        "resolve_autocomplete_source_path",
+                        side_effect=resolve_path,
+                    ),
+                    patch.object(api, "search_autocomplete", side_effect=search),
+                    patch.object(
+                        api,
+                        "_public_autocomplete_payload",
+                        side_effect=redact,
+                    ),
+                ):
+                    payload = api._search_autocomplete_payload_sync(
+                        "cat",
+                        requested_limit,
+                        "artist,general",
+                    )
+
+                self.assertIs(payload, public)
+                self.assertEqual(
+                    calls,
+                    [
+                        ("limit",),
+                        ("source",),
+                        ("path", selected_source),
+                        (
+                            "search",
+                            "cat",
+                            expected_limit,
+                            path,
+                            "artist,general",
+                        ),
+                        ("public", produced),
+                    ],
+                )
+
+    def test_classify_payload_keeps_dependency_identity_and_public_seam(self):
+        api, _routes = load_api_routes()
+        calls = []
+        path = object()
+        produced = {"status": {"path": "private"}}
+        public = {"status": {}}
+
+        def resolve_source():
+            calls.append(("source",))
+            return "configured"
+
+        def resolve_path(source_name):
+            calls.append(("path", source_name))
+            return "resolved", path
+
+        def classify(text, *, limit, path: object):
+            calls.append(("classify", text, limit, path))
+            return produced
+
+        def redact(payload):
+            calls.append(("public", payload))
+            return public
+
+        with (
+            patch.object(
+                api,
+                "resolve_autocomplete_source",
+                side_effect=resolve_source,
+            ),
+            patch.object(
+                api,
+                "resolve_autocomplete_source_path",
+                side_effect=resolve_path,
+            ),
+            patch.object(api, "classify_prompt_text", side_effect=classify),
+            patch.object(
+                api,
+                "_public_autocomplete_payload",
+                side_effect=redact,
+            ),
+        ):
+            payload = api._classify_prompt_payload_sync("cat", 17)
+
+        self.assertIs(payload, public)
+        self.assertEqual(
+            calls,
+            [
+                ("source",),
+                ("path", "configured"),
+                ("classify", "cat", 17, path),
+                ("public", produced),
+            ],
+        )
+
     def test_read_only_route_handlers_are_owned_by_the_canonical_factory(self):
         api, routes = load_api_routes()
         cases = (


### PR DESCRIPTION
## 목적과 변경 경계

D-08h roadmap slice로 autocomplete status/public redaction/search/classify payload helper 5개의 구현 소유권을 canonical `easyuse_anima.api.routes.autocomplete` 내부 builder로 이동합니다. autocomplete dataset/index/ranking/classification 동작, settings persistence, handler parse/category mapping, frontend 및 #199 인증 경계는 변경하지 않습니다.

## Base -> Head

- Base: `4ec2ce48e755573d1a6a82f5e3469108b6043d4f`
- Head: `ec7311b68dfe9fe692c4a52970e20fc8391bd621`
- Tree: `51cfc7159e08786434dcb2f22139278a6d679bb5`

## 주요 파일과 보존 계약

- `api.py`: root helper names와 runtime monkeypatch seam을 유지하고 canonical builder를 동적 dependency로 조립
- `easyuse_anima/api/routes/autocomplete.py`: status/public/search/classify payload의 canonical owner 추가, public `__all__`은 기존 두 handler factory만 유지
- `tests/test_api_contract.py`: owner/module/argcount, 동적 dependency와 호출 순서, identity, limit fallback, merge/redaction 계약 고정
- `tests/fixtures/python_backend_baseline.json`: 실제 owner/import/LOC 구조 변화 반영

보존 계약:
- source resolve → path resolve → status/source metadata 순서와 object identity
- source의 `path`만 제거한 fresh dict, selected label 및 status merge override 순서
- non-dict fallback, input 비변경, future field 유지, nested status path redaction
- search default limit 선조회와 absent/bad fallback, valid integer/category/query 전달
- classify text/limit/path 전달
- root public redaction helper의 runtime patch 의미와 handler payload seam
- 기존 canonical public export 및 import side-effect 없음

## 검증

Focused/edit loop:
- changed-file AST 3 / `git diff --check`
- `ApiAutocompleteRouteTests`: 9
- `ApiPathRedactionTests`: 4
- legacy autocomplete API limit consumer: 1
- autocomplete dataset compatibility: 3
- 전체 API contract: 90
- API compatibility 3, analyzer 18, scanner 8, import boundary 16, compatibility surface 26, package skeleton 1
- 직접 영향 frontend autocomplete smoke 6종
- Pyright baseline: 149 files, 기존 14 errors
- G-03: 11 groups, 0 violations
- Ruff: 120 report-only

Final candidate SHA official full 정확히 1회:
- Python unittest: 1306 passed
- Frontend: 120 JavaScript files passed
- Pyright/G-03/Ruff 결과 동일

Package:
- `comfy node validate` 통과
- `comfy node pack`: 308 entries, root/canonical autocomplete/search/classification 경로 포함
- 생성 archive 제거

Isolated live:
- autocomplete status/search/classify 모두 200 및 UUID `X-Request-ID`
- body `request_id` 비포함, status/source/nested payload 절대경로 redaction
- omitted limit과 bad limit의 query/results/status-count projection 동일, 각각 37 results
- runtime status 전체 byte equality는 cache/runtime 상태가 변할 수 있어 limit 계약 projection으로 검증
- source/runtime hash 일치, queue 0/0
- listener/설정/process 잔여물 정리 완료

## 남은 위험과 rollback

payload 구현의 물리적 owner만 이동한 slice입니다. 저장 형식이나 autocomplete domain migration은 없으며 rollback은 이 단일 commit revert로 가능합니다.

## Next task

최신 dev에서 남은 translation/preview/profile error payload와 handler composition inventory를 다시 나눠 별도 rollback slice로 진행합니다.