### PR TITLE
refactor: own autocomplete index store

### DIFF
--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -10,14 +10,14 @@ then only the active task section, owning Issue, direct source, and direct tests
 ## Active sequencing
 
 - Issue [#187](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/187)
-  owns Phase E. E-01 through E-04, E-05a, and E-05b are complete; the next bounded
-  unit is the separate E-05c index-store root and path-lock ownership Move.
+  owns Phase E. E-01 through E-04 and E-05a through E-05c are complete; the next
+  bounded unit is the separate E-05d bootstrap composition and adapter wiring Move.
   Issue #186 retains D-14/shim decisions.
 - [`backend-roadmap-resume-0.6.2.md`](backend-roadmap-resume-0.6.2.md)
   is the current execution source of truth. Read it before the older accumulated
   roadmap.
-- Reviewed code baseline before E-05b: E-05a / PR #542 at
-  `ce53be1c5eccc16967372952a3af8a64f862c4f6`.
+- Reviewed code baseline before E-05c: E-05b / PR #543 at
+  `707aee54244946058fb7f37cfb6e06b1c2dd9735`.
 - D-08 is complete and D-08v is not required.
 - D-14 readiness retains every root surface; retirement/final-freeze work is blocked.
 - E-01 inventory Contract:
@@ -36,14 +36,14 @@ then only the active task section, owning Issue, direct source, and direct tests
   [`python-runtime-e04-translation-contract.md`](python-runtime-e04-translation-contract.md).
 - E-05 autocomplete runtime ownership Contract:
   [`python-runtime-e05-autocomplete-contract.md`](python-runtime-e05-autocomplete-contract.md).
-- First READY task after E-05b: a separate #187 E-05c index-store root and
-  normalized-path publication-lock ownership Move only.
+- First READY task after E-05c: a separate #187 E-05d bootstrap composition and
+  narrow adapter wiring Move only.
 - Completed #470 and the #413/#414/#415 queue/live-UI lanes remain contract references,
   not active blockers.
 - Released code baseline: 0.6.2. Registry activation is external administration and
   does not block `dev`; do not republish or mutate the release.
 - Completed #409/#410/#411 and deferred #440/#441 do not alter the E-01 boundary.
-- E-05b authorizes only the separate E-05c Move. It does not authorize E-05d+
+- E-05c authorizes only the separate E-05d Move. It does not authorize E-05e+
   implementation, later Phase E work, root removal, release, or Registry.
 
 ## Current code boundary
@@ -89,8 +89,8 @@ aliases or absorbing feature behavior.
   completed translation provider/client, service cache/single-flight, route executor
   owners, lifecycle gaps, and the E-04 completion audit.
 - [`python-runtime-e05-autocomplete-contract.md`](python-runtime-e05-autocomplete-contract.md):
-  autocomplete declarative source policy, completed snapshot/Future owner Move,
-  queued index-store root/path-lock owner, compatibility seams, and bounded queue.
+  autocomplete declarative source policy, completed snapshot/Future and
+  index-store owner Moves, compatibility seams, and bounded queue.
 - [`adr-001-modular-monolith.md`](adr-001-modular-monolith.md): feature-oriented modular
   monolith decision.
 - [`adr-002-compatibility-shims.md`](adr-002-compatibility-shims.md): shim lifecycle and

--- a/docs/architecture/backend-roadmap-resume-0.6.2.md
+++ b/docs/architecture/backend-roadmap-resume-0.6.2.md
@@ -2,16 +2,15 @@
 
 ## Status and authority
 
-- Status: D-08, E-01 through E-04, E-05a, and E-05b are completed; the D-14
-  readiness audit retains every root surface and blocks retirement/final-freeze
-  work.
-- Code-review base before E-05b:
-  `dev@ce53be1c5eccc16967372952a3af8a64f862c4f6` after E-05a / PR #542.
-- Document baseline: completed E-05b dataset snapshot/single-flight owner Move.
+- Status: D-08, E-01 through E-04, and E-05a through E-05c are completed; the D-14
+  readiness audit retains every root surface and blocks retirement/final-freeze work.
+- Code-review base before E-05c:
+  `dev@707aee54244946058fb7f37cfb6e06b1c2dd9735` after E-05b / PR #543.
+- Document baseline: completed E-05c index-store root/path-lock owner Move.
 - Released baseline: 0.6.2.
 - Scope: completed D-08 evidence, the D-14 readiness decision, completed #187
   E-01/E-02/E-03/E-04 work, the E-05a Contract, the E-05b snapshot owner Move,
-  and the next bounded E-05c index-store Move.
+  the E-05c index-store owner Move, and the next bounded E-05d composition Move.
 - This document owns the current immediate queue and supersedes the stale queue and
   broad preflight command in `python-backend-execution-roadmap.md`.
 - `python-backend.md`, ADR-001, ADR-002, and the compatibility-shim registry still own
@@ -371,9 +370,14 @@ source-change retries, follower settlement, status behavior, and public identiti
 are unchanged. `clear()` affects only completed snapshots and no duplicate module
 dict/lock/Future state remains.
 
-Start only a separate #187 E-05c index-store root/normalized-path publication-lock
-owner Move from latest origin/dev. Preserve standalone index disablement, Windows
-pre-directory lock identity, rebuild/atomic publication/fallback diagnostics, and
-the isolated root seam. Do not start E-05d through E-05e, E-06 through E-10, D-14
-retirement, release, or Registry work inside E-05c.
+E-05c moves the import-stable Path-or-None root and retained normalized-path Locks
+behind one private `_AutocompleteIndexStore` referenced by
+`_DEFAULT_AUTOCOMPLETE_INDEX_STORE`. The owner-level isolated-store injection seam,
+standalone disablement, Windows pre-directory lock identity, rebuild/atomic
+publication/fallback diagnostics, and public explicit-root compatibility function
+are unchanged. `close()` is an idempotent no-op for the non-disposable process locks.
+
+Start only a separate #187 E-05d bootstrap composition and narrow adapter wiring
+Move from latest origin/dev. Do not start E-05e, E-06 through E-10, D-14 retirement,
+release, or Registry work inside E-05d.
 ```

--- a/docs/architecture/python-runtime-e05-autocomplete-contract.md
+++ b/docs/architecture/python-runtime-e05-autocomplete-contract.md
@@ -7,8 +7,9 @@ E-05a is a production-free Contract created from
 translation audit. It classifies current autocomplete source metadata, dataset
 snapshot and single-flight state, SQLite index publication state, production
 callers, compatibility seams, and the only authorized bounded Move order.
-E-05b moves only the dataset snapshot/cache/Future state behind its selected
-feature-private owner.
+E-05b moves the dataset snapshot/cache/Future state behind its selected
+feature-private owner. E-05c moves the immutable index root and retained path-lock
+registry behind the second selected owner.
 
 The executable source is
 `tests/fixtures/python_autocomplete_runtime_contract.v1.json`, checked by
@@ -54,25 +55,27 @@ public status continue to observe the same snapshot identity and status semantic
 
 ### Index store root and publication locks
 
-The current search module resolves `_AUTOCOMPLETE_INDEX_DIR` once from the process
-user-data boundary. When user data and package data resolve to the same standalone
-boundary, persistent indexing remains disabled so a package import cannot write to
-its source tree.
+`_DEFAULT_AUTOCOMPLETE_INDEX_STORE` is the process owner. Its private
+`_AutocompleteIndexStore` instance owns the immutable Path-or-None root, one guard,
+and the retained normalized-path Lock registry. The default root is still resolved
+once from the process user-data boundary. When user data and package data resolve to
+the same standalone boundary, persistent indexing remains disabled so a package
+import cannot write to its source tree.
 
-The current index module owns `_INDEX_LOCKS`, `_INDEX_LOCKS_GUARD`, and the
-per-path publication critical section. The lock key deliberately uses
-`normcase(abspath(path))` without `Path.resolve()` before the directory exists;
-changing that can split first Windows access across two locks for the same eventual
-file. One per-path lock protects the second validity check, rebuild, atomic
-publication, and concurrent reuse.
+The lock key still uses `normcase(abspath(path))` without `Path.resolve()` before
+the directory exists; changing that can split first Windows access across two locks
+for the same eventual file. One per-path lock protects the second validity check,
+rebuild, atomic publication, and concurrent reuse. `search.py` resolves its private
+store reference at call time, so tests inject an isolated root by replacing the
+store instead of mutating a raw root constant.
 
-E-05c moves the immutable root and retained path-lock registry behind one
-feature-private index-store owner. It does not create a generic filesystem lock
-service. Read-only hit behavior, source/schema/corrupt invalidation, temporary
-SQLite construction, backend selection, atomic replace, diagnostics, and exact
-Python snapshot fallback remain unchanged. The proven resource has no disposable
-handle, so its feature close shape is an idempotent no-op unless later direct
-evidence proves otherwise.
+The public `search_autocomplete_index(*, root, ...)` signature and identity remain
+unchanged. Its explicit-root compatibility path delegates to the same default owner
+and therefore retains the process-wide per-path lock registry. No generic filesystem
+lock service is added. Read-only hit behavior, source/schema/corrupt invalidation,
+temporary SQLite construction, backend selection, atomic replace, diagnostics, and
+exact Python snapshot fallback remain unchanged. `close()` is an idempotent no-op
+because the proven owner has no disposable handle.
 
 The dataset owner and index-store owner are not merged. Their locks protect
 different invariants, their failures have different meanings, and index
@@ -93,8 +96,8 @@ The following surfaces remain compatible throughout E-05:
   status functions retain their public identity and result contracts;
 - root `api.py` retains call-time callback seams for source resolution, status,
   search, and classification;
-- the import-stable index-root patch seam remains available until E-05c replaces it
-  with an equivalent isolated owner seam;
+- the former import-stable index-root patch seam is replaced by the equivalent
+  private isolated-store injection seam;
 - package/no-host imports do not create directories or require ComfyUI host state.
 
 E-05 does not add a public runtime/bootstrap/root export or a generic cache/lock
@@ -108,9 +111,9 @@ port.
    `_AutocompleteSnapshotStore` owns the cache, Future map, and Lock behind one
    default reference while preserving parser, source-change, Future settlement,
    status, and call-time patch behavior.
-3. **E-05c Move — index-store root and path-lock ownership:** encapsulate the
-   immutable Path-or-None root and normalized-path lock registry behind one
-   feature-private index store.
+3. **E-05c Move — index-store root and path-lock ownership — complete:**
+   `_AutocompleteIndexStore` owns the immutable root, guard, and retained
+   normalized-path Locks behind one default reference.
 4. **E-05d Move — bootstrap composition and adapter wiring:** compose both owners,
    add only a narrow autocomplete port to RuntimeServices, and preserve every
    canonical/root identity and call-time adapter seam.
@@ -122,8 +125,9 @@ Each Move is a separate PR and rollback boundary. E-09 retains whole-runtime rev
 close ordering and partial-initialization cleanup. E-05 supplies only the
 feature-owned resources and their proven cleanup shapes.
 
-E-05b leaves no duplicate module cache/lock/Future map. The next READY unit is the
-separate E-05c index-store root and normalized-path publication-lock Move.
+E-05b leaves no duplicate module cache/lock/Future map, and E-05c leaves no raw
+module root or index-lock registry. The next READY unit is the separate E-05d
+bootstrap composition and narrow adapter wiring Move.
 
 ## Preserved behavior
 
@@ -155,3 +159,4 @@ the two lock lifecycles, or cancellation/replacement of a shared Future.
 Direct source and tests select one snapshot owner, one index-store owner, and one
 declarative policy. E-05a therefore does not trigger additional PRO review.
 E-05b preserves that partition and does not trigger a new PRO review.
+E-05c preserves that partition and does not trigger a new PRO review.

--- a/docs/development/README.md
+++ b/docs/development/README.md
@@ -52,19 +52,19 @@ ordinary `dev` roadmap work.
 
 - Released baseline: 0.6.2.
 - Active owner: Issue #187 for Phase E; Issue #186 retains D-14/shim decisions.
-- Reviewed code baseline before E-05b: E-05a / PR #542.
+- Reviewed code baseline before E-05c: E-05b / PR #543.
 - D-08u integrated exit audit is complete.
 - D-08v is not required; the audit found no remaining D-08 production Move.
 - D-14 readiness is audited: every root surface is retained and retirement/final
   freeze is blocked by production/lifecycle consumers, missing release windows, or
   insufficient consumer evidence.
-- E-01 through E-04, E-05a, and E-05b are complete. The next work is only a
-  separate #187 E-05c index-store root and normalized-path publication-lock Move.
-  The #323 E-02a/E-07 bridge remains completed evidence, not authorization for
-  unrelated feature migration.
+- E-01 through E-04 and E-05a through E-05c are complete. The next work is only a
+  separate #187 E-05d bootstrap composition and narrow adapter wiring Move. The
+  #323 E-02a/E-07 bridge remains completed evidence, not authorization for unrelated
+  feature migration.
 - Completed #470 and the 0.6.1 Prompt Studio lane are behavior-contract references,
   not the active queue.
-- Do not remove root aliases or start E-05d+, E-06 through E-10, release, or
+- Do not remove root aliases or start E-05e+, E-06 through E-10, release, or
   Registry work from this entrypoint.
 
 ## Completed D-08 composition audit surface
@@ -156,6 +156,6 @@ representative profile list/load/save/delete/rename/fix live smoke
 - A version marker is not a publish action.
 - Technical PRO review is for unresolved cross-boundary architecture choices,
   unavoidable cycles, or insufficient compatibility evidence—not routine failures.
-- D-14 readiness is recorded and authorizes no removal. E-05b snapshot ownership is
-  complete; use it only to start the separate E-05c Move. Do not infer E-05d+,
+- D-14 readiness is recorded and authorizes no removal. E-05c index-store ownership
+  is complete; use it only to start the separate E-05d Move. Do not infer E-05e+,
   E-09 cleanup, release publication, or Registry actions.

--- a/easyuse_anima/autocomplete/index.py
+++ b/easyuse_anima/autocomplete/index.py
@@ -10,6 +10,11 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Protocol
 
+from ..infrastructure.filesystem.paths import (
+    PACKAGE_DATA_DIR as STORAGE_PACKAGE_DATA_DIR,
+)
+from ..infrastructure.filesystem.paths import USER_DATA_DIR
+
 
 AUTOCOMPLETE_INDEX_SCHEMA_VERSION = 1
 __all__ = (
@@ -80,25 +85,8 @@ class _InvalidAutocompleteIndex(RuntimeError):
         self.reason = reason
 
 
-_INDEX_LOCKS: dict[str, threading.Lock] = {}
-_INDEX_LOCKS_GUARD = threading.Lock()
-
-
 def _index_path(root: Path, source: AutocompleteIndexSource) -> Path:
     return Path(root) / f"autocomplete-{source.identity[:24]}.sqlite3"
-
-
-def _index_lock(path: Path) -> threading.Lock:
-    # Do not use Path.resolve() here. On Windows its canonicalization can
-    # differ before and after the index directory is created, splitting first
-    # access across two locks for the same eventual file.
-    key = os.path.normcase(os.path.abspath(path))
-    with _INDEX_LOCKS_GUARD:
-        lock = _INDEX_LOCKS.get(key)
-        if lock is None:
-            lock = threading.Lock()
-            _INDEX_LOCKS[key] = lock
-        return lock
 
 
 def _is_locked_error(error: BaseException) -> bool:
@@ -509,6 +497,172 @@ def _query_or_invalid(
         raise AutocompleteIndexUnavailable("unreadable") from error
 
 
+def _default_autocomplete_index_dir() -> Path | None:
+    user_data_dir = Path(USER_DATA_DIR).resolve(strict=False)
+    package_data_dir = Path(STORAGE_PACKAGE_DATA_DIR).resolve(strict=False)
+    if user_data_dir == package_data_dir:
+        # Standalone imports do not have a ComfyUI-owned writable user-data
+        # boundary. Keep the source/package tree immutable in that case.
+        return None
+    return user_data_dir / "autocomplete_index"
+
+
+class _AutocompleteIndexStore:
+    __slots__ = ("_locks", "_locks_guard", "_root")
+
+    def __init__(self, root: Path | None) -> None:
+        self._root = None if root is None else Path(root)
+        self._locks: dict[str, threading.Lock] = {}
+        self._locks_guard = threading.Lock()
+
+    @property
+    def root(self) -> Path | None:
+        return self._root
+
+    def close(self) -> None:
+        # Per-path locks have process lifetime and own no disposable resource.
+        return None
+
+    def _index_lock(self, path: Path) -> threading.Lock:
+        # Do not use Path.resolve() here. On Windows its canonicalization can
+        # differ before and after the index directory is created, splitting first
+        # access across two locks for the same eventual file.
+        key = os.path.normcase(os.path.abspath(path))
+        with self._locks_guard:
+            lock = self._locks.get(key)
+            if lock is None:
+                lock = threading.Lock()
+                self._locks[key] = lock
+            return lock
+
+    def search(
+        self,
+        *,
+        source: AutocompleteIndexSource,
+        normalized_query: str,
+        categories: set[str],
+        limit: int,
+        load_entries: Callable[[], Iterable[_AutocompleteIndexEntry]],
+        validate_source: Callable[[], None],
+    ) -> AutocompleteIndexResult:
+        return self._search_at_root(
+            root=self._root,
+            source=source,
+            normalized_query=normalized_query,
+            categories=categories,
+            limit=limit,
+            load_entries=load_entries,
+            validate_source=validate_source,
+        )
+
+    def _search_at_root(
+        self,
+        *,
+        root: Path | None,
+        source: AutocompleteIndexSource,
+        normalized_query: str,
+        categories: set[str],
+        limit: int,
+        load_entries: Callable[[], Iterable[_AutocompleteIndexEntry]],
+        validate_source: Callable[[], None],
+    ) -> AutocompleteIndexResult:
+        if root is None:
+            raise AutocompleteIndexUnavailable("disabled")
+
+        path = _index_path(Path(root), source)
+        try:
+            rows, entry_count, backend = _query_or_invalid(
+                path,
+                source,
+                normalized_query,
+                categories,
+                limit,
+            )
+        except _InvalidAutocompleteIndex:
+            with self._index_lock(path):
+                try:
+                    rows, entry_count, backend = _query_or_invalid(
+                        path,
+                        source,
+                        normalized_query,
+                        categories,
+                        limit,
+                    )
+                except _InvalidAutocompleteIndex as current_invalid:
+                    rebuild_reason = current_invalid.reason
+                    try:
+                        _build_index(
+                            path,
+                            source,
+                            load_entries(),
+                            validate_source,
+                        )
+                        rows, entry_count, backend = _query_or_invalid(
+                            path,
+                            source,
+                            normalized_query,
+                            categories,
+                            limit,
+                        )
+                    except AutocompleteIndexUnavailable:
+                        raise
+                    except _InvalidAutocompleteIndex as error:
+                        raise AutocompleteIndexUnavailable(
+                            "rebuild_unreadable"
+                        ) from error
+                    except sqlite3.OperationalError as error:
+                        reason = (
+                            "locked" if _is_locked_error(error) else "build_failed"
+                        )
+                        raise AutocompleteIndexUnavailable(reason) from error
+                    except (OSError, sqlite3.DatabaseError) as error:
+                        raise AutocompleteIndexUnavailable(
+                            "build_failed"
+                        ) from error
+                    diagnostics = AutocompleteIndexDiagnostics(
+                        outcome="rebuild",
+                        reason=rebuild_reason,
+                        backend=backend,
+                        source_revision=source.revision,
+                        entry_count=entry_count,
+                        index_path=path,
+                    )
+                    return AutocompleteIndexResult(
+                        entries=rows,
+                        diagnostics=diagnostics,
+                    )
+                else:
+                    diagnostics = AutocompleteIndexDiagnostics(
+                        outcome="hit",
+                        reason="concurrent_reuse",
+                        backend=backend,
+                        source_revision=source.revision,
+                        entry_count=entry_count,
+                        index_path=path,
+                    )
+                    return AutocompleteIndexResult(
+                        entries=rows,
+                        diagnostics=diagnostics,
+                    )
+        else:
+            diagnostics = AutocompleteIndexDiagnostics(
+                outcome="hit",
+                reason="valid",
+                backend=backend,
+                source_revision=source.revision,
+                entry_count=entry_count,
+                index_path=path,
+            )
+            return AutocompleteIndexResult(entries=rows, diagnostics=diagnostics)
+
+        raise AssertionError("unreachable autocomplete index state")
+
+
+_DEFAULT_AUTOCOMPLETE_INDEX_STORE = _AutocompleteIndexStore(
+    _default_autocomplete_index_dir()
+)
+
+
 def search_autocomplete_index(
     *,
     root: Path | None,
@@ -519,81 +673,12 @@ def search_autocomplete_index(
     load_entries: Callable[[], Iterable[_AutocompleteIndexEntry]],
     validate_source: Callable[[], None],
 ) -> AutocompleteIndexResult:
-    if root is None:
-        raise AutocompleteIndexUnavailable("disabled")
-
-    path = _index_path(Path(root), source)
-    try:
-        rows, entry_count, backend = _query_or_invalid(
-            path,
-            source,
-            normalized_query,
-            categories,
-            limit,
-        )
-    except _InvalidAutocompleteIndex:
-        with _index_lock(path):
-            try:
-                rows, entry_count, backend = _query_or_invalid(
-                    path,
-                    source,
-                    normalized_query,
-                    categories,
-                    limit,
-                )
-            except _InvalidAutocompleteIndex as current_invalid:
-                rebuild_reason = current_invalid.reason
-                try:
-                    _build_index(
-                        path,
-                        source,
-                        load_entries(),
-                        validate_source,
-                    )
-                    rows, entry_count, backend = _query_or_invalid(
-                        path,
-                        source,
-                        normalized_query,
-                        categories,
-                        limit,
-                    )
-                except AutocompleteIndexUnavailable:
-                    raise
-                except _InvalidAutocompleteIndex as error:
-                    raise AutocompleteIndexUnavailable("rebuild_unreadable") from error
-                except sqlite3.OperationalError as error:
-                    reason = "locked" if _is_locked_error(error) else "build_failed"
-                    raise AutocompleteIndexUnavailable(reason) from error
-                except (OSError, sqlite3.DatabaseError) as error:
-                    raise AutocompleteIndexUnavailable("build_failed") from error
-                diagnostics = AutocompleteIndexDiagnostics(
-                    outcome="rebuild",
-                    reason=rebuild_reason,
-                    backend=backend,
-                    source_revision=source.revision,
-                    entry_count=entry_count,
-                    index_path=path,
-                )
-                return AutocompleteIndexResult(entries=rows, diagnostics=diagnostics)
-            else:
-                diagnostics = AutocompleteIndexDiagnostics(
-                    outcome="hit",
-                    reason="concurrent_reuse",
-                    backend=backend,
-                    source_revision=source.revision,
-                    entry_count=entry_count,
-                    index_path=path,
-                )
-                return AutocompleteIndexResult(entries=rows, diagnostics=diagnostics)
-    else:
-        diagnostics = AutocompleteIndexDiagnostics(
-            outcome="hit",
-            reason="valid",
-            backend=backend,
-            source_revision=source.revision,
-            entry_count=entry_count,
-            index_path=path,
-        )
-        return AutocompleteIndexResult(entries=rows, diagnostics=diagnostics)
-
-    raise AssertionError("unreachable autocomplete index state")
+    return _DEFAULT_AUTOCOMPLETE_INDEX_STORE._search_at_root(
+        root=root,
+        source=source,
+        normalized_query=normalized_query,
+        categories=categories,
+        limit=limit,
+        load_entries=load_entries,
+        validate_source=validate_source,
+    )

--- a/easyuse_anima/autocomplete/search.py
+++ b/easyuse_anima/autocomplete/search.py
@@ -6,10 +6,6 @@ import heapq
 import time
 from pathlib import Path
 
-from ..infrastructure.filesystem.paths import (
-    PACKAGE_DATA_DIR as STORAGE_PACKAGE_DATA_DIR,
-)
-from ..infrastructure.filesystem.paths import USER_DATA_DIR
 from .dataset import (
     AUTOCOMPLETE_CSV,
     AutocompleteEntry,
@@ -30,21 +26,8 @@ from .index import (
     AutocompleteIndexDiagnostics,
     AutocompleteIndexSource,
     AutocompleteIndexUnavailable,
-    search_autocomplete_index,
+    _DEFAULT_AUTOCOMPLETE_INDEX_STORE,
 )
-
-
-def _default_autocomplete_index_dir() -> Path | None:
-    user_data_dir = Path(USER_DATA_DIR).resolve(strict=False)
-    package_data_dir = Path(STORAGE_PACKAGE_DATA_DIR).resolve(strict=False)
-    if user_data_dir == package_data_dir:
-        # Standalone imports do not have a ComfyUI-owned writable user-data
-        # boundary. Keep the source/package tree immutable in that case.
-        return None
-    return user_data_dir / "autocomplete_index"
-
-
-_AUTOCOMPLETE_INDEX_DIR = _default_autocomplete_index_dir()
 
 
 def _autocomplete_match_score(
@@ -136,8 +119,7 @@ def _search_autocomplete_with_diagnostics(
             break
 
         try:
-            indexed = search_autocomplete_index(
-                root=_AUTOCOMPLETE_INDEX_DIR,
+            indexed = _DEFAULT_AUTOCOMPLETE_INDEX_STORE.search(
                 source=_index_source(key),
                 normalized_query=normalized_query,
                 categories=categories,

--- a/tests/fixtures/python_autocomplete_runtime_contract.v1.json
+++ b/tests/fixtures/python_autocomplete_runtime_contract.v1.json
@@ -78,14 +78,14 @@
       "goal": "Encapsulate the immutable index root and normalized-path publication lock registry behind one autocomplete index-store owner.",
       "id": "E-05c",
       "name": "index-store root and path-lock ownership",
-      "status": "queued"
+      "status": "complete"
     },
     {
       "classification": "Move",
       "goal": "Compose the two autocomplete owners in bootstrap, expose one narrow RuntimeServices port, and wire existing adapter facades without changing public identities.",
       "id": "E-05d",
       "name": "bootstrap composition and adapter wiring",
-      "status": "blocked-by-E-05c"
+      "status": "queued"
     },
     {
       "classification": "Contract",
@@ -142,19 +142,22 @@
     },
     {
       "cleanup": {
-        "current": "The index root is immutable after import and path locks remain for process lifetime; production has no reset.",
-        "target": "The feature-private index store owns the immutable root and retained path-lock registry; close is an idempotent no-op unless direct evidence later proves disposable resources."
+        "current": "_AutocompleteIndexStore.close is an idempotent no-op because the immutable root and normalized-path Locks are retained for process lifetime.",
+        "target": "Whole-runtime reverse close ordering remains an E-09 gate; E-05c does not invent disposal for non-disposable Locks."
       },
-      "current_owners": [
+      "components": [
         {
-          "e01_entry": "autocomplete-index-locks",
-          "owner": "easyuse_anima.autocomplete.index"
-        },
-        {
-          "e01_entry": "autocomplete-index-root",
-          "owner": "easyuse_anima.autocomplete.search"
+          "class": "_AutocompleteIndexStore",
+          "module": "easyuse_anima/autocomplete/index.py",
+          "state_kind": "instance",
+          "state_symbols": [
+            "_locks",
+            "_locks_guard",
+            "_root"
+          ]
         }
       ],
+      "current_owner": "easyuse_anima.autocomplete.index._DEFAULT_AUTOCOMPLETE_INDEX_STORE",
       "e01_entries": [
         "autocomplete-index-locks",
         "autocomplete-index-root"
@@ -179,15 +182,11 @@
       ],
       "state_symbols": {
         "easyuse_anima/autocomplete/index.py": [
-          "_INDEX_LOCKS",
-          "_INDEX_LOCKS_GUARD"
-        ],
-        "easyuse_anima/autocomplete/search.py": [
-          "_AUTOCOMPLETE_INDEX_DIR"
+          "_DEFAULT_AUTOCOMPLETE_INDEX_STORE"
         ]
       },
-      "target_owner": "feature-private autocomplete index store",
-      "target_phase": "E-05c"
+      "target_owner": "easyuse_anima.autocomplete.index._DEFAULT_AUTOCOMPLETE_INDEX_STORE",
+      "target_phase": "E-05c-complete"
     }
   ],
   "production_callers": [
@@ -210,9 +209,9 @@
         "index-store"
       ],
       "uses": [
-        "_AUTOCOMPLETE_INDEX_DIR",
+        "_DEFAULT_AUTOCOMPLETE_INDEX_STORE",
         "_snapshot",
-        "search_autocomplete_index"
+        "_validate_index_source"
       ]
     },
     {
@@ -226,7 +225,7 @@
       ]
     }
   ],
-  "production_changes": 1,
+  "production_changes": 2,
   "schema_version": 1,
   "scope": "E-05 autocomplete source metadata, dataset snapshot/cache/Future single-flight, SQLite index root and publication path-lock ownership"
 }

--- a/tests/fixtures/python_backend_baseline.json
+++ b/tests/fixtures/python_backend_baseline.json
@@ -16531,6 +16531,42 @@
         "source": "easyuse_anima/autocomplete/index.py"
       },
       {
+        "alias": "STORAGE_PACKAGE_DATA_DIR",
+        "bound_name": "STORAGE_PACKAGE_DATA_DIR",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": "..infrastructure.filesystem.paths:PACKAGE_DATA_DIR",
+        "kind": "static_from",
+        "line": 13,
+        "name": "PACKAGE_DATA_DIR",
+        "optional": false,
+        "requested": "..infrastructure.filesystem.paths",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/autocomplete/index.py",
+        "target": "easyuse_anima/infrastructure/filesystem/paths.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "USER_DATA_DIR",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": "..infrastructure.filesystem.paths:USER_DATA_DIR",
+        "kind": "static_from",
+        "line": 16,
+        "name": "USER_DATA_DIR",
+        "optional": false,
+        "requested": "..infrastructure.filesystem.paths",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/autocomplete/index.py",
+        "target": "easyuse_anima/infrastructure/filesystem/paths.py"
+      },
+      {
         "alias": null,
         "bound_name": "annotations",
         "branch_context": [],
@@ -16599,42 +16635,6 @@
         "source": "easyuse_anima/autocomplete/search.py"
       },
       {
-        "alias": "STORAGE_PACKAGE_DATA_DIR",
-        "bound_name": "STORAGE_PACKAGE_DATA_DIR",
-        "branch_context": [],
-        "classification": "internal",
-        "column": 0,
-        "conditional": false,
-        "imported": "..infrastructure.filesystem.paths:PACKAGE_DATA_DIR",
-        "kind": "static_from",
-        "line": 9,
-        "name": "PACKAGE_DATA_DIR",
-        "optional": false,
-        "requested": "..infrastructure.filesystem.paths",
-        "role": "ordinary",
-        "scope": "<module>",
-        "source": "easyuse_anima/autocomplete/search.py",
-        "target": "easyuse_anima/infrastructure/filesystem/paths.py"
-      },
-      {
-        "alias": null,
-        "bound_name": "USER_DATA_DIR",
-        "branch_context": [],
-        "classification": "internal",
-        "column": 0,
-        "conditional": false,
-        "imported": "..infrastructure.filesystem.paths:USER_DATA_DIR",
-        "kind": "static_from",
-        "line": 12,
-        "name": "USER_DATA_DIR",
-        "optional": false,
-        "requested": "..infrastructure.filesystem.paths",
-        "role": "ordinary",
-        "scope": "<module>",
-        "source": "easyuse_anima/autocomplete/search.py",
-        "target": "easyuse_anima/infrastructure/filesystem/paths.py"
-      },
-      {
         "alias": null,
         "bound_name": "AUTOCOMPLETE_CSV",
         "branch_context": [],
@@ -16643,7 +16643,7 @@
         "conditional": false,
         "imported": ".dataset:AUTOCOMPLETE_CSV",
         "kind": "static_from",
-        "line": 13,
+        "line": 9,
         "name": "AUTOCOMPLETE_CSV",
         "optional": false,
         "requested": ".dataset",
@@ -16661,7 +16661,7 @@
         "conditional": false,
         "imported": ".dataset:AutocompleteEntry",
         "kind": "static_from",
-        "line": 13,
+        "line": 9,
         "name": "AutocompleteEntry",
         "optional": false,
         "requested": ".dataset",
@@ -16679,7 +16679,7 @@
         "conditional": false,
         "imported": ".dataset:_AUTOCOMPLETE_CACHE_LOAD_ATTEMPTS",
         "kind": "static_from",
-        "line": 13,
+        "line": 9,
         "name": "_AUTOCOMPLETE_CACHE_LOAD_ATTEMPTS",
         "optional": false,
         "requested": ".dataset",
@@ -16697,7 +16697,7 @@
         "conditional": false,
         "imported": ".dataset:_AutocompleteCacheKey",
         "kind": "static_from",
-        "line": 13,
+        "line": 9,
         "name": "_AutocompleteCacheKey",
         "optional": false,
         "requested": ".dataset",
@@ -16715,7 +16715,7 @@
         "conditional": false,
         "imported": ".dataset:_AutocompleteSnapshot",
         "kind": "static_from",
-        "line": 13,
+        "line": 9,
         "name": "_AutocompleteSnapshot",
         "optional": false,
         "requested": ".dataset",
@@ -16733,7 +16733,7 @@
         "conditional": false,
         "imported": ".dataset:_AutocompleteSourceChanged",
         "kind": "static_from",
-        "line": 13,
+        "line": 9,
         "name": "_AutocompleteSourceChanged",
         "optional": false,
         "requested": ".dataset",
@@ -16751,7 +16751,7 @@
         "conditional": false,
         "imported": ".dataset:_MISSING_FILE_STAT",
         "kind": "static_from",
-        "line": 13,
+        "line": 9,
         "name": "_MISSING_FILE_STAT",
         "optional": false,
         "requested": ".dataset",
@@ -16769,7 +16769,7 @@
         "conditional": false,
         "imported": ".dataset:_cache_key",
         "kind": "static_from",
-        "line": 13,
+        "line": 9,
         "name": "_cache_key",
         "optional": false,
         "requested": ".dataset",
@@ -16787,7 +16787,7 @@
         "conditional": false,
         "imported": ".dataset:_cache_key_from_resolved_path",
         "kind": "static_from",
-        "line": 13,
+        "line": 9,
         "name": "_cache_key_from_resolved_path",
         "optional": false,
         "requested": ".dataset",
@@ -16805,7 +16805,7 @@
         "conditional": false,
         "imported": ".dataset:_load_entries",
         "kind": "static_from",
-        "line": 13,
+        "line": 9,
         "name": "_load_entries",
         "optional": false,
         "requested": ".dataset",
@@ -16823,7 +16823,7 @@
         "conditional": false,
         "imported": ".dataset:_normalize",
         "kind": "static_from",
-        "line": 13,
+        "line": 9,
         "name": "_normalize",
         "optional": false,
         "requested": ".dataset",
@@ -16841,7 +16841,7 @@
         "conditional": false,
         "imported": ".dataset:_snapshot",
         "kind": "static_from",
-        "line": 13,
+        "line": 9,
         "name": "_snapshot",
         "optional": false,
         "requested": ".dataset",
@@ -16859,7 +16859,7 @@
         "conditional": false,
         "imported": ".dataset:_status_from_key",
         "kind": "static_from",
-        "line": 13,
+        "line": 9,
         "name": "_status_from_key",
         "optional": false,
         "requested": ".dataset",
@@ -16877,7 +16877,7 @@
         "conditional": false,
         "imported": ".dataset:autocomplete_status",
         "kind": "static_from",
-        "line": 13,
+        "line": 9,
         "name": "autocomplete_status",
         "optional": false,
         "requested": ".dataset",
@@ -16895,7 +16895,7 @@
         "conditional": false,
         "imported": ".index:AutocompleteIndexDiagnostics",
         "kind": "static_from",
-        "line": 29,
+        "line": 25,
         "name": "AutocompleteIndexDiagnostics",
         "optional": false,
         "requested": ".index",
@@ -16913,7 +16913,7 @@
         "conditional": false,
         "imported": ".index:AutocompleteIndexSource",
         "kind": "static_from",
-        "line": 29,
+        "line": 25,
         "name": "AutocompleteIndexSource",
         "optional": false,
         "requested": ".index",
@@ -16931,7 +16931,7 @@
         "conditional": false,
         "imported": ".index:AutocompleteIndexUnavailable",
         "kind": "static_from",
-        "line": 29,
+        "line": 25,
         "name": "AutocompleteIndexUnavailable",
         "optional": false,
         "requested": ".index",
@@ -16942,15 +16942,15 @@
       },
       {
         "alias": null,
-        "bound_name": "search_autocomplete_index",
+        "bound_name": "_DEFAULT_AUTOCOMPLETE_INDEX_STORE",
         "branch_context": [],
         "classification": "internal",
         "column": 0,
         "conditional": false,
-        "imported": ".index:search_autocomplete_index",
+        "imported": ".index:_DEFAULT_AUTOCOMPLETE_INDEX_STORE",
         "kind": "static_from",
-        "line": 29,
-        "name": "search_autocomplete_index",
+        "line": 25,
+        "name": "_DEFAULT_AUTOCOMPLETE_INDEX_STORE",
         "optional": false,
         "requested": ".index",
         "role": "ordinary",
@@ -65103,16 +65103,16 @@
         "to": "easyuse_anima/infrastructure/filesystem/paths.py"
       },
       {
+        "from": "easyuse_anima/autocomplete/index.py",
+        "to": "easyuse_anima/infrastructure/filesystem/paths.py"
+      },
+      {
         "from": "easyuse_anima/autocomplete/search.py",
         "to": "easyuse_anima/autocomplete/dataset.py"
       },
       {
         "from": "easyuse_anima/autocomplete/search.py",
         "to": "easyuse_anima/autocomplete/index.py"
-      },
-      {
-        "from": "easyuse_anima/autocomplete/search.py",
-        "to": "easyuse_anima/infrastructure/filesystem/paths.py"
       },
       {
         "from": "easyuse_anima/bootstrap.py",
@@ -68194,26 +68194,26 @@
       },
       {
         "is_package": false,
-        "loc": 599,
+        "loc": 684,
         "module": "easyuse_anima.autocomplete.index",
-        "normalized_git_blob_sha1": "5296ad1fcaa7aaa689b3b80a79ab1b23decf9fdb",
+        "normalized_git_blob_sha1": "d16540946907a69522ccc027dfc13eaafd6f4b41",
         "path": "easyuse_anima/autocomplete/index.py",
         "top_level": {
-          "class_count": 7,
+          "class_count": 8,
           "function_count": 15,
-          "global_count": 5
+          "global_count": 4
         }
       },
       {
         "is_package": false,
-        "loc": 226,
+        "loc": 208,
         "module": "easyuse_anima.autocomplete.search",
-        "normalized_git_blob_sha1": "e36fa147f72dd3bdaf5fb546b921b3a28255f55d",
+        "normalized_git_blob_sha1": "6b1c76d6970ed62284f98be436401f753cd8c0b6",
         "path": "easyuse_anima/autocomplete/search.py",
         "top_level": {
           "class_count": 0,
-          "function_count": 8,
-          "global_count": 2
+          "function_count": 7,
+          "global_count": 1
         }
       },
       {
@@ -91314,7 +91314,7 @@
         "column": 1,
         "context": "decorator:AutocompleteIndexSource",
         "kind": "import_time_call",
-        "line": 36,
+        "line": 41,
         "module": "easyuse_anima/autocomplete/index.py",
         "scope": "<module>"
       },
@@ -91323,7 +91323,7 @@
         "column": 1,
         "context": "decorator:IndexedAutocompleteEntry",
         "kind": "import_time_call",
-        "line": 47,
+        "line": 52,
         "module": "easyuse_anima/autocomplete/index.py",
         "scope": "<module>"
       },
@@ -91332,7 +91332,7 @@
         "column": 1,
         "context": "decorator:AutocompleteIndexDiagnostics",
         "kind": "import_time_call",
-        "line": 55,
+        "line": 60,
         "module": "easyuse_anima/autocomplete/index.py",
         "scope": "<module>"
       },
@@ -91341,26 +91341,26 @@
         "column": 1,
         "context": "decorator:AutocompleteIndexResult",
         "kind": "import_time_call",
-        "line": 65,
+        "line": 70,
         "module": "easyuse_anima/autocomplete/index.py",
         "scope": "<module>"
       },
       {
-        "callee": "threading.Lock",
-        "column": 21,
-        "context": "assign:_INDEX_LOCKS_GUARD",
+        "callee": "_AutocompleteIndexStore",
+        "column": 36,
+        "context": "assign:_DEFAULT_AUTOCOMPLETE_INDEX_STORE",
         "kind": "import_time_call",
-        "line": 84,
+        "line": 661,
         "module": "easyuse_anima/autocomplete/index.py",
         "scope": "<module>"
       },
       {
         "callee": "_default_autocomplete_index_dir",
-        "column": 26,
-        "context": "assign:_AUTOCOMPLETE_INDEX_DIR",
+        "column": 4,
+        "context": "assign:_DEFAULT_AUTOCOMPLETE_INDEX_STORE",
         "kind": "import_time_call",
-        "line": 47,
-        "module": "easyuse_anima/autocomplete/search.py",
+        "line": 662,
+        "module": "easyuse_anima/autocomplete/index.py",
         "scope": "<module>"
       },
       {
@@ -92343,12 +92343,6 @@
         "name": "_MERGED_E621_CATEGORY_NAMES"
       },
       {
-        "kind": "dict",
-        "line": 83,
-        "module": "easyuse_anima/autocomplete/index.py",
-        "name": "_INDEX_LOCKS"
-      },
-      {
         "kind": "list",
         "line": 277,
         "module": "easyuse_anima/bootstrap.py",
@@ -92685,25 +92679,6 @@
         "line": 9,
         "module": "easyuse_anima/api/file_io.py",
         "name": "_FILE_IO_LIMITERS_LOCK"
-      },
-      {
-        "categories": [
-          "lock",
-          "mutable_container"
-        ],
-        "initializer": "Dict",
-        "line": 83,
-        "module": "easyuse_anima/autocomplete/index.py",
-        "name": "_INDEX_LOCKS"
-      },
-      {
-        "categories": [
-          "lock"
-        ],
-        "initializer": "threading.Lock",
-        "line": 84,
-        "module": "easyuse_anima/autocomplete/index.py",
-        "name": "_INDEX_LOCKS_GUARD"
       },
       {
         "categories": [

--- a/tests/fixtures/python_runtime_state_ownership.v1.json
+++ b/tests/fixtures/python_runtime_state_ownership.v1.json
@@ -191,27 +191,27 @@
     },
     {
       "categories": ["lock", "path_registry"],
-      "cleanup": "No explicit cleanup; path locks remain after first index access.",
+      "cleanup": "_AutocompleteIndexStore.close is an idempotent no-op; retained path locks remain after first index access.",
       "id": "autocomplete-index-locks",
-      "lifetime": "Process lifetime, one Lock per normalized index path.",
+      "lifetime": "Process lifetime through one default store, one Lock per normalized index path.",
       "module": "easyuse_anima/autocomplete/index.py",
-      "owner": "easyuse_anima.autocomplete.index",
-      "symbols": ["_INDEX_LOCKS", "_INDEX_LOCKS_GUARD"],
-      "target_phase": "E-05c",
+      "owner": "easyuse_anima.autocomplete.index._DEFAULT_AUTOCOMPLETE_INDEX_STORE",
+      "symbols": ["_DEFAULT_AUTOCOMPLETE_INDEX_STORE"],
+      "target_phase": "E-05c-complete",
       "test_evidence": ["tests/test_autocomplete_index.py"],
-      "thread_safety": "The guard serializes creation; each per-path Lock serializes index publication."
+      "thread_safety": "The owner guard serializes creation; each retained per-path Lock serializes index publication."
     },
     {
       "categories": ["path_resolution", "runtime_config"],
-      "cleanup": "No reset; tests patch the module value when an isolated index root is required.",
+      "cleanup": "The immutable root owns no disposable resource; tests inject an isolated private store when a separate root is required.",
       "id": "autocomplete-index-root",
-      "lifetime": "Resolved once at import from process USER_DATA_DIR.",
-      "module": "easyuse_anima/autocomplete/search.py",
-      "owner": "easyuse_anima.autocomplete.search",
-      "symbols": ["_AUTOCOMPLETE_INDEX_DIR"],
-      "target_phase": "E-05c",
+      "lifetime": "Resolved once at import from process USER_DATA_DIR and retained by the default store.",
+      "module": "easyuse_anima/autocomplete/index.py",
+      "owner": "easyuse_anima.autocomplete.index._DEFAULT_AUTOCOMPLETE_INDEX_STORE",
+      "symbols": ["_DEFAULT_AUTOCOMPLETE_INDEX_STORE"],
+      "target_phase": "E-05c-complete",
       "test_evidence": ["tests/test_autocomplete_index.py", "tests/test_python_package_skeleton.py"],
-      "thread_safety": "Immutable Path-or-None after import."
+      "thread_safety": "The store exposes one immutable Path-or-None root after construction."
     },
     {
       "categories": ["lock", "path_registry"],

--- a/tests/test_autocomplete_index.py
+++ b/tests/test_autocomplete_index.py
@@ -27,6 +27,9 @@ class AutocompleteIndexTests(unittest.TestCase):
         )
         self.root = Path(self.temporary_directory.name)
         self.index_root = self.root / "index"
+        self.index_store = autocomplete_index_impl._AutocompleteIndexStore(
+            self.index_root
+        )
 
     def tearDown(self) -> None:
         dataset._DEFAULT_AUTOCOMPLETE_SNAPSHOTS.clear()
@@ -40,8 +43,8 @@ class AutocompleteIndexTests(unittest.TestCase):
     def _search(self, query: str, *, path: Path, limit: int = 20, category: str = ""):
         with patch.object(
             autocomplete_search_impl,
-            "_AUTOCOMPLETE_INDEX_DIR",
-            self.index_root,
+            "_DEFAULT_AUTOCOMPLETE_INDEX_STORE",
+            self.index_store,
         ):
             return autocomplete_search_impl._search_autocomplete_with_diagnostics(
                 query,
@@ -269,8 +272,8 @@ class AutocompleteIndexTests(unittest.TestCase):
 
         with patch.object(
             autocomplete_search_impl,
-            "_AUTOCOMPLETE_INDEX_DIR",
-            self.index_root,
+            "_DEFAULT_AUTOCOMPLETE_INDEX_STORE",
+            self.index_store,
         ):
             with ThreadPoolExecutor(max_workers=6) as executor:
                 futures = [executor.submit(search_once) for _ in range(6)]
@@ -309,7 +312,11 @@ class AutocompleteIndexTests(unittest.TestCase):
                 'custom general,0,100,"[일반] 사용자 정의 일반"',
             ],
         )
-        with patch.object(autocomplete_search_impl, "_AUTOCOMPLETE_INDEX_DIR", None):
+        with patch.object(
+            autocomplete_search_impl,
+            "_DEFAULT_AUTOCOMPLETE_INDEX_STORE",
+            autocomplete_index_impl._AutocompleteIndexStore(None),
+        ):
             result, diagnostics = autocomplete_search_impl._search_autocomplete_with_diagnostics(
                 "사용자 정의",
                 path=path,
@@ -321,6 +328,58 @@ class AutocompleteIndexTests(unittest.TestCase):
         self.assertEqual(result["results"][0]["tag"], "custom character")
         self.assertEqual(result["results"][0]["category"], "character")
         self.assertEqual(result["status"]["count"], 2)
+
+    def test_index_store_owns_immutable_root_and_retained_path_locks(self):
+        store = autocomplete_index_impl._AutocompleteIndexStore(self.index_root)
+        index_path = self.index_root / "nested" / ".." / "index.sqlite3"
+        normalized_path = self.index_root / "index.sqlite3"
+
+        first = store._index_lock(index_path)
+        store.close()
+        store.close()
+        retained = store._index_lock(normalized_path)
+
+        self.assertEqual(store.root, self.index_root)
+        self.assertIs(first, retained)
+        self.assertEqual(len(store._locks), 1)
+        with self.assertRaises(AttributeError):
+            setattr(store, "root", self.root)
+
+        isolated = autocomplete_index_impl._AutocompleteIndexStore(self.index_root)
+        self.assertIsNot(isolated._index_lock(normalized_path), first)
+
+    def test_public_explicit_root_uses_default_owner_and_shared_path_locks(self):
+        path = self._write(
+            "public-index.csv",
+            ['public indexed tag,0,100,"[일반] public"'],
+        )
+        source = autocomplete_index_impl.AutocompleteIndexSource(
+            resolved_path=str(path.resolve(strict=False)),
+            revision="public-test-revision",
+        )
+        search_args = {
+            "root": self.index_root,
+            "source": source,
+            "normalized_query": "public",
+            "categories": set(),
+            "limit": 20,
+            "load_entries": lambda: dataset._load_entries(path),
+            "validate_source": lambda: None,
+        }
+
+        first = autocomplete_index_impl.search_autocomplete_index(**search_args)
+        second = autocomplete_index_impl.search_autocomplete_index(**search_args)
+
+        self.assertEqual(first.diagnostics.outcome, "rebuild")
+        self.assertEqual(second.diagnostics.outcome, "hit")
+        self.assertEqual(second.entries[0].tag, "public indexed tag")
+        index_path = autocomplete_index_impl._index_path(self.index_root, source)
+        lock_key = os.path.normcase(os.path.abspath(index_path))
+        default_owner = autocomplete_index_impl._DEFAULT_AUTOCOMPLETE_INDEX_STORE
+        self.assertIs(
+            default_owner._locks[lock_key],
+            default_owner._index_lock(index_path),
+        )
 
     def test_index_module_is_inside_registry_package_closure(self):
         source = (ROOT / "easyuse_anima" / "autocomplete" / "search.py").read_text(

--- a/tests/test_python_autocomplete_runtime_contract.py
+++ b/tests/test_python_autocomplete_runtime_contract.py
@@ -190,7 +190,7 @@ class PythonAutocompleteRuntimeContractTests(unittest.TestCase):
         )
         self.assertEqual(self.fixture["schema_version"], 1)
         self.assertEqual(self.fixture["classification"], "Contract")
-        self.assertEqual(self.fixture["production_changes"], 1)
+        self.assertEqual(self.fixture["production_changes"], 2)
         self.assertEqual(
             [move["id"] for move in self.fixture["move_queue"]],
             ["E-05a", "E-05b", "E-05c", "E-05d", "E-05e"],
@@ -237,10 +237,6 @@ class PythonAutocompleteRuntimeContractTests(unittest.TestCase):
         )
 
         index_owner = owners["index-store"]
-        current_owners = {
-            item["e01_entry"]: item["owner"]
-            for item in index_owner["current_owners"]
-        }
         for entry_id in (
             "autocomplete-index-locks",
             "autocomplete-index-root",
@@ -248,11 +244,19 @@ class PythonAutocompleteRuntimeContractTests(unittest.TestCase):
             with self.subTest(entry=entry_id):
                 self.assertEqual(
                     e01_entries[entry_id]["owner"],
-                    current_owners[entry_id],
+                    index_owner["current_owner"],
                 )
                 self.assertEqual(
                     e01_entries[entry_id]["target_phase"],
-                    "E-05c",
+                    "E-05c-complete",
+                )
+                self.assertEqual(
+                    set(e01_entries[entry_id]["symbols"]),
+                    {
+                        symbol
+                        for symbols in index_owner["state_symbols"].values()
+                        for symbol in symbols
+                    },
                 )
 
     def test_source_metadata_remains_declarative_and_separate(self):
@@ -377,42 +381,89 @@ class PythonAutocompleteRuntimeContractTests(unittest.TestCase):
         )
 
     def test_index_root_and_path_publication_lock_contract_are_current(self):
+        module = "easyuse_anima/autocomplete/index.py"
         index_bindings = _top_level_bindings(
-            "easyuse_anima/autocomplete/index.py"
+            module
         )
         self.assertTrue(
-            {"_INDEX_LOCKS", "_INDEX_LOCKS_GUARD"} <= index_bindings
+            {
+                "_AutocompleteIndexStore",
+                "_DEFAULT_AUTOCOMPLETE_INDEX_STORE",
+                "_default_autocomplete_index_dir",
+            }
+            <= index_bindings
         )
-        lock_references = _function_references(
-            "easyuse_anima/autocomplete/index.py",
+        self.assertEqual(
+            {"_INDEX_LOCKS", "_INDEX_LOCKS_GUARD"} & index_bindings,
+            set(),
+        )
+        self.assertEqual(
+            _instance_assignments(module, "_AutocompleteIndexStore"),
+            {"_locks", "_locks_guard", "_root"},
+        )
+        owner_methods = {
+            statement.name
+            for statement in _top_level_class(
+                module,
+                "_AutocompleteIndexStore",
+            ).body
+            if isinstance(statement, (ast.FunctionDef, ast.AsyncFunctionDef))
+        }
+        self.assertEqual(
+            owner_methods,
+            {
+                "__init__",
+                "_index_lock",
+                "_search_at_root",
+                "close",
+                "root",
+                "search",
+            },
+        )
+        lock_method = _class_method(
+            module,
+            "_AutocompleteIndexStore",
             "_index_lock",
         )
+        lock_references = {
+            node.id
+            for node in ast.walk(lock_method)
+            if isinstance(node, ast.Name)
+        }
         self.assertTrue(
-            {"_INDEX_LOCKS", "_INDEX_LOCKS_GUARD", "os"} <= lock_references
+            {"os", "threading"} <= lock_references
         )
-        called = _called_attributes(
-            "easyuse_anima/autocomplete/index.py",
-            "_index_lock",
-        )
+        called = {
+            node.func.attr
+            for node in ast.walk(lock_method)
+            if isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+        }
         self.assertTrue({"abspath", "normcase"} <= called)
         self.assertNotIn("resolve", called)
+        search_method = _class_method(
+            module,
+            "_AutocompleteIndexStore",
+            "_search_at_root",
+        )
         self.assertIn(
             "_index_lock",
-            _function_references(
-                "easyuse_anima/autocomplete/index.py",
-                "search_autocomplete_index",
-            ),
+            {
+                node.attr
+                for node in ast.walk(search_method)
+                if isinstance(node, ast.Attribute)
+            },
         )
-
         self.assertEqual(
             _top_level_assignment_call(
-                "easyuse_anima/autocomplete/search.py",
-                "_AUTOCOMPLETE_INDEX_DIR",
+                module,
+                "_DEFAULT_AUTOCOMPLETE_INDEX_STORE",
             ),
-            "_default_autocomplete_index_dir",
+            "_AutocompleteIndexStore",
         )
+
         root_references = _function_references(
-            "easyuse_anima/autocomplete/search.py",
+            module,
             "_default_autocomplete_index_dir",
         )
         self.assertTrue(
@@ -421,14 +472,18 @@ class PythonAutocompleteRuntimeContractTests(unittest.TestCase):
         )
         self.assertTrue(
             {
-                "_AUTOCOMPLETE_INDEX_DIR",
+                "_DEFAULT_AUTOCOMPLETE_INDEX_STORE",
                 "_snapshot",
-                "search_autocomplete_index",
+                "_validate_index_source",
             }
             <= _function_references(
                 "easyuse_anima/autocomplete/search.py",
                 "_search_autocomplete_with_diagnostics",
             )
+        )
+        self.assertIn(
+            "_DEFAULT_AUTOCOMPLETE_INDEX_STORE",
+            _function_references(module, "search_autocomplete_index"),
         )
 
     def test_production_callers_and_compatibility_surfaces_are_current(self):

--- a/tests/test_python_runtime_state_ownership.py
+++ b/tests/test_python_runtime_state_ownership.py
@@ -245,11 +245,7 @@ class PythonRuntimeStateOwnershipContractTests(unittest.TestCase):
             ),
             (
                 "easyuse_anima/autocomplete/index.py",
-                "_INDEX_LOCKS_GUARD",
-            ),
-            (
-                "easyuse_anima/autocomplete/search.py",
-                "_AUTOCOMPLETE_INDEX_DIR",
+                "_DEFAULT_AUTOCOMPLETE_INDEX_STORE",
             ),
             ("easyuse_anima/bootstrap.py", "_DEFAULT_RUNTIME"),
             ("easyuse_anima/bootstrap.py", "_WILDCARDS_INITIALIZED"),


### PR DESCRIPTION
## 목적과 변경 경계

Issue #187 E-05c Move입니다. Autocomplete의 immutable index root와 normalized-path publication Lock registry를 하나의 feature-private index-store owner로 이동합니다.

- `_AUTOCOMPLETE_INDEX_DIR`, `_INDEX_LOCKS`, `_INDEX_LOCKS_GUARD` 제거
- private `_AutocompleteIndexStore`가 immutable Path-or-None root, guard, retained per-path Locks를 instance state로 소유
- `_DEFAULT_AUTOCOMPLETE_INDEX_STORE` 하나를 process default owner로 유지
- `search.py`는 raw root patch 대신 call-time isolated-store injection seam 사용
- public `search_autocomplete_index(*, root, ...)`는 같은 default owner의 explicit-root compatibility path로 위임
- RuntimeServices/bootstrap/API wiring은 변경하지 않음

## Base → Head

- Base: `707aee54244946058fb7f37cfb6e06b1c2dd9735` (E-05b / PR #543 merged `origin/dev`)
- Head: `d7745478fe8b02ab09bb5f14984e7ae62cf5fe57`

## 주요 파일과 보존 계약

Production:
- `easyuse_anima/autocomplete/index.py`
- `easyuse_anima/autocomplete/search.py`

Support:
- direct index owner/concurrency/public-compatibility tests
- E-01/E-05 ownership fixtures and drift gates
- actual-code analyzer baseline
- active E-05/resume/index docs

보존:
- standalone package-data boundary index disablement
- Windows pre-directory `normcase(abspath(path))` Lock identity; no `Path.resolve()`
- readonly hit, schema/source/corrupt rebuild
- temp SQLite build, synchronous FULL, atomic replace
- locked/unreadable/build failure exact Python snapshot fallback와 diagnostics
- concurrent first access exactly one rebuild와 reuse
- ranking/category/limit/payload/status
- dynamic query/build/source validation seams
- public `search_autocomplete_index`, root shim identity, `__all__`
- package/no-host import behavior

## 검증

Focused:
- autocomplete index owner/behavior/concurrency/public compatibility: 11
- API autocomplete routes: 9
- dataset compatibility: 3
- locale source settings: 7
- E-05 Contract: 8
- E-01 ownership: 5
- analyzer: 18
- package skeleton direct import: 1
- completed import boundary: 6
- changed Python syntax/fatal Ruff, JSON parse, `git diff --check` 통과

Final candidate official full 정확히 1회:
- Python unittest: 1,365
- frontend smoke: 120
- Pyright baseline ratchet: 통과
- import boundary: 11 groups / 0 violations
- project full: 통과

Package/live/validate/pack:
- 새 shipped file, external dependency, public surface, route/bootstrap/runtime wiring이 없고 package/no-host/import gates가 통과하여 기존 evidence 재사용(`not retriggered`)

## 위험과 rollback

- `index.py`가 default root를 소유하면서 내부 filesystem-path import edge가 `search.py`에서 이동합니다. package/no-host와 import-boundary가 이를 직접 검증했습니다.
- public explicit-root caller도 같은 default owner's retained Lock registry를 사용하는 직접 test가 있습니다.
- `close()`는 process lifetime Lock을 지우지 않는 idempotent no-op입니다.
- rollback은 이 단일 Move commit revert입니다.

## Next

Squash merge 후 최신 `origin/dev`에서 별도 E-05d bootstrap composition/narrow adapter wiring Move만 시작합니다. E-05e, E-06+, E-09 구현, D-14 retirement, release/Registry는 시작하지 않습니다.