### PR TITLE
refactor(api): move shared profile error owner

### DIFF
--- a/api.py
+++ b/api.py
@@ -273,42 +273,22 @@ _resolve_lora_preview_path = _api_lora_preview_routes.build_lora_preview_path_re
 )
 
 
-_SAFE_PROFILE_VALIDATION_MESSAGES = frozenset(
-    {
-        "Profile name is required",
-        "Profile name is reserved on Windows",
-        "Invalid profile path",
-        "System profile names are reserved",
-        "Profile settings must be an object",
-        "Profile settings are too large",
-        f"A maximum of {MAX_AIO_PROFILES} profiles can be saved",
-    }
-)
-
-
-def _profile_error_response(exc: Exception):
-    if isinstance(exc, ProfileMutationError):
-        return _error_response(
-            exc.status,
-            exc.code,
-            exc.message,
-            details=exc.details,
-        )
-    if isinstance(exc, FileExistsError):
-        return _error_response(409, "profile_exists", "Profile already exists")
-    if isinstance(exc, FileNotFoundError):
-        return _error_response(404, "profile_not_found", "Profile not found")
-    if isinstance(
+(
+    _SAFE_PROFILE_VALIDATION_MESSAGES,
+    _profile_error_response,
+) = _api_responses.build_profile_error_response(
+    max_aio_profiles=MAX_AIO_PROFILES,
+    is_profile_mutation_error=lambda exc: isinstance(exc, ProfileMutationError),
+    is_file_exists_error=lambda exc: isinstance(exc, FileExistsError),
+    is_file_not_found_error=lambda exc: isinstance(exc, FileNotFoundError),
+    is_invalid_profile_data_error=lambda exc: isinstance(
         exc,
         (json.JSONDecodeError, UnicodeDecodeError, InvalidProfileDataError),
-    ):
-        return _error_response(422, "invalid_profile_data", "Profile data is invalid")
-    if isinstance(exc, ValueError):
-        message = str(exc)
-        if message not in _SAFE_PROFILE_VALIDATION_MESSAGES:
-            message = "Request validation failed"
-        return _error_response(422, "invalid_request", message)
-    raise exc
+    ),
+    is_value_error=lambda exc: isinstance(exc, ValueError),
+    get_safe_validation_messages=lambda: _SAFE_PROFILE_VALIDATION_MESSAGES,
+    error_response=lambda *args, **kwargs: _error_response(*args, **kwargs),
+)
 
 
 (

--- a/easyuse_anima/api/responses.py
+++ b/easyuse_anima/api/responses.py
@@ -4,7 +4,7 @@ import asyncio
 import json
 import uuid
 from functools import wraps
-from typing import Any, Mapping
+from typing import Any, Mapping, cast
 
 
 REQUEST_ID_HEADER = "X-Request-ID"
@@ -95,6 +95,68 @@ def build_contract_error_response(*, error_response):
         )
 
     return _contract_error_response
+
+
+def build_profile_error_response(
+    *,
+    max_aio_profiles,
+    is_profile_mutation_error,
+    is_file_exists_error,
+    is_file_not_found_error,
+    is_invalid_profile_data_error,
+    is_value_error,
+    get_safe_validation_messages,
+    error_response,
+):
+    """Build the shared profile error mapper without profile-domain imports."""
+
+    safe_validation_messages = frozenset(
+        {
+            "Profile name is required",
+            "Profile name is reserved on Windows",
+            "Invalid profile path",
+            "System profile names are reserved",
+            "Profile settings must be an object",
+            "Profile settings are too large",
+            f"A maximum of {max_aio_profiles} profiles can be saved",
+        }
+    )
+
+    def _profile_error_response(exc: Exception):
+        if is_profile_mutation_error(exc):
+            mutation_error = cast(Any, exc)
+            return error_response(
+                mutation_error.status,
+                mutation_error.code,
+                mutation_error.message,
+                details=mutation_error.details,
+            )
+        if is_file_exists_error(exc):
+            return error_response(
+                409,
+                "profile_exists",
+                "Profile already exists",
+            )
+        if is_file_not_found_error(exc):
+            return error_response(
+                404,
+                "profile_not_found",
+                "Profile not found",
+            )
+        if is_invalid_profile_data_error(exc):
+            return error_response(
+                422,
+                "invalid_profile_data",
+                "Profile data is invalid",
+            )
+        if is_value_error(exc):
+            message = str(exc)
+            if message not in get_safe_validation_messages():
+                message = "Request validation failed"
+            return error_response(422, "invalid_request", message)
+        raise exc
+
+    return safe_validation_messages, _profile_error_response
 
 
 def build_request_correlator(

--- a/tests/fixtures/python_backend_baseline.json
+++ b/tests/fixtures/python_backend_baseline.json
@@ -15617,6 +15617,23 @@
       },
       {
         "alias": null,
+        "bound_name": "cast",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "typing:cast",
+        "kind": "static_from",
+        "line": 7,
+        "name": "cast",
+        "optional": false,
+        "requested": "typing",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/api/responses.py"
+      },
+      {
+        "alias": null,
         "bound_name": "annotations",
         "branch_context": [],
         "classification": "external",
@@ -66525,14 +66542,14 @@
       },
       {
         "is_package": false,
-        "loc": 687,
+        "loc": 667,
         "module": "api",
-        "normalized_git_blob_sha1": "c4e6cf59251e724cefe9b534c38434be1a479643",
+        "normalized_git_blob_sha1": "6ab7aa7fee71e485b07a6cd17f3739329844f2cc",
         "path": "api.py",
         "top_level": {
           "class_count": 0,
-          "function_count": 3,
-          "global_count": 109
+          "function_count": 2,
+          "global_count": 110
         }
       },
       {
@@ -67041,13 +67058,13 @@
       },
       {
         "is_package": false,
-        "loc": 146,
+        "loc": 208,
         "module": "easyuse_anima.api.responses",
-        "normalized_git_blob_sha1": "91a1f5bab47bc463d112594fd88e37586180b2b3",
+        "normalized_git_blob_sha1": "937217da3203b2b4a8da8f608231744480a5b3f7",
         "path": "easyuse_anima/api/responses.py",
         "top_level": {
           "class_count": 0,
-          "function_count": 7,
+          "function_count": 8,
           "global_count": 2
         }
       },
@@ -83505,6 +83522,17 @@
         "branch_context": [],
         "classification": "external",
         "conditional": false,
+        "imported": "typing:cast",
+        "kind": "static_from",
+        "line": 7,
+        "optional": false,
+        "role": "ordinary",
+        "source": "easyuse_anima/api/responses.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
         "imported": "__future__:annotations",
         "kind": "static_from",
         "line": 1,
@@ -89137,11 +89165,11 @@
         "scope": "<module>"
       },
       {
-        "callee": "frozenset",
-        "column": 36,
-        "context": "assign:_SAFE_PROFILE_VALIDATION_MESSAGES",
+        "callee": "_api_responses.build_profile_error_response",
+        "column": 4,
+        "context": "assign:_SAFE_PROFILE_VALIDATION_MESSAGES,_profile_error_response",
         "kind": "import_time_call",
-        "line": 276,
+        "line": 279,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -89150,7 +89178,7 @@
         "column": 4,
         "context": "assign:_get_settings_payload_sync,_save_setting_payload_sync",
         "kind": "route_registry_creation",
-        "line": 317,
+        "line": 297,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -89159,7 +89187,7 @@
         "column": 4,
         "context": "assign:_get_long_text_settings_payload_sync,_save_long_text_settings_payload_sync",
         "kind": "route_registry_creation",
-        "line": 326,
+        "line": 306,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -89168,7 +89196,7 @@
         "column": 26,
         "context": "assign:_wildcards_payload_sync",
         "kind": "route_registry_creation",
-        "line": 333,
+        "line": 313,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -89177,7 +89205,7 @@
         "column": 4,
         "context": "assign:_autocomplete_status_payload_sync,_classify_prompt_payload_sync,_public_autocomplete_payload,_public_autocomplete_status,_search_autocomplete_payload_sync",
         "kind": "route_registry_creation",
-        "line": 346,
+        "line": 326,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -89186,7 +89214,7 @@
         "column": 9,
         "context": "assign:routes",
         "kind": "route_registry_creation",
-        "line": 370,
+        "line": 350,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -89195,7 +89223,7 @@
         "column": 8,
         "context": "assign:get_settings_handler,set_setting_handler",
         "kind": "import_time_call",
-        "line": 378,
+        "line": 358,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -89204,7 +89232,7 @@
         "column": 23,
         "context": "assign:get_settings_handler,set_setting_handler",
         "kind": "import_time_call",
-        "line": 379,
+        "line": 359,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -89213,7 +89241,7 @@
         "column": 8,
         "context": "assign:get_long_text_settings_handler,save_long_text_settings_handler",
         "kind": "import_time_call",
-        "line": 408,
+        "line": 388,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -89222,7 +89250,7 @@
         "column": 23,
         "context": "assign:get_long_text_settings_handler,save_long_text_settings_handler",
         "kind": "import_time_call",
-        "line": 409,
+        "line": 389,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -89231,7 +89259,7 @@
         "column": 28,
         "context": "assign:get_wildcards_handler",
         "kind": "import_time_call",
-        "line": 423,
+        "line": 403,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -89240,7 +89268,7 @@
         "column": 8,
         "context": "assign:get_wildcards_handler",
         "kind": "import_time_call",
-        "line": 424,
+        "line": 404,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -89249,7 +89277,7 @@
         "column": 8,
         "context": "assign:autocomplete_handler,autocomplete_status_handler",
         "kind": "import_time_call",
-        "line": 435,
+        "line": 415,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -89258,7 +89286,7 @@
         "column": 23,
         "context": "assign:autocomplete_handler,autocomplete_status_handler",
         "kind": "import_time_call",
-        "line": 436,
+        "line": 416,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -89267,7 +89295,7 @@
         "column": 30,
         "context": "assign:classify_prompt_handler",
         "kind": "import_time_call",
-        "line": 446,
+        "line": 426,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -89276,7 +89304,7 @@
         "column": 8,
         "context": "assign:classify_prompt_handler",
         "kind": "import_time_call",
-        "line": 447,
+        "line": 427,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -89285,7 +89313,7 @@
         "column": 31,
         "context": "assign:translate_prompt_handler",
         "kind": "import_time_call",
-        "line": 465,
+        "line": 445,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -89294,7 +89322,7 @@
         "column": 8,
         "context": "assign:translate_prompt_handler",
         "kind": "import_time_call",
-        "line": 466,
+        "line": 446,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -89303,7 +89331,7 @@
         "column": 42,
         "context": "assign:aio_torch_compile_recommend_handler",
         "kind": "import_time_call",
-        "line": 478,
+        "line": 458,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -89312,7 +89340,7 @@
         "column": 8,
         "context": "assign:aio_torch_compile_recommend_handler",
         "kind": "import_time_call",
-        "line": 479,
+        "line": 459,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -89321,7 +89349,7 @@
         "column": 27,
         "context": "assign:lora_preview_handler",
         "kind": "import_time_call",
-        "line": 495,
+        "line": 475,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -89330,7 +89358,7 @@
         "column": 8,
         "context": "assign:lora_preview_handler",
         "kind": "import_time_call",
-        "line": 496,
+        "line": 476,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -89339,7 +89367,7 @@
         "column": 20,
         "context": "assign:loras_handler",
         "kind": "import_time_call",
-        "line": 505,
+        "line": 485,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -89348,7 +89376,7 @@
         "column": 8,
         "context": "assign:loras_handler",
         "kind": "import_time_call",
-        "line": 506,
+        "line": 486,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -89357,7 +89385,7 @@
         "column": 8,
         "context": "assign:aio_profiles_handler,lora_profiles_handler",
         "kind": "import_time_call",
-        "line": 517,
+        "line": 497,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -89366,7 +89394,7 @@
         "column": 23,
         "context": "assign:aio_profiles_handler,lora_profiles_handler",
         "kind": "import_time_call",
-        "line": 518,
+        "line": 498,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -89375,7 +89403,7 @@
         "column": 8,
         "context": "assign:load_aio_profile_handler,load_lora_profile_handler",
         "kind": "import_time_call",
-        "line": 532,
+        "line": 512,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -89384,7 +89412,7 @@
         "column": 23,
         "context": "assign:load_aio_profile_handler,load_lora_profile_handler",
         "kind": "import_time_call",
-        "line": 533,
+        "line": 513,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -89393,7 +89421,7 @@
         "column": 8,
         "context": "assign:save_aio_profile_handler,save_lora_profile_handler",
         "kind": "import_time_call",
-        "line": 553,
+        "line": 533,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -89402,7 +89430,7 @@
         "column": 23,
         "context": "assign:save_aio_profile_handler,save_lora_profile_handler",
         "kind": "import_time_call",
-        "line": 554,
+        "line": 534,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -89411,7 +89439,7 @@
         "column": 8,
         "context": "assign:delete_aio_profile_handler,rename_aio_profile_handler",
         "kind": "import_time_call",
-        "line": 588,
+        "line": 568,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -89420,7 +89448,7 @@
         "column": 23,
         "context": "assign:delete_aio_profile_handler,rename_aio_profile_handler",
         "kind": "import_time_call",
-        "line": 589,
+        "line": 569,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -89429,7 +89457,7 @@
         "column": 31,
         "context": "assign:fix_lora_profile_handler",
         "kind": "import_time_call",
-        "line": 620,
+        "line": 600,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -89438,7 +89466,7 @@
         "column": 8,
         "context": "assign:fix_lora_profile_handler",
         "kind": "import_time_call",
-        "line": 621,
+        "line": 601,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -89447,7 +89475,7 @@
         "column": 19,
         "context": "assign:_ROUTE_SIGNATURE",
         "kind": "route_registry_creation",
-        "line": 671,
+        "line": 651,
         "module": "api.py",
         "scope": "<module>"
       },

--- a/tests/test_api_contract.py
+++ b/tests/test_api_contract.py
@@ -545,6 +545,166 @@ class ApiRequestCorrelationTests(unittest.TestCase):
         self.assertIn("X-Request-ID", found.headers)
 
 
+class ApiProfileErrorResponseTests(unittest.TestCase):
+    def test_profile_error_boundary_is_owned_by_canonical_responses(self):
+        api, _routes = load_api_routes(register=False)
+        owner = sys.modules[api._profile_error_response.__module__]
+
+        self.assertEqual(
+            api._profile_error_response.__name__,
+            "_profile_error_response",
+        )
+        self.assertTrue(
+            api._profile_error_response.__module__.endswith(
+                ".easyuse_anima.api.responses"
+            )
+        )
+        self.assertEqual(api._profile_error_response.__code__.co_argcount, 1)
+        self.assertEqual(
+            api._SAFE_PROFILE_VALIDATION_MESSAGES,
+            frozenset(
+                {
+                    "Profile name is required",
+                    "Profile name is reserved on Windows",
+                    "Invalid profile path",
+                    "System profile names are reserved",
+                    "Profile settings must be an object",
+                    "Profile settings are too large",
+                    f"A maximum of {api.MAX_AIO_PROFILES} profiles can be saved",
+                }
+            ),
+        )
+        self.assertEqual(
+            owner.__all__,
+            (
+                "REQUEST_ID_HEADER",
+                "error_payload",
+                "create_request_id",
+                "attach_request_id_header",
+                "correlate_response",
+            ),
+        )
+
+    def test_profile_error_boundary_preserves_mapping_order_and_redaction(self):
+        api, _routes = load_api_routes(register=False)
+        mutation = api.ProfileMutationError(
+            status=409,
+            code="profile_revision_conflict",
+            message="Profile revision does not match",
+            details={"profile": "target"},
+        )
+        invalid_json = json.JSONDecodeError("private", "{", 0)
+        invalid_unicode = UnicodeDecodeError("utf-8", b"\xff", 0, 1, "private")
+        cases = (
+            (
+                mutation,
+                (
+                    409,
+                    "profile_revision_conflict",
+                    "Profile revision does not match",
+                ),
+                {"details": {"profile": "target"}},
+            ),
+            (
+                FileExistsError("private"),
+                (409, "profile_exists", "Profile already exists"),
+                {},
+            ),
+            (
+                FileNotFoundError("private"),
+                (404, "profile_not_found", "Profile not found"),
+                {},
+            ),
+            (
+                invalid_json,
+                (422, "invalid_profile_data", "Profile data is invalid"),
+                {},
+            ),
+            (
+                invalid_unicode,
+                (422, "invalid_profile_data", "Profile data is invalid"),
+                {},
+            ),
+            (
+                api.InvalidProfileDataError("private"),
+                (422, "invalid_profile_data", "Profile data is invalid"),
+                {},
+            ),
+            (
+                ValueError("Profile name is required"),
+                (422, "invalid_request", "Profile name is required"),
+                {},
+            ),
+            (
+                ValueError("C:\\private\\secret.json"),
+                (422, "invalid_request", "Request validation failed"),
+                {},
+            ),
+        )
+
+        for error, expected_args, expected_kwargs in cases:
+            expected_response = object()
+            with self.subTest(error=type(error).__name__), patch.object(
+                api,
+                "_error_response",
+                return_value=expected_response,
+            ) as error_response:
+                response = api._profile_error_response(error)
+
+            self.assertIs(response, expected_response)
+            error_response.assert_called_once_with(
+                *expected_args,
+                **expected_kwargs,
+            )
+
+        unexpected = RuntimeError("unexpected")
+        with self.assertRaises(RuntimeError) as raised:
+            api._profile_error_response(unexpected)
+        self.assertIs(raised.exception, unexpected)
+
+    def test_profile_error_boundary_keeps_dynamic_root_dependencies(self):
+        api, _routes = load_api_routes(register=False)
+
+        class DynamicMutationError(ValueError):
+            status = 428
+            code = "dynamic_precondition"
+            message = "Dynamic precondition"
+            details = {"profile": "dynamic"}
+
+        mutation = DynamicMutationError("private")
+        expected_response = object()
+        with (
+            patch.object(api, "ProfileMutationError", DynamicMutationError),
+            patch.object(
+                api,
+                "_SAFE_PROFILE_VALIDATION_MESSAGES",
+                frozenset({"dynamic-safe"}),
+            ),
+            patch.object(
+                api,
+                "_error_response",
+                return_value=expected_response,
+            ) as error_response,
+        ):
+            response = api._profile_error_response(mutation)
+            safe_response = api._profile_error_response(ValueError("dynamic-safe"))
+
+        self.assertIs(response, expected_response)
+        self.assertIs(safe_response, expected_response)
+        self.assertEqual(
+            error_response.call_args_list,
+            [
+                unittest.mock.call(
+                    428,
+                    "dynamic_precondition",
+                    "Dynamic precondition",
+                    details={"profile": "dynamic"},
+                ),
+                unittest.mock.call(422, "invalid_request", "dynamic-safe"),
+            ],
+        )
+
+
 class ApiLoraCatalogRouteTests(unittest.TestCase):
     def test_route_handler_is_owned_by_the_canonical_factory(self):
         api, routes = load_api_routes()


### PR DESCRIPTION
## 목적과 변경 경계

Issue #186 D-08k로 root API의 shared profile error allowlist/mapper 구현을 canonical `easyuse_anima.api.responses` internal builder로 이동합니다. Profile domain, route factory catch boundaries, handler composition과 공개 response surface는 변경하지 않습니다.

Related: #186, #163, #165

## Base → Head

- Base: `5a1ee213f3dd6a4bb7e22156a3477ae5d9e10a4d`
- Head: `66e734bfb8bb6b595af3ad6a52893320bbf4ab7b`

## 주요 파일과 보존 계약

- `api.py`: root names와 runtime type/allowlist/error-response seams를 canonical builder에 주입
- `easyuse_anima/api/responses.py`: exact safe message set과 shared profile error mapping owner
- `tests/test_api_contract.py`: owner, mapping order, redaction, reraise identity, dynamic dependency 계약
- `tests/fixtures/python_backend_baseline.json`: 실제 analyzer surface 반영

보존 사항:

- exact 7-message `frozenset`과 MAX_AIO_PROFILES projection
- ProfileMutationError → FileExists → FileNotFound → invalid data → ValueError mapping order
- status/code/message/details, safe-message 공개와 unknown ValueError redaction
- 미지원 exception 동일 객체 재발생
- 네 profile route factory의 catch/success/correlation 계약
- canonical responses `__all__` 및 import side effect

## 검증

- changed-file AST 통과
- 새 `ApiProfileErrorResponseTests`: 3
- 전체 API contract: 93
- analyzer 18, scanner 8, import boundary 16, compatibility 26, API compatibility 3, package skeleton 1
- 직접 frontend smoke: AiO profile API client, LoRA profile mutation/save-sync
- Ruff report-only 120, Pyright 149 files / 기존 14 errors, G-03 11 groups / 0 violations
- validate 포함 actual pack 통과: 308 entries, required runtime files 포함, forbidden 경로 0
- final candidate official full 정확히 1회: Python 1,315 / frontend 120 / TypeScript 6.0.3 / diff gate 통과
- isolated live: invalid sanitized profile name 422 safe message, missing profile load 404 redaction, UUID header/body 일치, queue 0/0
- listener/profile/settings/owned process tree cleanup 완료

초기 candidate `8484b537`의 official full은 canonical mapper의 domain-agnostic `Exception` shape를 Pyright가 좁히지 못해 신규 `reportAttributeAccessIssue` 4개로 중단됐습니다. Predicate가 참인 adapter 분기에서만 `cast(Any, exc)`를 적용한 새 candidate를 만들었고, focused quality gate와 final official full을 통과했습니다. 실패 SHA에서는 full을 반복하지 않았습니다.

## 위험과 rollback

변경은 내부 response owner 이동이며 public/behavior 변경은 없습니다. 회귀 시 이 PR의 squash commit을 revert하면 됩니다.

## Next

남은 profile/전체 handler composition과 route registration 경계는 최신 dev에서 별도 inventory 후 rollback slice로 진행합니다.