### PR TITLE
chore: sync 0.6.2 hotfix to dev

### DIFF
--- a/.github/registry/changelogs/0.6.2.txt
+++ b/.github/registry/changelogs/0.6.2.txt
@@ -1,0 +1,8 @@
+EasyUse Anima 0.6.2 restores LoRA Preset loading on supported ComfyUI frontends.
+
+Changes:
+1. Fixed the LoRA Preset profile bar and menus failing to draw when ComfyUI exposes LiteGraph through its host runtime binding.
+2. Existing presets, saved profiles, workflows, and other 0.6.1 features remain unchanged.
+
+Action required:
+After updating, restart ComfyUI and hard-refresh the browser.

--- a/.github/registry/metadata.json
+++ b/.github/registry/metadata.json
@@ -19,6 +19,11 @@
   },
   "versions": [
     {
+      "version": "0.6.2",
+      "deprecated": false,
+      "changelog_file": "changelogs/0.6.2.txt"
+    },
+    {
       "version": "0.6.1",
       "deprecated": false,
       "changelog_file": "changelogs/0.6.1.txt"

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,5 +1,21 @@
 # Release Notes
 
+## 0.6.2
+
+### Fixed
+
+- LoRA Preset now opens and draws its profile bar and menus when supported
+  ComfyUI frontends provide LiteGraph through their host runtime binding.
+
+### Compatibility
+
+- Existing LoRA presets, saved profiles, workflows, public node identifiers,
+  socket ordering, and the other 0.6.1 features remain unchanged.
+
+### Update
+
+- After updating, restart ComfyUI and hard-refresh the browser.
+
 ## 0.6.1
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "comfyui-easyuse-anima"
 description = "Prompt editing, ANIMA prompt correction, NAIA prompt integration, LoRA preset management, wildcard expansion, AiO generation, and ANIMA/Spectrum workflow helpers for ComfyUI."
-version = "0.6.1"
+version = "0.6.2"
 readme = "README.md"
 license = { file = "LICENSE" }
 requires-python = ">=3.10"

--- a/tests/test_frontend_lora_preset.py
+++ b/tests/test_frontend_lora_preset.py
@@ -79,7 +79,18 @@ class LoraPresetFrontendTests(unittest.TestCase):
                     source,
                 )
         self.assertIn("function loraLiteGraphRuntime()", source)
-        self.assertIn("}} */ (globalThis).LiteGraph;", source)
+        self.assertIn(
+            "// @ts-expect-error ComfyUI provides LiteGraph as a host lexical global.\n"
+            "  return LiteGraph;",
+            source,
+        )
+        self.assertIn(" * @returns {{", source)
+        self.assertNotIn("(globalThis).LiteGraph", source)
+        self.assertEqual(
+            source.count("new (loraLiteGraphRuntime().ContextMenu)("),
+            3,
+        )
+        self.assertNotIn("new loraLiteGraphRuntime().ContextMenu", source)
 
     def test_node_runtime_module_boundary(self):
         module_source = LORA_PRESET_NODE_RUNTIME.read_text(encoding="utf-8")
@@ -1073,7 +1084,7 @@ class LoraPresetFrontendTests(unittest.TestCase):
             let source = fs.readFileSync(sourcePath, "utf8");
             source = source.replace(/^import[\s\S]*?;\r?\n/gm, "");
             source = `${profileDataSource}\n${loraStateSource}\n${apiClientSource}\n${previewLifecycleSource}\n${menuLifecycleSource}\n${canvasWidgetsSource}\n${nodeRuntimeSource}\n${profileMutationsSource}\n${hostHookRegistrySource}\n${saveSyncSource}\n${entryLifecycleSource}\n${source}`;
-            source += "\nglobalThis.__loraPresetTest = { loraCanvasWidgets, LORA_PRESET_SETTINGS, applyLoraPresetSettings, loraPresetApi, loraPreviewLifecycle, loraMenuLifecycle, saveProfileSet };\n";
+            source += "\nglobalThis.__loraPresetTest = { loraLiteGraphRuntime, loraCanvasWidgets, LORA_PRESET_SETTINGS, applyLoraPresetSettings, loraPresetApi, loraPreviewLifecycle, loraMenuLifecycle, saveProfileSet };\n";
 
             const mutationObservers = [];
             class StubMutationObserver {
@@ -1120,14 +1131,6 @@ class LoraPresetFrontendTests(unittest.TestCase):
               HTMLInputElement: class {},
               HTMLTextAreaElement: class {},
               MutationObserver: StubMutationObserver,
-              LiteGraph: {
-                WIDGET_TEXT_COLOR: "#ddd",
-                WIDGET_BGCOLOR: "#222",
-                WIDGET_OUTLINE_COLOR: "#555",
-                ContextMenu: function ContextMenu(items, options) {
-                  globalThis.__lastContextMenu = { items, options };
-                },
-              },
               api: {
                 fetchApi: async () => ({ ok: true, json: async () => ({ loras: [] }) }),
               },
@@ -1168,9 +1171,25 @@ class LoraPresetFrontendTests(unittest.TestCase):
             };
 
             vm.createContext(context);
+            vm.runInContext(`
+              const LiteGraph = {
+                WIDGET_TEXT_COLOR: "#ddd",
+                WIDGET_BGCOLOR: "#222",
+                WIDGET_OUTLINE_COLOR: "#555",
+                ContextMenu: function ContextMenu(items, options) {
+                  globalThis.__lastContextMenu = { items, options };
+                },
+              };
+            `, context, { filename: "comfyui-host-litegraph.js" });
+            assert.strictEqual(
+              Object.prototype.hasOwnProperty.call(context, "LiteGraph"),
+              false,
+              "the fixture must expose LiteGraph only as a host lexical global",
+            );
             vm.runInContext(source, context, { filename: sourcePath });
 
             const {
+              loraLiteGraphRuntime,
               loraCanvasWidgets,
               LORA_PRESET_SETTINGS,
               applyLoraPresetSettings,
@@ -1179,6 +1198,7 @@ class LoraPresetFrontendTests(unittest.TestCase):
               loraMenuLifecycle,
               saveProfileSet,
             } = context.__loraPresetTest;
+            assert.strictEqual(loraLiteGraphRuntime().WIDGET_TEXT_COLOR, "#ddd");
             const { LoraRowWidget } = loraCanvasWidgets;
 
             function widget(name, value) {

--- a/web/js/easyuse_anima_lora_preset.js
+++ b/web/js/easyuse_anima_lora_preset.js
@@ -36,10 +36,17 @@ import {
   validComboEntryText,
 } from "./lora_preset/lora_state.js";
 
+/**
+ * @returns {{
+ *   ContextMenu: new (...args: any[]) => unknown,
+ *   WIDGET_TEXT_COLOR: string,
+ *   WIDGET_BGCOLOR: string,
+ *   WIDGET_OUTLINE_COLOR: string,
+ * }}
+ */
 function loraLiteGraphRuntime() {
-  return /** @type {typeof globalThis & {
-   *   LiteGraph: { ContextMenu: new (...args: any[]) => unknown }
-   * }} */ (globalThis).LiteGraph;
+  // @ts-expect-error ComfyUI provides LiteGraph as a host lexical global.
+  return LiteGraph;
 }
 
 const NODE_TYPE = "EasyUseAnimaLoraPreset";
@@ -553,7 +560,7 @@ async function openProfileLoadMenu(node, event, pos) {
   }
   const values = profiles.map((profile) => String(profile.name || "")).filter(Boolean);
   const clientPoint = menuClientPoint(node, pos, event);
-  new loraLiteGraphRuntime().ContextMenu(values, {
+  new (loraLiteGraphRuntime().ContextMenu)(values, {
     event: makeMenuEvent(clientPoint),
     title: lpText("profile.loadTitle"),
     scale: Math.max(1, Number(app.canvas?.ds?.scale) || 1),
@@ -800,7 +807,7 @@ function openLoraEntryMenu(node, event, index) {
       callback: () => removeLoraEntry(node, index),
     },
   );
-  new loraLiteGraphRuntime().ContextMenu(items, {
+  new (loraLiteGraphRuntime().ContextMenu)(items, {
     event,
     title: loraDisplayName(lora.name),
     scale: Math.max(1, Number(app.canvas?.ds?.scale) || 1),
@@ -926,7 +933,7 @@ async function openLoraMenu(node, event, pos, onChoose) {
     return;
   }
   loraMenuLifecycle.activateMenu(node, clientPoint, menuItems);
-  new loraLiteGraphRuntime().ContextMenu(menuItems, {
+  new (loraLiteGraphRuntime().ContextMenu)(menuItems, {
     event: makeMenuEvent(clientPoint),
     title: lpText("lora.chooseTitle"),
     scale: Math.max(1, Number(app.canvas?.ds?.scale) || 1),


### PR DESCRIPTION
목적과 변경 경계
- main hotfix PR #516의 검증된 0.6.2 변경을 최신 dev에 동일하게 반영합니다.
- 추가 구현이나 roadmap 범위 변경은 없습니다.

Base -> Head
- a20c1ecb09fc15d813569cf409531f96b1ddb0ac -> b411ddf

동일성 및 검증
- 6개 hotfix/release 파일은 origin/main 444abf9와 byte-identical합니다.
- node --check: PASS
- LoraPresetFrontendTests: 20/20 PASS
- RegistryReleaseCopyTests: 2/2 PASS
- git diff --check: PASS
- main candidate 2873b37의 official full/package/isolated ComfyUI browser evidence를 tree equality로 재사용합니다.

남은 위험과 rollback
- dev의 다른 composition 변경과 파일 경계가 겹치지 않습니다.
- 필요 시 이 단일 sync commit을 revert할 수 있습니다.

Next
- merge 후 v0.6.2 tag/GitHub release/Registry publish를 main에서 진행합니다.

Related #513 and #516