### PR TITLE
fix: restore LoRA Preset runtime for 0.6.2

### DIFF
--- a/.github/registry/changelogs/0.6.2.txt
+++ b/.github/registry/changelogs/0.6.2.txt
@@ -1,0 +1,8 @@
+EasyUse Anima 0.6.2 restores LoRA Preset loading on supported ComfyUI frontends.
+
+Changes:
+1. Fixed the LoRA Preset profile bar and menus failing to draw when ComfyUI exposes LiteGraph through its host runtime binding.
+2. Existing presets, saved profiles, workflows, and other 0.6.1 features remain unchanged.
+
+Action required:
+After updating, restart ComfyUI and hard-refresh the browser.

--- a/.github/registry/metadata.json
+++ b/.github/registry/metadata.json
@@ -19,6 +19,11 @@
   },
   "versions": [
     {
+      "version": "0.6.2",
+      "deprecated": false,
+      "changelog_file": "changelogs/0.6.2.txt"
+    },
+    {
       "version": "0.6.1",
       "deprecated": false,
       "changelog_file": "changelogs/0.6.1.txt"

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,5 +1,21 @@
 # Release Notes
 
+## 0.6.2
+
+### Fixed
+
+- LoRA Preset now opens and draws its profile bar and menus when supported
+  ComfyUI frontends provide LiteGraph through their host runtime binding.
+
+### Compatibility
+
+- Existing LoRA presets, saved profiles, workflows, public node identifiers,
+  socket ordering, and the other 0.6.1 features remain unchanged.
+
+### Update
+
+- After updating, restart ComfyUI and hard-refresh the browser.
+
 ## 0.6.1
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "comfyui-easyuse-anima"
 description = "Prompt editing, ANIMA prompt correction, NAIA prompt integration, LoRA preset management, wildcard expansion, AiO generation, and ANIMA/Spectrum workflow helpers for ComfyUI."
-version = "0.6.1"
+version = "0.6.2"
 readme = "README.md"
 license = { file = "LICENSE" }
 requires-python = ">=3.10"

--- a/tests/test_frontend_lora_preset.py
+++ b/tests/test_frontend_lora_preset.py
@@ -79,7 +79,18 @@ class LoraPresetFrontendTests(unittest.TestCase):
                     source,
                 )
         self.assertIn("function loraLiteGraphRuntime()", source)
-        self.assertIn("}} */ (globalThis).LiteGraph;", source)
+        self.assertIn(
+            "// @ts-expect-error ComfyUI provides LiteGraph as a host lexical global.\n"
+            "  return LiteGraph;",
+            source,
+        )
+        self.assertIn(" * @returns {{", source)
+        self.assertNotIn("(globalThis).LiteGraph", source)
+        self.assertEqual(
+            source.count("new (loraLiteGraphRuntime().ContextMenu)("),
+            3,
+        )
+        self.assertNotIn("new loraLiteGraphRuntime().ContextMenu", source)
 
     def test_node_runtime_module_boundary(self):
         module_source = LORA_PRESET_NODE_RUNTIME.read_text(encoding="utf-8")
@@ -1073,7 +1084,7 @@ class LoraPresetFrontendTests(unittest.TestCase):
             let source = fs.readFileSync(sourcePath, "utf8");
             source = source.replace(/^import[\s\S]*?;\r?\n/gm, "");
             source = `${profileDataSource}\n${loraStateSource}\n${apiClientSource}\n${previewLifecycleSource}\n${menuLifecycleSource}\n${canvasWidgetsSource}\n${nodeRuntimeSource}\n${profileMutationsSource}\n${hostHookRegistrySource}\n${saveSyncSource}\n${entryLifecycleSource}\n${source}`;
-            source += "\nglobalThis.__loraPresetTest = { loraCanvasWidgets, LORA_PRESET_SETTINGS, applyLoraPresetSettings, loraPresetApi, loraPreviewLifecycle, loraMenuLifecycle, saveProfileSet };\n";
+            source += "\nglobalThis.__loraPresetTest = { loraLiteGraphRuntime, loraCanvasWidgets, LORA_PRESET_SETTINGS, applyLoraPresetSettings, loraPresetApi, loraPreviewLifecycle, loraMenuLifecycle, saveProfileSet };\n";
 
             const mutationObservers = [];
             class StubMutationObserver {
@@ -1120,14 +1131,6 @@ class LoraPresetFrontendTests(unittest.TestCase):
               HTMLInputElement: class {},
               HTMLTextAreaElement: class {},
               MutationObserver: StubMutationObserver,
-              LiteGraph: {
-                WIDGET_TEXT_COLOR: "#ddd",
-                WIDGET_BGCOLOR: "#222",
-                WIDGET_OUTLINE_COLOR: "#555",
-                ContextMenu: function ContextMenu(items, options) {
-                  globalThis.__lastContextMenu = { items, options };
-                },
-              },
               api: {
                 fetchApi: async () => ({ ok: true, json: async () => ({ loras: [] }) }),
               },
@@ -1168,9 +1171,25 @@ class LoraPresetFrontendTests(unittest.TestCase):
             };
 
             vm.createContext(context);
+            vm.runInContext(`
+              const LiteGraph = {
+                WIDGET_TEXT_COLOR: "#ddd",
+                WIDGET_BGCOLOR: "#222",
+                WIDGET_OUTLINE_COLOR: "#555",
+                ContextMenu: function ContextMenu(items, options) {
+                  globalThis.__lastContextMenu = { items, options };
+                },
+              };
+            `, context, { filename: "comfyui-host-litegraph.js" });
+            assert.strictEqual(
+              Object.prototype.hasOwnProperty.call(context, "LiteGraph"),
+              false,
+              "the fixture must expose LiteGraph only as a host lexical global",
+            );
             vm.runInContext(source, context, { filename: sourcePath });
 
             const {
+              loraLiteGraphRuntime,
               loraCanvasWidgets,
               LORA_PRESET_SETTINGS,
               applyLoraPresetSettings,
@@ -1179,6 +1198,7 @@ class LoraPresetFrontendTests(unittest.TestCase):
               loraMenuLifecycle,
               saveProfileSet,
             } = context.__loraPresetTest;
+            assert.strictEqual(loraLiteGraphRuntime().WIDGET_TEXT_COLOR, "#ddd");
             const { LoraRowWidget } = loraCanvasWidgets;
 
             function widget(name, value) {

--- a/web/js/easyuse_anima_lora_preset.js
+++ b/web/js/easyuse_anima_lora_preset.js
@@ -36,10 +36,17 @@ import {
   validComboEntryText,
 } from "./lora_preset/lora_state.js";
 
+/**
+ * @returns {{
+ *   ContextMenu: new (...args: any[]) => unknown,
+ *   WIDGET_TEXT_COLOR: string,
+ *   WIDGET_BGCOLOR: string,
+ *   WIDGET_OUTLINE_COLOR: string,
+ * }}
+ */
 function loraLiteGraphRuntime() {
-  return /** @type {typeof globalThis & {
-   *   LiteGraph: { ContextMenu: new (...args: any[]) => unknown }
-   * }} */ (globalThis).LiteGraph;
+  // @ts-expect-error ComfyUI provides LiteGraph as a host lexical global.
+  return LiteGraph;
 }
 
 const NODE_TYPE = "EasyUseAnimaLoraPreset";
@@ -553,7 +560,7 @@ async function openProfileLoadMenu(node, event, pos) {
   }
   const values = profiles.map((profile) => String(profile.name || "")).filter(Boolean);
   const clientPoint = menuClientPoint(node, pos, event);
-  new loraLiteGraphRuntime().ContextMenu(values, {
+  new (loraLiteGraphRuntime().ContextMenu)(values, {
     event: makeMenuEvent(clientPoint),
     title: lpText("profile.loadTitle"),
     scale: Math.max(1, Number(app.canvas?.ds?.scale) || 1),
@@ -800,7 +807,7 @@ function openLoraEntryMenu(node, event, index) {
       callback: () => removeLoraEntry(node, index),
     },
   );
-  new loraLiteGraphRuntime().ContextMenu(items, {
+  new (loraLiteGraphRuntime().ContextMenu)(items, {
     event,
     title: loraDisplayName(lora.name),
     scale: Math.max(1, Number(app.canvas?.ds?.scale) || 1),
@@ -926,7 +933,7 @@ async function openLoraMenu(node, event, pos, onChoose) {
     return;
   }
   loraMenuLifecycle.activateMenu(node, clientPoint, menuItems);
-  new loraLiteGraphRuntime().ContextMenu(menuItems, {
+  new (loraLiteGraphRuntime().ContextMenu)(menuItems, {
     event: makeMenuEvent(clientPoint),
     title: lpText("lora.chooseTitle"),
     scale: Math.max(1, Number(app.canvas?.ds?.scale) || 1),


### PR DESCRIPTION
목적과 변경 경계
- Issue #513의 0.6.1 LoRA Preset 로딩 불능 회귀를 수정하고 0.6.2 patch release metadata를 준비합니다.
- LoRA Preset entry adapter, 직접 회귀 테스트, 버전/릴리즈/Registry copy만 변경합니다.

Base -> Head
- 0395db5932f032591870d3254b90402fa2e58234 -> 2873b372f186d2d017b4a12ecd9e41e6dbcdd4a2

주요 변경과 보존 계약
- LiteGraph host binding을 0.6.0과 같은 lexical runtime 값으로 복구했습니다.
- return 뒤 다중행 JSDoc의 자동 세미콜론 삽입을 제거하고, 세 ContextMenu 호출의 생성자 우선순위를 명시했습니다.
- globalThis에 LiteGraph 속성이 없는 fixture에서 ProfileBar 색상 값과 메뉴 runtime을 검증합니다.
- 기존 LoRA profile/menu/API, node/socket/workflow/profile 계약과 다른 0.6.1 기능은 유지합니다.

검증
- node --check: PASS
- LoraPresetFrontendTests: 20/20 PASS
- RegistryReleaseCopyTests: 2/2 PASS
- TypeScript 6.0.3: PASS
- final candidate official full: Python 1241, frontend 120, Pyright/import boundary/diff PASS
- comfy node validate/pack: PASS; 278 entries, CRC PASS, archive version 0.6.2
- isolated ComfyUI 0.27.0 / frontend 1.45.20: ProfileBar render 및 LoRA ContextMenu PASS, 관련 console error 0
- Legacy/other custom-node warnings are pre-existing and unrelated.

남은 위험과 rollback
- host lexical LiteGraph는 supported ComfyUI runtime 계약을 사용합니다. 회귀 시 이 단일 hotfix commit을 revert할 수 있습니다.
- Registry 0.6.1은 이미 deleted 상태이며 재사용하지 않습니다.

Next
- main merge 후 동일 변경을 dev에 동기화합니다.
- v0.6.2 annotated tag/GitHub release, Registry publish/metadata sync/live read-back을 진행합니다.

Tracks #513