### PR TITLE
E-04b: translation provider registry 소유권 이동

### DIFF
--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -10,14 +10,14 @@ then only the active task section, owning Issue, direct source, and direct tests
 ## Active sequencing
 
 - Issue [#187](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/187)
-  owns Phase E. E-01 through E-03 and the E-04a translation ownership Contract are
-  complete; E-04b provider registry/client ownership is the next bounded unit.
+  owns Phase E. E-01 through E-03, E-04a, and E-04b are complete; E-04c default
+  service/cache composition is the next bounded unit.
   Issue #186 retains D-14/shim decisions.
 - [`backend-roadmap-resume-0.6.2.md`](backend-roadmap-resume-0.6.2.md)
   is the current execution source of truth. Read it before the older accumulated
   roadmap.
-- Reviewed code baseline: E-03e / PR #536 at
-  `d952f15f637732ce45a1ab7d9a0006bd1a3362bc`.
+- Reviewed code baseline before E-04b: E-04a / PR #537 at
+  `77c7db822b2be2649f89eef249add95a9b110ef3`.
 - D-08 is complete and D-08v is not required.
 - D-14 readiness retains every root surface; retirement/final-freeze work is blocked.
 - E-01 inventory Contract:
@@ -34,14 +34,14 @@ then only the active task section, owning Issue, direct source, and direct tests
   [`python-runtime-e03-repository-filesystem-contract.md`](python-runtime-e03-repository-filesystem-contract.md).
 - E-04a translation runtime ownership Contract:
   [`python-runtime-e04-translation-contract.md`](python-runtime-e04-translation-contract.md).
-- First READY task after E-04a: #187 E-04b provider registry/client ownership Move
+- First READY task after E-04b: #187 E-04c default service/cache composition Move
   only.
 - Completed #470 and the #413/#414/#415 queue/live-UI lanes remain contract references,
   not active blockers.
 - Released code baseline: 0.6.2. Registry activation is external administration and
   does not block `dev`; do not republish or mutate the release.
 - Completed #409/#410/#411 and deferred #440/#441 do not alter the E-01 boundary.
-- E-04a completion authorizes only E-04b. It does not authorize later Phase E Moves,
+- E-04b completion authorizes only E-04c. It does not authorize later Phase E Moves,
   root removal, release, or Registry work.
 
 ## Current code boundary
@@ -68,7 +68,7 @@ aliases or absorbing feature behavior.
 
 - [`backend-roadmap-resume-0.6.2.md`](backend-roadmap-resume-0.6.2.md):
   completed D-08 evidence, D-14 readiness verdict, completed Phase E units, and the
-  bounded E-04b handoff.
+  bounded E-04c handoff.
 - [`python-backend.md`](python-backend.md): target ownership and dependency direction.
   Its early implementation snapshot is historical where the active checkpoint differs.
 - [`python-backend-execution-roadmap.md`](python-backend-execution-roadmap.md):

--- a/docs/architecture/backend-roadmap-resume-0.6.2.md
+++ b/docs/architecture/backend-roadmap-resume-0.6.2.md
@@ -2,16 +2,16 @@
 
 ## Status and authority
 
-- Status: D-08, E-01, E-02, E-03, and the E-04a translation ownership Contract are
+- Status: D-08, E-01, E-02, E-03, E-04a, and E-04b are
   completed; the D-14 readiness audit retains every root surface and blocks
   retirement/final-freeze work.
-- Code-review base: `dev@d952f15f637732ce45a1ab7d9a0006bd1a3362bc`
-  after E-03e / PR #536.
-- Document baseline: E-04a translation runtime ownership Contract.
+- Code-review base before E-04b:
+  `dev@77c7db822b2be2649f89eef249add95a9b110ef3` after E-04a / PR #537.
+- Document baseline: completed E-04b provider registry/client ownership Move.
 - Released baseline: 0.6.2.
 - Scope: completed D-08 evidence, the D-14 readiness decision, completed #187
-  E-01/E-02/E-03/E-04a work, and the next bounded E-04b provider registry/client
-  ownership Move.
+  E-01/E-02/E-03/E-04 work, and the next bounded E-04c default service/cache
+  composition Move.
 - This document owns the current immediate queue and supersedes the stale queue and
   broad preflight command in `python-backend-execution-roadmap.md`.
 - `python-backend.md`, ADR-001, ADR-002, and the compatibility-shim registry still own
@@ -281,9 +281,12 @@ The D-08u audit found no required D-08v. After D-08:
 15. E-04a keeps provider registry/client, service cache/per-key single-flight, and
     API route executor as three distinct translation-owned resources, rejects a
     generic executor/client port, and records the unproven client-close gap; and
-16. never remove root files merely to make the directory tree appear complete.
+16. E-04b moves provider factories, lazy instances, and registry locking behind one
+    private registry while retaining a call-time default seam and unchanged lazy
+    optional client behavior; and
+17. never remove root files merely to make the directory tree appear complete.
 
-## 6. E-01/E-02/E-03/E-04a result and Codex resume instruction
+## 6. E-01/E-02/E-03/E-04b result and Codex resume instruction
 
 ```text
 D-08 is complete. Do not restart D-08t or create D-08v without new contrary
@@ -335,9 +338,13 @@ service cache/per-key single-flight, and API route executor remain three distinc
 translation-owned resources. Bootstrap is the target concrete composition root;
 generic executor/client ports and unproven provider-client close calls are rejected.
 
-Start only #187 E-04b from latest origin/dev. Move provider factories, lazy instances,
-registry locking, and client ownership behind one explicit translation provider
-registry while preserving optional import, reuse, timeout, errors, and public/root
-identities. Do not start E-04c through E-10, D-14 retirement, release, or Registry
-work inside E-04b.
+E-04b moves provider factories, lazy instances, and registry locking behind one
+private translation provider registry. The canonical public facade resolves the
+current default registry on every call. Optional import, provider/client reuse,
+timeouts, errors, and public/root identities are unchanged.
+
+Start only #187 E-04c from latest origin/dev. Compose the process default translation
+service with its bounded cache and per-key single-flight owner through the narrow
+contract fixed by E-04a. Do not start E-04d through E-10, D-14 retirement, release,
+or Registry work inside E-04c.
 ```

--- a/docs/architecture/python-runtime-e04-translation-contract.md
+++ b/docs/architecture/python-runtime-e04-translation-contract.md
@@ -2,10 +2,10 @@
 
 ## Scope and authority
 
-E-04a is a production-free Contract at
-`dev@d952f15f637732ce45a1ab7d9a0006bd1a3362bc`. It inventories the current
-translation provider registry/client, default service cache/per-key single-flight,
-and API route executor before any E-04 Move.
+E-04a is a production-free Contract created at
+`dev@d952f15f637732ce45a1ab7d9a0006bd1a3362bc`. E-04b completes the first
+bounded Move from the E-04a queue: provider registry ownership is explicit while
+the default service/cache and API route executor remain unchanged.
 
 The executable source is
 `tests/fixtures/python_translation_runtime_contract.v1.json`, checked by
@@ -16,14 +16,18 @@ and API tests remain the behavior authorities.
 
 ### Provider registry and optional client
 
-`easyuse_anima.translation.service` owns the provider factory mapping, lazy instance
-mapping, and registry `RLock`. The first Google request constructs one
-`GoogleTranslationProvider`; that provider has a separate `RLock` and lazily imports
-and constructs the optional `googletrans` client on first use.
+`easyuse_anima.translation.service._DEFAULT_TRANSLATION_PROVIDER_REGISTRY` is the
+process owner. Its private `_TranslationProviderRegistry` owns a copied provider
+factory mapping, lazy instance mapping, and registry `RLock`. The public service
+facade resolves the current default registry on every call. The first Google request
+constructs one `GoogleTranslationProvider`; that provider has a separate `RLock` and
+lazily imports and constructs the optional `googletrans` client on first use.
 
-The provider registry owns lookup, construction, publication, and reuse. It does not
-own cache policy or API admission. The current client protocol exposes only
-`translate`, so a client `close` contract is not proven. E-04 must not invent one.
+The provider registry owns lookup, construction, publication, and reuse. Tests create
+isolated registries instead of mutating module-level factory and instance maps. The
+registry does not own cache policy or API admission. The current client protocol
+exposes only `translate`, so a client `close` contract is not proven. E-04 must not
+invent one.
 
 ### Default service, cache, and per-key single-flight
 
@@ -97,10 +101,10 @@ semantics are Behavior and remain out of scope.
 
 1. **E-04a Contract — complete:** current owners, callers, locks, cleanup gaps,
    compatibility seams, optional import, and Move order are versioned.
-2. **E-04b Move — provider registry/client ownership — READY:** move factories,
-   instances, and registry locking behind one explicit translation provider registry
-   while preserving lazy client behavior and errors.
-3. **E-04c Move — default service/cache composition — pending:** compose one
+2. **E-04b Move — provider registry/client ownership — complete:** factories,
+   instances, and registry locking are owned by one private provider registry; the
+   call-time default facade, lazy client behavior, and errors are preserved.
+3. **E-04c Move — default service/cache composition — READY:** compose one
    process translation service with its cache and flights, then wire current node/API
    callers through narrow seams.
 4. **E-04d Move — route executor/bootstrap lifecycle wiring — pending:** move worker

--- a/docs/architecture/python-runtime-state-inventory.md
+++ b/docs/architecture/python-runtime-state-inventory.md
@@ -52,7 +52,7 @@ E-01 drift gate until classified.
 | `root-translation-route-worker` | root compatibility runtime owns lazy single-thread executor | internal `RLock`; idempotent `atexit` shutdown only | E-04d |
 | `runtime-services` | identity-installed process runtime with Comfy and seed capabilities | bootstrap-serialized install; private-global test reset, no close | E-09 |
 | `translation-default-service` | canonical default cache/single-flight service | cache and flight `RLock`s; cache clear exists, no process reset | E-04c |
-| `translation-provider-registry` | canonical lazy provider-client registry | one `RLock`; test patch only, no provider close | E-04b |
+| `translation-provider-registry` | private process-owned lazy provider-client registry | one owned `RLock`; no provider close/reset | E-04b complete |
 | `wildcard-snapshot-cache` | root verified-snapshot LRU and build single-flight | one `Condition`; no owner reset/close | E-06 |
 
 The fixture contains exact symbols, tests, owner, lifetime, thread-safety, and
@@ -104,7 +104,7 @@ owners. The E-03e cross-fixture audit reconciles both E-01 owner entries with th
 E-03 owners and records zero ambiguous repository/filesystem state owners. The next
 bounded unit is the separate E-04 translation provider/client/cache Contract.
 
-## E-04a translation ownership Contract
+## E-04a Contract and E-04b result
 
 The production-free
 [`python-runtime-e04-translation-contract.md`](python-runtime-e04-translation-contract.md)
@@ -117,5 +117,10 @@ keeps three translation-owned resource boundaries distinct:
 No generic executor/client port is introduced. Bootstrap remains the target concrete
 composition root, feature/domain code does not import the complete runtime, and the
 current optional client protocol does not prove a close operation. E-04a therefore
-records that cleanup gap instead of inventing a provider-client lifecycle call. The
-next bounded unit is E-04b only.
+records that cleanup gap instead of inventing a provider-client lifecycle call.
+
+E-04b replaces the service module's separate factory map, instance map, and lock with
+one private `_TranslationProviderRegistry`. The process default remains in the
+canonical service module, and `get_translation_provider()` resolves that default at
+call time. Provider/client laziness, reuse, optional imports, timeout and error
+normalization remain unchanged. The next bounded unit is E-04c only.

--- a/easyuse_anima/translation/provider_registry.py
+++ b/easyuse_anima/translation/provider_registry.py
@@ -1,0 +1,43 @@
+"""Private prompt translation provider registry ownership."""
+
+from __future__ import annotations
+
+import threading
+from collections.abc import Callable, Mapping
+
+from .contracts import (
+    PromptTranslationError,
+    TranslationProvider,
+    TranslationProviderUnavailableError,
+)
+
+
+class _TranslationProviderRegistry:
+    def __init__(
+        self,
+        factories: Mapping[str, Callable[[], TranslationProvider]],
+    ):
+        self._factories = dict(factories)
+        self._instances: dict[str, TranslationProvider] = {}
+        self._lock = threading.RLock()
+
+    def get(self, provider: str) -> TranslationProvider:
+        name = str(provider or "").strip().lower()
+        with self._lock:
+            instance = self._instances.get(name)
+            if instance is not None:
+                return instance
+            factory = self._factories.get(name)
+            if factory is None:
+                raise TranslationProviderUnavailableError()
+            try:
+                instance = factory()
+            except PromptTranslationError:
+                raise
+            except Exception as exc:
+                raise TranslationProviderUnavailableError() from exc
+            self._instances[name] = instance
+            return instance
+
+
+__all__ = ()

--- a/easyuse_anima/translation/service.py
+++ b/easyuse_anima/translation/service.py
@@ -19,47 +19,28 @@ from .contracts import (
     PROMPT_TRANSLATION_CACHE_TTL_SECONDS,
     PROMPT_TRANSLATION_PROVIDER_GOOGLE,
     PROMPT_TRANSLATION_PROVIDER_OFF,
-    PromptTranslationError,
     PromptTranslationSettings,
     TranslationCacheKey,
     TranslationMarkerCountError,
     TranslationMarkerSizeError,
     TranslationProvider,
-    TranslationProviderUnavailableError,
     TranslationTotalSizeError,
     normalize_prompt_translation_language,
     normalize_prompt_translation_provider,
 )
 from .markers import iter_prompt_translation_markers
+from .provider_registry import _TranslationProviderRegistry
 from .providers.google import GoogleTranslationProvider
 
-_TRANSLATION_PROVIDER_FACTORIES: dict[
-    str,
-    Callable[[], TranslationProvider],
-] = {
-    PROMPT_TRANSLATION_PROVIDER_GOOGLE: GoogleTranslationProvider,
-}
-_TRANSLATION_PROVIDER_INSTANCES: dict[str, TranslationProvider] = {}
-_TRANSLATION_PROVIDER_LOCK = threading.RLock()
+_DEFAULT_TRANSLATION_PROVIDER_REGISTRY = _TranslationProviderRegistry(
+    {
+        PROMPT_TRANSLATION_PROVIDER_GOOGLE: GoogleTranslationProvider,
+    }
+)
 
 
 def get_translation_provider(provider: str) -> TranslationProvider:
-    name = str(provider or "").strip().lower()
-    with _TRANSLATION_PROVIDER_LOCK:
-        instance = _TRANSLATION_PROVIDER_INSTANCES.get(name)
-        if instance is not None:
-            return instance
-        factory = _TRANSLATION_PROVIDER_FACTORIES.get(name)
-        if factory is None:
-            raise TranslationProviderUnavailableError()
-        try:
-            instance = factory()
-        except PromptTranslationError:
-            raise
-        except Exception as exc:
-            raise TranslationProviderUnavailableError() from exc
-        _TRANSLATION_PROVIDER_INSTANCES[name] = instance
-        return instance
+    return _DEFAULT_TRANSLATION_PROVIDER_REGISTRY.get(provider)
 
 
 def google_translate_text(

--- a/tests/fixtures/python_backend_baseline.json
+++ b/tests/fixtures/python_backend_baseline.json
@@ -31823,6 +31823,128 @@
         "requested": "__future__",
         "role": "ordinary",
         "scope": "<module>",
+        "source": "easyuse_anima/translation/provider_registry.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "threading",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "threading",
+        "kind": "static_import",
+        "line": 5,
+        "name": null,
+        "optional": false,
+        "requested": "threading",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/translation/provider_registry.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "Callable",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "collections.abc:Callable",
+        "kind": "static_from",
+        "line": 6,
+        "name": "Callable",
+        "optional": false,
+        "requested": "collections.abc",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/translation/provider_registry.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "Mapping",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "collections.abc:Mapping",
+        "kind": "static_from",
+        "line": 6,
+        "name": "Mapping",
+        "optional": false,
+        "requested": "collections.abc",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/translation/provider_registry.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "PromptTranslationError",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".contracts:PromptTranslationError",
+        "kind": "static_from",
+        "line": 8,
+        "name": "PromptTranslationError",
+        "optional": false,
+        "requested": ".contracts",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/translation/provider_registry.py",
+        "target": "easyuse_anima/translation/contracts.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "TranslationProvider",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".contracts:TranslationProvider",
+        "kind": "static_from",
+        "line": 8,
+        "name": "TranslationProvider",
+        "optional": false,
+        "requested": ".contracts",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/translation/provider_registry.py",
+        "target": "easyuse_anima/translation/contracts.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "TranslationProviderUnavailableError",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".contracts:TranslationProviderUnavailableError",
+        "kind": "static_from",
+        "line": 8,
+        "name": "TranslationProviderUnavailableError",
+        "optional": false,
+        "requested": ".contracts",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/translation/provider_registry.py",
+        "target": "easyuse_anima/translation/contracts.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "annotations",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "__future__:annotations",
+        "kind": "static_from",
+        "line": 3,
+        "name": "annotations",
+        "optional": false,
+        "requested": "__future__",
+        "role": "ordinary",
+        "scope": "<module>",
         "source": "easyuse_anima/translation/providers/google.py"
       },
       {
@@ -32327,24 +32449,6 @@
       },
       {
         "alias": null,
-        "bound_name": "PromptTranslationError",
-        "branch_context": [],
-        "classification": "internal",
-        "column": 0,
-        "conditional": false,
-        "imported": ".contracts:PromptTranslationError",
-        "kind": "static_from",
-        "line": 12,
-        "name": "PromptTranslationError",
-        "optional": false,
-        "requested": ".contracts",
-        "role": "ordinary",
-        "scope": "<module>",
-        "source": "easyuse_anima/translation/service.py",
-        "target": "easyuse_anima/translation/contracts.py"
-      },
-      {
-        "alias": null,
         "bound_name": "PromptTranslationSettings",
         "branch_context": [],
         "classification": "internal",
@@ -32435,24 +32539,6 @@
       },
       {
         "alias": null,
-        "bound_name": "TranslationProviderUnavailableError",
-        "branch_context": [],
-        "classification": "internal",
-        "column": 0,
-        "conditional": false,
-        "imported": ".contracts:TranslationProviderUnavailableError",
-        "kind": "static_from",
-        "line": 12,
-        "name": "TranslationProviderUnavailableError",
-        "optional": false,
-        "requested": ".contracts",
-        "role": "ordinary",
-        "scope": "<module>",
-        "source": "easyuse_anima/translation/service.py",
-        "target": "easyuse_anima/translation/contracts.py"
-      },
-      {
-        "alias": null,
         "bound_name": "TranslationTotalSizeError",
         "branch_context": [],
         "classification": "internal",
@@ -32514,7 +32600,7 @@
         "conditional": false,
         "imported": ".markers:iter_prompt_translation_markers",
         "kind": "static_from",
-        "line": 33,
+        "line": 31,
         "name": "iter_prompt_translation_markers",
         "optional": false,
         "requested": ".markers",
@@ -32525,6 +32611,24 @@
       },
       {
         "alias": null,
+        "bound_name": "_TranslationProviderRegistry",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".provider_registry:_TranslationProviderRegistry",
+        "kind": "static_from",
+        "line": 32,
+        "name": "_TranslationProviderRegistry",
+        "optional": false,
+        "requested": ".provider_registry",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/translation/service.py",
+        "target": "easyuse_anima/translation/provider_registry.py"
+      },
+      {
+        "alias": null,
         "bound_name": "GoogleTranslationProvider",
         "branch_context": [],
         "classification": "internal",
@@ -32532,7 +32636,7 @@
         "conditional": false,
         "imported": ".providers.google:GoogleTranslationProvider",
         "kind": "static_from",
-        "line": 34,
+        "line": 33,
         "name": "GoogleTranslationProvider",
         "optional": false,
         "requested": ".providers.google",
@@ -65587,6 +65691,10 @@
         "to": "easyuse_anima/translation/contracts.py"
       },
       {
+        "from": "easyuse_anima/translation/provider_registry.py",
+        "to": "easyuse_anima/translation/contracts.py"
+      },
+      {
         "from": "easyuse_anima/translation/providers/google.py",
         "to": "easyuse_anima/translation/contracts.py"
       },
@@ -65597,6 +65705,10 @@
       {
         "from": "easyuse_anima/translation/service.py",
         "to": "easyuse_anima/translation/markers.py"
+      },
+      {
+        "from": "easyuse_anima/translation/service.py",
+        "to": "easyuse_anima/translation/provider_registry.py"
       },
       {
         "from": "easyuse_anima/translation/service.py",
@@ -66854,6 +66966,12 @@
       {
         "cyclic": false,
         "modules": [
+          "easyuse_anima/translation/provider_registry.py"
+        ]
+      },
+      {
+        "cyclic": false,
+        "modules": [
           "easyuse_anima/translation/providers/__init__.py"
         ]
       },
@@ -66962,7 +67080,7 @@
     ]
   },
   "inventory": {
-    "module_count": 166,
+    "module_count": 167,
     "modules": [
       {
         "is_package": true,
@@ -68741,6 +68859,18 @@
         }
       },
       {
+        "is_package": false,
+        "loc": 43,
+        "module": "easyuse_anima.translation.provider_registry",
+        "normalized_git_blob_sha1": "5e5f379283fb2ccb75c7bd3699169ee65667459c",
+        "path": "easyuse_anima/translation/provider_registry.py",
+        "top_level": {
+          "class_count": 1,
+          "function_count": 0,
+          "global_count": 1
+        }
+      },
+      {
         "is_package": true,
         "loc": 3,
         "module": "easyuse_anima.translation.providers",
@@ -68766,14 +68896,14 @@
       },
       {
         "is_package": false,
-        "loc": 349,
+        "loc": 330,
         "module": "easyuse_anima.translation.service",
-        "normalized_git_blob_sha1": "d8cf6fb4450540acb156ae516995e50b571e40fc",
+        "normalized_git_blob_sha1": "b3d93820b03ec4210ef69815bfc008d91417d6d7",
         "path": "easyuse_anima/translation/service.py",
         "top_level": {
           "class_count": 3,
           "function_count": 5,
-          "global_count": 6
+          "global_count": 4
         }
       },
       {
@@ -87701,6 +87831,50 @@
         "line": 3,
         "optional": false,
         "role": "ordinary",
+        "source": "easyuse_anima/translation/provider_registry.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "threading",
+        "kind": "static_import",
+        "line": 5,
+        "optional": false,
+        "role": "ordinary",
+        "source": "easyuse_anima/translation/provider_registry.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "collections.abc:Callable",
+        "kind": "static_from",
+        "line": 6,
+        "optional": false,
+        "role": "ordinary",
+        "source": "easyuse_anima/translation/provider_registry.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "collections.abc:Mapping",
+        "kind": "static_from",
+        "line": 6,
+        "optional": false,
+        "role": "ordinary",
+        "source": "easyuse_anima/translation/provider_registry.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "__future__:annotations",
+        "kind": "static_from",
+        "line": 3,
+        "optional": false,
+        "role": "ordinary",
         "source": "easyuse_anima/translation/providers/google.py"
       },
       {
@@ -89495,6 +89669,7 @@
       "easyuse_anima/translation/__init__.py",
       "easyuse_anima/translation/contracts.py",
       "easyuse_anima/translation/markers.py",
+      "easyuse_anima/translation/provider_registry.py",
       "easyuse_anima/translation/providers/__init__.py",
       "easyuse_anima/translation/providers/google.py",
       "easyuse_anima/translation/service.py",
@@ -89663,6 +89838,7 @@
       "easyuse_anima/translation/__init__.py",
       "easyuse_anima/translation/contracts.py",
       "easyuse_anima/translation/markers.py",
+      "easyuse_anima/translation/provider_registry.py",
       "easyuse_anima/translation/providers/__init__.py",
       "easyuse_anima/translation/providers/google.py",
       "easyuse_anima/translation/service.py",
@@ -91506,11 +91682,11 @@
         "scope": "<module>"
       },
       {
-        "callee": "threading.RLock",
-        "column": 29,
-        "context": "assign:_TRANSLATION_PROVIDER_LOCK",
+        "callee": "_TranslationProviderRegistry",
+        "column": 41,
+        "context": "assign:_DEFAULT_TRANSLATION_PROVIDER_REGISTRY",
         "kind": "import_time_call",
-        "line": 43,
+        "line": 35,
         "module": "easyuse_anima/translation/service.py",
         "scope": "<module>"
       },
@@ -91519,7 +91695,7 @@
         "column": 14,
         "context": "assign:_CACHE_MISS",
         "kind": "import_time_call",
-        "line": 107,
+        "line": 88,
         "module": "easyuse_anima/translation/service.py",
         "scope": "<module>"
       },
@@ -91528,7 +91704,7 @@
         "column": 31,
         "context": "assign:_DEFAULT_TRANSLATION_SERVICE",
         "kind": "import_time_call",
-        "line": 321,
+        "line": 302,
         "module": "easyuse_anima/translation/service.py",
         "scope": "<module>"
       },
@@ -92150,18 +92326,6 @@
       },
       {
         "kind": "dict",
-        "line": 36,
-        "module": "easyuse_anima/translation/service.py",
-        "name": "_TRANSLATION_PROVIDER_FACTORIES"
-      },
-      {
-        "kind": "dict",
-        "line": 42,
-        "module": "easyuse_anima/translation/service.py",
-        "name": "_TRANSLATION_PROVIDER_INSTANCES"
-      },
-      {
-        "kind": "dict",
         "line": 22,
         "module": "easyuse_anima/wildcard/mode.py",
         "name": "WILDCARD_MODE_ALIASES"
@@ -92316,25 +92480,6 @@
         "line": 18,
         "module": "easyuse_anima/infrastructure/filesystem/atomic_json.py",
         "name": "_PATH_LOCKS_GUARD"
-      },
-      {
-        "categories": [
-          "client",
-          "mutable_container"
-        ],
-        "initializer": "Dict",
-        "line": 42,
-        "module": "easyuse_anima/translation/service.py",
-        "name": "_TRANSLATION_PROVIDER_INSTANCES"
-      },
-      {
-        "categories": [
-          "lock"
-        ],
-        "initializer": "threading.RLock",
-        "line": 43,
-        "module": "easyuse_anima/translation/service.py",
-        "name": "_TRANSLATION_PROVIDER_LOCK"
       },
       {
         "categories": [

--- a/tests/fixtures/python_runtime_state_ownership.v1.json
+++ b/tests/fixtures/python_runtime_state_ownership.v1.json
@@ -135,11 +135,6 @@
       "symbols": ["PROMPT_TRANSLATION_PROVIDERS"]
     },
     {
-      "module": "easyuse_anima/translation/service.py",
-      "reason": "Static provider factory registry; provider instances are runtime state.",
-      "symbols": ["_TRANSLATION_PROVIDER_FACTORIES"]
-    },
-    {
       "module": "easyuse_anima/wildcard/mode.py",
       "reason": "Published immutable wildcard-mode alias lookup.",
       "symbols": ["WILDCARD_MODE_ALIASES"]
@@ -364,15 +359,15 @@
     },
     {
       "categories": ["client", "lock", "provider_registry"],
-      "cleanup": "Tests patch instances; production exposes no provider close/reset.",
+      "cleanup": "The registry owns provider references; production exposes no provider/client close or registry reset.",
       "id": "translation-provider-registry",
-      "lifetime": "Provider clients are lazy and cached for the process.",
+      "lifetime": "The default registry is process-owned; provider clients remain lazy and cached for the process.",
       "module": "easyuse_anima/translation/service.py",
-      "owner": "easyuse_anima.translation.service",
-      "symbols": ["_TRANSLATION_PROVIDER_INSTANCES", "_TRANSLATION_PROVIDER_LOCK"],
-      "target_phase": "E-04b",
+      "owner": "easyuse_anima.translation.service._DEFAULT_TRANSLATION_PROVIDER_REGISTRY",
+      "symbols": ["_DEFAULT_TRANSLATION_PROVIDER_REGISTRY"],
+      "target_phase": "E-04b-complete",
       "test_evidence": ["tests/test_prompt_translation.py"],
-      "thread_safety": "One RLock protects provider lookup, construction, and publication."
+      "thread_safety": "The private registry instance owns one RLock protecting provider lookup, construction, and publication."
     },
     {
       "categories": ["cache", "condition", "single_flight"],

--- a/tests/fixtures/python_translation_runtime_contract.v1.json
+++ b/tests/fixtures/python_translation_runtime_contract.v1.json
@@ -50,14 +50,14 @@
       "goal": "Move provider factories, lazy instances, registry lock, and client ownership behind one explicit translation provider registry while preserving optional import and errors.",
       "id": "E-04b",
       "name": "provider registry and client ownership",
-      "status": "ready"
+      "status": "complete"
     },
     {
       "classification": "Move",
       "goal": "Compose one process translation service with its bounded cache and per-key single-flight owner, then wire existing node/API callers through narrow seams.",
       "id": "E-04c",
       "name": "default service and cache composition",
-      "status": "pending"
+      "status": "ready"
     },
     {
       "classification": "Move",
@@ -171,18 +171,19 @@
     },
     {
       "cleanup": {
-        "current": "production exposes no registry reset or provider/client close; tests patch instance and factory mappings",
+        "current": "the registry owns provider references; production exposes no registry reset or provider/client close; tests construct isolated registries or patch the default registry facade",
         "implemented_methods": [],
-        "remaining_gap": "registry ownership may clear references, but client close cannot be claimed until a supported client cleanup interface is proven"
+        "remaining_gap": "client close cannot be claimed until a supported client cleanup interface is proven"
       },
       "components": [
         {
-          "module": "easyuse_anima/translation/service.py",
-          "state_kind": "top_level",
+          "class": "_TranslationProviderRegistry",
+          "module": "easyuse_anima/translation/provider_registry.py",
+          "state_kind": "instance",
           "state_symbols": [
-            "_TRANSLATION_PROVIDER_FACTORIES",
-            "_TRANSLATION_PROVIDER_INSTANCES",
-            "_TRANSLATION_PROVIDER_LOCK"
+            "_factories",
+            "_instances",
+            "_lock"
           ]
         },
         {
@@ -199,11 +200,11 @@
       ],
       "construction": {
         "at": "provider first use",
-        "factory_map": "_TRANSLATION_PROVIDER_FACTORIES",
+        "factory_map": "_TranslationProviderRegistry._factories",
         "invocation_module": "easyuse_anima/translation/service.py",
         "optional_client_at": "GoogleTranslationProvider._create_translator"
       },
-      "current_owner": "easyuse_anima.translation.service",
+      "current_owner": "easyuse_anima.translation.service._DEFAULT_TRANSLATION_PROVIDER_REGISTRY",
       "e01_entry": "translation-provider-registry",
       "evidence": [
         "tests/test_prompt_translation.py"
@@ -212,10 +213,9 @@
       "locking": "one registry RLock protects provider lookup, construction, and publication; each provider has a separate RLock protecting lazy client creation and calls",
       "module": "easyuse_anima/translation/service.py",
       "state_symbols": [
-        "_TRANSLATION_PROVIDER_INSTANCES",
-        "_TRANSLATION_PROVIDER_LOCK"
+        "_DEFAULT_TRANSLATION_PROVIDER_REGISTRY"
       ],
-      "target_phase": "E-04b"
+      "target_phase": "E-04b-complete"
     }
   ],
   "production_callers": [
@@ -265,7 +265,7 @@
       ]
     }
   ],
-  "production_changes": 0,
+  "production_changes": 2,
   "schema_version": 1,
-  "scope": "E-04a current translation provider, client, cache, single-flight, and route-executor ownership"
+  "scope": "E-04a translation ownership contract plus completed E-04b provider registry/client ownership Move"
 }

--- a/tests/test_prompt_translation.py
+++ b/tests/test_prompt_translation.py
@@ -26,11 +26,12 @@ from easyuse_anima.translation.providers import google as google_provider
 from easyuse_anima.translation.providers.google import (
     GoogleTranslationProvider,
 )
+from easyuse_anima.translation.provider_registry import (
+    _TranslationProviderRegistry,
+)
 from easyuse_anima.translation.service import (
     BoundedTranslationCache,
     PromptTranslationService,
-    _TRANSLATION_PROVIDER_FACTORIES,
-    _TRANSLATION_PROVIDER_INSTANCES,
     get_translation_provider,
 )
 
@@ -161,20 +162,82 @@ class PromptTranslationServiceTests(unittest.TestCase):
             factory_calls.append(True)
             return provider
 
-        with (
-            patch.dict(_TRANSLATION_PROVIDER_INSTANCES, {}, clear=True),
-            patch.dict(
-                _TRANSLATION_PROVIDER_FACTORIES,
-                {PROMPT_TRANSLATION_PROVIDER_GOOGLE: factory},
-                clear=True,
-            ),
-        ):
-            first = get_translation_provider(PROMPT_TRANSLATION_PROVIDER_GOOGLE)
-            second = get_translation_provider(PROMPT_TRANSLATION_PROVIDER_GOOGLE)
+        registry = _TranslationProviderRegistry(
+            {PROMPT_TRANSLATION_PROVIDER_GOOGLE: factory}
+        )
+        first = registry.get(PROMPT_TRANSLATION_PROVIDER_GOOGLE)
+        second = registry.get(PROMPT_TRANSLATION_PROVIDER_GOOGLE)
 
         self.assertIs(first, provider)
         self.assertIs(second, provider)
         self.assertEqual(len(factory_calls), 1)
+
+    def test_provider_registry_constructs_once_under_concurrency(self):
+        provider = GoogleTranslationProvider(translator_factory=lambda: object())
+        factory_calls = []
+
+        def factory():
+            factory_calls.append(True)
+            return provider
+
+        registry = _TranslationProviderRegistry(
+            {PROMPT_TRANSLATION_PROVIDER_GOOGLE: factory}
+        )
+        with ThreadPoolExecutor(max_workers=8) as executor:
+            instances = list(
+                executor.map(
+                    registry.get,
+                    [PROMPT_TRANSLATION_PROVIDER_GOOGLE] * 16,
+                )
+            )
+
+        self.assertTrue(all(instance is provider for instance in instances))
+        self.assertEqual(len(factory_calls), 1)
+
+    def test_provider_registry_preserves_factory_error_policy(self):
+        timeout = TranslationTimeoutError()
+
+        def timeout_factory():
+            raise timeout
+
+        def broken_factory():
+            raise ValueError("broken provider")
+
+        with self.assertRaises(TranslationProviderUnavailableError):
+            _TranslationProviderRegistry({}).get("missing")
+        with self.assertRaises(TranslationTimeoutError) as raised:
+            _TranslationProviderRegistry(
+                {PROMPT_TRANSLATION_PROVIDER_GOOGLE: timeout_factory}
+            ).get(PROMPT_TRANSLATION_PROVIDER_GOOGLE)
+        self.assertIs(raised.exception, timeout)
+
+        with self.assertRaises(TranslationProviderUnavailableError) as raised:
+            _TranslationProviderRegistry(
+                {PROMPT_TRANSLATION_PROVIDER_GOOGLE: broken_factory}
+            ).get(PROMPT_TRANSLATION_PROVIDER_GOOGLE)
+        self.assertIsInstance(raised.exception.__cause__, ValueError)
+
+    def test_provider_facade_resolves_current_default_registry(self):
+        provider = GoogleTranslationProvider(translator_factory=lambda: object())
+
+        class Registry:
+            def __init__(self):
+                self.calls = []
+
+            def get(self, name):
+                self.calls.append(name)
+                return provider
+
+        registry = Registry()
+        with patch.object(
+            service,
+            "_DEFAULT_TRANSLATION_PROVIDER_REGISTRY",
+            registry,
+        ):
+            resolved = get_translation_provider(" GOOGLE ")
+
+        self.assertIs(resolved, provider)
+        self.assertEqual(registry.calls, [" GOOGLE "])
 
     def test_cache_hit_ttl_expiry_and_lru_bound_are_deterministic(self):
         now = [0.0]

--- a/tests/test_python_backend_analyzer.py
+++ b/tests/test_python_backend_analyzer.py
@@ -690,9 +690,9 @@ ignored/
 
         self.assertEqual(analyzer.render_json(report), expected_text)
         self.assertEqual(report["schema_version"], 2)
-        self.assertEqual(report["inventory"]["module_count"], 166)
-        self.assertEqual(len(report["registry"]["shipped_python_modules"]), 166)
-        self.assertEqual(len(report["registry"]["runtime_import_closure"]), 166)
+        self.assertEqual(report["inventory"]["module_count"], 167)
+        self.assertEqual(len(report["registry"]["shipped_python_modules"]), 167)
+        self.assertEqual(len(report["registry"]["runtime_import_closure"]), 167)
         self.assertEqual(
             report["registry"]["entry_modules"],
             [

--- a/tests/test_python_translation_runtime_contract.py
+++ b/tests/test_python_translation_runtime_contract.py
@@ -178,14 +178,14 @@ class PythonTranslationRuntimeContractTests(unittest.TestCase):
         )
         self.assertEqual(self.fixture["schema_version"], 1)
         self.assertEqual(self.fixture["classification"], "Contract")
-        self.assertEqual(self.fixture["production_changes"], 0)
+        self.assertEqual(self.fixture["production_changes"], 2)
         self.assertEqual(
             [move["id"] for move in self.fixture["move_queue"]],
             ["E-04a", "E-04b", "E-04c", "E-04d", "E-04e"],
         )
         self.assertEqual(
             [move["status"] for move in self.fixture["move_queue"]],
-            ["complete", "ready", "pending", "pending", "pending"],
+            ["complete", "complete", "ready", "pending", "pending"],
         )
         self.assertEqual(
             [move["classification"] for move in self.fixture["move_queue"]],
@@ -229,7 +229,7 @@ class PythonTranslationRuntimeContractTests(unittest.TestCase):
             for entry in self.e01_fixture["declarative_mutable_globals"]
             for symbol in entry["symbols"]
         }
-        self.assertIn(
+        self.assertNotIn(
             (
                 "easyuse_anima/translation/service.py",
                 "_TRANSLATION_PROVIDER_FACTORIES",
@@ -293,6 +293,13 @@ class PythonTranslationRuntimeContractTests(unittest.TestCase):
                 "easyuse_anima/translation/providers/google.py",
                 "GoogleTranslationProvider",
             ),
+        )
+        self.assertEqual(
+            _class_methods(
+                "easyuse_anima/translation/provider_registry.py",
+                "_TranslationProviderRegistry",
+            ),
+            {"__init__", "get"},
         )
 
     def test_production_callers_and_dynamic_compatibility_seams_are_current(self):


### PR DESCRIPTION
## 목적과 변경 경계

Issue #187 E-04b Move만 수행합니다. provider factory mapping, lazy provider instance cache, registry RLock을 새 private `_TranslationProviderRegistry`가 소유하도록 이동했습니다. canonical service의 `get_translation_provider()`는 매 호출마다 현재 default registry를 조회합니다.

Base `77c7db822b2be2649f89eef249add95a9b110ef3` -> Head `75f2fe4ef27a54ab089dd6baefefb2d70b73fb83`

## 주요 파일과 보존 계약

- `easyuse_anima/translation/provider_registry.py`: factory/instance/lock의 단일 private owner
- `easyuse_anima/translation/service.py`: public/root identity를 유지하는 call-time default facade
- E-01/E-04 fixtures, analyzer baseline, direct contract와 active resume 문서 갱신
- lazy optional `googletrans` import, one provider/client reuse, timeout/error normalization, off mode, service cache/single-flight, route executor, bootstrap/RuntimeServices는 변경하지 않음
- provider/client close 또는 registry reset 계약은 증거가 없어 추가하지 않음

## 검증

- changed-file `py_compile`, Ruff E9/F63/F7/F82, JSON parse: 통과
- Prompt translation service 13, compatibility 1, provider errors 2, API 11: 통과
- E-04 contract 6, E-01 inventory 5, analyzer 18: 통과
- import boundary 6, package skeleton 1, RuntimeServices 8, bootstrap 5: 통과
- `comfy node validate`: 통과
- actual `comfy node pack`: 309 entries, `provider_registry.py` 1개 포함, 비어 있지 않은 zero-compressed entry 0
- final candidate official full 정확히 1회: Python 1349, frontend 120, 전체 통과
- `git diff --check`: 통과

## 위험, rollback, next

- 남은 의도적 gap은 지원되는 client close 인터페이스 부재입니다. E-04b에서 임의 lifecycle을 만들지 않습니다.
- rollback 경계는 이 단일 squash commit입니다.
- 다음 작업은 별도 E-04c default service/cache composition Move입니다. E-04d 이후, D-14 retirement, release/Registry는 시작하지 않습니다.