### PR TITLE
E-03b: stateless atomic JSON factory 추가

### DIFF
--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -10,14 +10,14 @@ then only the active task section, owning Issue, direct source, and direct tests
 ## Active sequencing
 
 - Issue [#187](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/187)
-  owns Phase E. E-01, E-02, and the E-03a repository/filesystem Contract are
-  complete; the E-03b filesystem factory Move is the next bounded unit.
+  owns Phase E. E-01, E-02, E-03a, and the E-03b filesystem factory Move are
+  complete; the E-03c settings repository Move is the next bounded unit.
   Issue #186 retains D-14/shim decisions.
 - [`backend-roadmap-resume-0.6.2.md`](backend-roadmap-resume-0.6.2.md)
   is the current execution source of truth. Read it before the older accumulated
   roadmap.
-- Reviewed code baseline: E-02d / PR #531 at
-  `204e74ab5897e1dc1f769067f9520ecee6803803`.
+- Reviewed code baseline: E-03a / PR #532 at
+  `92704b22fddd3b1b98e3fa037007f7e4916297a4`.
 - D-08 is complete and D-08v is not required.
 - D-14 readiness retains every root surface; retirement/final-freeze work is blocked.
 - E-01 inventory Contract:
@@ -30,9 +30,9 @@ then only the active task section, owning Issue, direct source, and direct tests
 - E-02 completion audit:
   [`python-runtime-e02-completion-audit.md`](python-runtime-e02-completion-audit.md).
 - E-02d canonicalizes the prompt knowledge package-data alias and completes E-02.
-- E-03a repository/filesystem Contract:
+- E-03a/E-03b repository/filesystem Contract and factory result:
   [`python-runtime-e03-repository-filesystem-contract.md`](python-runtime-e03-repository-filesystem-contract.md).
-- First READY task after E-03a: #187 E-03b filesystem factory Move only.
+- First READY task after E-03b: #187 E-03c settings repository Move only.
 - Completed #470 and the #413/#414/#415 queue/live-UI lanes remain contract references,
   not active blockers.
 - Released code baseline: 0.6.2. Registry activation is external administration and
@@ -78,7 +78,8 @@ aliases or absorbing feature behavior.
 - [`python-runtime-e02-completion-audit.md`](python-runtime-e02-completion-audit.md):
   E-02 path-owner disposition, E-02d completion, and E-03 Contract handoff.
 - [`python-runtime-e03-repository-filesystem-contract.md`](python-runtime-e03-repository-filesystem-contract.md):
-  current repository/path/lock/patch boundaries and the E-03b through E-03e queue.
+  current repository/path/lock/patch boundaries, E-03b factory result, and the
+  E-03c through E-03e queue.
 - [`adr-001-modular-monolith.md`](adr-001-modular-monolith.md): feature-oriented modular
   monolith decision.
 - [`adr-002-compatibility-shims.md`](adr-002-compatibility-shims.md): shim lifecycle and

--- a/docs/architecture/backend-roadmap-resume-0.6.2.md
+++ b/docs/architecture/backend-roadmap-resume-0.6.2.md
@@ -2,15 +2,15 @@
 
 ## Status and authority
 
-- Status: D-08, E-01, E-02, and the E-03a repository/filesystem Contract are
+- Status: D-08, E-01, E-02, E-03a, and the E-03b filesystem factory Move are
   completed; the D-14 readiness audit retains every root surface and blocks
   retirement/final-freeze work.
-- Code-review baseline: `dev@204e74ab5897e1dc1f769067f9520ecee6803803`
-  after E-02d / PR #531.
-- Document baseline: E-03a repository/filesystem Contract.
+- Code-review baseline: `dev@92704b22fddd3b1b98e3fa037007f7e4916297a4`
+  after E-03a / PR #532.
+- Document baseline: E-03b filesystem factory Move.
 - Released baseline: 0.6.2.
 - Scope: completed D-08 evidence, the D-14 readiness decision, completed #187
-  E-01/E-02/E-03a work, and the next bounded E-03b factory Move.
+  E-01/E-02/E-03a/E-03b work, and the next bounded E-03c settings Move.
 - This document owns the current immediate queue and supersedes the stale queue and
   broad preflight command in `python-backend-execution-roadmap.md`.
 - `python-backend.md`, ADR-001, ADR-002, and the compatibility-shim registry still own
@@ -269,9 +269,12 @@ The D-08u audit found no required D-08v. After D-08:
 9. E-03a fixes current repository constructors, path inputs, lock order, revision/CAS,
    dynamic dependencies, and monkeypatch seams without changing production;
 10. the first READY follow-up is the E-03b stateless filesystem factory Move only; and
-11. never remove root files merely to make the directory tree appear complete.
+11. E-03b adds `create_atomic_json_store` as a stateless canonical-constructor seam
+    without adding a lock registry or root export;
+12. the first READY follow-up is the E-03c settings repository Move only; and
+13. never remove root files merely to make the directory tree appear complete.
 
-## 6. E-01/E-02/E-03a result and Codex resume instruction
+## 6. E-01/E-02/E-03a/E-03b result and Codex resume instruction
 
 ```text
 D-08 is complete. Do not restart D-08t or create D-08v without new contrary
@@ -306,8 +309,12 @@ is a stateless AtomicJsonStore constructor seam; the canonical atomic module kee
 single process path-lock registry. The profile directory coordinator remains a
 separate shared CAS transaction dependency.
 
-Start only #187 E-03b from latest origin/dev. Add the filesystem factory seam while
-proving direct and factory-created stores share the canonical normalized-path lock.
-Do not start settings/profile repository Moves, E-04 through E-10, release, or
-Registry work inside E-03b.
+E-03b adds `create_atomic_json_store(path, *, backup=True)`. It delegates directly to
+the canonical `AtomicJsonStore`, creates no state, preserves root `storage.py`, and
+proves direct/factory stores share one normalized-path lock.
+
+Start only #187 E-03c from latest origin/dev. Add explicit settings paths and the
+store factory behind the existing module functions and path monkeypatch seams. Do not
+start profile repository Moves, E-04 through E-10, release, or Registry work inside
+E-03c.
 ```

--- a/docs/architecture/python-backend-execution-roadmap.md
+++ b/docs/architecture/python-backend-execution-roadmap.md
@@ -1485,9 +1485,9 @@ the duplicate prompt knowledge package path. E-02 is complete. The next bounded 
 is the production-free
 [`python-runtime-e03-repository-filesystem-contract.md`](python-runtime-e03-repository-filesystem-contract.md).
 It fixes the current paths, store construction, lock ordering, CAS ownership,
-dynamic dependencies, and monkeypatch seams. E-03b adds only a stateless filesystem
-factory that delegates to the canonical `AtomicJsonStore` path-lock owner; settings
-and profile repository Moves remain separate.
+dynamic dependencies, and monkeypatch seams. E-03b adds the stateless
+`create_atomic_json_store` seam, which delegates to the canonical `AtomicJsonStore`
+path-lock owner. E-03c settings and E-03d profile repository Moves remain separate.
 
 Feature services receive only narrow Protocols. They do not import or receive
 the entire `RuntimeServices` object. Node adapters may use `get_runtime()` only

--- a/docs/architecture/python-runtime-e03-repository-filesystem-contract.md
+++ b/docs/architecture/python-runtime-e03-repository-filesystem-contract.md
@@ -26,9 +26,9 @@ atomic publication, delete, and same-directory replacement. Multi-path replaceme
 acquires normalized path keys in sorted order and releases them in reverse order.
 The process registry has no explicit cleanup today.
 
-This owner must remain shared by direct `AtomicJsonStore(path)` callers and future
-factory-created stores. A factory that creates another lock registry would allow two
-writers for the same path and violate the direct storage contract.
+This owner remains shared by direct `AtomicJsonStore(path)` callers and stores created
+through `create_atomic_json_store(path, backup=...)`. The E-03b factory delegates to
+the canonical constructor and creates no lock registry of its own.
 
 ### Profile transaction coordination
 
@@ -98,7 +98,8 @@ its current constructor and methods.
 
 ## Factory decision
 
-The E-03 filesystem factory is a stateless narrow store-constructor seam:
+The E-03b filesystem factory is the stateless
+`create_atomic_json_store(path, *, backup=True)` seam:
 
 ```text
 explicit path + backup policy -> canonical AtomicJsonStore
@@ -111,9 +112,10 @@ constructor compatibility or introducing a dependency-injection framework.
 
 ## Bounded Move queue
 
-1. **E-03b Move — filesystem factory:** add only the stateless constructor seam and
-   prove direct and factory-created stores share the canonical path lock.
-2. **E-03c Move — settings repository:** add explicit settings paths and the store
+1. **E-03b Move — filesystem factory — complete:** the stateless constructor seam
+   delegates to `AtomicJsonStore`; direct and factory-created stores share the
+   canonical path lock and backup policy.
+2. **E-03c Move — settings repository — READY:** add explicit settings paths and the store
    factory behind current functions and monkeypatch seams.
 3. **E-03d Move — profile repositories:** add explicit LoRA/AiO directories, the
    store factory, and shared profile coordinator behind current canonical functions
@@ -132,8 +134,9 @@ bootstrap, RuntimeServices, persistence, schema, error, lock, response, or lifec
 behavior. Package/no-host and live evidence from the preceding runtime work remains
 valid.
 
-E-03a does not authorize E-03b production changes, E-04 or later work, root alias
-retirement, D-14 retirement, release, or Registry actions.
+E-03b changes only the canonical factory seam and its direct contract evidence. It
+does not authorize E-03c production changes, E-04 or later work, root alias retirement,
+D-14 retirement, release, or Registry actions.
 
 The direct evidence leaves one owner for each boundary, so no material PRO review is
 required.

--- a/docs/architecture/python-runtime-state-inventory.md
+++ b/docs/architecture/python-runtime-state-inventory.md
@@ -41,7 +41,7 @@ E-01 drift gate until classified.
 | `autocomplete-dataset-cache` | canonical dataset snapshot and Future single-flight maps | one `Lock`; test-only clear | E-05 |
 | `autocomplete-index-locks` | canonical index per-path lock registry | guard plus per-path locks; no clear | E-05 |
 | `autocomplete-index-root` | import-resolved user-data index path | immutable after import; test patch coupled to index fallback/publication | E-05 |
-| `atomic-json-path-locks` | filesystem atomic JSON per-path lock registry | guard plus per-path `RLock`; no clear | E-03b |
+| `atomic-json-path-locks` | filesystem atomic JSON per-path lock registry shared by direct/factory stores | guard plus per-path `RLock`; no clear | E-03b complete |
 | `bootstrap-initialize-state` | bootstrap default runtime and wildcard completion state | initialize `Lock`; private-global test reset, no shutdown | E-09 |
 | `filesystem-runtime-paths` | import-resolved package/user-data paths projected into the default RuntimeConfig | immutable after import; bootstrap composition does not re-resolve | E-02c complete |
 | `package-bootstrap-effect` | root import invokes bootstrap route/directory initialization | bootstrap `Lock`; retry behavior, no package shutdown | E-09 |
@@ -95,6 +95,7 @@ E-02 is complete. The production-free
 [`python-runtime-e03-repository-filesystem-contract.md`](python-runtime-e03-repository-filesystem-contract.md)
 fixes the current settings/profile paths, atomic store construction, path and
 directory lock ownership, revision/CAS boundary, dynamic dependencies, and
-monkeypatch seams. It narrows `atomic-json-path-locks` to E-03b and the profile
-directory coordinator to E-03d. The next bounded unit is the E-03b filesystem
-factory Move; later feature/lifecycle Moves remain separate.
+monkeypatch seams. E-03b adds a stateless factory that delegates to the canonical
+store constructor and keeps the same process path-lock owner. The profile directory
+coordinator remains targeted to E-03d. The next bounded unit is the E-03c settings
+repository Move; later feature/lifecycle Moves remain separate.

--- a/docs/development/README.md
+++ b/docs/development/README.md
@@ -48,18 +48,18 @@ ordinary `dev` roadmap work.
 
 - Released baseline: 0.6.2.
 - Active owner: Issue #187 for Phase E; Issue #186 retains D-14/shim decisions.
-- Reviewed code baseline: E-02d / PR #531.
+- Reviewed code baseline: E-03a / PR #532.
 - D-08u integrated exit audit is complete.
 - D-08v is not required; the audit found no remaining D-08 production Move.
 - D-14 readiness is audited: every root surface is retained and retirement/final
   freeze is blocked by production/lifecycle consumers, missing release windows, or
   insufficient consumer evidence.
-- E-01, E-02, and the E-03a repository/filesystem Contract are complete. The next
-  work is only #187 E-03b filesystem factory Move. The #323 E-02a/E-07 bridge
+- E-01, E-02, E-03a, and the E-03b filesystem factory Move are complete. The next
+  work is only #187 E-03c settings repository Move. The #323 E-02a/E-07 bridge
   remains completed evidence, not authorization for unrelated feature migration.
 - Completed #470 and the 0.6.1 Prompt Studio lane are behavior-contract references,
   not the active queue.
-- Do not remove root aliases or start E-03c through E-10, release, or Registry work
+- Do not remove root aliases or start E-03d through E-10, release, or Registry work
   from this entrypoint.
 
 ## Completed D-08 composition audit surface
@@ -151,6 +151,6 @@ representative profile list/load/save/delete/rename/fix live smoke
 - A version marker is not a publish action.
 - Technical PRO review is for unresolved cross-boundary architecture choices,
   unavoidable cycles, or insufficient compatibility evidence—not routine failures.
-- D-14 readiness is recorded and authorizes no removal. Use the E-03a Contract for
-  the bounded E-03b factory Move; do not expand it into settings/profile repository
-  Moves, release publication, or Registry actions.
+- D-14 readiness is recorded and authorizes no removal. Use the E-03a/E-03b Contract
+  evidence for the bounded E-03c settings repository Move; do not expand it into
+  profile repository Moves, release publication, or Registry actions.

--- a/easyuse_anima/infrastructure/filesystem/atomic_json.py
+++ b/easyuse_anima/infrastructure/filesystem/atomic_json.py
@@ -402,4 +402,14 @@ class AtomicJsonStore:
                     _unlink_if_present(source_backup_restore_temp)
 
 
-__all__ = ("AtomicJsonStore",)
+def create_atomic_json_store(
+    path: str | os.PathLike[str],
+    *,
+    backup: bool | str | os.PathLike[str] = True,
+) -> AtomicJsonStore:
+    """Create a store that uses the canonical process path-lock owner."""
+
+    return AtomicJsonStore(path, backup=backup)
+
+
+__all__ = ("AtomicJsonStore", "create_atomic_json_store")

--- a/tests/fixtures/python_backend_baseline.json
+++ b/tests/fixtures/python_backend_baseline.json
@@ -67848,13 +67848,13 @@
       },
       {
         "is_package": false,
-        "loc": 405,
+        "loc": 415,
         "module": "easyuse_anima.infrastructure.filesystem.atomic_json",
-        "normalized_git_blob_sha1": "f087db424ea5802640f24d3ddb2481a23ff8c580",
+        "normalized_git_blob_sha1": "740d64db2cadfbee74f6702799ca5e734da8471a",
         "path": "easyuse_anima/infrastructure/filesystem/atomic_json.py",
         "top_level": {
           "class_count": 1,
-          "function_count": 6,
+          "function_count": 7,
           "global_count": 7
         }
       },

--- a/tests/fixtures/python_repository_filesystem_contract.v1.json
+++ b/tests/fixtures/python_repository_filesystem_contract.v1.json
@@ -75,7 +75,7 @@
   ],
   "decisions": {
     "dynamic_host_dependencies": "folder_paths lookup remains late-bound in the owning settings or LoRA feature and is not part of the filesystem factory.",
-    "filesystem_factory": "A future factory is a stateless narrow AtomicJsonStore constructor seam. It neither owns nor duplicates the process path-lock registry.",
+    "filesystem_factory": "create_atomic_json_store is the stateless narrow AtomicJsonStore constructor seam. It neither owns nor duplicates the process path-lock registry.",
     "path_lock_owner": "easyuse_anima.infrastructure.filesystem.atomic_json remains the single process owner for normalized-path locks used by direct and factory-created stores.",
     "profile_directory_owner": "PROFILE_MUTATION_COORDINATOR remains a shared profile transaction dependency and is not absorbed into generic filesystem mechanics.",
     "runtime_access": "Repositories receive explicit paths and narrow dependencies; feature code does not receive RuntimeServices."
@@ -142,27 +142,31 @@
   "move_queue": [
     {
       "classification": "Move",
-      "goal": "Add the stateless store-constructor seam while every AtomicJsonStore instance continues to share the canonical path-lock owner.",
+      "goal": "The stateless store-constructor seam delegates to AtomicJsonStore while every instance shares the canonical path-lock owner.",
       "id": "E-03b",
-      "name": "filesystem factory"
+      "name": "filesystem factory",
+      "status": "complete"
     },
     {
       "classification": "Move",
       "goal": "Introduce explicit settings paths and store-factory construction behind the current module functions and patch seams.",
       "id": "E-03c",
-      "name": "settings repository"
+      "name": "settings repository",
+      "status": "ready"
     },
     {
       "classification": "Move",
       "goal": "Introduce explicit LoRA/AiO profile directories, store factory, and shared profile coordinator behind current canonical functions and root aliases.",
       "id": "E-03d",
-      "name": "profile repositories"
+      "name": "profile repositories",
+      "status": "pending"
     },
     {
       "classification": "Contract",
       "goal": "Reconcile ownership targets and prove no repository or filesystem state remains ambiguously owned before E-04.",
       "id": "E-03e",
-      "name": "completion audit"
+      "name": "completion audit",
+      "status": "pending"
     }
   ],
   "owners": [
@@ -175,6 +179,7 @@
           "backup"
         ]
       },
+      "factory": "create_atomic_json_store",
       "id": "atomic-json-store",
       "lifetime": "Direct and future factory-created stores share one process path-lock registry.",
       "methods": [
@@ -190,7 +195,8 @@
       "symbols": [
         "AtomicJsonStore",
         "_PATH_LOCKS",
-        "_PATH_LOCKS_GUARD"
+        "_PATH_LOCKS_GUARD",
+        "create_atomic_json_store"
       ],
       "test_evidence": [
         "tests/test_storage.py"

--- a/tests/fixtures/python_runtime_state_ownership.v1.json
+++ b/tests/fixtures/python_runtime_state_ownership.v1.json
@@ -226,7 +226,7 @@
       "module": "easyuse_anima/infrastructure/filesystem/atomic_json.py",
       "owner": "easyuse_anima.infrastructure.filesystem.atomic_json",
       "symbols": ["_PATH_LOCKS", "_PATH_LOCKS_GUARD"],
-      "target_phase": "E-03b",
+      "target_phase": "E-03b-complete",
       "test_evidence": ["tests/test_storage.py"],
       "thread_safety": "The guard serializes registry access; per-path RLocks serialize publish operations."
     },

--- a/tests/test_python_package_skeleton.py
+++ b/tests/test_python_package_skeleton.py
@@ -375,7 +375,7 @@ print(json.dumps({{
             PACKAGE_MODULES.index(
                 "easyuse_anima.infrastructure.filesystem.atomic_json"
             )
-        ] = ["AtomicJsonStore"]
+        ] = ["AtomicJsonStore", "create_atomic_json_store"]
         expected_all[
             PACKAGE_MODULES.index(
                 "easyuse_anima.infrastructure.filesystem.paths"

--- a/tests/test_python_repository_filesystem_contract.py
+++ b/tests/test_python_repository_filesystem_contract.py
@@ -153,6 +153,10 @@ class PythonRepositoryFilesystemContractTests(unittest.TestCase):
             [move["id"] for move in self.fixture["move_queue"]],
             ["E-03b", "E-03c", "E-03d", "E-03e"],
         )
+        self.assertEqual(
+            [move["status"] for move in self.fixture["move_queue"]],
+            ["complete", "ready", "pending", "pending"],
+        )
 
         evidence = {
             path
@@ -202,6 +206,12 @@ class PythonRepositoryFilesystemContractTests(unittest.TestCase):
         self.assertEqual(
             _assignment_expression(atomic["module"], "_PATH_LOCKS_GUARD"),
             "threading.Lock()",
+        )
+        self.assertEqual(atomic["factory"], "create_atomic_json_store")
+        self.assertEqual(
+            {"AtomicJsonStore"}
+            - _function_calls(atomic["module"], atomic["factory"]),
+            set(),
         )
 
         profile = self.fixture["owners"][1]

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -14,7 +14,10 @@ from unittest.mock import patch
 import storage as root_storage
 from easyuse_anima.infrastructure.filesystem import atomic_json as storage
 from easyuse_anima.infrastructure.filesystem import paths as storage_paths
-from easyuse_anima.infrastructure.filesystem.atomic_json import AtomicJsonStore
+from easyuse_anima.infrastructure.filesystem.atomic_json import (
+    AtomicJsonStore,
+    create_atomic_json_store,
+)
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -395,9 +398,9 @@ class AtomicJsonStoreTests(unittest.TestCase):
         with self.assertRaises(json.JSONDecodeError):
             store.read()
 
-    def test_store_instances_share_the_same_resolved_path_lock(self):
+    def test_direct_and_factory_stores_share_the_same_resolved_path_lock(self):
         first_store = AtomicJsonStore(self.root / "nested" / ".." / "state.json")
-        second_store = self._store()
+        second_store = create_atomic_json_store(self.root / "state.json")
         first_entered = threading.Event()
         release_first = threading.Event()
         second_attempted = threading.Event()
@@ -428,6 +431,21 @@ class AtomicJsonStoreTests(unittest.TestCase):
         self.assertFalse(first.is_alive())
         self.assertFalse(second.is_alive())
         self.assertTrue(second_entered.is_set())
+
+    def test_factory_forwards_backup_policy_to_canonical_store(self):
+        without_backup = create_atomic_json_store(
+            self.root / "without_backup.json",
+            backup=False,
+        )
+        custom_backup = self.root / "custom.backup"
+        with_backup = create_atomic_json_store(
+            self.root / "with_backup.json",
+            backup=custom_backup,
+        )
+
+        self.assertIsInstance(without_backup, AtomicJsonStore)
+        self.assertIsNone(without_backup.backup_path)
+        self.assertEqual(with_backup.backup_path, custom_backup.resolve())
 
     def test_reader_sees_complete_primary_while_publish_is_blocked(self):
         writer_store = self._store()


### PR DESCRIPTION
## 목적과 변경 경계

E-03a Contract에 따른 E-03b filesystem factory Move입니다. canonical atomic JSON module에 stateless `create_atomic_json_store(path, *, backup=True)` seam을 추가하고 기존 `AtomicJsonStore` constructor에 그대로 위임합니다.

- Base: `92704b22fddd3b1b98e3fa037007f7e4916297a4`
- Head: `6027486915d020fc4790e7abfdf0b52538066358`
- Production: `easyuse_anima/infrastructure/filesystem/atomic_json.py` 1개, 함수 10줄
- 새 state/singleton/lock registry: 없음
- root `storage.py`, `filesystem.__init__`, settings/profile consumers, RuntimeServices/bootstrap: 0변경

보존:
- `AtomicJsonStore` identity/signature/methods
- path resolve/backup/atomic publication/delete/replace semantics
- direct/factory stores의 canonical normalized-path `RLock` 공유
- root exports와 current patch seams

## 검증

Focused:
- AtomicJsonStoreTests: 18
- StorageCompatibilityTests: 1
- E-03 Contract: 6
- E-01 ownership: 5
- analyzer: 18
- package skeleton: 1
- import-boundary: 6
- changed Python/JSON syntax, Ruff fatal subset, `git diff --check`: passed

Analyzer baseline:
- `atomic_json.py` LOC 405→415
- top-level function 6→7
- hash만 갱신; edge/global 변화 없음

Final candidate official full — 정확히 1회:
- Python: 1336 passed
- Frontend: 120 files passed
- Pyright baseline ratchet, import-boundary, diff check: passed
- Ruff 122건은 G-01 report-only baseline

Package/live:
- package/no-host direct skeleton과 full 통과
- runtime behavior consumer 0변경이므로 #525 isolated live evidence 재사용
- material escalation trigger 없음

## 위험과 rollback

Factory가 공개 canonical module surface에 추가되지만 root compatibility surface는 넓히지 않습니다. rollback은 이 squash commit 단위입니다.

## 다음

별도 E-03c settings repository Move만 진행합니다. Profile repository, E-04+, D-14 retirement, release/Registry는 이 PR 범위가 아닙니다.

Refs #187