### PR TITLE
[E-05e] Complete autocomplete ownership audit

### DIFF
--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -10,15 +10,14 @@ then only the active task section, owning Issue, direct source, and direct tests
 ## Active sequencing
 
 - Issue [#187](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/187)
-  owns Phase E. E-01 through E-04 and E-05a through E-05d are complete; the next
-  bounded unit is the separate E-05e autocomplete ownership completion audit
-  Contract.
+  owns Phase E. E-01 through E-05 are complete; the next bounded unit is the
+  separate production-free E-06a wildcard snapshot ownership Contract.
   Issue #186 retains D-14/shim decisions.
 - [`backend-roadmap-resume-0.6.2.md`](backend-roadmap-resume-0.6.2.md)
   is the current execution source of truth. Read it before the older accumulated
   roadmap.
-- Reviewed code baseline before E-05d: E-05c / PR #544 at
-  `8dfbc1162ee83097f90472663557d0cc38f691e4`.
+- Reviewed code baseline before E-05e: E-05d / PR #545 at
+  `386d4632f5a903a5d03de52d6bd9a997ad1ffe2d`.
 - D-08 is complete and D-08v is not required.
 - D-14 readiness retains every root surface; retirement/final-freeze work is blocked.
 - E-01 inventory Contract:
@@ -35,17 +34,18 @@ then only the active task section, owning Issue, direct source, and direct tests
   [`python-runtime-e03-repository-filesystem-contract.md`](python-runtime-e03-repository-filesystem-contract.md).
 - Completed E-04 translation runtime ownership Contract and audit:
   [`python-runtime-e04-translation-contract.md`](python-runtime-e04-translation-contract.md).
-- E-05 autocomplete runtime ownership Contract:
+- Completed E-05 autocomplete runtime ownership Contract and audit:
   [`python-runtime-e05-autocomplete-contract.md`](python-runtime-e05-autocomplete-contract.md).
-- First READY task after E-05d: a separate #187 E-05e autocomplete ownership
-  completion audit Contract only.
+- First READY task after E-05e: a separate #187 E-06a wildcard snapshot ownership
+  Contract only.
 - Completed #470 and the #413/#414/#415 queue/live-UI lanes remain contract references,
   not active blockers.
 - Released code baseline: 0.6.2. Registry activation is external administration and
   does not block `dev`; do not republish or mutate the release.
 - Completed #409/#410/#411 and deferred #440/#441 do not alter the E-01 boundary.
-- E-05d authorizes only the separate E-05e Contract. It does not authorize E-06+
-  implementation, later Phase E work, root removal, release, or Registry.
+- E-05e authorizes only the separate production-free E-06a Contract. It does not
+  authorize an E-06 production Move, later Phase E work, root removal, release, or
+  Registry.
 
 ## Current code boundary
 

--- a/docs/architecture/backend-roadmap-resume-0.6.2.md
+++ b/docs/architecture/backend-roadmap-resume-0.6.2.md
@@ -2,16 +2,17 @@
 
 ## Status and authority
 
-- Status: D-08, E-01 through E-04, and E-05a through E-05d are completed; the D-14
+- Status: D-08 and E-01 through E-05 are completed; the D-14
   readiness audit retains every root surface and blocks retirement/final-freeze work.
-- Code-review base before E-05d:
-  `dev@8dfbc1162ee83097f90472663557d0cc38f691e4` after E-05c / PR #544.
-- Document baseline: completed E-05d autocomplete bootstrap composition Move.
+- Code-review base before E-05e:
+  `dev@386d4632f5a903a5d03de52d6bd9a997ad1ffe2d` after E-05d / PR #545.
+- Document baseline: completed production-free E-05e autocomplete ownership audit.
 - Released baseline: 0.6.2.
 - Scope: completed D-08 evidence, the D-14 readiness decision, completed #187
   E-01/E-02/E-03/E-04 work, the E-05a Contract, the E-05b snapshot owner Move,
-  the E-05c index-store owner Move, the E-05d composition Move, and the next
-  bounded E-05e completion audit Contract.
+  the E-05c index-store owner Move, the E-05d composition Move, the E-05e
+  completion audit Contract, and the next bounded E-06a wildcard snapshot
+  ownership Contract.
 - This document owns the current immediate queue and supersedes the stale queue and
   broad preflight command in `python-backend-execution-roadmap.md`.
 - `python-backend.md`, ADR-001, ADR-002, and the compatibility-shim registry still own
@@ -385,7 +386,12 @@ canonical pre-initialize fallback. Canonical feature identities, call-time root
 patch seams, owner identities, bootstrap retry/refresh behavior, and no-host import
 safety remain unchanged.
 
-Start only a separate #187 E-05e completion audit Contract from latest origin/dev.
-Do not start E-06 through E-10, D-14 retirement, release, or Registry work inside
-E-05e.
+E-05e reconciles the three E-01 autocomplete entries with exactly two owners,
+records completed-cache `clear()` and retained-lock no-op `close()` dispositions,
+proves direct root identities and package/no-host import safety, and records zero
+ambiguous autocomplete state without changing production. E-05 is complete.
+
+Start only a separate #187 E-06a wildcard snapshot ownership Contract from latest
+origin/dev. Do not start an E-06 production Move, E-07 through E-10, D-14 retirement,
+release, or Registry work inside E-06a.
 ```

--- a/docs/architecture/python-runtime-e05-autocomplete-contract.md
+++ b/docs/architecture/python-runtime-e05-autocomplete-contract.md
@@ -11,7 +11,9 @@ E-05b moves the dataset snapshot/cache/Future state behind its selected
 feature-private owner. E-05c moves the immutable index root and retained path-lock
 registry behind the second selected owner. E-05d composes those exact owners behind
 one private autocomplete service and exposes only its narrow port through the
-process runtime.
+process runtime. E-05e reconciles those completed owners with E-01 and records
+their cleanup, import, compatibility, and ambiguity disposition without changing
+production.
 
 The executable source is
 `tests/fixtures/python_autocomplete_runtime_contract.v1.json`, checked by
@@ -127,9 +129,9 @@ port.
 4. **E-05d Move — bootstrap composition and adapter wiring — complete:** compose
    both owners, add only a narrow autocomplete port to RuntimeServices, and
    preserve every canonical/root identity and call-time adapter seam.
-5. **E-05e Contract — completion audit:** reconcile E-01 targets, cleanup
-   dispositions, import safety, root identities, and zero ambiguous autocomplete
-   state before E-06.
+5. **E-05e Contract — completion audit — complete:** reconciles E-01 targets,
+   cleanup dispositions, import safety, root identities, and zero ambiguous
+   autocomplete state before E-06.
 
 Each Move is a separate PR and rollback boundary. E-09 retains whole-runtime reverse
 close ordering and partial-initialization cleanup. E-05 supplies only the
@@ -137,8 +139,31 @@ feature-owned resources and their proven cleanup shapes.
 
 E-05b leaves no duplicate module cache/lock/Future map, E-05c leaves no raw module
 root or index-lock registry, and E-05d creates no duplicate owner while adding the
-single bootstrap-composed narrow runtime port. The next READY unit is the separate
-E-05e completion audit Contract.
+single bootstrap-composed narrow runtime port. E-05e proves that completed state
+without changing production.
+
+## Completion audit result
+
+The E-01 and E-05 fixtures agree on all three autocomplete entries and exactly two
+feature-private owners:
+
+| E-01 entry | E-05 owner | Completed phase | Cleanup disposition |
+| --- | --- | --- | --- |
+| `autocomplete-dataset-cache` | `dataset-snapshots` | E-05b | idempotent completed-cache `clear()`; in-flight Futures remain until shared settlement; whole-runtime ordering remains E-09 |
+| `autocomplete-index-locks` | `index-store` | E-05c | retained normalized-path Locks and idempotent no-op `close()`; whole-runtime ordering remains E-09 |
+| `autocomplete-index-root` | `index-store` | E-05c | immutable Path-or-None root with no disposable handle; whole-runtime ordering remains E-09 |
+
+There are zero ambiguous autocomplete state owners. The source/category tables remain
+one separate declarative policy, not a runtime repository. Feature modules retain no
+runtime, bootstrap, API, or root-shim back-reference; package/no-host import remains
+the direct runtime evidence. Root dataset and index shims continue to import their
+canonical objects directly, while the root API retains the dynamic runtime-port
+facades and canonical pre-initialize fallbacks.
+
+E-05 is complete. The next bounded unit is a separate production-free **E-06a
+wildcard snapshot ownership Contract**. E-05e changes no production, analyzer
+baseline, public surface, package closure, or host-visible behavior and does not
+authorize E-09 cleanup implementation, D-14 retirement, release, or Registry work.
 
 ## Preserved behavior
 
@@ -173,3 +198,5 @@ E-05b preserves that partition and does not trigger a new PRO review.
 E-05c preserves that partition and does not trigger a new PRO review.
 E-05d composes the same two owners without changing their lifecycle partition and
 does not trigger a new PRO review.
+E-05e finds no ambiguous owner or unresolved E-05 boundary and does not trigger a
+new PRO review.

--- a/docs/architecture/python-runtime-state-inventory.md
+++ b/docs/architecture/python-runtime-state-inventory.md
@@ -38,9 +38,9 @@ E-01 drift gate until classified.
 | --- | --- | --- | --- |
 | `aio-first-pass-cache` | canonical AiO cache module, process lifetime with count/byte/TTL bounds | one `RLock`; explicit clear plus test-only metric/config reset | E-08 |
 | `api-file-io-limiters` | canonical API file-I/O module, weak per-event-loop limiter | registry `Lock`; weak expiry, no explicit close | E-09 |
-| `autocomplete-dataset-cache` | canonical dataset snapshot and Future single-flight owner, injected into the bootstrap-composed narrow service | one owner `Lock`; completed-snapshot clear only | E-05b/E-05d complete |
-| `autocomplete-index-locks` | canonical index-store per-path lock owner, injected into the bootstrap-composed narrow service | guard plus retained per-path locks; idempotent no-op close | E-05c/E-05d complete |
-| `autocomplete-index-root` | immutable user-data index root retained by the canonical index-store owner | isolated-store injection; no mutable raw root | E-05c/E-05d complete |
+| `autocomplete-dataset-cache` | canonical dataset snapshot and Future single-flight owner, injected into the bootstrap-composed narrow service | one owner `Lock`; completed-snapshot clear only | E-05 complete; E-05e audited |
+| `autocomplete-index-locks` | canonical index-store per-path lock owner, injected into the bootstrap-composed narrow service | guard plus retained per-path locks; idempotent no-op close | E-05 complete; E-05e audited |
+| `autocomplete-index-root` | immutable user-data index root retained by the canonical index-store owner | isolated-store injection; no mutable raw root | E-05 complete; E-05e audited |
 | `atomic-json-path-locks` | filesystem atomic JSON per-path lock registry shared by direct/factory stores | guard plus per-path `RLock`; no clear | E-03b complete |
 | `bootstrap-initialize-state` | bootstrap default runtime and wildcard completion state | initialize `Lock`; private-global test reset, no shutdown | E-09 |
 | `filesystem-runtime-paths` | import-resolved package/user-data paths projected into the default RuntimeConfig | immutable after import; bootstrap composition does not re-resolve | E-02c complete |
@@ -148,4 +148,8 @@ behind two distinct feature-private default owners. E-05d injects those exact
 identities into one private bootstrap-composed autocomplete service and adds only
 its narrow port to RuntimeServices. No duplicate cache, Future map, root, or lock
 registry is introduced. Whole-runtime cleanup ordering remains assigned to E-09;
-the next bounded unit is the separate E-05e completion audit Contract.
+the production-free E-05e audit reconciles all three E-01 entries with those two
+owners, records their explicit cleanup dispositions, preserves package/no-host and
+root identity contracts, and records zero ambiguous autocomplete state. E-05 is
+complete. The next bounded unit is a separate E-06a wildcard snapshot ownership
+Contract.

--- a/docs/development/README.md
+++ b/docs/development/README.md
@@ -52,20 +52,21 @@ ordinary `dev` roadmap work.
 
 - Released baseline: 0.6.2.
 - Active owner: Issue #187 for Phase E; Issue #186 retains D-14/shim decisions.
-- Reviewed code baseline before E-05c: E-05b / PR #543.
+- Reviewed code baseline before E-05e: E-05d / PR #545 at
+  `386d4632f5a903a5d03de52d6bd9a997ad1ffe2d`.
 - D-08u integrated exit audit is complete.
 - D-08v is not required; the audit found no remaining D-08 production Move.
 - D-14 readiness is audited: every root surface is retained and retirement/final
   freeze is blocked by production/lifecycle consumers, missing release windows, or
   insufficient consumer evidence.
-- E-01 through E-04 and E-05a through E-05c are complete. The next work is only a
-  separate #187 E-05d bootstrap composition and narrow adapter wiring Move. The
+- E-01 through E-05 are complete. The next work is only a separate production-free
+  #187 E-06a wildcard snapshot ownership Contract. The
   #323 E-02a/E-07 bridge remains completed evidence, not authorization for unrelated
   feature migration.
 - Completed #470 and the 0.6.1 Prompt Studio lane are behavior-contract references,
   not the active queue.
-- Do not remove root aliases or start E-05e+, E-06 through E-10, release, or
-  Registry work from this entrypoint.
+- Do not remove root aliases or start an E-06 production Move, E-07 through E-10,
+  release, or Registry work from this entrypoint.
 
 ## Completed D-08 composition audit surface
 
@@ -156,6 +157,7 @@ representative profile list/load/save/delete/rename/fix live smoke
 - A version marker is not a publish action.
 - Technical PRO review is for unresolved cross-boundary architecture choices,
   unavoidable cycles, or insufficient compatibility evidence—not routine failures.
-- D-14 readiness is recorded and authorizes no removal. E-05c index-store ownership
-  is complete; use it only to start the separate E-05d Move. Do not infer E-05e+,
-  E-09 cleanup, release publication, or Registry actions.
+- D-14 readiness is recorded and authorizes no removal. E-05 ownership and its
+  production-free completion audit are complete; use that evidence only to start the
+  separate E-06a Contract. Do not infer an E-06 production Move, E-09 cleanup,
+  release publication, or Registry actions.

--- a/tests/fixtures/python_autocomplete_runtime_contract.v1.json
+++ b/tests/fixtures/python_autocomplete_runtime_contract.v1.json
@@ -37,6 +37,101 @@
       ]
     }
   ],
+  "completion_audit": {
+    "ambiguous_state_owners": [],
+    "classification": "Contract",
+    "cleanup_dispositions": [
+      {
+        "feature_cleanup": "_AutocompleteSnapshotStore.clear idempotently clears completed snapshots while in-flight Futures remain registered until shared settlement",
+        "owner": "dataset-snapshots",
+        "remaining_phase": "E-09",
+        "status": "feature-cleanup-complete"
+      },
+      {
+        "feature_cleanup": "_AutocompleteIndexStore.close is an idempotent no-op because the immutable root and retained per-path Locks own no disposable handle",
+        "owner": "index-store",
+        "remaining_phase": "E-09",
+        "status": "intentional-no-op-close"
+      }
+    ],
+    "e01_reconciliation": [
+      {
+        "completed_phase": "E-05b-complete",
+        "e01_entry": "autocomplete-dataset-cache",
+        "owner": "dataset-snapshots"
+      },
+      {
+        "completed_phase": "E-05c-complete",
+        "e01_entry": "autocomplete-index-locks",
+        "owner": "index-store"
+      },
+      {
+        "completed_phase": "E-05c-complete",
+        "e01_entry": "autocomplete-index-root",
+        "owner": "index-store"
+      }
+    ],
+    "import_safety": {
+      "evidence": [
+        "tests/test_python_package_skeleton.py"
+      ],
+      "feature_modules": [
+        "easyuse_anima/autocomplete/classification.py",
+        "easyuse_anima/autocomplete/dataset.py",
+        "easyuse_anima/autocomplete/index.py",
+        "easyuse_anima/autocomplete/ports.py",
+        "easyuse_anima/autocomplete/search.py",
+        "easyuse_anima/autocomplete/service.py"
+      ],
+      "forbidden_imports": [
+        "api",
+        "autocomplete_dataset",
+        "autocomplete_index",
+        "easyuse_anima.api",
+        "easyuse_anima.bootstrap",
+        "easyuse_anima.runtime"
+      ],
+      "host_io_at_import": false
+    },
+    "next_phase": "E-06a wildcard snapshot ownership Contract",
+    "production_changes": 0,
+    "root_identity_bindings": [
+      {
+        "canonical_module": "easyuse_anima.autocomplete.dataset",
+        "root_module": "autocomplete_dataset.py",
+        "symbols": [
+          "AUTOCOMPLETE_CSV",
+          "AUTOCOMPLETE_SOURCES",
+          "AutocompleteEntry",
+          "autocomplete_status",
+          "resolve_autocomplete_source"
+        ]
+      },
+      {
+        "canonical_module": "easyuse_anima.autocomplete.search",
+        "root_module": "autocomplete_dataset.py",
+        "symbols": [
+          "search_autocomplete"
+        ]
+      },
+      {
+        "canonical_module": "easyuse_anima.autocomplete.classification",
+        "root_module": "autocomplete_dataset.py",
+        "symbols": [
+          "classify_prompt_text"
+        ]
+      },
+      {
+        "canonical_module": "easyuse_anima.autocomplete.index",
+        "root_module": "autocomplete_index.py",
+        "symbols": [
+          "AutocompleteIndexSource",
+          "AutocompleteIndexUnavailable",
+          "search_autocomplete_index"
+        ]
+      }
+    ]
+  },
   "decisions": {
     "adapter_access": "API adapters receive or resolve one narrow autocomplete port; autocomplete feature modules do not import RuntimeServices, bootstrap, API adapters, or root compatibility shims.",
     "bootstrap_composition": "Bootstrap is the only production composition root for the default snapshot and index-store owners and the narrow RuntimeServices autocomplete port.",
@@ -92,7 +187,7 @@
       "goal": "Reconcile E-01 targets, cleanup dispositions, root identities, and zero ambiguous autocomplete state before E-06.",
       "id": "E-05e",
       "name": "autocomplete ownership completion audit",
-      "status": "queued"
+      "status": "complete"
     }
   ],
   "owners": [
@@ -297,5 +392,5 @@
     }
   },
   "schema_version": 1,
-  "scope": "E-05 autocomplete source metadata, dataset snapshot/cache/Future single-flight, SQLite index root and publication path-lock ownership"
+  "scope": "Completed E-05 autocomplete ownership sequence through the production-free E-05e audit"
 }

--- a/tests/test_python_autocomplete_runtime_contract.py
+++ b/tests/test_python_autocomplete_runtime_contract.py
@@ -164,6 +164,15 @@ def _top_level_assignment_call(module: str, assigned_name: str) -> str:
     raise AssertionError(f"{module} has no call assignment for {assigned_name}")
 
 
+def _imported_names(module: str) -> set[tuple[str, str]]:
+    return {
+        (node.module, alias.name)
+        for node in ast.walk(_tree(module))
+        if isinstance(node, ast.ImportFrom) and node.module
+        for alias in node.names
+    }
+
+
 class PythonAutocompleteRuntimeContractTests(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
@@ -177,6 +186,7 @@ class PythonAutocompleteRuntimeContractTests(unittest.TestCase):
             set(self.fixture),
             {
                 "classification",
+                "completion_audit",
                 "compatibility_surfaces",
                 "decisions",
                 "declarative_policy",
@@ -201,6 +211,10 @@ class PythonAutocompleteRuntimeContractTests(unittest.TestCase):
             ["Contract", "Move", "Move", "Move", "Contract"],
         )
         self.assertEqual(
+            [move["status"] for move in self.fixture["move_queue"]],
+            ["complete", "complete", "complete", "complete", "complete"],
+        )
+        self.assertEqual(
             [owner["id"] for owner in self.fixture["owners"]],
             ["dataset-snapshots", "index-store"],
         )
@@ -209,6 +223,104 @@ class PythonAutocompleteRuntimeContractTests(unittest.TestCase):
                 self.assertTrue(owner["evidence"])
                 for evidence in owner["evidence"]:
                     self.assertTrue((ROOT / evidence).is_file(), evidence)
+
+    def test_completion_audit_reconciles_cleanup_import_and_root_identity(self):
+        audit = self.fixture["completion_audit"]
+        owners = {owner["id"]: owner for owner in self.fixture["owners"]}
+        e01_entries = {
+            entry["id"]: entry for entry in self.e01_fixture["entries"]
+        }
+
+        self.assertEqual(audit["classification"], "Contract")
+        self.assertEqual(audit["production_changes"], 0)
+        self.assertEqual(audit["ambiguous_state_owners"], [])
+        self.assertEqual(
+            len({owner["current_owner"] for owner in owners.values()}),
+            len(owners),
+        )
+        self.assertEqual(
+            audit["next_phase"],
+            "E-06a wildcard snapshot ownership Contract",
+        )
+
+        reconciliations = {
+            item["e01_entry"]: item
+            for item in audit["e01_reconciliation"]
+        }
+        self.assertEqual(
+            set(reconciliations),
+            {
+                e01_entry
+                for owner in owners.values()
+                for e01_entry in owner["e01_entries"]
+            },
+        )
+        for e01_entry, reconciliation in reconciliations.items():
+            with self.subTest(e01_entry=e01_entry):
+                owner = owners[reconciliation["owner"]]
+                self.assertIn(e01_entry, owner["e01_entries"])
+                self.assertEqual(
+                    e01_entries[e01_entry]["owner"],
+                    owner["current_owner"],
+                )
+                self.assertEqual(
+                    e01_entries[e01_entry]["target_phase"],
+                    reconciliation["completed_phase"],
+                )
+
+        cleanup = {
+            item["owner"]: item
+            for item in audit["cleanup_dispositions"]
+        }
+        self.assertEqual(set(cleanup), set(owners))
+        self.assertEqual(
+            cleanup["dataset-snapshots"]["status"],
+            "feature-cleanup-complete",
+        )
+        self.assertEqual(
+            cleanup["index-store"]["status"],
+            "intentional-no-op-close",
+        )
+        self.assertEqual(
+            {item["remaining_phase"] for item in cleanup.values()},
+            {"E-09"},
+        )
+
+        import_safety = audit["import_safety"]
+        self.assertFalse(import_safety["host_io_at_import"])
+        for evidence in import_safety["evidence"]:
+            self.assertTrue((ROOT / evidence).is_file(), evidence)
+        forbidden = set(import_safety["forbidden_imports"])
+        for module in import_safety["feature_modules"]:
+            imports = {
+                node.module
+                for node in ast.walk(_tree(module))
+                if isinstance(node, ast.ImportFrom) and node.module
+            }
+            with self.subTest(module=module):
+                self.assertEqual(imports & forbidden, set())
+
+        identity_surfaces = {
+            surface["module"]: set(surface["symbols"])
+            for surface in self.fixture["compatibility_surfaces"]
+            if surface["kind"] == "identity_reexport"
+        }
+        audited_bindings: dict[str, set[str]] = {}
+        for binding in audit["root_identity_bindings"]:
+            root_module = binding["root_module"]
+            expected = {
+                (binding["canonical_module"], symbol)
+                for symbol in binding["symbols"]
+            }
+            with self.subTest(root_module=root_module):
+                self.assertEqual(
+                    expected - _imported_names(root_module),
+                    set(),
+                )
+            audited_bindings.setdefault(root_module, set()).update(
+                binding["symbols"]
+            )
+        self.assertEqual(audited_bindings, identity_surfaces)
 
     def test_e01_entries_reconcile_to_two_exact_future_owners(self):
         e01_entries = {
@@ -587,22 +699,9 @@ class PythonAutocompleteRuntimeContractTests(unittest.TestCase):
                 )
 
     def test_feature_modules_do_not_depend_on_runtime_or_outer_adapters(self):
-        forbidden = {
-            "api",
-            "autocomplete_dataset",
-            "autocomplete_index",
-            "easyuse_anima.api",
-            "easyuse_anima.bootstrap",
-            "easyuse_anima.runtime",
-        }
-        for module in (
-            "easyuse_anima/autocomplete/classification.py",
-            "easyuse_anima/autocomplete/dataset.py",
-            "easyuse_anima/autocomplete/index.py",
-            "easyuse_anima/autocomplete/ports.py",
-            "easyuse_anima/autocomplete/search.py",
-            "easyuse_anima/autocomplete/service.py",
-        ):
+        import_safety = self.fixture["completion_audit"]["import_safety"]
+        forbidden = set(import_safety["forbidden_imports"])
+        for module in import_safety["feature_modules"]:
             imports = {
                 node.module
                 for node in ast.walk(_tree(module))


### PR DESCRIPTION
## 목적과 변경 경계

Issue #187의 E-05e production-free completion audit입니다. E-01의 autocomplete 3개 항목을 E-05의 정확한 2개 owner와 재조정하고, cleanup/import/root identity/ambiguity 결과를 실행 가능한 Contract로 고정합니다.

- Base: `386d4632f5a903a5d03de52d6bd9a997ad1ffe2d`
- Head: `d276bf5b00542eb51068b01cf0c6a542bb559961`
- Production Python 변경: 없음
- Analyzer/public surface/package closure/host-visible behavior 변경: 없음

## 주요 변경

- E-05 queue의 E-05a~E-05e를 모두 complete로 기록
- `autocomplete-dataset-cache`를 snapshot/Future owner에, index lock/root 두 항목을 index-store owner에 정확히 매핑
- snapshot completed-cache `clear()`와 retained-lock no-op `close()`의 처분 및 E-09 잔여 ordering을 명시
- feature → runtime/bootstrap/API/root back-reference 0건과 root direct canonical re-export를 AST Contract로 검증
- `ambiguous_state_owners=[]` 및 E-05 완료를 기록
- 다음 단위를 production-free E-06a wildcard snapshot ownership Contract로 제한

## 검증

Focused:

- E-05 autocomplete Contract: 10
- E-01 runtime ownership Contract: 5
- snapshot owner: 2
- index owner/identity: 11
- injected autocomplete service: 1
- package/no-host import: 1
- changed Python compile, JSON syntax, fatal Ruff, `git diff --check`: 통과

Final candidate official full, 정확히 1회:

- Python unittest: 1,370
- Frontend JavaScript: 120
- Pyright baseline ratchet: 통과
- Import boundary: 11 groups, 0 violations
- Project full: 통과

E-05e는 production/import/archive/metadata/host-visible 변경이 없으므로 E-05d의 동일 production base에서 통과한 package/live/validate/pack 증거를 재사용했습니다. 사용자 인스턴스는 변경하지 않았고 새 서버나 잔여 프로세스를 만들지 않았습니다.

## 위험과 rollback

런타임 위험은 없으며 변경은 Contract fixture/test와 active 문서 5개로 제한됩니다. Rollback은 이 단일 commit revert입니다.

## Next

병합 후 최신 `origin/dev`에서 별도 E-06a Contract만 시작합니다. E-06 production Move, E-07+, E-09 cleanup, D-14 retirement, release, Registry는 이 PR 범위가 아닙니다.