### PR TITLE
E-06a wildcard snapshot runtime ownership Contract

### DIFF
--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -10,14 +10,14 @@ then only the active task section, owning Issue, direct source, and direct tests
 ## Active sequencing
 
 - Issue [#187](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/187)
-  owns Phase E. E-01 through E-05 are complete; the next bounded unit is the
-  separate production-free E-06a wildcard snapshot ownership Contract.
+  owns Phase E. E-01 through E-05 and the E-06a Contract are complete; the next
+  bounded unit is the separate E-06b wildcard snapshot owner Move.
   Issue #186 retains D-14/shim decisions.
 - [`backend-roadmap-resume-0.6.2.md`](backend-roadmap-resume-0.6.2.md)
   is the current execution source of truth. Read it before the older accumulated
   roadmap.
-- Reviewed code baseline before E-05e: E-05d / PR #545 at
-  `386d4632f5a903a5d03de52d6bd9a997ad1ffe2d`.
+- Reviewed code baseline before E-06a: E-05e / PR #546 at
+  `1df6cab58df7abaec9cc86522e89b982b813bd79`.
 - D-08 is complete and D-08v is not required.
 - D-14 readiness retains every root surface; retirement/final-freeze work is blocked.
 - E-01 inventory Contract:
@@ -36,16 +36,17 @@ then only the active task section, owning Issue, direct source, and direct tests
   [`python-runtime-e04-translation-contract.md`](python-runtime-e04-translation-contract.md).
 - Completed E-05 autocomplete runtime ownership Contract and audit:
   [`python-runtime-e05-autocomplete-contract.md`](python-runtime-e05-autocomplete-contract.md).
-- First READY task after E-05e: a separate #187 E-06a wildcard snapshot ownership
-  Contract only.
+- E-06 wildcard snapshot runtime ownership Contract and bounded Move queue:
+  [`python-runtime-e06-wildcard-contract.md`](python-runtime-e06-wildcard-contract.md).
+- First READY task after E-06a: a separate #187 E-06b wildcard snapshot owner Move
+  only.
 - Completed #470 and the #413/#414/#415 queue/live-UI lanes remain contract references,
   not active blockers.
 - Released code baseline: 0.6.2. Registry activation is external administration and
   does not block `dev`; do not republish or mutate the release.
 - Completed #409/#410/#411 and deferred #440/#441 do not alter the E-01 boundary.
-- E-05e authorizes only the separate production-free E-06a Contract. It does not
-  authorize an E-06 production Move, later Phase E work, root removal, release, or
-  Registry.
+- E-06a authorizes only the separate E-06b snapshot owner Move. It does not authorize
+  E-06c or later Phase E work, root removal, release, or Registry.
 
 ## Current code boundary
 
@@ -71,7 +72,7 @@ aliases or absorbing feature behavior.
 
 - [`backend-roadmap-resume-0.6.2.md`](backend-roadmap-resume-0.6.2.md):
   completed D-08 evidence, D-14 readiness verdict, completed Phase E units, and the
-  bounded E-05 Contract handoff.
+  bounded E-06 handoff.
 - [`python-backend.md`](python-backend.md): target ownership and dependency direction.
   Its early implementation snapshot is historical where the active checkpoint differs.
 - [`python-backend-execution-roadmap.md`](python-backend-execution-roadmap.md):
@@ -92,6 +93,9 @@ aliases or absorbing feature behavior.
 - [`python-runtime-e05-autocomplete-contract.md`](python-runtime-e05-autocomplete-contract.md):
   autocomplete declarative source policy, completed snapshot/Future and
   index-store owner Moves, compatibility seams, and bounded queue.
+- [`python-runtime-e06-wildcard-contract.md`](python-runtime-e06-wildcard-contract.md):
+  wildcard snapshot LRU/single-flight ownership, compatibility seams, cleanup
+  disposition, and bounded Move queue.
 - [`adr-001-modular-monolith.md`](adr-001-modular-monolith.md): feature-oriented modular
   monolith decision.
 - [`adr-002-compatibility-shims.md`](adr-002-compatibility-shims.md): shim lifecycle and

--- a/docs/architecture/backend-roadmap-resume-0.6.2.md
+++ b/docs/architecture/backend-roadmap-resume-0.6.2.md
@@ -2,17 +2,18 @@
 
 ## Status and authority
 
-- Status: D-08 and E-01 through E-05 are completed; the D-14
+- Status: D-08, E-01 through E-05, and the E-06a Contract are completed; the D-14
   readiness audit retains every root surface and blocks retirement/final-freeze work.
-- Code-review base before E-05e:
-  `dev@386d4632f5a903a5d03de52d6bd9a997ad1ffe2d` after E-05d / PR #545.
-- Document baseline: completed production-free E-05e autocomplete ownership audit.
+- Code-review base before E-06a:
+  `dev@1df6cab58df7abaec9cc86522e89b982b813bd79` after E-05e / PR #546.
+- Document baseline: completed production-free E-06a wildcard snapshot ownership
+  Contract.
 - Released baseline: 0.6.2.
 - Scope: completed D-08 evidence, the D-14 readiness decision, completed #187
   E-01/E-02/E-03/E-04 work, the E-05a Contract, the E-05b snapshot owner Move,
   the E-05c index-store owner Move, the E-05d composition Move, the E-05e
-  completion audit Contract, and the next bounded E-06a wildcard snapshot
-  ownership Contract.
+  completion audit Contract, the E-06a wildcard snapshot ownership Contract, and
+  the next bounded E-06b snapshot owner Move.
 - This document owns the current immediate queue and supersedes the stale queue and
   broad preflight command in `python-backend-execution-roadmap.md`.
 - `python-backend.md`, ADR-001, ADR-002, and the compatibility-shim registry still own
@@ -391,7 +392,15 @@ records completed-cache `clear()` and retained-lock no-op `close()` dispositions
 proves direct root identities and package/no-host import safety, and records zero
 ambiguous autocomplete state without changing production. E-05 is complete.
 
-Start only a separate #187 E-06a wildcard snapshot ownership Contract from latest
-origin/dev. Do not start an E-06 production Move, E-07 through E-10, D-14 retirement,
-release, or Registry work inside E-06a.
+E-06a fixes the verified-snapshot LRU, building-key set, and Condition as one
+wildcard-specific runtime resource. It selects one private
+`_WildcardSnapshotStore` referenced by `_DEFAULT_WILDCARD_SNAPSHOTS`, preserves the
+root call-time source/build seams, and records completed-cache-only `clear()` while
+whole-runtime ordering remains E-09. The bounded E-06 queue is E-06a Contract,
+E-06b snapshot owner Move, E-06c canonical service/internal caller Move, E-06d
+narrow bootstrap composition Move, and E-06e completion audit Contract.
+
+Start only a separate #187 E-06b wildcard snapshot owner Move from latest
+origin/dev. Do not start E-06c or later Phase E work, E-09 cleanup, D-14 retirement,
+release, or Registry work inside E-06b.
 ```

--- a/docs/architecture/python-runtime-e06-wildcard-contract.md
+++ b/docs/architecture/python-runtime-e06-wildcard-contract.md
@@ -1,0 +1,170 @@
+# E-06 Wildcard Snapshot Runtime Ownership Contract
+
+## Scope and authority
+
+E-06a is a production-free Contract created from
+`dev@1df6cab58df7abaec9cc86522e89b982b813bd79` after the completed E-05
+autocomplete ownership audit. It freezes the verified wildcard snapshot LRU,
+building-key single-flight state, Condition, source-state rescan/publication loop,
+direct callers, compatibility seams, and the only authorized bounded Move order.
+
+The executable source is
+`tests/fixtures/python_wildcard_runtime_contract.v1.json`, checked by
+`tests/test_python_wildcard_runtime_contract.py`. Existing wildcard behavior,
+package/no-host, import-boundary, analyzer, API, node, workflow, and compatibility
+tests remain the behavior authorities.
+
+E-06a changes no production Python, analyzer baseline, public export, import
+closure, snapshot/cache policy, source parsing, expansion behavior, or lifecycle.
+
+## D-12 boundary retained
+
+D-12c moved only the immutable `_WildcardSnapshot` value and stateless
+`_build_wildcard_snapshot()` materializer to
+`easyuse_anima.wildcard.snapshot`. Root `wildcard_engine.py` intentionally retained:
+
+- `_SNAPSHOT_CACHE_LIMIT = 16`;
+- `_SNAPSHOT_CONDITION`;
+- `_SNAPSHOT_CACHE`;
+- `_SNAPSHOT_BUILDING`;
+- source scan, build, rescan, retry, and publication;
+- list, signature, library, and expansion entrypoints; and
+- the root-bound source/build monkeypatch seams.
+
+E-06 does not reopen immutable snapshot fields, source parsing, precedence,
+normalization, selector, NumPy/PCG64, seed, mode, expansion, budget, diagnostics, or
+payload behavior. The canonical snapshot module remains root-independent.
+
+## One runtime resource boundary
+
+The completed snapshot LRU, building-key set, and Condition are one owner. They
+share one source cache-key invariant:
+
+1. scan the ordered roots and source metadata;
+2. return and refresh an exact completed-cache hit;
+3. admit one builder for a missing key or wait on the same Condition;
+4. build an immutable candidate without holding the Condition;
+5. rescan the same ordered roots;
+6. publish only if the source cache key is unchanged and the candidate is cacheable;
+7. always remove the building key and notify all waiters; and
+8. propagate a builder exception unchanged or retry after source drift.
+
+Splitting the Condition, completed cache, or building set across owners would make
+admission and publication non-atomic. A generic cache/Condition port is rejected;
+this state has wildcard-specific rescan, cacheability, and fallback semantics.
+
+`_SNAPSHOT_CACHE_LIMIT` is immutable policy, not a separate lifecycle resource.
+Cache hits update recency, cacheable publication keeps the newest 16 keys, and
+different keys remain free to build outside the shared Condition.
+
+## Target owner and cleanup
+
+E-06b targets one private
+`easyuse_anima.wildcard.snapshot._WildcardSnapshotStore` referenced by
+`_DEFAULT_WILDCARD_SNAPSHOTS`. The owner will hold the completed LRU, building-key
+set, and Condition. Root lifecycle functions retain call-time source/build
+dependencies or an equivalent isolated-owner injection seam until their later
+canonical Move.
+
+The target idempotent `clear()` removes completed snapshots only. It must not cancel,
+remove, replace, or publish an active building key and must not wake a waiter into a
+different settlement contract. Whole-runtime reverse close ordering and partial
+initialization cleanup remain E-09.
+
+Bootstrap wildcard-directory initialization, its retry state, default root creation,
+and package import effects are separate E-09 resources. E-06 does not absorb them
+into the snapshot owner.
+
+## Compatibility and caller inventory
+
+Root `wildcard_engine.py` remains a transitional facade through E-06b. Its public
+listing/signature/expansion functions preserve signatures and results. The private
+`_WildcardSnapshot` and `_build_wildcard_snapshot` names remain exact canonical
+identities. The root-bound `_wildcard_sources` and build names remain call-time test
+seams or receive an equivalent owner-injection seam before raw lifecycle globals are
+removed.
+
+The current direct snapshot callers are:
+
+- `_load_wildcard_map()` — mutable-copy compatibility helper;
+- `list_wildcards()` — sorted relative wildcard names;
+- `wildcard_sources_signature()` — public roots/files revision payload;
+- `_WildcardLibrary.__init__()` — immutable mapping reuse; and
+- `expand_wildcard_texts()` — one snapshot per ordered expansion batch.
+
+`expand_wildcards()` delegates to the ordered-text entrypoint. Empty text batches
+still return before snapshot lifecycle. Root API, node adapters, Prompt Studio,
+Regional, and workflow consumers retain current list/signature/expansion behavior.
+
+E-06c separately moves the remaining lifecycle/service facade and internal callers to
+the canonical wildcard package while retaining the root compatibility identity
+surface. E-06d then installs only one feature-specific narrow wildcard snapshot
+capability backed by the exact default owner. Feature code does not receive or import
+the complete `RuntimeServices` object.
+
+## Bounded Move queue
+
+1. **E-06a Contract — complete:** current state, behavior authorities, one target
+   owner, direct callers, compatibility seams, cleanup gap, and Move order are
+   versioned.
+2. **E-06b Move — snapshot owner:** move the completed LRU, building-key set, and
+   Condition behind one feature-private default owner while preserving source
+   verification, publication, failure, and call-time seam behavior.
+3. **E-06c Move — canonical service and internal callers:** canonicalize the
+   lifecycle/service facade, convert internal consumers to that owner, and retain the
+   exact root compatibility surface.
+4. **E-06d Move — bootstrap composition:** install the exact default owner behind one
+   feature-specific narrow wildcard capability without changing initialization or
+   directory lifecycle.
+5. **E-06e Contract — completion audit:** reconcile E-01, cleanup, import direction,
+   root identities, and zero ambiguous wildcard snapshot state before E-07.
+
+Each Move is a separate PR and rollback boundary. The sequence separates state
+ownership, canonical caller direction, process composition, and final audit instead
+of combining the remaining D-12/E-06 surface into one high-risk Move.
+
+## Preserved behavior
+
+All E-06 Moves preserve:
+
+- ordered root identity and source metadata in the cache key;
+- source discovery, extension handling, TXT/YAML parsing, precedence, normalization,
+  option ordering, and immutable materialization;
+- LRU capacity, hit recency, eviction ordering, one-builder admission, waiter
+  wakeup, different-key parallelism, source-change retry, and exception propagation;
+- transient and persistent read `OSError` as non-cacheable candidates with no stale
+  building key;
+- malformed YAML as a cacheable empty parse;
+- list/signature payload, immutable library mapping, mutable-copy helper, and
+  expansion outputs;
+- selector stream, NumPy/PCG64 results, seed/mode semantics, budgets, diagnostics,
+  workflow serialization, and node/API behavior; and
+- package/no-host import with no import-time directory creation from canonical
+  wildcard modules.
+
+Changing cache policy, source behavior, selection, expansion, errors, payloads, or
+public signatures is Behavior and remains outside E-06 Moves.
+
+## Validation and evidence reuse
+
+E-06a focused validation covers the executable Contract, E-01 reconciliation,
+direct wildcard snapshot/cache/concurrency behavior, package/no-host import, current
+import boundaries/analyzer, JSON/Python syntax, document links, and `git diff
+--check`.
+
+Run the official full profile once on the final E-06a candidate SHA. Because E-06a
+adds only excluded test/docs support files and changes no shipped import, archive,
+metadata, or host-visible surface, package/live/validate/pack evidence remains the
+unchanged E-05d production evidence unless a material trigger is discovered.
+
+## Stop conditions
+
+Stop the owning Move if the three raw states do not converge on one owner, a target
+owner requires canonical-to-root/runtime/bootstrap back-references, source or
+expansion behavior changes, a root/public identity or call-time seam disappears
+without an equivalent seam, active builders must be cancelled or replaced, package
+import starts host/directory I/O, or bootstrap directory lifecycle must move with the
+snapshot owner.
+
+Direct source, E-01, D-12c, and concurrency tests select one owner and one Move
+order. E-06a therefore does not trigger additional PRO review.

--- a/docs/architecture/python-runtime-state-inventory.md
+++ b/docs/architecture/python-runtime-state-inventory.md
@@ -53,7 +53,7 @@ E-01 drift gate until classified.
 | `runtime-services` | identity-installed process runtime with Comfy, seed, config/clock, and narrow translation/autocomplete capabilities | bootstrap-serialized install; private-global test reset, no whole-runtime close | E-09 |
 | `translation-default-service` | RuntimeServices-owned translation port, mirrored by the canonical call-time facade | cache and flight `RLock`s; idempotent service close clears cache | E-04c complete |
 | `translation-provider-registry` | private process-owned lazy provider-client registry | one owned `RLock`; no provider close/reset | E-04b complete |
-| `wildcard-snapshot-cache` | root verified-snapshot LRU and build single-flight | one `Condition`; no owner reset/close | E-06 |
+| `wildcard-snapshot-cache` | root verified-snapshot LRU and build single-flight | one `Condition`; no owner reset/close | E-06a Contract complete; E-06b target |
 
 The fixture contains exact symbols, tests, owner, lifetime, thread-safety, and
 reset/close status. This table is a review index, not a second machine-readable
@@ -151,5 +151,10 @@ registry is introduced. Whole-runtime cleanup ordering remains assigned to E-09;
 the production-free E-05e audit reconciles all three E-01 entries with those two
 owners, records their explicit cleanup dispositions, preserves package/no-host and
 root identity contracts, and records zero ambiguous autocomplete state. E-05 is
-complete. The next bounded unit is a separate E-06a wildcard snapshot ownership
-Contract.
+complete. The production-free
+[`python-runtime-e06-wildcard-contract.md`](python-runtime-e06-wildcard-contract.md)
+reconciles the wildcard entry with one verified-snapshot LRU/building-key/Condition
+resource, preserves root dynamic seams and immutable D-12 materialization, selects a
+private `_WildcardSnapshotStore` default owner, and records completed-cache-only
+cleanup. E-06a is complete; the next bounded unit is the separate E-06b snapshot
+owner Move.

--- a/docs/development/README.md
+++ b/docs/development/README.md
@@ -30,6 +30,8 @@ Read only the sections needed by the active task.
      [`../architecture/python-runtime-e04-translation-contract.md`](../architecture/python-runtime-e04-translation-contract.md)
    - E-05 autocomplete runtime ownership Contract:
      [`../architecture/python-runtime-e05-autocomplete-contract.md`](../architecture/python-runtime-e05-autocomplete-contract.md)
+   - E-06 wildcard snapshot runtime ownership Contract:
+     [`../architecture/python-runtime-e06-wildcard-contract.md`](../architecture/python-runtime-e06-wildcard-contract.md)
 5. Read [`codex-blocker-escalation.md`](codex-blocker-escalation.md) only after a
    documented hard stop or unresolved cross-owner failure. Ordinary implementation
    and test failures remain local task work.
@@ -52,21 +54,21 @@ ordinary `dev` roadmap work.
 
 - Released baseline: 0.6.2.
 - Active owner: Issue #187 for Phase E; Issue #186 retains D-14/shim decisions.
-- Reviewed code baseline before E-05e: E-05d / PR #545 at
-  `386d4632f5a903a5d03de52d6bd9a997ad1ffe2d`.
+- Reviewed code baseline before E-06a: E-05e / PR #546 at
+  `1df6cab58df7abaec9cc86522e89b982b813bd79`.
 - D-08u integrated exit audit is complete.
 - D-08v is not required; the audit found no remaining D-08 production Move.
 - D-14 readiness is audited: every root surface is retained and retirement/final
   freeze is blocked by production/lifecycle consumers, missing release windows, or
   insufficient consumer evidence.
-- E-01 through E-05 are complete. The next work is only a separate production-free
-  #187 E-06a wildcard snapshot ownership Contract. The
+- E-01 through E-05 and the E-06a Contract are complete. The next work is only a
+  separate #187 E-06b wildcard snapshot owner Move. The
   #323 E-02a/E-07 bridge remains completed evidence, not authorization for unrelated
   feature migration.
 - Completed #470 and the 0.6.1 Prompt Studio lane are behavior-contract references,
   not the active queue.
-- Do not remove root aliases or start an E-06 production Move, E-07 through E-10,
-  release, or Registry work from this entrypoint.
+- Do not remove root aliases or start E-06c, E-07 through E-10, release, or Registry
+  work from this entrypoint.
 
 ## Completed D-08 composition audit surface
 
@@ -157,7 +159,7 @@ representative profile list/load/save/delete/rename/fix live smoke
 - A version marker is not a publish action.
 - Technical PRO review is for unresolved cross-boundary architecture choices,
   unavoidable cycles, or insufficient compatibility evidence—not routine failures.
-- D-14 readiness is recorded and authorizes no removal. E-05 ownership and its
-  production-free completion audit are complete; use that evidence only to start the
-  separate E-06a Contract. Do not infer an E-06 production Move, E-09 cleanup,
-  release publication, or Registry actions.
+- D-14 readiness is recorded and authorizes no removal. E-06a fixes one snapshot
+  owner and a five-step E-06 queue; use that evidence only to start the separate
+  E-06b Move. Do not infer E-06c, E-09 cleanup, release publication, or Registry
+  actions.

--- a/tests/fixtures/python_wildcard_runtime_contract.v1.json
+++ b/tests/fixtures/python_wildcard_runtime_contract.v1.json
@@ -1,0 +1,186 @@
+{
+  "classification": "Contract",
+  "compatibility_surfaces": [
+    {
+      "id": "root-public-wildcard-facade",
+      "kind": "transitional_root_facade",
+      "module": "wildcard_engine.py",
+      "symbols": [
+        "expand_wildcard_texts",
+        "expand_wildcards",
+        "list_wildcards",
+        "wildcard_sources_signature"
+      ]
+    },
+    {
+      "canonical_bindings": {
+        "_WildcardSnapshot": "easyuse_anima.wildcard.snapshot",
+        "_build_wildcard_snapshot": "easyuse_anima.wildcard.snapshot"
+      },
+      "id": "root-private-snapshot-identities",
+      "kind": "identity_reexport",
+      "module": "wildcard_engine.py",
+      "symbols": [
+        "_WildcardSnapshot",
+        "_build_wildcard_snapshot"
+      ]
+    },
+    {
+      "id": "root-lifecycle-patch-seams",
+      "kind": "dynamic_reference",
+      "module": "wildcard_engine.py",
+      "symbols": [
+        "_build_wildcard_snapshot",
+        "_wildcard_sources"
+      ]
+    }
+  ],
+  "decisions": {
+    "default_root_initialization": "Bootstrap wildcard-directory initialization and its retry state remain E-09 and are not part of the snapshot owner.",
+    "generic_cache_condition_port": "rejected",
+    "resource_partition": "Verified wildcard snapshots, building-key admission, and their Condition form one feature-private owner because they share one cache-key publication invariant.",
+    "root_facade": "Root wildcard_engine remains the current lifecycle/public facade through E-06b; E-06c separately canonicalizes the service surface and internal callers while retaining the root compatibility surface.",
+    "runtime_composition": "E-06d installs only one feature-specific narrow wildcard snapshot capability backed by the exact default owner; feature modules never receive the complete RuntimeServices object.",
+    "snapshot_materialization": "D-12c canonical immutable snapshot values and stateless materialization remain separate behavior authorities and are not reimplemented by E-06.",
+    "test_seams": "Root build and source-module patch seams remain call-time dependencies or gain an equivalent isolated-owner injection seam before raw globals are removed."
+  },
+  "move_queue": [
+    {
+      "classification": "Contract",
+      "goal": "Freeze current lifecycle state, callers, behavior authorities, compatibility seams, one target owner, and bounded Move order.",
+      "id": "E-06a",
+      "name": "wildcard snapshot runtime ownership contract",
+      "status": "complete"
+    },
+    {
+      "classification": "Move",
+      "goal": "Move the completed-snapshot LRU, building-key set, and Condition behind one feature-private owner while preserving source verification, publication, and call-time test seams.",
+      "id": "E-06b",
+      "name": "wildcard snapshot owner",
+      "status": "queued"
+    },
+    {
+      "classification": "Move",
+      "goal": "Canonicalize the wildcard lifecycle/service facade and internal callers while retaining exact root compatibility identities and behavior.",
+      "id": "E-06c",
+      "name": "canonical wildcard service and internal callers",
+      "status": "queued"
+    },
+    {
+      "classification": "Move",
+      "goal": "Compose the exact default snapshot owner behind one feature-specific narrow RuntimeServices wildcard capability without changing initialization or directory lifecycle.",
+      "id": "E-06d",
+      "name": "wildcard bootstrap composition",
+      "status": "queued"
+    },
+    {
+      "classification": "Contract",
+      "goal": "Reconcile E-01, cleanup, import direction, root identities, and zero ambiguous wildcard snapshot state before E-07.",
+      "id": "E-06e",
+      "name": "wildcard ownership completion audit",
+      "status": "queued"
+    }
+  ],
+  "owners": [
+    {
+      "cleanup": {
+        "current": "No owner-level reset or close; building keys self-remove and waiters are notified when each build settles.",
+        "target": "_WildcardSnapshotStore.clear idempotently clears only completed snapshots without cancelling, removing, or replacing active building keys; whole-runtime ordering remains E-09."
+      },
+      "components": [
+        {
+          "module": "wildcard_engine.py",
+          "state_kind": "module",
+          "state_symbols": [
+            "_SNAPSHOT_BUILDING",
+            "_SNAPSHOT_CACHE",
+            "_SNAPSHOT_CONDITION"
+          ]
+        }
+      ],
+      "current_owner": "wildcard_engine snapshot lifecycle",
+      "e01_entries": [
+        "wildcard-snapshot-cache"
+      ],
+      "evidence": [
+        "tests/test_wildcards.py",
+        "tests/test_python_package_skeleton.py"
+      ],
+      "id": "wildcard-snapshots",
+      "lifetime": "Process lifetime with an LRU bound of 16 verified snapshots; building keys live only until success, non-cacheable settlement, or failure.",
+      "locking": "One Condition protects cache lookup/recency/eviction, one-builder admission per source cache key, waiter sleep/wakeup, building-key removal, and publication.",
+      "module": "wildcard_engine.py",
+      "policy_symbols": [
+        "_SNAPSHOT_CACHE_LIMIT"
+      ],
+      "preserved_behavior": [
+        "root sequence and identity remain part of the source-state cache key",
+        "cache hits update LRU recency and eviction retains the newest 16 cacheable snapshots",
+        "one builder scans, builds, rescans, and publishes only when the source cache key is unchanged",
+        "same-key waiters wake and rescan while different keys may build independently",
+        "builder exceptions remove admission state, notify waiters, and propagate unchanged",
+        "non-cacheable snapshots return to the current caller but are not published",
+        "invalid YAML remains a cacheable empty parse while transient or persistent read OSError remains non-cacheable",
+        "list, signature, library, and expansion callers reuse the same immutable snapshot mapping"
+      ],
+      "state_symbols": [
+        "_SNAPSHOT_BUILDING",
+        "_SNAPSHOT_CACHE",
+        "_SNAPSHOT_CONDITION"
+      ],
+      "target_owner": "easyuse_anima.wildcard.snapshot._DEFAULT_WILDCARD_SNAPSHOTS",
+      "target_phase": "E-06b"
+    }
+  ],
+  "production_callers": [
+    {
+      "function": "_load_wildcard_map",
+      "kind": "function",
+      "module": "wildcard_engine.py",
+      "owner": "wildcard-snapshots",
+      "uses": [
+        "_wildcard_snapshot"
+      ]
+    },
+    {
+      "function": "list_wildcards",
+      "kind": "function",
+      "module": "wildcard_engine.py",
+      "owner": "wildcard-snapshots",
+      "uses": [
+        "_wildcard_snapshot"
+      ]
+    },
+    {
+      "function": "wildcard_sources_signature",
+      "kind": "function",
+      "module": "wildcard_engine.py",
+      "owner": "wildcard-snapshots",
+      "uses": [
+        "_wildcard_snapshot"
+      ]
+    },
+    {
+      "class": "_WildcardLibrary",
+      "function": "__init__",
+      "kind": "method",
+      "module": "wildcard_engine.py",
+      "owner": "wildcard-snapshots",
+      "uses": [
+        "_wildcard_snapshot"
+      ]
+    },
+    {
+      "function": "expand_wildcard_texts",
+      "kind": "function",
+      "module": "wildcard_engine.py",
+      "owner": "wildcard-snapshots",
+      "uses": [
+        "_wildcard_snapshot"
+      ]
+    }
+  ],
+  "production_changes": 0,
+  "schema_version": 1,
+  "scope": "E-06 wildcard verified-snapshot LRU, source-rescan publication, and Condition single-flight ownership"
+}

--- a/tests/test_python_wildcard_runtime_contract.py
+++ b/tests/test_python_wildcard_runtime_contract.py
@@ -1,0 +1,360 @@
+from __future__ import annotations
+
+import ast
+import json
+import unittest
+from functools import lru_cache
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+FIXTURE_PATH = (
+    ROOT / "tests" / "fixtures" / "python_wildcard_runtime_contract.v1.json"
+)
+E01_FIXTURE_PATH = (
+    ROOT / "tests" / "fixtures" / "python_runtime_state_ownership.v1.json"
+)
+CONTRACT_DOC = (
+    ROOT
+    / "docs"
+    / "architecture"
+    / "python-runtime-e06-wildcard-contract.md"
+)
+
+
+@lru_cache(maxsize=None)
+def _tree(module: str) -> ast.Module:
+    path = ROOT / module
+    return ast.parse(
+        path.read_text(encoding="utf-8-sig"),
+        filename=str(path),
+    )
+
+
+def _target_names(target: ast.expr) -> set[str]:
+    if isinstance(target, ast.Name):
+        return {target.id}
+    if isinstance(target, (ast.List, ast.Tuple)):
+        return {
+            name
+            for element in target.elts
+            for name in _target_names(element)
+        }
+    return set()
+
+
+def _top_level_bindings(module: str) -> set[str]:
+    names: set[str] = set()
+
+    def collect(statements: list[ast.stmt]) -> None:
+        for statement in statements:
+            if isinstance(
+                statement,
+                (ast.ClassDef, ast.FunctionDef, ast.AsyncFunctionDef),
+            ):
+                names.add(statement.name)
+            elif isinstance(statement, ast.Assign):
+                for target in statement.targets:
+                    names.update(_target_names(target))
+            elif isinstance(statement, ast.AnnAssign):
+                names.update(_target_names(statement.target))
+            elif isinstance(statement, (ast.Import, ast.ImportFrom)):
+                for alias in statement.names:
+                    names.add(alias.asname or alias.name.split(".", 1)[0])
+            elif isinstance(statement, ast.If):
+                collect(statement.body)
+                collect(statement.orelse)
+            elif isinstance(statement, ast.Try):
+                collect(statement.body)
+                for handler in statement.handlers:
+                    collect(handler.body)
+                collect(statement.orelse)
+                collect(statement.finalbody)
+
+    collect(_tree(module).body)
+    return names
+
+
+def _top_level_function(
+    module: str,
+    function_name: str,
+) -> ast.FunctionDef | ast.AsyncFunctionDef:
+    for statement in _tree(module).body:
+        if isinstance(statement, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            if statement.name == function_name:
+                return statement
+    raise AssertionError(f"{module} has no top-level function {function_name}")
+
+
+def _class_method(
+    module: str,
+    class_name: str,
+    method_name: str,
+) -> ast.FunctionDef | ast.AsyncFunctionDef:
+    for statement in _tree(module).body:
+        if not isinstance(statement, ast.ClassDef) or statement.name != class_name:
+            continue
+        for member in statement.body:
+            if isinstance(member, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                if member.name == method_name:
+                    return member
+    raise AssertionError(f"{module} has no {class_name}.{method_name}")
+
+
+def _references(function: ast.FunctionDef | ast.AsyncFunctionDef) -> set[str]:
+    return {
+        node.id
+        for node in ast.walk(function)
+        if isinstance(node, ast.Name)
+    }
+
+
+def _called(function: ast.FunctionDef | ast.AsyncFunctionDef) -> set[str]:
+    called: set[str] = set()
+    for node in ast.walk(function):
+        if not isinstance(node, ast.Call):
+            continue
+        if isinstance(node.func, ast.Name):
+            called.add(node.func.id)
+        elif isinstance(node.func, ast.Attribute):
+            called.add(node.func.attr)
+    return called
+
+
+def _assignment_value(module: str, assigned_name: str) -> ast.expr:
+    for statement in _tree(module).body:
+        if not isinstance(statement, (ast.Assign, ast.AnnAssign)):
+            continue
+        targets = (
+            statement.targets
+            if isinstance(statement, ast.Assign)
+            else [statement.target]
+        )
+        if any(assigned_name in _target_names(target) for target in targets):
+            return statement.value
+    raise AssertionError(f"{module} has no assignment for {assigned_name}")
+
+
+def _assignment_call(module: str, assigned_name: str) -> str:
+    value = _assignment_value(module, assigned_name)
+    if not isinstance(value, ast.Call):
+        raise AssertionError(f"{module}.{assigned_name} is not call-initialized")
+    if isinstance(value.func, ast.Name):
+        return value.func.id
+    if isinstance(value.func, ast.Attribute):
+        return value.func.attr
+    raise AssertionError(f"{module}.{assigned_name} has an unknown call target")
+
+
+def _imported_names(module: str) -> set[tuple[str, str]]:
+    return {
+        (node.module, alias.name)
+        for node in ast.walk(_tree(module))
+        if isinstance(node, ast.ImportFrom) and node.module
+        for alias in node.names
+    }
+
+
+class PythonWildcardRuntimeContractTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.fixture = json.loads(FIXTURE_PATH.read_text(encoding="utf-8"))
+        cls.e01_fixture = json.loads(
+            E01_FIXTURE_PATH.read_text(encoding="utf-8")
+        )
+
+    def test_schema_queue_and_evidence_are_complete(self):
+        self.assertEqual(
+            set(self.fixture),
+            {
+                "classification",
+                "compatibility_surfaces",
+                "decisions",
+                "move_queue",
+                "owners",
+                "production_callers",
+                "production_changes",
+                "schema_version",
+                "scope",
+            },
+        )
+        self.assertEqual(self.fixture["schema_version"], 1)
+        self.assertEqual(self.fixture["classification"], "Contract")
+        self.assertEqual(self.fixture["production_changes"], 0)
+        self.assertEqual(
+            [move["id"] for move in self.fixture["move_queue"]],
+            ["E-06a", "E-06b", "E-06c", "E-06d", "E-06e"],
+        )
+        self.assertEqual(
+            [move["classification"] for move in self.fixture["move_queue"]],
+            ["Contract", "Move", "Move", "Move", "Contract"],
+        )
+        self.assertEqual(
+            [move["status"] for move in self.fixture["move_queue"]],
+            ["complete", "queued", "queued", "queued", "queued"],
+        )
+        self.assertEqual(
+            [owner["id"] for owner in self.fixture["owners"]],
+            ["wildcard-snapshots"],
+        )
+        for owner in self.fixture["owners"]:
+            for evidence in owner["evidence"]:
+                self.assertTrue((ROOT / evidence).is_file(), evidence)
+
+    def test_e01_entry_reconciles_to_one_exact_target_owner(self):
+        owner = self.fixture["owners"][0]
+        entries = {
+            entry["id"]: entry for entry in self.e01_fixture["entries"]
+        }
+        self.assertEqual(owner["e01_entries"], ["wildcard-snapshot-cache"])
+        entry = entries["wildcard-snapshot-cache"]
+        self.assertEqual(entry["module"], owner["module"])
+        self.assertEqual(entry["owner"], owner["current_owner"])
+        self.assertEqual(entry["target_phase"], "E-06")
+        self.assertEqual(set(entry["symbols"]), set(owner["state_symbols"]))
+        self.assertEqual(owner["target_phase"], "E-06b")
+        self.assertEqual(
+            owner["target_owner"],
+            "easyuse_anima.wildcard.snapshot._DEFAULT_WILDCARD_SNAPSHOTS",
+        )
+        self.assertEqual(
+            self.fixture["decisions"]["generic_cache_condition_port"],
+            "rejected",
+        )
+
+    def test_current_condition_lru_and_building_state_are_exact(self):
+        module = "wildcard_engine.py"
+        owner = self.fixture["owners"][0]
+        bindings = _top_level_bindings(module)
+        self.assertEqual(set(owner["state_symbols"]) - bindings, set())
+        self.assertEqual(set(owner["policy_symbols"]) - bindings, set())
+        self.assertEqual(
+            _assignment_call(module, "_SNAPSHOT_CONDITION"),
+            "Condition",
+        )
+        self.assertEqual(
+            _assignment_call(module, "_SNAPSHOT_CACHE"),
+            "OrderedDict",
+        )
+        self.assertEqual(
+            _assignment_call(module, "_SNAPSHOT_BUILDING"),
+            "set",
+        )
+        limit = _assignment_value(module, "_SNAPSHOT_CACHE_LIMIT")
+        self.assertIsInstance(limit, ast.Constant)
+        self.assertEqual(limit.value, 16)
+
+        lifecycle = _top_level_function(module, "_wildcard_snapshot")
+        self.assertTrue(
+            {
+                "_SNAPSHOT_BUILDING",
+                "_SNAPSHOT_CACHE",
+                "_SNAPSHOT_CACHE_LIMIT",
+                "_SNAPSHOT_CONDITION",
+                "_build_wildcard_snapshot",
+                "_wildcard_sources",
+            }
+            <= _references(lifecycle)
+        )
+        self.assertTrue(
+            {
+                "_scan_wildcard_sources",
+                "add",
+                "discard",
+                "move_to_end",
+                "notify_all",
+                "popitem",
+                "wait",
+            }
+            <= _called(lifecycle)
+        )
+
+    def test_canonical_snapshot_remains_immutable_and_stateless(self):
+        module = "easyuse_anima/wildcard/snapshot.py"
+        self.assertTrue(
+            {"_WildcardSnapshot", "_build_wildcard_snapshot", "__all__"}
+            <= _top_level_bindings(module)
+        )
+        all_value = _assignment_value(module, "__all__")
+        self.assertIsInstance(all_value, ast.Tuple)
+        self.assertEqual(all_value.elts, [])
+        imports = {
+            node.module
+            for node in ast.walk(_tree(module))
+            if isinstance(node, ast.ImportFrom) and node.module
+        }
+        self.assertNotIn("wildcard_engine", imports)
+        call_initialized_state: set[str] = set()
+        for statement in _tree(module).body:
+            if isinstance(statement, ast.Assign):
+                if not isinstance(statement.value, ast.Call):
+                    continue
+                for target in statement.targets:
+                    call_initialized_state.update(_target_names(target))
+            elif isinstance(statement, ast.AnnAssign):
+                if not isinstance(statement.value, ast.Call):
+                    continue
+                call_initialized_state.update(_target_names(statement.target))
+        self.assertEqual(call_initialized_state, set())
+
+    def test_production_callers_resolve_the_one_snapshot_facade(self):
+        owner_ids = {owner["id"] for owner in self.fixture["owners"]}
+        for caller in self.fixture["production_callers"]:
+            with self.subTest(caller=caller["function"]):
+                self.assertIn(caller["owner"], owner_ids)
+                if caller["kind"] == "method":
+                    function = _class_method(
+                        caller["module"],
+                        caller["class"],
+                        caller["function"],
+                    )
+                else:
+                    function = _top_level_function(
+                        caller["module"],
+                        caller["function"],
+                    )
+                self.assertEqual(
+                    set(caller["uses"]) - _references(function),
+                    set(),
+                )
+
+    def test_root_compatibility_and_dynamic_seams_are_current(self):
+        bindings = _top_level_bindings("wildcard_engine.py")
+        for surface in self.fixture["compatibility_surfaces"]:
+            with self.subTest(surface=surface["id"]):
+                self.assertEqual(set(surface["symbols"]) - bindings, set())
+            for symbol, canonical_module in surface.get(
+                "canonical_bindings", {}
+            ).items():
+                self.assertIn(
+                    (canonical_module, symbol),
+                    _imported_names("wildcard_engine.py"),
+                )
+
+        lifecycle_references = _references(
+            _top_level_function("wildcard_engine.py", "_wildcard_snapshot")
+        )
+        dynamic = next(
+            surface
+            for surface in self.fixture["compatibility_surfaces"]
+            if surface["kind"] == "dynamic_reference"
+        )
+        self.assertEqual(set(dynamic["symbols"]) - lifecycle_references, set())
+
+    def test_contract_document_is_linked_from_maintained_entries(self):
+        self.assertTrue(CONTRACT_DOC.is_file())
+        architecture_entry = (
+            ROOT / "docs" / "architecture" / "README.md"
+        ).read_text(encoding="utf-8")
+        development_entry = (
+            ROOT / "docs" / "development" / "README.md"
+        ).read_text(encoding="utf-8")
+        self.assertIn(CONTRACT_DOC.name, architecture_entry)
+        self.assertIn(
+            f"../architecture/{CONTRACT_DOC.name}",
+            development_entry,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 목적과 변경 경계

Issue #187 E-06a production-free Contract입니다. wildcard verified-snapshot LRU, building-key single-flight set, Condition을 하나의 lifecycle owner로 고정하고 E-06b~E-06e의 bounded queue를 명시합니다.

- Base: `1df6cab58df7abaec9cc86522e89b982b813bd79` (E-05e / PR #546)
- Head: `63b03f8a2a915022088c511b6de403e46535648e`
- production Python, analyzer baseline, public export, import closure 변경 없음

## 주요 파일과 보존 계약

- `docs/architecture/python-runtime-e06-wildcard-contract.md`
- `tests/fixtures/python_wildcard_runtime_contract.v1.json`
- `tests/test_python_wildcard_runtime_contract.py`
- 활성 roadmap/architecture/development/inventory entrypoint 4개 갱신

보존:

- D-12c immutable snapshot/materializer 경계
- root public/private identity와 call-time source/build monkeypatch seam
- LRU 16, source scan/build/rescan/publication, one-builder/waiter/failure semantics
- list/signature/library/expansion payload 및 no-host import
- bootstrap wildcard-directory lifecycle는 E-09 유지

선택한 다음 단계는 E-06b private `_WildcardSnapshotStore` default owner Move 하나뿐입니다. E-06c canonical caller Move, E-06d narrow bootstrap composition, E-06e completion audit는 별도 PR/rollback 경계입니다.

## 검증

Focused:

- E-06 Contract: 7 passed
- E-01 runtime ownership: 5 passed
- wildcard direct/cache/concurrency: 51 passed
- package/no-host: 1 passed
- import boundary: 10 passed
- backend analyzer: 18 passed
- Python compile, JSON parse, fatal Ruff, `git diff --check`: passed

Final candidate SHA official full (exactly once):

- Python unittest: 1,377 passed
- frontend: 120 JavaScript files passed
- Pyright baseline ratchet: passed
- import boundary: 11 completed groups, 0 violations
- project full: passed

production/import/package/metadata/host-visible 변경이 없어 package/live/validate/pack은 기존 E-05d production evidence를 재사용합니다.

## 위험과 rollback

실행 동작 변경은 없습니다. 위험은 후속 Move가 snapshot state를 분리하거나 root dynamic seam을 잃는 경우이며 Contract stop condition이 이를 차단합니다. rollback은 이 단일 Contract commit을 되돌리면 됩니다.

## Next

검토 및 squash merge 후 Issue #187 checkpoint를 남기고, 최신 dev에서 별도 E-06b snapshot owner Move만 시작합니다.

Refs #187