### PR TITLE
refactor: own autocomplete snapshot flights

### DIFF
--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -10,15 +10,14 @@ then only the active task section, owning Issue, direct source, and direct tests
 ## Active sequencing
 
 - Issue [#187](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/187)
-  owns Phase E. E-01 through E-04 and the production-free E-05a Contract are
-  complete; the next bounded unit is the separate E-05b dataset snapshot and
-  single-flight ownership Move.
+  owns Phase E. E-01 through E-04, E-05a, and E-05b are complete; the next bounded
+  unit is the separate E-05c index-store root and path-lock ownership Move.
   Issue #186 retains D-14/shim decisions.
 - [`backend-roadmap-resume-0.6.2.md`](backend-roadmap-resume-0.6.2.md)
   is the current execution source of truth. Read it before the older accumulated
   roadmap.
-- Reviewed code baseline before E-05a: E-04e / PR #541 at
-  `e8f3b5b3abb7633aa122dc28956c65f664b017c6`.
+- Reviewed code baseline before E-05b: E-05a / PR #542 at
+  `ce53be1c5eccc16967372952a3af8a64f862c4f6`.
 - D-08 is complete and D-08v is not required.
 - D-14 readiness retains every root surface; retirement/final-freeze work is blocked.
 - E-01 inventory Contract:
@@ -37,14 +36,14 @@ then only the active task section, owning Issue, direct source, and direct tests
   [`python-runtime-e04-translation-contract.md`](python-runtime-e04-translation-contract.md).
 - E-05 autocomplete runtime ownership Contract:
   [`python-runtime-e05-autocomplete-contract.md`](python-runtime-e05-autocomplete-contract.md).
-- First READY task after E-05a: a separate #187 E-05b dataset snapshot and
-  single-flight ownership Move only.
+- First READY task after E-05b: a separate #187 E-05c index-store root and
+  normalized-path publication-lock ownership Move only.
 - Completed #470 and the #413/#414/#415 queue/live-UI lanes remain contract references,
   not active blockers.
 - Released code baseline: 0.6.2. Registry activation is external administration and
   does not block `dev`; do not republish or mutate the release.
 - Completed #409/#410/#411 and deferred #440/#441 do not alter the E-01 boundary.
-- E-05a authorizes only the separate E-05b Move. It does not authorize E-05c+
+- E-05b authorizes only the separate E-05c Move. It does not authorize E-05d+
   implementation, later Phase E work, root removal, release, or Registry.
 
 ## Current code boundary
@@ -90,8 +89,8 @@ aliases or absorbing feature behavior.
   completed translation provider/client, service cache/single-flight, route executor
   owners, lifecycle gaps, and the E-04 completion audit.
 - [`python-runtime-e05-autocomplete-contract.md`](python-runtime-e05-autocomplete-contract.md):
-  autocomplete declarative source policy, snapshot/Future owner, index-store root
-  and path-lock owner, compatibility seams, and bounded Move queue.
+  autocomplete declarative source policy, completed snapshot/Future owner Move,
+  queued index-store root/path-lock owner, compatibility seams, and bounded queue.
 - [`adr-001-modular-monolith.md`](adr-001-modular-monolith.md): feature-oriented modular
   monolith decision.
 - [`adr-002-compatibility-shims.md`](adr-002-compatibility-shims.md): shim lifecycle and

--- a/docs/architecture/backend-roadmap-resume-0.6.2.md
+++ b/docs/architecture/backend-roadmap-resume-0.6.2.md
@@ -2,17 +2,16 @@
 
 ## Status and authority
 
-- Status: D-08, E-01 through E-04, and the production-free E-05a Contract are
-  completed; the D-14 readiness audit retains every root surface and blocks
-  retirement/final-freeze work.
-- Code-review base before E-05a:
-  `dev@e8f3b5b3abb7633aa122dc28956c65f664b017c6` after E-04e / PR #541.
-- Document baseline: completed production-free E-05 autocomplete ownership
-  Contract.
+- Status: D-08, E-01 through E-04, E-05a, and E-05b are completed; the D-14
+  readiness audit retains every root surface and blocks retirement/final-freeze
+  work.
+- Code-review base before E-05b:
+  `dev@ce53be1c5eccc16967372952a3af8a64f862c4f6` after E-05a / PR #542.
+- Document baseline: completed E-05b dataset snapshot/single-flight owner Move.
 - Released baseline: 0.6.2.
 - Scope: completed D-08 evidence, the D-14 readiness decision, completed #187
-  E-01/E-02/E-03/E-04 work, the E-05a ownership Contract, and the next bounded
-  E-05b dataset snapshot/single-flight Move.
+  E-01/E-02/E-03/E-04 work, the E-05a Contract, the E-05b snapshot owner Move,
+  and the next bounded E-05c index-store Move.
 - This document owns the current immediate queue and supersedes the stale queue and
   broad preflight command in `python-backend-execution-roadmap.md`.
 - `python-backend.md`, ADR-001, ADR-002, and the compatibility-shim registry still own
@@ -365,9 +364,16 @@ Dataset snapshots plus the cache-key Future map form one owner. The immutable in
 root plus normalized-path SQLite publication locks form a second owner. Their locks,
 failure semantics, and cleanup remain separate; no generic cache/lock port is added.
 
-Start only a separate #187 E-05b dataset snapshot/cache/Future single-flight owner
-Move from latest origin/dev. Preserve parser/source-change/status behavior, public
-identities, call-time test seams, and follower Future settlement. Do not start E-05c
-through E-05e, E-06 through E-10, D-14 retirement, release, or Registry work inside
-E-05b.
+E-05b moves completed snapshots, cache-key Futures, and their Lock behind one
+private `_AutocompleteSnapshotStore` referenced by
+`_DEFAULT_AUTOCOMPLETE_SNAPSHOTS`. Call-time parser/stat/build/await facades,
+source-change retries, follower settlement, status behavior, and public identities
+are unchanged. `clear()` affects only completed snapshots and no duplicate module
+dict/lock/Future state remains.
+
+Start only a separate #187 E-05c index-store root/normalized-path publication-lock
+owner Move from latest origin/dev. Preserve standalone index disablement, Windows
+pre-directory lock identity, rebuild/atomic publication/fallback diagnostics, and
+the isolated root seam. Do not start E-05d through E-05e, E-06 through E-10, D-14
+retirement, release, or Registry work inside E-05c.
 ```

--- a/docs/architecture/python-runtime-e05-autocomplete-contract.md
+++ b/docs/architecture/python-runtime-e05-autocomplete-contract.md
@@ -7,6 +7,8 @@ E-05a is a production-free Contract created from
 translation audit. It classifies current autocomplete source metadata, dataset
 snapshot and single-flight state, SQLite index publication state, production
 callers, compatibility seams, and the only authorized bounded Move order.
+E-05b moves only the dataset snapshot/cache/Future state behind its selected
+feature-private owner.
 
 The executable source is
 `tests/fixtures/python_autocomplete_runtime_contract.v1.json`, checked by
@@ -33,20 +35,22 @@ entry ordering also remain feature behavior owned by the canonical dataset modul
 
 ### Dataset snapshots and Future single-flight
 
-The current dataset module owns `_CACHE`, `_INFLIGHT`, and `_CACHE_LOCK`.
-Snapshots are keyed by the resolved source path plus `mtime_ns`, size, and cache
-schema version. One loader publishes a snapshot for a cache key while followers
-await the same `Future`. Loader exceptions propagate through that Future, stale
-snapshots are not published, and a source that changes during load is retried up to
-the existing four-attempt bound.
+`_DEFAULT_AUTOCOMPLETE_SNAPSHOTS` is the process owner. Its private
+`_AutocompleteSnapshotStore` instance owns one Lock, the resolved-path completed
+snapshot cache, and the cache-key Future map. Snapshots remain keyed by the resolved
+source path plus `mtime_ns`, size, and cache schema version. One loader publishes a
+snapshot for a cache key while followers await the same `Future`. Loader exceptions
+propagate through that Future, stale snapshots are not published, and a source that
+changes during load is retried up to the existing four-attempt bound.
 
-E-05b moves this state behind one feature-private snapshot owner. The owner provides
-an idempotent completed-snapshot clear for isolated tests, but it does not invent a
-terminal close policy or cancel, remove, or replace an in-flight Future. Future
-settlement and whole-runtime shutdown disposition remain explicit later gates.
-Parser calls and current dynamic test seams remain call-time dependencies.
-Classification, search fallback, and public status continue to observe the same
-snapshot identity and status semantics.
+The module `_snapshot_for_key()` and `_cached_snapshot_for_key()` facades resolve
+the current default owner at call time. The owner method likewise resolves
+`_build_snapshot`, `_cache_key_from_resolved_path`, and `_await_snapshot` at call
+time, preserving the direct monkeypatch seams. `clear()` idempotently clears only
+completed snapshots; it does not invent a terminal close policy or cancel, remove,
+or replace an in-flight Future. Future settlement and whole-runtime shutdown
+disposition remain explicit later gates. Classification, search fallback, and
+public status continue to observe the same snapshot identity and status semantics.
 
 ### Index store root and publication locks
 
@@ -100,9 +104,10 @@ port.
 
 1. **E-05a Contract — complete:** current state, two target owners, callers,
    compatibility seams, lifecycle gaps, and Move order are versioned.
-2. **E-05b Move — dataset snapshot and single-flight ownership:** encapsulate
-   `_CACHE`, `_INFLIGHT`, and `_CACHE_LOCK` behind one feature-private owner while
-   preserving parser, source-change, Future settlement, and status behavior.
+2. **E-05b Move — dataset snapshot and single-flight ownership — complete:**
+   `_AutocompleteSnapshotStore` owns the cache, Future map, and Lock behind one
+   default reference while preserving parser, source-change, Future settlement,
+   status, and call-time patch behavior.
 3. **E-05c Move — index-store root and path-lock ownership:** encapsulate the
    immutable Path-or-None root and normalized-path lock registry behind one
    feature-private index store.
@@ -116,6 +121,9 @@ port.
 Each Move is a separate PR and rollback boundary. E-09 retains whole-runtime reverse
 close ordering and partial-initialization cleanup. E-05 supplies only the
 feature-owned resources and their proven cleanup shapes.
+
+E-05b leaves no duplicate module cache/lock/Future map. The next READY unit is the
+separate E-05c index-store root and normalized-path publication-lock Move.
 
 ## Preserved behavior
 
@@ -146,3 +154,4 @@ the two lock lifecycles, or cancellation/replacement of a shared Future.
 
 Direct source and tests select one snapshot owner, one index-store owner, and one
 declarative policy. E-05a therefore does not trigger additional PRO review.
+E-05b preserves that partition and does not trigger a new PRO review.

--- a/docs/development/README.md
+++ b/docs/development/README.md
@@ -52,19 +52,19 @@ ordinary `dev` roadmap work.
 
 - Released baseline: 0.6.2.
 - Active owner: Issue #187 for Phase E; Issue #186 retains D-14/shim decisions.
-- Reviewed code baseline before E-05a: E-04e / PR #541.
+- Reviewed code baseline before E-05b: E-05a / PR #542.
 - D-08u integrated exit audit is complete.
 - D-08v is not required; the audit found no remaining D-08 production Move.
 - D-14 readiness is audited: every root surface is retained and retirement/final
   freeze is blocked by production/lifecycle consumers, missing release windows, or
   insufficient consumer evidence.
-- E-01 through E-04 and the E-05a production-free Contract are complete. The next
-  work is only a separate #187 E-05b dataset snapshot and single-flight ownership
-  Move. The #323 E-02a/E-07 bridge remains completed evidence, not authorization
-  for unrelated feature migration.
+- E-01 through E-04, E-05a, and E-05b are complete. The next work is only a
+  separate #187 E-05c index-store root and normalized-path publication-lock Move.
+  The #323 E-02a/E-07 bridge remains completed evidence, not authorization for
+  unrelated feature migration.
 - Completed #470 and the 0.6.1 Prompt Studio lane are behavior-contract references,
   not the active queue.
-- Do not remove root aliases or start E-05c+, E-06 through E-10, release, or
+- Do not remove root aliases or start E-05d+, E-06 through E-10, release, or
   Registry work from this entrypoint.
 
 ## Completed D-08 composition audit surface
@@ -156,6 +156,6 @@ representative profile list/load/save/delete/rename/fix live smoke
 - A version marker is not a publish action.
 - Technical PRO review is for unresolved cross-boundary architecture choices,
   unavoidable cycles, or insufficient compatibility evidence—not routine failures.
-- D-14 readiness is recorded and authorizes no removal. E-05a ownership is fixed;
-  use it only to start the separate E-05b Move. Do not infer E-05c+, E-09 cleanup,
-  release publication, or Registry actions.
+- D-14 readiness is recorded and authorizes no removal. E-05b snapshot ownership is
+  complete; use it only to start the separate E-05c Move. Do not infer E-05d+,
+  E-09 cleanup, release publication, or Registry actions.

--- a/easyuse_anima/autocomplete/dataset.py
+++ b/easyuse_anima/autocomplete/dataset.py
@@ -145,13 +145,83 @@ class _AutocompleteSourceChanged(RuntimeError):
     pass
 
 
-_CACHE_LOCK = threading.Lock()
+class _AutocompleteSnapshotStore:
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._cache: dict[str, _AutocompleteSnapshot] = {}
+        self._inflight: dict[
+            _AutocompleteCacheKey,
+            Future[_AutocompleteSnapshot],
+        ] = {}
+
+    def clear(self) -> None:
+        with self._lock:
+            self._cache.clear()
+
+    def cached_snapshot_for_key(
+        self,
+        key: _AutocompleteCacheKey,
+    ) -> _AutocompleteSnapshot | None:
+        with self._lock:
+            snapshot = self._cache.get(key.resolved_path)
+            if snapshot is not None and snapshot.key == key:
+                return snapshot
+        return None
+
+    def snapshot_for_key(
+        self,
+        key: _AutocompleteCacheKey,
+    ) -> _AutocompleteSnapshot:
+        with self._lock:
+            cached = self._cache.get(key.resolved_path)
+            if cached is not None and cached.key == key:
+                return cached
+            future = self._inflight.get(key)
+            is_loader = future is None
+            if future is None:
+                future = Future()
+                self._inflight[key] = future
+
+        if not is_loader:
+            return _await_snapshot(future)
+
+        try:
+            try:
+                snapshot = _build_snapshot(key)
+            except Exception as load_error:
+                current_key = _cache_key_from_resolved_path(
+                    Path(key.resolved_path)
+                )
+                if current_key != key:
+                    raise _AutocompleteSourceChanged(
+                        key.resolved_path
+                    ) from load_error
+                raise
+            current_key = _cache_key_from_resolved_path(
+                Path(key.resolved_path)
+            )
+            if current_key != key:
+                raise _AutocompleteSourceChanged(key.resolved_path)
+            with self._lock:
+                current_cached = self._cache.get(key.resolved_path)
+                if current_cached is not cached and (
+                    current_cached is not None and current_cached.key != key
+                ):
+                    raise _AutocompleteSourceChanged(key.resolved_path)
+                self._cache[key.resolved_path] = snapshot
+                self._inflight.pop(key, None)
+        except BaseException as error:
+            with self._lock:
+                if self._inflight.get(key) is future:
+                    self._inflight.pop(key, None)
+            future.set_exception(error)
+            raise
+
+        future.set_result(snapshot)
+        return snapshot
 
 
-_CACHE: dict[str, _AutocompleteSnapshot] = {}
-
-
-_INFLIGHT: dict[_AutocompleteCacheKey, Future[_AutocompleteSnapshot]] = {}
+_DEFAULT_AUTOCOMPLETE_SNAPSHOTS = _AutocompleteSnapshotStore()
 
 
 def resolve_autocomplete_source(source: str | None = None) -> tuple[str, Path]:
@@ -355,47 +425,7 @@ def _await_snapshot(future: Future[_AutocompleteSnapshot]) -> _AutocompleteSnaps
 
 
 def _snapshot_for_key(key: _AutocompleteCacheKey) -> _AutocompleteSnapshot:
-    with _CACHE_LOCK:
-        cached = _CACHE.get(key.resolved_path)
-        if cached is not None and cached.key == key:
-            return cached
-        future = _INFLIGHT.get(key)
-        is_loader = future is None
-        if future is None:
-            future = Future()
-            _INFLIGHT[key] = future
-
-    if not is_loader:
-        return _await_snapshot(future)
-
-    try:
-        try:
-            snapshot = _build_snapshot(key)
-        except Exception as load_error:
-            current_key = _cache_key_from_resolved_path(Path(key.resolved_path))
-            if current_key != key:
-                raise _AutocompleteSourceChanged(key.resolved_path) from load_error
-            raise
-        current_key = _cache_key_from_resolved_path(Path(key.resolved_path))
-        if current_key != key:
-            raise _AutocompleteSourceChanged(key.resolved_path)
-        with _CACHE_LOCK:
-            current_cached = _CACHE.get(key.resolved_path)
-            if current_cached is not cached and (
-                current_cached is None or current_cached.key != key
-            ):
-                raise _AutocompleteSourceChanged(key.resolved_path)
-            _CACHE[key.resolved_path] = snapshot
-            _INFLIGHT.pop(key, None)
-    except BaseException as error:
-        with _CACHE_LOCK:
-            if _INFLIGHT.get(key) is future:
-                _INFLIGHT.pop(key, None)
-        future.set_exception(error)
-        raise
-
-    future.set_result(snapshot)
-    return snapshot
+    return _DEFAULT_AUTOCOMPLETE_SNAPSHOTS.snapshot_for_key(key)
 
 
 def _snapshot(path: Path = AUTOCOMPLETE_CSV) -> _AutocompleteSnapshot:
@@ -436,11 +466,7 @@ def _snapshot_status(snapshot: _AutocompleteSnapshot, path: Path) -> dict:
 def _cached_snapshot_for_key(
     key: _AutocompleteCacheKey,
 ) -> _AutocompleteSnapshot | None:
-    with _CACHE_LOCK:
-        snapshot = _CACHE.get(key.resolved_path)
-        if snapshot is not None and snapshot.key == key:
-            return snapshot
-    return None
+    return _DEFAULT_AUTOCOMPLETE_SNAPSHOTS.cached_snapshot_for_key(key)
 
 
 def _builtin_manifest_entry_count(key: _AutocompleteCacheKey) -> int | None:

--- a/tests/fixtures/python_autocomplete_runtime_contract.v1.json
+++ b/tests/fixtures/python_autocomplete_runtime_contract.v1.json
@@ -71,14 +71,14 @@
       "goal": "Encapsulate dataset snapshots, cache publication, and Future single-flight behind one feature-private owner while preserving call-time parser and test seams.",
       "id": "E-05b",
       "name": "dataset snapshot and single-flight ownership",
-      "status": "queued"
+      "status": "complete"
     },
     {
       "classification": "Move",
       "goal": "Encapsulate the immutable index root and normalized-path publication lock registry behind one autocomplete index-store owner.",
       "id": "E-05c",
       "name": "index-store root and path-lock ownership",
-      "status": "blocked-by-E-05b"
+      "status": "queued"
     },
     {
       "classification": "Move",
@@ -98,17 +98,30 @@
   "owners": [
     {
       "cleanup": {
-        "current": "Tests clear _CACHE and _INFLIGHT under _CACHE_LOCK; production has no owner-level close or reset.",
-        "target": "The feature-private owner exposes an idempotent completed-snapshot clear for isolated tests; in-flight Future settlement and whole-runtime shutdown disposition remain explicit later gates."
+        "current": "_AutocompleteSnapshotStore.clear idempotently clears completed snapshots without cancelling, removing, or replacing in-flight Futures.",
+        "target": "Whole-runtime shutdown disposition remains an explicit E-09 gate; E-05b does not invent a terminal close state."
       },
-      "current_owner": "easyuse_anima.autocomplete.dataset",
+      "components": [
+        {
+          "class": "_AutocompleteSnapshotStore",
+          "module": "easyuse_anima/autocomplete/dataset.py",
+          "state_kind": "instance",
+          "state_symbols": [
+            "_cache",
+            "_inflight",
+            "_lock"
+          ]
+        }
+      ],
+      "current_owner": "easyuse_anima.autocomplete.dataset._DEFAULT_AUTOCOMPLETE_SNAPSHOTS",
       "e01_entries": [
         "autocomplete-dataset-cache"
       ],
       "evidence": [
         "tests/test_autocomplete_index.py",
         "tests/test_autocomplete_dataset_compatibility.py",
-        "tests/test_autocomplete_locale_settings.py"
+        "tests/test_autocomplete_locale_settings.py",
+        "tests/test_prompt_corrector.py"
       ],
       "id": "dataset-snapshots",
       "lifetime": "Process lifetime, keyed by resolved source path and source stat/schema revision.",
@@ -122,12 +135,10 @@
         "status fast path and arbitrary-path exact count semantics"
       ],
       "state_symbols": [
-        "_CACHE",
-        "_CACHE_LOCK",
-        "_INFLIGHT"
+        "_DEFAULT_AUTOCOMPLETE_SNAPSHOTS"
       ],
-      "target_owner": "feature-private autocomplete dataset snapshot owner",
-      "target_phase": "E-05b"
+      "target_owner": "easyuse_anima.autocomplete.dataset._DEFAULT_AUTOCOMPLETE_SNAPSHOTS",
+      "target_phase": "E-05b-complete"
     },
     {
       "cleanup": {
@@ -215,7 +226,7 @@
       ]
     }
   ],
-  "production_changes": 0,
+  "production_changes": 1,
   "schema_version": 1,
   "scope": "E-05 autocomplete source metadata, dataset snapshot/cache/Future single-flight, SQLite index root and publication path-lock ownership"
 }

--- a/tests/fixtures/python_backend_baseline.json
+++ b/tests/fixtures/python_backend_baseline.json
@@ -68182,14 +68182,14 @@
       },
       {
         "is_package": false,
-        "loc": 493,
+        "loc": 519,
         "module": "easyuse_anima.autocomplete.dataset",
-        "normalized_git_blob_sha1": "4544b4e59e500f0290db4172744347ce13c5f079",
+        "normalized_git_blob_sha1": "c4cd01c977d8210e30e34d82124f1a6b0ea3619f",
         "path": "easyuse_anima/autocomplete/dataset.py",
         "top_level": {
-          "class_count": 4,
+          "class_count": 5,
           "function_count": 24,
-          "global_count": 22
+          "global_count": 20
         }
       },
       {
@@ -91301,11 +91301,11 @@
         "scope": "<module>"
       },
       {
-        "callee": "threading.Lock",
-        "column": 14,
-        "context": "assign:_CACHE_LOCK",
+        "callee": "_AutocompleteSnapshotStore",
+        "column": 34,
+        "context": "assign:_DEFAULT_AUTOCOMPLETE_SNAPSHOTS",
         "kind": "import_time_call",
-        "line": 148,
+        "line": 224,
         "module": "easyuse_anima/autocomplete/dataset.py",
         "scope": "<module>"
       },
@@ -92326,12 +92326,6 @@
       },
       {
         "kind": "dict",
-        "line": 151,
-        "module": "easyuse_anima/autocomplete/dataset.py",
-        "name": "_CACHE"
-      },
-      {
-        "kind": "dict",
         "line": 78,
         "module": "easyuse_anima/autocomplete/dataset.py",
         "name": "_DANBOORU_CATEGORY_NAMES"
@@ -92341,12 +92335,6 @@
         "line": 87,
         "module": "easyuse_anima/autocomplete/dataset.py",
         "name": "_E621_CATEGORY_NAMES"
-      },
-      {
-        "kind": "dict",
-        "line": 154,
-        "module": "easyuse_anima/autocomplete/dataset.py",
-        "name": "_INFLIGHT"
       },
       {
         "kind": "dict",
@@ -92697,36 +92685,6 @@
         "line": 9,
         "module": "easyuse_anima/api/file_io.py",
         "name": "_FILE_IO_LIMITERS_LOCK"
-      },
-      {
-        "categories": [
-          "cache",
-          "mutable_container"
-        ],
-        "initializer": "Dict",
-        "line": 151,
-        "module": "easyuse_anima/autocomplete/dataset.py",
-        "name": "_CACHE"
-      },
-      {
-        "categories": [
-          "lock"
-        ],
-        "initializer": "threading.Lock",
-        "line": 148,
-        "module": "easyuse_anima/autocomplete/dataset.py",
-        "name": "_CACHE_LOCK"
-      },
-      {
-        "categories": [
-          "future",
-          "mutable_container",
-          "single_flight"
-        ],
-        "initializer": "Dict",
-        "line": 154,
-        "module": "easyuse_anima/autocomplete/dataset.py",
-        "name": "_INFLIGHT"
       },
       {
         "categories": [

--- a/tests/fixtures/python_runtime_state_ownership.v1.json
+++ b/tests/fixtures/python_runtime_state_ownership.v1.json
@@ -179,15 +179,15 @@
     },
     {
       "categories": ["cache", "future", "lock", "single_flight"],
-      "cleanup": "Tests clear _CACHE and _INFLIGHT under _CACHE_LOCK; production has no owner-level close/reset.",
+      "cleanup": "_AutocompleteSnapshotStore.clear idempotently clears completed snapshots without cancelling, removing, or replacing in-flight Futures.",
       "id": "autocomplete-dataset-cache",
-      "lifetime": "Process lifetime with entries keyed by source identity and work retained until completion.",
+      "lifetime": "Process lifetime through one default store; completed entries are keyed by source identity and in-flight work is retained until settlement.",
       "module": "easyuse_anima/autocomplete/dataset.py",
-      "owner": "easyuse_anima.autocomplete.dataset",
-      "symbols": ["_CACHE", "_CACHE_LOCK", "_INFLIGHT"],
-      "target_phase": "E-05b",
-      "test_evidence": ["tests/test_autocomplete_index.py"],
-      "thread_safety": "One Lock protects cache snapshots and the Future single-flight map."
+      "owner": "easyuse_anima.autocomplete.dataset._DEFAULT_AUTOCOMPLETE_SNAPSHOTS",
+      "symbols": ["_DEFAULT_AUTOCOMPLETE_SNAPSHOTS"],
+      "target_phase": "E-05b-complete",
+      "test_evidence": ["tests/test_autocomplete_index.py", "tests/test_prompt_corrector.py"],
+      "thread_safety": "One owner Lock protects its completed snapshot cache and cache-key Future single-flight map."
     },
     {
       "categories": ["lock", "path_registry"],

--- a/tests/test_autocomplete_index.py
+++ b/tests/test_autocomplete_index.py
@@ -29,9 +29,7 @@ class AutocompleteIndexTests(unittest.TestCase):
         self.index_root = self.root / "index"
 
     def tearDown(self) -> None:
-        with dataset._CACHE_LOCK:
-            dataset._CACHE.clear()
-            dataset._INFLIGHT.clear()
+        dataset._DEFAULT_AUTOCOMPLETE_SNAPSHOTS.clear()
         self.temporary_directory.cleanup()
 
     def _write(self, name: str, rows: list[str]) -> Path:
@@ -397,6 +395,106 @@ class AutocompleteIndexTests(unittest.TestCase):
             autocomplete_dataset.search_autocomplete,
             autocomplete_search_impl.search_autocomplete,
         )
+
+
+class AutocompleteSnapshotStoreTests(unittest.TestCase):
+    def test_store_instances_isolate_snapshots_and_clear_completed_cache(self):
+        with tempfile.TemporaryDirectory(
+            prefix="easyuse-anima-snapshot-store-test-"
+        ) as temporary_directory:
+            path = Path(temporary_directory) / "tags.csv"
+            path.write_text(
+                'isolated tag,0,100,"[일반] isolated"\n',
+                encoding="utf-8",
+            )
+            key = dataset._cache_key(path)
+            first_store = dataset._AutocompleteSnapshotStore()
+            second_store = dataset._AutocompleteSnapshotStore()
+            original_build = dataset._build_snapshot
+
+            with patch.object(
+                dataset,
+                "_build_snapshot",
+                wraps=original_build,
+            ) as build_snapshot:
+                first = first_store.snapshot_for_key(key)
+                first_hit = first_store.snapshot_for_key(key)
+                second = second_store.snapshot_for_key(key)
+                first_store.clear()
+                first_after_clear = first_store.snapshot_for_key(key)
+
+        self.assertIs(first_hit, first)
+        self.assertIsNot(second, first)
+        self.assertIsNot(first_after_clear, first)
+        self.assertEqual(build_snapshot.call_count, 3)
+
+    def test_clear_retains_inflight_future_until_shared_settlement(self):
+        with tempfile.TemporaryDirectory(
+            prefix="easyuse-anima-snapshot-flight-test-"
+        ) as temporary_directory:
+            path = Path(temporary_directory) / "tags.csv"
+            path.write_text(
+                'shared tag,0,100,"[일반] shared"\n',
+                encoding="utf-8",
+            )
+            key = dataset._cache_key(path)
+            store = dataset._AutocompleteSnapshotStore()
+            old_snapshot = store.snapshot_for_key(key)
+            previous_stat = path.stat()
+            path.write_text(
+                'shared replacement tag,0,90,"[일반] replacement"\n',
+                encoding="utf-8",
+            )
+            next_mtime = previous_stat.st_mtime_ns + 1_000_000_000
+            os.utime(path, ns=(next_mtime, next_mtime))
+            key = dataset._cache_key(path)
+            self.assertNotEqual(key, old_snapshot.key)
+            load_started = threading.Event()
+            waiter_joined = threading.Event()
+            release_load = threading.Event()
+            original_build = dataset._build_snapshot
+            original_await = dataset._await_snapshot
+
+            def blocking_build(build_key):
+                load_started.set()
+                if not release_load.wait(timeout=5):
+                    raise AssertionError("timed out waiting to release snapshot build")
+                return original_build(build_key)
+
+            def observed_await(future):
+                waiter_joined.set()
+                return original_await(future)
+
+            with (
+                patch.object(
+                    dataset,
+                    "_build_snapshot",
+                    side_effect=blocking_build,
+                ) as build_snapshot,
+                patch.object(
+                    dataset,
+                    "_await_snapshot",
+                    side_effect=observed_await,
+                ),
+                ThreadPoolExecutor(max_workers=2) as executor,
+            ):
+                loader = executor.submit(store.snapshot_for_key, key)
+                self.assertTrue(load_started.wait(timeout=5))
+                store.clear()
+                with store._lock:
+                    self.assertIn(key, store._inflight)
+                follower = executor.submit(store.snapshot_for_key, key)
+                self.assertTrue(waiter_joined.wait(timeout=5))
+                release_load.set()
+                loaded = loader.result(timeout=5)
+                followed = follower.result(timeout=5)
+
+            with store._lock:
+                self.assertNotIn(key, store._inflight)
+
+        self.assertIs(followed, loaded)
+        self.assertIsNot(loaded, old_snapshot)
+        self.assertEqual(build_snapshot.call_count, 1)
 
 
 if __name__ == "__main__":

--- a/tests/test_python_autocomplete_runtime_contract.py
+++ b/tests/test_python_autocomplete_runtime_contract.py
@@ -86,6 +86,43 @@ def _top_level_function(
     raise AssertionError(f"{module} has no top-level function {function_name}")
 
 
+def _top_level_class(module: str, class_name: str) -> ast.ClassDef:
+    for statement in _tree(module).body:
+        if isinstance(statement, ast.ClassDef) and statement.name == class_name:
+            return statement
+    raise AssertionError(f"{module} has no top-level class {class_name}")
+
+
+def _class_method(
+    module: str,
+    class_name: str,
+    method_name: str,
+) -> ast.FunctionDef | ast.AsyncFunctionDef:
+    for statement in _top_level_class(module, class_name).body:
+        if isinstance(statement, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            if statement.name == method_name:
+                return statement
+    raise AssertionError(f"{class_name} has no method {method_name}")
+
+
+def _instance_assignments(module: str, class_name: str) -> set[str]:
+    assigned: set[str] = set()
+    for node in ast.walk(_top_level_class(module, class_name)):
+        targets: list[ast.expr] = []
+        if isinstance(node, ast.Assign):
+            targets = node.targets
+        elif isinstance(node, ast.AnnAssign):
+            targets = [node.target]
+        for target in targets:
+            if (
+                isinstance(target, ast.Attribute)
+                and isinstance(target.value, ast.Name)
+                and target.value.id == "self"
+            ):
+                assigned.add(target.attr)
+    return assigned
+
+
 def _function_references(module: str, function_name: str) -> set[str]:
     return {
         node.id
@@ -153,7 +190,7 @@ class PythonAutocompleteRuntimeContractTests(unittest.TestCase):
         )
         self.assertEqual(self.fixture["schema_version"], 1)
         self.assertEqual(self.fixture["classification"], "Contract")
-        self.assertEqual(self.fixture["production_changes"], 0)
+        self.assertEqual(self.fixture["production_changes"], 1)
         self.assertEqual(
             [move["id"] for move in self.fixture["move_queue"]],
             ["E-05a", "E-05b", "E-05c", "E-05d", "E-05e"],
@@ -193,7 +230,7 @@ class PythonAutocompleteRuntimeContractTests(unittest.TestCase):
         dataset_owner = owners["dataset-snapshots"]
         dataset_entry = e01_entries["autocomplete-dataset-cache"]
         self.assertEqual(dataset_entry["owner"], dataset_owner["current_owner"])
-        self.assertEqual(dataset_entry["target_phase"], "E-05b")
+        self.assertEqual(dataset_entry["target_phase"], "E-05b-complete")
         self.assertEqual(
             set(dataset_entry["symbols"]),
             set(dataset_owner["state_symbols"]),
@@ -239,42 +276,102 @@ class PythonAutocompleteRuntimeContractTests(unittest.TestCase):
         self.assertIn("second owner", partition)
 
     def test_dataset_snapshot_state_and_single_flight_contract_are_current(self):
+        module = "easyuse_anima/autocomplete/dataset.py"
         bindings = _top_level_bindings(
-            "easyuse_anima/autocomplete/dataset.py"
-        )
-        self.assertTrue({"_CACHE", "_CACHE_LOCK", "_INFLIGHT"} <= bindings)
-        snapshot_references = _function_references(
-            "easyuse_anima/autocomplete/dataset.py",
-            "_snapshot_for_key",
+            module
         )
         self.assertTrue(
-            {"_CACHE", "_CACHE_LOCK", "_INFLIGHT", "Future"}
+            {
+                "_AutocompleteSnapshotStore",
+                "_DEFAULT_AUTOCOMPLETE_SNAPSHOTS",
+            }
+            <= bindings
+        )
+        self.assertEqual(
+            {"_CACHE", "_CACHE_LOCK", "_INFLIGHT"} & bindings,
+            set(),
+        )
+        self.assertEqual(
+            _instance_assignments(module, "_AutocompleteSnapshotStore"),
+            {"_cache", "_inflight", "_lock"},
+        )
+        owner_methods = {
+            statement.name
+            for statement in _top_level_class(
+                module,
+                "_AutocompleteSnapshotStore",
+            ).body
+            if isinstance(statement, (ast.FunctionDef, ast.AsyncFunctionDef))
+        }
+        self.assertEqual(
+            owner_methods,
+            {
+                "__init__",
+                "cached_snapshot_for_key",
+                "clear",
+                "snapshot_for_key",
+            },
+        )
+        snapshot_method = _class_method(
+            module,
+            "_AutocompleteSnapshotStore",
+            "snapshot_for_key",
+        )
+        snapshot_references = {
+            node.id
+            for node in ast.walk(snapshot_method)
+            if isinstance(node, ast.Name)
+        }
+        self.assertTrue(
+            {
+                "Future",
+                "_await_snapshot",
+                "_build_snapshot",
+                "_cache_key_from_resolved_path",
+            }
             <= snapshot_references
         )
+        snapshot_attributes = {
+            node.attr
+            for node in ast.walk(snapshot_method)
+            if isinstance(node, ast.Attribute)
+        }
         self.assertTrue(
-            {"set_exception", "set_result", "result"}
-            <= (
-                _called_attributes(
-                    "easyuse_anima/autocomplete/dataset.py",
-                    "_snapshot_for_key",
-                )
-                | _called_attributes(
-                    "easyuse_anima/autocomplete/dataset.py",
-                    "_await_snapshot",
+            {"_cache", "_inflight", "_lock", "set_exception", "set_result"}
+            <= snapshot_attributes
+        )
+        clear_attributes = {
+            node.attr
+            for node in ast.walk(
+                _class_method(
+                    module,
+                    "_AutocompleteSnapshotStore",
+                    "clear",
                 )
             )
+            if isinstance(node, ast.Attribute)
+        }
+        self.assertIn("_cache", clear_attributes)
+        self.assertNotIn("_inflight", clear_attributes)
+        self.assertTrue(
+            {"_DEFAULT_AUTOCOMPLETE_SNAPSHOTS", "key"}
+            <= _function_references(module, "_snapshot_for_key")
+        )
+        self.assertTrue(
+            {"_DEFAULT_AUTOCOMPLETE_SNAPSHOTS", "key"}
+            <= _function_references(module, "_cached_snapshot_for_key")
         )
         self.assertIn(
             "_AUTOCOMPLETE_CACHE_LOAD_ATTEMPTS",
             _function_references(
-                "easyuse_anima/autocomplete/dataset.py",
+                module,
                 "_snapshot",
             ),
         )
         self.assertTrue(
             {"_cached_snapshot_for_key", "_snapshot"}
             <= _function_references(
-                "easyuse_anima/autocomplete/dataset.py",
+                module,
                 "autocomplete_status",
             )
         )

--- a/tests/test_python_runtime_state_ownership.py
+++ b/tests/test_python_runtime_state_ownership.py
@@ -239,7 +239,10 @@ class PythonRuntimeStateOwnershipContractTests(unittest.TestCase):
                 "_AIO_FIRST_PASS_CACHE_GENERATION",
             ),
             ("easyuse_anima/api/file_io.py", "_FILE_IO_LIMITERS"),
-            ("easyuse_anima/autocomplete/dataset.py", "_CACHE_LOCK"),
+            (
+                "easyuse_anima/autocomplete/dataset.py",
+                "_DEFAULT_AUTOCOMPLETE_SNAPSHOTS",
+            ),
             (
                 "easyuse_anima/autocomplete/index.py",
                 "_INDEX_LOCKS_GUARD",


### PR DESCRIPTION
## 목적과 변경 경계

Issue #187 E-05b Move입니다. Autocomplete dataset의 module-level cache/Lock/Future map을 하나의 feature-private snapshot owner로 이동합니다.

- `_CACHE`, `_CACHE_LOCK`, `_INFLIGHT` 제거
- private `_AutocompleteSnapshotStore`가 completed snapshots, cache-key Futures, Lock을 instance state로 소유
- module에는 `_DEFAULT_AUTOCOMPLETE_SNAPSHOTS` reference 하나만 유지
- `_snapshot_for_key`와 `_cached_snapshot_for_key`는 call-time default-owner facade 유지
- `clear()`는 completed snapshots만 비우고 in-flight Future를 cancel/remove/replace하지 않음
- index root/path-lock, RuntimeServices/bootstrap/API wiring은 변경하지 않음

## Base → Head

- Base: `ce53be1c5eccc16967372952a3af8a64f862c4f6` (E-05a / PR #542 merged `origin/dev`)
- Head: `be173a9c1773ff6908165ef4dfbde0fd1ab1e22f`

## 주요 파일과 보존 계약

Production:
- `easyuse_anima/autocomplete/dataset.py`

Support:
- direct snapshot/index/concurrency tests
- E-01/E-05 ownership fixtures and drift gates
- actual-code analyzer baseline
- active E-05/resume/index docs

보존:
- CSV parsing/header/category/normalization/order
- cache key resolved path/mtime_ns/size/schema
- four-attempt source-change retry
- one loader per key, same Future result/exception propagation
- different-source parallel load, stale-publication rejection
- replacement/deletion/missing/status/manifest behavior
- classification/search/API payloads
- canonical/root identity, `__all__`
- dynamic `_load_entries`, `_build_snapshot`, `_await_snapshot`, `_snapshot_for_key` seams

## 검증

Focused:
- snapshot owner isolation/clear/in-flight settlement: 2
- autocomplete dataset direct behavior/concurrency: 36
- autocomplete index: 9
- API autocomplete routes: 9
- dataset compatibility: 3
- locale source settings: 7
- E-05 Contract: 8
- E-01 ownership: 5
- analyzer: 18
- package skeleton: 1
- completed import boundary: 6
- changed Python syntax/fatal Ruff, JSON parse, `git diff --check` 통과

Final candidate official full 정확히 1회:
- Python unittest: 1,363
- frontend smoke: 120
- Pyright baseline ratchet: 통과
- import boundary: 11 groups / 0 violations
- project full: 통과

Package/live/validate/pack:
- 새 shipped file/import closure/public surface/route/runtime wiring이 없어 기존 evidence 재사용(`not retriggered`)

## 위험과 rollback

- 새 `clear()`와 old-revision cache/new-revision in-flight load가 겹쳐도 one-build/shared settlement가 유지되는 직접 test가 있습니다.
- terminal close나 whole-runtime shutdown은 도입하지 않았고 E-09에 남깁니다.
- rollback은 이 단일 Move commit revert입니다.

## Next

Squash merge 후 최신 `origin/dev`에서 별도 E-05c index-store root/normalized-path publication-lock owner Move만 시작합니다. E-05d+, E-06+, E-09 구현, D-14 retirement, release/Registry는 시작하지 않습니다.