### PR TITLE
fix: Prompt Studio 하이라이트 줄바꿈 폭 일치

### DIFF
--- a/tests/frontend_highlight_overlay_core_smoke.mjs
+++ b/tests/frontend_highlight_overlay_core_smoke.mjs
@@ -28,6 +28,8 @@ Object.assign(style, {
   borderRightWidth: "1px",
   borderTopWidth: "2px",
   borderBottomWidth: "2px",
+  overflowY: "auto",
+  paddingLeft: "4px",
   paddingRight: "4px",
   paddingBottom: "6px",
   font: "12px sans-serif",
@@ -41,6 +43,7 @@ const input = {
   offsetHeight: 80,
   clientWidth: 100,
   clientHeight: 70,
+  scrollHeight: 140,
   scrollTop: 17,
   scrollLeft: 5,
 };
@@ -53,6 +56,32 @@ const overlay = {
 const padding = overlayScrollbarPadding(input, style);
 assert(padding.right === "22px", "Vertical scrollbar padding changed");
 assert(padding.bottom === "12px", "Horizontal scrollbar padding changed");
+
+const noScrollbarStyle = { ...style, overflowY: "hidden" };
+const noScrollbarInput = { ...input, scrollHeight: input.clientHeight };
+const noScrollbarPadding = overlayScrollbarPadding(noScrollbarInput, noScrollbarStyle);
+assert(
+  noScrollbarPadding.right === "4px",
+  "Hidden overflow must not reserve a vertical scrollbar gutter",
+);
+const textareaWrapWidth = input.offsetWidth
+  - Number.parseFloat(style.borderLeftWidth)
+  - Number.parseFloat(style.borderRightWidth)
+  - Number.parseFloat(style.paddingLeft)
+  - Number.parseFloat(style.paddingRight);
+const overlayWrapWidth = input.offsetWidth
+  - Number.parseFloat(style.borderLeftWidth)
+  - Number.parseFloat(style.borderRightWidth)
+  - Number.parseFloat(style.paddingLeft)
+  - Number.parseFloat(noScrollbarPadding.right);
+assert(
+  overlayWrapWidth === textareaWrapWidth,
+  "No-scrollbar overlay and textarea effective wrap widths diverged",
+);
+assert(
+  overlayScrollbarPadding(noScrollbarInput, style).right === "4px",
+  "Auto overflow without content overflow must not reserve a scrollbar gutter",
+);
 assert(
   JSON.stringify(overlayBounds(input)) === JSON.stringify({
     left: "8px",

--- a/web/js/prompt_studio/highlight_overlay_core.js
+++ b/web/js/prompt_studio/highlight_overlay_core.js
@@ -69,16 +69,33 @@ function cssPixel(value) {
 
 /**
  * @param {HTMLTextAreaElement | HTMLInputElement} input
+ * @param {CSSStyleDeclaration} style
+ */
+function hasVisibleVerticalScrollbar(input, style) {
+  const overflowY = String(style.overflowY || "").trim().toLowerCase();
+  if (overflowY === "scroll") {
+    return true;
+  }
+  if (overflowY !== "auto" && overflowY !== "overlay") {
+    return false;
+  }
+  return (Number(input.scrollHeight) || 0) > (Number(input.clientHeight) || 0);
+}
+
+/**
+ * @param {HTMLTextAreaElement | HTMLInputElement} input
  * @param {CSSStyleDeclaration} [style]
  */
 function overlayScrollbarPadding(input, style = getComputedStyle(input)) {
-  const verticalGutter = Math.max(
-    0,
-    (Number(input.offsetWidth) || 0)
-      - (Number(input.clientWidth) || 0)
-      - cssPixelNumber(style.borderLeftWidth)
-      - cssPixelNumber(style.borderRightWidth),
-  );
+  const verticalGutter = hasVisibleVerticalScrollbar(input, style)
+    ? Math.max(
+      0,
+      (Number(input.offsetWidth) || 0)
+        - (Number(input.clientWidth) || 0)
+        - cssPixelNumber(style.borderLeftWidth)
+        - cssPixelNumber(style.borderRightWidth),
+    )
+    : 0;
   const horizontalGutter = Math.max(
     0,
     (Number(input.offsetHeight) || 0)


### PR DESCRIPTION
## 목적과 변경 경계

Prompt Studio의 투명 editable textarea와 visible highlight overlay가 세로 scrollbar가 없는 상태에서 같은 유효 wrap 폭을 사용하도록 수정합니다.

Base 6df01023c1a535e4e8f27df01251e0024985feae -> Head 50b1e2c21d0253f9ea8030272c29b01765f68398

## 주요 변경

- offset/client geometry 차이를 무조건 vertical scrollbar gutter로 더하지 않습니다.
- overflowY가 scroll이면 기존 gutter를 유지합니다.
- overflowY가 auto 또는 overlay이면 실제 scrollHeight가 clientHeight를 넘을 때만 gutter를 유지합니다.
- hidden과 no-overflow 상태에서는 textarea의 원래 right padding만 overlay에 복사합니다.
- hidden no-scrollbar, auto no-overflow, real overflow와 effective wrap-width parity fixture를 고정합니다.

## 보존 계약

- font, line-height, padding, border와 overlay bounds
- scrollTop/scrollLeft 동기화
- Classic, Advanced/AdvancedV2, Regional의 shared overlay core 사용
- textarea autosize와 수동 resize
- highlight token 및 autocomplete preview HTML
- Node 2.0/Legacy Canvas DOM widget, workflow serialization, backend/API 계약

## 검증

- node --check on both changed files: PASS
- frontend_highlight_overlay_core_smoke.mjs: PASS
- focused ownership unittest: 1/1 PASS
- final candidate official full: Python 1316, frontend 120, TypeScript 6.0.3, Pyright/import boundary/diff PASS
- git diff --check: PASS

## 남은 위험 / 미검증

- semantic fixture와 official full로 scrollbar 유무 및 wrap-width 계산을 검증했습니다.
- 이 PR에서 실제 Legacy Canvas/Node 2.0 browser smoke는 실행하지 않았습니다. backend/API/package 계약은 변경하지 않습니다.

Fixes #514