### PR TITLE
refactor: bootstrap에서 settings route group 조합

### DIFF
--- a/api.py
+++ b/api.py
@@ -75,6 +75,9 @@ from .easyuse_anima.api.router import (
     build_route_signature as _build_route_signature,
     register_route_definitions as _register_route_definitions,
 )
+from .easyuse_anima.bootstrap import (
+    build_settings_route_group as _build_settings_route_group,
+)
 from .easyuse_anima.api.routes.aio_profile_mutations import (
     build_aio_profile_mutation_handlers as _build_aio_profile_mutation_handlers,
 )
@@ -84,9 +87,6 @@ from .easyuse_anima.api.routes.autocomplete import (
     build_classify_prompt_handler as _build_classify_prompt_handler,
 )
 from .easyuse_anima.api.routes import long_text_settings as _api_long_text_routes
-from .easyuse_anima.api.routes.long_text_settings import (
-    build_long_text_settings_handlers as _build_long_text_settings_handlers,
-)
 from .easyuse_anima.api.routes.lora_catalog import (
     build_loras_handler as _build_loras_handler,
 )
@@ -107,9 +107,6 @@ from .easyuse_anima.api.routes.profile_saves import (
     build_profile_save_handlers as _build_profile_save_handlers,
 )
 from .easyuse_anima.api.routes import settings as _api_settings_routes
-from .easyuse_anima.api.routes.settings import (
-    build_settings_handlers as _build_settings_handlers,
-)
 from .easyuse_anima.api.routes import wildcards as _api_wildcard_routes
 from .easyuse_anima.api.routes.wildcards import (
     build_wildcards_handler as _build_wildcards_handler,
@@ -354,50 +351,45 @@ if web is not None:
     (
         get_settings_handler,
         set_setting_handler,
-    ) = (
-        _request_correlated(handler)
-        for handler in _build_settings_handlers(
-            parse_json_object=parse_json_object,
-            json_string=json_string,
-            contract_error_type=ApiContractError,
-            contract_error_response=lambda exc: _contract_error_response(exc),
-            run_file_io=lambda function, *args, **kwargs: _run_file_io(
+        get_long_text_settings_handler,
+        save_long_text_settings_handler,
+    ) = _build_settings_route_group(
+        request_correlated=_request_correlated,
+        settings_dependencies={
+            "parse_json_object": parse_json_object,
+            "json_string": json_string,
+            "contract_error_type": ApiContractError,
+            "contract_error_response": lambda exc: _contract_error_response(exc),
+            "run_file_io": lambda function, *args, **kwargs: _run_file_io(
                 function,
                 *args,
                 **kwargs,
             ),
-            get_settings_payload=lambda: _get_settings_payload_sync(),
-            save_setting_payload=lambda key, value: _save_setting_payload_sync(
+            "get_settings_payload": lambda: _get_settings_payload_sync(),
+            "save_setting_payload": lambda key, value: _save_setting_payload_sync(
                 key,
                 value,
             ),
-            unknown_setting_error_type=KeyError,
-            unknown_setting_response=lambda: _error_response(
+            "unknown_setting_error_type": KeyError,
+            "unknown_setting_response": lambda: _error_response(
                 422,
                 "unknown_setting",
                 "Unknown setting",
             ),
-            json_response=lambda payload: web.json_response(payload),
-        )
-    )
-
-    (
-        get_long_text_settings_handler,
-        save_long_text_settings_handler,
-    ) = (
-        _request_correlated(handler)
-        for handler in _build_long_text_settings_handlers(
-            parse_json_object=lambda request: parse_json_object(request),
-            json_object=lambda data, field: json_object(data, field),
-            contract_error_type=ApiContractError,
-            contract_error_response=lambda exc: _contract_error_response(exc),
-            run_file_io=lambda function, *args: _run_file_io(function, *args),
-            get_long_text_settings_payload=lambda: _get_long_text_settings_payload_sync(),
-            save_long_text_settings_payload=lambda values: _save_long_text_settings_payload_sync(
+            "json_response": lambda payload: web.json_response(payload),
+        },
+        long_text_settings_dependencies={
+            "parse_json_object": lambda request: parse_json_object(request),
+            "json_object": lambda data, field: json_object(data, field),
+            "contract_error_type": ApiContractError,
+            "contract_error_response": lambda exc: _contract_error_response(exc),
+            "run_file_io": lambda function, *args: _run_file_io(function, *args),
+            "get_long_text_settings_payload": lambda: _get_long_text_settings_payload_sync(),
+            "save_long_text_settings_payload": lambda values: _save_long_text_settings_payload_sync(
                 values
             ),
-            json_response=lambda payload: web.json_response(payload),
-        )
+            "json_response": lambda payload: web.json_response(payload),
+        },
     )
 
     get_wildcards_handler = _request_correlated(

--- a/easyuse_anima/bootstrap.py
+++ b/easyuse_anima/bootstrap.py
@@ -6,6 +6,10 @@ import logging
 import threading
 from collections.abc import Callable
 
+from .api.routes.long_text_settings import (
+    build_long_text_settings_handlers as _build_long_text_settings_handlers,
+)
+from .api.routes.settings import build_settings_handlers as _build_settings_handlers
 from .infrastructure.comfy.provider import DefaultComfyHostProvider
 from .runtime import RuntimeServices, install_runtime
 from .seed.service import InMemorySeedReservationService
@@ -18,6 +22,21 @@ _DEFAULT_RUNTIME: RuntimeServices | None = None
 
 def _missing_comfy_nodes() -> None:
     return None
+
+
+def build_settings_route_group(
+    *,
+    request_correlated,
+    settings_dependencies,
+    long_text_settings_dependencies,
+):
+    """Compose the correlated settings route group from canonical factories."""
+
+    handlers = (
+        *_build_settings_handlers(**settings_dependencies),
+        *_build_long_text_settings_handlers(**long_text_settings_dependencies),
+    )
+    return tuple(request_correlated(handler) for handler in handlers)
 
 
 def initialize(

--- a/tests/fixtures/python_backend_baseline.json
+++ b/tests/fixtures/python_backend_baseline.json
@@ -3764,6 +3764,24 @@
         "target": "easyuse_anima/api/router.py"
       },
       {
+        "alias": "_build_settings_route_group",
+        "bound_name": "_build_settings_route_group",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".easyuse_anima.bootstrap:build_settings_route_group",
+        "kind": "static_from",
+        "line": 78,
+        "name": "build_settings_route_group",
+        "optional": false,
+        "requested": ".easyuse_anima.bootstrap",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "api.py",
+        "target": "easyuse_anima/bootstrap.py"
+      },
+      {
         "alias": "_build_aio_profile_mutation_handlers",
         "bound_name": "_build_aio_profile_mutation_handlers",
         "branch_context": [],
@@ -3772,7 +3790,7 @@
         "conditional": false,
         "imported": ".easyuse_anima.api.routes.aio_profile_mutations:build_aio_profile_mutation_handlers",
         "kind": "static_from",
-        "line": 78,
+        "line": 81,
         "name": "build_aio_profile_mutation_handlers",
         "optional": false,
         "requested": ".easyuse_anima.api.routes.aio_profile_mutations",
@@ -3790,7 +3808,7 @@
         "conditional": false,
         "imported": ".easyuse_anima.api.routes:autocomplete",
         "kind": "static_from",
-        "line": 81,
+        "line": 84,
         "name": "autocomplete",
         "optional": false,
         "requested": ".easyuse_anima.api.routes",
@@ -3808,7 +3826,7 @@
         "conditional": false,
         "imported": ".easyuse_anima.api.routes.autocomplete:build_autocomplete_handlers",
         "kind": "static_from",
-        "line": 82,
+        "line": 85,
         "name": "build_autocomplete_handlers",
         "optional": false,
         "requested": ".easyuse_anima.api.routes.autocomplete",
@@ -3826,7 +3844,7 @@
         "conditional": false,
         "imported": ".easyuse_anima.api.routes.autocomplete:build_classify_prompt_handler",
         "kind": "static_from",
-        "line": 82,
+        "line": 85,
         "name": "build_classify_prompt_handler",
         "optional": false,
         "requested": ".easyuse_anima.api.routes.autocomplete",
@@ -3844,28 +3862,10 @@
         "conditional": false,
         "imported": ".easyuse_anima.api.routes:long_text_settings",
         "kind": "static_from",
-        "line": 86,
+        "line": 89,
         "name": "long_text_settings",
         "optional": false,
         "requested": ".easyuse_anima.api.routes",
-        "role": "ordinary",
-        "scope": "<module>",
-        "source": "api.py",
-        "target": "easyuse_anima/api/routes/long_text_settings.py"
-      },
-      {
-        "alias": "_build_long_text_settings_handlers",
-        "bound_name": "_build_long_text_settings_handlers",
-        "branch_context": [],
-        "classification": "internal",
-        "column": 0,
-        "conditional": false,
-        "imported": ".easyuse_anima.api.routes.long_text_settings:build_long_text_settings_handlers",
-        "kind": "static_from",
-        "line": 87,
-        "name": "build_long_text_settings_handlers",
-        "optional": false,
-        "requested": ".easyuse_anima.api.routes.long_text_settings",
         "role": "ordinary",
         "scope": "<module>",
         "source": "api.py",
@@ -4016,24 +4016,6 @@
         "target": "easyuse_anima/api/routes/settings.py"
       },
       {
-        "alias": "_build_settings_handlers",
-        "bound_name": "_build_settings_handlers",
-        "branch_context": [],
-        "classification": "internal",
-        "column": 0,
-        "conditional": false,
-        "imported": ".easyuse_anima.api.routes.settings:build_settings_handlers",
-        "kind": "static_from",
-        "line": 110,
-        "name": "build_settings_handlers",
-        "optional": false,
-        "requested": ".easyuse_anima.api.routes.settings",
-        "role": "ordinary",
-        "scope": "<module>",
-        "source": "api.py",
-        "target": "easyuse_anima/api/routes/settings.py"
-      },
-      {
         "alias": "_api_wildcard_routes",
         "bound_name": "_api_wildcard_routes",
         "branch_context": [],
@@ -4042,7 +4024,7 @@
         "conditional": false,
         "imported": ".easyuse_anima.api.routes:wildcards",
         "kind": "static_from",
-        "line": 113,
+        "line": 110,
         "name": "wildcards",
         "optional": false,
         "requested": ".easyuse_anima.api.routes",
@@ -4060,7 +4042,7 @@
         "conditional": false,
         "imported": ".easyuse_anima.api.routes.wildcards:build_wildcards_handler",
         "kind": "static_from",
-        "line": 114,
+        "line": 111,
         "name": "build_wildcards_handler",
         "optional": false,
         "requested": ".easyuse_anima.api.routes.wildcards",
@@ -4078,7 +4060,7 @@
         "conditional": false,
         "imported": ".easyuse_anima.api.routes:translation",
         "kind": "static_from",
-        "line": 117,
+        "line": 114,
         "name": "translation",
         "optional": false,
         "requested": ".easyuse_anima.api.routes",
@@ -4096,7 +4078,7 @@
         "conditional": false,
         "imported": ".easyuse_anima.api.routes.translation:build_translate_prompt_handler",
         "kind": "static_from",
-        "line": 118,
+        "line": 115,
         "name": "build_translate_prompt_handler",
         "optional": false,
         "requested": ".easyuse_anima.api.routes.translation",
@@ -4114,7 +4096,7 @@
         "conditional": false,
         "imported": ".easyuse_anima.api.routes.translation_execution:PromptTranslationRouteExecutor",
         "kind": "static_from",
-        "line": 121,
+        "line": 118,
         "name": "PromptTranslationRouteExecutor",
         "optional": false,
         "requested": ".easyuse_anima.api.routes.translation_execution",
@@ -4132,7 +4114,7 @@
         "conditional": false,
         "imported": ".easyuse_anima.api.routes.aio_torch_compile:build_aio_torch_compile_recommend_handler",
         "kind": "static_from",
-        "line": 124,
+        "line": 121,
         "name": "build_aio_torch_compile_recommend_handler",
         "optional": false,
         "requested": ".easyuse_anima.api.routes.aio_torch_compile",
@@ -4150,7 +4132,7 @@
         "conditional": false,
         "imported": ".easyuse_anima.aio.torch_compile_diagnostics:collect_torch_compile_diagnostics",
         "kind": "static_from",
-        "line": 127,
+        "line": 124,
         "name": "collect_torch_compile_diagnostics",
         "optional": false,
         "requested": ".easyuse_anima.aio.torch_compile_diagnostics",
@@ -4168,7 +4150,7 @@
         "conditional": false,
         "imported": ".easyuse_anima.aio.torch_compile_recommendation:recommend_torch_compile",
         "kind": "static_from",
-        "line": 130,
+        "line": 127,
         "name": "recommend_torch_compile",
         "optional": false,
         "requested": ".easyuse_anima.aio.torch_compile_recommendation",
@@ -4186,7 +4168,7 @@
         "conditional": false,
         "imported": ".easyuse_anima.profiles:aio",
         "kind": "static_from",
-        "line": 133,
+        "line": 130,
         "name": "aio",
         "optional": false,
         "requested": ".easyuse_anima.profiles",
@@ -4204,7 +4186,7 @@
         "conditional": false,
         "imported": ".easyuse_anima.profiles:contract",
         "kind": "static_from",
-        "line": 134,
+        "line": 131,
         "name": "contract",
         "optional": false,
         "requested": ".easyuse_anima.profiles",
@@ -4222,7 +4204,7 @@
         "conditional": false,
         "imported": ".easyuse_anima.profiles:lora",
         "kind": "static_from",
-        "line": 135,
+        "line": 132,
         "name": "lora",
         "optional": false,
         "requested": ".easyuse_anima.profiles",
@@ -4240,7 +4222,7 @@
         "conditional": false,
         "imported": ".easyuse_anima.profiles:mutation",
         "kind": "static_from",
-        "line": 136,
+        "line": 133,
         "name": "mutation",
         "optional": false,
         "requested": ".easyuse_anima.profiles",
@@ -4258,7 +4240,7 @@
         "conditional": false,
         "imported": ".easyuse_anima.profiles:repository",
         "kind": "static_from",
-        "line": 137,
+        "line": 134,
         "name": "repository",
         "optional": false,
         "requested": ".easyuse_anima.profiles",
@@ -17170,6 +17152,42 @@
         "source": "easyuse_anima/bootstrap.py"
       },
       {
+        "alias": "_build_long_text_settings_handlers",
+        "bound_name": "_build_long_text_settings_handlers",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".api.routes.long_text_settings:build_long_text_settings_handlers",
+        "kind": "static_from",
+        "line": 9,
+        "name": "build_long_text_settings_handlers",
+        "optional": false,
+        "requested": ".api.routes.long_text_settings",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/bootstrap.py",
+        "target": "easyuse_anima/api/routes/long_text_settings.py"
+      },
+      {
+        "alias": "_build_settings_handlers",
+        "bound_name": "_build_settings_handlers",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".api.routes.settings:build_settings_handlers",
+        "kind": "static_from",
+        "line": 12,
+        "name": "build_settings_handlers",
+        "optional": false,
+        "requested": ".api.routes.settings",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/bootstrap.py",
+        "target": "easyuse_anima/api/routes/settings.py"
+      },
+      {
         "alias": null,
         "bound_name": "DefaultComfyHostProvider",
         "branch_context": [],
@@ -17178,7 +17196,7 @@
         "conditional": false,
         "imported": ".infrastructure.comfy.provider:DefaultComfyHostProvider",
         "kind": "static_from",
-        "line": 9,
+        "line": 13,
         "name": "DefaultComfyHostProvider",
         "optional": false,
         "requested": ".infrastructure.comfy.provider",
@@ -17196,7 +17214,7 @@
         "conditional": false,
         "imported": ".runtime:RuntimeServices",
         "kind": "static_from",
-        "line": 10,
+        "line": 14,
         "name": "RuntimeServices",
         "optional": false,
         "requested": ".runtime",
@@ -17214,7 +17232,7 @@
         "conditional": false,
         "imported": ".runtime:install_runtime",
         "kind": "static_from",
-        "line": 10,
+        "line": 14,
         "name": "install_runtime",
         "optional": false,
         "requested": ".runtime",
@@ -17232,7 +17250,7 @@
         "conditional": false,
         "imported": ".seed.service:InMemorySeedReservationService",
         "kind": "static_from",
-        "line": 11,
+        "line": 15,
         "name": "InMemorySeedReservationService",
         "optional": false,
         "requested": ".seed.service",
@@ -63744,6 +63762,10 @@
       },
       {
         "from": "api.py",
+        "to": "easyuse_anima/bootstrap.py"
+      },
+      {
+        "from": "api.py",
         "to": "easyuse_anima/profiles/aio.py"
       },
       {
@@ -64361,6 +64383,14 @@
       {
         "from": "easyuse_anima/autocomplete/search.py",
         "to": "easyuse_anima/infrastructure/filesystem/paths.py"
+      },
+      {
+        "from": "easyuse_anima/bootstrap.py",
+        "to": "easyuse_anima/api/routes/long_text_settings.py"
+      },
+      {
+        "from": "easyuse_anima/bootstrap.py",
+        "to": "easyuse_anima/api/routes/settings.py"
       },
       {
         "from": "easyuse_anima/bootstrap.py",
@@ -66578,9 +66608,9 @@
       },
       {
         "is_package": false,
-        "loc": 657,
+        "loc": 649,
         "module": "api",
-        "normalized_git_blob_sha1": "deae7e368d391c3e850ee4b4fbc86052db3c1273",
+        "normalized_git_blob_sha1": "842604e84cd0026c6fea4ce533c77c28da9f6bf4",
         "path": "api.py",
         "top_level": {
           "class_count": 0,
@@ -67358,13 +67388,13 @@
       },
       {
         "is_package": false,
-        "loc": 57,
+        "loc": 76,
         "module": "easyuse_anima.bootstrap",
-        "normalized_git_blob_sha1": "cb2cd3859544d21d822bcab887daaf27af629254",
+        "normalized_git_blob_sha1": "ae979e3b91f4dd2671edae5d34eb857458d84e25",
         "path": "easyuse_anima/bootstrap.py",
         "top_level": {
           "class_count": 0,
-          "function_count": 2,
+          "function_count": 3,
           "global_count": 5
         }
       },
@@ -89151,7 +89181,7 @@
         "column": 10,
         "context": "assign:_LOGGER",
         "kind": "import_time_call",
-        "line": 218,
+        "line": 215,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -89160,7 +89190,7 @@
         "column": 4,
         "context": "assign:_PROMPT_TRANSLATION_WORKER,_prompt_translation_error_response,_translate_prompt_for_route,_translate_prompt_sync",
         "kind": "route_registry_creation",
-        "line": 226,
+        "line": 223,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -89169,7 +89199,7 @@
         "column": 18,
         "context": "assign:_error_response",
         "kind": "import_time_call",
-        "line": 244,
+        "line": 241,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -89178,7 +89208,7 @@
         "column": 27,
         "context": "assign:_contract_error_response",
         "kind": "import_time_call",
-        "line": 252,
+        "line": 249,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -89187,7 +89217,7 @@
         "column": 22,
         "context": "assign:_request_correlated",
         "kind": "import_time_call",
-        "line": 255,
+        "line": 252,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -89196,7 +89226,7 @@
         "column": 29,
         "context": "assign:_resolve_lora_preview_path",
         "kind": "route_registry_creation",
-        "line": 268,
+        "line": 265,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -89205,7 +89235,7 @@
         "column": 4,
         "context": "assign:_SAFE_PROFILE_VALIDATION_MESSAGES,_profile_error_response",
         "kind": "import_time_call",
-        "line": 281,
+        "line": 278,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -89214,7 +89244,7 @@
         "column": 4,
         "context": "assign:_get_settings_payload_sync,_save_setting_payload_sync",
         "kind": "route_registry_creation",
-        "line": 299,
+        "line": 296,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -89223,7 +89253,7 @@
         "column": 4,
         "context": "assign:_get_long_text_settings_payload_sync,_save_long_text_settings_payload_sync",
         "kind": "route_registry_creation",
-        "line": 308,
+        "line": 305,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -89232,7 +89262,7 @@
         "column": 26,
         "context": "assign:_wildcards_payload_sync",
         "kind": "route_registry_creation",
-        "line": 315,
+        "line": 312,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -89241,7 +89271,7 @@
         "column": 4,
         "context": "assign:_autocomplete_status_payload_sync,_classify_prompt_payload_sync,_public_autocomplete_payload,_public_autocomplete_status,_search_autocomplete_payload_sync",
         "kind": "route_registry_creation",
-        "line": 328,
+        "line": 325,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -89250,7 +89280,7 @@
         "column": 21,
         "context": "assign:_get_prompt_routes",
         "kind": "route_registry_creation",
-        "line": 345,
+        "line": 342,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -89259,43 +89289,16 @@
         "column": 9,
         "context": "assign:routes",
         "kind": "route_registry_creation",
-        "line": 350,
+        "line": 347,
         "module": "api.py",
         "scope": "<module>"
       },
       {
-        "callee": "_request_correlated",
+        "callee": "_build_settings_route_group",
         "column": 8,
-        "context": "assign:get_settings_handler,set_setting_handler",
-        "kind": "import_time_call",
-        "line": 358,
-        "module": "api.py",
-        "scope": "<module>"
-      },
-      {
-        "callee": "_build_settings_handlers",
-        "column": 23,
-        "context": "assign:get_settings_handler,set_setting_handler",
-        "kind": "import_time_call",
-        "line": 359,
-        "module": "api.py",
-        "scope": "<module>"
-      },
-      {
-        "callee": "_request_correlated",
-        "column": 8,
-        "context": "assign:get_long_text_settings_handler,save_long_text_settings_handler",
-        "kind": "import_time_call",
-        "line": 388,
-        "module": "api.py",
-        "scope": "<module>"
-      },
-      {
-        "callee": "_build_long_text_settings_handlers",
-        "column": 23,
-        "context": "assign:get_long_text_settings_handler,save_long_text_settings_handler",
-        "kind": "import_time_call",
-        "line": 389,
+        "context": "assign:get_long_text_settings_handler,get_settings_handler,save_long_text_settings_handler,set_setting_handler",
+        "kind": "route_registry_creation",
+        "line": 356,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -89304,7 +89307,7 @@
         "column": 28,
         "context": "assign:get_wildcards_handler",
         "kind": "import_time_call",
-        "line": 403,
+        "line": 395,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -89313,7 +89316,7 @@
         "column": 8,
         "context": "assign:get_wildcards_handler",
         "kind": "import_time_call",
-        "line": 404,
+        "line": 396,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -89322,7 +89325,7 @@
         "column": 8,
         "context": "assign:autocomplete_handler,autocomplete_status_handler",
         "kind": "import_time_call",
-        "line": 415,
+        "line": 407,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -89331,7 +89334,7 @@
         "column": 23,
         "context": "assign:autocomplete_handler,autocomplete_status_handler",
         "kind": "import_time_call",
-        "line": 416,
+        "line": 408,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -89340,7 +89343,7 @@
         "column": 30,
         "context": "assign:classify_prompt_handler",
         "kind": "import_time_call",
-        "line": 426,
+        "line": 418,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -89349,7 +89352,7 @@
         "column": 8,
         "context": "assign:classify_prompt_handler",
         "kind": "import_time_call",
-        "line": 427,
+        "line": 419,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -89358,7 +89361,7 @@
         "column": 31,
         "context": "assign:translate_prompt_handler",
         "kind": "import_time_call",
-        "line": 445,
+        "line": 437,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -89367,7 +89370,7 @@
         "column": 8,
         "context": "assign:translate_prompt_handler",
         "kind": "import_time_call",
-        "line": 446,
+        "line": 438,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -89376,7 +89379,7 @@
         "column": 42,
         "context": "assign:aio_torch_compile_recommend_handler",
         "kind": "import_time_call",
-        "line": 458,
+        "line": 450,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -89385,7 +89388,7 @@
         "column": 8,
         "context": "assign:aio_torch_compile_recommend_handler",
         "kind": "import_time_call",
-        "line": 459,
+        "line": 451,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -89394,7 +89397,7 @@
         "column": 27,
         "context": "assign:lora_preview_handler",
         "kind": "import_time_call",
-        "line": 475,
+        "line": 467,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -89403,7 +89406,7 @@
         "column": 8,
         "context": "assign:lora_preview_handler",
         "kind": "import_time_call",
-        "line": 476,
+        "line": 468,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -89412,7 +89415,7 @@
         "column": 20,
         "context": "assign:loras_handler",
         "kind": "import_time_call",
-        "line": 485,
+        "line": 477,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -89421,7 +89424,7 @@
         "column": 8,
         "context": "assign:loras_handler",
         "kind": "import_time_call",
-        "line": 486,
+        "line": 478,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -89430,7 +89433,7 @@
         "column": 8,
         "context": "assign:aio_profiles_handler,lora_profiles_handler",
         "kind": "import_time_call",
-        "line": 497,
+        "line": 489,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -89439,7 +89442,7 @@
         "column": 23,
         "context": "assign:aio_profiles_handler,lora_profiles_handler",
         "kind": "import_time_call",
-        "line": 498,
+        "line": 490,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -89448,7 +89451,7 @@
         "column": 8,
         "context": "assign:load_aio_profile_handler,load_lora_profile_handler",
         "kind": "import_time_call",
-        "line": 512,
+        "line": 504,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -89457,7 +89460,7 @@
         "column": 23,
         "context": "assign:load_aio_profile_handler,load_lora_profile_handler",
         "kind": "import_time_call",
-        "line": 513,
+        "line": 505,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -89466,7 +89469,7 @@
         "column": 8,
         "context": "assign:save_aio_profile_handler,save_lora_profile_handler",
         "kind": "import_time_call",
-        "line": 533,
+        "line": 525,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -89475,7 +89478,7 @@
         "column": 23,
         "context": "assign:save_aio_profile_handler,save_lora_profile_handler",
         "kind": "import_time_call",
-        "line": 534,
+        "line": 526,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -89484,7 +89487,7 @@
         "column": 8,
         "context": "assign:delete_aio_profile_handler,rename_aio_profile_handler",
         "kind": "import_time_call",
-        "line": 568,
+        "line": 560,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -89493,7 +89496,7 @@
         "column": 23,
         "context": "assign:delete_aio_profile_handler,rename_aio_profile_handler",
         "kind": "import_time_call",
-        "line": 569,
+        "line": 561,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -89502,7 +89505,7 @@
         "column": 31,
         "context": "assign:fix_lora_profile_handler",
         "kind": "import_time_call",
-        "line": 600,
+        "line": 592,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -89511,7 +89514,7 @@
         "column": 8,
         "context": "assign:fix_lora_profile_handler",
         "kind": "import_time_call",
-        "line": 601,
+        "line": 593,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -89520,7 +89523,7 @@
         "column": 25,
         "context": "assign:_ROUTE_DEFINITIONS",
         "kind": "route_registry_creation",
-        "line": 616,
+        "line": 608,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -89529,7 +89532,7 @@
         "column": 19,
         "context": "assign:_ROUTE_SIGNATURE",
         "kind": "route_registry_creation",
-        "line": 643,
+        "line": 635,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -89538,7 +89541,7 @@
         "column": 18,
         "context": "assign:register_routes",
         "kind": "route_registry_creation",
-        "line": 646,
+        "line": 638,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -90537,7 +90540,7 @@
         "column": 10,
         "context": "assign:_LOGGER",
         "kind": "import_time_call",
-        "line": 13,
+        "line": 17,
         "module": "easyuse_anima/bootstrap.py",
         "scope": "<module>"
       },
@@ -90546,7 +90549,7 @@
         "column": 19,
         "context": "assign:_INITIALIZE_LOCK",
         "kind": "import_time_call",
-        "line": 14,
+        "line": 18,
         "module": "easyuse_anima/bootstrap.py",
         "scope": "<module>"
       },
@@ -91522,7 +91525,7 @@
       },
       {
         "kind": "list",
-        "line": 57,
+        "line": 76,
         "module": "easyuse_anima/bootstrap.py",
         "name": "__all__"
       },
@@ -91924,7 +91927,7 @@
           "lock"
         ],
         "initializer": "threading.Lock",
-        "line": 14,
+        "line": 18,
         "module": "easyuse_anima/bootstrap.py",
         "name": "_INITIALIZE_LOCK"
       },

--- a/tests/test_api_contract.py
+++ b/tests/test_api_contract.py
@@ -181,6 +181,15 @@ class ApiRouteRegistrationOwnerTests(unittest.TestCase):
             )
         )
         self.assertTrue(
+            api._build_settings_route_group.__module__.endswith(
+                ".easyuse_anima.bootstrap"
+            )
+        )
+        self.assertNotIn(
+            "build_settings_route_group",
+            sys.modules[api._build_settings_route_group.__module__].__all__,
+        )
+        self.assertTrue(
             api._register_route_definitions.__module__.endswith(
                 ".easyuse_anima.api.router"
             )


### PR DESCRIPTION
## 목적과 변경 경계

Issue #186 D-08n으로 settings/long-text settings 네 handler의 factory invocation과 request-correlation 조합을 production composition root로 이동합니다.

- Base: `a774cd0309795ff9629dddfe02cb50b19f211530` (`dev`)
- Head: `6926261684a4cb25d48cda98c7c2f2161a6e74e9`
- `api/router.py`는 concrete route를 import하지 않으며 기존 ordered definitions/signature/idempotent registration 책임만 유지합니다.
- root `api.py`는 전환 기간의 outer facade로서 기존 dependency callback mapping을 bootstrap private builder에 주입합니다.
- route behavior, exact 21-route order/signature, bootstrap initialize order/retry semantics와 다른 17 handlers는 변경하지 않습니다.

## 주요 파일과 보존 계약

- `easyuse_anima/bootstrap.py`: settings route group private composition builder
- `api.py`: 기존 두 factory 직접 호출을 bootstrap builder 호출로 교체
- `tests/test_api_contract.py`: composition owner와 비공개 surface 계약
- `tests/fixtures/python_backend_baseline.json`: 새 `api.py -> bootstrap -> api/routes` import graph

`build_settings_route_group`은 bootstrap `__all__`에 노출하지 않습니다. #165/G-03a import-boundary 계약은 그대로 유지합니다.

## 검증

- changed-file AST / `git diff --check`: 통과
- focused:
  - settings 8
  - long-text settings 5
  - route registration owner 4
  - Python bootstrap 5
  - RuntimeServices 8
  - 전체 API contract 94
  - backend analyzer 18
  - API compatibility 3
  - Registry scanner 8
  - current repository import-boundary 1
  - compatibility surface 26
  - package skeleton direct import/no-side-effect 1
- Python quality:
  - Ruff report-only 기존 120 findings
  - Pyright 기존 14 / 신규 0
  - completed import groups 11 / violations 0
- final candidate official full, 정확히 1회:
  - Python unittest 1316
  - frontend 120 JavaScript files
  - 전체 통과
- package:
  - `comfy node validate` 통과
  - `comfy node pack` 308 entries, CRC 오류 없음
- isolated live:
  - installed/source hashes 일치
  - invalid settings 두 요청 모두 400/`json_object_required`
  - header/body request ID 일치 및 요청 간 distinct
  - settings 200, queue 0/0
  - test instance process/listener 정리 완료

## 남은 위험과 rollback

bootstrap import closure에 import-pure settings route factory 두 모듈이 추가됩니다. package-skeleton direct import와 import-time side-effect gate로 방어했으며, 문제 시 이 단일 commit을 revert할 수 있습니다.

## Next

D-08o도 동일한 bootstrap outer composition owner를 사용합니다. root `api.py` shim/삭제는 모든 root-only dependency seam이 해소된 뒤 별도 final cutover로 진행합니다.

Refs #186