### PR TITLE
docs: D-08 route composition owner 명확화

### DIFF
--- a/docs/architecture/python-backend.md
+++ b/docs/architecture/python-backend.md
@@ -179,16 +179,26 @@ ComfyUI-EasyUseAnima/
 | --- | --- | --- | --- |
 | Root `__init__.py` | ComfyUI entrypoint | `WEB_DIRECTORY`, exported mappings, one guarded bootstrap call | feature rules, repositories, caches, route implementations |
 | Root compatibility files | [shim registry](python-compatibility-shims.md) | explicit direct re-exports and `__all__` | wrappers/subclasses, star imports, new logic, I/O, clients, caches |
-| `bootstrap.py` | production composition | `RuntimeConfig`, factories, route registration, user-directory initialization, initialize/shutdown | Prompt rules, schemas, ranking, AiO stages |
+| `bootstrap.py` | production composition | `RuntimeConfig`, factories, concrete route factory/dependency/correlation wiring, the single production route-registration call site, user-directory initialization, initialize/shutdown | Prompt rules, schemas, ranking, AiO stages |
 | `runtime.py` | process runtime | access to the single production `RuntimeServices`, lifecycle state | feature behavior or request-local mutable state |
 | `registration.py` | node registration | class/display mapping composition | file/network access, routes, service creation, cache initialization |
 | `nodes/*_nodes.py` | ComfyUI adapters | node metadata, raw-to-typed conversion, service call, ComfyUI output/UI conversion | persistence, migration, provider HTTP, cache implementation, invoking another node class for reuse |
-| `api/router.py`, `api/routes/*` | HTTP adapters | route composition, request parse, service call, response/error mapping | repository internals, filesystem writes, source scanning, provider construction, mutable module cache |
+| `api/router.py` | HTTP routing infrastructure | injected handler order, route definitions/signature, resolver/registrar, idempotent route-table registration | concrete route factories, `api/routes/*` imports, feature dependency wiring, provider construction |
+| `api/routes/*` | HTTP feature adapters | request parse, service call, response/error mapping | route-table lifecycle/registration, repository internals, filesystem writes, source scanning, provider construction, mutable module cache |
 | Feature packages | feature owner | domain rules, typed request/result/config, validation, use cases, feature migrations and ports | node/API adapters, registration/bootstrap, root shims |
 | `infrastructure/comfy` | ComfyUI integration | capability discovery, invocation, resources, events, paths | feature schema meaning, node classes |
 | `infrastructure/filesystem` | generic persistence | atomic JSON publish, locks, path primitives | profile revisions, settings keys, workflow semantics |
 | `infrastructure/http` | transport | client lifecycle, timeout and transport primitives | provider-specific feature policy |
 | `common` | cross-feature primitives | coercion/serialization proven to be domain-neutral | Prompt, AiO, profile, or settings meaning; miscellaneous helpers |
+
+Here, router composition means binding injected handlers to the canonical
+ordered route definitions. Bootstrap owns the concrete route factories,
+dependency callbacks, and correlation wiring, then invokes registration from
+the single production call site. “Single” is not process-once: every
+`initialize` refreshes the current route table, identical signatures remain
+idempotent, and a new table is registered. During the transition, root
+`api.py` only forwards legacy callback mappings into bootstrap; it is not the
+durable composition owner and remains subject to the existing removal gate.
 
 ## RuntimeServices and lifecycle
 
@@ -311,7 +321,7 @@ while changing profile migration semantics.
 | Phase A - baseline | A-01 whole-backend AST inventory; A-02 public node/workflow snapshot; A-03 report-only import gate; A-04 ADR/shim policy. PR #189 is only an A-02/A-03 seed. | Deterministic inventory, real current-surface reports, versioned public fixtures, and these docs exist independently. No production move is hidden here. |
 | Phase B - `nodes.py` extraction | B-01 package/archive skeleton; B-02 common primitives; B-03 Comfy adapters; B-04 through B-10 vertical Move PRs; B-11 registration/bootstrap and `nodes.py` shim. Owned by #184. | `nodes.py` is an explicit re-export shim, node implementations live under `easyuse_anima`, and node/workflow parity plus package closure pass. |
 | Phase C - feature contracts/behavior | #162 Autocomplete, #163 profile/storage, #164 translation, #165 API, #167 seed, #168 AiO schema, #169 AiO stage/cache. #166 is the adjacent frontend lifecycle registry and is explicitly excluded; it does not gate this or any other Python backend phase. These Python PRs remain separate from moves. | Each feature's contract and behavior are stable enough for its D/E move; unresolved behavior is not smuggled into a move. |
-| Phase D - root consolidation | D-01 translation; D-02 API contracts; D-03 through D-07 route groups and router composition; D-08 filesystem; D-09 settings; D-10 profiles; D-11 autocomplete; D-12 wildcard; D-13 `anima_prompt`; D-14 root shim surface freeze. Owned by #186. | All production implementations use `easyuse_anima`; root files are entrypoints or explicit shims; internal root-shim imports are zero. |
+| Phase D - root consolidation | D-01 translation; D-02 API contracts; D-03 through D-07 route groups and injected route-table composition, with concrete wiring in bootstrap; D-08 filesystem; D-09 settings; D-10 profiles; D-11 autocomplete; D-12 wildcard; D-13 `anima_prompt`; D-14 root shim surface freeze. Owned by #186. | All production implementations use `easyuse_anima`; root files are entrypoints or explicit shims; internal root-shim imports are zero. |
 | Phase E - runtime ownership | E-01 global-state inventory; E-02 base runtime; E-03 through E-08 feature owners; E-09 idempotent lifecycle; E-10 isolated test runtime. Owned by #187. | Every process-wide cache/lock/client/executor/repository/capability has one owner and tested initialize/shutdown/partial-failure behavior. |
 | Phase F - typed boundaries | Extend #163/#165/#168 patterns to settings/profile/workflow, API, Prompt, Wildcard, Autocomplete, and AiO; establish the common error taxonomy. | Raw dictionaries remain only at adapter/migration boundaries; migrations and error mappings are versioned and tested. |
 | Phase G - quality ratchet | G-01 Ruff report-only; G-02 Pyright baseline; G-03 import-boundary fail gate; G-04 public API snapshot; G-05 size/complexity ratchet; G-06 test ownership layout. Owned by #188. | Fixed-version, offline-reproducible gates reject new violations without hiding existing debt. |


### PR DESCRIPTION
## 목적

Issue #186의 D-08 composition-owner 설명을 PRO 결정 B와 merge된 #509 구현에 맞춥니다.

- Base: `fd8b0b047134c3e530f76696dd49302dc5074e6f`
- Head: `0e7dba35f5f15b38584ec85e5d1adae78714f84b`
- 변경: `docs/architecture/python-backend.md` 한 파일

## 문서 계약

- bootstrap: concrete route factory/dependency/correlation wiring과 single production registration call-site
- router: 주입된 handler order/definition/signature/resolver/registrar/idempotent table registration
- route modules: request parse/service call/response mapping
- `single`은 process-once가 아니며, 매 initialize에서 현재 table을 refresh
- root `api.py`는 임시 callback-forwarding facade이며 durable owner가 아님
- #165/G-03a boundary와 기존 root-api removal gate 유지

## 검증

- owner 용어 exact search: 통과
- 로컬 architecture link target: 통과
- `git diff --check`: 통과
- docs-only 변경이므로 #509의 code full/package/live 증거를 무효화하지 않으며 재실행하지 않음

## 위험과 rollback

동작 변경은 없습니다. 문구가 구현/ADR과 어긋날 경우 이 한 commit만 revert할 수 있습니다.

## Next

최신 dev에서 D-08o concrete wiring을 같은 bootstrap owner로 이동합니다.

Refs #186