### PR TITLE
docs: restore Registry safety guide link

### DIFF
--- a/docs/development/README.md
+++ b/docs/development/README.md
@@ -26,7 +26,8 @@ Read only the sections needed by the active task.
    - Prompt Studio execution projection: `../architecture/prompt-studio-execution-derived-projection.md`
    - dual-canvas UI checks: `browser-smoke-matrix.md`
    - custom-node integrations: `custom-node-integrations.md`
-   - Registry scanner prevention for a future release: `registry-scanner-safety.md`
+   - Registry scanner prevention for a future release:
+     [docs/development/registry-scanner-safety.md](registry-scanner-safety.md)
    - workflows: `../Anima AiO/Workflow_Management.md`
 7. Confirm `git status --short`, current branch/worktree, direct source, and direct
    tests.


### PR DESCRIPTION
## 목적과 변경 경계

PR #522가 개발 entry의 Registry scanner guide를 inline-code로 바꾸면서 기존 문서 링크 contract가 실패한 회귀를 복구합니다. Production 코드는 변경하지 않습니다.

## Base -> Head

- `fc88de042e60e2b39ecc7e4594696bdfeacab000` -> `46a6011`

## 변경

- `docs/development/README.md`
  - repository-relative 표기를 보존하면서 실제 Markdown 링크로 복구
  - 기존 test가 요구하는 `docs/development/registry-scanner-safety.md` 식별자 유지

## 검증

- `RegistryScannerSafetyTests.test_registry_safety_doc_is_linked_from_development_entry`: 1 passed
- `git diff --check`: passed
- official full: D-08t candidate에서 이 base-only 실패 1건을 확인했고, 이 docs-only prerequisite merge 후 갱신한 D-08t final SHA에서 다시 실행

## 위험과 rollback

- 문서 링크 한 줄만 변경하므로 runtime/package/live 영향 없음
- rollback은 이 commit의 단순 revert
