### PR TITLE
docs: resume backend D-08 queue after 0.6.2

### DIFF
--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -13,91 +13,90 @@ section, owning Issue, direct owner files, and direct tests.
 ## Active sequencing notes
 
 - [`codex-execution-efficiency.md`](../development/codex-execution-efficiency.md)
-  applies to every active and ordinary roadmap. It defines the bounded task card,
-  focused edit loop, final-full-once rule, package/live/benchmark triggers,
-  evidence reuse, and current task-specific test maps. It reduces repeated work;
-  it does not weaken an Issue or release gate.
-- Issue [#470](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/470) is the
-  active P1 post-0.6.0 regression lane. Read
-  [`prompt-studio-execution-derived-projection.md`](prompt-studio-execution-derived-projection.md)
-  before modifying Prompt Studio queue/result behavior. QSTATE-04C1 is the first
-  READY task and targets a 0.6.1 patch.
+  applies to every roadmap. It defines the bounded task card, focused edit loop,
+  final-full-once rule, evidence reuse, and package/live/benchmark triggers.
+- Issue [#186](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/186)
+  currently owns the active backend queue. Read
+  [`backend-roadmap-resume-0.6.2.md`](backend-roadmap-resume-0.6.2.md) before the
+  older execution roadmap. The first READY task is D-08t, profile-load route
+  composition.
+- The reviewed baseline is `dev@a509e87c7021257d514e66710f4ca4afb74c4a05`
+  after D-08s / PR #520. D-08q, D-08r, and D-08s are complete.
+- Issue [#470](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/470) and
+  the 0.6.1 Prompt Studio patch lane are complete. Its projection roadmap remains
+  a behavior-contract reference and no longer blocks backend work.
 - Issues [#413](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/413),
   [#414](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/414), and
-  [#415](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/415) completed the
-  original queue/live-UI hotfix and release lane. Their two-phase correlation and
-  seed ownership contracts remain authoritative. Issue #470 supersedes only the
-  old classification that treated linked `field_inputs` and NAIA responses as
-  non-projectable submitted snapshots.
-- Before Prompt Studio wildcard next-seed publication or AiO seed cutover, read
-  [`seed-ui-semantics-gate.md`](seed-ui-semantics-gate.md). Prompt Studio uses a
-  concrete seed plus an after-generate transition; AiO special `-1/-2/-3` values
-  are persistent selection tokens. The shared transaction owner must not merge
-  those feature meanings.
-- Issue [#395](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/395)
-  separately tracks the external Comfy Registry activation checkpoint for the
-  immutable 0.5.5 release. Waiting for that external approval does not block
-  confirmed P1 post-release bug fixes, and it does not authorize rewriting the
-  `v0.5.5` tag.
-- The DAVE stage-scope, Torch Compile recommendation, and NegPip plans are
-  recorded in
-  [`aio-advanced-integrations-roadmap.md`](aio-advanced-integrations-roadmap.md).
-  Issues #409, #410, and #411 and the 0.6.0 release lane #452 are complete.
-- Deferred patch-specific follow-ups #440/#441, ordinary backend work,
-  opportunistic cleanup, and unrelated features do not jump the active #470
-  patch lane.
-- The former B-11 Comfy host-provider bridge is complete. Its document remains a
-  historical sequencing record and no longer overrides the active queue.
+  [#415](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/415) are historical
+  queue/live-UI contract sources.
+- The current released code baseline is 0.6.2. Comfy Registry manual review or
+  activation is external release administration and does not block the `dev`
+  refactor queue. Do not republish or mutate the immutable 0.6.2 artifact.
+- Before Prompt Studio wildcard next-seed publication or AiO seed work, read
+  [`seed-ui-semantics-gate.md`](seed-ui-semantics-gate.md). Prompt Studio and AiO
+  seed meanings remain separate.
+- Issues #409, #410, #411 and the 0.6.0 advanced-integration release lane are
+  complete. Deferred #440/#441, opportunistic cleanup, and unrelated feature work
+  do not jump the active D-08 queue.
+- The former B-11 host-provider bridge is complete and remains historical.
 
 ## Documents
 
 - [`../development/codex-execution-efficiency.md`](../development/codex-execution-efficiency.md):
-  cross-roadmap Codex context budget, work-packet format, test ladder, invalidation
-  rules, compact evidence format, and scoped test maps for queue/UI, AiO integration,
-  and ordinary backend work.
-- [`prompt-studio-execution-derived-projection.md`](prompt-studio-execution-derived-projection.md):
-  active Issue #470 plan separating submitted Prompt Studio snapshots from
-  execution-derived linked-input and NAIA deltas; defines latest-accepted queue
-  ownership, per-field revisions, persistence rules, one-envelope fan-out,
-  implementation units, focused tests, dual-canvas evidence, and the 0.6.1 gate.
-- [`queue-ui-two-phase-correlation-addendum.md`](queue-ui-two-phase-correlation-addendum.md):
-  identity/revision correction after QSTATE-02A. It separates provisional
-  submission, accepted `promptId`, and the executed-event envelope; removes
-  mandatory `listIndex` from node-level stale-result correlation; and defines
-  cache, subgraph, mapped-result, transaction-core, and envelope-bridge boundaries.
-- [`seed-ui-semantics-gate.md`](seed-ui-semantics-gate.md): feature boundary and
-  hard test gate separating Prompt Studio Wildcard concrete after-generate seed
-  publication from AiO rgthree-style persistent special-token selection, including
-  the special-token x stored-control no-double-advance matrix.
-- [`queue-ui-execution-state-hotfix.md`](queue-ui-execution-state-hotfix.md):
-  historical base runbook for stale LoRA/Prompt Studio execution results (#413),
-  rgthree-compatible AiO special-seed display semantics (#414), integrated
-  validation, and the completed release gate owned by #415. Its exact-identity-at-
-  submission assumptions are superseded by the two-phase addendum.
-- [`python-backend.md`](python-backend.md): living architecture, ownership,
-  execution phases, validation gates, and overall Definition of Done.
+  cross-roadmap context budget, work-packet format, test ladder, invalidation
+  rules, evidence format, and scoped test maps.
+- [`backend-roadmap-resume-0.6.2.md`](backend-roadmap-resume-0.6.2.md):
+  active Issue #186 checkpoint after D-08s; current code review, D-08t through
+  D-08x boundaries, package/live evidence reuse, stop conditions, and Codex start
+  instruction.
+- [`python-backend.md`](python-backend.md): target architecture, ownership,
+  execution phases, validation gates, and overall Definition of Done. Its older
+  implementation snapshot is historical where the active resume checkpoint says
+  otherwise.
 - [`python-backend-execution-roadmap.md`](python-backend-execution-roadmap.md):
-  verified backend progress, ordered work units, stop conditions, and task-level
-  validation gates. Its next-work ordering is paused while #470 is open. When it
-  resumes, apply the efficiency protocol instead of rerunning every historical
-  inventory and broad test after each edit.
-- [`aio-advanced-integrations-roadmap.md`](aio-advanced-integrations-roadmap.md):
-  completed sequencing plan for stage-scoped DAVE (#409), KJNodes Torch Compile
-  recommendations (#410), and ComfyUI-ppm NegPip (#411). Patch-specific follow-ups
-  remain independently tracked.
-- [`aio-hook-extensibility-plan.md`](aio-hook-extensibility-plan.md): follow-on AiO
-  extension contract and stage/cache/lifecycle sequencing. It does not authorize
-  implementation while a higher-priority bug or release gate is active.
-- [`comfy-host-provider-bridge.md`](comfy-host-provider-bridge.md): completed
-  historical sequencing addendum for the seven former root Comfy capability and
-  invocation wrappers and the minimum runtime-bound provider Contract required
-  before the final B-11 shim.
+  accumulated backend progress and historical task details. For the current
+  immediate queue and preflight rules, the 0.6.2 resume checkpoint takes priority.
+- [`python-compatibility-shims.md`](python-compatibility-shims.md): compatibility
+  surface registry and removal evidence.
 - [`adr-001-modular-monolith.md`](adr-001-modular-monolith.md): why the backend
   converges on a feature-oriented modular monolith under `easyuse_anima`.
 - [`adr-002-compatibility-shims.md`](adr-002-compatibility-shims.md): policy for
   introducing, supporting, and retiring root compatibility shims.
-- [`python-compatibility-shims.md`](python-compatibility-shims.md): registry schema
-  and inventory of root/module compatibility surfaces.
+- [`prompt-studio-execution-derived-projection.md`](prompt-studio-execution-derived-projection.md):
+  completed #470 contract separating submitted snapshots from linked-input and
+  NAIA execution-derived deltas.
+- [`queue-ui-two-phase-correlation-addendum.md`](queue-ui-two-phase-correlation-addendum.md):
+  provisional submission, accepted `promptId`, executed-envelope, cache,
+  subgraph, mapped-result, and transaction-core contracts.
+- [`seed-ui-semantics-gate.md`](seed-ui-semantics-gate.md): Prompt Studio concrete
+  after-generate seed versus AiO persistent special-token contract.
+- [`queue-ui-execution-state-hotfix.md`](queue-ui-execution-state-hotfix.md):
+  historical base runbook for #413/#414/#415.
+- [`aio-advanced-integrations-roadmap.md`](aio-advanced-integrations-roadmap.md):
+  completed DAVE, Torch Compile recommendation, and NegPip sequencing plan.
+- [`aio-hook-extensibility-plan.md`](aio-hook-extensibility-plan.md): follow-on AiO
+  extension contract. It does not override a higher-priority bug or active
+  backend queue.
+- [`comfy-host-provider-bridge.md`](comfy-host-provider-bridge.md): completed
+  historical host-provider sequencing addendum.
+
+## Current code boundary
+
+At the D-08s checkpoint:
+
+- root `api.py` remains a temporary compatibility/composition facade;
+- canonical route implementations live under `easyuse_anima/api/routes/`;
+- `api/router.py` owns injected route definition/signature/registration mechanics;
+- `bootstrap.py` owns concrete factory/dependency/correlation composition already
+  migrated through D-08s and the production initialization call site;
+- seven profile handlers remain directly composed in root `api.py` and are the
+  exact D-08t through D-08w queue;
+- no current evidence requires changing public routes, payloads, persistence,
+  error policy, workflow contracts, or optional-dependency behavior.
+
+This is reviewed transitional debt, not a reason to perform a broad rewrite.
+Bootstrap must not import root `api.py`, and D-08 must not remove compatibility
+aliases or absorb runtime-lifecycle work.
 
 ## Authority and scope
 
@@ -106,22 +105,21 @@ section, owning Issue, direct owner files, and direct tests.
 - The development-document entry point remains
   [`docs/development/README.md`](../development/README.md).
 - The efficiency protocol selects the smallest sufficient evidence and timing;
-  it does not permit skipping explicit correctness, compatibility, package, live,
-  or release gates owned by a task.
-- The architecture ADRs and ordinary backend roadmap own Python package and
-  lifecycle boundaries.
-- Cross-surface bug and AiO plans may also cover frontend state, queue identity,
-  workflow/profile compatibility, optional custom-node contracts, packaging,
-  and live ComfyUI evidence when those surfaces are inseparable from the backend
-  execution contract.
-- The active post-0.6.0 patch is tracked by
-  [#470](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/470). Completed
-  #413/#414/#415 remain historical contract sources and are not reopened.
-- Long-term implementation is tracked by
+  it does not weaken explicit correctness, compatibility, package, live, or
+  release gates.
+- The active resume checkpoint owns the current D-08 order. The accumulated
+  execution roadmap owns historical details; `python-backend.md` and the ADRs own
+  target architecture.
+- Cross-surface plans may cover frontend state, queue identity, workflow/profile
+  compatibility, packaging, and live evidence when inseparable from the feature
+  contract.
+- Long-term work remains tracked by
   [#184](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/184),
-  [#185](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/185), and their
-  child issues. Deferred patch-specific integrations are tracked independently by
-  [#440](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/440) and
-  [#441](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/441).
-- An ADR, roadmap, or sequencing note does not authorize a behavior change,
-  package move, merge, version bump, tag, or Registry publication by itself.
+  [#185](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/185),
+  [#186](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/186),
+  [#187](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/187), and
+  [#188](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/188).
+- D-14 shim retirement is not authorized by D-08 completion alone. It requires a
+  separate compatibility-evidence gate.
+- A roadmap note does not itself authorize behavior changes, release publication,
+  tag creation, or root-shim deletion.

--- a/docs/architecture/backend-roadmap-resume-0.6.2.md
+++ b/docs/architecture/backend-roadmap-resume-0.6.2.md
@@ -1,0 +1,280 @@
+# Backend Roadmap Resume Checkpoint after 0.6.2
+
+## Status and authority
+
+- Status: active execution correction for Issue #186.
+- Reviewed baseline: `dev@a509e87c7021257d514e66710f4ca4afb74c4a05` after D-08s / PR #520.
+- Released baseline: 0.6.2.
+- Scope: the remaining root `api.py` consolidation and its immediate exit gate.
+- This document supersedes the stale immediate queue and broad preflight command in
+  `python-backend-execution-roadmap.md` for the current D-08 continuation only.
+- The target architecture in `python-backend.md`, ADR-001, ADR-002, and the
+  compatibility-shim registry remain authoritative.
+- Comfy Registry review or activation status is external release administration and
+  does not block this `dev` refactor queue. Codex must not poll, republish, mutate, or
+  replace 0.6.2 while executing this roadmap.
+
+## 1. Current code review
+
+The current D-08 direction is sound. No P0/P1 correctness defect was found in the
+reviewed route-composition surface.
+
+Verified structure at the reviewed baseline:
+
+- root `api.py` is still a transitional 640-line compatibility/composition facade;
+- `easyuse_anima/bootstrap.py` is 173 lines and owns the private composition helpers
+  already moved through D-08s;
+- canonical route modules remain request/response adapters and do not own route-table
+  registration;
+- `api/router.py` owns the injected route order, signature, resolver, registrar, and
+  idempotent registration mechanics;
+- `bootstrap.initialize()` remains the single production call site that invokes the
+  registrar;
+- package import, route order/signature, request correlation, error redaction, profile
+  persistence/CAS, and repeated initialization were covered by the merged D-08 evidence;
+- import-boundary and package-skeleton gates report no new canonical-to-root back edge.
+
+The current remaining debt is deliberate, but it must not become permanent:
+
+1. Seven handlers are still factory-composed and correlated directly in root `api.py`:
+   two profile loads, two profile saves, two AiO profile mutations, and one LoRA
+   profile-fix handler.
+2. Root `api.py` still constructs compatibility payload/runtime helpers and the route
+   registrar. Those responsibilities are not automatically part of the remaining
+   handler-composition Moves.
+3. The root facade retains many evidence-backed aliases and dynamic monkeypatch seams.
+   They cannot be deleted merely because canonical owners exist.
+4. `bootstrap.py` must never import root `api.py` to finish the move; that would invert
+   the dependency direction and create a cycle.
+5. Translation executor creation, file-I/O lifecycle, profile repositories, request
+   parsing, error policy, and route behavior stay outside D-08 composition Moves.
+
+## 2. Exact remaining D-08 queue
+
+Execute one task at a time from the latest `origin/dev`. Search open PRs and branches
+for the task ID before creating a competing implementation.
+
+```text
+DONE  D-08q  AiO Torch Compile recommendation composition      PR #518
+DONE  D-08r  LoRA preview/catalog composition                   PR #519
+DONE  D-08s  LoRA/AiO profile-list composition                  PR #520
+READY D-08t  LoRA/AiO profile-load composition
+NEXT  D-08u  LoRA/AiO profile-save composition
+NEXT  D-08v  AiO profile delete/rename composition
+NEXT  D-08w  LoRA profile-fix composition
+NEXT  D-08x  D-08 exit audit and final composition checkpoint
+```
+
+Do not skip to D-14, Phase E, quality cleanup, or shim removal while one of D-08t
+through D-08x is incomplete.
+
+### D-08t — Profile load composition
+
+Type: Move.
+
+Goal:
+
+- move only `build_profile_load_handlers()` invocation and request-correlation wrapping
+  from root `api.py` to a private bootstrap composition helper;
+- preserve the two handler objects, dependency callbacks, error tuples, response
+  payloads, route order, and root dynamic load seams.
+
+Allowed production files:
+
+```text
+api.py
+easyuse_anima/bootstrap.py
+```
+
+Allowed support files:
+
+```text
+tests/test_api_contract.py
+tests/test_bootstrap.py or the current bootstrap owner test
+tests/fixtures/python_backend_baseline.json
+```
+
+Forbidden:
+
+- profile repository or error-policy changes;
+- query/default/response changes;
+- route-definition or registration changes;
+- root alias removal;
+- importing root `api.py` from bootstrap.
+
+### D-08u — Profile save composition
+
+Type: Move.
+
+Move only the two save factory invocations and correlation wrapping. Preserve JSON
+validation, optional profile identity/revision fields, strict CAS behavior, error
+mapping, file-I/O dispatch, and success payloads.
+
+Do not combine delete/rename behavior, persistence changes, or profile schema changes.
+
+### D-08v — AiO profile mutation composition
+
+Type: Move.
+
+Move only delete/rename factory invocation and correlation wrapping. Preserve source
+and target preconditions, overwrite semantics, multi-token CAS, error ordering, and
+response shapes.
+
+### D-08w — LoRA profile-fix composition
+
+Type: Move.
+
+Move only the fix factory invocation and correlation wrapping. Preserve the current
+read-only projection meaning, input-object forwarding, file-I/O dispatch, and safe
+error boundary. Do not turn the fix endpoint into a persistence operation.
+
+### D-08x — D-08 exit audit
+
+Type: Contract/gate first. If a final Move is necessary, use a separate PR.
+
+The audit must prove:
+
+- all 21 route handlers are created through canonical route factories;
+- all concrete route factory invocation and correlation wiring is owned by private
+  bootstrap composition helpers;
+- root `api.py` has no remaining direct concrete route-factory import;
+- `api/router.py` still has no concrete `api/routes/*` dependency;
+- exact route order, signature, marker, idempotence, mismatch behavior, and repeated
+  `initialize()` behavior remain unchanged;
+- root compatibility aliases and dynamic seams are classified in the compatibility
+  registry before any deletion;
+- root `api.py` does not gain new implementation while the final facade is audited;
+- package/no-host import remains side-effect-safe except for the explicitly preserved
+  root compatibility runtime.
+
+D-08x does not authorize D-14 shim retirement. It only records whether D-14 has enough
+release and consumer evidence to start a separate Contract gate.
+
+## 3. Validation policy for D-08t through D-08w
+
+### Edit loop
+
+Run only:
+
+```text
+changed-file Python syntax/static check
+owning route direct contract tests
+route-composition owner test
+bootstrap/runtime owner tests directly affected by the diff
+current import-boundary/analyzer fixture
+`git diff --check`
+```
+
+Do not run the repository `quick` profile as a baseline or per-edit command. A clean
+latest `dev`, the owning focused tests, and existing integrated evidence are the
+preflight.
+
+### Final PR candidate
+
+Run the official full profile once on the exact final code/test SHA.
+
+### Evidence reuse
+
+For D-08t through D-08w, package and live evidence may be reused when all of the
+following remain true:
+
+- the diff is limited to `api.py`, `bootstrap.py`, direct tests, and the analyzer
+  baseline;
+- no shipped file is added, removed, or renamed;
+- no dependency, `.comfyignore`, registration table, route method/path/order, public
+  response, error taxonomy, worker/lifecycle owner, or optional import changes;
+- the corresponding canonical route already passed direct package and isolated live
+  evidence in its earlier extraction PR;
+- the composition change is covered by package-skeleton/import-boundary tests.
+
+Under those conditions, record package/live as `evidence reused; not retriggered`.
+Do not repeat `comfy node pack` and an isolated server/browser run merely because the
+same two production files changed again.
+
+### Immediate escalation triggers
+
+Run package and/or live validation in the same PR if any of the following occurs:
+
+- a shipped module or import closure changes beyond already-packed canonical modules;
+- route order/signature/registration or `__all__` changes;
+- an optional dependency moves to import time;
+- request parsing, error mapping, file-I/O, persistence, response shape, or runtime
+  lifecycle changes;
+- the focused tests cannot distinguish a mechanical composition move from behavior.
+
+### D-08x exit validation
+
+At the integrated D-08x candidate, run once:
+
+```text
+official full
+comfy node validate
+comfy node pack + CRC/archive closure inspection
+package/no-host import and repeated initialize/idempotence
+representative isolated ComfyUI API smoke for all remaining profile groups
+```
+
+The live checkpoint must cover at least list, load, save, delete/rename, fix, request
+correlation, one safe error path, and queue-count stability. It need not repeat every
+per-route matrix already proven by focused tests.
+
+## 4. Review and stop conditions
+
+Codex should resolve ordinary focused failures inside the owning task. Stop and record
+a blocker only when:
+
+- bootstrap would need to import root `api.py`;
+- a root dynamic seam or supported object identity cannot be preserved;
+- route order/signature, public response, error mapping, persistence, or execution
+  order must change;
+- the change requires a new public bootstrap/router export;
+- an optional dependency becomes import-time required;
+- the root facade cannot be reduced without an undocumented consumer decision;
+- a Move cannot be separated from a Behavior or lifecycle change.
+
+A technical PRO review is warranted only if several valid architecture choices remain
+across bootstrap/router/root-shim boundaries, a cycle cannot be removed by the existing
+injection pattern, or compatibility evidence is insufficient to choose safely. Normal
+implementation or test failures do not require PRO review.
+
+## 5. After D-08
+
+After D-08x:
+
+1. reconcile Issue #186 and the compatibility-shim registry;
+2. create a D-14 readiness Contract only if canonical-plus-shim release evidence and
+   actual consumer inventory are sufficient;
+3. if D-14 is still blocked, record the blocker and select the first independent READY
+   Phase E task whose canonical owner and lifecycle Contract already exist;
+4. do not remove root files merely to make the directory tree look complete.
+
+The Registry activation state of 0.6.2 does not select or block these tasks.
+
+## 6. Codex resume instruction
+
+```text
+Start D-08t only from the latest origin/dev.
+
+Read:
+- current-policies.md
+- codex-execution-efficiency.md universal rules
+- this document's D-08t and validation sections
+- Issue #186 latest checkpoint
+- api.py, bootstrap.py, profile_loads.py, and direct tests
+
+Do not reread the full historical backend roadmap or all D-08 PRs.
+
+Create one bounded task card. Confirm no open PR owns D-08t.
+Move only profile-load factory invocation and correlation wrapping into a private
+bootstrap helper. Preserve every dynamic dependency, error tuple, handler identity,
+route order/signature, and root compatibility seam.
+
+Edit loop: changed-file syntax, direct profile-load/API owner tests,
+bootstrap/runtime/import-boundary/analyzer tests, git diff --check.
+Run official full once on the final candidate SHA.
+Do not run package/live unless an escalation trigger in this document occurs.
+Push and open a dev-targeted Draft PR. Review and squash-merge after the Move boundary
+and evidence are confirmed. Then continue to D-08u.
+
+Do not poll Registry status, republish 0.6.2, start D-14, or begin Phase E.
+```

--- a/docs/development/README.md
+++ b/docs/development/README.md
@@ -11,31 +11,30 @@ conversation.
    - use focused edit-loop tests;
    - run the official full runner once per final candidate SHA;
    - escalate to package, live, and benchmark evidence only when triggered.
-3. Only after a documented stop condition or final live-gate failure, read
-   [`docs/development/codex-blocker-escalation.md`](codex-blocker-escalation.md)
-   before requesting PRO review. A stop condition starts bounded local triage; it
-   is not an automatic whole-roadmap stop.
-4. While Issue #470 is open, read
-   [`docs/architecture/prompt-studio-execution-derived-projection.md`](../architecture/prompt-studio-execution-derived-projection.md)
-   and only the current QSTATE-04C task section. It owns the 0.6.0 regression
-   correction that distinguishes submitted editor snapshots from linked-input and
-   NAIA execution deltas.
-5. Queue identity or stale-result lifecycle work may also require
-   [`docs/architecture/queue-ui-two-phase-correlation-addendum.md`](../architecture/queue-ui-two-phase-correlation-addendum.md).
-   It remains the identity/revision foundation, but its older QSTATE-04 field-input
-   classification is superseded by the Issue #470 projection roadmap.
-6. Python backend architecture or migration work:
+3. For the active backend continuation owned by Issue #186, read
+   [`docs/architecture/backend-roadmap-resume-0.6.2.md`](../architecture/backend-roadmap-resume-0.6.2.md)
+   and only the current D-08 task section. It supersedes the stale immediate queue
+   and broad preflight command in the older execution roadmap.
+4. Python backend architecture or migration work:
    [`docs/architecture/README.md`](../architecture/README.md)
+5. Only after a documented hard stop or unresolved cross-owner failure, read
+   [`docs/development/codex-blocker-escalation.md`](codex-blocker-escalation.md)
+   before requesting a technical PRO review. Ordinary test failures remain local
+   task work.
+6. Queue identity or stale-result lifecycle work may require
+   [`docs/architecture/queue-ui-two-phase-correlation-addendum.md`](../architecture/queue-ui-two-phase-correlation-addendum.md).
+   Prompt Studio linked-input/NAIA projection Issue #470 is completed; its roadmap
+   is now a behavior-contract reference, not the active implementation queue.
 7. Active frontend maintenance execution plan:
    `docs/development/frontend-maintenance-execution-plan.md`
-8. Current released baseline: `docs/development/0.6.0.md`
+8. Current released baseline: `RELEASE.md` / `pyproject.toml` version 0.6.2.
 9. Relevant topic guide:
-   - Registry publish or flagged-version prevention:
+   - Registry scanner prevention for a future release:
      `docs/development/registry-scanner-safety.md`
    - workflow docs or release templates: `docs/Anima AiO/Workflow_Management.md`
    - user-facing AiO docs: `docs/Anima AiO/README.md`
    - custom-node model patch integrations: `docs/development/custom-node-integrations.md`
-   - current frontend maintenance roadmap and Issue #14 close boundary:
+   - frontend maintenance roadmap and Issue #14 close boundary:
      `docs/development/frontend-maintenance-roadmap.md`
    - repeatable legacy-canvas and Node 2.0 browser validation:
      `docs/development/browser-smoke-matrix.md`
@@ -53,102 +52,92 @@ conversation.
 
 Do not read every roadmap or historical document by default. The efficiency
 protocol defines the maximum initial context and the conditions that justify
-expanding it. The blocker-escalation document is conditional context and should
-not be loaded during ordinary successful tasks.
+expanding it. Registry activation is external release administration; do not poll
+or modify an immutable release while performing ordinary `dev` roadmap work.
 
 ## Source Map
 
 - Current policy baseline: `docs/development/current-policies.md`
 - Codex work-packet, test-escalation, evidence-reuse, and token policy:
   [`docs/development/codex-execution-efficiency.md`](codex-execution-efficiency.md)
-- Conditional stop-triage, self-resolution budget, and hard-PRO criteria:
+- Active backend D-08 continuation and exact resume point:
+  [`docs/architecture/backend-roadmap-resume-0.6.2.md`](../architecture/backend-roadmap-resume-0.6.2.md)
+- Conditional stop-triage and technical-PRO criteria:
   [`docs/development/codex-blocker-escalation.md`](codex-blocker-escalation.md)
-- Active Prompt Studio linked-input/NAIA projection correction:
+- Python backend architecture and compatibility-shim registry:
+  [`docs/architecture/README.md`](../architecture/README.md)
+- Completed Prompt Studio execution-derived projection contract:
   [`docs/architecture/prompt-studio-execution-derived-projection.md`](../architecture/prompt-studio-execution-derived-projection.md)
 - Queue/live-UI identity and revision foundation:
   [`docs/architecture/queue-ui-two-phase-correlation-addendum.md`](../architecture/queue-ui-two-phase-correlation-addendum.md)
-- Python backend architecture and compatibility-shim registry:
-  [`docs/architecture/README.md`](../architecture/README.md)
 - Active frontend maintenance execution ledger:
   `docs/development/frontend-maintenance-execution-plan.md`
-- Current released baseline: `docs/development/0.6.0.md`
-- Registry scanner safety: `docs/development/registry-scanner-safety.md`
+- Current release notes: `RELEASE.md`
+- Registry scanner safety for future changes: `docs/development/registry-scanner-safety.md`
 - Older implementation history: `docs/version-plans/`
 - Public workflow JSON templates and preview/source images: `docs/example_workflows/`
 - User-facing workflow documentation: `docs/Anima AiO/`
 - User-facing node documentation: `docs/nodes/`
 - User-facing wildcard syntax: `docs/wildcards.ko.md` /
   `docs/wildcards.en.md`
-- Current frontend maintenance roadmap:
-  `docs/development/frontend-maintenance-roadmap.md`
-- Dual-canvas browser smoke matrix:
-  `docs/development/browser-smoke-matrix.md`
-- Safe PAG stage-scope live matrix:
-  `docs/development/aio-safe-pag-live-matrix.md`
-- SageAttention stage-scope live matrix:
-  `docs/development/aio-sage-live-matrix.md`
-- Historical Issue #14 PR #18 execution plan:
-  `docs/development/issue-14-frontend-js-maintenance.md`
-- Deferred Node 2.0 DOM widget resize investigation:
-  `docs/development/node2-dom-widget-resize-limitation.md`
+- Frontend maintenance roadmap: `docs/development/frontend-maintenance-roadmap.md`
+- Dual-canvas browser smoke matrix: `docs/development/browser-smoke-matrix.md`
 
 ## Area-Specific Files
 
-- LoRA preset bugs:
+- Active D-08 API root consolidation / Issue #186:
   - `api.py`
+  - `easyuse_anima/bootstrap.py`
+  - `easyuse_anima/api/router.py`
+  - the current `easyuse_anima/api/routes/*` owner
+  - `tests/test_api_contract.py`
+  - bootstrap/runtime owner tests
+  - `tests/fixtures/python_backend_baseline.json`
+  - compatibility-shim and package-skeleton tests when the task triggers them
+- LoRA preset bugs:
   - `web/js/easyuse_anima_lora_preset.js`
-  - `tests/test_lora_profiles.py`
   - `tests/test_frontend_lora_preset.py`
-- Prompt Studio execution-derived projection / Issue #470:
+  - canonical profile/API owners confirmed by targeted symbol search
+- Prompt Studio execution-derived projection reference:
   - `easyuse_anima/nodes/prompt_advanced_nodes.py`
   - `easyuse_anima/prompt/advanced.py`
   - `web/js/prompt_studio/extension_runtime.js`
   - `web/js/prompt_studio/advanced_values.js`
   - `web/js/prompt_studio/advanced_fields_ui.js`
   - `web/js/prompt_studio/serialization.js`
-  - `web/js/prompt_studio/wildcard_seed_transaction.js`
   - `web/js/lifecycle/queue_ui_transaction.js`
   - `web/js/lifecycle/executed_event_context.js`
-  - direct Prompt Studio projection, Wildcard, transaction, and backend payload tests
 - Other Prompt Studio or wildcard work:
   - confirm the current canonical Python owner under `easyuse_anima/prompt/` and
     `easyuse_anima/nodes/` before using a root compatibility shim;
-  - `web/js/easyuse_anima_autocomplete.js`
-  - `web/js/easyuse_anima_prompt_studio.js`
-  - `web/js/easyuse_anima_prompt_studio_common.js`
-  - `web/js/easyuse_anima_settings.js`
-  - `docs/development/frontend-maintenance-roadmap.md`
-  - prompt-related tests
-  - `tests/test_wildcards.py`
-  - `docs/nodes/anima-prompt-studio-advanced.*.md`
-  - `docs/nodes/anima-wildcard.*.md`
-  - `docs/wildcards.ko.md` / `docs/wildcards.en.md`
-  - workflow serialization paths
+  - relevant modular frontend owner and direct smoke tests;
+  - workflow serialization paths when the behavior is persisted.
 - Workflow template work:
   - `docs/example_workflows/`
   - `tests/test_workflows.py`
   - `docs/Anima AiO/Workflow_Management.md`
 - Custom-node integration work:
   - `docs/development/custom-node-integrations.md`
-  - `nodes.py`
-  - `web/js/easyuse_anima_aio.js`
-  - `tests/test_aio_nodes.py`
-  - `tests/test_workflows.py`
+  - canonical AiO owner under `easyuse_anima/aio/`
+  - direct AiO/integration/workflow tests.
 
 Use this map only as an initial hint. Confirm the current canonical owner with a
 targeted symbol search; do not automatically read every listed file.
 
 ## Current Policy Notes
 
-- Issue #470 is the first READY production lane. Start QSTATE-04C1 Contract work
-  before #440/#441, ordinary backend refactoring, or opportunistic feature work.
+- The first READY roadmap task is D-08t under Issue #186. Do not resume from the
+  old #470 or 0.6.1 patch queue.
+- D-08t through D-08w move only handler factory invocation and correlation into
+  private bootstrap composition helpers. They do not change route behavior,
+  persistence, error policy, runtime lifecycle, or root compatibility aliases.
+- D-08x is the integrated exit audit. D-14 or Phase E starts only after that gate
+  records its prerequisites.
+- Comfy Registry review of 0.6.2 does not block `dev` work and does not authorize
+  republishing or mutating the released artifact.
 - Do not keep duplicated workflow JSON outside `docs/example_workflows/`.
-- `docs/workflows/` has been removed; use `docs/example_workflows/` as the
-  workflow JSON and preview/source image source.
-- Example workflow JSON and matching PNG/JPG assets should share a basename.
-- If another document conflicts with `docs/development/current-policies.md`,
-  update or treat the conflicting document as stale before using it as a basis
-  for implementation.
+- If another document conflicts with `docs/development/current-policies.md` or the
+  active resume checkpoint, update or treat it as historical before implementation.
 - `pyproject.toml` may be bumped early as a next-version marker, but it is not a
   release or publish step by itself.
 
@@ -157,35 +146,32 @@ targeted symbol search; do not automatically read every listed file.
 ### Edit loop
 
 Use only changed-file syntax checks and the task-specific focused tests listed in
-`codex-execution-efficiency.md`, the active Issue #470 projection roadmap, the
-two-phase addendum, or the owning Issue.
+the efficiency protocol, active resume checkpoint, or owning Issue.
 
 ```text
 node --check web/js/<changed-file>.js
-node tests/<focused-frontend-smoke>.mjs
-python -m unittest <focused test modules>
+python -m unittest <one focused target>
 git diff --check
 ```
 
-The repository `quick` profile is still broad: it runs repository-wide Python
-quality, all frontend syntax/smoke checks, TypeScript, and diff checks. Do not run
-it after every edit.
-
-A failed stop condition or live path should follow the bounded self-resolution
-budget in `codex-blocker-escalation.md`. Do not request PRO review until a hard
-technical-depth criterion is evidenced.
+The repository `quick` profile is broad and is not a task preflight or per-edit
+command.
 
 ### Final PR candidate
 
 - Official full, once per final code/test diff:
   `powershell -ExecutionPolicy Bypass -File tools\check_project.ps1 -Profile full`
-- Rerun only when an invalidating code, test, runner, shared fixture, or
-  configuration change occurs.
+- Rerun only when an invalidating code, test, runner, shared fixture,
+  configuration, or overlapping-rebase change occurs.
+- For D-08 composition-only slices, follow the evidence-reuse and escalation
+  rules in `backend-roadmap-resume-0.6.2.md`; do not repeat package/live checks
+  without a trigger.
 - Frontend behavior changes: follow
   `docs/development/browser-smoke-matrix.md` once per final diff.
 - `comfy node validate` and `comfy node pack` only when package/import/registration,
-  `.comfyignore`, dependency, release, or runtime closure can change.
-- Registry scanner grep from `docs/development/registry-scanner-safety.md` only
-  for scanner-sensitive or release work.
-- Workflow JSON parse and package-version checks for
-  `docs/example_workflows/*.json` only when workflow/release metadata changes.
+  `.comfyignore`, dependency, release, or runtime closure can materially change,
+  or at an explicit integrated exit gate.
+- Registry scanner grep only for scanner-sensitive source changes or future
+  release preparation.
+- Workflow JSON parse and package-version checks only when workflow/release
+  metadata changes.


### PR DESCRIPTION
## 목적

0.6.2 Registry 활성화 대기를 `dev` 구현 차단 조건에서 제거하고, Issue #186의 실제 다음 작업을 현재 코드 기준으로 고정합니다.

Reviewed base: `dev@a509e87c7021257d514e66710f4ca4afb74c4a05` after D-08s / PR #520.

## 검토 결과

- 현재 D-08 route composition 방향에서 P0/P1 동작 결함은 확인되지 않았습니다.
- root `api.py`는 아직 7개 profile handler를 직접 factory-compose/correlate하는 640-line transitional facade입니다.
- canonical route behavior, `api/router.py` registration ownership, bootstrap initialization, import boundary, package import, request correlation과 profile contracts는 merged evidence상 정상입니다.
- 다음 위험은 기능 오류보다 roadmap drift와 반복 package/live 검증 비용입니다.

## 변경

- `docs/architecture/backend-roadmap-resume-0.6.2.md` 추가
  - D-08t profile load
  - D-08u profile save
  - D-08v AiO delete/rename
  - D-08w LoRA fix
  - D-08x integrated exit audit
  - exact allowed/forbidden boundaries와 stop conditions
  - composition-only PR의 package/live evidence reuse
- architecture/development entry points를 현재 D-08 queue와 0.6.2 baseline으로 갱신
- 완료된 #470/0.6.1 lane을 historical contract로 전환
- Registry review는 external/non-blocking으로 명시

## 검증 정책 변경

D-08t-w가 `api.py`, `bootstrap.py`, direct tests와 analyzer baseline만 변경하고 behavior/import-shipping/registration을 바꾸지 않으면:

- changed-file + focused tests
- final SHA official full 1회
- package/live는 기존 route extraction evidence 재사용

D-08x에서 validate/pack/archive 및 대표 profile API live matrix를 한 번 통합 실행합니다. Shipped file, route signature, error/persistence/lifecycle 변경이 생기면 해당 PR에서 즉시 승격합니다.

## 범위

Docs-only입니다. Production Python/JavaScript, tests, workflow, version, release artifact는 변경하지 않습니다.

Refs #186
Refs #513