### PR TITLE
E-04c: default translation service runtime 조합

### DIFF
--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -10,14 +10,14 @@ then only the active task section, owning Issue, direct source, and direct tests
 ## Active sequencing
 
 - Issue [#187](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/187)
-  owns Phase E. E-01 through E-03, E-04a, and E-04b are complete; E-04c default
-  service/cache composition is the next bounded unit.
+  owns Phase E. E-01 through E-03 and E-04a through E-04c are complete; E-04d
+  route executor/bootstrap lifecycle wiring is the next bounded unit.
   Issue #186 retains D-14/shim decisions.
 - [`backend-roadmap-resume-0.6.2.md`](backend-roadmap-resume-0.6.2.md)
   is the current execution source of truth. Read it before the older accumulated
   roadmap.
-- Reviewed code baseline before E-04b: E-04a / PR #537 at
-  `77c7db822b2be2649f89eef249add95a9b110ef3`.
+- Reviewed code baseline before E-04c: E-04b / PR #538 at
+  `738747105a75801597054088b68860ee43e5eef1`.
 - D-08 is complete and D-08v is not required.
 - D-14 readiness retains every root surface; retirement/final-freeze work is blocked.
 - E-01 inventory Contract:
@@ -34,14 +34,14 @@ then only the active task section, owning Issue, direct source, and direct tests
   [`python-runtime-e03-repository-filesystem-contract.md`](python-runtime-e03-repository-filesystem-contract.md).
 - E-04a translation runtime ownership Contract:
   [`python-runtime-e04-translation-contract.md`](python-runtime-e04-translation-contract.md).
-- First READY task after E-04b: #187 E-04c default service/cache composition Move
+- First READY task after E-04c: #187 E-04d route executor/bootstrap lifecycle Move
   only.
 - Completed #470 and the #413/#414/#415 queue/live-UI lanes remain contract references,
   not active blockers.
 - Released code baseline: 0.6.2. Registry activation is external administration and
   does not block `dev`; do not republish or mutate the release.
 - Completed #409/#410/#411 and deferred #440/#441 do not alter the E-01 boundary.
-- E-04b completion authorizes only E-04c. It does not authorize later Phase E Moves,
+- E-04c completion authorizes only E-04d. It does not authorize later Phase E Moves,
   root removal, release, or Registry work.
 
 ## Current code boundary
@@ -68,7 +68,7 @@ aliases or absorbing feature behavior.
 
 - [`backend-roadmap-resume-0.6.2.md`](backend-roadmap-resume-0.6.2.md):
   completed D-08 evidence, D-14 readiness verdict, completed Phase E units, and the
-  bounded E-04c handoff.
+  bounded E-04d handoff.
 - [`python-backend.md`](python-backend.md): target ownership and dependency direction.
   Its early implementation snapshot is historical where the active checkpoint differs.
 - [`python-backend-execution-roadmap.md`](python-backend-execution-roadmap.md):

--- a/docs/architecture/backend-roadmap-resume-0.6.2.md
+++ b/docs/architecture/backend-roadmap-resume-0.6.2.md
@@ -2,16 +2,16 @@
 
 ## Status and authority
 
-- Status: D-08, E-01, E-02, E-03, E-04a, and E-04b are
+- Status: D-08, E-01, E-02, E-03, and E-04a through E-04c are
   completed; the D-14 readiness audit retains every root surface and blocks
   retirement/final-freeze work.
-- Code-review base before E-04b:
-  `dev@77c7db822b2be2649f89eef249add95a9b110ef3` after E-04a / PR #537.
-- Document baseline: completed E-04b provider registry/client ownership Move.
+- Code-review base before E-04c:
+  `dev@738747105a75801597054088b68860ee43e5eef1` after E-04b / PR #538.
+- Document baseline: completed E-04c default translation service/cache composition.
 - Released baseline: 0.6.2.
 - Scope: completed D-08 evidence, the D-14 readiness decision, completed #187
-  E-01/E-02/E-03/E-04 work, and the next bounded E-04c default service/cache
-  composition Move.
+  E-01/E-02/E-03/E-04 work, and the next bounded E-04d route executor/bootstrap
+  lifecycle Move.
 - This document owns the current immediate queue and supersedes the stale queue and
   broad preflight command in `python-backend-execution-roadmap.md`.
 - `python-backend.md`, ADR-001, ADR-002, and the compatibility-shim registry still own
@@ -284,9 +284,12 @@ The D-08u audit found no required D-08v. After D-08:
 16. E-04b moves provider factories, lazy instances, and registry locking behind one
     private registry while retaining a call-time default seam and unchanged lazy
     optional client behavior; and
-17. never remove root files merely to make the directory tree appear complete.
+17. E-04c composes one runtime-owned translation port from the process clock, bounded
+    cache, and per-key single-flight service while preserving the canonical facade;
+    and
+18. never remove root files merely to make the directory tree appear complete.
 
-## 6. E-01/E-02/E-03/E-04b result and Codex resume instruction
+## 6. E-01/E-02/E-03/E-04c result and Codex resume instruction
 
 ```text
 D-08 is complete. Do not restart D-08t or create D-08v without new contrary
@@ -343,8 +346,13 @@ private translation provider registry. The canonical public facade resolves the
 current default registry on every call. Optional import, provider/client reuse,
 timeouts, errors, and public/root identities are unchanged.
 
-Start only #187 E-04c from latest origin/dev. Compose the process default translation
-service with its bounded cache and per-key single-flight owner through the narrow
-contract fixed by E-04a. Do not start E-04d through E-10, D-14 retirement, release,
-or Registry work inside E-04c.
+E-04c adds a translation-owned narrow port to RuntimeServices. Bootstrap composes the
+process clock, bounded cache, and service, and installs the same service identity
+behind the canonical call-time facade. Service close clears only its cache;
+provider/client cleanup and whole-runtime close ordering remain separate.
+
+Start only #187 E-04d from latest origin/dev. Move route executor construction and
+lifecycle registration from the root API facade into bootstrap-owned composition
+while preserving every dynamic root seam. Do not start E-04e through E-10, D-14
+retirement, release, or Registry work inside E-04d.
 ```

--- a/docs/architecture/python-runtime-e04-translation-contract.md
+++ b/docs/architecture/python-runtime-e04-translation-contract.md
@@ -3,9 +3,10 @@
 ## Scope and authority
 
 E-04a is a production-free Contract created at
-`dev@d952f15f637732ce45a1ab7d9a0006bd1a3362bc`. E-04b completes the first
-bounded Move from the E-04a queue: provider registry ownership is explicit while
-the default service/cache and API route executor remain unchanged.
+`dev@d952f15f637732ce45a1ab7d9a0006bd1a3362bc`. E-04b makes provider registry
+ownership explicit. E-04c completes the second bounded Move by composing the process
+translation service/cache into RuntimeServices while the API route executor remains
+unchanged.
 
 The executable source is
 `tests/fixtures/python_translation_runtime_contract.v1.json`, checked by
@@ -31,15 +32,19 @@ invent one.
 
 ### Default service, cache, and per-key single-flight
 
-The canonical service module constructs `_DEFAULT_TRANSLATION_SERVICE` at import.
-That service owns one bounded TTL/LRU cache and a per-key single-flight registry.
+Bootstrap constructs one `_SystemClock`, one bounded TTL/LRU cache using that
+clock's `monotonic` method, and one `PromptTranslationService`. RuntimeServices owns
+the service through the translation-owned `PromptTranslationPort`; the canonical
+service facade installs and resolves the same identity for current node/API calls.
+A standalone canonical import retains its local compatibility default until
+production bootstrap composition.
+
 Cache entries use one `RLock`; flight registration uses a second `RLock`; each cache
 key gets its own `Lock`, so different translation keys can proceed independently.
-
-`BoundedTranslationCache.clear()` exists, and each flight removes itself after the
-last user settles. The module default service has no process reset or idempotent
-close. API and Prompt-node paths currently converge through
-`translate_prompt_markers()`.
+`PromptTranslationService.close()` idempotently clears its owned cache, and each
+flight removes itself after the last user settles. It does not close providers,
+cancel work, or create a terminal closed state. API and Prompt-node paths continue
+to converge through `translate_prompt_markers()`.
 
 ### API route executor
 
@@ -104,10 +109,10 @@ semantics are Behavior and remain out of scope.
 2. **E-04b Move — provider registry/client ownership — complete:** factories,
    instances, and registry locking are owned by one private provider registry; the
    call-time default facade, lazy client behavior, and errors are preserved.
-3. **E-04c Move — default service/cache composition — READY:** compose one
-   process translation service with its cache and flights, then wire current node/API
-   callers through narrow seams.
-4. **E-04d Move — route executor/bootstrap lifecycle wiring — pending:** move worker
+3. **E-04c Move — default service/cache composition — complete:** bootstrap composes
+   the clock/cache/service, RuntimeServices owns the narrow port, and current node/API
+   callers retain the call-time service facade.
+4. **E-04d Move — route executor/bootstrap lifecycle wiring — READY:** move worker
    construction and lifecycle registration from root `api.py` into bootstrap-owned
    composition while preserving every dynamic root seam.
 5. **E-04e Contract — completion audit — pending:** reconcile E-01 targets, prove

--- a/docs/architecture/python-runtime-state-inventory.md
+++ b/docs/architecture/python-runtime-state-inventory.md
@@ -50,8 +50,8 @@ E-01 drift gate until classified.
 | `prompt-knowledge-path` | canonical filesystem package path re-exported for ANIMA root compatibility | immutable after import | E-02d complete |
 | `root-route-registration` | injected router registrar called by bootstrap | serialized refresh; idempotent marker, no deregistration | E-09 |
 | `root-translation-route-worker` | root compatibility runtime owns lazy single-thread executor | internal `RLock`; idempotent `atexit` shutdown only | E-04d |
-| `runtime-services` | identity-installed process runtime with Comfy and seed capabilities | bootstrap-serialized install; private-global test reset, no close | E-09 |
-| `translation-default-service` | canonical default cache/single-flight service | cache and flight `RLock`s; cache clear exists, no process reset | E-04c |
+| `runtime-services` | identity-installed process runtime with Comfy, seed, config/clock, and narrow translation capabilities | bootstrap-serialized install; private-global test reset, no whole-runtime close | E-09 |
+| `translation-default-service` | RuntimeServices-owned translation port, mirrored by the canonical call-time facade | cache and flight `RLock`s; idempotent service close clears cache | E-04c complete |
 | `translation-provider-registry` | private process-owned lazy provider-client registry | one owned `RLock`; no provider close/reset | E-04b complete |
 | `wildcard-snapshot-cache` | root verified-snapshot LRU and build single-flight | one `Condition`; no owner reset/close | E-06 |
 
@@ -104,7 +104,7 @@ owners. The E-03e cross-fixture audit reconciles both E-01 owner entries with th
 E-03 owners and records zero ambiguous repository/filesystem state owners. The next
 bounded unit is the separate E-04 translation provider/client/cache Contract.
 
-## E-04a Contract and E-04b result
+## E-04a Contract and E-04b/E-04c result
 
 The production-free
 [`python-runtime-e04-translation-contract.md`](python-runtime-e04-translation-contract.md)
@@ -123,4 +123,11 @@ E-04b replaces the service module's separate factory map, instance map, and lock
 one private `_TranslationProviderRegistry`. The process default remains in the
 canonical service module, and `get_translation_provider()` resolves that default at
 call time. Provider/client laziness, reuse, optional imports, timeout and error
-normalization remain unchanged. The next bounded unit is E-04c only.
+normalization remain unchanged.
+
+E-04c adds a translation-owned narrow port to RuntimeServices. Bootstrap constructs
+the process clock, bounded cache, and service together, then installs that exact
+service identity behind the existing node/API facade. `PromptTranslationService`
+implements the E-02 idempotent resource shape by clearing only its owned cache;
+per-key flights still self-remove and provider/client cleanup remains separate. The
+next bounded unit is E-04d only.

--- a/easyuse_anima/bootstrap.py
+++ b/easyuse_anima/bootstrap.py
@@ -48,6 +48,11 @@ from .api.routes.wildcards import (
 from .infrastructure.comfy.provider import DefaultComfyHostProvider
 from .runtime import RuntimeConfig, RuntimeServices, install_runtime
 from .seed.service import InMemorySeedReservationService
+from .translation.service import (
+    BoundedTranslationCache,
+    PromptTranslationService,
+    _install_default_translation_service,
+)
 
 _LOGGER = logging.getLogger("ComfyUI-EasyUseAnima")
 _INITIALIZE_LOCK = threading.Lock()
@@ -201,16 +206,24 @@ def initialize(
     with _INITIALIZE_LOCK:
         runtime = _DEFAULT_RUNTIME
         if runtime is None:
+            clock = _SystemClock()
             runtime = RuntimeServices(
                 comfy=DefaultComfyHostProvider(load_comfy_nodes),
                 seed_reservations=InMemorySeedReservationService(),
                 config=_load_runtime_config(),
-                clock=_SystemClock(),
+                clock=clock,
+                translation=PromptTranslationService(
+                    cache=BoundedTranslationCache(
+                        time_func=clock.monotonic,
+                    )
+                ),
             )
             install_runtime(runtime)
+            _install_default_translation_service(runtime.translation)
             _DEFAULT_RUNTIME = runtime
         else:
             install_runtime(runtime)
+            _install_default_translation_service(runtime.translation)
         register_routes()
         if _WILDCARDS_INITIALIZED:
             return

--- a/easyuse_anima/runtime.py
+++ b/easyuse_anima/runtime.py
@@ -8,6 +8,7 @@ from typing import Protocol
 
 from .infrastructure.comfy.provider import ComfyHostProvider
 from .seed.reservation import SeedReservationService
+from .translation.ports import PromptTranslationPort
 
 
 @dataclass(frozen=True, slots=True)
@@ -39,6 +40,7 @@ class RuntimeServices:
     seed_reservations: SeedReservationService
     config: RuntimeConfig
     clock: Clock
+    translation: PromptTranslationPort
 
 
 _RUNTIME_SERVICES: RuntimeServices | None = None

--- a/easyuse_anima/translation/ports.py
+++ b/easyuse_anima/translation/ports.py
@@ -1,0 +1,20 @@
+"""Narrow process translation service port."""
+
+from __future__ import annotations
+
+from typing import Protocol
+
+from .contracts import PromptTranslationSettings
+
+
+class PromptTranslationPort(Protocol):
+    def translate_prompt(
+        self,
+        text: str,
+        settings: PromptTranslationSettings | None = None,
+    ) -> str: ...
+
+    def close(self) -> None: ...
+
+
+__all__ = ()

--- a/easyuse_anima/translation/service.py
+++ b/easyuse_anima/translation/service.py
@@ -29,6 +29,7 @@ from .contracts import (
     normalize_prompt_translation_provider,
 )
 from .markers import iter_prompt_translation_markers
+from .ports import PromptTranslationPort
 from .provider_registry import _TranslationProviderRegistry
 from .providers.google import GoogleTranslationProvider
 
@@ -298,8 +299,21 @@ class PromptTranslationService:
         output.append(value[cursor:])
         return "".join(output)
 
+    def close(self) -> None:
+        self.cache.clear()
 
-_DEFAULT_TRANSLATION_SERVICE = PromptTranslationService()
+
+_DEFAULT_TRANSLATION_SERVICE: PromptTranslationPort = (
+    PromptTranslationService()
+)
+
+
+def _install_default_translation_service(
+    translation: PromptTranslationPort,
+) -> None:
+    global _DEFAULT_TRANSLATION_SERVICE
+
+    _DEFAULT_TRANSLATION_SERVICE = translation
 
 
 def strip_prompt_translation_markers(text: str) -> str:

--- a/tests/comfy_host_fakes.py
+++ b/tests/comfy_host_fakes.py
@@ -23,6 +23,14 @@ class FakeClock:
         return 0.0
 
 
+class FakeTranslationService:
+    def translate_prompt(self, text, settings=None):
+        return str(text or "")
+
+    def close(self) -> None:
+        return None
+
+
 class FakeComfyHostProvider:
     def __init__(
         self,
@@ -108,7 +116,7 @@ def _runtime_module_for(root_module):
 def _runtime_support(runtime_module):
     installed = runtime_module._RUNTIME_SERVICES
     if installed is not None:
-        return installed.config, installed.clock
+        return installed.config, installed.clock, installed.translation
     return (
         runtime_module.RuntimeConfig(
             package_root=Path("package-root"),
@@ -116,18 +124,20 @@ def _runtime_support(runtime_module):
             user_data_dir=Path("user-data"),
         ),
         FakeClock(),
+        FakeTranslationService(),
     )
 
 
 @contextmanager
 def use_fake_comfy_host(root_module, provider):
     runtime_module = _runtime_module_for(root_module)
-    config, clock = _runtime_support(runtime_module)
+    config, clock, translation = _runtime_support(runtime_module)
     runtime = runtime_module.RuntimeServices(
         comfy=provider,
         seed_reservations=FakeSeedReservationService(),
         config=config,
         clock=clock,
+        translation=translation,
     )
     with patch.object(runtime_module, "_RUNTIME_SERVICES", runtime):
         yield provider
@@ -157,12 +167,13 @@ def patch_comfy_helper(
         else FakeComfyHostProvider()
     )
     provider = _LayeredFakeComfyHostProvider(base, symbol, replacement)
-    config, clock = _runtime_support(runtime_module)
+    config, clock, translation = _runtime_support(runtime_module)
     runtime = runtime_module.RuntimeServices(
         comfy=provider,
         seed_reservations=FakeSeedReservationService(),
         config=config,
         clock=clock,
+        translation=translation,
     )
     with patch.object(runtime_module, "_RUNTIME_SERVICES", runtime):
         yield replacement

--- a/tests/fixtures/python_backend_baseline.json
+++ b/tests/fixtures/python_backend_baseline.json
@@ -17404,6 +17404,60 @@
       },
       {
         "alias": null,
+        "bound_name": "BoundedTranslationCache",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".translation.service:BoundedTranslationCache",
+        "kind": "static_from",
+        "line": 51,
+        "name": "BoundedTranslationCache",
+        "optional": false,
+        "requested": ".translation.service",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/bootstrap.py",
+        "target": "easyuse_anima/translation/service.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "PromptTranslationService",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".translation.service:PromptTranslationService",
+        "kind": "static_from",
+        "line": 51,
+        "name": "PromptTranslationService",
+        "optional": false,
+        "requested": ".translation.service",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/bootstrap.py",
+        "target": "easyuse_anima/translation/service.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_install_default_translation_service",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".translation.service:_install_default_translation_service",
+        "kind": "static_from",
+        "line": 51,
+        "name": "_install_default_translation_service",
+        "optional": false,
+        "requested": ".translation.service",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/bootstrap.py",
+        "target": "easyuse_anima/translation/service.py"
+      },
+      {
+        "alias": null,
         "bound_name": "PACKAGE_DATA_DIR",
         "branch_context": [],
         "classification": "internal",
@@ -17411,7 +17465,7 @@
         "conditional": false,
         "imported": ".infrastructure.filesystem.paths:PACKAGE_DATA_DIR",
         "kind": "static_from",
-        "line": 66,
+        "line": 71,
         "name": "PACKAGE_DATA_DIR",
         "optional": false,
         "requested": ".infrastructure.filesystem.paths",
@@ -17429,7 +17483,7 @@
         "conditional": false,
         "imported": ".infrastructure.filesystem.paths:PACKAGE_ROOT",
         "kind": "static_from",
-        "line": 66,
+        "line": 71,
         "name": "PACKAGE_ROOT",
         "optional": false,
         "requested": ".infrastructure.filesystem.paths",
@@ -17447,7 +17501,7 @@
         "conditional": false,
         "imported": ".infrastructure.filesystem.paths:USER_DATA_DIR",
         "kind": "static_from",
-        "line": 66,
+        "line": 71,
         "name": "USER_DATA_DIR",
         "optional": false,
         "requested": ".infrastructure.filesystem.paths",
@@ -30037,6 +30091,24 @@
         "target": "easyuse_anima/seed/reservation.py"
       },
       {
+        "alias": null,
+        "bound_name": "PromptTranslationPort",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".translation.ports:PromptTranslationPort",
+        "kind": "static_from",
+        "line": 11,
+        "name": "PromptTranslationPort",
+        "optional": false,
+        "requested": ".translation.ports",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/runtime.py",
+        "target": "easyuse_anima/translation/ports.py"
+      },
+      {
         "alias": "_execution_identity",
         "bound_name": "_execution_identity",
         "branch_context": [],
@@ -31823,6 +31895,58 @@
         "requested": "__future__",
         "role": "ordinary",
         "scope": "<module>",
+        "source": "easyuse_anima/translation/ports.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "Protocol",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "typing:Protocol",
+        "kind": "static_from",
+        "line": 5,
+        "name": "Protocol",
+        "optional": false,
+        "requested": "typing",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/translation/ports.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "PromptTranslationSettings",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".contracts:PromptTranslationSettings",
+        "kind": "static_from",
+        "line": 7,
+        "name": "PromptTranslationSettings",
+        "optional": false,
+        "requested": ".contracts",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/translation/ports.py",
+        "target": "easyuse_anima/translation/contracts.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "annotations",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "__future__:annotations",
+        "kind": "static_from",
+        "line": 3,
+        "name": "annotations",
+        "optional": false,
+        "requested": "__future__",
+        "role": "ordinary",
+        "scope": "<module>",
         "source": "easyuse_anima/translation/provider_registry.py"
       },
       {
@@ -32611,6 +32735,24 @@
       },
       {
         "alias": null,
+        "bound_name": "PromptTranslationPort",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".ports:PromptTranslationPort",
+        "kind": "static_from",
+        "line": 32,
+        "name": "PromptTranslationPort",
+        "optional": false,
+        "requested": ".ports",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/translation/service.py",
+        "target": "easyuse_anima/translation/ports.py"
+      },
+      {
+        "alias": null,
         "bound_name": "_TranslationProviderRegistry",
         "branch_context": [],
         "classification": "internal",
@@ -32618,7 +32760,7 @@
         "conditional": false,
         "imported": ".provider_registry:_TranslationProviderRegistry",
         "kind": "static_from",
-        "line": 32,
+        "line": 33,
         "name": "_TranslationProviderRegistry",
         "optional": false,
         "requested": ".provider_registry",
@@ -32636,7 +32778,7 @@
         "conditional": false,
         "imported": ".providers.google:GoogleTranslationProvider",
         "kind": "static_from",
-        "line": 33,
+        "line": 34,
         "name": "GoogleTranslationProvider",
         "optional": false,
         "requested": ".providers.google",
@@ -64955,6 +65097,10 @@
         "to": "easyuse_anima/seed/service.py"
       },
       {
+        "from": "easyuse_anima/bootstrap.py",
+        "to": "easyuse_anima/translation/service.py"
+      },
+      {
         "from": "easyuse_anima/image/detailer.py",
         "to": "easyuse_anima/image/geometry.py"
       },
@@ -65635,6 +65781,10 @@
         "to": "easyuse_anima/seed/reservation.py"
       },
       {
+        "from": "easyuse_anima/runtime.py",
+        "to": "easyuse_anima/translation/ports.py"
+      },
+      {
         "from": "easyuse_anima/seed/__init__.py",
         "to": "easyuse_anima/seed/execution_identity.py"
       },
@@ -65691,6 +65841,10 @@
         "to": "easyuse_anima/translation/contracts.py"
       },
       {
+        "from": "easyuse_anima/translation/ports.py",
+        "to": "easyuse_anima/translation/contracts.py"
+      },
+      {
         "from": "easyuse_anima/translation/provider_registry.py",
         "to": "easyuse_anima/translation/contracts.py"
       },
@@ -65705,6 +65859,10 @@
       {
         "from": "easyuse_anima/translation/service.py",
         "to": "easyuse_anima/translation/markers.py"
+      },
+      {
+        "from": "easyuse_anima/translation/service.py",
+        "to": "easyuse_anima/translation/ports.py"
       },
       {
         "from": "easyuse_anima/translation/service.py",
@@ -66966,6 +67124,12 @@
       {
         "cyclic": false,
         "modules": [
+          "easyuse_anima/translation/ports.py"
+        ]
+      },
+      {
+        "cyclic": false,
+        "modules": [
           "easyuse_anima/translation/provider_registry.py"
         ]
       },
@@ -67080,7 +67244,7 @@
     ]
   },
   "inventory": {
-    "module_count": 167,
+    "module_count": 168,
     "modules": [
       {
         "is_package": true,
@@ -67960,9 +68124,9 @@
       },
       {
         "is_package": false,
-        "loc": 228,
+        "loc": 241,
         "module": "easyuse_anima.bootstrap",
-        "normalized_git_blob_sha1": "7d15b126b7dfc806532cd4d070e475e716dc576a",
+        "normalized_git_blob_sha1": "6d041b84fc0c79afbc946d06f5e71d51d0c38244",
         "path": "easyuse_anima/bootstrap.py",
         "top_level": {
           "class_count": 1,
@@ -68692,9 +68856,9 @@
       },
       {
         "is_package": false,
-        "loc": 79,
+        "loc": 81,
         "module": "easyuse_anima.runtime",
-        "normalized_git_blob_sha1": "33fac86f2b5b7fe09d52174a8e4ff2cdc097c973",
+        "normalized_git_blob_sha1": "b9339ce39a4456304dbad7236eeca07bb4ed2a8a",
         "path": "easyuse_anima/runtime.py",
         "top_level": {
           "class_count": 4,
@@ -68860,6 +69024,18 @@
       },
       {
         "is_package": false,
+        "loc": 20,
+        "module": "easyuse_anima.translation.ports",
+        "normalized_git_blob_sha1": "b78b04177af52a2cccd7dcce0710356996b57454",
+        "path": "easyuse_anima/translation/ports.py",
+        "top_level": {
+          "class_count": 1,
+          "function_count": 0,
+          "global_count": 1
+        }
+      },
+      {
+        "is_package": false,
         "loc": 43,
         "module": "easyuse_anima.translation.provider_registry",
         "normalized_git_blob_sha1": "5e5f379283fb2ccb75c7bd3699169ee65667459c",
@@ -68896,13 +69072,13 @@
       },
       {
         "is_package": false,
-        "loc": 330,
+        "loc": 344,
         "module": "easyuse_anima.translation.service",
-        "normalized_git_blob_sha1": "b3d93820b03ec4210ef69815bfc008d91417d6d7",
+        "normalized_git_blob_sha1": "3407db664c5d78d5d707c89b69432524ffb8ac43",
         "path": "easyuse_anima/translation/service.py",
         "top_level": {
           "class_count": 3,
-          "function_count": 5,
+          "function_count": 6,
           "global_count": 4
         }
       },
@@ -87831,6 +88007,28 @@
         "line": 3,
         "optional": false,
         "role": "ordinary",
+        "source": "easyuse_anima/translation/ports.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "typing:Protocol",
+        "kind": "static_from",
+        "line": 5,
+        "optional": false,
+        "role": "ordinary",
+        "source": "easyuse_anima/translation/ports.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "__future__:annotations",
+        "kind": "static_from",
+        "line": 3,
+        "optional": false,
+        "role": "ordinary",
         "source": "easyuse_anima/translation/provider_registry.py"
       },
       {
@@ -89669,6 +89867,7 @@
       "easyuse_anima/translation/__init__.py",
       "easyuse_anima/translation/contracts.py",
       "easyuse_anima/translation/markers.py",
+      "easyuse_anima/translation/ports.py",
       "easyuse_anima/translation/provider_registry.py",
       "easyuse_anima/translation/providers/__init__.py",
       "easyuse_anima/translation/providers/google.py",
@@ -89838,6 +90037,7 @@
       "easyuse_anima/translation/__init__.py",
       "easyuse_anima/translation/contracts.py",
       "easyuse_anima/translation/markers.py",
+      "easyuse_anima/translation/ports.py",
       "easyuse_anima/translation/provider_registry.py",
       "easyuse_anima/translation/providers/__init__.py",
       "easyuse_anima/translation/providers/google.py",
@@ -91074,7 +91274,7 @@
         "column": 10,
         "context": "assign:_LOGGER",
         "kind": "import_time_call",
-        "line": 52,
+        "line": 57,
         "module": "easyuse_anima/bootstrap.py",
         "scope": "<module>"
       },
@@ -91083,7 +91283,7 @@
         "column": 19,
         "context": "assign:_INITIALIZE_LOCK",
         "kind": "import_time_call",
-        "line": 53,
+        "line": 58,
         "module": "easyuse_anima/bootstrap.py",
         "scope": "<module>"
       },
@@ -91542,7 +91742,7 @@
         "column": 1,
         "context": "decorator:RuntimeConfig",
         "kind": "import_time_call",
-        "line": 13,
+        "line": 14,
         "module": "easyuse_anima/runtime.py",
         "scope": "<module>"
       },
@@ -91551,7 +91751,7 @@
         "column": 1,
         "context": "decorator:RuntimeServices",
         "kind": "import_time_call",
-        "line": 34,
+        "line": 35,
         "module": "easyuse_anima/runtime.py",
         "scope": "<module>"
       },
@@ -91686,7 +91886,7 @@
         "column": 41,
         "context": "assign:_DEFAULT_TRANSLATION_PROVIDER_REGISTRY",
         "kind": "import_time_call",
-        "line": 35,
+        "line": 36,
         "module": "easyuse_anima/translation/service.py",
         "scope": "<module>"
       },
@@ -91695,16 +91895,16 @@
         "column": 14,
         "context": "assign:_CACHE_MISS",
         "kind": "import_time_call",
-        "line": 88,
+        "line": 89,
         "module": "easyuse_anima/translation/service.py",
         "scope": "<module>"
       },
       {
         "callee": "PromptTranslationService",
-        "column": 31,
+        "column": 4,
         "context": "assign:_DEFAULT_TRANSLATION_SERVICE",
         "kind": "import_time_call",
-        "line": 302,
+        "line": 307,
         "module": "easyuse_anima/translation/service.py",
         "scope": "<module>"
       },
@@ -92068,7 +92268,7 @@
       },
       {
         "kind": "list",
-        "line": 228,
+        "line": 241,
         "module": "easyuse_anima/bootstrap.py",
         "name": "__all__"
       },
@@ -92458,7 +92658,7 @@
           "lock"
         ],
         "initializer": "threading.Lock",
-        "line": 53,
+        "line": 58,
         "module": "easyuse_anima/bootstrap.py",
         "name": "_INITIALIZE_LOCK"
       },

--- a/tests/fixtures/python_runtime_state_ownership.v1.json
+++ b/tests/fixtures/python_runtime_state_ownership.v1.json
@@ -334,10 +334,10 @@
       "thread_safety": "One RLock protects executor creation, admission, Future identity, and close state."
     },
     {
-      "categories": ["capability", "clock", "runtime_config", "runtime_reference", "seed_reservation_service"],
+      "categories": ["capability", "clock", "runtime_config", "runtime_reference", "seed_reservation_service", "translation_port"],
       "cleanup": "No production uninstall/close; tests patch _RUNTIME_SERVICES.",
       "id": "runtime-services",
-      "lifetime": "One identity-installed RuntimeServices object for the process, including immutable config and a monotonic clock.",
+      "lifetime": "One identity-installed RuntimeServices object for the process, including immutable config, a monotonic clock, and the narrow translation service port.",
       "module": "easyuse_anima/runtime.py",
       "owner": "easyuse_anima.runtime.RuntimeServices",
       "symbols": ["RuntimeServices", "_RUNTIME_SERVICES"],
@@ -347,14 +347,14 @@
     },
     {
       "categories": ["cache", "lock", "service", "single_flight"],
-      "cleanup": "Cache.clear exists, but the module default service has no process reset/close.",
+      "cleanup": "PromptTranslationService.close idempotently clears its owned cache; flights self-remove after the last user settles; E-09 owns whole-runtime close ordering.",
       "id": "translation-default-service",
-      "lifetime": "Created at translation service import and reused by node and API callbacks.",
+      "lifetime": "Bootstrap composes one process service from the runtime clock; RuntimeServices owns it and the service facade retains the same identity for node/API callbacks.",
       "module": "easyuse_anima/translation/service.py",
-      "owner": "easyuse_anima.translation.service._DEFAULT_TRANSLATION_SERVICE",
+      "owner": "easyuse_anima.runtime.RuntimeServices.translation",
       "symbols": ["_DEFAULT_TRANSLATION_SERVICE"],
-      "target_phase": "E-04c",
-      "test_evidence": ["tests/test_prompt_translation.py"],
+      "target_phase": "E-04c-complete",
+      "test_evidence": ["tests/test_prompt_translation.py", "tests/test_runtime_services.py"],
       "thread_safety": "Separate RLocks protect bounded cache and per-key single-flight registry."
     },
     {

--- a/tests/fixtures/python_translation_runtime_contract.v1.json
+++ b/tests/fixtures/python_translation_runtime_contract.v1.json
@@ -35,7 +35,7 @@
     "generic_executor_client_port": "rejected",
     "provider_client_cleanup": "unproven: the current optional client protocol exposes translate only, so no close call may be invented in E-04 Moves.",
     "resource_partition": "Provider registry/client, service cache/per-key single-flight, and API route executor remain three distinct translation-owned resource boundaries.",
-    "runtime_fields": "Any RuntimeServices expansion is limited to narrow translation-owned ports selected by the owning Move; feature code never receives the complete runtime."
+    "runtime_fields": "E-04c adds only PromptTranslationPort to RuntimeServices; feature code never receives the complete runtime."
   },
   "move_queue": [
     {
@@ -57,14 +57,14 @@
       "goal": "Compose one process translation service with its bounded cache and per-key single-flight owner, then wire existing node/API callers through narrow seams.",
       "id": "E-04c",
       "name": "default service and cache composition",
-      "status": "ready"
+      "status": "complete"
     },
     {
       "classification": "Move",
       "goal": "Move route executor construction and lifecycle registration from the root API facade to bootstrap-owned runtime composition while preserving root dynamic seams.",
       "id": "E-04d",
       "name": "route executor bootstrap lifecycle wiring",
-      "status": "pending"
+      "status": "ready"
     },
     {
       "classification": "Contract",
@@ -118,11 +118,12 @@
     },
     {
       "cleanup": {
-        "current": "BoundedTranslationCache.clear exists; flights self-remove when the last user settles; the default service has no close/reset",
+        "current": "PromptTranslationService.close idempotently clears its owned cache; flights self-remove when the last user settles",
         "implemented_methods": [
-          "BoundedTranslationCache.clear"
+          "BoundedTranslationCache.clear",
+          "PromptTranslationService.close"
         ],
-        "remaining_gap": "explicit process owner and idempotent service cleanup are deferred to E-04c/E-09"
+        "remaining_gap": "whole-runtime reverse close ordering and partial-initialization cleanup remain deferred to E-09"
       },
       "components": [
         {
@@ -152,11 +153,14 @@
         }
       ],
       "construction": {
-        "at": "translation service module import",
+        "at": "first serialized bootstrap initialization",
+        "cache_clock": "RuntimeServices.clock.monotonic",
         "class": "PromptTranslationService",
-        "invocation_module": "easyuse_anima/translation/service.py"
+        "facade_binding": "easyuse_anima.translation.service._DEFAULT_TRANSLATION_SERVICE",
+        "invocation_module": "easyuse_anima/bootstrap.py",
+        "runtime_field": "RuntimeServices.translation"
       },
-      "current_owner": "easyuse_anima.translation.service._DEFAULT_TRANSLATION_SERVICE",
+      "current_owner": "easyuse_anima.runtime.RuntimeServices.translation",
       "e01_entry": "translation-default-service",
       "evidence": [
         "tests/test_prompt_translation.py"
@@ -167,7 +171,7 @@
       "state_symbols": [
         "_DEFAULT_TRANSLATION_SERVICE"
       ],
-      "target_phase": "E-04c"
+      "target_phase": "E-04c-complete"
     },
     {
       "cleanup": {
@@ -265,7 +269,7 @@
       ]
     }
   ],
-  "production_changes": 2,
+  "production_changes": 6,
   "schema_version": 1,
-  "scope": "E-04a translation ownership contract plus completed E-04b provider registry/client ownership Move"
+  "scope": "E-04a translation ownership contract plus completed E-04b provider registry and E-04c default service/cache Moves"
 }

--- a/tests/test_comfy_host_wiring.py
+++ b/tests/test_comfy_host_wiring.py
@@ -15,6 +15,7 @@ from tests.comfy_host_fakes import (
     FakeClock,
     FakeComfyHostProvider,
     FakeSeedReservationService,
+    FakeTranslationService,
 )
 
 
@@ -250,6 +251,7 @@ class ComfyHostWiringTests(unittest.TestCase):
                 user_data_dir=Path("user-data"),
             ),
             clock=FakeClock(),
+            translation=FakeTranslationService(),
         )
 
         self.assertEqual(
@@ -300,6 +302,7 @@ class ComfyHostWiringTests(unittest.TestCase):
                 user_data_dir=Path("user-data"),
             ),
             clock=FakeClock(),
+            translation=FakeTranslationService(),
         )
 
         require = resolve_comfy_host_helper(

--- a/tests/test_prompt_translation.py
+++ b/tests/test_prompt_translation.py
@@ -299,6 +299,43 @@ class PromptTranslationServiceTests(unittest.TestCase):
 
         self.assertEqual(provider.call_count, 4)
 
+    def test_service_close_clears_cache_and_is_idempotent(self):
+        cache = BoundedTranslationCache(max_entries=8, ttl_seconds=60)
+        translation = PromptTranslationService(cache=cache)
+
+        with patch(
+            "easyuse_anima.translation.service.google_translate_text",
+            return_value="cached",
+        ) as provider:
+            translation.translate_prompt("%{same}", GOOGLE_SETTINGS)
+            translation.translate_prompt("%{same}", GOOGLE_SETTINGS)
+            self.assertEqual(len(cache), 1)
+            translation.close()
+            translation.close()
+            self.assertEqual(len(cache), 0)
+            translation.translate_prompt("%{same}", GOOGLE_SETTINGS)
+
+        self.assertEqual(provider.call_count, 2)
+
+    def test_translation_facade_resolves_current_default_service(self):
+        current = SimpleNamespace(
+            translate_prompt=lambda text, settings=None: (
+                text,
+                settings,
+            )
+        )
+        with patch.object(
+            service,
+            "_DEFAULT_TRANSLATION_SERVICE",
+            current,
+        ):
+            resolved = service.translate_prompt_markers(
+                "%{value}",
+                GOOGLE_SETTINGS,
+            )
+
+        self.assertEqual(resolved, ("%{value}", GOOGLE_SETTINGS))
+
     def test_cache_and_request_dedup_are_thread_safe(self):
         service = PromptTranslationService(
             cache=BoundedTranslationCache(max_entries=8, ttl_seconds=60)

--- a/tests/test_python_backend_analyzer.py
+++ b/tests/test_python_backend_analyzer.py
@@ -690,9 +690,9 @@ ignored/
 
         self.assertEqual(analyzer.render_json(report), expected_text)
         self.assertEqual(report["schema_version"], 2)
-        self.assertEqual(report["inventory"]["module_count"], 167)
-        self.assertEqual(len(report["registry"]["shipped_python_modules"]), 167)
-        self.assertEqual(len(report["registry"]["runtime_import_closure"]), 167)
+        self.assertEqual(report["inventory"]["module_count"], 168)
+        self.assertEqual(len(report["registry"]["shipped_python_modules"]), 168)
+        self.assertEqual(len(report["registry"]["runtime_import_closure"]), 168)
         self.assertEqual(
             report["registry"]["entry_modules"],
             [

--- a/tests/test_python_translation_runtime_contract.py
+++ b/tests/test_python_translation_runtime_contract.py
@@ -178,14 +178,14 @@ class PythonTranslationRuntimeContractTests(unittest.TestCase):
         )
         self.assertEqual(self.fixture["schema_version"], 1)
         self.assertEqual(self.fixture["classification"], "Contract")
-        self.assertEqual(self.fixture["production_changes"], 2)
+        self.assertEqual(self.fixture["production_changes"], 6)
         self.assertEqual(
             [move["id"] for move in self.fixture["move_queue"]],
             ["E-04a", "E-04b", "E-04c", "E-04d", "E-04e"],
         )
         self.assertEqual(
             [move["status"] for move in self.fixture["move_queue"]],
-            ["complete", "complete", "ready", "pending", "pending"],
+            ["complete", "complete", "complete", "ready", "pending"],
         )
         self.assertEqual(
             [move["classification"] for move in self.fixture["move_queue"]],
@@ -280,7 +280,7 @@ class PythonTranslationRuntimeContractTests(unittest.TestCase):
                 "BoundedTranslationCache",
             ),
         )
-        self.assertNotIn(
+        self.assertIn(
             "close",
             _class_methods(
                 "easyuse_anima/translation/service.py",
@@ -379,7 +379,33 @@ class PythonTranslationRuntimeContractTests(unittest.TestCase):
         }
         self.assertEqual(
             runtime_fields,
-            {"clock", "comfy", "config", "seed_reservations"},
+            {
+                "clock",
+                "comfy",
+                "config",
+                "seed_reservations",
+                "translation",
+            },
+        )
+        self.assertEqual(
+            _class_methods(
+                "easyuse_anima/translation/ports.py",
+                "PromptTranslationPort",
+            ),
+            {"close", "translate_prompt"},
+        )
+        bootstrap_references = _function_references(
+            "easyuse_anima/bootstrap.py",
+            "initialize",
+        )
+        self.assertTrue(
+            {
+                "BoundedTranslationCache",
+                "PromptTranslationService",
+                "RuntimeServices",
+                "_install_default_translation_service",
+            }
+            <= bootstrap_references
         )
         self.assertEqual(
             self.fixture["decisions"]["generic_executor_client_port"],

--- a/tests/test_runtime_services.py
+++ b/tests/test_runtime_services.py
@@ -24,6 +24,8 @@ from easyuse_anima.runtime import (
     install_runtime,
 )
 from easyuse_anima.seed.service import InMemorySeedReservationService
+from easyuse_anima.translation import service as translation_service
+from easyuse_anima.translation.service import PromptTranslationService
 
 
 class FakeComfyHostProvider:
@@ -140,6 +142,7 @@ class RuntimeServicesTests(unittest.TestCase):
                 user_data_dir=Path("user-data"),
             ),
             clock=FakeClock(),
+            translation=PromptTranslationService(),
         )
 
     def test_runtime_value_is_frozen(self):
@@ -221,6 +224,14 @@ class RuntimeServicesTests(unittest.TestCase):
         self.assertIs(first.config.package_root, storage_paths.PACKAGE_ROOT)
         self.assertIs(first.config.package_data_dir, storage_paths.PACKAGE_DATA_DIR)
         self.assertIs(first.config.user_data_dir, storage_paths.USER_DATA_DIR)
+        self.assertIs(
+            first.translation,
+            translation_service._DEFAULT_TRANSLATION_SERVICE,
+        )
+        self.assertIs(
+            first.translation.cache._time_func.__self__,
+            first.clock,
+        )
         with patch.object(bootstrap.time, "monotonic", return_value=12.5):
             self.assertEqual(first.clock.monotonic(), 12.5)
         self.assertEqual(first.comfy.max_resolution(), 8192)


### PR DESCRIPTION
## 목적과 변경 경계

Issue #187 E-04c Move만 수행합니다. Bootstrap이 process clock, bounded translation cache, `PromptTranslationService`를 조합하고 `RuntimeServices.translation` narrow port와 canonical call-time facade에 동일 identity를 설치합니다.

Base `738747105a75801597054088b68860ee43e5eef1` -> Head `55f7fd2302412520c706093d101320af2bf503df`

## 주요 파일과 보존 계약

- `easyuse_anima/translation/ports.py`: `translate_prompt()`/idempotent `close()`만 가진 private narrow port
- `easyuse_anima/runtime.py`: RuntimeServices에 translation-owned port 하나만 추가
- `easyuse_anima/bootstrap.py`: one clock -> bounded cache -> service concrete composition
- `easyuse_anima/translation/service.py`: current default installer와 cache-only idempotent close
- root/canonical `__all__`, marker/cache/provider/error behavior, API route executor, dynamic root seams, initialize signature/order/retry는 유지
- provider/client close, terminal closed state, cancellation, E-04d route executor 이동, E-09 whole-runtime close는 포함하지 않음

## 검증

- changed-file `py_compile`, Ruff E9/F63/F7/F82, JSON parse: 통과
- translation service 15, root identity 1, translation API 11: 통과
- Prompt Corrector 15, Prompt Corrector Move 7: 통과
- RuntimeServices 8, runtime base 5, bootstrap 5, Comfy wiring 10: 통과
- E-04 Contract 6, E-01 ownership 5, analyzer 18: 통과
- compatibility surface 19, historical ledger 7, import boundary 6, package skeleton 1: 통과
- `comfy node validate`: 통과
- actual `comfy node pack`: 310 entries, 4/4 production targets 포함, archive 전체 35,283,777 bytes read 성공
- final candidate official full 정확히 1회: Python 1351, frontend 120, 전체 통과
- `git diff --check`: 통과

## 위험, rollback, next

- standalone canonical import는 compatibility default를 유지하고, production bootstrap 이후 runtime field와 facade는 동일 service identity입니다.
- service close는 cache만 clear하며 flights는 기존 last-user settlement로 self-remove합니다. Whole-runtime ordering은 E-09입니다.
- rollback 경계는 이 단일 squash commit입니다.
- 다음 작업은 별도 E-04d route executor/bootstrap lifecycle wiring Move입니다. E-04e 이후, D-14 retirement, release/Registry는 시작하지 않습니다.