### PR TITLE
[Maintenance] E-01 Python runtime state ownership inventory

### DIFF
--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -10,21 +10,24 @@ then only the active task section, owning Issue, direct source, and direct tests
 ## Active sequencing
 
 - Issue [#187](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/187)
-  owns the next E-01 inventory Contract. Issue #186 retains D-14/shim decisions.
+  owns Phase E. E-01 inventory is complete; E-02b is the next bounded Contract.
+  Issue #186 retains D-14/shim decisions.
 - [`backend-roadmap-resume-0.6.2.md`](backend-roadmap-resume-0.6.2.md)
   is the current execution source of truth. Read it before the older accumulated
   roadmap.
-- Reviewed code baseline: D-08u / PR #525 at
-  `597d1c9fc1305baeacd3483b24d7fcec68fc9cf9`.
+- Reviewed code baseline: D-14 readiness / PR #526 at
+  `3c15a34c8e10f3f1999b16496b72343ce30759ae`.
 - D-08 is complete and D-08v is not required.
 - D-14 readiness retains every root surface; retirement/final-freeze work is blocked.
-- First READY task: #187 E-01 global-state inventory only.
+- E-01 inventory Contract:
+  [`python-runtime-state-inventory.md`](python-runtime-state-inventory.md).
+- First READY task after E-01: #187 E-02b RuntimeConfig/base lifecycle Contract only.
 - Completed #470 and the #413/#414/#415 queue/live-UI lanes remain contract references,
   not active blockers.
 - Released code baseline: 0.6.2. Registry activation is external administration and
   does not block `dev`; do not republish or mutate the release.
 - Completed #409/#410/#411 and deferred #440/#441 do not alter the E-01 boundary.
-- E-01 inventory does not authorize later Phase E Moves, root removal, release, or
+- E-01 completion does not authorize later Phase E Moves, root removal, release, or
   Registry work.
 
 ## Current code boundary
@@ -43,9 +46,9 @@ After D-08u:
 - no reviewed evidence requires changing routes, payloads, persistence, error policy,
   workflow contracts, or optional-dependency behavior.
 
-This is transitional debt, not a reason for a broad rewrite. E-01 records ownership,
-lifetime, locking, cleanup, and test evidence without removing aliases or absorbing
-feature behavior.
+This is transitional debt, not a reason for a broad rewrite. The E-01 inventory
+records ownership, lifetime, locking, cleanup, and test evidence without removing
+aliases or absorbing feature behavior.
 
 ## Core documents
 
@@ -57,6 +60,8 @@ feature behavior.
   accumulated progress and historical task details; not the current immediate queue.
 - [`python-compatibility-shims.md`](python-compatibility-shims.md): supported root/shim
   inventory and removal evidence.
+- [`python-runtime-state-inventory.md`](python-runtime-state-inventory.md): E-01
+  runtime-owned/declarative state partition, lifecycle gaps, and target phases.
 - [`adr-001-modular-monolith.md`](adr-001-modular-monolith.md): feature-oriented modular
   monolith decision.
 - [`adr-002-compatibility-shims.md`](adr-002-compatibility-shims.md): shim lifecycle and

--- a/docs/architecture/backend-roadmap-resume-0.6.2.md
+++ b/docs/architecture/backend-roadmap-resume-0.6.2.md
@@ -2,14 +2,14 @@
 
 ## Status and authority
 
-- Status: D-08 completed; the D-14 readiness audit retains every root surface and
-  blocks retirement/final-freeze work.
-- Code-review baseline: `dev@597d1c9fc1305baeacd3483b24d7fcec68fc9cf9`
-  after D-08u / PR #525.
-- Document baseline: D-14 readiness audit after PR #525.
+- Status: D-08 and the E-01 inventory Contract are completed; the D-14 readiness
+  audit retains every root surface and blocks retirement/final-freeze work.
+- Code-review baseline: `dev@3c15a34c8e10f3f1999b16496b72343ce30759ae`
+  after the D-14 readiness audit / PR #526.
+- Document baseline: E-01 inventory Contract after the D-14 readiness audit.
 - Released baseline: 0.6.2.
-- Scope: completed D-08 evidence, the D-14 readiness decision, and the next bounded
-  #187 E-01 inventory handoff.
+- Scope: completed D-08 evidence, the D-14 readiness decision, the completed #187
+  E-01 inventory, and the next bounded E-02b Contract handoff.
 - This document owns the current immediate queue and supersedes the stale queue and
   broad preflight command in `python-backend-execution-roadmap.md`.
 - `python-backend.md`, ADR-001, ADR-002, and the compatibility-shim registry still own
@@ -257,11 +257,12 @@ The D-08u audit found no required D-08v. After D-08:
    public shims lack removal-supporting consumer evidence;
 3. D-14 retirement/final-freeze work remains blocked and no root file or alias is
    removed;
-4. the first independent READY Phase E unit is #187 E-01 global-state inventory;
-   the narrow E-02a/E-07a/E-07b bridge is already complete through #323; and
-5. never remove root files merely to make the directory tree appear complete.
+4. #187 E-01 global-state inventory is complete and versioned; the narrow
+   E-02a/E-07a/E-07b bridge is already complete through #323;
+5. the first READY follow-up is E-02b RuntimeConfig/base lifecycle Contract; and
+6. never remove root files merely to make the directory tree appear complete.
 
-## 6. Codex resume instruction
+## 6. E-01 result and Codex resume instruction
 
 ```text
 D-08 is complete. Do not restart D-08t or create D-08v without new contrary
@@ -270,11 +271,12 @@ production evidence.
 D-14 retirement is blocked. Retain every root file and alias. Do not turn the
 readiness audit into removal, deprecation, or release work.
 
-Start only #187 E-01 global-state inventory from latest origin/dev. Read the
-current #187 body/checkpoint, runtime shell, bootstrap, root api/wildcard runtime
-owners, and direct inventory/analyzer tests. Record owner, lifetime, lock,
-cleanup/reset, and test evidence before proposing any feature migration.
+E-01 is owned by python-runtime-state-inventory.md and
+tests/fixtures/python_runtime_state_ownership.v1.json. Its direct gate requires
+every analyzer mutable global to be runtime-owned or declarative-only, maps every
+owner candidate, and adds manual singleton/path/import-effect coverage.
 
-Do not start E-03 through E-10 behavior/lifecycle Moves, release, or Registry work
-inside the E-01 inventory Contract.
+Start only #187 E-02b RuntimeConfig/base lifecycle Contract from latest origin/dev.
+Use the E-01 target phases and cleanup gaps as input. Do not start E-03 through E-10
+behavior/lifecycle Moves, release, or Registry work inside E-02b.
 ```

--- a/docs/architecture/python-backend-execution-roadmap.md
+++ b/docs/architecture/python-backend-execution-roadmap.md
@@ -1463,6 +1463,14 @@ Recommended sequence:
 10. E-10 isolated runtime fixtures and removal of module reload/private-global
     reset patterns.
 
+E-01 is complete through the versioned
+[`python-runtime-state-inventory.md`](python-runtime-state-inventory.md) Contract and
+`tests/fixtures/python_runtime_state_ownership.v1.json`. The direct gate partitions
+every analyzer mutable global, maps owner candidates, and covers manual
+singleton/path/import-effect gaps without changing production behavior. The next
+bounded unit is E-02b RuntimeConfig/base lifecycle Contract; feature owner Moves
+remain separate.
+
 Feature services receive only narrow Protocols. They do not import or receive
 the entire `RuntimeServices` object. Node adapters may use `get_runtime()` only
 at the ComfyUI construction boundary.

--- a/docs/architecture/python-runtime-state-inventory.md
+++ b/docs/architecture/python-runtime-state-inventory.md
@@ -1,0 +1,85 @@
+# Python Runtime State Ownership Inventory
+
+## Status and authority
+
+This is the E-01 Contract owned by
+[Issue #187](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/187).
+The executable source of truth is
+`tests/fixtures/python_runtime_state_ownership.v1.json`; the direct contract test
+rejects stale symbols, missing evidence, analyzer owner candidates without an owner,
+and mutable globals without an explicit disposition.
+
+E-01 records the current state. It does not move state, add lifecycle behavior, or
+claim that Phase E is complete.
+
+## Method
+
+The inventory combines:
+
+1. `tools/analyze_python_backend.py` mutable-global and owner-candidate output;
+2. direct review of cache, lock, Future, executor, provider, repository, capability,
+   path-resolution, route-registration, and directory-initialization owners; and
+3. current reset, close, synchronization, and test evidence.
+
+The analyzer's `__all__` lists are excluded as export metadata. Every other detected
+mutable global is partitioned exactly once:
+
+- **runtime-owned**: mutated, populated, or identity-installed during process work;
+- **declarative-only**: a Python mutable container used as an immutable table or
+  public metadata surface.
+
+Declarative-only does not grant mutation permission. It records why those containers
+are not lifecycle resources and makes any newly introduced mutable global fail the
+E-01 drift gate until classified.
+
+## Runtime owners and migration targets
+
+| Entry | Current owner and lifetime | Synchronization / cleanup today | Target |
+| --- | --- | --- | --- |
+| `aio-first-pass-cache` | canonical AiO cache module, process lifetime with count/byte/TTL bounds | one `RLock`; explicit clear plus test-only metric/config reset | E-08 |
+| `api-file-io-limiters` | canonical API file-I/O module, weak per-event-loop limiter | registry `Lock`; weak expiry, no explicit close | E-09 |
+| `autocomplete-dataset-cache` | canonical dataset snapshot and Future single-flight maps | one `Lock`; test-only clear | E-05 |
+| `autocomplete-index-locks` | canonical index per-path lock registry | guard plus per-path locks; no clear | E-05 |
+| `autocomplete-index-root` | import-resolved user-data index path | immutable after import; test patch only | E-02 |
+| `atomic-json-path-locks` | filesystem atomic JSON per-path lock registry | guard plus per-path `RLock`; no clear | E-03 |
+| `bootstrap-initialize-state` | bootstrap default runtime and wildcard completion state | initialize `Lock`; private-global test reset, no shutdown | E-09 |
+| `filesystem-runtime-paths` | import-resolved package/user-data paths | immutable after import; no runtime config object | E-02 |
+| `package-bootstrap-effect` | root import invokes bootstrap route/directory initialization | bootstrap `Lock`; retry behavior, no package shutdown | E-09 |
+| `profile-directory-mutation-coordinator` | canonical process coordinator with weak per-directory locks | guard plus per-directory `RLock`; weak expiry | E-03 |
+| prompt warning-dedupe entries | two canonical Prompt feature modules, process lifetime | unprotected sets; direct-test clear only | E-09 |
+| `prompt-knowledge-path` | canonical ANIMA prompt package path | immutable after import | E-02 |
+| `root-route-registration` | injected router registrar called by bootstrap | serialized refresh; idempotent marker, no deregistration | E-09 |
+| `root-translation-route-worker` | root compatibility runtime owns lazy single-thread executor | internal `RLock`; idempotent `atexit` shutdown only | E-04 |
+| `runtime-services` | identity-installed process runtime with Comfy and seed capabilities | bootstrap-serialized install; private-global test reset, no close | E-09 |
+| `translation-default-service` | canonical default cache/single-flight service | cache and flight `RLock`s; cache clear exists, no process reset | E-04 |
+| `translation-provider-registry` | canonical lazy provider-client registry | one `RLock`; test patch only, no provider close | E-04 |
+| `wildcard-snapshot-cache` | root verified-snapshot LRU and build single-flight | one `Condition`; no owner reset/close | E-06 |
+
+The fixture contains exact symbols, tests, owner, lifetime, thread-safety, and
+reset/close status. This table is a review index, not a second machine-readable
+source.
+
+## E-01 exit result
+
+- All current analyzer owner candidates map to a runtime owner.
+- All analyzer mutable globals other than `__all__` have exactly one runtime-owned or
+  declarative-only disposition.
+- Manual gaps cover RuntimeServices identity, bootstrap state, weak registries,
+  Conditions, scalar cache state, provider/default-service instances, profile
+  coordination, path resolution, root translation executor, and package/route
+  initialization effects.
+- The completed E-02a/E-07 Comfy provider bridge remains unchanged.
+- No production Python, analyzer heuristic, public surface, cache policy, or
+  lifecycle behavior changes in E-01.
+
+## Next bounded unit
+
+The first follow-up is an **E-02b Contract** for `RuntimeConfig` and the common
+clock/executor/client lifecycle ports. It must decide how import-resolved paths,
+process close ordering, and isolated construction are represented before any feature
+owner is moved. E-03 through E-09 Moves remain separate and use this fixture's target
+phase and cleanup gaps as their input.
+
+No PRO review is required for E-01: the analyzer and direct source converge on one
+current owner for every item. Escalate only if E-02b finds multiple viable production
+composition owners or an unavoidable compatibility cycle.

--- a/docs/development/README.md
+++ b/docs/development/README.md
@@ -18,6 +18,8 @@ Read only the sections needed by the active task.
      execution roadmap.
 4. Backend target architecture and compatibility policy:
    [`../architecture/README.md`](../architecture/README.md)
+   - E-01 runtime state ledger:
+     [`../architecture/python-runtime-state-inventory.md`](../architecture/python-runtime-state-inventory.md)
 5. Read [`codex-blocker-escalation.md`](codex-blocker-escalation.md) only after a
    documented hard stop or unresolved cross-owner failure. Ordinary implementation
    and test failures remain local task work.
@@ -39,19 +41,19 @@ ordinary `dev` roadmap work.
 ## Active state
 
 - Released baseline: 0.6.2.
-- Active owner: Issue #187 for the next inventory Contract; Issue #186 retains
-  D-14/shim decisions.
-- Reviewed code baseline: D-08u / PR #525.
+- Active owner: Issue #187 for Phase E; Issue #186 retains D-14/shim decisions.
+- Reviewed code baseline: D-14 readiness / PR #526.
 - D-08u integrated exit audit is complete.
 - D-08v is not required; the audit found no remaining D-08 production Move.
 - D-14 readiness is audited: every root surface is retained and retirement/final
   freeze is blocked by production/lifecycle consumers, missing release windows, or
   insufficient consumer evidence.
-- Next work is only #187 E-01 global-state inventory. The #323 E-02a/E-07 bridge
-  remains completed evidence, not authorization for later feature migration.
+- E-01 global-state inventory is complete and versioned. The next work is only #187
+  E-02b RuntimeConfig/base lifecycle Contract. The #323 E-02a/E-07 bridge remains
+  completed evidence, not authorization for later feature migration.
 - Completed #470 and the 0.6.1 Prompt Studio lane are behavior-contract references,
   not the active queue.
-- Do not remove root aliases or start E-03 through E-10, release, or Registry work
+- Do not remove root aliases or start E-03 through E-10 Moves, release, or Registry work
   from this entrypoint.
 
 ## Completed D-08 composition audit surface
@@ -143,6 +145,6 @@ representative profile list/load/save/delete/rename/fix live smoke
 - A version marker is not a publish action.
 - Technical PRO review is for unresolved cross-boundary architecture choices,
   unavoidable cycles, or insufficient compatibility evidence—not routine failures.
-- D-14 readiness is recorded and authorizes no removal. Start only #187 E-01
-  global-state inventory; do not expand it into feature lifecycle Moves, release
-  publication, or Registry actions.
+- D-14 readiness is recorded and authorizes no removal. Use the completed E-01
+  ledger for E-02b; do not expand that Contract into feature lifecycle Moves,
+  release publication, or Registry actions.

--- a/tests/fixtures/python_runtime_state_ownership.v1.json
+++ b/tests/fixtures/python_runtime_state_ownership.v1.json
@@ -1,0 +1,393 @@
+{
+  "declarative_mutable_globals": [
+    {
+      "module": "easyuse_anima/aio/generation_defaults.py",
+      "reason": "Published generation defaults and special-seed lookup data; production treats both containers as immutable tables.",
+      "symbols": ["AIO_GENERATION_DEFAULT_SETTINGS", "AIO_SPECIAL_SEEDS"]
+    },
+    {
+      "module": "easyuse_anima/aio/generation_normalization.py",
+      "reason": "Private immutable membership table used by normalization.",
+      "symbols": ["_AIO_DETAILER_RESERVED_KEYS"]
+    },
+    {
+      "module": "easyuse_anima/aio/input_defaults.py",
+      "reason": "Published immutable input-default table.",
+      "symbols": ["AIO_INPUT_DEFAULT_SETTINGS"]
+    },
+    {
+      "module": "easyuse_anima/aio/negpip.py",
+      "reason": "Static compatibility and bracket lookup tables.",
+      "symbols": ["_EXPECTED_INPUTS", "_OPEN_TO_CLOSE"]
+    },
+    {
+      "module": "easyuse_anima/aio/preview.py",
+      "reason": "Published immutable stage-label table.",
+      "symbols": ["AIO_PREVIEW_STAGE_LABELS"]
+    },
+    {
+      "module": "easyuse_anima/aio/torch_compile_recommendation.py",
+      "reason": "Static recommendation lookup values.",
+      "symbols": ["_COMMON_VALUES"]
+    },
+    {
+      "module": "easyuse_anima/autocomplete/dataset.py",
+      "reason": "Source and category metadata; distinct from the runtime snapshot cache.",
+      "symbols": [
+        "AUTOCOMPLETE_SOURCES",
+        "_DANBOORU_CATEGORY_NAMES",
+        "_E621_CATEGORY_NAMES",
+        "_MERGED_E621_CATEGORY_NAMES"
+      ]
+    },
+    {
+      "module": "easyuse_anima/image/scaling.py",
+      "reason": "Published immutable UI choice lists.",
+      "symbols": ["IMAGE_SCALE_MULTIPLES", "IMAGE_UPSCALE_METHODS"]
+    },
+    {
+      "module": "easyuse_anima/infrastructure/filesystem/atomic_json.py",
+      "reason": "Static platform error-code membership table; distinct from the runtime path-lock registry.",
+      "symbols": ["_UNSUPPORTED_DIRECTORY_FSYNC_ERRORS"]
+    },
+    {
+      "module": "easyuse_anima/naia/client.py",
+      "reason": "Published immutable host and payload-key metadata.",
+      "symbols": ["NAIA_LOCAL_HOSTS", "PP_STATE_CHOICES", "PREPROCESSING_KEYS"]
+    },
+    {
+      "module": "easyuse_anima/naia/resolution.py",
+      "reason": "Published immutable resolution-bucket table.",
+      "symbols": ["ADVANCED_RESOLUTION_BUCKETS"]
+    },
+    {
+      "module": "easyuse_anima/nodes/wildcard_nodes.py",
+      "reason": "Published immutable display-label table.",
+      "symbols": ["WILDCARD_MODE_DISPLAY_LABELS"]
+    },
+    {
+      "module": "easyuse_anima/profiles/aio.py",
+      "reason": "Static reserved-name membership table.",
+      "symbols": ["AIO_RESERVED_PROFILE_NAMES"]
+    },
+    {
+      "module": "easyuse_anima/profiles/repository.py",
+      "reason": "Static Windows reserved-name membership table.",
+      "symbols": ["WINDOWS_RESERVED_FILE_BASENAMES"]
+    },
+    {
+      "module": "easyuse_anima/prompt/advanced.py",
+      "reason": "Published immutable Prompt Studio schema, alias, and layout metadata.",
+      "symbols": [
+        "ADVANCED_FIELD_LABELS",
+        "ADVANCED_FIELD_PANES",
+        "ADVANCED_FIELD_TYPES",
+        "EXTEND_PROMPT_SLOT_SPECS",
+        "PROMPT_STUDIO_LEGACY_FIXED_WILDCARD_MODES",
+        "PROMPT_STUDIO_WILDCARD_SEED_CONTROL_ALIASES"
+      ]
+    },
+    {
+      "module": "easyuse_anima/prompt/anima/ordering.py",
+      "reason": "Static tag-section ordering tables.",
+      "symbols": ["BUILTIN_TAG_SECTIONS", "SECTION_ORDER"]
+    },
+    {
+      "module": "easyuse_anima/prompt/artist_mix.py",
+      "reason": "Immutable mode descriptions; distinct from the runtime warning-dedupe set.",
+      "symbols": ["ARTIST_MIX_MODE_DESCRIPTIONS"]
+    },
+    {
+      "module": "easyuse_anima/prompt/regional.py",
+      "reason": "Published immutable regional field schema metadata.",
+      "symbols": ["ADVANCED_FIELD_LABELS", "ADVANCED_FIELD_PANES", "REGIONAL_FIELD_TYPES"]
+    },
+    {
+      "module": "easyuse_anima/registration.py",
+      "reason": "ComfyUI node registration metadata assembled once and treated as immutable.",
+      "symbols": ["NODE_CLASS_MAPPINGS", "NODE_DISPLAY_NAME_MAPPINGS"]
+    },
+    {
+      "module": "easyuse_anima/seed/reservation.py",
+      "reason": "Static legacy seed-selection compatibility lookup.",
+      "symbols": ["_LEGACY_SELECTION_BY_SEED"]
+    },
+    {
+      "module": "easyuse_anima/settings/schema.py",
+      "reason": "Published immutable settings schema, defaults, keys, aliases, and choices.",
+      "symbols": [
+        "AUTOCOMPLETE_COMMIT_KEYS",
+        "AUTOCOMPLETE_COMMIT_MODES",
+        "AUTOCOMPLETE_MODES",
+        "COMFY_SETTING_KEYS",
+        "DEFAULT_SETTINGS",
+        "LONG_TEXT_SETTING_ALIASES",
+        "LONG_TEXT_SETTING_KEYS",
+        "NAIA_PREPROCESSING_KEYS",
+        "NAIA_RESOLUTION_BUCKETS",
+        "NAIA_RESOLUTION_MODES",
+        "PROMPT_STUDIO_COLOR_KEYS"
+      ]
+    },
+    {
+      "module": "easyuse_anima/translation/contracts.py",
+      "reason": "Published immutable provider-choice membership table.",
+      "symbols": ["PROMPT_TRANSLATION_PROVIDERS"]
+    },
+    {
+      "module": "easyuse_anima/translation/service.py",
+      "reason": "Static provider factory registry; provider instances are runtime state.",
+      "symbols": ["_TRANSLATION_PROVIDER_FACTORIES"]
+    },
+    {
+      "module": "easyuse_anima/wildcard/mode.py",
+      "reason": "Published immutable wildcard-mode alias lookup.",
+      "symbols": ["WILDCARD_MODE_ALIASES"]
+    },
+    {
+      "module": "easyuse_anima/wildcard/sources.py",
+      "reason": "Published immutable wildcard-extension membership table.",
+      "symbols": ["WILDCARD_EXTENSIONS"]
+    }
+  ],
+  "entries": [
+    {
+      "categories": ["cache", "lock", "metrics"],
+      "cleanup": "_clear_aio_first_pass_cache clears entries/order and advances generation; tests also reset metrics and the enabled flag.",
+      "id": "aio-first-pass-cache",
+      "lifetime": "Process lifetime from module import; entries are bounded by count, bytes, and TTL.",
+      "module": "easyuse_anima/aio/first_pass_cache.py",
+      "owner": "easyuse_anima.aio.first_pass_cache",
+      "symbols": [
+        "_AIO_FIRST_PASS_CACHE",
+        "_AIO_FIRST_PASS_CACHE_ENABLED",
+        "_AIO_FIRST_PASS_CACHE_GENERATION",
+        "_AIO_FIRST_PASS_CACHE_LOCK",
+        "_AIO_FIRST_PASS_CACHE_METRICS",
+        "_AIO_FIRST_PASS_CACHE_ORDER"
+      ],
+      "target_phase": "E-08",
+      "test_evidence": ["tests/test_aio_first_pass_cache.py", "tests/test_aio_first_pass_cache_benchmark.py"],
+      "thread_safety": "One RLock protects enabled/generation/cache/order/metrics publication and mutation."
+    },
+    {
+      "categories": ["async_limiter", "lock", "weak_registry"],
+      "cleanup": "Weak loop keys and weak semaphore values self-expire; no explicit process shutdown hook.",
+      "id": "api-file-io-limiters",
+      "lifetime": "One limiter per live asyncio event loop while the loop and active work remain reachable.",
+      "module": "easyuse_anima/api/file_io.py",
+      "owner": "easyuse_anima.api.file_io",
+      "symbols": ["_FILE_IO_LIMITERS", "_FILE_IO_LIMITERS_LOCK"],
+      "target_phase": "E-09",
+      "test_evidence": ["tests/test_api_contract.py"],
+      "thread_safety": "A module Lock serializes weak-registry lookup and semaphore creation."
+    },
+    {
+      "categories": ["cache", "future", "lock", "single_flight"],
+      "cleanup": "Tests clear _CACHE and _INFLIGHT under _CACHE_LOCK; production has no owner-level close/reset.",
+      "id": "autocomplete-dataset-cache",
+      "lifetime": "Process lifetime with entries keyed by source identity and work retained until completion.",
+      "module": "easyuse_anima/autocomplete/dataset.py",
+      "owner": "easyuse_anima.autocomplete.dataset",
+      "symbols": ["_CACHE", "_CACHE_LOCK", "_INFLIGHT"],
+      "target_phase": "E-05",
+      "test_evidence": ["tests/test_autocomplete_index.py"],
+      "thread_safety": "One Lock protects cache snapshots and the Future single-flight map."
+    },
+    {
+      "categories": ["lock", "path_registry"],
+      "cleanup": "No explicit cleanup; path locks remain after first index access.",
+      "id": "autocomplete-index-locks",
+      "lifetime": "Process lifetime, one Lock per normalized index path.",
+      "module": "easyuse_anima/autocomplete/index.py",
+      "owner": "easyuse_anima.autocomplete.index",
+      "symbols": ["_INDEX_LOCKS", "_INDEX_LOCKS_GUARD"],
+      "target_phase": "E-05",
+      "test_evidence": ["tests/test_autocomplete_index.py"],
+      "thread_safety": "The guard serializes creation; each per-path Lock serializes index publication."
+    },
+    {
+      "categories": ["path_resolution", "runtime_config"],
+      "cleanup": "No reset; tests patch the module value when an isolated index root is required.",
+      "id": "autocomplete-index-root",
+      "lifetime": "Resolved once at import from process USER_DATA_DIR.",
+      "module": "easyuse_anima/autocomplete/search.py",
+      "owner": "easyuse_anima.autocomplete.search",
+      "symbols": ["_AUTOCOMPLETE_INDEX_DIR"],
+      "target_phase": "E-02",
+      "test_evidence": ["tests/test_autocomplete_index.py", "tests/test_python_package_skeleton.py"],
+      "thread_safety": "Immutable Path-or-None after import."
+    },
+    {
+      "categories": ["lock", "path_registry"],
+      "cleanup": "No explicit cleanup; normalized-path locks remain after first atomic operation.",
+      "id": "atomic-json-path-locks",
+      "lifetime": "Process lifetime, one RLock per normalized filesystem path.",
+      "module": "easyuse_anima/infrastructure/filesystem/atomic_json.py",
+      "owner": "easyuse_anima.infrastructure.filesystem.atomic_json",
+      "symbols": ["_PATH_LOCKS", "_PATH_LOCKS_GUARD"],
+      "target_phase": "E-03",
+      "test_evidence": ["tests/test_storage.py"],
+      "thread_safety": "The guard serializes registry access; per-path RLocks serialize publish operations."
+    },
+    {
+      "categories": ["bootstrap", "lock", "runtime_reference"],
+      "cleanup": "No production reset or shutdown; tests patch _DEFAULT_RUNTIME and _WILDCARDS_INITIALIZED.",
+      "id": "bootstrap-initialize-state",
+      "lifetime": "Process lifetime after first successful package initialization.",
+      "module": "easyuse_anima/bootstrap.py",
+      "owner": "easyuse_anima.bootstrap.initialize",
+      "symbols": ["_DEFAULT_RUNTIME", "_INITIALIZE_LOCK", "_WILDCARDS_INITIALIZED", "initialize"],
+      "target_phase": "E-09",
+      "test_evidence": ["tests/test_python_bootstrap.py", "tests/test_runtime_services.py"],
+      "thread_safety": "One Lock serializes runtime install, route refresh, and wildcard initialization."
+    },
+    {
+      "categories": ["path_resolution", "runtime_config"],
+      "cleanup": "No reset; tests isolate imports or patch consumers.",
+      "id": "filesystem-runtime-paths",
+      "lifetime": "Package paths are import-stable; USER_DATA_DIR is resolved once from ComfyUI or package fallback.",
+      "module": "easyuse_anima/infrastructure/filesystem/paths.py",
+      "owner": "easyuse_anima.infrastructure.filesystem.paths",
+      "symbols": ["PACKAGE_DATA_DIR", "PACKAGE_ROOT", "USER_DATA_DIR"],
+      "target_phase": "E-02",
+      "test_evidence": ["tests/test_python_package_skeleton.py", "tests/test_runtime_services.py"],
+      "thread_safety": "Immutable Path values after import."
+    },
+    {
+      "categories": ["directory_initialization", "import_effect", "route_registration"],
+      "cleanup": "No package shutdown or route deregistration; bootstrap retries failed initialization.",
+      "id": "package-bootstrap-effect",
+      "lifetime": "Executed once per root package import; bootstrap state survives for the process.",
+      "module": "__init__.py",
+      "owner": "easyuse_anima.bootstrap.initialize",
+      "symbols": ["_initialize"],
+      "target_phase": "E-09",
+      "test_evidence": ["tests/test_python_bootstrap.py", "tests/test_python_package_skeleton.py", "tests/test_runtime_services.py"],
+      "thread_safety": "Bootstrap serializes the production call with _INITIALIZE_LOCK."
+    },
+    {
+      "categories": ["lock", "repository", "weak_registry"],
+      "cleanup": "Per-directory RLocks disappear when unreferenced; the process coordinator has no close.",
+      "id": "profile-directory-mutation-coordinator",
+      "lifetime": "One process coordinator created at canonical profile module import.",
+      "module": "easyuse_anima/profiles/mutation.py",
+      "owner": "easyuse_anima.profiles.mutation.PROFILE_MUTATION_COORDINATOR",
+      "symbols": ["PROFILE_MUTATION_COORDINATOR"],
+      "target_phase": "E-03",
+      "test_evidence": ["tests/test_aio_profiles.py", "tests/test_lora_profiles.py"],
+      "thread_safety": "A guard protects the weak registry; one RLock serializes CAS per directory."
+    },
+    {
+      "categories": ["compatibility_warning", "dedupe_set"],
+      "cleanup": "No production reset; direct tests clear the set.",
+      "id": "prompt-artist-mix-warning-dedupe",
+      "lifetime": "Process lifetime, keyed by external patcher class.",
+      "module": "easyuse_anima/prompt/artist_mix.py",
+      "owner": "easyuse_anima.prompt.artist_mix",
+      "symbols": ["_SPECTRUM_ANIMA_MOD_GUIDANCE_OLD_SIGNATURE_WARNED"],
+      "target_phase": "E-09",
+      "test_evidence": ["tests/test_prompt_corrector.py"],
+      "thread_safety": "Unprotected membership/add; current execution accepts benign duplicate-warning races."
+    },
+    {
+      "categories": ["compatibility_warning", "dedupe_set"],
+      "cleanup": "No production reset; compatibility tests inspect canonical identity.",
+      "id": "prompt-conditioning-warning-dedupe",
+      "lifetime": "Process lifetime, keyed by external patcher class.",
+      "module": "easyuse_anima/prompt/conditioning.py",
+      "owner": "easyuse_anima.prompt.conditioning",
+      "symbols": ["_SPECTRUM_ANIMA_MOD_GUIDANCE_OLD_SIGNATURE_WARNED"],
+      "target_phase": "E-09",
+      "test_evidence": ["tests/test_node_contracts.py", "tests/test_python_compatibility_surface.py"],
+      "thread_safety": "Unprotected membership/add; current execution accepts benign duplicate-warning races."
+    },
+    {
+      "categories": ["path_resolution"],
+      "cleanup": "No reset is needed for the package-owned data path.",
+      "id": "prompt-knowledge-path",
+      "lifetime": "Resolved once from installed package location at import.",
+      "module": "easyuse_anima/prompt/anima/knowledge.py",
+      "owner": "easyuse_anima.prompt.anima.knowledge",
+      "symbols": ["PACKAGE_DATA_DIR"],
+      "target_phase": "E-02",
+      "test_evidence": ["tests/test_python_package_skeleton.py"],
+      "thread_safety": "Immutable Path after import."
+    },
+    {
+      "categories": ["route_registration", "route_table"],
+      "cleanup": "No deregistration; identical tables are idempotent and changed tables register on refresh.",
+      "id": "root-route-registration",
+      "lifetime": "Route table built at api import; registration refreshed on every bootstrap initialize.",
+      "module": "api.py",
+      "owner": "easyuse_anima.api.router registrar composed through easyuse_anima.bootstrap",
+      "symbols": ["_ROUTE_DEFINITIONS", "_ROUTE_SIGNATURE", "register_routes"],
+      "target_phase": "E-09",
+      "test_evidence": ["tests/test_api_contract.py", "tests/test_python_bootstrap.py"],
+      "thread_safety": "Bootstrap serializes production registration; router markers guard duplicate signatures."
+    },
+    {
+      "categories": ["atexit", "executor", "future", "single_flight"],
+      "cleanup": "Executor shutdown is registered with atexit and idempotent; package shutdown does not call it.",
+      "id": "root-translation-route-worker",
+      "lifetime": "Created at api import; ThreadPoolExecutor is lazy and process-lived until atexit.",
+      "module": "api.py",
+      "owner": "api._PROMPT_TRANSLATION_WORKER",
+      "symbols": ["_PROMPT_TRANSLATION_WORKER"],
+      "target_phase": "E-04",
+      "test_evidence": ["tests/test_api_contract.py", "tests/test_prompt_translation_api.py"],
+      "thread_safety": "One RLock protects executor creation, admission, Future identity, and close state."
+    },
+    {
+      "categories": ["capability", "runtime_reference", "seed_reservation_service"],
+      "cleanup": "No production uninstall/close; tests patch _RUNTIME_SERVICES.",
+      "id": "runtime-services",
+      "lifetime": "One identity-installed RuntimeServices object for the process.",
+      "module": "easyuse_anima/runtime.py",
+      "owner": "easyuse_anima.runtime.RuntimeServices",
+      "symbols": ["RuntimeServices", "_RUNTIME_SERVICES"],
+      "target_phase": "E-09",
+      "test_evidence": ["tests/test_comfy_host_wiring.py", "tests/test_runtime_services.py", "tests/test_seed_reservation_service.py"],
+      "thread_safety": "Bootstrap serializes production install; install_runtime enforces identity without a Lock."
+    },
+    {
+      "categories": ["cache", "lock", "service", "single_flight"],
+      "cleanup": "Cache.clear exists, but the module default service has no process reset/close.",
+      "id": "translation-default-service",
+      "lifetime": "Created at translation service import and reused by node and API callbacks.",
+      "module": "easyuse_anima/translation/service.py",
+      "owner": "easyuse_anima.translation.service._DEFAULT_TRANSLATION_SERVICE",
+      "symbols": ["_DEFAULT_TRANSLATION_SERVICE"],
+      "target_phase": "E-04",
+      "test_evidence": ["tests/test_prompt_translation.py"],
+      "thread_safety": "Separate RLocks protect bounded cache and per-key single-flight registry."
+    },
+    {
+      "categories": ["client", "lock", "provider_registry"],
+      "cleanup": "Tests patch instances; production exposes no provider close/reset.",
+      "id": "translation-provider-registry",
+      "lifetime": "Provider clients are lazy and cached for the process.",
+      "module": "easyuse_anima/translation/service.py",
+      "owner": "easyuse_anima.translation.service",
+      "symbols": ["_TRANSLATION_PROVIDER_INSTANCES", "_TRANSLATION_PROVIDER_LOCK"],
+      "target_phase": "E-04",
+      "test_evidence": ["tests/test_prompt_translation.py"],
+      "thread_safety": "One RLock protects provider lookup, construction, and publication."
+    },
+    {
+      "categories": ["cache", "condition", "single_flight"],
+      "cleanup": "No owner-level reset/close; tests isolate keys and inspect settlement.",
+      "id": "wildcard-snapshot-cache",
+      "lifetime": "Process lifetime with an LRU bound of 16 verified snapshots.",
+      "module": "wildcard_engine.py",
+      "owner": "wildcard_engine snapshot lifecycle",
+      "symbols": ["_SNAPSHOT_BUILDING", "_SNAPSHOT_CACHE", "_SNAPSHOT_CONDITION"],
+      "target_phase": "E-06",
+      "test_evidence": ["tests/test_wildcards.py"],
+      "thread_safety": "One Condition protects publication, LRU mutation, admission, wait, and notification."
+    }
+  ],
+  "ignored_mutable_global_names": ["__all__"],
+  "schema_version": 1,
+  "scope": "Shipped Python process-wide state, import/bootstrap effects, and analyzer mutable-global disposition after D-08u and D-14 readiness."
+}

--- a/tests/test_python_runtime_state_ownership.py
+++ b/tests/test_python_runtime_state_ownership.py
@@ -1,0 +1,296 @@
+from __future__ import annotations
+
+import ast
+import importlib.util
+import json
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+ANALYZER_PATH = ROOT / "tools" / "analyze_python_backend.py"
+FIXTURE_PATH = (
+    ROOT / "tests" / "fixtures" / "python_runtime_state_ownership.v1.json"
+)
+INVENTORY_DOC = (
+    ROOT / "docs" / "architecture" / "python-runtime-state-inventory.md"
+)
+
+
+def load_analyzer():
+    spec = importlib.util.spec_from_file_location(
+        "easyuse_anima_python_backend_analyzer_for_state_contract",
+        ANALYZER_PATH,
+    )
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Could not load analyzer: {ANALYZER_PATH.name}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _target_names(target: ast.expr) -> set[str]:
+    if isinstance(target, ast.Name):
+        return {target.id}
+    if isinstance(target, (ast.List, ast.Tuple)):
+        return {
+            name
+            for item in target.elts
+            for name in _target_names(item)
+        }
+    return set()
+
+
+def module_bindings(path: Path) -> set[str]:
+    tree = ast.parse(
+        path.read_text(encoding="utf-8-sig"),
+        filename=str(path),
+    )
+    names: set[str] = set()
+
+    def collect(statements: list[ast.stmt]) -> None:
+        for statement in statements:
+            if isinstance(
+                statement,
+                (ast.ClassDef, ast.FunctionDef, ast.AsyncFunctionDef),
+            ):
+                names.add(statement.name)
+            elif isinstance(statement, ast.Assign):
+                for target in statement.targets:
+                    names.update(_target_names(target))
+            elif isinstance(statement, ast.AnnAssign):
+                names.update(_target_names(statement.target))
+            elif isinstance(statement, (ast.Import, ast.ImportFrom)):
+                for alias in statement.names:
+                    if alias.name == "*":
+                        continue
+                    names.add(alias.asname or alias.name.split(".", 1)[0])
+            elif isinstance(statement, ast.If):
+                collect(statement.body)
+                collect(statement.orelse)
+            elif isinstance(statement, ast.Try):
+                collect(statement.body)
+                for handler in statement.handlers:
+                    collect(handler.body)
+                collect(statement.orelse)
+                collect(statement.finalbody)
+
+    collect(tree.body)
+    return names
+
+
+analyzer = load_analyzer()
+
+
+class PythonRuntimeStateOwnershipContractTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.fixture = json.loads(FIXTURE_PATH.read_text(encoding="utf-8"))
+        cls.report = analyzer.analyze_repository(ROOT)
+
+    def test_fixture_schema_owner_fields_and_evidence_are_complete(self):
+        self.assertEqual(
+            set(self.fixture),
+            {
+                "declarative_mutable_globals",
+                "entries",
+                "ignored_mutable_global_names",
+                "schema_version",
+                "scope",
+            },
+        )
+        self.assertEqual(self.fixture["schema_version"], 1)
+        self.assertEqual(
+            self.fixture["ignored_mutable_global_names"],
+            ["__all__"],
+        )
+
+        entries = self.fixture["entries"]
+        ids = [entry["id"] for entry in entries]
+        self.assertEqual(len(ids), len(set(ids)))
+
+        required_fields = {
+            "categories",
+            "cleanup",
+            "id",
+            "lifetime",
+            "module",
+            "owner",
+            "symbols",
+            "target_phase",
+            "test_evidence",
+            "thread_safety",
+        }
+        for entry in entries:
+            with self.subTest(entry=entry["id"]):
+                self.assertEqual(set(entry), required_fields)
+                for field in (
+                    "cleanup",
+                    "lifetime",
+                    "module",
+                    "owner",
+                    "target_phase",
+                    "thread_safety",
+                ):
+                    self.assertTrue(str(entry[field]).strip())
+                self.assertEqual(
+                    entry["categories"],
+                    sorted(set(entry["categories"])),
+                )
+                self.assertEqual(
+                    entry["symbols"],
+                    sorted(set(entry["symbols"])),
+                )
+                self.assertEqual(
+                    entry["test_evidence"],
+                    sorted(set(entry["test_evidence"])),
+                )
+                self.assertTrue(entry["test_evidence"])
+                for evidence in entry["test_evidence"]:
+                    self.assertTrue((ROOT / evidence).is_file(), evidence)
+
+        declarative_pairs: set[tuple[str, str]] = set()
+        for disposition in self.fixture["declarative_mutable_globals"]:
+            with self.subTest(declarative=disposition["module"]):
+                self.assertEqual(
+                    set(disposition),
+                    {"module", "reason", "symbols"},
+                )
+                self.assertTrue(disposition["reason"].strip())
+                self.assertEqual(
+                    disposition["symbols"],
+                    sorted(set(disposition["symbols"])),
+                )
+                module_path = ROOT / disposition["module"]
+                self.assertTrue(module_path.is_file())
+                self.assertEqual(
+                    set(disposition["symbols"]) - module_bindings(module_path),
+                    set(),
+                )
+                for symbol in disposition["symbols"]:
+                    pair = (disposition["module"], symbol)
+                    self.assertNotIn(pair, declarative_pairs)
+                    declarative_pairs.add(pair)
+
+    def test_runtime_entries_bind_existing_shipped_symbols(self):
+        for entry in self.fixture["entries"]:
+            module_path = ROOT / entry["module"]
+            with self.subTest(
+                entry=entry["id"],
+                module=entry["module"],
+            ):
+                self.assertTrue(module_path.is_file())
+                bindings = module_bindings(module_path)
+                self.assertEqual(
+                    set(entry["symbols"]) - bindings,
+                    set(),
+                    f"{entry['id']} has stale symbols",
+                )
+
+    def test_analyzer_mutable_globals_have_one_explicit_disposition(self):
+        ignored = set(self.fixture["ignored_mutable_global_names"])
+        mutable_globals = {
+            (item["module"], item["name"])
+            for item in self.report["state"]["mutable_globals"]
+            if item["name"] not in ignored
+        }
+        runtime_owned = {
+            (entry["module"], symbol)
+            for entry in self.fixture["entries"]
+            for symbol in entry["symbols"]
+        }
+        declarative = {
+            (entry["module"], symbol)
+            for entry in self.fixture["declarative_mutable_globals"]
+            for symbol in entry["symbols"]
+        }
+
+        self.assertFalse(runtime_owned & declarative)
+        self.assertEqual(declarative - mutable_globals, set())
+        self.assertEqual(
+            mutable_globals,
+            (mutable_globals & runtime_owned) | declarative,
+        )
+
+        owner_candidates = {
+            (item["module"], item["name"])
+            for item in self.report["state"]["owner_candidates"]
+        }
+        self.assertEqual(owner_candidates - runtime_owned, set())
+
+    def test_manual_resource_and_import_effect_inventory_covers_analyzer_gaps(
+        self,
+    ):
+        runtime_owned = {
+            (entry["module"], symbol)
+            for entry in self.fixture["entries"]
+            for symbol in entry["symbols"]
+        }
+        required = {
+            ("__init__.py", "_initialize"),
+            ("api.py", "_PROMPT_TRANSLATION_WORKER"),
+            ("api.py", "register_routes"),
+            (
+                "easyuse_anima/aio/first_pass_cache.py",
+                "_AIO_FIRST_PASS_CACHE_ENABLED",
+            ),
+            (
+                "easyuse_anima/aio/first_pass_cache.py",
+                "_AIO_FIRST_PASS_CACHE_GENERATION",
+            ),
+            ("easyuse_anima/api/file_io.py", "_FILE_IO_LIMITERS"),
+            ("easyuse_anima/autocomplete/dataset.py", "_CACHE_LOCK"),
+            (
+                "easyuse_anima/autocomplete/index.py",
+                "_INDEX_LOCKS_GUARD",
+            ),
+            (
+                "easyuse_anima/autocomplete/search.py",
+                "_AUTOCOMPLETE_INDEX_DIR",
+            ),
+            ("easyuse_anima/bootstrap.py", "_DEFAULT_RUNTIME"),
+            ("easyuse_anima/bootstrap.py", "_WILDCARDS_INITIALIZED"),
+            (
+                "easyuse_anima/infrastructure/filesystem/atomic_json.py",
+                "_PATH_LOCKS_GUARD",
+            ),
+            (
+                "easyuse_anima/infrastructure/filesystem/paths.py",
+                "USER_DATA_DIR",
+            ),
+            (
+                "easyuse_anima/profiles/mutation.py",
+                "PROFILE_MUTATION_COORDINATOR",
+            ),
+            (
+                "easyuse_anima/prompt/artist_mix.py",
+                "_SPECTRUM_ANIMA_MOD_GUIDANCE_OLD_SIGNATURE_WARNED",
+            ),
+            (
+                "easyuse_anima/prompt/conditioning.py",
+                "_SPECTRUM_ANIMA_MOD_GUIDANCE_OLD_SIGNATURE_WARNED",
+            ),
+            ("easyuse_anima/runtime.py", "_RUNTIME_SERVICES"),
+            (
+                "easyuse_anima/translation/service.py",
+                "_DEFAULT_TRANSLATION_SERVICE",
+            ),
+            ("wildcard_engine.py", "_SNAPSHOT_CONDITION"),
+        }
+        self.assertEqual(required - runtime_owned, set())
+
+    def test_inventory_document_is_linked_from_maintained_entries(self):
+        self.assertTrue(INVENTORY_DOC.is_file())
+        link = "python-runtime-state-inventory.md"
+        architecture_entry = (
+            ROOT / "docs" / "architecture" / "README.md"
+        ).read_text(encoding="utf-8")
+        development_entry = (
+            ROOT / "docs" / "development" / "README.md"
+        ).read_text(encoding="utf-8")
+        self.assertIn(link, architecture_entry)
+        self.assertIn(f"../architecture/{link}", development_entry)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 목적과 변경 경계

Issue #187의 E-01 Global state inventory Contract입니다.

- Production Python과 analyzer 구현은 변경하지 않습니다.
- shipped Python의 process-wide state, import/bootstrap effect, path resolution을 19개 owner entry(40 symbols)로 고정합니다.
- analyzer가 보고하는 `__all__` 외 mutable global은 runtime-owned 또는 25개 declarative-only group(52 symbols)으로 정확히 분할합니다.
- 각 runtime entry에 owner, lifetime, thread-safety, reset/close, test evidence, target Phase를 기록합니다.
- E-02a/E-07 bridge, root aliases, route/cache/persistence/lifecycle 동작은 그대로 보존합니다.

## Base -> Head

- Base: `dev@3c15a34c8e10f3f1999b16496b72343ce30759ae`
- Head: `de1ed359d415a8fd4392309d7006ecd9ab1edd63`

## 주요 파일

- `docs/architecture/python-runtime-state-inventory.md`
- `tests/fixtures/python_runtime_state_ownership.v1.json`
- `tests/test_python_runtime_state_ownership.py`
- active architecture/development queue 문서

## 검증

Focused:

- E-01 ownership Contract: 5 passed
- Python backend analyzer: 18 passed
- RuntimeServices: 8 passed
- bootstrap: 5 passed
- package/no-host skeleton: 1 passed
- completed-package import boundary: 6 passed
- changed-file syntax/JSON, Ruff fatal subset, `git diff --check`: passed

Final candidate `de1ed359...` official full 1회:

- Python unittest: 1324 passed
- Frontend: 120 JavaScript files, TypeScript 6.0.3
- Pyright baseline: 0 new diagnostics
- G-03: 11 package groups, 0 violations
- project diff check: passed

Production/package boundary가 바뀌지 않아 PR #525의 package/live evidence를 재사용했습니다.

## 위험과 rollback

- runtime owner 이동이나 lifecycle 동작 변경은 없습니다.
- 새 mutable global 또는 stale symbol은 direct gate가 분류 전까지 실패합니다.
- rollback은 이 Contract/fixture/docs commit을 되돌리는 것으로 제한됩니다.

## Next

E-01 병합 뒤 별도 E-02b Contract에서 RuntimeConfig와 clock/executor/client lifecycle port, close ordering, isolated construction을 결정합니다. E-03 이후 feature Moves, D-14 removal, release/Registry 작업은 이 PR에 포함하지 않습니다.

Refs #187