### PR TITLE
E-03a: repository/filesystem Contract 고정

### DIFF
--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -10,14 +10,14 @@ then only the active task section, owning Issue, direct source, and direct tests
 ## Active sequencing
 
 - Issue [#187](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/187)
-  owns Phase E. E-01 and E-02 are complete; an E-03 repository/filesystem
-  Contract is the next bounded unit.
+  owns Phase E. E-01, E-02, and the E-03a repository/filesystem Contract are
+  complete; the E-03b filesystem factory Move is the next bounded unit.
   Issue #186 retains D-14/shim decisions.
 - [`backend-roadmap-resume-0.6.2.md`](backend-roadmap-resume-0.6.2.md)
   is the current execution source of truth. Read it before the older accumulated
   roadmap.
-- Reviewed code baseline: D-14 readiness / PR #526 at
-  `3c15a34c8e10f3f1999b16496b72343ce30759ae`.
+- Reviewed code baseline: E-02d / PR #531 at
+  `204e74ab5897e1dc1f769067f9520ecee6803803`.
 - D-08 is complete and D-08v is not required.
 - D-14 readiness retains every root surface; retirement/final-freeze work is blocked.
 - E-01 inventory Contract:
@@ -30,7 +30,9 @@ then only the active task section, owning Issue, direct source, and direct tests
 - E-02 completion audit:
   [`python-runtime-e02-completion-audit.md`](python-runtime-e02-completion-audit.md).
 - E-02d canonicalizes the prompt knowledge package-data alias and completes E-02.
-- First READY task after E-02: #187 E-03 repository/filesystem Contract only.
+- E-03a repository/filesystem Contract:
+  [`python-runtime-e03-repository-filesystem-contract.md`](python-runtime-e03-repository-filesystem-contract.md).
+- First READY task after E-03a: #187 E-03b filesystem factory Move only.
 - Completed #470 and the #413/#414/#415 queue/live-UI lanes remain contract references,
   not active blockers.
 - Released code baseline: 0.6.2. Registry activation is external administration and
@@ -75,6 +77,8 @@ aliases or absorbing feature behavior.
   base types plus the E-02c private bootstrap composition and feature-port boundary.
 - [`python-runtime-e02-completion-audit.md`](python-runtime-e02-completion-audit.md):
   E-02 path-owner disposition, E-02d completion, and E-03 Contract handoff.
+- [`python-runtime-e03-repository-filesystem-contract.md`](python-runtime-e03-repository-filesystem-contract.md):
+  current repository/path/lock/patch boundaries and the E-03b through E-03e queue.
 - [`adr-001-modular-monolith.md`](adr-001-modular-monolith.md): feature-oriented modular
   monolith decision.
 - [`adr-002-compatibility-shims.md`](adr-002-compatibility-shims.md): shim lifecycle and

--- a/docs/architecture/backend-roadmap-resume-0.6.2.md
+++ b/docs/architecture/backend-roadmap-resume-0.6.2.md
@@ -2,14 +2,15 @@
 
 ## Status and authority
 
-- Status: D-08, E-01, and E-02 are completed; the D-14 readiness audit retains
-  every root surface and blocks retirement/final-freeze work.
-- Code-review baseline: `dev@bb8c9d499c37f60a770cdbe74b81600c57a6770c`
-  after the E-02 audit / PR #530.
-- Document baseline: E-02d prompt knowledge path Move.
+- Status: D-08, E-01, E-02, and the E-03a repository/filesystem Contract are
+  completed; the D-14 readiness audit retains every root surface and blocks
+  retirement/final-freeze work.
+- Code-review baseline: `dev@204e74ab5897e1dc1f769067f9520ecee6803803`
+  after E-02d / PR #531.
+- Document baseline: E-03a repository/filesystem Contract.
 - Released baseline: 0.6.2.
 - Scope: completed D-08 evidence, the D-14 readiness decision, completed #187
-  E-01/E-02 work, and the next bounded E-03 Contract.
+  E-01/E-02/E-03a work, and the next bounded E-03b factory Move.
 - This document owns the current immediate queue and supersedes the stale queue and
   broad preflight command in `python-backend-execution-roadmap.md`.
 - `python-backend.md`, ADR-001, ADR-002, and the compatibility-shim registry still own
@@ -265,10 +266,12 @@ The D-08u audit found no required D-08v. After D-08:
 7. the E-02 completion audit assigns the autocomplete index root to E-05, records
    filesystem paths as complete, and selects E-02d for the prompt knowledge path;
 8. E-02d canonicalizes the prompt knowledge path and completes E-02;
-9. the first READY follow-up is an E-03 repository/filesystem Contract only; and
-10. never remove root files merely to make the directory tree appear complete.
+9. E-03a fixes current repository constructors, path inputs, lock order, revision/CAS,
+   dynamic dependencies, and monkeypatch seams without changing production;
+10. the first READY follow-up is the E-03b stateless filesystem factory Move only; and
+11. never remove root files merely to make the directory tree appear complete.
 
-## 6. E-01/E-02 result and Codex resume instruction
+## 6. E-01/E-02/E-03a result and Codex resume instruction
 
 ```text
 D-08 is complete. Do not restart D-08t or create D-08v without new contrary
@@ -297,9 +300,14 @@ python-runtime-e02-completion-audit.md. It assigns the autocomplete index root t
 E-05, records filesystem paths as E-02c complete, and E-02d canonicalizes the prompt
 knowledge path. E-02 is complete.
 
-Start only the #187 E-03 repository/filesystem Contract from latest origin/dev.
-Inventory current settings/profile repository constructors, atomic filesystem
-dependencies, path inputs, locks, revisions, and monkeypatch seams before any Move.
-Do not start E-03 production migration, E-04 through E-10, release, or Registry work
-inside that Contract.
+E-03a is owned by python-runtime-e03-repository-filesystem-contract.md and
+tests/fixtures/python_repository_filesystem_contract.v1.json. The filesystem factory
+is a stateless AtomicJsonStore constructor seam; the canonical atomic module keeps the
+single process path-lock registry. The profile directory coordinator remains a
+separate shared CAS transaction dependency.
+
+Start only #187 E-03b from latest origin/dev. Add the filesystem factory seam while
+proving direct and factory-created stores share the canonical normalized-path lock.
+Do not start settings/profile repository Moves, E-04 through E-10, release, or
+Registry work inside E-03b.
 ```

--- a/docs/architecture/python-backend-execution-roadmap.md
+++ b/docs/architecture/python-backend-execution-roadmap.md
@@ -1482,7 +1482,12 @@ objects without changing `paths.py`, and a private system clock delegates to
 The E-02 completion audit records filesystem paths as E-02c complete, assigns the
 autocomplete index root to its E-05 cache/index lifecycle, and E-02d canonicalizes
 the duplicate prompt knowledge package path. E-02 is complete. The next bounded unit
-is an E-03 repository/filesystem Contract; feature owner Moves remain separate.
+is the production-free
+[`python-runtime-e03-repository-filesystem-contract.md`](python-runtime-e03-repository-filesystem-contract.md).
+It fixes the current paths, store construction, lock ordering, CAS ownership,
+dynamic dependencies, and monkeypatch seams. E-03b adds only a stateless filesystem
+factory that delegates to the canonical `AtomicJsonStore` path-lock owner; settings
+and profile repository Moves remain separate.
 
 Feature services receive only narrow Protocols. They do not import or receive
 the entire `RuntimeServices` object. Node adapters may use `get_runtime()` only

--- a/docs/architecture/python-runtime-e03-repository-filesystem-contract.md
+++ b/docs/architecture/python-runtime-e03-repository-filesystem-contract.md
@@ -1,0 +1,139 @@
+# E-03 Repository and Filesystem Contract
+
+## Scope
+
+E-03a is a production-free Contract at
+`dev@204e74ab5897e1dc1f769067f9520ecee6803803`. It inventories the current
+settings, LoRA profile, AiO profile, atomic JSON, and profile mutation boundaries
+before any factory or repository Move.
+
+The executable source of this inventory is
+`tests/fixtures/python_repository_filesystem_contract.v1.json`, checked by
+`tests/test_python_repository_filesystem_contract.py`. Existing storage, settings,
+profile contract, LoRA, and AiO tests remain the behavior authorities.
+
+## Current owners
+
+### Atomic JSON mechanics
+
+`easyuse_anima.infrastructure.filesystem.atomic_json.AtomicJsonStore` accepts a
+primary path and optional same-directory backup. It expands and resolves the path,
+then uses the canonical module's process registry to share one `RLock` among every
+store for the same normalized primary path.
+
+The store owns JSON encoding, durable temporary files, fsync, backup recovery,
+atomic publication, delete, and same-directory replacement. Multi-path replacement
+acquires normalized path keys in sorted order and releases them in reverse order.
+The process registry has no explicit cleanup today.
+
+This owner must remain shared by direct `AtomicJsonStore(path)` callers and future
+factory-created stores. A factory that creates another lock registry would allow two
+writers for the same path and violate the direct storage contract.
+
+### Profile transaction coordination
+
+`easyuse_anima.profiles.mutation.PROFILE_MUTATION_COORDINATOR` owns a guarded weak
+registry of per-directory `RLock` objects. LoRA and AiO mutations acquire the
+directory lock before discovery, identity-before-revision verification, and
+publication. Atomic store path locks are acquired inside that directory transaction.
+
+The coordinator is feature transaction policy, not generic filesystem mechanics.
+It therefore remains a separate shared dependency and is not absorbed into the
+filesystem factory.
+
+## Path and dependency inputs
+
+| Lane | Current path inputs | Other dynamic inputs |
+| --- | --- | --- |
+| settings | `SETTINGS_FILE`, `LONG_TEXT_SETTINGS_FILE` from `USER_DATA_DIR` | per-call Comfy `folder_paths.get_user_directory()` overlay discovery |
+| shared profile helpers | caller-supplied profile file | profile kind, filename, document |
+| LoRA profile | `LORA_PROFILE_DIR`, optional `profile_dir` helper arguments | per-call Comfy LoRA list/full-path lookup for repair |
+| AiO profile | `AIO_PROFILE_DIR`, optional `profile_dir` helper arguments | none |
+
+Future repositories receive explicit paths and a narrow store factory. Profile
+repositories additionally receive the shared directory coordinator. No feature
+repository receives the complete `RuntimeServices` object.
+
+Dynamic Comfy `folder_paths` lookup stays late-bound in the owning feature. Moving it
+into a filesystem factory would mix host discovery with persistence mechanics and
+would break the current optional-host behavior.
+
+## Lock and revision invariants
+
+The required acquisition order is:
+
+1. profile mutation operations acquire the profile directory `RLock`;
+2. they discover source and target files and verify identity before revision;
+3. they acquire one or more atomic store path `RLock` objects;
+4. they publish, restore, or delete while the directory transaction remains held.
+
+Settings use only atomic path locks. `save_setting()` deliberately holds the settings
+path `RLock` while calling `get_settings()`, which can re-enter the same normalized
+path lock. The lock therefore remains reentrant.
+
+Repository construction does not own profile schema meaning. The following stay with
+the existing profile contract and feature owners:
+
+- server-owned profile IDs and legacy identity projection;
+- revision one on create and increment on normal overwrite;
+- identity mismatch before revision mismatch;
+- source and target preconditions for rename;
+- rename revision preservation;
+- overwrite, missing, invalid-data, backup, rollback, and response error policy.
+
+## Compatibility and monkeypatch seams
+
+Current direct tests patch settings/profile path constants on their canonical
+modules. API route tests patch root operation aliases after route construction, and
+the callbacks resolve those aliases dynamically. The root also exposes identity
+aliases for the profile coordinator, profile directories, and profile operations.
+
+No E-03 Move may capture a default repository at import in a way that bypasses these
+seams. A future module-level compatibility wrapper may construct or resolve an
+explicit repository from the current canonical path symbols at call time. Removing a
+seam requires separate consumer evidence and the compatibility-shim process.
+
+`AtomicJsonStore` itself remains the canonical/root identity-compatible class with
+its current constructor and methods.
+
+## Factory decision
+
+The E-03 filesystem factory is a stateless narrow store-constructor seam:
+
+```text
+explicit path + backup policy -> canonical AtomicJsonStore
+```
+
+It owns no cache, lock registry, host lookup, schema, error translation, or lifecycle.
+The canonical atomic JSON module continues to own process path locks. This is the
+smallest boundary that permits repository construction without weakening direct
+constructor compatibility or introducing a dependency-injection framework.
+
+## Bounded Move queue
+
+1. **E-03b Move — filesystem factory:** add only the stateless constructor seam and
+   prove direct and factory-created stores share the canonical path lock.
+2. **E-03c Move — settings repository:** add explicit settings paths and the store
+   factory behind current functions and monkeypatch seams.
+3. **E-03d Move — profile repositories:** add explicit LoRA/AiO directories, the
+   store factory, and shared profile coordinator behind current canonical functions
+   and root aliases.
+4. **E-03e Contract — completion audit:** reconcile E-01 ownership targets and prove
+   no repository/filesystem state remains ambiguously owned before E-04.
+
+Each Move is a separate rollback boundary. A Move may be split further when direct
+source review proves that preserving AiO rename/delete transactions would otherwise
+mix behavior with mechanical construction.
+
+## Preserved and forbidden
+
+E-03a changes no production code, analyzer, existing feature test, package surface,
+bootstrap, RuntimeServices, persistence, schema, error, lock, response, or lifecycle
+behavior. Package/no-host and live evidence from the preceding runtime work remains
+valid.
+
+E-03a does not authorize E-03b production changes, E-04 or later work, root alias
+retirement, D-14 retirement, release, or Registry actions.
+
+The direct evidence leaves one owner for each boundary, so no material PRO review is
+required.

--- a/docs/architecture/python-runtime-state-inventory.md
+++ b/docs/architecture/python-runtime-state-inventory.md
@@ -41,11 +41,11 @@ E-01 drift gate until classified.
 | `autocomplete-dataset-cache` | canonical dataset snapshot and Future single-flight maps | one `Lock`; test-only clear | E-05 |
 | `autocomplete-index-locks` | canonical index per-path lock registry | guard plus per-path locks; no clear | E-05 |
 | `autocomplete-index-root` | import-resolved user-data index path | immutable after import; test patch coupled to index fallback/publication | E-05 |
-| `atomic-json-path-locks` | filesystem atomic JSON per-path lock registry | guard plus per-path `RLock`; no clear | E-03 |
+| `atomic-json-path-locks` | filesystem atomic JSON per-path lock registry | guard plus per-path `RLock`; no clear | E-03b |
 | `bootstrap-initialize-state` | bootstrap default runtime and wildcard completion state | initialize `Lock`; private-global test reset, no shutdown | E-09 |
 | `filesystem-runtime-paths` | import-resolved package/user-data paths projected into the default RuntimeConfig | immutable after import; bootstrap composition does not re-resolve | E-02c complete |
 | `package-bootstrap-effect` | root import invokes bootstrap route/directory initialization | bootstrap `Lock`; retry behavior, no package shutdown | E-09 |
-| `profile-directory-mutation-coordinator` | canonical process coordinator with weak per-directory locks | guard plus per-directory `RLock`; weak expiry | E-03 |
+| `profile-directory-mutation-coordinator` | canonical process coordinator with weak per-directory locks | guard plus per-directory `RLock`; weak expiry | E-03d |
 | prompt warning-dedupe entries | two canonical Prompt feature modules, process lifetime | unprotected sets; direct-test clear only | E-09 |
 | `prompt-knowledge-path` | canonical filesystem package path re-exported for ANIMA root compatibility | immutable after import | E-02d complete |
 | `root-route-registration` | injected router registrar called by bootstrap | serialized refresh; idempotent marker, no deregistration | E-09 |
@@ -72,7 +72,7 @@ source.
 - No production Python, analyzer heuristic, public surface, cache policy, or
   lifecycle behavior changes in E-01.
 
-## E-02 audit result and next bounded unit
+## E-02 and E-03a result
 
 E-02b is owned by
 [`python-runtime-base-contract.md`](python-runtime-base-contract.md). It fixes
@@ -91,6 +91,10 @@ The
 assigns the autocomplete index root to E-05 and records the filesystem paths as E-02c
 complete. E-02d then replaces the duplicate prompt knowledge path resolution with the
 canonical filesystem Path object while preserving the root compatibility alias.
-E-02 is complete; the next bounded unit is an E-03 Contract. E-03 through E-09
-feature/lifecycle Moves remain separate and use this fixture's target phases and
-cleanup gaps.
+E-02 is complete. The production-free
+[`python-runtime-e03-repository-filesystem-contract.md`](python-runtime-e03-repository-filesystem-contract.md)
+fixes the current settings/profile paths, atomic store construction, path and
+directory lock ownership, revision/CAS boundary, dynamic dependencies, and
+monkeypatch seams. It narrows `atomic-json-path-locks` to E-03b and the profile
+directory coordinator to E-03d. The next bounded unit is the E-03b filesystem
+factory Move; later feature/lifecycle Moves remain separate.

--- a/docs/development/README.md
+++ b/docs/development/README.md
@@ -24,6 +24,8 @@ Read only the sections needed by the active task.
      [`../architecture/python-runtime-base-contract.md`](../architecture/python-runtime-base-contract.md)
    - E-02 completion audit:
      [`../architecture/python-runtime-e02-completion-audit.md`](../architecture/python-runtime-e02-completion-audit.md)
+   - E-03 repository/filesystem Contract:
+     [`../architecture/python-runtime-e03-repository-filesystem-contract.md`](../architecture/python-runtime-e03-repository-filesystem-contract.md)
 5. Read [`codex-blocker-escalation.md`](codex-blocker-escalation.md) only after a
    documented hard stop or unresolved cross-owner failure. Ordinary implementation
    and test failures remain local task work.
@@ -46,18 +48,18 @@ ordinary `dev` roadmap work.
 
 - Released baseline: 0.6.2.
 - Active owner: Issue #187 for Phase E; Issue #186 retains D-14/shim decisions.
-- Reviewed code baseline: D-14 readiness / PR #526.
+- Reviewed code baseline: E-02d / PR #531.
 - D-08u integrated exit audit is complete.
 - D-08v is not required; the audit found no remaining D-08 production Move.
 - D-14 readiness is audited: every root surface is retained and retirement/final
   freeze is blocked by production/lifecycle consumers, missing release windows, or
   insufficient consumer evidence.
-- E-01 and E-02 are complete through the audit and E-02d canonical path Move. The
-  next work is only #187 E-03 repository/filesystem Contract. The #323 E-02a/E-07
-  bridge remains completed evidence, not authorization for feature migration.
+- E-01, E-02, and the E-03a repository/filesystem Contract are complete. The next
+  work is only #187 E-03b filesystem factory Move. The #323 E-02a/E-07 bridge
+  remains completed evidence, not authorization for unrelated feature migration.
 - Completed #470 and the 0.6.1 Prompt Studio lane are behavior-contract references,
   not the active queue.
-- Do not remove root aliases or start E-03 through E-10 Moves, release, or Registry work
+- Do not remove root aliases or start E-03c through E-10, release, or Registry work
   from this entrypoint.
 
 ## Completed D-08 composition audit surface
@@ -149,6 +151,6 @@ representative profile list/load/save/delete/rename/fix live smoke
 - A version marker is not a publish action.
 - Technical PRO review is for unresolved cross-boundary architecture choices,
   unavoidable cycles, or insufficient compatibility evidence—not routine failures.
-- D-14 readiness is recorded and authorizes no removal. Use the completed E-02
-  evidence for the E-03 Contract; do not expand that Contract into production
-  migration, release publication, or Registry actions.
+- D-14 readiness is recorded and authorizes no removal. Use the E-03a Contract for
+  the bounded E-03b factory Move; do not expand it into settings/profile repository
+  Moves, release publication, or Registry actions.

--- a/tests/fixtures/python_repository_filesystem_contract.v1.json
+++ b/tests/fixtures/python_repository_filesystem_contract.v1.json
@@ -1,0 +1,436 @@
+{
+  "compatibility_bindings": [
+    {
+      "expression": "_profile_mutation.PROFILE_MUTATION_COORDINATOR",
+      "kind": "assignment",
+      "module": "api.py",
+      "symbol": "PROFILE_MUTATION_COORDINATOR"
+    },
+    {
+      "expression": "_lora_profiles.LORA_PROFILE_DIR",
+      "kind": "assignment",
+      "module": "api.py",
+      "symbol": "LORA_PROFILE_DIR"
+    },
+    {
+      "expression": "_lora_profiles._load_lora_profile",
+      "kind": "assignment",
+      "module": "api.py",
+      "symbol": "_load_lora_profile"
+    },
+    {
+      "expression": "_lora_profiles._save_lora_profile",
+      "kind": "assignment",
+      "module": "api.py",
+      "symbol": "_save_lora_profile"
+    },
+    {
+      "expression": "_aio_profiles.AIO_PROFILE_DIR",
+      "kind": "assignment",
+      "module": "api.py",
+      "symbol": "AIO_PROFILE_DIR"
+    },
+    {
+      "expression": "_aio_profiles._delete_aio_profile",
+      "kind": "assignment",
+      "module": "api.py",
+      "symbol": "_delete_aio_profile"
+    },
+    {
+      "expression": "_aio_profiles._load_aio_profile",
+      "kind": "assignment",
+      "module": "api.py",
+      "symbol": "_load_aio_profile"
+    },
+    {
+      "expression": "_aio_profiles._rename_aio_profile",
+      "kind": "assignment",
+      "module": "api.py",
+      "symbol": "_rename_aio_profile"
+    },
+    {
+      "expression": "_aio_profiles._save_aio_profile",
+      "kind": "assignment",
+      "module": "api.py",
+      "symbol": "_save_aio_profile"
+    },
+    {
+      "kind": "import",
+      "module": "api.py",
+      "source": ".easyuse_anima.settings.repository",
+      "symbol": "load_long_text_settings"
+    },
+    {
+      "kind": "import",
+      "module": "api.py",
+      "source": ".easyuse_anima.settings.repository",
+      "symbol": "save_long_text_settings"
+    },
+    {
+      "kind": "import",
+      "module": "api.py",
+      "source": ".easyuse_anima.settings.repository",
+      "symbol": "save_setting"
+    }
+  ],
+  "decisions": {
+    "dynamic_host_dependencies": "folder_paths lookup remains late-bound in the owning settings or LoRA feature and is not part of the filesystem factory.",
+    "filesystem_factory": "A future factory is a stateless narrow AtomicJsonStore constructor seam. It neither owns nor duplicates the process path-lock registry.",
+    "path_lock_owner": "easyuse_anima.infrastructure.filesystem.atomic_json remains the single process owner for normalized-path locks used by direct and factory-created stores.",
+    "profile_directory_owner": "PROFILE_MUTATION_COORDINATOR remains a shared profile transaction dependency and is not absorbed into generic filesystem mechanics.",
+    "runtime_access": "Repositories receive explicit paths and narrow dependencies; feature code does not receive RuntimeServices."
+  },
+  "lock_order": [
+    {
+      "evidence": [
+        "tests/test_storage.py"
+      ],
+      "id": "atomic-multi-path",
+      "order": "normalized path keys ascending, release in reverse order",
+      "owner": "easyuse_anima.infrastructure.filesystem.atomic_json._locked_paths"
+    },
+    {
+      "evidence": [
+        "tests/test_lora_profiles.py",
+        "tests/test_aio_profiles.py"
+      ],
+      "id": "profile-mutation",
+      "order": "profile directory RLock before one or more AtomicJsonStore path RLocks",
+      "owner": "easyuse_anima.profiles.mutation.PROFILE_MUTATION_COORDINATOR"
+    },
+    {
+      "evidence": [
+        "tests/test_prompt_corrector.py"
+      ],
+      "id": "settings-reentrant-path",
+      "order": "save_setting holds the settings path RLock while get_settings re-enters the same normalized path lock",
+      "owner": "easyuse_anima.infrastructure.filesystem.atomic_json"
+    }
+  ],
+  "monkeypatch_seams": [
+    {
+      "evidence": "tests/test_prompt_corrector.py",
+      "target": "easyuse_anima.settings.repository.SETTINGS_FILE",
+      "token": "patch.object(settings_repository, \"SETTINGS_FILE\""
+    },
+    {
+      "evidence": "tests/test_prompt_corrector.py",
+      "target": "easyuse_anima.settings.repository.LONG_TEXT_SETTINGS_FILE",
+      "token": "patch.object(settings_repository, \"LONG_TEXT_SETTINGS_FILE\""
+    },
+    {
+      "evidence": "tests/test_lora_profiles.py",
+      "target": "easyuse_anima.profiles.lora.LORA_PROFILE_DIR",
+      "token": "patch.object(api._lora_profiles, \"LORA_PROFILE_DIR\""
+    },
+    {
+      "evidence": "tests/test_lora_profiles.py",
+      "target": "api._save_lora_profile",
+      "token": "patch.object(api, \"_save_lora_profile\""
+    },
+    {
+      "evidence": "tests/test_aio_profiles.py",
+      "target": "easyuse_anima.profiles.aio.AIO_PROFILE_DIR",
+      "token": "patch.object(api._aio_profiles, \"AIO_PROFILE_DIR\""
+    },
+    {
+      "evidence": "tests/test_aio_profiles.py",
+      "target": "api.PROFILE_MUTATION_COORDINATOR",
+      "token": "api.PROFILE_MUTATION_COORDINATOR"
+    }
+  ],
+  "move_queue": [
+    {
+      "classification": "Move",
+      "goal": "Add the stateless store-constructor seam while every AtomicJsonStore instance continues to share the canonical path-lock owner.",
+      "id": "E-03b",
+      "name": "filesystem factory"
+    },
+    {
+      "classification": "Move",
+      "goal": "Introduce explicit settings paths and store-factory construction behind the current module functions and patch seams.",
+      "id": "E-03c",
+      "name": "settings repository"
+    },
+    {
+      "classification": "Move",
+      "goal": "Introduce explicit LoRA/AiO profile directories, store factory, and shared profile coordinator behind current canonical functions and root aliases.",
+      "id": "E-03d",
+      "name": "profile repositories"
+    },
+    {
+      "classification": "Contract",
+      "goal": "Reconcile ownership targets and prove no repository or filesystem state remains ambiguously owned before E-04.",
+      "id": "E-03e",
+      "name": "completion audit"
+    }
+  ],
+  "owners": [
+    {
+      "cleanup": "No explicit cleanup; normalized-path RLocks remain for the process lifetime.",
+      "constructor": {
+        "backup_default": "True",
+        "parameters": [
+          "path",
+          "backup"
+        ]
+      },
+      "id": "atomic-json-store",
+      "lifetime": "Direct and future factory-created stores share one process path-lock registry.",
+      "methods": [
+        "delete",
+        "locked",
+        "read",
+        "replace_from",
+        "update",
+        "write"
+      ],
+      "module": "easyuse_anima/infrastructure/filesystem/atomic_json.py",
+      "path_normalization": "Path(path).expanduser().resolve(strict=False)",
+      "symbols": [
+        "AtomicJsonStore",
+        "_PATH_LOCKS",
+        "_PATH_LOCKS_GUARD"
+      ],
+      "test_evidence": [
+        "tests/test_storage.py"
+      ],
+      "thread_safety": "The registry guard protects lookup; one RLock serializes each normalized primary path and sorted acquisition prevents multi-path inversion."
+    },
+    {
+      "cleanup": "Weak per-directory locks expire when unreferenced; the process coordinator has no close.",
+      "constructor": {
+        "parameters": []
+      },
+      "id": "profile-directory-coordinator",
+      "lifetime": "One canonical process coordinator shared by LoRA and AiO profile mutations.",
+      "methods": [
+        "_key",
+        "_lock",
+        "locked"
+      ],
+      "module": "easyuse_anima/profiles/mutation.py",
+      "path_normalization": "os.path.normcase(str(Path(directory).resolve(strict=False)))",
+      "symbols": [
+        "DirectoryMutationCoordinator",
+        "PROFILE_MUTATION_COORDINATOR"
+      ],
+      "test_evidence": [
+        "tests/test_aio_profiles.py",
+        "tests/test_lora_profiles.py"
+      ],
+      "thread_safety": "A guard protects the weak registry and one directory RLock spans discovery, identity-before-revision verification, and publication."
+    }
+  ],
+  "repository_lanes": [
+    {
+      "dynamic_dependencies": [
+        {
+          "dependency": "folder_paths.get_user_directory",
+          "function": "_comfy_settings_candidates",
+          "token": "import folder_paths"
+        }
+      ],
+      "function_contracts": [
+        {
+          "function": "_read_json_file",
+          "required_calls": [
+            "AtomicJsonStore",
+            "AtomicJsonStore().read"
+          ]
+        },
+        {
+          "function": "save_long_text_settings",
+          "required_calls": [
+            "AtomicJsonStore",
+            "AtomicJsonStore().update"
+          ]
+        },
+        {
+          "function": "_initialize_autocomplete_source",
+          "required_calls": [
+            "AtomicJsonStore",
+            "AtomicJsonStore().update"
+          ]
+        },
+        {
+          "function": "save_setting",
+          "required_calls": [
+            "AtomicJsonStore",
+            "get_settings",
+            "store.locked",
+            "store.write"
+          ]
+        }
+      ],
+      "id": "settings",
+      "module": "easyuse_anima/settings/repository.py",
+      "path_inputs": [
+        {
+          "expression": "USER_DATA_DIR / 'settings.json'",
+          "symbol": "SETTINGS_FILE"
+        },
+        {
+          "expression": "USER_DATA_DIR / 'long_text_settings.json'",
+          "symbol": "LONG_TEXT_SETTINGS_FILE"
+        }
+      ],
+      "preserved_contract": "Defaults, Comfy overlay precedence, long-text merge, unknown-key rejection, trailing newline, and current OSError/JSON fallbacks remain feature behavior.",
+      "test_evidence": [
+        "tests/test_prompt_corrector.py",
+        "tests/test_storage.py"
+      ]
+    },
+    {
+      "dynamic_dependencies": [],
+      "function_contracts": [
+        {
+          "function": "_read_profile_json",
+          "required_calls": [
+            "AtomicJsonStore",
+            "store.locked",
+            "store.read"
+          ]
+        },
+        {
+          "function": "_profile_list_item",
+          "required_calls": [
+            "_read_profile_json",
+            "interpret_profile_document",
+            "legacy_profile_id"
+          ]
+        }
+      ],
+      "id": "profile-shared",
+      "module": "easyuse_anima/profiles/repository.py",
+      "path_inputs": [],
+      "preserved_contract": "Filename validation, legacy identity/revision projection, invalid-data mapping, and list metadata remain profile behavior.",
+      "test_evidence": [
+        "tests/test_lora_profiles.py",
+        "tests/test_aio_profiles.py",
+        "tests/test_profile_contract.py"
+      ]
+    },
+    {
+      "dynamic_dependencies": [
+        {
+          "dependency": "folder_paths LoRA list/full-path lookup",
+          "function": "_list_loras",
+          "token": "import folder_paths"
+        }
+      ],
+      "function_contracts": [
+        {
+          "function": "_save_lora_profile",
+          "required_calls": [
+            "AtomicJsonStore",
+            "AtomicJsonStore().write",
+            "PROFILE_MUTATION_COORDINATOR.locked",
+            "_find_lora_profile_path",
+            "verify_profile_precondition"
+          ]
+        },
+        {
+          "function": "_load_lora_profile",
+          "required_calls": [
+            "_find_lora_profile_path",
+            "_read_profile_json",
+            "interpret_profile_document"
+          ]
+        }
+      ],
+      "id": "lora-profile",
+      "module": "easyuse_anima/profiles/lora.py",
+      "optional_path_parameters": [
+        {
+          "function": "_find_lora_profile_path",
+          "parameter": "profile_dir"
+        },
+        {
+          "function": "_lora_profile_path",
+          "parameter": "profile_dir"
+        }
+      ],
+      "path_inputs": [
+        {
+          "expression": "USER_DATA_DIR / 'profiles'",
+          "symbol": "LORA_PROFILE_DIR"
+        }
+      ],
+      "preserved_contract": "Create/overwrite identity and revision, filename collision, backup recovery, profile payload normalization, and LoRA repair behavior remain unchanged.",
+      "test_evidence": [
+        "tests/test_lora_profiles.py",
+        "tests/test_profile_contract.py",
+        "tests/test_storage.py"
+      ]
+    },
+    {
+      "dynamic_dependencies": [],
+      "function_contracts": [
+        {
+          "function": "_save_aio_profile",
+          "required_calls": [
+            "AtomicJsonStore",
+            "AtomicJsonStore().write",
+            "PROFILE_MUTATION_COORDINATOR.locked",
+            "_find_aio_profile_path",
+            "verify_profile_precondition"
+          ]
+        },
+        {
+          "function": "_load_aio_profile",
+          "required_calls": [
+            "_find_aio_profile_path",
+            "_read_profile_json"
+          ]
+        },
+        {
+          "function": "_delete_aio_profile",
+          "required_calls": [
+            "AtomicJsonStore",
+            "PROFILE_MUTATION_COORDINATOR.locked",
+            "_find_aio_profile_path",
+            "store.delete",
+            "verify_profile_precondition"
+          ]
+        },
+        {
+          "function": "_rename_aio_profile",
+          "required_calls": [
+            "AtomicJsonStore",
+            "AtomicJsonStore().replace_from",
+            "PROFILE_MUTATION_COORDINATOR.locked",
+            "_find_aio_profile_path",
+            "verify_profile_precondition"
+          ]
+        }
+      ],
+      "id": "aio-profile",
+      "module": "easyuse_anima/profiles/aio.py",
+      "optional_path_parameters": [
+        {
+          "function": "_aio_profile_path",
+          "parameter": "profile_dir"
+        },
+        {
+          "function": "_find_aio_profile_path",
+          "parameter": "profile_dir"
+        }
+      ],
+      "path_inputs": [
+        {
+          "expression": "USER_DATA_DIR / 'aio_profiles'",
+          "symbol": "AIO_PROFILE_DIR"
+        }
+      ],
+      "preserved_contract": "Create/overwrite/delete/rename identity-before-revision CAS, source/target preconditions, same-name rename, backup rollback, size validation, and response payloads remain unchanged.",
+      "test_evidence": [
+        "tests/test_aio_profiles.py",
+        "tests/test_profile_contract.py",
+        "tests/test_storage.py"
+      ]
+    }
+  ],
+  "schema_version": 1,
+  "scope": "E-03a current settings/profile repository and filesystem boundary"
+}

--- a/tests/fixtures/python_runtime_state_ownership.v1.json
+++ b/tests/fixtures/python_runtime_state_ownership.v1.json
@@ -226,7 +226,7 @@
       "module": "easyuse_anima/infrastructure/filesystem/atomic_json.py",
       "owner": "easyuse_anima.infrastructure.filesystem.atomic_json",
       "symbols": ["_PATH_LOCKS", "_PATH_LOCKS_GUARD"],
-      "target_phase": "E-03",
+      "target_phase": "E-03b",
       "test_evidence": ["tests/test_storage.py"],
       "thread_safety": "The guard serializes registry access; per-path RLocks serialize publish operations."
     },
@@ -274,7 +274,7 @@
       "module": "easyuse_anima/profiles/mutation.py",
       "owner": "easyuse_anima.profiles.mutation.PROFILE_MUTATION_COORDINATOR",
       "symbols": ["PROFILE_MUTATION_COORDINATOR"],
-      "target_phase": "E-03",
+      "target_phase": "E-03d",
       "test_evidence": ["tests/test_aio_profiles.py", "tests/test_lora_profiles.py"],
       "thread_safety": "A guard protects the weak registry; one RLock serializes CAS per directory."
     },

--- a/tests/test_python_repository_filesystem_contract.py
+++ b/tests/test_python_repository_filesystem_contract.py
@@ -1,0 +1,316 @@
+from __future__ import annotations
+
+import ast
+import json
+import unittest
+from functools import lru_cache
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+FIXTURE_PATH = (
+    ROOT
+    / "tests"
+    / "fixtures"
+    / "python_repository_filesystem_contract.v1.json"
+)
+CONTRACT_DOC = (
+    ROOT
+    / "docs"
+    / "architecture"
+    / "python-runtime-e03-repository-filesystem-contract.md"
+)
+
+
+@lru_cache(maxsize=None)
+def _tree(module: str) -> ast.Module:
+    path = ROOT / module
+    return ast.parse(path.read_text(encoding="utf-8-sig"), filename=str(path))
+
+
+def _top_level_function(module: str, name: str) -> ast.FunctionDef:
+    for statement in _tree(module).body:
+        if isinstance(statement, ast.FunctionDef) and statement.name == name:
+            return statement
+    raise AssertionError(f"{module} has no top-level function {name}")
+
+
+def _top_level_class(module: str, name: str) -> ast.ClassDef:
+    for statement in _tree(module).body:
+        if isinstance(statement, ast.ClassDef) and statement.name == name:
+            return statement
+    raise AssertionError(f"{module} has no top-level class {name}")
+
+
+def _assignment_expression(module: str, name: str) -> str:
+    for statement in _tree(module).body:
+        if isinstance(statement, ast.Assign):
+            if any(
+                isinstance(target, ast.Name) and target.id == name
+                for target in statement.targets
+            ):
+                return ast.unparse(statement.value)
+        if (
+            isinstance(statement, ast.AnnAssign)
+            and isinstance(statement.target, ast.Name)
+            and statement.target.id == name
+            and statement.value is not None
+        ):
+            return ast.unparse(statement.value)
+    raise AssertionError(f"{module} has no top-level assignment {name}")
+
+
+def _expression_name(expression: ast.expr) -> str:
+    if isinstance(expression, ast.Name):
+        return expression.id
+    if isinstance(expression, ast.Attribute):
+        owner = _expression_name(expression.value)
+        return f"{owner}.{expression.attr}" if owner else expression.attr
+    if isinstance(expression, ast.Call):
+        owner = _expression_name(expression.func)
+        return f"{owner}()" if owner else ""
+    return ""
+
+
+def _function_calls(module: str, name: str) -> set[str]:
+    function = _top_level_function(module, name)
+    return {
+        call_name
+        for node in ast.walk(function)
+        if isinstance(node, ast.Call)
+        if (call_name := _expression_name(node.func))
+    }
+
+
+def _function_parameters(module: str, name: str) -> set[str]:
+    function = _top_level_function(module, name)
+    return {
+        argument.arg
+        for argument in (
+            *function.args.posonlyargs,
+            *function.args.args,
+            *function.args.kwonlyargs,
+        )
+    }
+
+
+def _class_methods(module: str, name: str) -> dict[str, ast.FunctionDef]:
+    return {
+        statement.name: statement
+        for statement in _top_level_class(module, name).body
+        if isinstance(statement, ast.FunctionDef)
+    }
+
+
+def _import_source(module: str, symbol: str) -> str | None:
+    for statement in _tree(module).body:
+        if not isinstance(statement, ast.ImportFrom):
+            continue
+        for alias in statement.names:
+            if (alias.asname or alias.name) == symbol:
+                return f"{'.' * statement.level}{statement.module or ''}"
+    return None
+
+
+def _normalized_source(path: Path) -> str:
+    return "".join(path.read_text(encoding="utf-8-sig").split())
+
+
+def _normalized_source_token(value: str) -> str:
+    return "".join(value.split())
+
+
+class PythonRepositoryFilesystemContractTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.fixture = json.loads(FIXTURE_PATH.read_text(encoding="utf-8"))
+
+    def test_schema_ids_and_evidence_are_complete(self):
+        self.assertEqual(
+            set(self.fixture),
+            {
+                "compatibility_bindings",
+                "decisions",
+                "lock_order",
+                "monkeypatch_seams",
+                "move_queue",
+                "owners",
+                "repository_lanes",
+                "schema_version",
+                "scope",
+            },
+        )
+        self.assertEqual(self.fixture["schema_version"], 1)
+        self.assertEqual(
+            [owner["id"] for owner in self.fixture["owners"]],
+            ["atomic-json-store", "profile-directory-coordinator"],
+        )
+        self.assertEqual(
+            [lane["id"] for lane in self.fixture["repository_lanes"]],
+            ["settings", "profile-shared", "lora-profile", "aio-profile"],
+        )
+        self.assertEqual(
+            [move["id"] for move in self.fixture["move_queue"]],
+            ["E-03b", "E-03c", "E-03d", "E-03e"],
+        )
+
+        evidence = {
+            path
+            for owner in self.fixture["owners"]
+            for path in owner["test_evidence"]
+        }
+        evidence.update(
+            path
+            for lane in self.fixture["repository_lanes"]
+            for path in lane["test_evidence"]
+        )
+        evidence.update(
+            path
+            for lock in self.fixture["lock_order"]
+            for path in lock["evidence"]
+        )
+        evidence.update(
+            seam["evidence"] for seam in self.fixture["monkeypatch_seams"]
+        )
+        for path in sorted(evidence):
+            with self.subTest(evidence=path):
+                self.assertTrue((ROOT / path).is_file(), path)
+
+    def test_current_owners_keep_constructor_methods_and_symbols(self):
+        atomic = self.fixture["owners"][0]
+        atomic_methods = _class_methods(atomic["module"], "AtomicJsonStore")
+        self.assertEqual(set(atomic["methods"]) - set(atomic_methods), set())
+        constructor = atomic_methods["__init__"]
+        parameters = [
+            argument.arg
+            for argument in (
+                *constructor.args.posonlyargs,
+                *constructor.args.args,
+                *constructor.args.kwonlyargs,
+            )
+            if argument.arg != "self"
+        ]
+        self.assertEqual(parameters, atomic["constructor"]["parameters"])
+        self.assertEqual(
+            ast.unparse(constructor.args.kw_defaults[0]),
+            atomic["constructor"]["backup_default"],
+        )
+        self.assertEqual(
+            _assignment_expression(atomic["module"], "_PATH_LOCKS"),
+            "{}",
+        )
+        self.assertEqual(
+            _assignment_expression(atomic["module"], "_PATH_LOCKS_GUARD"),
+            "threading.Lock()",
+        )
+
+        profile = self.fixture["owners"][1]
+        profile_methods = _class_methods(
+            profile["module"],
+            "DirectoryMutationCoordinator",
+        )
+        self.assertEqual(set(profile["methods"]) - set(profile_methods), set())
+        self.assertEqual(
+            _assignment_expression(
+                profile["module"],
+                "PROFILE_MUTATION_COORDINATOR",
+            ),
+            "DirectoryMutationCoordinator()",
+        )
+
+    def test_repository_paths_parameters_and_calls_match_current_source(self):
+        for lane in self.fixture["repository_lanes"]:
+            module = lane["module"]
+            for path_input in lane["path_inputs"]:
+                with self.subTest(lane=lane["id"], path=path_input["symbol"]):
+                    self.assertEqual(
+                        _assignment_expression(module, path_input["symbol"]),
+                        path_input["expression"],
+                    )
+            for optional in lane.get("optional_path_parameters", []):
+                with self.subTest(lane=lane["id"], parameter=optional):
+                    self.assertIn(
+                        optional["parameter"],
+                        _function_parameters(module, optional["function"]),
+                    )
+            for contract in lane["function_contracts"]:
+                with self.subTest(lane=lane["id"], function=contract["function"]):
+                    self.assertEqual(
+                        set(contract["required_calls"])
+                        - _function_calls(module, contract["function"]),
+                        set(),
+                    )
+            module_source = _normalized_source(ROOT / module)
+            for dependency in lane["dynamic_dependencies"]:
+                with self.subTest(
+                    lane=lane["id"],
+                    dependency=dependency["dependency"],
+                ):
+                    self.assertIn(
+                        _normalized_source_token(dependency["token"]),
+                        module_source,
+                    )
+
+    def test_root_compatibility_bindings_and_patch_seams_are_preserved(self):
+        for binding in self.fixture["compatibility_bindings"]:
+            with self.subTest(symbol=binding["symbol"]):
+                if binding["kind"] == "assignment":
+                    self.assertEqual(
+                        _assignment_expression(
+                            binding["module"],
+                            binding["symbol"],
+                        ),
+                        binding["expression"],
+                    )
+                else:
+                    self.assertEqual(
+                        _import_source(binding["module"], binding["symbol"]),
+                        binding["source"],
+                    )
+
+        for seam in self.fixture["monkeypatch_seams"]:
+            with self.subTest(target=seam["target"]):
+                self.assertIn(
+                    _normalized_source_token(seam["token"]),
+                    _normalized_source(ROOT / seam["evidence"]),
+                )
+
+    def test_decisions_lock_order_and_next_moves_are_explicit(self):
+        self.assertEqual(
+            set(self.fixture["decisions"]),
+            {
+                "dynamic_host_dependencies",
+                "filesystem_factory",
+                "path_lock_owner",
+                "profile_directory_owner",
+                "runtime_access",
+            },
+        )
+        for decision in self.fixture["decisions"].values():
+            self.assertTrue(decision.strip())
+        self.assertEqual(
+            [entry["id"] for entry in self.fixture["lock_order"]],
+            [
+                "atomic-multi-path",
+                "profile-mutation",
+                "settings-reentrant-path",
+            ],
+        )
+        self.assertEqual(
+            [move["classification"] for move in self.fixture["move_queue"]],
+            ["Move", "Move", "Move", "Contract"],
+        )
+
+    def test_contract_document_is_linked_from_maintained_entries(self):
+        self.assertTrue(CONTRACT_DOC.is_file())
+        link = CONTRACT_DOC.name
+        architecture_entry = (
+            ROOT / "docs" / "architecture" / "README.md"
+        ).read_text(encoding="utf-8")
+        development_entry = (
+            ROOT / "docs" / "development" / "README.md"
+        ).read_text(encoding="utf-8")
+        self.assertIn(link, architecture_entry)
+        self.assertIn(f"../architecture/{link}", development_entry)
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 목적과 변경 경계

Phase E의 production-free E-03a Contract입니다. settings/LoRA/AiO repository의 현재 경로 입력, `AtomicJsonStore` constructor/operations, lock order/lifetime, profile revision/CAS, dynamic host dependency와 monkeypatch seam을 versioned fixture와 AST drift gate로 고정합니다.

- Base: `204e74ab5897e1dc1f769067f9520ecee6803803`
- Head: `9a37cd1263faf809b3610c1dab860d2428398257`
- Production/analyzer/existing feature tests: 0변경
- 새 산출물: E-03 architecture Contract, v1 fixture, direct source-drift test

결정:
- future filesystem factory는 무상태 `AtomicJsonStore` constructor seam
- canonical atomic module이 direct/factory store 모두의 single process path-lock owner 유지
- `PROFILE_MUTATION_COORDINATOR`는 generic filesystem이 아니라 profile CAS transaction dependency
- repository는 explicit paths + narrow dependencies만 받고 `RuntimeServices` 전체를 받지 않음
- dynamic `folder_paths`와 current root/canonical patch seams 보존

## 검증

Focused:
- E-03a Contract: 6
- AtomicJsonStore + root compatibility: 18
- settings: 25
- profile contract: 9
- LoRA storage: 19
- AiO storage: 34
- E-01 ownership: 5
- analyzer: 18
- package skeleton: 1
- import-boundary: 6
- changed Python/JSON syntax, `git diff --check`: passed

Final candidate official full — 정확히 1회:
- Python: 1335 passed
- Frontend: 120 files passed
- Pyright baseline ratchet, import-boundary, diff check: passed
- Ruff 122건은 G-01 report-only baseline

Package/live:
- production/package closure 0변경
- package/no-host는 #531 focused/full 증거 재사용
- isolated live는 #525 증거 재사용
- material escalation trigger 없음

## 위험과 rollback

이 PR은 behavior를 바꾸지 않지만 후속 Move의 lock owner와 patch seam을 제한합니다. fixture/doc/test를 하나의 squash commit으로 rollback할 수 있습니다.

## 다음

별도 E-03b Move에서 stateless filesystem factory만 추가합니다. E-03c settings, E-03d profiles, E-03e audit는 각각 별도 rollback 경계입니다. E-04+, D-14 retirement, release/Registry는 이 PR 범위가 아닙니다.

Refs #187