### PR TITLE
docs: define E-05 autocomplete runtime ownership contract

### DIFF
--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -10,14 +10,15 @@ then only the active task section, owning Issue, direct source, and direct tests
 ## Active sequencing
 
 - Issue [#187](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/187)
-  owns Phase E. E-01 through E-04 are complete; the next bounded unit is a separate
-  E-05 autocomplete source/index/single-flight ownership Contract.
+  owns Phase E. E-01 through E-04 and the production-free E-05a Contract are
+  complete; the next bounded unit is the separate E-05b dataset snapshot and
+  single-flight ownership Move.
   Issue #186 retains D-14/shim decisions.
 - [`backend-roadmap-resume-0.6.2.md`](backend-roadmap-resume-0.6.2.md)
   is the current execution source of truth. Read it before the older accumulated
   roadmap.
-- Reviewed code baseline before E-04e: E-04d / PR #540 at
-  `3cc4e413f8147f508a3a7efb45e8eb85f1028981`.
+- Reviewed code baseline before E-05a: E-04e / PR #541 at
+  `e8f3b5b3abb7633aa122dc28956c65f664b017c6`.
 - D-08 is complete and D-08v is not required.
 - D-14 readiness retains every root surface; retirement/final-freeze work is blocked.
 - E-01 inventory Contract:
@@ -34,15 +35,17 @@ then only the active task section, owning Issue, direct source, and direct tests
   [`python-runtime-e03-repository-filesystem-contract.md`](python-runtime-e03-repository-filesystem-contract.md).
 - Completed E-04 translation runtime ownership Contract and audit:
   [`python-runtime-e04-translation-contract.md`](python-runtime-e04-translation-contract.md).
-- First READY task after E-04: a separate #187 E-05 autocomplete ownership Contract
-  only.
+- E-05 autocomplete runtime ownership Contract:
+  [`python-runtime-e05-autocomplete-contract.md`](python-runtime-e05-autocomplete-contract.md).
+- First READY task after E-05a: a separate #187 E-05b dataset snapshot and
+  single-flight ownership Move only.
 - Completed #470 and the #413/#414/#415 queue/live-UI lanes remain contract references,
   not active blockers.
 - Released code baseline: 0.6.2. Registry activation is external administration and
   does not block `dev`; do not republish or mutate the release.
 - Completed #409/#410/#411 and deferred #440/#441 do not alter the E-01 boundary.
-- E-04 completion authorizes only the separate E-05 Contract. It does not authorize
-  an E-05 production Move, later Phase E work, root removal, release, or Registry.
+- E-05a authorizes only the separate E-05b Move. It does not authorize E-05c+
+  implementation, later Phase E work, root removal, release, or Registry.
 
 ## Current code boundary
 
@@ -86,6 +89,9 @@ aliases or absorbing feature behavior.
 - [`python-runtime-e04-translation-contract.md`](python-runtime-e04-translation-contract.md):
   completed translation provider/client, service cache/single-flight, route executor
   owners, lifecycle gaps, and the E-04 completion audit.
+- [`python-runtime-e05-autocomplete-contract.md`](python-runtime-e05-autocomplete-contract.md):
+  autocomplete declarative source policy, snapshot/Future owner, index-store root
+  and path-lock owner, compatibility seams, and bounded Move queue.
 - [`adr-001-modular-monolith.md`](adr-001-modular-monolith.md): feature-oriented modular
   monolith decision.
 - [`adr-002-compatibility-shims.md`](adr-002-compatibility-shims.md): shim lifecycle and

--- a/docs/architecture/backend-roadmap-resume-0.6.2.md
+++ b/docs/architecture/backend-roadmap-resume-0.6.2.md
@@ -2,16 +2,17 @@
 
 ## Status and authority
 
-- Status: D-08 and E-01 through E-04 are
+- Status: D-08, E-01 through E-04, and the production-free E-05a Contract are
   completed; the D-14 readiness audit retains every root surface and blocks
   retirement/final-freeze work.
-- Code-review base before E-04e:
-  `dev@3cc4e413f8147f508a3a7efb45e8eb85f1028981` after E-04d / PR #540.
-- Document baseline: completed production-free E-04 translation ownership audit.
+- Code-review base before E-05a:
+  `dev@e8f3b5b3abb7633aa122dc28956c65f664b017c6` after E-04e / PR #541.
+- Document baseline: completed production-free E-05 autocomplete ownership
+  Contract.
 - Released baseline: 0.6.2.
 - Scope: completed D-08 evidence, the D-14 readiness decision, completed #187
-  E-01/E-02/E-03/E-04 work, and the next bounded E-05 autocomplete ownership
-  Contract.
+  E-01/E-02/E-03/E-04 work, the E-05a ownership Contract, and the next bounded
+  E-05b dataset snapshot/single-flight Move.
 - This document owns the current immediate queue and supersedes the stale queue and
   broad preflight command in `python-backend-execution-roadmap.md`.
 - `python-backend.md`, ADR-001, ADR-002, and the compatibility-shim registry still own
@@ -359,7 +360,14 @@ E-04e reconciles all three translation resources with E-01 and records zero
 ambiguous owners. Optional-client import remains lazy, feature cleanup dispositions
 are explicit, and whole-runtime ordering remains assigned to E-09. E-04 is complete.
 
-Start only a separate #187 E-05 autocomplete source/index/single-flight ownership
-Contract from latest origin/dev. Do not start an E-05 production Move, E-06 through
-E-10, D-14 retirement, release, or Registry work inside that Contract.
+E-05a classifies one declarative source policy and two runtime resource boundaries.
+Dataset snapshots plus the cache-key Future map form one owner. The immutable index
+root plus normalized-path SQLite publication locks form a second owner. Their locks,
+failure semantics, and cleanup remain separate; no generic cache/lock port is added.
+
+Start only a separate #187 E-05b dataset snapshot/cache/Future single-flight owner
+Move from latest origin/dev. Preserve parser/source-change/status behavior, public
+identities, call-time test seams, and follower Future settlement. Do not start E-05c
+through E-05e, E-06 through E-10, D-14 retirement, release, or Registry work inside
+E-05b.
 ```

--- a/docs/architecture/python-runtime-e05-autocomplete-contract.md
+++ b/docs/architecture/python-runtime-e05-autocomplete-contract.md
@@ -1,0 +1,148 @@
+# E-05 Autocomplete Runtime Ownership Contract
+
+## Scope and authority
+
+E-05a is a production-free Contract created from
+`dev@e8f3b5b3abb7633aa122dc28956c65f664b017c6` after the completed E-04
+translation audit. It classifies current autocomplete source metadata, dataset
+snapshot and single-flight state, SQLite index publication state, production
+callers, compatibility seams, and the only authorized bounded Move order.
+
+The executable source is
+`tests/fixtures/python_autocomplete_runtime_contract.v1.json`, checked by
+`tests/test_python_autocomplete_runtime_contract.py`. Existing autocomplete index,
+dataset compatibility, locale settings, API, package, and import tests remain the
+behavior authorities.
+
+E-05a changes no production Python, analyzer, public export, import closure, cache
+policy, index schema, payload, or persistence behavior.
+
+## Declarative source policy
+
+`AUTOCOMPLETE_SOURCES` and the category-name maps remain declarative dataset
+metadata. `resolve_autocomplete_source()` selects the requested source and falls
+back to the default source when the Korean asset is absent.
+`available_autocomplete_sources()` reports the effective selection. The fallback
+does not rewrite the stored setting.
+
+These tables are not cache state and must not be absorbed into a mutable runtime
+repository. CSV parsing, header detection, category mapping, normalization, and
+entry ordering also remain feature behavior owned by the canonical dataset module.
+
+## Two runtime resource boundaries
+
+### Dataset snapshots and Future single-flight
+
+The current dataset module owns `_CACHE`, `_INFLIGHT`, and `_CACHE_LOCK`.
+Snapshots are keyed by the resolved source path plus `mtime_ns`, size, and cache
+schema version. One loader publishes a snapshot for a cache key while followers
+await the same `Future`. Loader exceptions propagate through that Future, stale
+snapshots are not published, and a source that changes during load is retried up to
+the existing four-attempt bound.
+
+E-05b moves this state behind one feature-private snapshot owner. The owner provides
+an idempotent completed-snapshot clear for isolated tests, but it does not invent a
+terminal close policy or cancel, remove, or replace an in-flight Future. Future
+settlement and whole-runtime shutdown disposition remain explicit later gates.
+Parser calls and current dynamic test seams remain call-time dependencies.
+Classification, search fallback, and public status continue to observe the same
+snapshot identity and status semantics.
+
+### Index store root and publication locks
+
+The current search module resolves `_AUTOCOMPLETE_INDEX_DIR` once from the process
+user-data boundary. When user data and package data resolve to the same standalone
+boundary, persistent indexing remains disabled so a package import cannot write to
+its source tree.
+
+The current index module owns `_INDEX_LOCKS`, `_INDEX_LOCKS_GUARD`, and the
+per-path publication critical section. The lock key deliberately uses
+`normcase(abspath(path))` without `Path.resolve()` before the directory exists;
+changing that can split first Windows access across two locks for the same eventual
+file. One per-path lock protects the second validity check, rebuild, atomic
+publication, and concurrent reuse.
+
+E-05c moves the immutable root and retained path-lock registry behind one
+feature-private index-store owner. It does not create a generic filesystem lock
+service. Read-only hit behavior, source/schema/corrupt invalidation, temporary
+SQLite construction, backend selection, atomic replace, diagnostics, and exact
+Python snapshot fallback remain unchanged. The proven resource has no disposable
+handle, so its feature close shape is an idempotent no-op unless later direct
+evidence proves otherwise.
+
+The dataset owner and index-store owner are not merged. Their locks protect
+different invariants, their failures have different meanings, and index
+unavailability intentionally falls back to a valid dataset snapshot.
+
+## Composition and compatibility target
+
+E-05d composes the two feature-private owners in bootstrap and exposes one narrow
+autocomplete-owned port through `RuntimeServices`. API adapters may receive or
+resolve that port at the adapter boundary. Autocomplete feature modules do not
+import the complete runtime, bootstrap, API adapters, or root shims.
+
+The following surfaces remain compatible throughout E-05:
+
+- `autocomplete_dataset.py` and `autocomplete_index.py` remain exact canonical
+  identity shims with unchanged `__all__`;
+- canonical `search_autocomplete`, `classify_prompt_text`, source-resolution, and
+  status functions retain their public identity and result contracts;
+- root `api.py` retains call-time callback seams for source resolution, status,
+  search, and classification;
+- the import-stable index-root patch seam remains available until E-05c replaces it
+  with an equivalent isolated owner seam;
+- package/no-host imports do not create directories or require ComfyUI host state.
+
+E-05 does not add a public runtime/bootstrap/root export or a generic cache/lock
+port.
+
+## Bounded Move queue
+
+1. **E-05a Contract — complete:** current state, two target owners, callers,
+   compatibility seams, lifecycle gaps, and Move order are versioned.
+2. **E-05b Move — dataset snapshot and single-flight ownership:** encapsulate
+   `_CACHE`, `_INFLIGHT`, and `_CACHE_LOCK` behind one feature-private owner while
+   preserving parser, source-change, Future settlement, and status behavior.
+3. **E-05c Move — index-store root and path-lock ownership:** encapsulate the
+   immutable Path-or-None root and normalized-path lock registry behind one
+   feature-private index store.
+4. **E-05d Move — bootstrap composition and adapter wiring:** compose both owners,
+   add only a narrow autocomplete port to RuntimeServices, and preserve every
+   canonical/root identity and call-time adapter seam.
+5. **E-05e Contract — completion audit:** reconcile E-01 targets, cleanup
+   dispositions, import safety, root identities, and zero ambiguous autocomplete
+   state before E-06.
+
+Each Move is a separate PR and rollback boundary. E-09 retains whole-runtime reverse
+close ordering and partial-initialization cleanup. E-05 supplies only the
+feature-owned resources and their proven cleanup shapes.
+
+## Preserved behavior
+
+All E-05 Moves preserve:
+
+- source selection, missing-source fallback, settings non-persistence, manifest
+  count fast path, and arbitrary-path exact count;
+- CSV parsing, category normalization, tag/search normalization, duplicate handling,
+  ranking, category filtering, and limit clamping;
+- snapshot cache key, source-change retry, single-loader publication, follower wait,
+  Future exception propagation, and stale-publication rejection;
+- SQLite schema/version, source identity/revision, FTS5 or prefix backend,
+  corruption/schema/source rebuild, read-only queries, temporary build, atomic
+  replace, and diagnostics;
+- locked/unreadable/build-failed fallback to exact Python snapshot results;
+- public payload/status/error meaning, root identities, API callback timing,
+  package/no-host import, and no import-time host I/O.
+
+Repository/schema/persistence/error/ranking policy changes are Behavior and remain
+out of scope.
+
+## Stop conditions
+
+Stop the owning Move if it requires a feature-to-runtime/API/bootstrap/root
+back-reference, a generic cache/lock abstraction, changed source or index behavior,
+loss of a public identity or dynamic seam, import-time directory/host I/O, merging
+the two lock lifecycles, or cancellation/replacement of a shared Future.
+
+Direct source and tests select one snapshot owner, one index-store owner, and one
+declarative policy. E-05a therefore does not trigger additional PRO review.

--- a/docs/development/README.md
+++ b/docs/development/README.md
@@ -28,6 +28,8 @@ Read only the sections needed by the active task.
      [`../architecture/python-runtime-e03-repository-filesystem-contract.md`](../architecture/python-runtime-e03-repository-filesystem-contract.md)
    - E-04 translation runtime ownership Contract:
      [`../architecture/python-runtime-e04-translation-contract.md`](../architecture/python-runtime-e04-translation-contract.md)
+   - E-05 autocomplete runtime ownership Contract:
+     [`../architecture/python-runtime-e05-autocomplete-contract.md`](../architecture/python-runtime-e05-autocomplete-contract.md)
 5. Read [`codex-blocker-escalation.md`](codex-blocker-escalation.md) only after a
    documented hard stop or unresolved cross-owner failure. Ordinary implementation
    and test failures remain local task work.
@@ -50,20 +52,20 @@ ordinary `dev` roadmap work.
 
 - Released baseline: 0.6.2.
 - Active owner: Issue #187 for Phase E; Issue #186 retains D-14/shim decisions.
-- Reviewed code baseline before E-04e: E-04d / PR #540.
+- Reviewed code baseline before E-05a: E-04e / PR #541.
 - D-08u integrated exit audit is complete.
 - D-08v is not required; the audit found no remaining D-08 production Move.
 - D-14 readiness is audited: every root surface is retained and retirement/final
   freeze is blocked by production/lifecycle consumers, missing release windows, or
   insufficient consumer evidence.
-- E-01 through E-04 are complete. The next work is only a separate #187 E-05
-  autocomplete source/index/single-flight ownership Contract. The #323 E-02a/E-07
-  bridge remains completed evidence, not authorization for unrelated feature
-  migration.
+- E-01 through E-04 and the E-05a production-free Contract are complete. The next
+  work is only a separate #187 E-05b dataset snapshot and single-flight ownership
+  Move. The #323 E-02a/E-07 bridge remains completed evidence, not authorization
+  for unrelated feature migration.
 - Completed #470 and the 0.6.1 Prompt Studio lane are behavior-contract references,
   not the active queue.
-- Do not remove root aliases or start an E-05 production Move, E-06 through E-10,
-  release, or Registry work from this entrypoint.
+- Do not remove root aliases or start E-05c+, E-06 through E-10, release, or
+  Registry work from this entrypoint.
 
 ## Completed D-08 composition audit surface
 
@@ -154,6 +156,6 @@ representative profile list/load/save/delete/rename/fix live smoke
 - A version marker is not a publish action.
 - Technical PRO review is for unresolved cross-boundary architecture choices,
   unavoidable cycles, or insufficient compatibility evidence—not routine failures.
-- D-14 readiness is recorded and authorizes no removal. E-04 ownership is complete;
-  use its evidence only as the finished translation boundary before the separate
-  E-05 Contract. Do not infer E-09 cleanup, release publication, or Registry actions.
+- D-14 readiness is recorded and authorizes no removal. E-05a ownership is fixed;
+  use it only to start the separate E-05b Move. Do not infer E-05c+, E-09 cleanup,
+  release publication, or Registry actions.

--- a/tests/fixtures/python_autocomplete_runtime_contract.v1.json
+++ b/tests/fixtures/python_autocomplete_runtime_contract.v1.json
@@ -1,0 +1,221 @@
+{
+  "classification": "Contract",
+  "compatibility_surfaces": [
+    {
+      "id": "root-dataset-identity-shim",
+      "kind": "identity_reexport",
+      "module": "autocomplete_dataset.py",
+      "symbols": [
+        "AUTOCOMPLETE_CSV",
+        "AUTOCOMPLETE_SOURCES",
+        "AutocompleteEntry",
+        "autocomplete_status",
+        "classify_prompt_text",
+        "resolve_autocomplete_source",
+        "search_autocomplete"
+      ]
+    },
+    {
+      "id": "root-index-identity-shim",
+      "kind": "identity_reexport",
+      "module": "autocomplete_index.py",
+      "symbols": [
+        "AutocompleteIndexSource",
+        "AutocompleteIndexUnavailable",
+        "search_autocomplete_index"
+      ]
+    },
+    {
+      "id": "root-api-call-time-seams",
+      "kind": "dynamic_callback",
+      "module": "api.py",
+      "symbols": [
+        "autocomplete_status",
+        "classify_prompt_text",
+        "resolve_autocomplete_source",
+        "search_autocomplete"
+      ]
+    }
+  ],
+  "decisions": {
+    "adapter_access": "API adapters receive or resolve one narrow autocomplete port; autocomplete feature modules do not import RuntimeServices, bootstrap, API adapters, or root compatibility shims.",
+    "bootstrap_composition": "Bootstrap is the only target production composition root for the default snapshot and index-store owners and the eventual narrow RuntimeServices autocomplete port.",
+    "declarative_source_policy": "AUTOCOMPLETE_SOURCES and category maps remain declarative dataset metadata; source selection and missing Korean-source fallback do not become runtime mutable state.",
+    "generic_cache_lock_port": "rejected",
+    "resource_partition": "Dataset snapshots and Future single-flight form one owner. The index root and normalized-path publication locks form a second owner. They retain independent locks, cleanup, and failure semantics.",
+    "runtime_fields": "E-05d may add only a narrow autocomplete-owned port to RuntimeServices; feature code never receives the complete runtime."
+  },
+  "declarative_policy": [
+    {
+      "e01_module": "easyuse_anima/autocomplete/dataset.py",
+      "id": "source-and-category-metadata",
+      "module": "easyuse_anima/autocomplete/dataset.py",
+      "symbols": [
+        "AUTOCOMPLETE_SOURCES",
+        "_DANBOORU_CATEGORY_NAMES",
+        "_E621_CATEGORY_NAMES",
+        "_MERGED_E621_CATEGORY_NAMES"
+      ]
+    }
+  ],
+  "move_queue": [
+    {
+      "classification": "Contract",
+      "goal": "Freeze current state, behavior authorities, compatibility seams, target owners, and bounded Move order.",
+      "id": "E-05a",
+      "name": "autocomplete runtime ownership contract",
+      "status": "complete"
+    },
+    {
+      "classification": "Move",
+      "goal": "Encapsulate dataset snapshots, cache publication, and Future single-flight behind one feature-private owner while preserving call-time parser and test seams.",
+      "id": "E-05b",
+      "name": "dataset snapshot and single-flight ownership",
+      "status": "queued"
+    },
+    {
+      "classification": "Move",
+      "goal": "Encapsulate the immutable index root and normalized-path publication lock registry behind one autocomplete index-store owner.",
+      "id": "E-05c",
+      "name": "index-store root and path-lock ownership",
+      "status": "blocked-by-E-05b"
+    },
+    {
+      "classification": "Move",
+      "goal": "Compose the two autocomplete owners in bootstrap, expose one narrow RuntimeServices port, and wire existing adapter facades without changing public identities.",
+      "id": "E-05d",
+      "name": "bootstrap composition and adapter wiring",
+      "status": "blocked-by-E-05c"
+    },
+    {
+      "classification": "Contract",
+      "goal": "Reconcile E-01 targets, cleanup dispositions, root identities, and zero ambiguous autocomplete state before E-06.",
+      "id": "E-05e",
+      "name": "autocomplete ownership completion audit",
+      "status": "blocked-by-E-05d"
+    }
+  ],
+  "owners": [
+    {
+      "cleanup": {
+        "current": "Tests clear _CACHE and _INFLIGHT under _CACHE_LOCK; production has no owner-level close or reset.",
+        "target": "The feature-private owner exposes an idempotent completed-snapshot clear for isolated tests; in-flight Future settlement and whole-runtime shutdown disposition remain explicit later gates."
+      },
+      "current_owner": "easyuse_anima.autocomplete.dataset",
+      "e01_entries": [
+        "autocomplete-dataset-cache"
+      ],
+      "evidence": [
+        "tests/test_autocomplete_index.py",
+        "tests/test_autocomplete_dataset_compatibility.py",
+        "tests/test_autocomplete_locale_settings.py"
+      ],
+      "id": "dataset-snapshots",
+      "lifetime": "Process lifetime, keyed by resolved source path and source stat/schema revision.",
+      "locking": "One Lock protects the path snapshot cache and cache-key Future map; one loader builds each key while followers await the same Future.",
+      "module": "easyuse_anima/autocomplete/dataset.py",
+      "preserved_behavior": [
+        "CSV parsing, header detection, normalization, category mapping, and stable entry ordering",
+        "cache key resolved path, mtime_ns, size, and schema version",
+        "four-attempt source-change retry and no publication of a stale snapshot",
+        "loader exception propagation through the shared Future",
+        "status fast path and arbitrary-path exact count semantics"
+      ],
+      "state_symbols": [
+        "_CACHE",
+        "_CACHE_LOCK",
+        "_INFLIGHT"
+      ],
+      "target_owner": "feature-private autocomplete dataset snapshot owner",
+      "target_phase": "E-05b"
+    },
+    {
+      "cleanup": {
+        "current": "The index root is immutable after import and path locks remain for process lifetime; production has no reset.",
+        "target": "The feature-private index store owns the immutable root and retained path-lock registry; close is an idempotent no-op unless direct evidence later proves disposable resources."
+      },
+      "current_owners": [
+        {
+          "e01_entry": "autocomplete-index-locks",
+          "owner": "easyuse_anima.autocomplete.index"
+        },
+        {
+          "e01_entry": "autocomplete-index-root",
+          "owner": "easyuse_anima.autocomplete.search"
+        }
+      ],
+      "e01_entries": [
+        "autocomplete-index-locks",
+        "autocomplete-index-root"
+      ],
+      "evidence": [
+        "tests/test_autocomplete_index.py",
+        "tests/test_python_package_skeleton.py"
+      ],
+      "id": "index-store",
+      "lifetime": "Process lifetime, one immutable Path-or-None root and one retained Lock per normalized index path.",
+      "locking": "A guard serializes per-path Lock creation; each Lock serializes recheck, rebuild, atomic publication, and concurrent reuse for one index path.",
+      "modules": [
+        "easyuse_anima/autocomplete/index.py",
+        "easyuse_anima/autocomplete/search.py"
+      ],
+      "preserved_behavior": [
+        "standalone package-data boundary disables persistent indexing",
+        "tests may isolate the import-stable index root without host I/O",
+        "lock keys use normcase(abspath(path)) without pre-directory Path.resolve",
+        "readonly hit, schema/source/corrupt rebuild, temporary SQLite build, synchronous FULL commit, and atomic replace",
+        "locked, unreadable, or build failures keep exact Python snapshot fallback and diagnostics"
+      ],
+      "state_symbols": {
+        "easyuse_anima/autocomplete/index.py": [
+          "_INDEX_LOCKS",
+          "_INDEX_LOCKS_GUARD"
+        ],
+        "easyuse_anima/autocomplete/search.py": [
+          "_AUTOCOMPLETE_INDEX_DIR"
+        ]
+      },
+      "target_owner": "feature-private autocomplete index store",
+      "target_phase": "E-05c"
+    }
+  ],
+  "production_callers": [
+    {
+      "entry": "classification snapshot",
+      "function": "classify_prompt_text",
+      "module": "easyuse_anima/autocomplete/classification.py",
+      "owner": "dataset-snapshots",
+      "uses": [
+        "_snapshot",
+        "_snapshot_status"
+      ]
+    },
+    {
+      "entry": "search snapshot and index",
+      "function": "_search_autocomplete_with_diagnostics",
+      "module": "easyuse_anima/autocomplete/search.py",
+      "owners": [
+        "dataset-snapshots",
+        "index-store"
+      ],
+      "uses": [
+        "_AUTOCOMPLETE_INDEX_DIR",
+        "_snapshot",
+        "search_autocomplete_index"
+      ]
+    },
+    {
+      "entry": "public status",
+      "function": "autocomplete_status",
+      "module": "easyuse_anima/autocomplete/dataset.py",
+      "owner": "dataset-snapshots",
+      "uses": [
+        "_cached_snapshot_for_key",
+        "_snapshot"
+      ]
+    }
+  ],
+  "production_changes": 0,
+  "schema_version": 1,
+  "scope": "E-05 autocomplete source metadata, dataset snapshot/cache/Future single-flight, SQLite index root and publication path-lock ownership"
+}

--- a/tests/fixtures/python_runtime_state_ownership.v1.json
+++ b/tests/fixtures/python_runtime_state_ownership.v1.json
@@ -185,7 +185,7 @@
       "module": "easyuse_anima/autocomplete/dataset.py",
       "owner": "easyuse_anima.autocomplete.dataset",
       "symbols": ["_CACHE", "_CACHE_LOCK", "_INFLIGHT"],
-      "target_phase": "E-05",
+      "target_phase": "E-05b",
       "test_evidence": ["tests/test_autocomplete_index.py"],
       "thread_safety": "One Lock protects cache snapshots and the Future single-flight map."
     },
@@ -197,7 +197,7 @@
       "module": "easyuse_anima/autocomplete/index.py",
       "owner": "easyuse_anima.autocomplete.index",
       "symbols": ["_INDEX_LOCKS", "_INDEX_LOCKS_GUARD"],
-      "target_phase": "E-05",
+      "target_phase": "E-05c",
       "test_evidence": ["tests/test_autocomplete_index.py"],
       "thread_safety": "The guard serializes creation; each per-path Lock serializes index publication."
     },
@@ -209,7 +209,7 @@
       "module": "easyuse_anima/autocomplete/search.py",
       "owner": "easyuse_anima.autocomplete.search",
       "symbols": ["_AUTOCOMPLETE_INDEX_DIR"],
-      "target_phase": "E-05",
+      "target_phase": "E-05c",
       "test_evidence": ["tests/test_autocomplete_index.py", "tests/test_python_package_skeleton.py"],
       "thread_safety": "Immutable Path-or-None after import."
     },

--- a/tests/test_python_autocomplete_runtime_contract.py
+++ b/tests/test_python_autocomplete_runtime_contract.py
@@ -1,0 +1,412 @@
+from __future__ import annotations
+
+import ast
+import json
+import unittest
+from functools import lru_cache
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+FIXTURE_PATH = (
+    ROOT / "tests" / "fixtures" / "python_autocomplete_runtime_contract.v1.json"
+)
+E01_FIXTURE_PATH = (
+    ROOT / "tests" / "fixtures" / "python_runtime_state_ownership.v1.json"
+)
+CONTRACT_DOC = (
+    ROOT
+    / "docs"
+    / "architecture"
+    / "python-runtime-e05-autocomplete-contract.md"
+)
+
+
+@lru_cache(maxsize=None)
+def _tree(module: str) -> ast.Module:
+    path = ROOT / module
+    return ast.parse(
+        path.read_text(encoding="utf-8-sig"),
+        filename=str(path),
+    )
+
+
+def _target_names(target: ast.expr) -> set[str]:
+    if isinstance(target, ast.Name):
+        return {target.id}
+    if isinstance(target, (ast.List, ast.Tuple)):
+        return {
+            name
+            for element in target.elts
+            for name in _target_names(element)
+        }
+    return set()
+
+
+def _top_level_bindings(module: str) -> set[str]:
+    names: set[str] = set()
+
+    def collect(statements: list[ast.stmt]) -> None:
+        for statement in statements:
+            if isinstance(
+                statement,
+                (ast.ClassDef, ast.FunctionDef, ast.AsyncFunctionDef),
+            ):
+                names.add(statement.name)
+            elif isinstance(statement, ast.Assign):
+                for target in statement.targets:
+                    names.update(_target_names(target))
+            elif isinstance(statement, ast.AnnAssign):
+                names.update(_target_names(statement.target))
+            elif isinstance(statement, (ast.Import, ast.ImportFrom)):
+                for alias in statement.names:
+                    names.add(alias.asname or alias.name.split(".", 1)[0])
+            elif isinstance(statement, ast.If):
+                collect(statement.body)
+                collect(statement.orelse)
+            elif isinstance(statement, ast.Try):
+                collect(statement.body)
+                for handler in statement.handlers:
+                    collect(handler.body)
+                collect(statement.orelse)
+                collect(statement.finalbody)
+
+    collect(_tree(module).body)
+    return names
+
+
+def _top_level_function(
+    module: str,
+    function_name: str,
+) -> ast.FunctionDef | ast.AsyncFunctionDef:
+    for statement in _tree(module).body:
+        if isinstance(statement, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            if statement.name == function_name:
+                return statement
+    raise AssertionError(f"{module} has no top-level function {function_name}")
+
+
+def _function_references(module: str, function_name: str) -> set[str]:
+    return {
+        node.id
+        for node in ast.walk(_top_level_function(module, function_name))
+        if isinstance(node, ast.Name)
+    }
+
+
+def _called_attributes(module: str, function_name: str) -> set[str]:
+    called: set[str] = set()
+    for node in ast.walk(_top_level_function(module, function_name)):
+        if not isinstance(node, ast.Call):
+            continue
+        function = node.func
+        if isinstance(function, ast.Attribute):
+            called.add(function.attr)
+        elif isinstance(function, ast.Name):
+            called.add(function.id)
+    return called
+
+
+def _top_level_assignment_call(module: str, assigned_name: str) -> str:
+    for statement in _tree(module).body:
+        if not isinstance(statement, (ast.Assign, ast.AnnAssign)):
+            continue
+        targets = (
+            statement.targets
+            if isinstance(statement, ast.Assign)
+            else [statement.target]
+        )
+        if not any(assigned_name in _target_names(target) for target in targets):
+            continue
+        value = statement.value
+        if isinstance(value, ast.Call):
+            if isinstance(value.func, ast.Name):
+                return value.func.id
+            if isinstance(value.func, ast.Attribute):
+                return value.func.attr
+    raise AssertionError(f"{module} has no call assignment for {assigned_name}")
+
+
+class PythonAutocompleteRuntimeContractTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.fixture = json.loads(FIXTURE_PATH.read_text(encoding="utf-8"))
+        cls.e01_fixture = json.loads(
+            E01_FIXTURE_PATH.read_text(encoding="utf-8")
+        )
+
+    def test_schema_queue_and_evidence_are_complete(self):
+        self.assertEqual(
+            set(self.fixture),
+            {
+                "classification",
+                "compatibility_surfaces",
+                "decisions",
+                "declarative_policy",
+                "move_queue",
+                "owners",
+                "production_callers",
+                "production_changes",
+                "schema_version",
+                "scope",
+            },
+        )
+        self.assertEqual(self.fixture["schema_version"], 1)
+        self.assertEqual(self.fixture["classification"], "Contract")
+        self.assertEqual(self.fixture["production_changes"], 0)
+        self.assertEqual(
+            [move["id"] for move in self.fixture["move_queue"]],
+            ["E-05a", "E-05b", "E-05c", "E-05d", "E-05e"],
+        )
+        self.assertEqual(
+            [move["classification"] for move in self.fixture["move_queue"]],
+            ["Contract", "Move", "Move", "Move", "Contract"],
+        )
+        self.assertEqual(
+            [owner["id"] for owner in self.fixture["owners"]],
+            ["dataset-snapshots", "index-store"],
+        )
+        for owner in self.fixture["owners"]:
+            with self.subTest(owner=owner["id"]):
+                self.assertTrue(owner["evidence"])
+                for evidence in owner["evidence"]:
+                    self.assertTrue((ROOT / evidence).is_file(), evidence)
+
+    def test_e01_entries_reconcile_to_two_exact_future_owners(self):
+        e01_entries = {
+            entry["id"]: entry for entry in self.e01_fixture["entries"]
+        }
+        owners = {owner["id"]: owner for owner in self.fixture["owners"]}
+        self.assertEqual(
+            {
+                e01_entry
+                for owner in owners.values()
+                for e01_entry in owner["e01_entries"]
+            },
+            {
+                "autocomplete-dataset-cache",
+                "autocomplete-index-locks",
+                "autocomplete-index-root",
+            },
+        )
+
+        dataset_owner = owners["dataset-snapshots"]
+        dataset_entry = e01_entries["autocomplete-dataset-cache"]
+        self.assertEqual(dataset_entry["owner"], dataset_owner["current_owner"])
+        self.assertEqual(dataset_entry["target_phase"], "E-05b")
+        self.assertEqual(
+            set(dataset_entry["symbols"]),
+            set(dataset_owner["state_symbols"]),
+        )
+
+        index_owner = owners["index-store"]
+        current_owners = {
+            item["e01_entry"]: item["owner"]
+            for item in index_owner["current_owners"]
+        }
+        for entry_id in (
+            "autocomplete-index-locks",
+            "autocomplete-index-root",
+        ):
+            with self.subTest(entry=entry_id):
+                self.assertEqual(
+                    e01_entries[entry_id]["owner"],
+                    current_owners[entry_id],
+                )
+                self.assertEqual(
+                    e01_entries[entry_id]["target_phase"],
+                    "E-05c",
+                )
+
+    def test_source_metadata_remains_declarative_and_separate(self):
+        expected = {
+            (policy["e01_module"], symbol)
+            for policy in self.fixture["declarative_policy"]
+            for symbol in policy["symbols"]
+        }
+        actual = {
+            (entry["module"], symbol)
+            for entry in self.e01_fixture["declarative_mutable_globals"]
+            for symbol in entry["symbols"]
+        }
+        self.assertEqual(expected - actual, set())
+        self.assertEqual(
+            self.fixture["decisions"]["generic_cache_lock_port"],
+            "rejected",
+        )
+        partition = self.fixture["decisions"]["resource_partition"].lower()
+        self.assertIn("one owner", partition)
+        self.assertIn("second owner", partition)
+
+    def test_dataset_snapshot_state_and_single_flight_contract_are_current(self):
+        bindings = _top_level_bindings(
+            "easyuse_anima/autocomplete/dataset.py"
+        )
+        self.assertTrue({"_CACHE", "_CACHE_LOCK", "_INFLIGHT"} <= bindings)
+        snapshot_references = _function_references(
+            "easyuse_anima/autocomplete/dataset.py",
+            "_snapshot_for_key",
+        )
+        self.assertTrue(
+            {"_CACHE", "_CACHE_LOCK", "_INFLIGHT", "Future"}
+            <= snapshot_references
+        )
+        self.assertTrue(
+            {"set_exception", "set_result", "result"}
+            <= (
+                _called_attributes(
+                    "easyuse_anima/autocomplete/dataset.py",
+                    "_snapshot_for_key",
+                )
+                | _called_attributes(
+                    "easyuse_anima/autocomplete/dataset.py",
+                    "_await_snapshot",
+                )
+            )
+        )
+        self.assertIn(
+            "_AUTOCOMPLETE_CACHE_LOAD_ATTEMPTS",
+            _function_references(
+                "easyuse_anima/autocomplete/dataset.py",
+                "_snapshot",
+            ),
+        )
+        self.assertTrue(
+            {"_cached_snapshot_for_key", "_snapshot"}
+            <= _function_references(
+                "easyuse_anima/autocomplete/dataset.py",
+                "autocomplete_status",
+            )
+        )
+
+    def test_index_root_and_path_publication_lock_contract_are_current(self):
+        index_bindings = _top_level_bindings(
+            "easyuse_anima/autocomplete/index.py"
+        )
+        self.assertTrue(
+            {"_INDEX_LOCKS", "_INDEX_LOCKS_GUARD"} <= index_bindings
+        )
+        lock_references = _function_references(
+            "easyuse_anima/autocomplete/index.py",
+            "_index_lock",
+        )
+        self.assertTrue(
+            {"_INDEX_LOCKS", "_INDEX_LOCKS_GUARD", "os"} <= lock_references
+        )
+        called = _called_attributes(
+            "easyuse_anima/autocomplete/index.py",
+            "_index_lock",
+        )
+        self.assertTrue({"abspath", "normcase"} <= called)
+        self.assertNotIn("resolve", called)
+        self.assertIn(
+            "_index_lock",
+            _function_references(
+                "easyuse_anima/autocomplete/index.py",
+                "search_autocomplete_index",
+            ),
+        )
+
+        self.assertEqual(
+            _top_level_assignment_call(
+                "easyuse_anima/autocomplete/search.py",
+                "_AUTOCOMPLETE_INDEX_DIR",
+            ),
+            "_default_autocomplete_index_dir",
+        )
+        root_references = _function_references(
+            "easyuse_anima/autocomplete/search.py",
+            "_default_autocomplete_index_dir",
+        )
+        self.assertTrue(
+            {"USER_DATA_DIR", "STORAGE_PACKAGE_DATA_DIR", "Path"}
+            <= root_references
+        )
+        self.assertTrue(
+            {
+                "_AUTOCOMPLETE_INDEX_DIR",
+                "_snapshot",
+                "search_autocomplete_index",
+            }
+            <= _function_references(
+                "easyuse_anima/autocomplete/search.py",
+                "_search_autocomplete_with_diagnostics",
+            )
+        )
+
+    def test_production_callers_and_compatibility_surfaces_are_current(self):
+        owner_ids = {owner["id"] for owner in self.fixture["owners"]}
+        for caller in self.fixture["production_callers"]:
+            with self.subTest(caller=caller["entry"]):
+                claimed = set(caller.get("owners", [caller.get("owner")]))
+                self.assertEqual(claimed - owner_ids, set())
+                self.assertEqual(
+                    set(caller["uses"])
+                    - _function_references(
+                        caller["module"],
+                        caller["function"],
+                    ),
+                    set(),
+                )
+        for surface in self.fixture["compatibility_surfaces"]:
+            with self.subTest(surface=surface["id"]):
+                self.assertEqual(
+                    set(surface["symbols"])
+                    - _top_level_bindings(surface["module"]),
+                    set(),
+                )
+
+    def test_feature_modules_do_not_depend_on_runtime_or_outer_adapters(self):
+        forbidden = {
+            "api",
+            "autocomplete_dataset",
+            "autocomplete_index",
+            "easyuse_anima.api",
+            "easyuse_anima.bootstrap",
+            "easyuse_anima.runtime",
+        }
+        for module in (
+            "easyuse_anima/autocomplete/classification.py",
+            "easyuse_anima/autocomplete/dataset.py",
+            "easyuse_anima/autocomplete/index.py",
+            "easyuse_anima/autocomplete/search.py",
+        ):
+            imports = {
+                node.module
+                for node in ast.walk(_tree(module))
+                if isinstance(node, ast.ImportFrom) and node.module
+            }
+            with self.subTest(module=module):
+                self.assertEqual(imports & forbidden, set())
+
+        runtime = next(
+            statement
+            for statement in _tree("easyuse_anima/runtime.py").body
+            if isinstance(statement, ast.ClassDef)
+            and statement.name == "RuntimeServices"
+        )
+        fields = {
+            statement.target.id
+            for statement in runtime.body
+            if isinstance(statement, ast.AnnAssign)
+            and isinstance(statement.target, ast.Name)
+        }
+        self.assertNotIn("autocomplete", fields)
+
+    def test_contract_document_is_linked_from_maintained_entries(self):
+        self.assertTrue(CONTRACT_DOC.is_file())
+        architecture_entry = (
+            ROOT / "docs" / "architecture" / "README.md"
+        ).read_text(encoding="utf-8")
+        development_entry = (
+            ROOT / "docs" / "development" / "README.md"
+        ).read_text(encoding="utf-8")
+        self.assertIn(CONTRACT_DOC.name, architecture_entry)
+        self.assertIn(
+            f"../architecture/{CONTRACT_DOC.name}",
+            development_entry,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 목적과 변경 경계

Issue #187 E-05a production-free Contract입니다. Autocomplete의 declarative source policy와 두 runtime resource owner를 실행 가능한 계약으로 고정합니다.

- source/category metadata와 missing-source fallback은 declarative dataset policy로 유지
- dataset snapshot/cache/Future single-flight는 E-05b의 단일 feature-private owner로 지정
- immutable index root와 normalized-path SQLite publication locks는 E-05c의 단일 index-store owner로 지정
- generic cache/lock port, production wiring, public export, behavior 변경 없음
- E-05b → E-05c → E-05d → E-05e의 별도 rollback queue 고정

## Base → Head

- Base: `e8f3b5b3abb7633aa122dc28956c65f664b017c6` (latest `origin/dev`, PR #541)
- Head: `8c69583e6580750cfa859aab6afc32dc9fd3db55`

## 주요 파일과 보존 계약

- `tests/fixtures/python_autocomplete_runtime_contract.v1.json`
- `tests/test_python_autocomplete_runtime_contract.py`
- `docs/architecture/python-runtime-e05-autocomplete-contract.md`
- E-01 target reconciliation 및 maintained resume/index 문서

보존:
- source fallback/settings non-persistence
- CSV parsing/category/normalization/ranking/status
- cache key, four-attempt source-change retry, one-loader/Future settlement
- SQLite schema/rebuild/atomic publication/fallback diagnostics
- `normcase(abspath())` Windows lock identity
- canonical/root identity, `__all__`, root API call-time seams
- package/no-host import 및 import-time host I/O 없음

## 검증

Focused:
- E-05 Contract: 8
- E-01 ownership: 5
- autocomplete index: 9
- dataset compatibility: 3
- locale source settings: 7
- RuntimeServices: 8
- bootstrap: 5
- package skeleton: 1
- completed import boundary: 6
- analyzer: 18
- changed Python syntax/fatal Ruff, JSON parse, `git diff --check` 통과

Final candidate official full 정확히 1회:
- Python unittest: 1,361
- frontend smoke: 120
- Pyright baseline ratchet: 통과
- import boundary: 11 groups / 0 violations
- project full: 통과

Package/live/validate/pack:
- production/shipped/import closure 변경이 없어 기존 evidence 재사용(`not retriggered`)

## 위험과 rollback

- 이 PR은 owner Move가 아니라 Contract이므로 runtime behavior는 바뀌지 않습니다.
- E-05b에서 in-flight Future를 clear/cancel/replace하거나 parser/source-change seam을 정적으로 고정하면 stop condition입니다.
- rollback은 이 단일 production-free commit revert입니다.

## Next

Squash merge 후 최신 `origin/dev`에서 별도 E-05b dataset snapshot/cache/Future single-flight owner Move만 시작합니다. E-05c+, E-06+, E-09 구현, D-14 retirement, release/Registry는 시작하지 않습니다.