### PR TITLE
test: E-03 repository ownership completion audit

### DIFF
--- a/docs/architecture/backend-roadmap-resume-0.6.2.md
+++ b/docs/architecture/backend-roadmap-resume-0.6.2.md
@@ -2,16 +2,16 @@
 
 ## Status and authority
 
-- Status: D-08, E-01, E-02, E-03a, E-03b, E-03c, and the E-03d profile repositories
-  Move are completed; the D-14 readiness audit retains every root surface and blocks
+- Status: D-08, E-01, E-02, and E-03 through the E-03e completion audit are
+  completed; the D-14 readiness audit retains every root surface and blocks
   retirement/final-freeze work.
-- Code-review base: `dev@2ccf6f91a1bf458fc4afbc6352c66fb67a934a6d`
-  after E-03c / PR #534.
-- Document baseline: E-03d profile repositories Move.
+- Code-review base: `dev@45215242615dccfe647f2c410788f0d61fdd2091`
+  after E-03d / PR #535.
+- Document baseline: E-03e repository/filesystem completion audit.
 - Released baseline: 0.6.2.
 - Scope: completed D-08 evidence, the D-14 readiness decision, completed #187
-  E-01/E-02/E-03a/E-03b/E-03c/E-03d work, and the next bounded E-03e completion
-  Contract/audit.
+  E-01/E-02/E-03 work, and the next bounded E-04 translation
+  provider/client/cache Contract.
 - This document owns the current immediate queue and supersedes the stale queue and
   broad preflight command in `python-backend-execution-roadmap.md`.
 - `python-backend.md`, ADR-001, ADR-002, and the compatibility-shim registry still own
@@ -272,10 +272,15 @@ The D-08u audit found no required D-08v. After D-08:
 10. the first READY follow-up is the E-03b stateless filesystem factory Move only; and
 11. E-03b adds `create_atomic_json_store` as a stateless canonical-constructor seam
     without adding a lock registry or root export;
-12. the first READY follow-up is the E-03c settings repository Move only; and
-13. never remove root files merely to make the directory tree appear complete.
+12. E-03c adds a private per-call settings repository without capturing an
+    import-time default or mutable process state;
+13. E-03d adds a shared private per-call profile repository while retaining the
+    canonical store factory and profile directory coordinator as the state owners;
+14. E-03e reconciles both E-01 owners with E-03, records zero ambiguous
+    repository/filesystem state owners, and completes E-03; and
+15. never remove root files merely to make the directory tree appear complete.
 
-## 6. E-01/E-02/E-03a/E-03b result and Codex resume instruction
+## 6. E-01/E-02/E-03 result and Codex resume instruction
 
 ```text
 D-08 is complete. Do not restart D-08t or create D-08v without new contrary
@@ -314,8 +319,14 @@ E-03b adds `create_atomic_json_store(path, *, backup=True)`. It delegates direct
 the canonical `AtomicJsonStore`, creates no state, preserves root `storage.py`, and
 proves direct/factory stores share one normalized-path lock.
 
-Start only #187 E-03e from latest origin/dev. Reconcile E-01 ownership targets with
-the completed E-03 factory/repository Moves and prove no repository/filesystem state
-is ambiguously owned before E-04. E-03e is a production-free Contract/audit. Do not
-start E-04 through E-10, D-14 retirement, release, or Registry work inside E-03e.
+E-03c and E-03d add private per-call settings and profile repository values. They
+retain current path and monkeypatch seams, the canonical stateless store factory, and
+the shared profile directory coordinator. They own no mutable process state.
+
+E-03e reconciles E-01 ownership targets with those completed Moves and records zero
+ambiguous repository/filesystem state owners. E-03 is complete.
+
+Start only #187 E-04 from latest origin/dev as a production-free translation
+provider/client/cache Contract. Do not start E-04 implementation, E-05 through E-10,
+D-14 retirement, release, or Registry work inside that Contract.
 ```

--- a/docs/architecture/python-runtime-e03-repository-filesystem-contract.md
+++ b/docs/architecture/python-runtime-e03-repository-filesystem-contract.md
@@ -2,10 +2,11 @@
 
 ## Scope
 
-E-03a is a production-free Contract at
-`dev@204e74ab5897e1dc1f769067f9520ecee6803803`. It inventories the current
-settings, LoRA profile, AiO profile, atomic JSON, and profile mutation boundaries
-before any factory or repository Move.
+E-03 began with a production-free Contract at
+`dev@204e74ab5897e1dc1f769067f9520ecee6803803` and completed its factory and
+repository Moves at `dev@45215242615dccfe647f2c410788f0d61fdd2091`. This
+completion audit reconciles the current settings, LoRA profile, AiO profile, atomic
+JSON, and profile mutation boundaries after those Moves.
 
 The executable source of this inventory is
 `tests/fixtures/python_repository_filesystem_contract.v1.json`, checked by
@@ -123,12 +124,28 @@ constructor compatibility or introducing a dependency-injection framework.
 3. **E-03d Move — profile repositories — complete:** a shared private per-call value
    binds each current LoRA/AiO directory to the canonical store factory and shared
    coordinator behind the existing canonical functions and root aliases.
-4. **E-03e Contract — completion audit — READY:** reconcile E-01 ownership targets and prove
-   no repository/filesystem state remains ambiguously owned before E-04.
+4. **E-03e Contract — completion audit — complete:** E-01 ownership targets are
+   reconciled and no repository/filesystem state remains ambiguously owned before
+   E-04.
 
 Each Move is a separate rollback boundary. A Move may be split further when direct
 source review proves that preserving AiO rename/delete transactions would otherwise
 mix behavior with mechanical construction.
+
+## Completion audit result
+
+The E-01 and E-03 fixtures now agree on both stateful owners:
+
+| E-01 entry | E-03 owner | Completed phase | Mutable state |
+| --- | --- | --- | --- |
+| `atomic-json-path-locks` | `atomic-json-store` | E-03b | `_PATH_LOCKS`, `_PATH_LOCKS_GUARD` |
+| `profile-directory-mutation-coordinator` | `profile-directory-coordinator` | E-03d | `PROFILE_MUTATION_COORDINATOR` |
+
+`_SettingsRepository` and `_ProfileRepository` remain private per-call values. They
+capture neither an import-time default instance nor mutable process state; their
+builders resolve the current module path, factory, and coordinator seams on every
+call. The completion fixture therefore records zero ambiguous state owners and zero
+production changes.
 
 ## Preserved and forbidden
 
@@ -137,9 +154,11 @@ bootstrap, RuntimeServices, persistence, schema, error, lock, response, or lifec
 behavior. Package/no-host and live evidence from the preceding runtime work remains
 valid.
 
-E-03d changes only private profile repository construction and its direct contract
-evidence. It does not authorize the E-03e audit, E-04 or later work, root alias
-retirement, D-14 retirement, release, or Registry actions.
+E-03e changes only the versioned ownership fixtures, their direct Contract test, and
+maintained architecture records. E-03 is complete. The next bounded unit is a
+separate E-04 translation provider/client/cache Contract; E-03e does not authorize
+its implementation, root alias retirement, D-14 retirement, release, or Registry
+actions.
 
 The direct evidence leaves one owner for each boundary, so no material PRO review is
 required.

--- a/docs/architecture/python-runtime-state-inventory.md
+++ b/docs/architecture/python-runtime-state-inventory.md
@@ -45,7 +45,7 @@ E-01 drift gate until classified.
 | `bootstrap-initialize-state` | bootstrap default runtime and wildcard completion state | initialize `Lock`; private-global test reset, no shutdown | E-09 |
 | `filesystem-runtime-paths` | import-resolved package/user-data paths projected into the default RuntimeConfig | immutable after import; bootstrap composition does not re-resolve | E-02c complete |
 | `package-bootstrap-effect` | root import invokes bootstrap route/directory initialization | bootstrap `Lock`; retry behavior, no package shutdown | E-09 |
-| `profile-directory-mutation-coordinator` | canonical process coordinator with weak per-directory locks | guard plus per-directory `RLock`; weak expiry | E-03d |
+| `profile-directory-mutation-coordinator` | canonical process coordinator with weak per-directory locks | guard plus per-directory `RLock`; weak expiry | E-03d complete |
 | prompt warning-dedupe entries | two canonical Prompt feature modules, process lifetime | unprotected sets; direct-test clear only | E-09 |
 | `prompt-knowledge-path` | canonical filesystem package path re-exported for ANIMA root compatibility | immutable after import | E-02d complete |
 | `root-route-registration` | injected router registrar called by bootstrap | serialized refresh; idempotent marker, no deregistration | E-09 |
@@ -72,7 +72,7 @@ source.
 - No production Python, analyzer heuristic, public surface, cache policy, or
   lifecycle behavior changes in E-01.
 
-## E-02 and E-03a result
+## E-02 and E-03 result
 
 E-02b is owned by
 [`python-runtime-base-contract.md`](python-runtime-base-contract.md). It fixes
@@ -96,6 +96,10 @@ E-02 is complete. The production-free
 fixes the current settings/profile paths, atomic store construction, path and
 directory lock ownership, revision/CAS boundary, dynamic dependencies, and
 monkeypatch seams. E-03b adds a stateless factory that delegates to the canonical
-store constructor and keeps the same process path-lock owner. The profile directory
-coordinator remains targeted to E-03d. The next bounded unit is the E-03c settings
-repository Move; later feature/lifecycle Moves remain separate.
+store constructor and keeps the same process path-lock owner. E-03c adds a private
+per-call settings repository value without capturing an import-time default. E-03d
+adds the shared private per-call profile repository value while retaining the
+canonical store factory and profile directory coordinator as the only mutable-state
+owners. The E-03e cross-fixture audit reconciles both E-01 owner entries with those
+E-03 owners and records zero ambiguous repository/filesystem state owners. The next
+bounded unit is the separate E-04 translation provider/client/cache Contract.

--- a/tests/fixtures/python_repository_filesystem_contract.v1.json
+++ b/tests/fixtures/python_repository_filesystem_contract.v1.json
@@ -73,6 +73,42 @@
       "symbol": "save_setting"
     }
   ],
+  "completion_audit": {
+    "ambiguous_state_owners": [],
+    "classification": "Contract",
+    "next_phase": "E-04 translation provider/client/cache Contract",
+    "production_changes": 0,
+    "repository_values": [
+      {
+        "builders": [
+          {
+            "function": "_current_settings_repository",
+            "module": "easyuse_anima/settings/repository.py"
+          }
+        ],
+        "captures_import_default": false,
+        "class": "_SettingsRepository",
+        "module": "easyuse_anima/settings/repository.py",
+        "owns_mutable_state": false
+      },
+      {
+        "builders": [
+          {
+            "function": "_current_lora_profile_repository",
+            "module": "easyuse_anima/profiles/lora.py"
+          },
+          {
+            "function": "_current_aio_profile_repository",
+            "module": "easyuse_anima/profiles/aio.py"
+          }
+        ],
+        "captures_import_default": false,
+        "class": "_ProfileRepository",
+        "module": "easyuse_anima/profiles/repository.py",
+        "owns_mutable_state": false
+      }
+    ]
+  },
   "decisions": {
     "dynamic_host_dependencies": "folder_paths lookup remains late-bound in the owning settings or LoRA feature and is not part of the filesystem factory.",
     "filesystem_factory": "create_atomic_json_store is the stateless narrow AtomicJsonStore constructor seam. It neither owns nor duplicates the process path-lock registry.",
@@ -166,7 +202,7 @@
       "goal": "Reconcile ownership targets and prove no repository or filesystem state remains ambiguously owned before E-04.",
       "id": "E-03e",
       "name": "completion audit",
-      "status": "ready"
+      "status": "complete"
     }
   ],
   "owners": [
@@ -191,6 +227,7 @@
         "write"
       ],
       "module": "easyuse_anima/infrastructure/filesystem/atomic_json.py",
+      "owner": "easyuse_anima.infrastructure.filesystem.atomic_json",
       "path_normalization": "Path(path).expanduser().resolve(strict=False)",
       "symbols": [
         "AtomicJsonStore",
@@ -216,6 +253,7 @@
         "locked"
       ],
       "module": "easyuse_anima/profiles/mutation.py",
+      "owner": "easyuse_anima.profiles.mutation.PROFILE_MUTATION_COORDINATOR",
       "path_normalization": "os.path.normcase(str(Path(directory).resolve(strict=False)))",
       "symbols": [
         "DirectoryMutationCoordinator",
@@ -527,6 +565,29 @@
       ]
     }
   ],
+  "ownership_reconciliation": [
+    {
+      "completed_phase": "E-03b-complete",
+      "e01_entry": "atomic-json-path-locks",
+      "e03_owner": "atomic-json-store",
+      "module": "easyuse_anima/infrastructure/filesystem/atomic_json.py",
+      "owner": "easyuse_anima.infrastructure.filesystem.atomic_json",
+      "state_symbols": [
+        "_PATH_LOCKS",
+        "_PATH_LOCKS_GUARD"
+      ]
+    },
+    {
+      "completed_phase": "E-03d-complete",
+      "e01_entry": "profile-directory-mutation-coordinator",
+      "e03_owner": "profile-directory-coordinator",
+      "module": "easyuse_anima/profiles/mutation.py",
+      "owner": "easyuse_anima.profiles.mutation.PROFILE_MUTATION_COORDINATOR",
+      "state_symbols": [
+        "PROFILE_MUTATION_COORDINATOR"
+      ]
+    }
+  ],
   "schema_version": 1,
-  "scope": "E-03a current settings/profile repository and filesystem boundary"
+  "scope": "Completed E-03 settings/profile repository and filesystem boundary"
 }

--- a/tests/fixtures/python_runtime_state_ownership.v1.json
+++ b/tests/fixtures/python_runtime_state_ownership.v1.json
@@ -274,7 +274,7 @@
       "module": "easyuse_anima/profiles/mutation.py",
       "owner": "easyuse_anima.profiles.mutation.PROFILE_MUTATION_COORDINATOR",
       "symbols": ["PROFILE_MUTATION_COORDINATOR"],
-      "target_phase": "E-03d",
+      "target_phase": "E-03d-complete",
       "test_evidence": ["tests/test_aio_profiles.py", "tests/test_lora_profiles.py"],
       "thread_safety": "A guard protects the weak registry; one RLock serializes CAS per directory."
     },

--- a/tests/test_python_repository_filesystem_contract.py
+++ b/tests/test_python_repository_filesystem_contract.py
@@ -14,6 +14,12 @@ FIXTURE_PATH = (
     / "fixtures"
     / "python_repository_filesystem_contract.v1.json"
 )
+E01_FIXTURE_PATH = (
+    ROOT
+    / "tests"
+    / "fixtures"
+    / "python_runtime_state_ownership.v1.json"
+)
 CONTRACT_DOC = (
     ROOT
     / "docs"
@@ -139,21 +145,48 @@ def _normalized_source_token(value: str) -> str:
     return "".join(value.split())
 
 
+def _top_level_constructor_assignments(module: str, class_name: str) -> set[str]:
+    assigned = set()
+    for statement in _tree(module).body:
+        value = None
+        targets: tuple[ast.expr, ...] = ()
+        if isinstance(statement, ast.Assign):
+            value = statement.value
+            targets = tuple(statement.targets)
+        elif isinstance(statement, ast.AnnAssign):
+            value = statement.value
+            targets = (statement.target,)
+        if (
+            not isinstance(value, ast.Call)
+            or _expression_name(value.func) != class_name
+        ):
+            continue
+        assigned.update(
+            target.id for target in targets if isinstance(target, ast.Name)
+        )
+    return assigned
+
+
 class PythonRepositoryFilesystemContractTests(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.fixture = json.loads(FIXTURE_PATH.read_text(encoding="utf-8"))
+        cls.e01_fixture = json.loads(
+            E01_FIXTURE_PATH.read_text(encoding="utf-8")
+        )
 
     def test_schema_ids_and_evidence_are_complete(self):
         self.assertEqual(
             set(self.fixture),
             {
                 "compatibility_bindings",
+                "completion_audit",
                 "decisions",
                 "lock_order",
                 "monkeypatch_seams",
                 "move_queue",
                 "owners",
+                "ownership_reconciliation",
                 "repository_lanes",
                 "schema_version",
                 "scope",
@@ -174,7 +207,7 @@ class PythonRepositoryFilesystemContractTests(unittest.TestCase):
         )
         self.assertEqual(
             [move["status"] for move in self.fixture["move_queue"]],
-            ["complete", "complete", "complete", "ready"],
+            ["complete", "complete", "complete", "complete"],
         )
 
         evidence = {
@@ -388,6 +421,99 @@ class PythonRepositoryFilesystemContractTests(unittest.TestCase):
             [move["classification"] for move in self.fixture["move_queue"]],
             ["Move", "Move", "Move", "Contract"],
         )
+
+    def test_completion_audit_reconciles_e01_owners_and_per_call_values(self):
+        e01_entries = {
+            entry["id"]: entry for entry in self.e01_fixture["entries"]
+        }
+        e03_owners = {
+            owner["id"]: owner for owner in self.fixture["owners"]
+        }
+        reconciliations = self.fixture["ownership_reconciliation"]
+        self.assertEqual(
+            {item["e01_entry"] for item in reconciliations},
+            {
+                entry["id"]
+                for entry in self.e01_fixture["entries"]
+                if entry["target_phase"].startswith("E-03")
+            },
+        )
+        self.assertEqual(
+            {item["e03_owner"] for item in reconciliations},
+            set(e03_owners),
+        )
+        self.assertEqual(
+            len(reconciliations),
+            len({item["e01_entry"] for item in reconciliations}),
+        )
+        for reconciliation in reconciliations:
+            with self.subTest(owner=reconciliation["e03_owner"]):
+                e01 = e01_entries[reconciliation["e01_entry"]]
+                e03 = e03_owners[reconciliation["e03_owner"]]
+                self.assertEqual(e01["module"], reconciliation["module"])
+                self.assertEqual(e03["module"], reconciliation["module"])
+                self.assertEqual(e01["owner"], reconciliation["owner"])
+                self.assertEqual(e03["owner"], reconciliation["owner"])
+                self.assertEqual(
+                    e01["target_phase"],
+                    reconciliation["completed_phase"],
+                )
+                self.assertEqual(
+                    set(reconciliation["state_symbols"]) - set(e01["symbols"]),
+                    set(),
+                )
+                self.assertEqual(
+                    set(reconciliation["state_symbols"]) - set(e03["symbols"]),
+                    set(),
+                )
+
+        audit = self.fixture["completion_audit"]
+        self.assertEqual(audit["classification"], "Contract")
+        self.assertEqual(audit["production_changes"], 0)
+        self.assertEqual(audit["ambiguous_state_owners"], [])
+        self.assertEqual(
+            audit["next_phase"],
+            "E-04 translation provider/client/cache Contract",
+        )
+        for repository in audit["repository_values"]:
+            with self.subTest(repository=repository["class"]):
+                self.assertFalse(repository["owns_mutable_state"])
+                self.assertFalse(repository["captures_import_default"])
+                _top_level_class(repository["module"], repository["class"])
+                self.assertEqual(
+                    _top_level_constructor_assignments(
+                        repository["module"],
+                        repository["class"],
+                    ),
+                    set(),
+                )
+                for builder in repository["builders"]:
+                    builder_function = _top_level_function(
+                        builder["module"],
+                        builder["function"],
+                    )
+                    defaults = (
+                        *builder_function.args.defaults,
+                        *(
+                            default
+                            for default in builder_function.args.kw_defaults
+                            if default is not None
+                        ),
+                    )
+                    self.assertTrue(
+                        all(
+                            isinstance(default, ast.Constant)
+                            and default.value is None
+                            for default in defaults
+                        )
+                    )
+                    self.assertIn(
+                        repository["class"],
+                        _function_calls(
+                            builder["module"],
+                            builder["function"],
+                        ),
+                    )
 
     def test_contract_document_is_linked_from_maintained_entries(self):
         self.assertTrue(CONTRACT_DOC.is_file())


### PR DESCRIPTION
## 목적과 변경 경계

#187 E-03e production-free Contract/audit입니다. E-01 runtime-state ownership과 완료된 E-03 factory/repository 경계를 교차 대조해 repository/filesystem mutable-state owner를 확정합니다.

- Base: `dev@45215242615dccfe647f2c410788f0d61fdd2091`
- Head: `be8c5f8ff08ca23476b40971c16af097627e2574`
- Production/analyzer/existing feature tests: 변경 없음

## 주요 변경

- atomic path-lock registry와 profile directory coordinator의 E-01/E-03 owner를 1:1로 reconciliation
- E-03e queue를 complete로 전환하고 ambiguous state owner 0개를 fixture에 고정
- `_SettingsRepository`와 `_ProfileRepository`가 per-call value이며 import-time default/mutable state를 소유하지 않음을 AST Contract로 검증
- maintained runtime inventory, E-03 Contract, 0.6.2 resume checkpoint를 E-03 완료 및 다음 E-04 Contract로 갱신

## 보존 계약

- production, persistence/schema/error/lock/lifecycle 동작
- canonical atomic path-lock registry와 shared profile directory coordinator 단일 ownership
- 현재 path/factory/coordinator monkeypatch seam
- root aliases, bootstrap/RuntimeServices/package surface

## 검증

Focused:
- repository/filesystem Contract: 7 passed
- E-01 runtime-state Contract: 5 passed
- storage: 21 passed
- analyzer: 18 passed
- package skeleton: 1 passed
- completed import boundary: 6 passed
- changed Python compile + fatal Ruff: passed
- JSON fixture parse + `git diff --check`: passed

Final candidate `be8c5f8ff08ca23476b40971c16af097627e2574`:
- official full exactly once: Python 1,340 passed; frontend 120 passed
- Pyright baseline ratchet, import-boundary gate, project diff check: passed
- Ruff repository findings: existing G-01 report-only baseline

Package/live:
- not retriggered; production/shipped/import/route/runtime boundary가 변하지 않아 E-03c/E-03d evidence를 재사용

## 위험과 rollback

남은 위험은 문서/fixture 분류 drift뿐이며 executable cross-fixture Contract가 차단합니다. 독립 squash revert로 rollback 가능합니다.

## Next

별도 #187 E-04 production-free translation provider/client/cache Contract. 이 PR은 E-04 구현, E-05+, D-14 retirement, release, Registry 작업을 포함하지 않습니다.