### PR TITLE
test: define E-04 translation runtime ownership contract

### DIFF
--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -10,14 +10,14 @@ then only the active task section, owning Issue, direct source, and direct tests
 ## Active sequencing
 
 - Issue [#187](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/187)
-  owns Phase E. E-01, E-02, E-03a, and the E-03b filesystem factory Move are
-  complete; the E-03c settings repository Move is the next bounded unit.
+  owns Phase E. E-01 through E-03 and the E-04a translation ownership Contract are
+  complete; E-04b provider registry/client ownership is the next bounded unit.
   Issue #186 retains D-14/shim decisions.
 - [`backend-roadmap-resume-0.6.2.md`](backend-roadmap-resume-0.6.2.md)
   is the current execution source of truth. Read it before the older accumulated
   roadmap.
-- Reviewed code baseline: E-03a / PR #532 at
-  `92704b22fddd3b1b98e3fa037007f7e4916297a4`.
+- Reviewed code baseline: E-03e / PR #536 at
+  `d952f15f637732ce45a1ab7d9a0006bd1a3362bc`.
 - D-08 is complete and D-08v is not required.
 - D-14 readiness retains every root surface; retirement/final-freeze work is blocked.
 - E-01 inventory Contract:
@@ -30,16 +30,19 @@ then only the active task section, owning Issue, direct source, and direct tests
 - E-02 completion audit:
   [`python-runtime-e02-completion-audit.md`](python-runtime-e02-completion-audit.md).
 - E-02d canonicalizes the prompt knowledge package-data alias and completes E-02.
-- E-03a/E-03b repository/filesystem Contract and factory result:
+- E-03 repository/filesystem Contract and completion result:
   [`python-runtime-e03-repository-filesystem-contract.md`](python-runtime-e03-repository-filesystem-contract.md).
-- First READY task after E-03b: #187 E-03c settings repository Move only.
+- E-04a translation runtime ownership Contract:
+  [`python-runtime-e04-translation-contract.md`](python-runtime-e04-translation-contract.md).
+- First READY task after E-04a: #187 E-04b provider registry/client ownership Move
+  only.
 - Completed #470 and the #413/#414/#415 queue/live-UI lanes remain contract references,
   not active blockers.
 - Released code baseline: 0.6.2. Registry activation is external administration and
   does not block `dev`; do not republish or mutate the release.
 - Completed #409/#410/#411 and deferred #440/#441 do not alter the E-01 boundary.
-- E-01 completion does not authorize later Phase E Moves, root removal, release, or
-  Registry work.
+- E-04a completion authorizes only E-04b. It does not authorize later Phase E Moves,
+  root removal, release, or Registry work.
 
 ## Current code boundary
 
@@ -64,7 +67,8 @@ aliases or absorbing feature behavior.
 ## Core documents
 
 - [`backend-roadmap-resume-0.6.2.md`](backend-roadmap-resume-0.6.2.md):
-  completed D-08 evidence, D-14 readiness verdict, and the bounded E-01 handoff.
+  completed D-08 evidence, D-14 readiness verdict, completed Phase E units, and the
+  bounded E-04b handoff.
 - [`python-backend.md`](python-backend.md): target ownership and dependency direction.
   Its early implementation snapshot is historical where the active checkpoint differs.
 - [`python-backend-execution-roadmap.md`](python-backend-execution-roadmap.md):
@@ -78,8 +82,10 @@ aliases or absorbing feature behavior.
 - [`python-runtime-e02-completion-audit.md`](python-runtime-e02-completion-audit.md):
   E-02 path-owner disposition, E-02d completion, and E-03 Contract handoff.
 - [`python-runtime-e03-repository-filesystem-contract.md`](python-runtime-e03-repository-filesystem-contract.md):
-  current repository/path/lock/patch boundaries, E-03b factory result, and the
-  E-03c through E-03e queue.
+  repository/path/lock/patch boundaries and the completed E-03 queue.
+- [`python-runtime-e04-translation-contract.md`](python-runtime-e04-translation-contract.md):
+  current translation provider/client, service cache/single-flight, route executor
+  owners, lifecycle gaps, and the E-04b through E-04e queue.
 - [`adr-001-modular-monolith.md`](adr-001-modular-monolith.md): feature-oriented modular
   monolith decision.
 - [`adr-002-compatibility-shims.md`](adr-002-compatibility-shims.md): shim lifecycle and

--- a/docs/architecture/backend-roadmap-resume-0.6.2.md
+++ b/docs/architecture/backend-roadmap-resume-0.6.2.md
@@ -2,16 +2,16 @@
 
 ## Status and authority
 
-- Status: D-08, E-01, E-02, and E-03 through the E-03e completion audit are
+- Status: D-08, E-01, E-02, E-03, and the E-04a translation ownership Contract are
   completed; the D-14 readiness audit retains every root surface and blocks
   retirement/final-freeze work.
-- Code-review base: `dev@45215242615dccfe647f2c410788f0d61fdd2091`
-  after E-03d / PR #535.
-- Document baseline: E-03e repository/filesystem completion audit.
+- Code-review base: `dev@d952f15f637732ce45a1ab7d9a0006bd1a3362bc`
+  after E-03e / PR #536.
+- Document baseline: E-04a translation runtime ownership Contract.
 - Released baseline: 0.6.2.
 - Scope: completed D-08 evidence, the D-14 readiness decision, completed #187
-  E-01/E-02/E-03 work, and the next bounded E-04 translation
-  provider/client/cache Contract.
+  E-01/E-02/E-03/E-04a work, and the next bounded E-04b provider registry/client
+  ownership Move.
 - This document owns the current immediate queue and supersedes the stale queue and
   broad preflight command in `python-backend-execution-roadmap.md`.
 - `python-backend.md`, ADR-001, ADR-002, and the compatibility-shim registry still own
@@ -277,10 +277,13 @@ The D-08u audit found no required D-08v. After D-08:
 13. E-03d adds a shared private per-call profile repository while retaining the
     canonical store factory and profile directory coordinator as the state owners;
 14. E-03e reconciles both E-01 owners with E-03, records zero ambiguous
-    repository/filesystem state owners, and completes E-03; and
-15. never remove root files merely to make the directory tree appear complete.
+    repository/filesystem state owners, and completes E-03;
+15. E-04a keeps provider registry/client, service cache/per-key single-flight, and
+    API route executor as three distinct translation-owned resources, rejects a
+    generic executor/client port, and records the unproven client-close gap; and
+16. never remove root files merely to make the directory tree appear complete.
 
-## 6. E-01/E-02/E-03 result and Codex resume instruction
+## 6. E-01/E-02/E-03/E-04a result and Codex resume instruction
 
 ```text
 D-08 is complete. Do not restart D-08t or create D-08v without new contrary
@@ -326,7 +329,15 @@ the shared profile directory coordinator. They own no mutable process state.
 E-03e reconciles E-01 ownership targets with those completed Moves and records zero
 ambiguous repository/filesystem state owners. E-03 is complete.
 
-Start only #187 E-04 from latest origin/dev as a production-free translation
-provider/client/cache Contract. Do not start E-04 implementation, E-05 through E-10,
-D-14 retirement, release, or Registry work inside that Contract.
+E-04a is owned by python-runtime-e04-translation-contract.md and
+tests/fixtures/python_translation_runtime_contract.v1.json. Provider registry/client,
+service cache/per-key single-flight, and API route executor remain three distinct
+translation-owned resources. Bootstrap is the target concrete composition root;
+generic executor/client ports and unproven provider-client close calls are rejected.
+
+Start only #187 E-04b from latest origin/dev. Move provider factories, lazy instances,
+registry locking, and client ownership behind one explicit translation provider
+registry while preserving optional import, reuse, timeout, errors, and public/root
+identities. Do not start E-04c through E-10, D-14 retirement, release, or Registry
+work inside E-04b.
 ```

--- a/docs/architecture/python-runtime-e04-translation-contract.md
+++ b/docs/architecture/python-runtime-e04-translation-contract.md
@@ -1,0 +1,125 @@
+# E-04 Translation Runtime Ownership Contract
+
+## Scope and authority
+
+E-04a is a production-free Contract at
+`dev@d952f15f637732ce45a1ab7d9a0006bd1a3362bc`. It inventories the current
+translation provider registry/client, default service cache/per-key single-flight,
+and API route executor before any E-04 Move.
+
+The executable source is
+`tests/fixtures/python_translation_runtime_contract.v1.json`, checked by
+`tests/test_python_translation_runtime_contract.py`. Existing translation service
+and API tests remain the behavior authorities.
+
+## Three distinct resource boundaries
+
+### Provider registry and optional client
+
+`easyuse_anima.translation.service` owns the provider factory mapping, lazy instance
+mapping, and registry `RLock`. The first Google request constructs one
+`GoogleTranslationProvider`; that provider has a separate `RLock` and lazily imports
+and constructs the optional `googletrans` client on first use.
+
+The provider registry owns lookup, construction, publication, and reuse. It does not
+own cache policy or API admission. The current client protocol exposes only
+`translate`, so a client `close` contract is not proven. E-04 must not invent one.
+
+### Default service, cache, and per-key single-flight
+
+The canonical service module constructs `_DEFAULT_TRANSLATION_SERVICE` at import.
+That service owns one bounded TTL/LRU cache and a per-key single-flight registry.
+Cache entries use one `RLock`; flight registration uses a second `RLock`; each cache
+key gets its own `Lock`, so different translation keys can proceed independently.
+
+`BoundedTranslationCache.clear()` exists, and each flight removes itself after the
+last user settles. The module default service has no process reset or idempotent
+close. API and Prompt-node paths currently converge through
+`translate_prompt_markers()`.
+
+### API route executor
+
+Root `api.py` invokes the canonical `build_translation_runtime()` factory at module
+import and assigns `_PROMPT_TRANSLATION_WORKER` plus three helper closures. The
+canonical `PromptTranslationRouteExecutor` lazily creates a one-thread executor,
+permits one in-flight request, and keeps admission occupied after timeout or
+cancellation until the synchronous worker actually settles.
+
+The worker has idempotent `shutdown()`, registered once with `atexit`, but package
+shutdown and partial-initialization cleanup do not own it. The root worker, sync
+function, timeout, settings resolver, translation function, and error response remain
+dynamic compatibility/test seams.
+
+## Target ownership decision
+
+E-04 does not create a generic executor or client abstraction. Direct evidence shows
+three different contracts:
+
+- provider registry/client: lazy optional dependency, reusable provider identity,
+  provider-specific timeout and error normalization;
+- service/cache: marker budgets, TTL/LRU, cache-key partitioning, and per-key
+  single-flight settlement;
+- API route executor: single admission, busy/cancel/timeout mapping, event-loop
+  offload, and late worker settlement.
+
+Each remains a translation-owned narrow resource/port. Bootstrap is the only target
+production composition root for their concrete instances and lifecycle registration.
+Adapters receive or resolve only the translation port they need. Feature/domain code
+must not import `RuntimeServices`, bootstrap, API adapters, or root shims.
+
+This refines the ADR statement that `RuntimeServices` owns process resources: any
+runtime expansion is made only by the owning Move and contains narrow
+translation-owned ports, not a shared generic executor/client or the complete
+runtime passed into feature code.
+
+## Preserved behavior and compatibility
+
+All E-04 Moves preserve:
+
+- root `prompt_translation.py` identity re-exports and canonical public `__all__`;
+- marker syntax, off-mode unwrapping, settings defaults, budgets, and error classes;
+- cache key `(provider, source, target, text)`, TTL boundary, LRU bound, and
+  per-key single-flight;
+- lazy optional import, one provider/client reuse, provider timeout, HTML unescape,
+  and unavailable/timeout/upstream error normalization;
+- one route worker, no shared executor use, busy admission, cancellation/timeout
+  response, late settlement, and event-loop responsiveness;
+- dynamic root worker/sync/timeout/settings/translation patch seams;
+- request parsing, payload/status/error mapping, request correlation, route identity,
+  registration, and repeated bootstrap behavior;
+- package/no-host import with the provider disabled.
+
+No E-04 Move may add a provider close call without direct supported-client evidence.
+Cache policy, timeout values, error meaning, admission count, and cancellation
+semantics are Behavior and remain out of scope.
+
+## Bounded Move queue
+
+1. **E-04a Contract — complete:** current owners, callers, locks, cleanup gaps,
+   compatibility seams, optional import, and Move order are versioned.
+2. **E-04b Move — provider registry/client ownership — READY:** move factories,
+   instances, and registry locking behind one explicit translation provider registry
+   while preserving lazy client behavior and errors.
+3. **E-04c Move — default service/cache composition — pending:** compose one
+   process translation service with its cache and flights, then wire current node/API
+   callers through narrow seams.
+4. **E-04d Move — route executor/bootstrap lifecycle wiring — pending:** move worker
+   construction and lifecycle registration from root `api.py` into bootstrap-owned
+   composition while preserving every dynamic root seam.
+5. **E-04e Contract — completion audit — pending:** reconcile E-01 targets, prove
+   one owner per resource, optional-import safety, cleanup disposition, and zero
+   ambiguous translation state before E-05.
+
+Each Move is a separate rollback boundary. E-09 still owns whole-runtime
+initialize/shutdown ordering and partial-failure cleanup; E-04 supplies the
+translation-owned resources and idempotent cleanup shapes that E-09 will compose.
+
+## Stop conditions
+
+Stop the owning Move if it would require a generic executor/client port, a
+feature-to-runtime/API/bootstrap/root back-reference, an import-time optional
+dependency, loss of a supported identity/dynamic seam, changed cache/provider/error
+or admission behavior, or an unproven client cleanup call.
+
+The direct evidence and existing ADRs select one resource partition, so E-04a does
+not trigger additional PRO review.

--- a/docs/architecture/python-runtime-state-inventory.md
+++ b/docs/architecture/python-runtime-state-inventory.md
@@ -49,10 +49,10 @@ E-01 drift gate until classified.
 | prompt warning-dedupe entries | two canonical Prompt feature modules, process lifetime | unprotected sets; direct-test clear only | E-09 |
 | `prompt-knowledge-path` | canonical filesystem package path re-exported for ANIMA root compatibility | immutable after import | E-02d complete |
 | `root-route-registration` | injected router registrar called by bootstrap | serialized refresh; idempotent marker, no deregistration | E-09 |
-| `root-translation-route-worker` | root compatibility runtime owns lazy single-thread executor | internal `RLock`; idempotent `atexit` shutdown only | E-04 |
+| `root-translation-route-worker` | root compatibility runtime owns lazy single-thread executor | internal `RLock`; idempotent `atexit` shutdown only | E-04d |
 | `runtime-services` | identity-installed process runtime with Comfy and seed capabilities | bootstrap-serialized install; private-global test reset, no close | E-09 |
-| `translation-default-service` | canonical default cache/single-flight service | cache and flight `RLock`s; cache clear exists, no process reset | E-04 |
-| `translation-provider-registry` | canonical lazy provider-client registry | one `RLock`; test patch only, no provider close | E-04 |
+| `translation-default-service` | canonical default cache/single-flight service | cache and flight `RLock`s; cache clear exists, no process reset | E-04c |
+| `translation-provider-registry` | canonical lazy provider-client registry | one `RLock`; test patch only, no provider close | E-04b |
 | `wildcard-snapshot-cache` | root verified-snapshot LRU and build single-flight | one `Condition`; no owner reset/close | E-06 |
 
 The fixture contains exact symbols, tests, owner, lifetime, thread-safety, and
@@ -103,3 +103,19 @@ canonical store factory and profile directory coordinator as the only mutable-st
 owners. The E-03e cross-fixture audit reconciles both E-01 owner entries with those
 E-03 owners and records zero ambiguous repository/filesystem state owners. The next
 bounded unit is the separate E-04 translation provider/client/cache Contract.
+
+## E-04a translation ownership Contract
+
+The production-free
+[`python-runtime-e04-translation-contract.md`](python-runtime-e04-translation-contract.md)
+keeps three translation-owned resource boundaries distinct:
+
+- E-04b owns the provider factory/instance registry and lazy optional client;
+- E-04c owns the process default service, bounded cache, and per-key single-flight;
+- E-04d owns the API route executor construction and bootstrap lifecycle wiring.
+
+No generic executor/client port is introduced. Bootstrap remains the target concrete
+composition root, feature/domain code does not import the complete runtime, and the
+current optional client protocol does not prove a close operation. E-04a therefore
+records that cleanup gap instead of inventing a provider-client lifecycle call. The
+next bounded unit is E-04b only.

--- a/docs/development/README.md
+++ b/docs/development/README.md
@@ -26,6 +26,8 @@ Read only the sections needed by the active task.
      [`../architecture/python-runtime-e02-completion-audit.md`](../architecture/python-runtime-e02-completion-audit.md)
    - E-03 repository/filesystem Contract:
      [`../architecture/python-runtime-e03-repository-filesystem-contract.md`](../architecture/python-runtime-e03-repository-filesystem-contract.md)
+   - E-04 translation runtime ownership Contract:
+     [`../architecture/python-runtime-e04-translation-contract.md`](../architecture/python-runtime-e04-translation-contract.md)
 5. Read [`codex-blocker-escalation.md`](codex-blocker-escalation.md) only after a
    documented hard stop or unresolved cross-owner failure. Ordinary implementation
    and test failures remain local task work.
@@ -48,18 +50,19 @@ ordinary `dev` roadmap work.
 
 - Released baseline: 0.6.2.
 - Active owner: Issue #187 for Phase E; Issue #186 retains D-14/shim decisions.
-- Reviewed code baseline: E-03a / PR #532.
+- Reviewed code baseline: E-03e / PR #536.
 - D-08u integrated exit audit is complete.
 - D-08v is not required; the audit found no remaining D-08 production Move.
 - D-14 readiness is audited: every root surface is retained and retirement/final
   freeze is blocked by production/lifecycle consumers, missing release windows, or
   insufficient consumer evidence.
-- E-01, E-02, E-03a, and the E-03b filesystem factory Move are complete. The next
-  work is only #187 E-03c settings repository Move. The #323 E-02a/E-07 bridge
-  remains completed evidence, not authorization for unrelated feature migration.
+- E-01 through E-03 and the E-04a translation ownership Contract are complete. The
+  next work is only #187 E-04b provider registry/client ownership Move. The #323
+  E-02a/E-07 bridge remains completed evidence, not authorization for unrelated
+  feature migration.
 - Completed #470 and the 0.6.1 Prompt Studio lane are behavior-contract references,
   not the active queue.
-- Do not remove root aliases or start E-03d through E-10, release, or Registry work
+- Do not remove root aliases or start E-04c through E-10, release, or Registry work
   from this entrypoint.
 
 ## Completed D-08 composition audit surface
@@ -151,6 +154,7 @@ representative profile list/load/save/delete/rename/fix live smoke
 - A version marker is not a publish action.
 - Technical PRO review is for unresolved cross-boundary architecture choices,
   unavoidable cycles, or insufficient compatibility evidence—not routine failures.
-- D-14 readiness is recorded and authorizes no removal. Use the E-03a/E-03b Contract
-  evidence for the bounded E-03c settings repository Move; do not expand it into
-  profile repository Moves, release publication, or Registry actions.
+- D-14 readiness is recorded and authorizes no removal. Use the E-04a Contract
+  evidence for the bounded E-04b provider registry/client ownership Move; do not
+  expand it into service/cache or route-executor Moves, release publication, or
+  Registry actions.

--- a/tests/fixtures/python_runtime_state_ownership.v1.json
+++ b/tests/fixtures/python_runtime_state_ownership.v1.json
@@ -334,7 +334,7 @@
       "module": "api.py",
       "owner": "api._PROMPT_TRANSLATION_WORKER",
       "symbols": ["_PROMPT_TRANSLATION_WORKER"],
-      "target_phase": "E-04",
+      "target_phase": "E-04d",
       "test_evidence": ["tests/test_api_contract.py", "tests/test_prompt_translation_api.py"],
       "thread_safety": "One RLock protects executor creation, admission, Future identity, and close state."
     },
@@ -358,7 +358,7 @@
       "module": "easyuse_anima/translation/service.py",
       "owner": "easyuse_anima.translation.service._DEFAULT_TRANSLATION_SERVICE",
       "symbols": ["_DEFAULT_TRANSLATION_SERVICE"],
-      "target_phase": "E-04",
+      "target_phase": "E-04c",
       "test_evidence": ["tests/test_prompt_translation.py"],
       "thread_safety": "Separate RLocks protect bounded cache and per-key single-flight registry."
     },
@@ -370,7 +370,7 @@
       "module": "easyuse_anima/translation/service.py",
       "owner": "easyuse_anima.translation.service",
       "symbols": ["_TRANSLATION_PROVIDER_INSTANCES", "_TRANSLATION_PROVIDER_LOCK"],
-      "target_phase": "E-04",
+      "target_phase": "E-04b",
       "test_evidence": ["tests/test_prompt_translation.py"],
       "thread_safety": "One RLock protects provider lookup, construction, and publication."
     },

--- a/tests/fixtures/python_translation_runtime_contract.v1.json
+++ b/tests/fixtures/python_translation_runtime_contract.v1.json
@@ -1,0 +1,271 @@
+{
+  "classification": "Contract",
+  "compatibility_surfaces": [
+    {
+      "id": "root-translation-identity-shim",
+      "kind": "identity_reexport",
+      "module": "prompt_translation.py",
+      "symbols": [
+        "BoundedTranslationCache",
+        "GoogleTranslationProvider",
+        "PromptTranslationService",
+        "get_translation_provider",
+        "google_translate_text",
+        "translate_prompt_markers"
+      ]
+    },
+    {
+      "id": "root-api-dynamic-runtime-seams",
+      "kind": "dynamic_patch",
+      "module": "api.py",
+      "symbols": [
+        "PROMPT_TRANSLATION_ROUTE_TIMEOUT_SECONDS",
+        "_PROMPT_TRANSLATION_WORKER",
+        "_prompt_translation_error_response",
+        "_translate_prompt_for_route",
+        "_translate_prompt_sync",
+        "resolve_prompt_translation_settings",
+        "translate_prompt_markers"
+      ]
+    }
+  ],
+  "decisions": {
+    "adapter_access": "API and node adapters receive or resolve narrow translation-owned ports; feature/domain code does not import RuntimeServices, bootstrap, API adapters, or root shims.",
+    "bootstrap_composition": "Bootstrap is the only target production composition root for concrete translation resources and lifecycle registration.",
+    "generic_executor_client_port": "rejected",
+    "provider_client_cleanup": "unproven: the current optional client protocol exposes translate only, so no close call may be invented in E-04 Moves.",
+    "resource_partition": "Provider registry/client, service cache/per-key single-flight, and API route executor remain three distinct translation-owned resource boundaries.",
+    "runtime_fields": "Any RuntimeServices expansion is limited to narrow translation-owned ports selected by the owning Move; feature code never receives the complete runtime."
+  },
+  "move_queue": [
+    {
+      "classification": "Contract",
+      "goal": "Freeze current owners, lifecycle gaps, callers, compatibility seams, and bounded Move order.",
+      "id": "E-04a",
+      "name": "translation runtime ownership contract",
+      "status": "complete"
+    },
+    {
+      "classification": "Move",
+      "goal": "Move provider factories, lazy instances, registry lock, and client ownership behind one explicit translation provider registry while preserving optional import and errors.",
+      "id": "E-04b",
+      "name": "provider registry and client ownership",
+      "status": "ready"
+    },
+    {
+      "classification": "Move",
+      "goal": "Compose one process translation service with its bounded cache and per-key single-flight owner, then wire existing node/API callers through narrow seams.",
+      "id": "E-04c",
+      "name": "default service and cache composition",
+      "status": "pending"
+    },
+    {
+      "classification": "Move",
+      "goal": "Move route executor construction and lifecycle registration from the root API facade to bootstrap-owned runtime composition while preserving root dynamic seams.",
+      "id": "E-04d",
+      "name": "route executor bootstrap lifecycle wiring",
+      "status": "pending"
+    },
+    {
+      "classification": "Contract",
+      "goal": "Reconcile E-01 targets and prove one owner, optional-import safety, idempotent cleanup coverage, and no ambiguous translation state before E-05.",
+      "id": "E-04e",
+      "name": "translation ownership completion audit",
+      "status": "pending"
+    }
+  ],
+  "owners": [
+    {
+      "cleanup": {
+        "current": "idempotent shutdown registered once with atexit during root api import; package shutdown does not own it",
+        "implemented_methods": [
+          "shutdown"
+        ],
+        "remaining_gap": "bootstrap/runtime shutdown and partial-failure cleanup remain unowned until E-04d and E-09"
+      },
+      "components": [
+        {
+          "class": "PromptTranslationRouteExecutor",
+          "module": "easyuse_anima/api/routes/translation_execution.py",
+          "state_kind": "instance",
+          "state_symbols": [
+            "_closed",
+            "_executor",
+            "_in_flight",
+            "_lock"
+          ]
+        }
+      ],
+      "construction": {
+        "at": "root api module import",
+        "factory": "build_translation_runtime",
+        "factory_module": "easyuse_anima/api/routes/translation.py",
+        "invocation_module": "api.py"
+      },
+      "current_owner": "api._PROMPT_TRANSLATION_WORKER",
+      "e01_entry": "root-translation-route-worker",
+      "evidence": [
+        "tests/test_api_contract.py",
+        "tests/test_prompt_translation_api.py"
+      ],
+      "id": "route-executor",
+      "locking": "one RLock protects lazy executor creation, one in-flight Future identity, admission, release, and closed state",
+      "module": "api.py",
+      "state_symbols": [
+        "_PROMPT_TRANSLATION_WORKER"
+      ],
+      "target_phase": "E-04d"
+    },
+    {
+      "cleanup": {
+        "current": "BoundedTranslationCache.clear exists; flights self-remove when the last user settles; the default service has no close/reset",
+        "implemented_methods": [
+          "BoundedTranslationCache.clear"
+        ],
+        "remaining_gap": "explicit process owner and idempotent service cleanup are deferred to E-04c/E-09"
+      },
+      "components": [
+        {
+          "class": "BoundedTranslationCache",
+          "module": "easyuse_anima/translation/service.py",
+          "state_kind": "instance",
+          "state_symbols": [
+            "_entries",
+            "_lock",
+            "_time_func",
+            "max_entries",
+            "ttl_seconds"
+          ]
+        },
+        {
+          "class": "PromptTranslationService",
+          "module": "easyuse_anima/translation/service.py",
+          "state_kind": "instance",
+          "state_symbols": [
+            "_flights",
+            "_flights_lock",
+            "cache",
+            "max_marker_characters",
+            "max_markers",
+            "max_total_characters"
+          ]
+        }
+      ],
+      "construction": {
+        "at": "translation service module import",
+        "class": "PromptTranslationService",
+        "invocation_module": "easyuse_anima/translation/service.py"
+      },
+      "current_owner": "easyuse_anima.translation.service._DEFAULT_TRANSLATION_SERVICE",
+      "e01_entry": "translation-default-service",
+      "evidence": [
+        "tests/test_prompt_translation.py"
+      ],
+      "id": "default-service",
+      "locking": "cache entries use one RLock; a second RLock protects per-key flight registration while each key has its own Lock",
+      "module": "easyuse_anima/translation/service.py",
+      "state_symbols": [
+        "_DEFAULT_TRANSLATION_SERVICE"
+      ],
+      "target_phase": "E-04c"
+    },
+    {
+      "cleanup": {
+        "current": "production exposes no registry reset or provider/client close; tests patch instance and factory mappings",
+        "implemented_methods": [],
+        "remaining_gap": "registry ownership may clear references, but client close cannot be claimed until a supported client cleanup interface is proven"
+      },
+      "components": [
+        {
+          "module": "easyuse_anima/translation/service.py",
+          "state_kind": "top_level",
+          "state_symbols": [
+            "_TRANSLATION_PROVIDER_FACTORIES",
+            "_TRANSLATION_PROVIDER_INSTANCES",
+            "_TRANSLATION_PROVIDER_LOCK"
+          ]
+        },
+        {
+          "class": "GoogleTranslationProvider",
+          "module": "easyuse_anima/translation/providers/google.py",
+          "state_kind": "instance",
+          "state_symbols": [
+            "_lock",
+            "_timeout_seconds",
+            "_translator",
+            "_translator_factory"
+          ]
+        }
+      ],
+      "construction": {
+        "at": "provider first use",
+        "factory_map": "_TRANSLATION_PROVIDER_FACTORIES",
+        "invocation_module": "easyuse_anima/translation/service.py",
+        "optional_client_at": "GoogleTranslationProvider._create_translator"
+      },
+      "current_owner": "easyuse_anima.translation.service",
+      "e01_entry": "translation-provider-registry",
+      "evidence": [
+        "tests/test_prompt_translation.py"
+      ],
+      "id": "provider-registry-client",
+      "locking": "one registry RLock protects provider lookup, construction, and publication; each provider has a separate RLock protecting lazy client creation and calls",
+      "module": "easyuse_anima/translation/service.py",
+      "state_symbols": [
+        "_TRANSLATION_PROVIDER_INSTANCES",
+        "_TRANSLATION_PROVIDER_LOCK"
+      ],
+      "target_phase": "E-04b"
+    }
+  ],
+  "production_callers": [
+    {
+      "entry": "_translate_prompt_for_route",
+      "function": "build_translation_runtime",
+      "module": "easyuse_anima/api/routes/translation.py",
+      "owner": "route-executor",
+      "uses": [
+        "get_translate_prompt_sync",
+        "get_worker"
+      ]
+    },
+    {
+      "entry": "_translate_prompt_sync",
+      "function": "build_translation_runtime",
+      "module": "easyuse_anima/api/routes/translation.py",
+      "owner": "default-service",
+      "uses": [
+        "resolve_prompt_translation_settings",
+        "translate_prompt_markers"
+      ]
+    },
+    {
+      "entry": "_translate_prompt_text",
+      "module": "easyuse_anima/prompt/correction.py",
+      "owner": "default-service",
+      "uses": [
+        "resolve_prompt_translation_settings",
+        "translate_prompt_markers"
+      ]
+    },
+    {
+      "entry": "translate_prompt_markers",
+      "module": "easyuse_anima/translation/service.py",
+      "owner": "default-service",
+      "uses": [
+        "_DEFAULT_TRANSLATION_SERVICE"
+      ]
+    },
+    {
+      "entry": "google_translate_text",
+      "module": "easyuse_anima/translation/service.py",
+      "owner": "provider-registry-client",
+      "uses": [
+        "get_translation_provider"
+      ]
+    }
+  ],
+  "production_changes": 0,
+  "schema_version": 1,
+  "scope": "E-04a current translation provider, client, cache, single-flight, and route-executor ownership"
+}

--- a/tests/test_python_translation_runtime_contract.py
+++ b/tests/test_python_translation_runtime_contract.py
@@ -1,0 +1,408 @@
+from __future__ import annotations
+
+import ast
+import json
+import unittest
+from functools import lru_cache
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+FIXTURE_PATH = (
+    ROOT / "tests" / "fixtures" / "python_translation_runtime_contract.v1.json"
+)
+E01_FIXTURE_PATH = (
+    ROOT / "tests" / "fixtures" / "python_runtime_state_ownership.v1.json"
+)
+CONTRACT_DOC = (
+    ROOT
+    / "docs"
+    / "architecture"
+    / "python-runtime-e04-translation-contract.md"
+)
+
+
+@lru_cache(maxsize=None)
+def _tree(module: str) -> ast.Module:
+    path = ROOT / module
+    return ast.parse(
+        path.read_text(encoding="utf-8-sig"),
+        filename=str(path),
+    )
+
+
+def _top_level_bindings(module: str) -> set[str]:
+    names: set[str] = set()
+
+    def collect(statements: list[ast.stmt]) -> None:
+        for statement in statements:
+            if isinstance(
+                statement,
+                (ast.ClassDef, ast.FunctionDef, ast.AsyncFunctionDef),
+            ):
+                names.add(statement.name)
+            elif isinstance(statement, ast.Assign):
+                for target in statement.targets:
+                    names.update(_target_names(target))
+            elif isinstance(statement, ast.AnnAssign):
+                names.update(_target_names(statement.target))
+            elif isinstance(statement, (ast.Import, ast.ImportFrom)):
+                for alias in statement.names:
+                    names.add(alias.asname or alias.name.split(".", 1)[0])
+            elif isinstance(statement, ast.If):
+                collect(statement.body)
+                collect(statement.orelse)
+            elif isinstance(statement, ast.Try):
+                collect(statement.body)
+                for handler in statement.handlers:
+                    collect(handler.body)
+                collect(statement.orelse)
+                collect(statement.finalbody)
+
+    collect(_tree(module).body)
+    return names
+
+
+def _target_names(target: ast.expr) -> set[str]:
+    if isinstance(target, ast.Name):
+        return {target.id}
+    if isinstance(target, (ast.List, ast.Tuple)):
+        return {
+            name
+            for element in target.elts
+            for name in _target_names(element)
+        }
+    return set()
+
+
+def _top_level_function(
+    module: str,
+    function_name: str,
+) -> ast.FunctionDef | ast.AsyncFunctionDef:
+    for statement in _tree(module).body:
+        if isinstance(statement, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            if statement.name == function_name:
+                return statement
+    raise AssertionError(f"{module} has no top-level function {function_name}")
+
+
+def _top_level_class(module: str, class_name: str) -> ast.ClassDef:
+    for statement in _tree(module).body:
+        if isinstance(statement, ast.ClassDef) and statement.name == class_name:
+            return statement
+    raise AssertionError(f"{module} has no top-level class {class_name}")
+
+
+def _expression_name(expression: ast.expr) -> str:
+    if isinstance(expression, ast.Name):
+        return expression.id
+    if isinstance(expression, ast.Attribute):
+        return expression.attr
+    return ""
+
+
+def _function_references(module: str, function_name: str) -> set[str]:
+    function = _top_level_function(module, function_name)
+    return {
+        node.id
+        for node in ast.walk(function)
+        if isinstance(node, ast.Name)
+    }
+
+
+def _instance_assignments(module: str, class_name: str) -> set[str]:
+    class_node = _top_level_class(module, class_name)
+    assigned: set[str] = set()
+    for node in ast.walk(class_node):
+        target = None
+        if isinstance(node, ast.Assign):
+            for candidate in node.targets:
+                if (
+                    isinstance(candidate, ast.Attribute)
+                    and isinstance(candidate.value, ast.Name)
+                    and candidate.value.id == "self"
+                ):
+                    assigned.add(candidate.attr)
+        elif isinstance(node, ast.AnnAssign):
+            target = node.target
+        if (
+            isinstance(target, ast.Attribute)
+            and isinstance(target.value, ast.Name)
+            and target.value.id == "self"
+        ):
+            assigned.add(target.attr)
+    return assigned
+
+
+def _class_methods(module: str, class_name: str) -> set[str]:
+    return {
+        statement.name
+        for statement in _top_level_class(module, class_name).body
+        if isinstance(statement, (ast.FunctionDef, ast.AsyncFunctionDef))
+    }
+
+
+def _tuple_assignment_call(module: str, assigned_name: str) -> str:
+    for statement in _tree(module).body:
+        if not isinstance(statement, ast.Assign):
+            continue
+        if not any(assigned_name in _target_names(target) for target in statement.targets):
+            continue
+        if isinstance(statement.value, ast.Call):
+            return _expression_name(statement.value.func)
+    raise AssertionError(f"{module} has no call assignment for {assigned_name}")
+
+
+class PythonTranslationRuntimeContractTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.fixture = json.loads(FIXTURE_PATH.read_text(encoding="utf-8"))
+        cls.e01_fixture = json.loads(
+            E01_FIXTURE_PATH.read_text(encoding="utf-8")
+        )
+
+    def test_schema_queue_and_evidence_are_complete(self):
+        self.assertEqual(
+            set(self.fixture),
+            {
+                "classification",
+                "compatibility_surfaces",
+                "decisions",
+                "move_queue",
+                "owners",
+                "production_callers",
+                "production_changes",
+                "schema_version",
+                "scope",
+            },
+        )
+        self.assertEqual(self.fixture["schema_version"], 1)
+        self.assertEqual(self.fixture["classification"], "Contract")
+        self.assertEqual(self.fixture["production_changes"], 0)
+        self.assertEqual(
+            [move["id"] for move in self.fixture["move_queue"]],
+            ["E-04a", "E-04b", "E-04c", "E-04d", "E-04e"],
+        )
+        self.assertEqual(
+            [move["status"] for move in self.fixture["move_queue"]],
+            ["complete", "ready", "pending", "pending", "pending"],
+        )
+        self.assertEqual(
+            [move["classification"] for move in self.fixture["move_queue"]],
+            ["Contract", "Move", "Move", "Move", "Contract"],
+        )
+        for owner in self.fixture["owners"]:
+            with self.subTest(owner=owner["id"]):
+                self.assertTrue(owner["evidence"])
+                for evidence in owner["evidence"]:
+                    self.assertTrue((ROOT / evidence).is_file(), evidence)
+
+    def test_e01_translation_entries_reconcile_to_exact_future_moves(self):
+        e01_entries = {
+            entry["id"]: entry for entry in self.e01_fixture["entries"]
+        }
+        owners = self.fixture["owners"]
+        self.assertEqual(
+            [owner["id"] for owner in owners],
+            ["route-executor", "default-service", "provider-registry-client"],
+        )
+        self.assertEqual(
+            {owner["e01_entry"] for owner in owners},
+            {
+                "root-translation-route-worker",
+                "translation-default-service",
+                "translation-provider-registry",
+            },
+        )
+        for owner in owners:
+            with self.subTest(owner=owner["id"]):
+                e01 = e01_entries[owner["e01_entry"]]
+                self.assertEqual(e01["module"], owner["module"])
+                self.assertEqual(e01["owner"], owner["current_owner"])
+                self.assertEqual(e01["target_phase"], owner["target_phase"])
+                self.assertEqual(
+                    set(owner["state_symbols"]) - set(e01["symbols"]),
+                    set(),
+                )
+        declarative = {
+            (entry["module"], symbol)
+            for entry in self.e01_fixture["declarative_mutable_globals"]
+            for symbol in entry["symbols"]
+        }
+        self.assertIn(
+            (
+                "easyuse_anima/translation/service.py",
+                "_TRANSLATION_PROVIDER_FACTORIES",
+            ),
+            declarative,
+        )
+
+    def test_current_owner_components_bind_exact_shipped_state(self):
+        for owner in self.fixture["owners"]:
+            with self.subTest(owner=owner["id"]):
+                self.assertEqual(
+                    set(owner["state_symbols"])
+                    - _top_level_bindings(owner["module"]),
+                    set(),
+                )
+            for component in owner["components"]:
+                with self.subTest(
+                    owner=owner["id"],
+                    component=component.get("class", component["module"]),
+                ):
+                    if component["state_kind"] == "top_level":
+                        actual = _top_level_bindings(component["module"])
+                    else:
+                        actual = _instance_assignments(
+                            component["module"],
+                            component["class"],
+                        )
+                    self.assertEqual(
+                        set(component["state_symbols"]) - actual,
+                        set(),
+                    )
+
+        self.assertEqual(
+            _tuple_assignment_call("api.py", "_PROMPT_TRANSLATION_WORKER"),
+            "build_translation_runtime",
+        )
+        self.assertIn(
+            "shutdown",
+            _class_methods(
+                "easyuse_anima/api/routes/translation_execution.py",
+                "PromptTranslationRouteExecutor",
+            ),
+        )
+        self.assertIn(
+            "clear",
+            _class_methods(
+                "easyuse_anima/translation/service.py",
+                "BoundedTranslationCache",
+            ),
+        )
+        self.assertNotIn(
+            "close",
+            _class_methods(
+                "easyuse_anima/translation/service.py",
+                "PromptTranslationService",
+            ),
+        )
+        self.assertNotIn(
+            "close",
+            _class_methods(
+                "easyuse_anima/translation/providers/google.py",
+                "GoogleTranslationProvider",
+            ),
+        )
+
+    def test_production_callers_and_dynamic_compatibility_seams_are_current(self):
+        owner_ids = {owner["id"] for owner in self.fixture["owners"]}
+        for caller in self.fixture["production_callers"]:
+            with self.subTest(caller=caller["entry"]):
+                self.assertIn(caller["owner"], owner_ids)
+                references = _function_references(
+                    caller["module"],
+                    caller.get("function", caller["entry"]),
+                )
+                self.assertEqual(set(caller["uses"]) - references, set())
+
+        for surface in self.fixture["compatibility_surfaces"]:
+            with self.subTest(surface=surface["id"]):
+                self.assertEqual(
+                    set(surface["symbols"])
+                    - _top_level_bindings(surface["module"]),
+                    set(),
+                )
+
+        root_references = _function_references(
+            "easyuse_anima/api/routes/translation.py",
+            "build_translation_runtime",
+        )
+        self.assertTrue(
+            {
+                "get_worker",
+                "get_translate_prompt_sync",
+                "get_timeout_seconds",
+                "register_shutdown",
+            }
+            <= root_references
+        )
+
+    def test_optional_client_stays_lazy_and_no_generic_runtime_port_exists(self):
+        provider_tree = _tree(
+            "easyuse_anima/translation/providers/google.py"
+        )
+        top_level_googletrans_imports = [
+            statement
+            for statement in provider_tree.body
+            if isinstance(statement, (ast.Import, ast.ImportFrom))
+            and any(
+                alias.name.startswith("googletrans")
+                for alias in statement.names
+            )
+        ]
+        self.assertEqual(top_level_googletrans_imports, [])
+
+        create_translator = None
+        for statement in _top_level_class(
+            "easyuse_anima/translation/providers/google.py",
+            "GoogleTranslationProvider",
+        ).body:
+            if (
+                isinstance(statement, ast.FunctionDef)
+                and statement.name == "_create_translator"
+            ):
+                create_translator = statement
+                break
+        self.assertIsNotNone(create_translator)
+        local_imports = [
+            node
+            for node in ast.walk(create_translator)
+            if isinstance(node, ast.ImportFrom)
+            and node.module == "googletrans"
+        ]
+        self.assertEqual(len(local_imports), 1)
+
+        runtime = _top_level_class("easyuse_anima/runtime.py", "RuntimeServices")
+        runtime_fields = {
+            statement.target.id
+            for statement in runtime.body
+            if isinstance(statement, ast.AnnAssign)
+            and isinstance(statement.target, ast.Name)
+        }
+        self.assertEqual(
+            runtime_fields,
+            {"clock", "comfy", "config", "seed_reservations"},
+        )
+        self.assertEqual(
+            self.fixture["decisions"]["generic_executor_client_port"],
+            "rejected",
+        )
+        for module in (
+            "easyuse_anima/translation/service.py",
+            "easyuse_anima/translation/providers/google.py",
+        ):
+            imports = [
+                node.module
+                for node in ast.walk(_tree(module))
+                if isinstance(node, ast.ImportFrom)
+            ]
+            self.assertNotIn("runtime", imports)
+
+    def test_contract_document_is_linked_from_maintained_entries(self):
+        self.assertTrue(CONTRACT_DOC.is_file())
+        architecture_entry = (
+            ROOT / "docs" / "architecture" / "README.md"
+        ).read_text(encoding="utf-8")
+        development_entry = (
+            ROOT / "docs" / "development" / "README.md"
+        ).read_text(encoding="utf-8")
+        self.assertIn(CONTRACT_DOC.name, architecture_entry)
+        self.assertIn(
+            f"../architecture/{CONTRACT_DOC.name}",
+            development_entry,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 목적과 변경 경계

#187 E-04a production-free Contract입니다. translation provider registry/client, default service cache/per-key single-flight, API route executor의 현재 owner와 lifecycle gap을 고정하고 후속 Move 순서를 결정합니다.

- Base: `dev@d952f15f637732ce45a1ab7d9a0006bd1a3362bc`
- Head: `192c7a94621671763412f4565cc6627516aa7d87`
- Production/analyzer/existing feature tests: 변경 없음

## 주요 결정

- provider registry/client, service cache/single-flight, API route executor를 서로 다른 translation-owned resource로 유지
- generic executor/client port 기각
- bootstrap만 concrete resource와 lifecycle registration을 조합하는 target owner
- feature/domain은 complete RuntimeServices, bootstrap, API adapter, root shim을 import하지 않음
- 현재 optional client protocol은 `translate`만 증명하므로 client close 호출은 추정 구현하지 않고 gap으로 기록
- E-04b provider registry/client -> E-04c service/cache -> E-04d route executor/bootstrap -> E-04e audit 순서 고정

## 보존 계약

- root `prompt_translation.py` identity exports와 canonical `__all__`
- marker/off-mode/default/budget/cache key/TTL/LRU/per-key single-flight
- lazy optional import, provider/client one-instance reuse, timeout/error normalization
- single route admission, busy/cancel/timeout/late settlement, event-loop offload
- root dynamic worker/sync/timeout/settings/translation seams
- API payload/status/error/correlation, route/registration/repeated initialize
- package/no-host optional-provider safety

## 검증

Focused:
- E-04 Contract: 6 passed
- E-01 ownership Contract: 5 passed
- translation service: 13 passed
- translation API: 11 passed
- RuntimeServices: 13 passed
- bootstrap: 5 passed
- analyzer: 18 passed
- package skeleton: 1 passed
- completed import boundary: 6 passed
- changed Python compile/fatal Ruff, JSON parse, staged diff check: passed

Final candidate `192c7a94621671763412f4565cc6627516aa7d87`:
- official full exactly once: Python 1,346 passed; frontend 120 passed
- Pyright baseline ratchet, import-boundary gate, project diff check: passed
- Ruff repository findings: existing G-01 report-only baseline

Package/live:
- not retriggered; production/shipped/import/route/runtime behavior closure 0이며 preceding valid evidence 재사용

## 위험과 rollback

현재 provider client cleanup interface가 증명되지 않은 점을 명시적 gap으로 남겼습니다. 후속 Move는 unproven close를 추가하면 중단합니다. 이 Contract는 독립 squash revert 가능합니다.

## Next

별도 E-04b provider registry/client ownership Move만 시작합니다. 이 PR은 E-04b 구현, E-04c+, E-09 lifecycle, D-14 retirement, release, Registry 작업을 포함하지 않습니다.