### PR TITLE
refactor(api): move translation route runtime owner

### DIFF
--- a/api.py
+++ b/api.py
@@ -112,6 +112,7 @@ from .easyuse_anima.api.routes import wildcards as _api_wildcard_routes
 from .easyuse_anima.api.routes.wildcards import (
     build_wildcards_handler as _build_wildcards_handler,
 )
+from .easyuse_anima.api.routes import translation as _api_translation_routes
 from .easyuse_anima.api.routes.translation import (
     build_translate_prompt_handler as _build_translate_prompt_handler,
 )
@@ -209,36 +210,33 @@ _rename_aio_profile_payload = _aio_profiles._rename_aio_profile_payload
 
 
 LORA_PREVIEW_EXTENSIONS = _api_lora_preview_routes.LORA_PREVIEW_EXTENSIONS
-PROMPT_TRANSLATION_ROUTE_TIMEOUT_SECONDS = 15.0
+PROMPT_TRANSLATION_ROUTE_TIMEOUT_SECONDS = (
+    _api_translation_routes.PROMPT_TRANSLATION_ROUTE_TIMEOUT_SECONDS
+)
 _LOGGER = logging.getLogger(__name__)
 
 
-_PROMPT_TRANSLATION_WORKER = _PromptTranslationRouteExecutor(
+(
+    _PROMPT_TRANSLATION_WORKER,
+    _translate_prompt_sync,
+    _translate_prompt_for_route,
+    _prompt_translation_error_response,
+) = _api_translation_routes.build_translation_runtime(
+    executor_type=_PromptTranslationRouteExecutor,
     busy_error_type=TranslationBusyError,
     cancelled_error_type=TranslationCancelledError,
     timeout_error_type=TranslationTimeoutError,
-)
-atexit.register(_PROMPT_TRANSLATION_WORKER.shutdown)
-
-
-def _translate_prompt_sync(text: str) -> str:
-    return translate_prompt_markers(text, resolve_prompt_translation_settings())
-
-
-async def _translate_prompt_for_route(text: str) -> str:
-    return await _PROMPT_TRANSLATION_WORKER.execute(
-        _translate_prompt_sync,
+    register_shutdown=lambda callback: atexit.register(callback),
+    translate_prompt_markers=lambda text, settings: translate_prompt_markers(
         text,
-        timeout_seconds=PROMPT_TRANSLATION_ROUTE_TIMEOUT_SECONDS,
-    )
-
-
-def _prompt_translation_error_response(exc: PromptTranslationError):
-    return _error_response(
-        exc.status,
-        exc.code,
-        exc.message,
-    )
+        settings,
+    ),
+    resolve_prompt_translation_settings=lambda: resolve_prompt_translation_settings(),
+    get_worker=lambda: _PROMPT_TRANSLATION_WORKER,
+    get_translate_prompt_sync=lambda: _translate_prompt_sync,
+    get_timeout_seconds=lambda: PROMPT_TRANSLATION_ROUTE_TIMEOUT_SECONDS,
+    error_response=lambda *args, **kwargs: _error_response(*args, **kwargs),
+)
 
 
 _error_response = _api_responses.build_error_response(

--- a/easyuse_anima/api/routes/translation.py
+++ b/easyuse_anima/api/routes/translation.py
@@ -1,5 +1,58 @@
 from __future__ import annotations
 
+PROMPT_TRANSLATION_ROUTE_TIMEOUT_SECONDS = 15.0
+
+
+def build_translation_runtime(
+    *,
+    executor_type,
+    busy_error_type,
+    cancelled_error_type,
+    timeout_error_type,
+    register_shutdown,
+    translate_prompt_markers,
+    resolve_prompt_translation_settings,
+    get_worker,
+    get_translate_prompt_sync,
+    get_timeout_seconds,
+    error_response,
+):
+    """Build the translation runtime without module-import side effects."""
+
+    worker = executor_type(
+        busy_error_type=busy_error_type,
+        cancelled_error_type=cancelled_error_type,
+        timeout_error_type=timeout_error_type,
+    )
+    register_shutdown(worker.shutdown)
+
+    def _translate_prompt_sync(text: str) -> str:
+        return translate_prompt_markers(
+            text,
+            resolve_prompt_translation_settings(),
+        )
+
+    async def _translate_prompt_for_route(text: str) -> str:
+        return await get_worker().execute(
+            get_translate_prompt_sync(),
+            text,
+            timeout_seconds=get_timeout_seconds(),
+        )
+
+    def _prompt_translation_error_response(exc):
+        return error_response(
+            exc.status,
+            exc.code,
+            exc.message,
+        )
+
+    return (
+        worker,
+        _translate_prompt_sync,
+        _translate_prompt_for_route,
+        _prompt_translation_error_response,
+    )
+
 
 def build_translate_prompt_handler(
     *,

--- a/tests/fixtures/python_backend_baseline.json
+++ b/tests/fixtures/python_backend_baseline.json
@@ -4034,6 +4034,24 @@
         "target": "easyuse_anima/api/routes/wildcards.py"
       },
       {
+        "alias": "_api_translation_routes",
+        "bound_name": "_api_translation_routes",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".easyuse_anima.api.routes:translation",
+        "kind": "static_from",
+        "line": 115,
+        "name": "translation",
+        "optional": false,
+        "requested": ".easyuse_anima.api.routes",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "api.py",
+        "target": "easyuse_anima/api/routes/translation.py"
+      },
+      {
         "alias": "_build_translate_prompt_handler",
         "bound_name": "_build_translate_prompt_handler",
         "branch_context": [],
@@ -4042,7 +4060,7 @@
         "conditional": false,
         "imported": ".easyuse_anima.api.routes.translation:build_translate_prompt_handler",
         "kind": "static_from",
-        "line": 115,
+        "line": 116,
         "name": "build_translate_prompt_handler",
         "optional": false,
         "requested": ".easyuse_anima.api.routes.translation",
@@ -4060,7 +4078,7 @@
         "conditional": false,
         "imported": ".easyuse_anima.api.routes.translation_execution:PromptTranslationRouteExecutor",
         "kind": "static_from",
-        "line": 118,
+        "line": 119,
         "name": "PromptTranslationRouteExecutor",
         "optional": false,
         "requested": ".easyuse_anima.api.routes.translation_execution",
@@ -4078,7 +4096,7 @@
         "conditional": false,
         "imported": ".easyuse_anima.api.routes.aio_torch_compile:build_aio_torch_compile_recommend_handler",
         "kind": "static_from",
-        "line": 121,
+        "line": 122,
         "name": "build_aio_torch_compile_recommend_handler",
         "optional": false,
         "requested": ".easyuse_anima.api.routes.aio_torch_compile",
@@ -4096,7 +4114,7 @@
         "conditional": false,
         "imported": ".easyuse_anima.aio.torch_compile_diagnostics:collect_torch_compile_diagnostics",
         "kind": "static_from",
-        "line": 124,
+        "line": 125,
         "name": "collect_torch_compile_diagnostics",
         "optional": false,
         "requested": ".easyuse_anima.aio.torch_compile_diagnostics",
@@ -4114,7 +4132,7 @@
         "conditional": false,
         "imported": ".easyuse_anima.aio.torch_compile_recommendation:recommend_torch_compile",
         "kind": "static_from",
-        "line": 127,
+        "line": 128,
         "name": "recommend_torch_compile",
         "optional": false,
         "requested": ".easyuse_anima.aio.torch_compile_recommendation",
@@ -4132,7 +4150,7 @@
         "conditional": false,
         "imported": ".easyuse_anima.profiles:aio",
         "kind": "static_from",
-        "line": 130,
+        "line": 131,
         "name": "aio",
         "optional": false,
         "requested": ".easyuse_anima.profiles",
@@ -4150,7 +4168,7 @@
         "conditional": false,
         "imported": ".easyuse_anima.profiles:contract",
         "kind": "static_from",
-        "line": 131,
+        "line": 132,
         "name": "contract",
         "optional": false,
         "requested": ".easyuse_anima.profiles",
@@ -4168,7 +4186,7 @@
         "conditional": false,
         "imported": ".easyuse_anima.profiles:lora",
         "kind": "static_from",
-        "line": 132,
+        "line": 133,
         "name": "lora",
         "optional": false,
         "requested": ".easyuse_anima.profiles",
@@ -4186,7 +4204,7 @@
         "conditional": false,
         "imported": ".easyuse_anima.profiles:mutation",
         "kind": "static_from",
-        "line": 133,
+        "line": 134,
         "name": "mutation",
         "optional": false,
         "requested": ".easyuse_anima.profiles",
@@ -4204,7 +4222,7 @@
         "conditional": false,
         "imported": ".easyuse_anima.profiles:repository",
         "kind": "static_from",
-        "line": 134,
+        "line": 135,
         "name": "repository",
         "optional": false,
         "requested": ".easyuse_anima.profiles",
@@ -66507,14 +66525,14 @@
       },
       {
         "is_package": false,
-        "loc": 689,
+        "loc": 687,
         "module": "api",
-        "normalized_git_blob_sha1": "e981d02aaff82e857a2f4a7ecb5737f2208689d6",
+        "normalized_git_blob_sha1": "c4e6cf59251e724cefe9b534c38434be1a479643",
         "path": "api.py",
         "top_level": {
           "class_count": 0,
-          "function_count": 6,
-          "global_count": 106
+          "function_count": 3,
+          "global_count": 109
         }
       },
       {
@@ -67191,14 +67209,14 @@
       },
       {
         "is_package": false,
-        "loc": 32,
+        "loc": 85,
         "module": "easyuse_anima.api.routes.translation",
-        "normalized_git_blob_sha1": "b1254bef5e5cc9f2231a52fbc1ea8cb13a8ea296",
+        "normalized_git_blob_sha1": "7be0a07e0b07bfc7cda7cfdde00465856ba5d59d",
         "path": "easyuse_anima/api/routes/translation.py",
         "top_level": {
           "class_count": 0,
-          "function_count": 1,
-          "global_count": 1
+          "function_count": 2,
+          "global_count": 2
         }
       },
       {
@@ -89069,25 +89087,16 @@
         "column": 10,
         "context": "assign:_LOGGER",
         "kind": "import_time_call",
-        "line": 213,
-        "module": "api.py",
-        "scope": "<module>"
-      },
-      {
-        "callee": "_PromptTranslationRouteExecutor",
-        "column": 29,
-        "context": "assign:_PROMPT_TRANSLATION_WORKER",
-        "kind": "route_registry_creation",
         "line": 216,
         "module": "api.py",
         "scope": "<module>"
       },
       {
-        "callee": "atexit.register",
-        "column": 0,
-        "context": "expression",
-        "kind": "import_time_call",
-        "line": 221,
+        "callee": "_api_translation_routes.build_translation_runtime",
+        "column": 4,
+        "context": "assign:_PROMPT_TRANSLATION_WORKER,_prompt_translation_error_response,_translate_prompt_for_route,_translate_prompt_sync",
+        "kind": "route_registry_creation",
+        "line": 224,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -89096,7 +89105,7 @@
         "column": 18,
         "context": "assign:_error_response",
         "kind": "import_time_call",
-        "line": 244,
+        "line": 242,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -89105,7 +89114,7 @@
         "column": 27,
         "context": "assign:_contract_error_response",
         "kind": "import_time_call",
-        "line": 252,
+        "line": 250,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -89114,7 +89123,7 @@
         "column": 22,
         "context": "assign:_request_correlated",
         "kind": "import_time_call",
-        "line": 255,
+        "line": 253,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -89123,7 +89132,7 @@
         "column": 29,
         "context": "assign:_resolve_lora_preview_path",
         "kind": "route_registry_creation",
-        "line": 268,
+        "line": 266,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -89132,7 +89141,7 @@
         "column": 36,
         "context": "assign:_SAFE_PROFILE_VALIDATION_MESSAGES",
         "kind": "import_time_call",
-        "line": 278,
+        "line": 276,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -89141,7 +89150,7 @@
         "column": 4,
         "context": "assign:_get_settings_payload_sync,_save_setting_payload_sync",
         "kind": "route_registry_creation",
-        "line": 319,
+        "line": 317,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -89150,7 +89159,7 @@
         "column": 4,
         "context": "assign:_get_long_text_settings_payload_sync,_save_long_text_settings_payload_sync",
         "kind": "route_registry_creation",
-        "line": 328,
+        "line": 326,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -89159,7 +89168,7 @@
         "column": 26,
         "context": "assign:_wildcards_payload_sync",
         "kind": "route_registry_creation",
-        "line": 335,
+        "line": 333,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -89168,7 +89177,7 @@
         "column": 4,
         "context": "assign:_autocomplete_status_payload_sync,_classify_prompt_payload_sync,_public_autocomplete_payload,_public_autocomplete_status,_search_autocomplete_payload_sync",
         "kind": "route_registry_creation",
-        "line": 348,
+        "line": 346,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -89177,7 +89186,7 @@
         "column": 9,
         "context": "assign:routes",
         "kind": "route_registry_creation",
-        "line": 372,
+        "line": 370,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -89186,7 +89195,7 @@
         "column": 8,
         "context": "assign:get_settings_handler,set_setting_handler",
         "kind": "import_time_call",
-        "line": 380,
+        "line": 378,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -89195,7 +89204,7 @@
         "column": 23,
         "context": "assign:get_settings_handler,set_setting_handler",
         "kind": "import_time_call",
-        "line": 381,
+        "line": 379,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -89204,7 +89213,7 @@
         "column": 8,
         "context": "assign:get_long_text_settings_handler,save_long_text_settings_handler",
         "kind": "import_time_call",
-        "line": 410,
+        "line": 408,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -89213,7 +89222,7 @@
         "column": 23,
         "context": "assign:get_long_text_settings_handler,save_long_text_settings_handler",
         "kind": "import_time_call",
-        "line": 411,
+        "line": 409,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -89222,7 +89231,7 @@
         "column": 28,
         "context": "assign:get_wildcards_handler",
         "kind": "import_time_call",
-        "line": 425,
+        "line": 423,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -89231,7 +89240,7 @@
         "column": 8,
         "context": "assign:get_wildcards_handler",
         "kind": "import_time_call",
-        "line": 426,
+        "line": 424,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -89240,7 +89249,7 @@
         "column": 8,
         "context": "assign:autocomplete_handler,autocomplete_status_handler",
         "kind": "import_time_call",
-        "line": 437,
+        "line": 435,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -89249,7 +89258,7 @@
         "column": 23,
         "context": "assign:autocomplete_handler,autocomplete_status_handler",
         "kind": "import_time_call",
-        "line": 438,
+        "line": 436,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -89258,7 +89267,7 @@
         "column": 30,
         "context": "assign:classify_prompt_handler",
         "kind": "import_time_call",
-        "line": 448,
+        "line": 446,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -89267,7 +89276,7 @@
         "column": 8,
         "context": "assign:classify_prompt_handler",
         "kind": "import_time_call",
-        "line": 449,
+        "line": 447,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -89276,7 +89285,7 @@
         "column": 31,
         "context": "assign:translate_prompt_handler",
         "kind": "import_time_call",
-        "line": 467,
+        "line": 465,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -89285,7 +89294,7 @@
         "column": 8,
         "context": "assign:translate_prompt_handler",
         "kind": "import_time_call",
-        "line": 468,
+        "line": 466,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -89294,7 +89303,7 @@
         "column": 42,
         "context": "assign:aio_torch_compile_recommend_handler",
         "kind": "import_time_call",
-        "line": 480,
+        "line": 478,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -89303,7 +89312,7 @@
         "column": 8,
         "context": "assign:aio_torch_compile_recommend_handler",
         "kind": "import_time_call",
-        "line": 481,
+        "line": 479,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -89312,7 +89321,7 @@
         "column": 27,
         "context": "assign:lora_preview_handler",
         "kind": "import_time_call",
-        "line": 497,
+        "line": 495,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -89321,7 +89330,7 @@
         "column": 8,
         "context": "assign:lora_preview_handler",
         "kind": "import_time_call",
-        "line": 498,
+        "line": 496,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -89330,7 +89339,7 @@
         "column": 20,
         "context": "assign:loras_handler",
         "kind": "import_time_call",
-        "line": 507,
+        "line": 505,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -89339,7 +89348,7 @@
         "column": 8,
         "context": "assign:loras_handler",
         "kind": "import_time_call",
-        "line": 508,
+        "line": 506,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -89348,7 +89357,7 @@
         "column": 8,
         "context": "assign:aio_profiles_handler,lora_profiles_handler",
         "kind": "import_time_call",
-        "line": 519,
+        "line": 517,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -89357,7 +89366,7 @@
         "column": 23,
         "context": "assign:aio_profiles_handler,lora_profiles_handler",
         "kind": "import_time_call",
-        "line": 520,
+        "line": 518,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -89366,7 +89375,7 @@
         "column": 8,
         "context": "assign:load_aio_profile_handler,load_lora_profile_handler",
         "kind": "import_time_call",
-        "line": 534,
+        "line": 532,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -89375,7 +89384,7 @@
         "column": 23,
         "context": "assign:load_aio_profile_handler,load_lora_profile_handler",
         "kind": "import_time_call",
-        "line": 535,
+        "line": 533,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -89384,7 +89393,7 @@
         "column": 8,
         "context": "assign:save_aio_profile_handler,save_lora_profile_handler",
         "kind": "import_time_call",
-        "line": 555,
+        "line": 553,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -89393,7 +89402,7 @@
         "column": 23,
         "context": "assign:save_aio_profile_handler,save_lora_profile_handler",
         "kind": "import_time_call",
-        "line": 556,
+        "line": 554,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -89402,7 +89411,7 @@
         "column": 8,
         "context": "assign:delete_aio_profile_handler,rename_aio_profile_handler",
         "kind": "import_time_call",
-        "line": 590,
+        "line": 588,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -89411,7 +89420,7 @@
         "column": 23,
         "context": "assign:delete_aio_profile_handler,rename_aio_profile_handler",
         "kind": "import_time_call",
-        "line": 591,
+        "line": 589,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -89420,7 +89429,7 @@
         "column": 31,
         "context": "assign:fix_lora_profile_handler",
         "kind": "import_time_call",
-        "line": 622,
+        "line": 620,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -89429,7 +89438,7 @@
         "column": 8,
         "context": "assign:fix_lora_profile_handler",
         "kind": "import_time_call",
-        "line": 623,
+        "line": 621,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -89438,7 +89447,7 @@
         "column": 19,
         "context": "assign:_ROUTE_SIGNATURE",
         "kind": "route_registry_creation",
-        "line": 673,
+        "line": 671,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -91722,15 +91731,6 @@
       }
     ],
     "owner_candidates": [
-      {
-        "categories": [
-          "executor"
-        ],
-        "initializer": "_PromptTranslationRouteExecutor",
-        "line": 216,
-        "module": "api.py",
-        "name": "_PROMPT_TRANSLATION_WORKER"
-      },
       {
         "categories": [
           "cache",

--- a/tests/test_prompt_translation_api.py
+++ b/tests/test_prompt_translation_api.py
@@ -104,6 +104,166 @@ class PromptTranslationApiTests(unittest.TestCase):
         )
         self.assertTrue(handler._easyuse_anima_request_correlation)
 
+    def test_route_runtime_helpers_are_owned_by_the_canonical_factory(self):
+        api, _routes, _translation, _translation_service = self.load_routes()
+        cases = (
+            ("_translate_prompt_sync", 1),
+            ("_translate_prompt_for_route", 1),
+            ("_prompt_translation_error_response", 1),
+        )
+
+        for name, argcount in cases:
+            with self.subTest(name=name):
+                helper = getattr(api, name)
+                self.assertEqual(helper.__name__, name)
+                self.assertEqual(
+                    helper.__module__,
+                    f"{PACKAGE_NAME}.easyuse_anima.api.routes.translation",
+                )
+                self.assertEqual(helper.__code__.co_argcount, argcount)
+
+        owner = sys.modules[api._translate_prompt_sync.__module__]
+        self.assertIs(
+            api.PROMPT_TRANSLATION_ROUTE_TIMEOUT_SECONDS,
+            owner.PROMPT_TRANSLATION_ROUTE_TIMEOUT_SECONDS,
+        )
+        self.assertEqual(api.PROMPT_TRANSLATION_ROUTE_TIMEOUT_SECONDS, 15.0)
+        self.assertEqual(owner.__all__, ("build_translate_prompt_handler",))
+        self.assertFalse(hasattr(owner, "_PROMPT_TRANSLATION_WORKER"))
+
+    def test_runtime_builder_constructs_and_registers_one_worker(self):
+        api, _routes, _translation, _translation_service = self.load_routes()
+        owner = sys.modules[api._translate_prompt_sync.__module__]
+        created = []
+        registered = []
+
+        class FakeExecutor:
+            def __init__(
+                self,
+                *,
+                busy_error_type,
+                cancelled_error_type,
+                timeout_error_type,
+            ):
+                created.append(
+                    (
+                        busy_error_type,
+                        cancelled_error_type,
+                        timeout_error_type,
+                    )
+                )
+
+            def shutdown(self):
+                return None
+
+        runtime = owner.build_translation_runtime(
+            executor_type=FakeExecutor,
+            busy_error_type=api.TranslationBusyError,
+            cancelled_error_type=api.TranslationCancelledError,
+            timeout_error_type=api.TranslationTimeoutError,
+            register_shutdown=registered.append,
+            translate_prompt_markers=lambda text, settings: text,
+            resolve_prompt_translation_settings=lambda: object(),
+            get_worker=lambda: runtime[0],
+            get_translate_prompt_sync=lambda: runtime[1],
+            get_timeout_seconds=lambda: 15.0,
+            error_response=lambda *args: args,
+        )
+
+        worker = runtime[0]
+        self.assertEqual(
+            created,
+            [
+                (
+                    api.TranslationBusyError,
+                    api.TranslationCancelledError,
+                    api.TranslationTimeoutError,
+                )
+            ],
+        )
+        self.assertEqual(len(registered), 1)
+        self.assertIs(registered[0].__self__, worker)
+        self.assertIs(registered[0].__func__, FakeExecutor.shutdown)
+        self.assertFalse(hasattr(owner, "_PROMPT_TRANSLATION_WORKER"))
+
+    def test_runtime_helpers_keep_dynamic_root_dependencies(self):
+        api, _routes, _translation, _translation_service = self.load_routes()
+        calls = []
+        settings = object()
+
+        def resolve_settings():
+            calls.append(("settings",))
+            return settings
+
+        def translate(text, resolved_settings):
+            calls.append(("translate", text, resolved_settings))
+            return "translated"
+
+        with (
+            patch.object(
+                api,
+                "resolve_prompt_translation_settings",
+                side_effect=resolve_settings,
+            ),
+            patch.object(
+                api,
+                "translate_prompt_markers",
+                side_effect=translate,
+            ),
+        ):
+            translated = api._translate_prompt_sync("%{text}")
+
+        self.assertEqual(translated, "translated")
+        self.assertEqual(
+            calls,
+            [
+                ("settings",),
+                ("translate", "%{text}", settings),
+            ],
+        )
+
+        calls.clear()
+        replacement_sync = lambda text: text
+
+        class FakeWorker:
+            async def execute(self, function, text, *, timeout_seconds):
+                calls.append(("execute", function, text, timeout_seconds))
+                return "async-translated"
+
+        worker = FakeWorker()
+        with (
+            patch.object(api, "_PROMPT_TRANSLATION_WORKER", worker),
+            patch.object(api, "_translate_prompt_sync", replacement_sync),
+            patch.object(api, "PROMPT_TRANSLATION_ROUTE_TIMEOUT_SECONDS", 0.25),
+        ):
+            translated = asyncio.run(api._translate_prompt_for_route("%{async}"))
+
+        self.assertEqual(translated, "async-translated")
+        self.assertEqual(
+            calls,
+            [("execute", replacement_sync, "%{async}", 0.25)],
+        )
+
+        error = types.SimpleNamespace(
+            status=502,
+            code="translation_upstream_error",
+            message="The translation provider request failed.",
+        )
+        expected_response = {"status": 502}
+        with patch.object(
+            api,
+            "_error_response",
+            return_value=expected_response,
+        ) as error_response:
+            response = api._prompt_translation_error_response(error)
+
+        self.assertIs(response, expected_response)
+        error_response.assert_called_once_with(
+            error.status,
+            error.code,
+            error.message,
+        )
+
     def test_route_executor_is_owned_by_the_canonical_module(self):
         api, _routes, _translation, _translation_service = self.load_routes()
         executor = api._PROMPT_TRANSLATION_WORKER


### PR DESCRIPTION
## 목적과 변경 경계

Issue #186 D-08j로 root API의 prompt translation route runtime 구현을 canonical `easyuse_anima.api.routes.translation` 내부 builder로 이동합니다. Executor 정책, provider/domain 동작, handler composition과 공개 surface는 변경하지 않습니다.

Related: #186, #164, #165

## Base → Head

- Base: `9a0d58e195a38eed33bd895d463c9f983a5ee661`
- Head: `c8ab21cc779f6c0c4b2a95254336dc60d9849f75`

## 주요 파일과 보존 계약

- `api.py`: 기존 root symbols와 runtime patch seams를 유지하며 canonical builder를 조립
- `easyuse_anima/api/routes/translation.py`: timeout, worker construction/atexit, sync/async/error helper owner
- `tests/test_prompt_translation_api.py`: owner, import side effect, worker registration, dynamic dependency 계약
- `tests/fixtures/python_backend_baseline.json`: 실제 analyzer surface 반영

보존 사항:

- timeout `15.0`, helper names/argcount와 root monkeypatch seams
- root import당 executor 1개와 bound shutdown 등록 1회
- canonical module 단독 import 시 worker/atexit side effect 없음
- single-flight, timeout, cancel, busy, error taxonomy와 request correlation
- canonical `__all__` 및 execution module 공개 surface

## 검증

- changed-file AST: 3 files
- PromptTranslationApiTests: 11
- 전체 API contract: 90
- prompt translation domain: 13
- analyzer 18, scanner 8, import boundary 16, compatibility 26, package skeleton 1
- Ruff report-only 120, Pyright 149 files / 기존 14 errors, G-03 11 groups / 0 violations
- Registry validate 통과, actual pack 308 entries 및 root/canonical closure 확인
- final candidate official full 정확히 1회: Python 1,312 / frontend 120 / TypeScript 6.0.3 / diff gate 통과
- isolated live: invalid object 400+UUID, no-marker 200, provider-off marker unwrap 200, provider resolution 전 marker budget 413+UUID, queue 0/0
- listener, temporary settings와 owned process tree 정리 완료

## Roadmap 검증 항목 정정

기존 task card의 `provider-disabled marker error taxonomy`는 이미 고정된 provider-off 계약과 충돌했습니다. Provider `off`는 marker를 unwrap하고 외부 provider를 호출하지 않는 성공 경로이므로 이를 200으로 검증했고, 오류 taxonomy는 provider를 일시적으로 `google`로 설정한 뒤 65-marker budget을 사용해 provider resolution 전에 413으로 검증했습니다. 이 정정은 production 동작 변경 없이 기존 계약에 task card를 맞춘 것입니다.

## 위험과 rollback

변경은 내부 runtime owner 이동이며 public/behavior 변경은 없습니다. 회귀 시 이 PR의 squash commit을 revert하면 됩니다.

## Next

shared profile error owner는 별도 D-08k rollback slice로 진행합니다.